### PR TITLE
feat(cli): TON-950: explicitly configure fs sync from serve

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -28,6 +28,7 @@ export const serveCommand = new Command('serve')
   .description('Start a Tonk app in production mode')
   .option('-p, --port <port>', 'Port to run the server on', '8080')
   .option('-d, --dist <path>', 'Path to the dist directory', 'dist')
+  .option('-f, --filesystem <path>', 'Filesystem path for document storage')
   .action(async options => {
     const projectRoot = process.cwd();
     const port = parseInt(options.port, 10);
@@ -67,6 +68,9 @@ export const serveCommand = new Command('serve')
     let filesystemConfig = null;
     let primaryStorage = null;
 
+    // Check if filesystem path was provided via command line
+    const hasFilesystemFlag = !!options.filesystem;
+
     if (fs.existsSync(configFilePath)) {
       try {
         const configData = JSON.parse(fs.readFileSync(configFilePath, 'utf8'));
@@ -87,7 +91,12 @@ export const serveCommand = new Command('serve')
         }
 
         // If filesystem storage is configured and enabled in the config file
-        if (configData.filesystem && configData.filesystem.enabled) {
+        // and no command line path was provided
+        if (
+          !hasFilesystemFlag &&
+          configData.filesystem &&
+          configData.filesystem.enabled
+        ) {
           let storagePath = configData.filesystem.storagePath || '~/tonk-data';
           storagePath = normalizePath(storagePath);
 
@@ -119,6 +128,32 @@ export const serveCommand = new Command('serve')
           ),
         );
         console.warn(chalk.yellow(`Error details: ${error}`));
+      }
+    }
+
+    // If filesystem path was provided via command line, override config settings
+    if (hasFilesystemFlag) {
+      const storagePath = normalizePath(options.filesystem);
+
+      filesystemConfig = {
+        enabled: true,
+        storagePath,
+        syncInterval: 30000, // 30 seconds default
+        createIfMissing: true, // default to true
+      };
+
+      console.log(
+        chalk.blue(`Filesystem storage enabled with path: ${storagePath}`),
+      );
+
+      // If no primary storage set and we have backblaze, set filesystem as primary
+      if (!primaryStorage && backblazeConfig) {
+        primaryStorage = 'filesystem';
+        console.log(
+          chalk.blue(
+            'Primary storage set to filesystem from command line argument',
+          ),
+        );
       }
     }
 

--- a/packages/hub/apps/test-app/package.json
+++ b/packages/hub/apps/test-app/package.json
@@ -14,7 +14,7 @@
     "test:watch": "jest --watch"
   },
   "devDependencies": {
-    "@tonk/cli": "^0.1.0",
+    "@tonk/cli": "file:../../../cli",
     "@tonk/server": "^0.1.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",


### PR DESCRIPTION
### Description

- added `--filesystem` flag to explicitly set fs sync path from `serve` command

### Other changes

None

### Tested

Yes

```
❯ tonk serve -f "~/.tonk/my-world"
Filesystem storage enabled with path: /Users/jackdouglas/.tonk/my-world
Starting Tonk production server...
[2025-03-28T17:32:39.540Z] DEBUG [TonkServer-Filesystem]: Using normalized storage path: /Users/jackdouglas/.tonk/my-world
[2025-03-28T17:32:39.541Z] DEBUG [TonkServer-Filesystem]: Initializing filesystem storage at: /Users/jackdouglas/.tonk/my-world
undefined
No service worker found. Skipping WASM cache update.
Server running on port 8080, update: 5
Open http://localhost:8080 to view your app
On your phone, connect to this server using your computer's local IP address
Use pinggy to expose this server: ssh -p 443 -R0:localhost:8080 a.pinggy.io
Server running at http://localhost:8080

Filesystem storage is enabled for your Automerge documents.
Documents will be stored at: /Users/jackdouglas/.tonk/my-world

Press Ctrl+C to stop the server
[2025-03-28T17:32:39.544Z] DEBUG [TonkServer-Filesystem]: Creating storage directory: /Users/jackdouglas/.tonk/my-world
[2025-03-28T17:32:39.544Z] DEBUG [TonkServer-Filesystem]: Storage directory is writable
[2025-03-28T17:32:39.544Z] DEBUG [TonkServer-Filesystem]: Found 0 documents in storage
[2025-03-28T17:32:39.544Z] DEBUG [TonkServer-Filesystem]: FileSystem storage initialized at /Users/jackdouglas/.tonk/my-world
```

### Related issues

- closes TON-950

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `serve` command in the `@tonk/cli` by adding a new option for specifying a filesystem path for document storage. It allows users to override configuration settings with command line arguments.

### Detailed summary
- Updated `@tonk/cli` dependency in `package.json` to a local file reference.
- Added `-f, --filesystem <path>` option to the `serve` command in `serve.ts`.
- Implemented logic to check if a filesystem path was provided via command line.
- Added conditional logic to handle filesystem storage configuration based on the command line input.
- Configured default settings for filesystem storage if the command line argument is used.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->