### PR TITLE
fix(create): update node websocket url

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Bootstrap apps on the Tonk stack",
   "type": "module",
   "bin": {

--- a/packages/create/templates/node/src/index.ts
+++ b/packages/create/templates/node/src/index.ts
@@ -7,8 +7,8 @@ import {
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { createStore } from "zustand/vanilla";
 
-const wsAdapter = new BrowserWebSocketClientAdapter("ws://localhost:7777");
-const syncEngine = configureSyncEngine({
+const wsAdapter = new BrowserWebSocketClientAdapter("ws://localhost:7777/sync");
+configureSyncEngine({
   networkAdapters: [wsAdapter as any as NetworkAdapterInterface],
 });
 
@@ -28,8 +28,8 @@ const createStoreAndRun = () => {
       }),
       {
         docId: "counter-doc" as DocumentId,
-      }
-    )
+      },
+    ),
   );
 
   const state = store.getState();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@tonk/create` package and modifies the WebSocket URL in the `createStore` configuration to include `/sync`. It also makes minor adjustments to the code structure for improved clarity.

### Detailed summary
- Updated `version` in `packages/create/package.json` from `0.3.0` to `0.3.1`.
- Changed WebSocket URL in `packages/create/templates/node/src/index.ts` from `ws://localhost:7777` to `ws://localhost:7777/sync`.
- Adjusted the configuration structure in `configureSyncEngine` by changing the placement of a closing bracket.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->