### PR TITLE
feat(hub): add ipc for saving and reading documents

### DIFF
--- a/packages/hub/index.js
+++ b/packages/hub/index.js
@@ -13,6 +13,7 @@ require("./src/ipc/hub.js");
 require("./src/ipc/integrations.js");
 require("./src/ipc/files.js");
 require("./src/ipc/watcher.js");
+require("./src/ipc/docs.js");
 
 let createProtocol = (scheme, normalize = true) => {
     protocol.registerBufferProtocol(

--- a/packages/hub/preload.js
+++ b/packages/hub/preload.js
@@ -34,6 +34,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     getInstalledIntegrations: () =>
         ipcRenderer.invoke("get-installed-integrations"),
     runServer: (restart) => ipcRenderer.invoke('run-server', restart), 
+    saveDocument: (id, content) => ipcRenderer.invoke('save-document', id, content),
+    readDocument: (id) => ipcRenderer.invoke('read-document', id),
 });
 
 // Add IPC listener for file changes

--- a/packages/hub/src/ipc/docs.js
+++ b/packages/hub/src/ipc/docs.js
@@ -1,0 +1,51 @@
+const { ipcMain } = require('electron');
+const path = require('node:path');
+const fs = require('node:fs');
+const { getConfig } = require('../config.js');
+
+const getFilePathForId = (docId) => {
+  const { homePath } = getConfig();
+  if (!homePath) {
+    throw new Error(`Config is not properly set, found ${getConfig()}`);
+  }
+  const filePath = path.join(homePath, 'stores', `${docId}.automerge`);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`No file exists at path: ${filePath}`);
+  }
+}
+
+const readDoc = async (docId) => {
+  const filePath = getFilePathForId(docId);
+  return new Promise((onSuccess, onError) => {
+    // First try reading as UTF-8
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (!err) {
+        onSuccess(data);
+        return;
+      }
+      onError(err);
+    });
+  });
+};
+
+ipcMain.handle('read-document', async (e, id) => {
+  return await readDoc(id);
+});
+
+const writeFile = async (id, content) => {
+  return new Promise((onSuccess, onError) => {
+    const filePath = getFilePathForId(id);
+    // Write the file
+    fs.writeFile(filePath, content, (err) => {
+      if (err) {
+        onError(err);
+        return;
+      }
+      onSuccess();
+    });
+  });
+};
+
+ipcMain.handle('save-document', async (e, docId, content) => {
+  return await writeFile(docId, content);
+});


### PR DESCRIPTION
### Description

This allows the saving and reading of documents through electron ipc

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces document handling functionality to the application, allowing users to save and read documents through IPC (Inter-Process Communication) using Electron.

### Detailed summary
- Added `./src/ipc/docs.js` to handle document-related IPC calls.
- Implemented `saveDocument` and `readDocument` methods in `packages/hub/preload.js`.
- Created `getFilePathForId`, `readDoc`, and `writeFile` functions in `docs.js` for file operations.
- Set up IPC handlers for `read-document` and `save-document` in `docs.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->