### PR TITLE
docs(cli): update with persistence features

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,6 +67,28 @@ Options:
 - `-k, --key <path>` - Path to SSH key file
 - `-u, --user <name>` - SSH username (default: ec2-user)
 - `-t, --token <token>` - Pinggy.io access token for public URL
+- `-b, --backblaze` - Enable Backblaze B2 storage for document backup
+- `-f, --filesystem` - Enable filesystem storage for document backup
+
+#### Persistence Features
+
+Tonk supports multiple options for persisting your documents:
+
+1. **Backblaze B2 Storage**: Cloud-based backup for your documents
+   - Secure, scalable cloud storage
+   - Automatic synchronization at configurable intervals
+   - Requires a Backblaze B2 account with bucket and application keys
+
+2. **Filesystem Storage**: Local file-based storage on your server
+   - Store documents directly on the server's filesystem
+   - Configurable storage path and sync intervals
+   - Automatic directory creation
+
+3. **Dual Storage**: Use both Backblaze and filesystem storage
+   - Configure a primary storage option
+   - Automatic fallback to secondary storage
+
+During deployment, you'll be guided through setting up your preferred storage options interactively if not specified via command-line options.
 
 ## Development
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "The Tonk stack command line utility",
   "type": "module",
   "bin": {


### PR DESCRIPTION
### Description

- updated docs with info on persistence

### Other changes

None

### Tested

N/A

### Related issues

- closes TON-935

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

N/A

### Documentation

The docs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@tonk/cli` package version and enhances the documentation in the `README.md` to include new persistence features for document backup options, specifically Backblaze B2 and filesystem storage.

### Detailed summary
- Updated `version` in `package.json` from `0.1.12` to `0.1.13`.
- Added new command-line options for document backup:
  - `-b, --backblaze`: Enable Backblaze B2 storage.
  - `-f, --filesystem`: Enable filesystem storage.
- Introduced a section on persistence features in `README.md` detailing:
  - Backblaze B2 storage.
  - Filesystem storage.
  - Dual storage option.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->