### PR TITLE
Open App In ELECTRON

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "keepsync": "file:../keepsync",
     "listr2": "^8.2.5",
     "marked": "^15.0.7",
+    "ngrok": "5.0.0-beta.2",
     "open": "^10.1.0",
     "ora": "^7.0.1",
     "zod": "^3.24.2"

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       marked:
         specifier: ^15.0.7
         version: 15.0.7
+      ngrok:
+        specifier: 5.0.0-beta.2
+        version: 5.0.0-beta.2
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -74,7 +77,7 @@ importers:
         version: 5.0.10
       tsup:
         specifier: ^8.0.1
-        version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)
+        version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.1)
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -757,6 +760,10 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -973,6 +980,10 @@ packages:
     resolution: {integrity: sha512-JtaY3FxmD+te+KSI2FJuEcfNC9T/DGGVf551babM7fAaXhjJUt7oSYurH1Devxd2+BOSUACCgt3buinx4UnmEA==}
     engines: {node: '>=18.0.0'}
 
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -995,6 +1006,9 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -1003,6 +1017,9 @@ packages:
 
   '@types/gradient-string@1.1.6':
     resolution: {integrity: sha512-LkaYxluY4G5wR1M4AKQUal2q61Di1yVVCw42ImFTuaIoQVgmV0WP1xUaLB8zwb47mp82vWTpePI9JmrjEnJ7nQ==}
+
+  '@types/http-cache-semantics@4.0.4':
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
   '@types/http-proxy@1.17.16':
     resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
@@ -1016,6 +1033,9 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
@@ -1025,6 +1045,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
@@ -1033,6 +1056,9 @@ packages:
 
   '@types/tinycolor2@1.4.6':
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -1226,6 +1252,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
@@ -1254,6 +1283,14 @@ packages:
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -1329,6 +1366,9 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -1427,6 +1467,10 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1444,6 +1488,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -1499,6 +1547,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1691,6 +1742,11 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1717,6 +1773,9 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
@@ -1839,6 +1898,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -1878,6 +1941,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1919,6 +1986,12 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  hpagent@0.1.2:
+    resolution: {integrity: sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==}
+
+  http-cache-semantics@4.1.1:
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -1930,6 +2003,10 @@ packages:
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2171,6 +2248,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2194,6 +2274,10 @@ packages:
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2293,6 +2377,14 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2357,11 +2449,20 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  ngrok@5.0.0-beta.2:
+    resolution: {integrity: sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==}
+    engines: {node: '>=14.2'}
+    hasBin: true
+
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
   normalize-package-data@3.0.3:
     resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
   npm-run-path@4.0.1:
