### PR TITLE
feat(create): create integration from template

### DIFF
--- a/packages/create/src/templates/integration.ts
+++ b/packages/create/src/templates/integration.ts
@@ -4,13 +4,13 @@ import ora from "ora";
 import chalk from "chalk";
 import { ProjectPlan } from "../types";
 
-export async function createReactTemplate(
+export async function createIntegrationTemplate(
   projectPath: string,
   projectName: string,
   templatePath: string,
   plan: ProjectPlan,
 ) {
-  const spinner = ora("Creating React project structure...").start();
+  const spinner = ora("Creating Integration project structure...").start();
 
   try {
     // Copy template files
@@ -58,12 +58,12 @@ export async function createReactTemplate(
       {
         name: projectName,
         plan,
-        template: "react",
+        template: "integration",
       },
       { spaces: 2 },
     );
 
-    spinner.succeed("React project created successfully!");
+    spinner.succeed("Integration project created successfully!");
 
     // Install dependencies
     spinner.start("Installing dependencies...");
@@ -73,8 +73,11 @@ export async function createReactTemplate(
     spinner.succeed("Dependencies installed successfully!");
 
     // Print next steps instructions
-    console.log("\n" + chalk.bold("🎉 Your Tonk react app is ready! 🎉"));
+    console.log("\n" + chalk.bold("🎉 Your Tonk integration is ready! 🎉"));
     console.log("\n" + chalk.bold("Next steps:"));
+    console.log(
+      "  • " + chalk.cyan("npm run build") + " - Build the integration",
+    );
     console.log(
       "  • " + chalk.cyan("npm run dev") + " - Start the development server",
     );
@@ -82,7 +85,7 @@ export async function createReactTemplate(
       "  • You may launch claude code or any other AI editor in this directory to begin coding.\n",
     );
   } catch (error) {
-    spinner.fail("Failed to create React project");
+    spinner.fail("Failed to create Integration project");
     console.error(error);
     throw error;
   }

--- a/packages/create/src/types.ts
+++ b/packages/create/src/types.ts
@@ -3,10 +3,10 @@ export interface ProjectPlan {
   projectDescription: string;
 }
 
-export type TemplateType = "default" | "React-PWA";
+export type TemplateType = "default" | "React-PWA" | "react" | "integration";
 
 export interface TemplateConfig {
   name: string;
   plan: ProjectPlan;
   template: TemplateType;
-} 
+}


### PR DESCRIPTION
### Description

- added `integration` option to `@tonk/create` command
- configure name and description of integration
- copies integration template to working directory

### Other changes

None

### Tested

Yes

### Related issues

None

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new project template type called `integration` to the project scaffolding tool, along with updates to the associated functions and messaging to support this new template.

### Detailed summary
- Updated `TemplateType` to include `"integration"`.
- Renamed `createReactTemplate` to `createIntegrationTemplate`.
- Changed spinner messages and success logs to reflect the integration template.
- Added new prompts for integration project details.
- Updated `createProject` function to handle the new `integration` template type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->