### PR TITLE
feat(cli): TON-1043: tonk cli abstracts pinggy

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "The Tonk stack command line utility",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -1,0 +1,86 @@
+import {Command} from 'commander';
+import chalk from 'chalk';
+import fetch from 'node-fetch';
+import {spawn} from 'child_process';
+
+interface BundleInfo {
+  id: string;
+  bundleName: string;
+  port: number;
+  status: string;
+}
+
+export const proxyCommand = new Command('proxy')
+  .description('Create a reverse proxy to access a Tonk bundle')
+  .option('-u, --url <url>', 'URL of the Tonk server', 'http://localhost:7777')
+  .argument('<bundleName>', 'Name of the bundle to proxy')
+  .action(async (bundleName, options) => {
+    const serverUrl = options.url;
+
+    try {
+      console.log(chalk.blue(`Setting up proxy for bundle ${bundleName}...`));
+      
+      // First, check if the bundle is running
+      const response = await fetch(`${serverUrl}/ps`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Server error: ${errorText}`);
+      }
+
+      const runningBundles = (await response.json()) as BundleInfo[];
+      const targetBundle = runningBundles.find(bundle => bundle.bundleName === bundleName);
+
+      if (!targetBundle) {
+        throw new Error(`Bundle '${bundleName}' is not running. Start it first with 'tonk start ${bundleName}'`);
+      }
+
+      console.log(chalk.green(`Found running bundle: ${targetBundle.bundleName}`));
+      console.log(chalk.green(`Bundle port: ${targetBundle.port}`));
+      console.log(chalk.blue(`Creating SSH tunnel with Pinggy...`));
+
+      // Create SSH tunnel using Pinggy
+      const sshProcess = spawn('ssh', [
+        '-p', '443',
+        '-R0:localhost:' + targetBundle.port,
+        'qr@free.pinggy.io'
+      ], {
+        stdio: 'inherit' // This will show the QR code and URLs directly in the terminal
+      });
+
+      // Handle process exit
+      sshProcess.on('close', (code) => {
+        if (code !== 0) {
+          console.log(chalk.yellow(`SSH tunnel closed with code ${code}`));
+        }
+        console.log(chalk.green('Proxy connection terminated.'));
+      });
+
+      // Handle errors
+      sshProcess.on('error', (err) => {
+        console.error(chalk.red(`Error creating SSH tunnel: ${err.message}`));
+        process.exit(1);
+      });
+
+      console.log(chalk.blue(`Press Ctrl+C to stop the proxy`));
+
+      // Handle SIGINT (Ctrl+C)
+      process.on('SIGINT', () => {
+        console.log(chalk.yellow('\nShutting down proxy...'));
+        sshProcess.kill();
+      });
+
+    } catch (error) {
+      console.error(
+        chalk.red(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/tonk.ts
+++ b/packages/cli/src/tonk.ts
@@ -6,6 +6,7 @@ import {psCommand} from './commands/ps.js';
 import {startCommand} from './commands/start.js';
 import {killCommand} from './commands/kill.js';
 import {pushCommand} from './commands/push.js';
+import {proxyCommand} from './commands/proxy.js';
 import {createServer} from '@tonk/server';
 import chalk from 'chalk';
 import envPaths from 'env-paths';
@@ -32,6 +33,7 @@ program.addCommand(startCommand);
 program.addCommand(psCommand);
 program.addCommand(lsCommand);
 program.addCommand(killCommand);
+program.addCommand(proxyCommand);
 
 const startServer = async () => {
   try {


### PR DESCRIPTION
### Description

- run `tonk proxy <bundle name>` to start a reverse proxy to the running bundle
- returns links and QR code to access bundle

### Other changes

None

### Tested

```
❯ tonk help          
Usage: tonk [options] [command]

The tonk cli helps you to manage your tonk stack and apps.

Options:
  -V, --version                 output the version number
  -d                            Run the Tonk daemon
  -h, --help                    display help for command

Commands:
  hello                         Say hello to start and launch the tonk daemon
  create [options]              Create a new tonk application or component
  push [options]                Package and upload a bundle to the Tonk server
  start [options] <bundleName>  Start a bundle server
  ps [options]                  List running bundle servers
  ls [options]                  List available bundles on the Tonk server
  kill [options] <serverId>     Stop a running bundle server
  proxy [options] <bundleName>  Create a reverse proxy to access a Tonk bundle
  help [command]                display help for command

Work in progress!
```

```
❯ tonk proxy my-world
Setting up proxy for bundle my-world...
Found running bundle: my-world
Bundle port: 8000
Creating SSH tunnel with Pinggy...
Press Ctrl+C to stop the proxy
Allocated port 5 for remote forward to localhost:8000
Connection to free.pinggy.io closed by remote host.
Connection to free.pinggy.io closed.
SSH tunnel closed with code 255
Proxy connection terminated.
```

### Related issues

- closes TON-1043

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@tonk/cli` package to version `0.2.4` and introduces a new command, `proxyCommand`, which allows users to create a reverse proxy for accessing Tonk bundles. It enhances the CLI functionality by enabling SSH tunneling to running bundles.

### Detailed summary
- Updated `version` in `packages/cli/package.json` from `0.2.3` to `0.2.4`.
- Added `proxyCommand` to `program` in `packages/cli/src/tonk.ts`.
- Created a new file `packages/cli/src/commands/proxy.ts` with:
  - Definition of `proxyCommand` using `commander`.
  - Functionality to check running bundles and create an SSH tunnel.
  - Error handling for server responses and SSH process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->