### PR TITLE
fix(server): make automerge normal dependency

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Server package for Tonk applications",
   "type": "module",
   "main": "dist/index.js",
@@ -12,6 +12,7 @@
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
+    "@automerge/automerge": "^2.2.8",
     "@flystorage/aws-s3": "^1.0.1",
     "@flystorage/file-storage": "^1.0.1",
     "@flystorage/local-fs": "^1.0.1",
@@ -22,7 +23,6 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@automerge/automerge": "^2.2.8",
     "@types/backblaze-b2": "^1.5.6",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.25",

--- a/packages/server/pnpm-lock.yaml
+++ b/packages/server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@automerge/automerge':
+        specifier: ^2.2.8
+        version: 2.2.8
       '@flystorage/aws-s3':
         specifier: ^1.0.1
         version: 1.0.1
@@ -33,9 +36,6 @@ importers:
         specifier: ^8.18.0
         version: 8.18.1
     devDependencies:
-      '@automerge/automerge':
-        specifier: ^2.2.8
-        version: 2.2.8
       '@types/backblaze-b2':
         specifier: ^1.5.6
         version: 1.5.6


### PR DESCRIPTION
### Description

- make automerge normal dependency for server so that cli can properly install it outside of development

### Other changes

None

### Tested

Yes

### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `@tonk/server` package and managing the `@automerge/automerge` dependency in the project.

### Detailed summary
- Updated `version` of `@tonk/server` from `0.1.5` to `0.1.6`.
- Added `@automerge/automerge` dependency with version `^2.2.8` in `package.json`.
- Removed `@automerge/automerge` from `devDependencies` in `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->