### PR TITLE
docs: update main README with new deploy flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We've found these LLM-assisted code editors to require more human intervention t
 ## Usage
 
 ```
-tonk create app
+tonk create [app name]
 ```
 
 ### 2. Start the dev tools and open it in your favorite AI-friendly code editor
@@ -69,19 +69,37 @@ Tonk is not opinionated about which AI tooling you use.
 
 In the root of the tonk project run `npm run dev`
 
-### Building (unstable)
+### Building
 
 When you are happy with your mini-app and ready to use it, you should serve it up and save it to your device as a PWA. This should allow the app to continue working even when you're offline or away from the network.
 
+#### Building Locally
 ```bash
 npm run serve
 ```
+
+#### AWS Deployment
+```bash
+# Interactive configuration (with existing instance)
+tonk config
+
+# Provision a new EC2 instance
+tonk config --provision [--key-name my-key]
+
+# Configure with existing EC2 instance
+tonk config --instance ec2-xx-xx-xx-xx.compute-1.amazonaws.com --key ~/path/to/key.pem
+```
+
+Options:
+- `-i, --instance <address>` - EC2 instance address
+- `-k, --key <path>` - Path to SSH key file
+- `-u, --user <name>` - SSH username (default: ec2-user)
+- `-p, --provision` - Provision a new EC2 instance
+- `-n, --key-name <name>` - AWS key pair name (for provisioning)
+
 [Guide to saving PWAs for iOS](https://help.shore.com/en/how-do-i-save-the-pwa-on-my-smartphone)
 
-
 You can ask the LLM to change the name of the app (which is default to Tonk) in the `public/manifest.json`
-
-NOTE: still some issues with this step, we're working on stabilizing it.
 
 ---
 


### PR DESCRIPTION
### Description

- update main README with `tonk create` and `config` commands

### Other changes

None

### Tested

N/A

### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `README.md` to clarify commands and enhance deployment instructions for the `tonk` app, including building for local use and AWS deployment options.

### Detailed summary
- Changed command from `tonk create app` to `tonk create [app name]`.
- Updated section title from "Building (unstable)" to "Building".
- Added a new subsection "Building Locally" with the command `npm run serve`.
- Introduced a new subsection "AWS Deployment" with detailed commands for configuration and provisioning EC2 instances.
- Listed options for configuring EC2 instances with specific flags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->