### PR TITLE
fix(hub): auto allow fingerprint for pinggy ssh

### DIFF
--- a/packages/hub/src/ipc/app.js
+++ b/packages/hub/src/ipc/app.js
@@ -30,6 +30,8 @@ const startPinggy = async () => {
     pinggyProcess = spawn("ssh", [
       "-p",
       "443",
+      "-o",
+      "StrictHostKeyChecking=no",
       "-R0:localhost:8080",
       "a.pinggy.io",
     ]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the command-line options for a process in the `ipc/app.js` file, specifically adjusting SSH options for remote port forwarding.

### Detailed summary
- Added the option `-o` with value `StrictHostKeyChecking=no` to the command.
- Kept the existing port forwarding option `-R0:localhost:8080`.
- Retained the host `a.pinggy.io` in the command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->