### PR TITLE
fix(keepsync): patch the listen doc function with new refactor

### DIFF
--- a/packages/keepsync/src/middleware/sync.ts
+++ b/packages/keepsync/src/middleware/sync.ts
@@ -509,13 +509,10 @@ export const listenToDoc = async <T>(
   }
 
   // Find the document
-  const docNode = await findDocument(repo, root, path);
-  if (!docNode) {
+  const docHandle = await findDocument<T>(repo, root, path);
+  if (!docHandle) {
     throw new Error(`Document not found at path: ${path}`);
   }
-
-  // Get a handle to the document
-  const docHandle = repo.find<T>(docNode.pointer!);
 
   // Create a wrapper function that will call the listener with the document
   const handleChange = ({doc}: {doc: T | undefined}) => {


### PR DESCRIPTION
### Description

Updates listen doc to work with new internal API


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines the document retrieval process in the `sync.ts` file by improving variable naming and ensuring that the error handling is more explicit when a document is not found.

### Detailed summary
- Changed the variable name from `docNode` to `docHandle` for clarity.
- Updated the type parameter in `findDocument` from a generic to `<T>`.
- Enhanced error handling by throwing an error with a specific message if the document is not found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->