@@ -2422,6 +2523,10 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -2517,6 +2622,9 @@ packages:
     resolution: {integrity: sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==}
     engines: {node: '>=18'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2586,6 +2694,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.2:
+    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2604,6 +2715,10 @@ packages:
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -2658,6 +2773,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2670,6 +2788,9 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -3106,6 +3227,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -3243,6 +3368,11 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.7.1:
+    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -3254,6 +3384,9 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4136,6 +4269,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@smithy/abort-controller@4.0.2':
@@ -4469,6 +4604,10 @@ snapshots:
       '@smithy/types': 4.2.0
       tslib: 2.8.1
 
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.0
@@ -4521,6 +4660,13 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      '@types/keyv': 3.1.4
+      '@types/node': 22.13.10
+      '@types/responselike': 1.0.3
+
   '@types/estree@1.0.6': {}
 
   '@types/fs-extra@11.0.4':
@@ -4531,6 +4677,8 @@ snapshots:
   '@types/gradient-string@1.1.6':
     dependencies:
       '@types/tinycolor2': 1.4.6
+
+  '@types/http-cache-semantics@4.0.4': {}
 
   '@types/http-proxy@1.17.16':
     dependencies:
@@ -4547,6 +4695,10 @@ snapshots:
     dependencies:
       '@types/node': 22.13.10
 
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 22.13.10
+
   '@types/minimist@1.2.5': {}
 
   '@types/node@22.13.10':
@@ -4555,6 +4707,10 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 22.13.10
+
   '@types/semver@7.5.8': {}
 
   '@types/through@0.0.33':
@@ -4562,6 +4718,11 @@ snapshots:
       '@types/node': 22.13.10
 
   '@types/tinycolor2@1.4.6': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.13.10
+    optional: true
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
@@ -4818,6 +4979,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-crc32@0.2.13: {}
+
   buffer@5.6.0:
     dependencies:
       base64-js: 1.5.1
@@ -4849,6 +5012,18 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.1.1
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4926,6 +5101,10 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
   clone@1.0.4: {}
 
   color-convert@2.0.1:
@@ -4992,6 +5171,10 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
@@ -5008,6 +5191,8 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-lazy-prop@3.0.0: {}
 
@@ -5046,6 +5231,10 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.4:
+    dependencies:
+      once: 1.4.0
 
   environment@1.1.0: {}
 
@@ -5382,6 +5571,16 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.0
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -5421,6 +5620,10 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
@@ -5555,6 +5758,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.2
+
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -5605,6 +5812,20 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   graceful-fs@4.2.11: {}
 
   gradient-string@2.0.2:
@@ -5652,6 +5873,11 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  hpagent@0.1.2:
+    optional: true
+
+  http-cache-semantics@4.1.1: {}
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -5678,6 +5904,11 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   human-signals@2.1.0: {}
 
@@ -5883,6 +6114,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.clonedeep@4.5.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
@@ -5910,6 +6143,8 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -5991,6 +6226,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -6044,6 +6283,18 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  ngrok@5.0.0-beta.2:
+    dependencies:
+      extract-zip: 2.0.1
+      got: 11.8.6
+      lodash.clonedeep: 4.5.0
+      uuid: 8.3.2
+      yaml: 2.7.1
+    optionalDependencies:
+      hpagent: 0.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
@@ -6057,6 +6308,8 @@ snapshots:
       is-core-module: 2.16.1
       semver: 7.7.1
       validate-npm-package-license: 3.0.4
+
+  normalize-url@6.1.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -6137,6 +6390,8 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  p-cancelable@2.1.1: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -6207,6 +6462,8 @@ snapshots:
 
   peek-readable@7.0.0: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6223,11 +6480,12 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.3):
+  postcss-load-config@6.0.1(postcss@8.5.3)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.3
+      yaml: 2.7.1
 
   postcss@8.5.3:
     dependencies:
@@ -6258,6 +6516,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.2:
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   qs@6.13.0:
@@ -6271,6 +6534,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
+
+  quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
 
@@ -6326,6 +6591,8 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -6335,6 +6602,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   restore-cursor@3.1.0:
     dependencies:
@@ -6440,7 +6711,7 @@ snapshots:
 
   send@1.1.0:
     dependencies:
-      debug: 4.3.6
+      debug: 4.4.0
       destroy: 1.2.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -6710,7 +6981,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(postcss@8.5.3)(typescript@5.8.2):
+  tsup@8.4.0(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.1)
       cac: 6.7.14
@@ -6720,7 +6991,7 @@ snapshots:
       esbuild: 0.25.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.3)
+      postcss-load-config: 6.0.1(postcss@8.5.3)(yaml@2.7.1)
       resolve-from: 5.0.0
       rollup: 4.36.0
       source-map: 0.8.0-beta.0
