### PR TITLE
fix(keepsync): this addresses a bug when adding docs to existing dire…

### DIFF
--- a/packages/keepsync/src/documents/addressing.ts
+++ b/packages/keepsync/src/documents/addressing.ts
@@ -336,8 +336,15 @@ export async function createDocument<T>(
     throw new Error(`Failed to create directory structure for ${path}`);
   }
 
+  let parentHandle;
+  if (result.targetRef) {
+    parentHandle = repo.find<DirNode>(result.targetRef.pointer);
+  } else {
+    parentHandle = result.nodeHandle;
+  }
+
   // Add the document to its parent directory
-  result.nodeHandle.change((doc: DirNode) => {
+  parentHandle.change((doc: DirNode) => {
     if (!doc.children) {
       doc.children = [];
     }

--- a/packages/keepsync/tests/documents/addressing.test.ts
+++ b/packages/keepsync/tests/documents/addressing.test.ts
@@ -135,6 +135,24 @@ describe('Document Addressing', () => {
     ).rejects.toThrow('Timeout');
   });
 
+  it('protect bug on writing a document to a top-level dir', async () => {
+    const {repo, rootId} = await setup();
+    const newDoc = repo.create();
+    const id = newDoc.documentId;
+    newDoc.change((doc: any) => {
+      doc.text = 'HI!';
+    });
+    await createDocument(repo, rootId, '/test/this', newDoc);
+    const doc = await findDocument<{text: string}>(repo, rootId, '/test/this');
+    expect(doc).toBeDefined();
+    expect((await doc!.doc())!.text).toBe('HI!');
+
+    await createDocument(repo, rootId, '/test/next', newDoc);
+    const doc2 = await findDocument<{text: string}>(repo, rootId, '/test/next');
+    expect(doc2).toBeDefined();
+    expect((await doc2!.doc())!.text).toBe('HI!');
+  });
+
   // it('it can find a directory document', async () => {
   //   const {repo, rootId} = await setup();
   //   const newDoc = repo.create();


### PR DESCRIPTION
…ctory paths

### Description

Fixes a bug in createDoc where if a document was added to a pre-existing path it would add that doc to the wrong parent.


### Tested

Added a defensive test case for this instance

### Backwards compatibility

Fully backwards compatible.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the document handling functionality in the `addressing.ts` file by ensuring documents are correctly added to their parent directories and includes a new test case to verify the behavior of writing documents to top-level directories.

### Detailed summary
- Introduced a variable `parentHandle` to reference the correct parent directory for a document.
- Updated the document addition logic to use `parentHandle` instead of `result.nodeHandle`.
- Added a test case to check the behavior of writing a document to a top-level directory, ensuring it retains its content.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->