### PR TITLE
feat(keepsync): refactor, add more filesystem related functionality.

### DIFF
--- a/packages/keepsync/package.json
+++ b/packages/keepsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/keepsync",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A reactive sync engine framework for use with Tonk apps",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/keepsync/src/documents/addressing.ts
+++ b/packages/keepsync/src/documents/addressing.ts
@@ -1,20 +1,46 @@
 import {DocumentId, Repo, DocHandle, Doc} from '@automerge/automerge-repo';
 
-export type DocNode = {
-  pointer?: DocumentId;
+// Reference to a node stored in a parent's children array
+export type RefNode = {
+  pointer: DocumentId;
   type: 'doc' | 'dir';
   timestamps: {
     create: number;
     modified: number;
   };
-  name?: string;
-  children?: DocNode[];
+  name: string;
+};
+
+// The full document node stored at a DocumentId
+export type DirNode = {
+  type: 'dir';
+  name: string;
+  timestamps: {
+    create: number;
+    modified: number;
+  };
+  children?: RefNode[];
+};
+
+export type DocNode = {
+  type: 'doc' | 'dir';
+  pointer?: DocumentId;
+  name: string;
+  timestamps: {
+    create: number;
+    modified: number;
+  };
+  children?: RefNode[];
 };
 
 type TraverseResult = {
-  handle: DocHandle<DocNode>;
-  doc: DocNode;
-  childNode?: DocNode;
+  // Handle to the node at the parent path
+  nodeHandle: DocHandle<DirNode>;
+  // The actual node at the parent path
+  node: DirNode;
+  // Reference to the target node in the parent's children array (if target is not root)
+  targetRef?: RefNode;
+  // Path to the parent directory
   parentPath: string;
 };
 
@@ -24,9 +50,9 @@ type TraverseResult = {
  * @param rootId The ID of the root document
  * @param path The path to traverse
  * @param createMissing Whether to create missing directories along the way
- * @returns Information about the final node and its parent
+ * @returns Information about the target node and its parent
  */
-async function traverseDocTree(
+export async function traverseDocTree(
   repo: Repo,
   rootId: DocumentId,
   path: string,
@@ -38,20 +64,21 @@ async function traverseDocTree(
 
   // No segments means root path
   if (segments.length === 0) {
-    const rootHandle = repo.find<DocNode>(rootId);
+    const rootHandle = repo.find<DirNode>(rootId);
     const rootDoc = await rootHandle.doc();
 
     // Initialize root if it doesn't exist and we're creating missing nodes
     if (!rootDoc && createMissing) {
-      rootHandle.change((doc: DocNode) => {
+      rootHandle.change((doc: DirNode) => {
         Object.assign(doc, {
           type: 'dir',
+          name: '/',
           timestamps: {
             create: Date.now(),
             modified: Date.now(),
           },
           children: [],
-        } as DocNode);
+        } as DirNode);
       });
 
       const newDoc = await rootHandle.doc();
@@ -60,8 +87,8 @@ async function traverseDocTree(
       }
 
       return {
-        handle: rootHandle,
-        doc: newDoc as DocNode,
+        nodeHandle: rootHandle,
+        node: newDoc as DirNode,
         parentPath: '',
       };
     } else if (!rootDoc) {
@@ -69,46 +96,47 @@ async function traverseDocTree(
     }
 
     return {
-      handle: rootHandle,
-      doc: rootDoc as DocNode,
+      nodeHandle: rootHandle,
+      node: rootDoc as DirNode,
       parentPath: '',
     };
   }
 
   // Navigate through the tree
   let currentNodeId = rootId;
-  let currentHandle = repo.find<DocNode>(currentNodeId);
+  let currentHandle = repo.find<DirNode>(currentNodeId);
   let currentDoc = await currentHandle.doc();
   let currentPath = '';
 
   // Initialize root if needed and we're creating missing directories
   if (!currentDoc && createMissing) {
-    currentHandle.change((doc: DocNode) => {
+    currentHandle.change((doc: DirNode) => {
       Object.assign(doc, {
         type: 'dir',
+        name: '/',
         timestamps: {
           create: Date.now(),
           modified: Date.now(),
         },
         children: [],
-      } as DocNode);
+      } as DirNode);
     });
 
     const updatedDoc = await currentHandle.doc();
     if (!updatedDoc) {
       return undefined;
     }
-    currentDoc = updatedDoc as DocNode;
+    currentDoc = updatedDoc as DirNode;
   } else if (!currentDoc) {
     return undefined;
   } else {
-    currentDoc = currentDoc as DocNode;
+    currentDoc = currentDoc as DirNode;
   }
 
   // Track parent for document creation
   let parentHandle = currentHandle;
   let parentDoc = currentDoc;
-  let lastSegmentNode: DocNode | undefined;
+  let lastSegmentRef: RefNode | undefined;
 
   // Process each path segment
   for (let i = 0; i < segments.length; i++) {
@@ -120,14 +148,14 @@ async function traverseDocTree(
 
     // Ensure children array exists and is an array
     if (!currentDoc.children && createMissing) {
-      currentHandle.change((doc: DocNode) => {
+      currentHandle.change((doc: DirNode) => {
         doc.children = [];
       });
       const updatedDoc = await currentHandle.doc();
       if (!updatedDoc) {
         return undefined;
       }
-      currentDoc = updatedDoc as DocNode;
+      currentDoc = updatedDoc as DirNode;
     } else if (!currentDoc.children) {
       return undefined;
     }
@@ -136,32 +164,34 @@ async function traverseDocTree(
     const children = currentDoc.children || [];
 
     // Find the child with the matching name
-    let childNode = children.find(child => child.name === segment);
+    let childRef = children.find(child => child.name === segment);
 
-    if (!childNode && createMissing) {
+    if (!childRef && createMissing) {
       // Create a new directory document with repo.create()
-      const newNodeHandle = repo.create<DocNode>();
+      const newNodeHandle = repo.create<DirNode>();
       const newNodeId = newNodeHandle.documentId;
 
       // Initialize the new node as a directory
-      newNodeHandle.change((doc: DocNode) => {
+      newNodeHandle.change((doc: DirNode) => {
         Object.assign(doc, {
           type: 'dir',
+          name: segment,
           timestamps: {
             create: Date.now(),
             modified: Date.now(),
           },
           children: [],
-        } as DocNode);
+        } as DirNode);
       });
 
       // Add the new node to the parent's children
-      currentHandle.change((doc: DocNode) => {
+      currentHandle.change((doc: DirNode) => {
         if (!doc.children) {
           doc.children = [];
         }
 
-        const newDirNode: DocNode = {
+        // Create a reference node that points to the actual directory node
+        const newDirRef: RefNode = {
           name: segment,
           type: 'dir',
           pointer: newNodeId,
@@ -171,7 +201,7 @@ async function traverseDocTree(
           },
         };
 
-        doc.children.push(newDirNode);
+        doc.children.push(newDirRef);
 
         if (doc.timestamps) {
           doc.timestamps.modified = Date.now();
@@ -189,46 +219,46 @@ async function traverseDocTree(
         return undefined;
       }
 
-      currentDoc = newDoc as DocNode;
-      lastSegmentNode = undefined;
+      currentDoc = newDoc as DirNode;
+      lastSegmentRef = undefined;
 
       if (isLastSegment) {
         return {
-          handle: currentHandle,
-          doc: currentDoc,
+          nodeHandle: currentHandle,
+          node: currentDoc,
           parentPath: currentPath,
         };
       }
-    } else if (!childNode) {
+    } else if (!childRef) {
       // Node doesn't exist and we're not creating it
       return undefined;
-    } else if (childNode.pointer) {
+    } else if (childRef.pointer) {
       // Navigate to existing node (whether document or directory)
       parentHandle = currentHandle;
       parentDoc = currentDoc;
-      lastSegmentNode = childNode;
+      lastSegmentRef = childRef;
 
       // If this is the last segment, we can return without further navigation
       if (isLastSegment) {
         return {
-          handle: currentHandle,
-          doc: currentDoc,
-          childNode,
+          nodeHandle: currentHandle,
+          node: currentDoc,
+          targetRef: childRef,
           parentPath: currentPath,
         };
       }
 
       // Only try to navigate further if it's a directory
-      if (childNode.type === 'dir') {
-        currentNodeId = childNode.pointer;
-        currentHandle = repo.find<DocNode>(currentNodeId);
-        const newDoc = await currentHandle.doc();
+      if (childRef.type === 'dir') {
+        currentNodeId = childRef.pointer;
+        currentHandle = repo.find<DirNode>(currentNodeId);
+        const nextDoc = await currentHandle.doc();
 
-        if (!newDoc) {
+        if (!nextDoc) {
           return undefined;
         }
 
-        currentDoc = newDoc as DocNode;
+        currentDoc = nextDoc as DirNode;
       } else {
         // Found a document when we need to navigate further, so fail
         return undefined;
@@ -241,9 +271,9 @@ async function traverseDocTree(
 
   // If we get here, we've reached the requested node
   return {
-    handle: currentHandle,
-    doc: currentDoc,
-    childNode: lastSegmentNode,
+    nodeHandle: currentHandle,
+    node: currentDoc,
+    targetRef: lastSegmentRef,
     parentPath: currentPath,
   };
 }
@@ -253,26 +283,25 @@ async function traverseDocTree(
  * @param repo The Automerge repository
  * @param rootId The ID of the root document
  * @param path The path to the document
- * @returns The DocNode if found, undefined otherwise
+ * @returns The RefNode if found at the leaf, or the FullNode for the root
  */
-export async function findDocument(
+export async function findDocument<T>(
   repo: Repo,
   rootId: DocumentId,
   path: string,
-): Promise<DocNode | undefined> {
+): Promise<DocHandle<T> | undefined> {
   const result = await traverseDocTree(repo, rootId, path);
 
   if (!result) {
     return undefined;
   }
 
-  // If this is a path to a document/directory in a parent directory, return the child node
-  if (result.childNode) {
-    return result.childNode;
+  // If this is a path to a document/directory in a parent directory, return the target reference
+  if (!result.targetRef || result.targetRef?.type === 'dir') {
+    return undefined;
   }
-
   // Otherwise, return the node itself (for root or created nodes)
-  return result.doc;
+  return repo.find(result.targetRef!.pointer);
 }
 
 /**
@@ -308,17 +337,17 @@ export async function createDocument<T>(
   }
 
   // Add the document to its parent directory
-  result.handle.change((doc: DocNode) => {
+  result.nodeHandle.change((doc: DirNode) => {
     if (!doc.children) {
       doc.children = [];
     }
 
     // Check if document already exists
     const existingIndex = doc.children.findIndex(
-      (child: DocNode) => child.name === fileName,
+      (child: RefNode) => child.name === fileName,
     );
 
-    const docNode: DocNode = {
+    const docRef: RefNode = {
       name: fileName,
       type: 'doc',
       pointer: docHandle.documentId,
@@ -330,14 +359,80 @@ export async function createDocument<T>(
 
     if (existingIndex >= 0) {
       // Update existing entry
-      doc.children[existingIndex] = docNode;
+      doc.children[existingIndex] = docRef;
     } else {
       // Add new entry
-      doc.children.push(docNode);
+      doc.children.push(docRef);
     }
 
     if (doc.timestamps) {
       doc.timestamps.modified = Date.now();
     }
   });
+}
+
+/**
+ * Removes a document at the specified path
+ * @param repo The Automerge repository
+ * @param rootId The ID of the root document
+ * @param path The path to the document to remove
+ * @returns Whether the document was successfully removed
+ */
+export async function removeDocument(
+  repo: Repo,
+  rootId: DocumentId,
+  path: string,
+): Promise<boolean> {
+  // Find the document and its parent
+  const result = await traverseDocTree(repo, rootId, path);
+
+  if (!result || !result.targetRef) {
+    return false; // Document or directory not found
+  }
+
+  // Get the document ID to delete
+  const docId = result.targetRef.pointer;
+  if (!docId) {
+    return false; // No pointer to document
+  }
+
+  // Handle directory: recursively remove all children first
+  if (result.targetRef.type === 'dir') {
+    const dirHandle = repo.find<DirNode>(docId);
+    const dirDoc = await dirHandle.doc();
+
+    if (dirDoc && dirDoc.children && dirDoc.children.length > 0) {
+      // Process all children recursively
+      for (const child of [...dirDoc.children]) {
+        // Create a copy of the array to iterate over
+        const childPath = `${path}/${child.name}`;
+        await removeDocument(repo, rootId, childPath);
+      }
+    }
+  }
+
+  // Remove from parent's children array
+  result.nodeHandle.change((doc: DirNode) => {
+    if (!doc.children) return;
+
+    const index = doc.children.findIndex(
+      child =>
+        child.name === result.targetRef!.name &&
+        child.pointer === result.targetRef!.pointer,
+    );
+
+    if (index >= 0) {
+      doc.children.splice(index, 1);
+
+      // Update modified timestamp
+      if (doc.timestamps) {
+        doc.timestamps.modified = Date.now();
+      }
+    }
+  });
+
+  // Delete the document from the repo
+  repo.delete(docId);
+
+  return true;
 }

--- a/packages/keepsync/src/index.ts
+++ b/packages/keepsync/src/index.ts
@@ -2,8 +2,11 @@
 export * from './engine/index.js';
 
 // Export the middleware
-export {readDoc, writeDoc, sync} from './middleware/index.js';
+export {ls, mkDir, rm, readDoc, writeDoc, sync} from './middleware/index.js';
 export type {SyncOptions, DocumentId} from './middleware/index.js';
+
+// This is useful for exploring the filesystem
+export type {DocNode, DirNode, RefNode} from './documents/addressing.js';
 
 // Export the core functionality
 export * from './core/index.js';

--- a/packages/keepsync/src/middleware/index.ts
+++ b/packages/keepsync/src/middleware/index.ts
@@ -1,6 +1,6 @@
-import {sync, readDoc, writeDoc} from './sync.js';
+import {sync, ls, mkDir, rm, readDoc, writeDoc} from './sync.js';
 import {DocumentId} from '@automerge/automerge-repo';
 export type {DocumentId};
 
-export {sync, readDoc, writeDoc};
+export {ls, sync, mkDir, rm, readDoc, writeDoc};
 export type {SyncOptions} from './sync.js';


### PR DESCRIPTION
### Description

This adds the ability to ls directories, make directories and delete docs and directories. 

### Other changes

Some internal refactor

### Tested

Tests were added for the new functionality

### Backwards compatibility

Fully backwards compatible.

### Documentation

We need to update the documentation to be current, haven't done that yet.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates the `keepsync` package by incrementing the version and enhancing the document handling capabilities. It introduces new functions for filesystem operations and improves document traversal and removal functionalities.

### Detailed summary
- Bumped `version` from `0.4.4` to `0.4.5` in `package.json`.
- Added `ls`, `mkDir`, and `rm` functions in `sync.ts`.
- Updated exports in `index.ts` and `middleware/index.ts`.
- Enhanced `traverseDocTree` for improved directory handling.
- Implemented `removeDocument` function for recursive document deletion.
- Refactored types for nodes (`DocNode`, `DirNode`, `RefNode`) in `addressing.ts`.
- Improved test cases for document addressing in `addressing.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->