@@ -6794,6 +7065,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 
@@ -6925,6 +7198,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
+  yaml@2.7.1: {}
+
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
@@ -6938,6 +7213,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/packages/cli/src/commands/expose.ts
+++ b/packages/cli/src/commands/expose.ts
@@ -1,0 +1,54 @@
+import chalk from 'chalk';
+import {Command} from 'commander';
+import ngrok from 'ngrok';
+import ora from 'ora';
+
+export const exposeCommand = new Command('expose')
+  .description('Expose a local server to the internet using ngrok')
+  .option('-p, --port <port>', 'Port to expose (default: 8080)', '8080')
+  .option(
+    '-a, --auth <auth>',
+    'Basic auth credentials in format username:password',
+  )
+  .option('-r, --region <region>', 'Region to use (default: us)', 'us')
+  .option('--subdomain <subdomain>', 'Custom subdomain (requires ngrok Pro)')
+  .action(async options => {
+    const spinner = ora('Starting ngrok tunnel...').start();
+
+    try {
+      const url = await ngrok.connect({
+        addr: options.port,
+        basicAuth: options.auth,
+        region: options.region,
+        subdomain: options.subdomain,
+      });
+
+      spinner.succeed(
+        `Tunnel established! Your local server on port ${chalk.cyan(options.port)} is now available at:\n${chalk.green(url)}`,
+      );
+      console.log(chalk.yellow('\nPress Ctrl+C to stop the tunnel'));
+
+      // Keep the process running until interrupted
+      process.on('SIGINT', async () => {
+        const closeSpinner = ora('Closing ngrok tunnel...').start();
+        await ngrok.disconnect();
+        await ngrok.kill();
+        closeSpinner.succeed('Ngrok tunnel closed');
+        process.exit(0);
+      });
+    } catch (e) {
+      const error = e as Error;
+      spinner.fail(`Failed to establish tunnel: ${error.message}`);
+
+      if (error.message.includes('failed to start ngrok')) {
+        console.log(chalk.yellow('\nTips:'));
+        console.log('- Make sure you have installed ngrok correctly');
+        console.log(
+          '- If using a custom subdomain or other Pro features, set your authtoken with:',
+        );
+        console.log(chalk.cyan('  npx ngrok authtoken YOUR_AUTH_TOKEN'));
+      }
+
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/tonk.ts
+++ b/packages/cli/src/tonk.ts
@@ -3,6 +3,7 @@ import {configCommand} from './commands/config.js';
 import {createCommand} from './commands/create.js';
 import {deployCommand} from './commands/deploy.js';
 import {devCommand} from './commands/dev.js';
+import {exposeCommand} from './commands/expose.js';
 import {helloCommand} from './commands/hello.js';
 import {printMarkdown} from './commands/prettyPrint.js';
 import {serveCommand} from './commands/serve.js';
@@ -25,5 +26,6 @@ program.addCommand(deployCommand);
 program.addCommand(configCommand);
 program.addCommand(helloCommand);
 program.addCommand(printMarkdown);
+program.addCommand(exposeCommand);
 
 program.parse();

--- a/packages/hub/hub-ui/src/components/LaunchBar/LaunchBar.module.css
+++ b/packages/hub/hub-ui/src/components/LaunchBar/LaunchBar.module.css
@@ -11,8 +11,14 @@
 
 .buttonArea {
   display: flex;
+  flex-direction: column;
   align-items: flex-end;
   justify-content: flex-end;
   gap: 0.25rem;
   margin-right: 8px;
+}
+
+.buttonArea a {
+  color: #00aaff;
+  text-decoration: underline;
 }

--- a/packages/hub/hub-ui/src/components/LaunchBar/index.tsx
+++ b/packages/hub/hub-ui/src/components/LaunchBar/index.tsx
@@ -1,24 +1,41 @@
-import React from "react";
-import styles from "./LaunchBar.module.css";
+import { useState } from "react";
 import { Button } from "../";
-import { TreeItem, FileType } from "../Tree";
 import { launchApp } from "../../ipc/app";
 import { getConfig } from "../../ipc/config";
 import { platformSensitiveJoin } from "../../ipc/files";
 import { useProjectStore } from "../../stores/projectStore";
+import { FileType, TreeItem } from "../Tree";
+import styles from "./LaunchBar.module.css";
 
 const AppLaunchBar = (props: {
     selectedItem: TreeItem;
     commandCallback: (cmd: string) => void;
 }) => {
     const { selectedItem, commandCallback } = props;
+    const [url, setUrl] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+
     const launch = async () => {
-        const config = await getConfig();
-        const fullPath = await platformSensitiveJoin([
-            config!.homePath,
-            selectedItem.index,
-        ]);
-        await launchApp(fullPath!);
+        try {
+            const config = await getConfig();
+            const fullPath = await platformSensitiveJoin([
+                config!.homePath,
+                selectedItem.index,
+            ]);
+            const url = await launchApp(fullPath!);
+            setUrl(url || null);
+        } catch (error) {
+            console.error("Error launching app:", error);
+            setUrl(null);
+        }
+    };
+
+    const copyToClipboard = () => {
+        if (url) {
+            navigator.clipboard.writeText(url);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
     };
 
     return (
@@ -26,6 +43,30 @@ const AppLaunchBar = (props: {
             <Button color="green" size="sm" shape="rounded" onClick={launch}>
                 Launch
             </Button>
+            {url && (
+                <div
+                    style={{
+                        fontSize: "12px",
+                        opacity: 0.8,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "5px",
+                        marginTop: "5px",
+                    }}
+                >
+                    Your app is live at{" "}
+                    <Button
+                        size="sm"
+                        onClick={copyToClipboard}
+                        title="Click to copy URL"
+                    >
+                        <span style={{ marginRight: "5px" }}>{url}</span>
+                        <span style={{ fontSize: "14px" }}>
+                            {copied ? "✓" : "📋"}
+                        </span>
+                    </Button>
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/hub/hub-ui/src/ipc/app.ts
+++ b/packages/hub/hub-ui/src/ipc/app.ts
@@ -1,7 +1,8 @@
 export const launchApp = async (appPath: string) => {
     try {
         // Launch the app with the selected docId
-        await window.electronAPI.launchApp(appPath);
+        const url = await window.electronAPI.launchApp(appPath);
+        return url;
     } catch (error: unknown) {
         console.error("Error launching app:", error);
         if (error instanceof Error) {
@@ -11,11 +12,12 @@ export const launchApp = async (appPath: string) => {
         }
     }
 };
+
 
 export const openExternal = async (link: string) => {
     try {
         // Launch the app with the selected docId
-        await window.electronAPI.openExternal(link);
+        return await window.electronAPI.openExternal(link);
     } catch (error: unknown) {
         console.error("Error launching app:", error);
         if (error instanceof Error) {
@@ -24,19 +26,4 @@ export const openExternal = async (link: string) => {
             alert("An unexpected error occurred while launching the app");
         }
     }
-};
-
-export const isAppRunning = async () => {
-    try {
-        const response = await window.electronAPI.isAppRunning();
-        return response;
-    } catch (error: unknown) {
-        console.error("Error checking app status:", error);
-        if (error instanceof Error) {
-            alert("Error checking app status: " + error.message);
-        } else {
-            alert("An unexpected error occurred while checking app status");
-        }
-    }
-    return false;
 };

--- a/packages/hub/hub-ui/src/types.ts
+++ b/packages/hub/hub-ui/src/types.ts
@@ -2,7 +2,7 @@
 declare global {
   interface Window {
     electronAPI: {
-      launchApp: (projectPath: string) => Promise<void>;
+      launchApp: (projectPath: string) => Promise<string>;
       createApp: (projectName: string) => Promise<void>;
       runShell: (dirPath: string) => Promise<void>;
       closeShell: () => Promise<void>;

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -20,6 +20,7 @@
     "@electron/remote": "^2.1.2",
     "chokidar": "^4.0.3",
     "fs-extra": "^11.3.0",
+    "ngrok": "5.0.0-beta.2",
     "node-pty": "^1.1.0-beta22",
     "which": "^5.0.0",
     "ws": "^8.18.1"

--- a/packages/hub/pnpm-lock.yaml
+++ b/packages/hub/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
+      ngrok:
+        specifier: 5.0.0-beta.2
+        version: 5.0.0-beta.2
       node-pty:
         specifier: ^1.1.0-beta22
         version: 1.1.0-beta9
@@ -235,6 +238,9 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
+  hpagent@0.1.2:
+    resolution: {integrity: sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -280,6 +286,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
@@ -301,6 +310,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  ngrok@5.0.0-beta.2:
+    resolution: {integrity: sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==}
+    engines: {node: '>=14.2'}
+    hasBin: true
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -431,6 +445,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -450,6 +468,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yaml@2.7.1:
+    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -705,6 +728,9 @@ snapshots:
       es-define-property: 1.0.1
     optional: true
 
+  hpagent@0.1.2:
+    optional: true
+
   http-cache-semantics@4.1.1: {}
 
   http2-wrapper@1.0.3:
@@ -747,6 +773,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  lodash.clonedeep@4.5.0: {}
+
   lowercase-keys@2.0.0: {}
 
   matcher@3.0.0:
@@ -763,6 +791,18 @@ snapshots:
       brace-expansion: 1.1.11
 
   ms@2.1.3: {}
+
+  ngrok@5.0.0-beta.2:
+    dependencies:
+      extract-zip: 2.0.1
+      got: 11.8.6
+      lodash.clonedeep: 4.5.0
+      uuid: 8.3.2
+      yaml: 2.7.1
+    optionalDependencies:
+      hpagent: 0.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   node-addon-api@7.1.1: {}
 
@@ -881,6 +921,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  uuid@8.3.2: {}
+
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
@@ -888,6 +930,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.1: {}
+
+  yaml@2.7.1: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/packages/hub/src/ipc/app.js
+++ b/packages/hub/src/ipc/app.js
@@ -1,48 +1,97 @@
-const { ipcMain, shell } = require('electron');
-const { getConfig } = require('../config.js');
-const path = require('node:path');
-const http = require('http');
+const { ipcMain, shell, BrowserWindow } = require("electron");
+const { getConfig } = require("../config.js");
+const path = require("node:path");
+const http = require("http");
 
-ipcMain.handle('launch-app', async (event, projectPath) => {
-  try {
-    const distPath = path.join(projectPath, 'dist');
-    // Set the distPath via API call
-    const requestData = JSON.stringify({ distPath });
-    
-    return new Promise((resolve, reject) => {
-      const req = http.request({
-        hostname: 'localhost',
-        port: 8080,
-        path: '/api/toggle-dist-path',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(requestData)
-        }
-      }, (res) => {
-        if (res.statusCode === 200) {
-          shell.openExternal('http://localhost:8080');
-          resolve(true);
-        } else {
-          reject(new Error(`Failed to set distPath: Status ${res.statusCode}`));
-        }
-      });
-      
-      req.on('error', (error) => {
-        console.error('Error configuring server:', error);
-        reject(error);
-      });
-      
-      req.write(requestData);
-      req.end();
-    });
-  } catch (error) {
-    console.error('Error launching app:', error);
-    throw error;
-  }
+ipcMain.handle("launch-app", async (event, projectPath) => {
+    try {
+        const distPath = path.join(projectPath, "dist");
+        // Set the distPath via API call
+        const requestData = JSON.stringify({ distPath });
+
+        return new Promise((resolve, reject) => {
+            const req = http.request(
+                {
+                    hostname: "localhost",
+                    port: 8080,
+                    path: "/api/toggle-dist-path",
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Content-Length": Buffer.byteLength(requestData),
+                    },
+                },
+                (res) => {
+                    if (res.statusCode === 200) {
+                        // Create a new browser window instead of opening externally
+                        const appWindow = new BrowserWindow({
+                            width: 1024,
+                            height: 800,
+                            title: "",
+                            webPreferences: {
+                                nodeIntegration: false,
+                                contextIsolation: true,
+                            },
+                        });
+
+                        appWindow.loadURL("http://localhost:8080");
+
+                        // Set the window title to match the page title
+                        appWindow.webContents.on(
+                            "page-title-updated",
+                            (event, title) => {
+                                appWindow.setTitle(title);
+                            }
+                        );
+
+                        // Clean up the window reference when window is closed
+                        appWindow.on("closed", () => {
+                            // Optional: track window state if needed
+                        });
+
+                        resolve(true);
+                    } else {
+                        reject(
+                            new Error(
+                                `Failed to set distPath: Status ${res.statusCode}`
+                            )
+                        );
+                    }
+                }
+            );
+
+            req.on("error", (error) => {
+                console.error("Error configuring server:", error);
+                reject(error);
+            });
+
+            req.write(requestData);
+            req.end();
+        });
+    } catch (error) {
+        console.error("Error launching app:", error);
+        throw error;
+    }
 });
 
 ipcMain.handle("open-external-link", async (event, link) => {
-    await shell.openExternal(link);
-});
+    // Also modify this handler to offer opening in a new window
+    const appWindow = new BrowserWindow({
+        width: 1200,
+        height: 800,
+        title: "",
+        webPreferences: {
+            nodeIntegration: false,
+            contextIsolation: true,
+        },
+    });
 
+    appWindow.loadURL(link);
+
+    // Set the window title to match the page title
+    appWindow.webContents.on("page-title-updated", (event, title) => {
+        appWindow.setTitle(title);
+    });
+
+    return true;
+});

--- a/packages/hub/src/ipc/app.js
+++ b/packages/hub/src/ipc/app.js
@@ -2,8 +2,58 @@ const { ipcMain, shell, BrowserWindow } = require("electron");
 const { getConfig } = require("../config.js");
 const path = require("node:path");
 const http = require("http");
+const ngrok = require("ngrok");
 
-ipcMain.handle("launch-app", async (event, projectPath) => {
+// Track the app window globally
+let appWindow = null;
+
+// Export appWindow for use in other modules
+module.exports = { appWindow };
+
+ipcMain.handle("launch-app", async (_, projectPath) => {
+    try {
+        console.log("Launching app...");
+
+        // Check if ngrok is already connected to port 8080
+        let url;
+        try {
+            // Get all active tunnels and find one for port 8080
+            const dummyUrl = await ngrok.connect(0);
+            const api = ngrok.getApi();
+            const tunnels = await api.listTunnels();
+
+            const existingTunnel = tunnels.tunnels?.find(
+                (tunnel) => tunnel.config?.addr === "http://localhost:8080"
+            );
+            await ngrok.disconnect(dummyUrl);
+
+            if (existingTunnel) {
+                url = existingTunnel.public_url;
+                console.log("Using existing ngrok connection:", url);
+            } else {
+                // No active connection for port 8080, create a new one
+                console.log("Connecting to ngrok...");
+                url = await ngrok.connect(8080);
+                console.log("App launched at:", url);
+            }
+        } catch (error) {
+            // Failed to get tunnels or no tunnels exist, create a new one
+            console.log("Connecting to ngrok...");
+            url = await ngrok.connect(8080);
+            console.log("App launched at:", url);
+        }
+
+        // Launch the app with the ngrok URL
+        await launchApp(projectPath, url);
+
+        // Keep the process running until interrupted
+        return url;
+    } catch (e) {
+        throw e;
+    }
+});
+
+const launchApp = async (projectPath, ngrokUrl) => {
     try {
         const distPath = path.join(projectPath, "dist");
         // Set the distPath via API call
@@ -23,30 +73,74 @@ ipcMain.handle("launch-app", async (event, projectPath) => {
                 },
                 (res) => {
                     if (res.statusCode === 200) {
-                        // Create a new browser window instead of opening externally
-                        const appWindow = new BrowserWindow({
-                            width: 1024,
-                            height: 800,
-                            title: "",
-                            webPreferences: {
-                                nodeIntegration: false,
-                                contextIsolation: true,
-                            },
-                        });
+                        // Reuse existing window if it exists, otherwise create a new one
+                        if (!appWindow || appWindow.isDestroyed()) {
+                            appWindow = new BrowserWindow({
+                                width: 1024,
+                                height: 800,
+                                title: "",
+                                webPreferences: {
+                                    nodeIntegration: false,
+                                    contextIsolation: true,
+                                },
+                            });
+
+                            // Set the window title to match the page title
+                            appWindow.webContents.on(
+                                "page-title-updated",
+                                (event, title) => {
+                                    appWindow.setTitle(title);
+                                }
+                            );
+
+                            // Clean up the window reference when window is closed
+                            appWindow.on("closed", () => {
+                                appWindow = null;
+                            });
+                        }
 
                         appWindow.loadURL("http://localhost:8080");
 
-                        // Set the window title to match the page title
-                        appWindow.webContents.on(
-                            "page-title-updated",
-                            (event, title) => {
-                                appWindow.setTitle(title);
-                            }
-                        );
-
-                        // Clean up the window reference when window is closed
-                        appWindow.on("closed", () => {
-                            // Optional: track window state if needed
+                        // Display the ngrok URL in the corner of the window
+                        appWindow.webContents.on("did-finish-load", () => {
+                            appWindow.webContents.executeJavaScript(`
+                                (function() {
+                                    const urlDisplay = document.createElement('div');
+                                    urlDisplay.textContent = '${
+                                        ngrokUrl || "http://localhost:8080"
+                                    }';
+                                    urlDisplay.style.position = 'fixed';
+                                    urlDisplay.style.bottom = '6px';
+                                    urlDisplay.style.right = '6px';
+                                    urlDisplay.style.background = 'rgba(0, 0, 0, 0.7)';
+                                    urlDisplay.style.color = 'white';
+                                    urlDisplay.style.padding = '5px 10px';
+                                    urlDisplay.style.borderRadius = '4px';
+                                    urlDisplay.style.fontSize = '12px';
+                                    urlDisplay.style.zIndex = '9999';
+                                    urlDisplay.style.cursor = 'pointer';
+                                    urlDisplay.title = 'Click to copy URL';
+                                    
+                                    urlDisplay.addEventListener('click', function() {
+                                        const url = this.textContent;
+                                        navigator.clipboard.writeText(url).then(() => {
+                                            // Visual feedback
+                                            const originalText = this.textContent;
+                                            const originalBg = this.style.background;
+                                            
+                                            this.textContent = 'Copied!';
+                                            this.style.background = 'rgba(0, 128, 0, 0.7)';
+                                            
+                                            setTimeout(() => {
+                                                this.textContent = originalText;
+                                                this.style.background = originalBg;
+                                            }, 1000);
+                                        });
+                                    });
+                                    
+                                    document.body.appendChild(urlDisplay);
+                                })();
+                            `);
                         });
 
                         resolve(true);
@@ -72,26 +166,9 @@ ipcMain.handle("launch-app", async (event, projectPath) => {
         console.error("Error launching app:", error);
         throw error;
     }
-});
-
+};
 ipcMain.handle("open-external-link", async (event, link) => {
-    // Also modify this handler to offer opening in a new window
-    const appWindow = new BrowserWindow({
-        width: 1200,
-        height: 800,
-        title: "",
-        webPreferences: {
-            nodeIntegration: false,
-            contextIsolation: true,
-        },
-    });
-
-    appWindow.loadURL(link);
-
-    // Set the window title to match the page title
-    appWindow.webContents.on("page-title-updated", (event, title) => {
-        appWindow.setTitle(title);
-    });
-
+    // Open links in the user's default browser
+    await shell.openExternal(link);
     return true;
 });


### PR DESCRIPTION
# Add ngrok integration for app sharing

## Description
This PR adds ngrok integration to the CLI package, enabling users to access their local applications via public URLs. The implementation adds a dedicated app window that displays and allows copying of the ngrok URL.

## Changes
- Add ngrok dependency (v5.0.0-beta.2) to CLI package
- Refactor app launch functionality in IPC module to:
  - Manage ngrok tunnels for port 8080
  - Create a dedicated app window instead of opening in browser
  - Display the public ngrok URL in the app window with copy functionality
- Update build dependencies