### PR TITLE
Small change get server building

### DIFF
--- a/packages/server/pnpm-lock.yaml
+++ b/packages/server/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  server: link:../../../../Library/pnpm/global/5/node_modules/@tonk/server
-
 importers:
 
   .:
@@ -47,9 +44,6 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.3
         version: 3.0.3
-      server:
-        specifier: link:../../../../Library/pnpm/global/5/node_modules/@tonk/server
-        version: link:../../../../Library/pnpm/global/5/node_modules/@tonk/server
       ws:
         specifier: ^8.18.0
         version: 8.18.1

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,6 @@ import {FileSystemStorageMiddleware} from './filesystemMiddleware.js';
 import {FileSystemStorageOptions} from './filesystemStorage.js';
 import {createProxyMiddleware} from 'http-proxy-middleware';
 import cors from 'cors';
-import {loadIntegrations} from './workerManager.js';
 
 export interface ServerOptions {
   port?: number;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the import of `loadIntegrations` from `./workerManager.js` in the `index.ts` file and updating the `pnpm-lock.yaml` by removing the `server` link specification for `@tonk/server`.

### Detailed summary
- Removed the import of `loadIntegrations` from `./workerManager.js` in `packages/server/src/index.ts`.
- Updated `packages/server/pnpm-lock.yaml` by:
  - Removing the `server` link specification for `@tonk/server`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->