### PR TITLE
fix(hub): TON-999: only show .automerge files in store

### DIFF
--- a/packages/hub/hub-ui/src/components/FileViewer/index.tsx
+++ b/packages/hub/hub-ui/src/components/FileViewer/index.tsx
@@ -24,7 +24,10 @@ const FileViewer: React.FC = () => {
     );
   }
 
-  if (selectedItem.index.startsWith("stores/")) {
+  if (
+    selectedItem.index.startsWith("stores/") &&
+    selectedItem.index.endsWith(".automerge")
+  ) {
     if (!automergeContent) {
       return (
         <div className={styles.container}>

--- a/packages/hub/hub-ui/src/stores/projectStore.ts
+++ b/packages/hub/hub-ui/src/stores/projectStore.ts
@@ -6,7 +6,6 @@ import * as Automerge from "@automerge/automerge";
 import * as AutomergeWasm from "@automerge/automerge-wasm";
 import debounce from "lodash.debounce";
 import { FileChangeEvent } from "../types";
-import { StaticTreeDataProvider } from "react-complex-tree";
 import { runServer } from "../ipc/hub";
 
 // Initialize Automerge with WASM for Electron environment
@@ -56,7 +55,7 @@ const shouldIgnoreFile = (filename: string): boolean => {
 };
 
 const validateProjectStructure = async (
-  homePath: string
+  homePath: string,
 ): Promise<string | null> => {
   try {
     const contents = await ls(homePath);
@@ -65,11 +64,11 @@ const validateProjectStructure = async (
     }
 
     const existingDirs = new Set(
-      contents.filter((item) => item.isDirectory).map((item) => item.name)
+      contents.filter((item) => item.isDirectory).map((item) => item.name),
     );
 
     const missingDirs = REQUIRED_DIRECTORIES.filter(
-      (dir) => !existingDirs.has(dir)
+      (dir) => !existingDirs.has(dir),
     );
 
     if (missingDirs.length > 0) {
@@ -87,7 +86,7 @@ const createTreeItem = (
   name: string,
   fileType: FileType,
   isFolder = false,
-  children: string[] = []
+  children: string[] = [],
 ): TreeItem => ({
   index,
   isFolder,
@@ -122,7 +121,7 @@ const initializeBaseTreeItems = (): TreeItems => ({
     "root",
     FileType.Section,
     true,
-    REQUIRED_DIRECTORIES
+    REQUIRED_DIRECTORIES,
   ),
   apps: createTreeItem("apps", "apps", FileType.Section, true, []),
   stores: createTreeItem("stores", "stores", FileType.Section, true, []),
@@ -132,7 +131,7 @@ const processSubContents = async (
   parentPath: string,
   parentId: string,
   items: TreeItems,
-  sectionType: FileType
+  sectionType: FileType,
 ): Promise<void> => {
   const subContents = await ls(parentPath);
   if (!subContents) return;
@@ -151,7 +150,7 @@ const processSubContents = async (
       subItem.name,
       sectionType, // Use the parent section's type for all children
       subItem.isDirectory,
-      []
+      [],
     );
 
     items[parentId].children.push(subItemId);
@@ -162,7 +161,7 @@ const processDirectoryContents = async (
   dirPath: string,
   dir: string,
   items: TreeItems,
-  sectionType: FileType
+  sectionType: FileType,
 ): Promise<void> => {
   const contents = await ls(dirPath);
   if (!contents) return;
@@ -181,7 +180,7 @@ const processDirectoryContents = async (
       sectionType, // Use the section type for all items in this directory
       false,
       // item.isDirectory,
-      []
+      [],
     );
 
     // Add to parent's children
@@ -212,7 +211,7 @@ const loadProjectStructure = async (homePath: string): Promise<TreeItems> => {
 
 const findChangedParents = (
   oldItems: TreeItems,
-  newItems: TreeItems
+  newItems: TreeItems,
 ): string[] => {
   const changedParents = new Set<string>();
 
@@ -280,7 +279,12 @@ const useProjectStore = create<ProjectState>((set, get) => ({
   setSelectedItem: async (item: TreeItem | null) => {
     set({ selectedItem: item });
 
-    if (item && item.index.startsWith("stores/") && !item.isFolder) {
+    if (
+      item &&
+      item.index.startsWith("stores/") &&
+      item.index.endsWith(".automerge") &&
+      !item.isFolder
+    ) {
       await get().inspectAutomergeFile(item.index);
     } else {
       set({ automergeContent: null });
@@ -364,7 +368,7 @@ const useProjectStore = create<ProjectState>((set, get) => ({
       }
 
       if (event.type === "addDir") {
-          debounce(async () => await runServer(true), 1000);
+        debounce(async () => await runServer(true), 1000);
       }
 
       const oldItems = { ...get().items };


### PR DESCRIPTION
### Description

- only show contents of `.automerge` files in store

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-999

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the logic for handling `selectedItem` in the `FileViewer` component and improving the `validateProjectStructure` function in the `projectStore`. It introduces additional conditions for file handling and corrects function signatures for better clarity.

### Detailed summary
- Updated condition in `FileViewer` to check if `selectedItem.index` ends with `.automerge`.
- Added a comma in the `validateProjectStructure` function signature.
- Added commas in multiple places to improve code consistency.
- Revised the condition in `useProjectStore` to check for `.automerge` files.
- Ensured consistent formatting in function parameters and return types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->