### PR TITLE
fix(hub): only automerge inspect automerge files

### DIFF
--- a/packages/hub/hub-ui/src/stores/projectStore.ts
+++ b/packages/hub/hub-ui/src/stores/projectStore.ts
@@ -396,9 +396,15 @@ const useProjectStore = create<ProjectState>((set, get) => ({
         changedParents,
       });
 
-      // If the changed file is the currently selected file, reload its content
+      // If the changed file is the currently selected file and it's an automerge file in the stores directory, reload its content
       const selectedItem = get().selectedItem;
-      if (selectedItem && event.path.includes(selectedItem.index)) {
+      if (
+        selectedItem &&
+        event.path.includes(selectedItem.index) &&
+        selectedItem.index.startsWith("stores/") &&
+        selectedItem.index.endsWith(".automerge") &&
+        !selectedItem.isFolder
+      ) {
         await get().inspectAutomergeFile(selectedItem.index);
       }
     } catch (error) {

--- a/packages/hub/src/ipc/files.js
+++ b/packages/hub/src/ipc/files.js
@@ -31,7 +31,6 @@ ipcMain.handle("read-binary", async (e, filePath) => {
 
   // Use fs.promises for better async handling
   try {
-    console.log("attempting to read:", filePath);
     // Check file stats to ensure it's fully written and accessible
     const stats = await fs.promises.stat(filePath);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances file handling and conditional logic in the application. It improves asynchronous file operations and updates the criteria for reloading content based on specific file types.

### Detailed summary
- Updated `ipc/files.js` to use `fs.promises` for better asynchronous file handling.
- Modified logic in `projectStore.ts` to reload content only if the selected file is an automerge file located in the `stores` directory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->