### PR TITLE
feat(cli): TON-1052: implement CLI worker commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@tonk/server": "^0.2.4",
     "chalk": "^5.3.0",
+    "cli-table3": "^0.6.5",
     "commander": "^11.1.0",
     "dotenv": "^16.4.7",
     "env-paths": "^3.0.0",
@@ -55,6 +56,7 @@
     "ora": "^7.0.1",
     "react": "18",
     "tar": "^6.2.1",
+    "yaml": "^2.3.4",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -65,6 +68,9 @@ importers:
       tar:
         specifier: ^6.2.1
         version: 6.2.1
+      yaml:
+        specifier: ^2.3.4
+        version: 2.7.1
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -326,6 +332,10 @@ packages:
     resolution: {integrity: sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==}
     cpu: [x64]
     os: [win32]
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1483,6 +1493,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
@@ -4305,6 +4319,9 @@ snapshots:
   '@cbor-extract/cbor-extract-win32-x64@2.2.0':
     optional: true
 
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5533,6 +5550,12 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   cli-truncate@4.0.0:
     dependencies:
@@ -7830,8 +7853,7 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml@2.7.1:
-    optional: true
+  yaml@2.7.1: {}
 
   yargs-parser@20.2.9: {}
 

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -1,0 +1,678 @@
+import {Command} from 'commander';
+import chalk from 'chalk';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as YAML from 'yaml';
+import Table from 'cli-table3';
+import inquirer from 'inquirer';
+import {TonkWorkerManager} from '../lib/workerManager.js';
+
+export const workerCommand = new Command('worker')
+  .description('Manage Tonk workers')
+  .action(async () => {
+    // Display help when no subcommand is provided
+    workerCommand.help();
+  });
+
+workerCommand
+  .command('inspect <id>')
+  .description('Inspect a specific worker')
+  .option('-s, --start', 'Start the worker')
+  .option('-S, --stop', 'Stop the worker')
+  .option('-c, --config <path>', 'Path to worker configuration file')
+  .option('-p, --ping', 'Ping the worker to check its status')
+  .action(async (id, options) => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      // If no options provided, show worker details
+      if (!options.start && !options.stop && !options.config && !options.ping) {
+        displayWorkerDetails(worker);
+        return;
+      }
+
+      // Handle ping option
+      if (options.ping) {
+        console.log(
+          chalk.blue(
+            `Pinging worker '${worker.name}' at ${worker.endpoint}...`,
+          ),
+        );
+
+        // Check worker health
+        const isHealthy = await workerManager.checkHealth(id);
+
+        if (isHealthy) {
+          console.log(chalk.green(`Worker '${worker.name}' is active!`));
+        } else {
+          console.log(chalk.red(`Worker '${worker.name}' is not responding.`));
+        }
+        return;
+      }
+
+      // Handle start option
+      if (options.start) {
+        console.log(chalk.blue(`Starting worker '${worker.name}'...`));
+        await workerManager.start(id);
+        console.log(
+          chalk.green(`Worker '${worker.name}' started successfully!`),
+        );
+        return;
+      }
+
+      // Handle stop option
+      if (options.stop) {
+        console.log(chalk.blue(`Stopping worker '${worker.name}'...`));
+        await workerManager.stop(id);
+        console.log(
+          chalk.green(`Worker '${worker.name}' stopped successfully!`),
+        );
+        return;
+      }
+
+      // Handle config option
+      if (options.config) {
+        await updateWorkerConfig(workerManager, worker.id, options.config);
+      }
+    } catch (error) {
+      console.error(chalk.red('Failed to manage worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('ls')
+  .description('List all registered workers')
+  .action(async () => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get all workers
+      const workers = await workerManager.list();
+
+      if (workers.length === 0) {
+        console.log(chalk.yellow('No workers registered yet.'));
+        console.log(
+          chalk.blue(
+            `Use '${chalk.bold('tonk worker register')}' to register a worker.`,
+          ),
+        );
+        return;
+      }
+
+      // Create a table for display
+      const table = new Table({
+        head: [
+          chalk.cyan('ID'),
+          chalk.cyan('Name'),
+          chalk.cyan('Type'),
+          chalk.cyan('Endpoint'),
+          chalk.cyan('Protocol'),
+          chalk.cyan('Status'),
+          chalk.cyan('Last Seen'),
+        ],
+        colWidths: [24, 20, 10, 30, 10, 10, 20],
+      });
+
+      // Add workers to table
+      workers.forEach(worker => {
+        const lastSeen = worker.status.lastSeen
+          ? new Date(worker.status.lastSeen).toLocaleString()
+          : 'Never';
+
+        table.push([
+          worker.id,
+          worker.name,
+          worker.config.type || 'custom',
+          worker.endpoint,
+          worker.protocol,
+          worker.status.active
+            ? chalk.green('Active')
+            : chalk.yellow('Inactive'),
+          lastSeen,
+        ]);
+      });
+
+      console.log(chalk.bold(`Registered Workers (${workers.length}):`));
+      console.log(table.toString());
+      console.log(
+        chalk.blue(
+          `\nUse '${chalk.bold('tonk worker inspect <id>')}' to view details of a specific worker.`,
+        ),
+      );
+    } catch (error) {
+      console.error(chalk.red('Failed to list workers:'), error);
+    }
+  });
+
+workerCommand
+  .command('rm <id>')
+  .description('Remove a registered worker')
+  .action(async id => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      // Remove worker
+      await workerManager.remove(id);
+      console.log(
+        chalk.green(`Worker '${worker.name}' (${id}) removed successfully.`),
+      );
+    } catch (error) {
+      console.error(chalk.red('Failed to remove worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('ping <id>')
+  .description('Ping a worker to check its status')
+  .action(async id => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      console.log(
+        chalk.blue(`Pinging worker '${worker.name}' at ${worker.endpoint}...`),
+      );
+
+      // Check worker health
+      const isHealthy = await workerManager.checkHealth(id);
+
+      if (isHealthy) {
+        console.log(chalk.green(`Worker '${worker.name}' is active!`));
+      } else {
+        console.log(chalk.red(`Worker '${worker.name}' is not responding.`));
+      }
+    } catch (error) {
+      console.error(chalk.red('Failed to ping worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('start <id>')
+  .description('Start a worker')
+  .action(async id => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      console.log(chalk.blue(`Starting worker '${worker.name}'...`));
+      await workerManager.start(id);
+      console.log(chalk.green(`Worker '${worker.name}' started successfully!`));
+    } catch (error) {
+      console.error(chalk.red('Failed to start worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('stop <id>')
+  .description('Stop a worker')
+  .action(async id => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      console.log(chalk.blue(`Stopping worker '${worker.name}'...`));
+      await workerManager.stop(id);
+      console.log(chalk.green(`Worker '${worker.name}' stopped successfully!`));
+    } catch (error) {
+      console.error(chalk.red('Failed to stop worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('logs <id>')
+  .description('View logs for a worker')
+  .option('-f, --follow', 'Follow log output')
+  .option('-l, --lines <n>', 'Number of lines to show', '100')
+  .option('-e, --error', 'Show only error logs')
+  .option('-o, --out', 'Show only standard output logs')
+  .action(async (id, options) => {
+    try {
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Get worker
+      const worker = await workerManager.get(id);
+
+      if (!worker) {
+        console.error(chalk.red(`Worker with ID '${id}' not found.`));
+        return;
+      }
+
+      console.log(chalk.blue(`Fetching logs for worker '${worker.name}'...`));
+
+      const {spawn} = await import('node:child_process');
+
+      try {
+        // Build the PM2 logs command arguments
+        const args = ['logs', worker.id];
+
+        // Add options
+        if (options.lines) {
+          args.push('--lines', options.lines);
+        }
+
+        if (options.error) {
+          args.push('--err');
+        } else if (options.out) {
+          args.push('--out');
+        }
+
+        // Always use --raw to get cleaner output
+        args.push('--raw');
+
+        // For non-follow mode, we'll use --lines and then kill the process after a short delay
+        if (!options.follow) {
+          console.log(
+            chalk.blue(
+              `Showing last ${options.lines || '100'} lines of logs...`,
+            ),
+          );
+
+          const child = spawn('pm2', args, {
+            stdio: 'inherit',
+          });
+
+          // Kill the process after a short delay to get just the initial output
+          setTimeout(() => {
+            child.kill('SIGINT');
+          }, 1000);
+
+          // Wait for the child process to exit
+          await new Promise(resolve => {
+            child.on('exit', resolve);
+          });
+
+          console.log(
+            chalk.blue('\nUse -f or --follow to stream logs in real-time'),
+          );
+        } else {
+          // For follow mode
+          console.log(
+            chalk.blue('Streaming logs in real-time. Press Ctrl+C to exit.'),
+          );
+
+          const child = spawn('pm2', args, {
+            stdio: 'inherit',
+          });
+
+          // Handle process exit
+          process.on('SIGINT', () => {
+            child.kill();
+            process.exit(0);
+          });
+
+          // Wait for the child process to exit
+          await new Promise(resolve => {
+            child.on('exit', resolve);
+          });
+        }
+      } catch (error) {
+        console.error(chalk.red('Failed to fetch logs:'), error);
+      }
+    } catch (error) {
+      console.error(chalk.red('Failed to fetch worker logs:'), error);
+    }
+  });
+
+workerCommand
+  .command('register')
+  .description('Register a worker with Tonk')
+  .argument('[dir]', 'Path to worker directory (defaults to current directory)')
+  .action(async (dir = '.') => {
+    try {
+      // Find the worker.yaml file
+      const workerDir = await findWorkerRoot(dir);
+
+      if (!workerDir) {
+        console.error(
+          chalk.red(
+            `No worker.yaml file found in ${path.resolve(dir)} or its parent directories.`,
+          ),
+        );
+        console.log(
+          chalk.yellow(
+            'Make sure you are in a valid worker directory or specify the path to one.',
+          ),
+        );
+        return;
+      }
+
+      console.log(chalk.blue(`Found worker directory at: ${workerDir}`));
+
+      // Read the worker.yaml file
+      const workerYamlPath = path.join(workerDir, 'worker.yaml');
+      const workerConfig = await readWorkerConfig(workerYamlPath);
+
+      if (!workerConfig) {
+        console.error(
+          chalk.red(`Failed to parse worker.yaml file at ${workerYamlPath}`),
+        );
+        return;
+      }
+
+      // Create worker manager
+      const workerManager = new TonkWorkerManager();
+
+      // Register worker using the YAML config
+      const worker = await workerManager.registerFromYamlConfig(workerConfig);
+
+      console.log(
+        chalk.green(`Worker '${worker.name}' registered successfully!`),
+      );
+      console.log(chalk.cyan('Worker ID:'), chalk.bold(worker.id));
+      console.log(chalk.cyan('Endpoint:'), chalk.bold(worker.endpoint));
+      console.log(chalk.cyan('Protocol:'), chalk.bold(worker.protocol));
+      console.log(
+        chalk.cyan('Status:'),
+        worker.status.active ? chalk.green('Active') : chalk.yellow('Inactive'),
+      );
+
+      if (Object.keys(worker.env).length > 0) {
+        console.log(chalk.cyan('Environment Variables:'));
+        Object.entries(worker.env).forEach(([key, value]) => {
+          console.log(`  ${key}=${value}`);
+        });
+      }
+    } catch (error) {
+      console.error(chalk.red('Failed to register worker:'), error);
+    }
+  });
+
+workerCommand
+  .command('init')
+  .description('Initialise a new worker configuration file')
+  .option(
+    '-d, --dir <directory>',
+    'Directory to create the configuration file in',
+    '.',
+  )
+  .option('-n, --name <n>', 'Name of the worker')
+  .option('-p, --port <port>', 'Port number for the worker', '5555')
+  .action(async options => {
+    try {
+      // Prompt for missing options
+      const answers = await promptForMissingOptions(options);
+      const mergedOptions = {...options, ...answers};
+
+      // Create the directory if it doesn't exist
+      const targetDir = path.resolve(mergedOptions.dir);
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, {recursive: true});
+        console.log(chalk.blue(`Created directory: ${targetDir}`));
+      }
+
+      // Generate the YAML content
+      const yamlContent = generateYamlContent(mergedOptions);
+
+      // Write the YAML file
+      const yamlPath = path.join(targetDir, 'worker.yaml');
+      fs.writeFileSync(yamlPath, yamlContent);
+
+      console.log(
+        chalk.green(`Worker configuration file created at: ${yamlPath}`),
+      );
+      console.log(chalk.blue(`\nYou can now register this worker with:`));
+      console.log(chalk.cyan(`  tonk worker register ${targetDir}`));
+    } catch (error) {
+      console.error(
+        chalk.red('Failed to initialise worker configuration:'),
+        error,
+      );
+    }
+  });
+
+// Helper function to display worker details
+function displayWorkerDetails(worker: any) {
+  console.log(chalk.bold(`Worker Details: ${worker.name}`));
+  console.log(chalk.cyan('ID:'), worker.id);
+  console.log(chalk.cyan('Name:'), worker.name);
+  console.log(
+    chalk.cyan('Description:'),
+    worker.description || '(No description)',
+  );
+  console.log(chalk.cyan('Type:'), worker.config.type || 'custom');
+  console.log(chalk.cyan('Endpoint:'), worker.endpoint);
+  console.log(chalk.cyan('Protocol:'), worker.protocol);
+  console.log(
+    chalk.cyan('Status:'),
+    worker.status.active ? chalk.green('Active') : chalk.yellow('Inactive'),
+  );
+
+  if (worker.status.lastSeen) {
+    console.log(
+      chalk.cyan('Last Seen:'),
+      new Date(worker.status.lastSeen).toLocaleString(),
+    );
+  } else {
+    console.log(chalk.cyan('Last Seen:'), 'Never');
+  }
+
+  console.log(
+    chalk.cyan('Created:'),
+    new Date(worker.createdAt).toLocaleString(),
+  );
+  console.log(
+    chalk.cyan('Updated:'),
+    new Date(worker.updatedAt).toLocaleString(),
+  );
+
+  if (Object.keys(worker.env).length > 0) {
+    console.log(chalk.cyan('\nEnvironment Variables:'));
+    Object.entries(worker.env).forEach(([key, value]) => {
+      console.log(`  ${key}=${value}`);
+    });
+  }
+
+  if (Object.keys(worker.config).length > 0) {
+    console.log(chalk.cyan('\nConfiguration:'));
+    console.log(JSON.stringify(worker.config, null, 2));
+  }
+}
+
+// Helper function to update worker configuration
+async function updateWorkerConfig(
+  workerManager: TonkWorkerManager,
+  id: string,
+  configPath: string,
+) {
+  try {
+    // Check if config file exists
+    if (!fs.existsSync(configPath)) {
+      console.error(chalk.red(`Configuration file not found: ${configPath}`));
+      return;
+    }
+
+    // Read config file
+    const configContent = fs.readFileSync(configPath, 'utf-8');
+    let config: Record<string, any>;
+
+    try {
+      config = JSON.parse(configContent);
+    } catch (error) {
+      console.error(chalk.red('Invalid JSON in configuration file:'), error);
+      return;
+    }
+
+    // Get worker
+    const worker = await workerManager.get(id);
+
+    if (!worker) {
+      console.error(chalk.red(`Worker with ID '${id}' not found.`));
+      return;
+    }
+
+    // Update worker config
+    await workerManager.update(id, {
+      config: {...worker.config, ...config},
+    });
+
+    console.log(
+      chalk.green(
+        `Worker '${worker.name}' configuration updated successfully!`,
+      ),
+    );
+  } catch (error) {
+    console.error(chalk.red('Failed to update worker configuration:'), error);
+  }
+}
+
+/**
+ * Find the worker root directory by looking for worker.yaml
+ * Searches in the given directory and parent directories
+ */
+async function findWorkerRoot(startDir: string): Promise<string | null> {
+  try {
+    let currentDir = path.resolve(startDir);
+    const rootDir = path.parse(currentDir).root;
+
+    // Search up to the root directory
+    while (currentDir !== rootDir) {
+      const workerYamlPath = path.join(currentDir, 'worker.yaml');
+
+      if (fs.existsSync(workerYamlPath)) {
+        return currentDir;
+      }
+
+      // Move up one directory
+      const parentDir = path.dirname(currentDir);
+
+      // If we've reached the root, stop searching
+      if (parentDir === currentDir) {
+        break;
+      }
+
+      currentDir = parentDir;
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error finding worker root:', error);
+    return null;
+  }
+}
+
+/**
+ * Read and parse the worker.yaml file
+ */
+async function readWorkerConfig(configPath: string): Promise<any | null> {
+  try {
+    if (!fs.existsSync(configPath)) {
+      return null;
+    }
+
+    const fileContent = fs.readFileSync(configPath, 'utf-8');
+    return YAML.parse(fileContent);
+  } catch (error) {
+    console.error('Error reading worker config:', error);
+    return null;
+  }
+}
+
+// Helper function to prompt for missing options (for init command)
+async function promptForMissingOptions(options: any) {
+  const questions = [];
+
+  if (!options.name) {
+    questions.push({
+      type: 'input',
+      name: 'name',
+      message: 'Enter worker name:',
+      validate: (input: string) =>
+        input.trim() !== '' ? true : 'Name is required',
+    });
+  }
+
+  if (!options.port) {
+    questions.push({
+      type: 'input',
+      name: 'port',
+      message: 'Enter port number for the worker:',
+      default: '5555',
+      validate: (input: string) =>
+        /^\d+$/.test(input) ? true : 'Port must be a number',
+    });
+  }
+
+  return inquirer.prompt(questions);
+}
+
+// Helper function to generate YAML content (for init command)
+function generateYamlContent(options: any): string {
+  const port = options.port || '5555';
+
+  return `# Worker Configuration
+
+# Worker Information
+name: ${options.name}
+description: Tonk worker
+version: 1.0.0
+
+# Connection Details
+endpoint: http://localhost:${port}/tonk
+protocol: http
+
+# Health Check Configuration
+healthCheck:
+  endpoint: http://localhost:${port}/health
+  method: GET
+  interval: 30000
+  timeout: 5000
+
+# Process Management
+process:
+  script: ./dist/index.js
+  cwd: ./
+  instances: 1
+  autorestart: true
+  watch: false
+  max_memory_restart: 500M
+  env:
+    NODE_ENV: production
+
+# Additional Configuration
+config: {}
+`;
+}

--- a/packages/cli/src/lib/workerManager.ts
+++ b/packages/cli/src/lib/workerManager.ts
@@ -1,0 +1,444 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import envPaths from 'env-paths';
+import {
+  Worker,
+  WorkerManager,
+  WorkerRegistrationOptions,
+} from '../types/worker.js';
+import {WorkerConfigSchema} from '../types/workerConfig.js';
+import http from 'node:http';
+import https from 'node:https';
+import {exec} from 'node:child_process';
+import {promisify} from 'node:util';
+import * as YAML from 'yaml';
+
+/**
+ * Implementation of the WorkerManager interface
+ */
+export class TonkWorkerManager implements WorkerManager {
+  private workersPath: string;
+
+  constructor() {
+    // Create paths for Tonk daemon home
+    const paths = envPaths('tonk', {suffix: ''});
+    const tonkHome = paths.data;
+    this.workersPath = path.join(tonkHome, 'workers');
+
+    // Ensure workers directory exists
+    if (!fs.existsSync(this.workersPath)) {
+      fs.mkdirSync(this.workersPath, {recursive: true});
+    }
+  }
+
+  /**
+   * Register a new worker
+   */
+  async register(options: WorkerRegistrationOptions): Promise<Worker> {
+    // Generate a unique ID for the worker
+    const workerId = this.generateWorkerId(options.name);
+
+    // Parse environment variables
+    const env: Record<string, string> = {};
+    if (options.env && Array.isArray(options.env)) {
+      options.env.forEach((envVar: string) => {
+        const [key, value] = envVar.split('=');
+        if (key && value) {
+          env[key] = value;
+        }
+      });
+    }
+
+    let workerConfig = {
+      type: options.type || 'custom',
+    };
+
+    // If config file provided, load it
+    if (options.config && fs.existsSync(options.config)) {
+      try {
+        const configContent = fs.readFileSync(options.config, 'utf-8');
+
+        // Check if it's a YAML file
+        if (
+          options.config.endsWith('.yml') ||
+          options.config.endsWith('.yaml')
+        ) {
+          try {
+            const config = YAML.parse(configContent);
+
+            // Validate against schema
+            const result = WorkerConfigSchema.safeParse(config);
+            if (result.success) {
+              // Use the YAML config to populate worker fields
+              return this.registerFromYamlConfig(result.data);
+            } else {
+              console.error('Invalid YAML configuration:', result.error);
+              // Continue with basic registration
+            }
+          } catch (yamlError) {
+            console.error('Error parsing YAML config:', yamlError);
+          }
+        } else {
+          // Assume JSON
+          const config = JSON.parse(configContent);
+          workerConfig = {...workerConfig, ...config};
+        }
+      } catch (error) {
+        console.error('Error loading config file:', error);
+      }
+    }
+
+    // Create worker object
+    const worker: Worker = {
+      id: workerId,
+      name: options.name,
+      description: options.description || '',
+      endpoint: options.endpoint,
+      protocol: options.protocol || 'http',
+      status: {
+        active: false,
+        lastSeen: null,
+      },
+      env,
+      config: workerConfig,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // Save worker to file
+    const workerFilePath = path.join(this.workersPath, `${workerId}.json`);
+    fs.writeFileSync(workerFilePath, JSON.stringify(worker, null, 2));
+
+    return worker;
+  }
+
+  /**
+   * Register a worker from a YAML configuration file
+   */
+  async registerFromYamlConfig(yamlConfig: any): Promise<Worker> {
+    // Generate a unique ID for the worker
+    const workerId = this.generateWorkerId(yamlConfig.name);
+    // Create worker object from YAML config
+    const worker: Worker = {
+      id: workerId,
+      name: yamlConfig.name,
+      description: yamlConfig.description || '',
+      endpoint: yamlConfig.endpoint,
+      protocol: yamlConfig.protocol || 'http',
+      status: {
+        active: false,
+        lastSeen: null,
+      },
+      env: yamlConfig.process?.env || {},
+      config: {
+        type: yamlConfig.type || 'custom',
+        version: yamlConfig.version,
+        capabilities: yamlConfig.capabilities,
+        healthCheck: yamlConfig.healthCheck,
+        process: yamlConfig.process,
+        ...yamlConfig.config,
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // Save worker to file
+    const workerFilePath = path.join(this.workersPath, `${workerId}.json`);
+    fs.writeFileSync(workerFilePath, JSON.stringify(worker, null, 2));
+
+    return worker;
+  }
+
+  /**
+   * Get a worker by ID
+   */
+  async get(id: string): Promise<Worker | null> {
+    const workerFilePath = path.join(this.workersPath, `${id}.json`);
+
+    if (!fs.existsSync(workerFilePath)) {
+      return null;
+    }
+
+    const fileContent = fs.readFileSync(workerFilePath, 'utf-8');
+    return JSON.parse(fileContent);
+  }
+
+  /**
+   * List all registered workers
+   */
+  async list(): Promise<Worker[]> {
+    const workerFiles = fs
+      .readdirSync(this.workersPath)
+      .filter(file => file.endsWith('.json'));
+
+    if (workerFiles.length === 0) {
+      return [];
+    }
+
+    return workerFiles.map(file => {
+      const filePath = path.join(this.workersPath, file);
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(fileContent);
+    });
+  }
+
+  /**
+   * Update a worker
+   */
+  async update(id: string, updates: Partial<Worker>): Promise<Worker> {
+    const worker = await this.get(id);
+
+    if (!worker) {
+      throw new Error(`Worker with ID '${id}' not found.`);
+    }
+
+    // Update worker properties
+    const updatedWorker: Worker = {
+      ...worker,
+      ...updates,
+      updatedAt: Date.now(),
+    };
+
+    // Save updated worker
+    const workerFilePath = path.join(this.workersPath, `${id}.json`);
+    fs.writeFileSync(workerFilePath, JSON.stringify(updatedWorker, null, 2));
+
+    return updatedWorker;
+  }
+
+  /**
+   * Remove a worker
+   */
+  async remove(id: string): Promise<boolean> {
+    const workerFilePath = path.join(this.workersPath, `${id}.json`);
+
+    if (!fs.existsSync(workerFilePath)) {
+      return false;
+    }
+
+    // Get worker details before removing
+    const worker = await this.get(id);
+    if (!worker) {
+      return false;
+    }
+
+    // Try to stop and delete from PM2 if it's running
+    const execAsync = promisify(exec);
+    try {
+      // Check if worker is running in PM2
+      const {stdout} = await execAsync('pm2 list');
+
+      if (stdout.includes(`${worker.id}`)) {
+        // Stop the worker with PM2 first
+        await execAsync(`pm2 stop ${worker.id}`);
+        // Then delete it from PM2
+        await execAsync(`pm2 delete ${worker.id}`);
+        console.log(`Worker '${worker.name}' stopped and removed from PM2.`);
+      }
+    } catch (error) {
+      console.error(`Error stopping worker in PM2:`, error);
+      // Continue with removal even if PM2 operations fail
+    }
+
+    // Remove worker file
+    fs.unlinkSync(workerFilePath);
+    return true;
+  }
+
+  /**
+   * Start a worker
+   */
+  async start(id: string): Promise<boolean> {
+    const worker = await this.get(id);
+
+    if (!worker) {
+      throw new Error(`Worker with ID '${id}' not found.`);
+    }
+
+    const execAsync = promisify(exec);
+
+    try {
+      // Check if worker has process configuration
+      if (!worker.config.process || !worker.config.process.script) {
+        throw new Error(
+          `Worker '${worker.name}' does not have a valid process configuration.`,
+        );
+      }
+
+      // Check if worker is already running in PM2
+      const {stdout} = await execAsync('pm2 list');
+
+      if (stdout.includes(`${worker.id}`)) {
+        console.log(
+          `Worker '${worker.name}' is already running. Restarting...`,
+        );
+        await execAsync(`pm2 restart ${worker.id}`);
+      } else {
+        // Prepare environment variables
+        const envVars = Object.entries(worker.env)
+          .map(([key, value]) => `${key}=${value}`)
+          .join(' ');
+
+        // Start the worker with PM2
+        const cwd = worker.config.process.cwd || '.';
+        const instances = worker.config.process.instances || 1;
+        const watch = worker.config.process.watch ? '--watch' : '';
+        const maxMemory = worker.config.process.max_memory_restart
+          ? `--max-memory-restart ${worker.config.process.max_memory_restart}`
+          : '';
+
+        const startCmd = `cd ${cwd} && ${envVars} pm2 start ${worker.config.process.script} --name ${worker.id} --instances ${instances} ${watch} ${maxMemory}`;
+
+        await execAsync(startCmd);
+      }
+
+      // Update worker status
+      await this.update(id, {
+        status: {
+          active: true,
+          lastSeen: Date.now(),
+        },
+      });
+
+      return true;
+    } catch (error) {
+      console.error(`Error starting worker:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Stop a worker
+   */
+  async stop(id: string): Promise<boolean> {
+    const worker = await this.get(id);
+
+    if (!worker) {
+      throw new Error(`Worker with ID '${id}' not found.`);
+    }
+
+    const execAsync = promisify(exec);
+
+    try {
+      console.log(`Stopping worker '${worker.name}'...`);
+
+      // Check if worker is running in PM2
+      const {stdout} = await execAsync('pm2 list');
+
+      if (stdout.includes(`${worker.id}`)) {
+        // Stop the worker with PM2
+        await execAsync(`pm2 stop ${worker.id}`);
+      } else {
+        console.log(`Worker '${worker.name}' is not running.`);
+      }
+
+      // Update worker status
+      await this.update(id, {
+        status: {
+          active: false,
+          lastSeen: worker.status.lastSeen,
+        },
+      });
+
+      return true;
+    } catch (error) {
+      console.error(`Error stopping worker:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Check worker health
+   */
+  async checkHealth(id: string): Promise<boolean> {
+    const worker = await this.get(id);
+
+    if (!worker) {
+      throw new Error(`Worker with ID '${id}' not found.`);
+    }
+
+    // If no health check configured, just ping the endpoint
+    const healthCheckEndpoint =
+      worker.config.healthCheck?.endpoint || worker.endpoint;
+    const healthCheckTimeout = worker.config.healthCheck?.timeout || 5000;
+
+    try {
+      // Perform health check based on protocol
+      if (worker.protocol === 'http' || worker.protocol === 'https') {
+        const isHealthy = await this.httpHealthCheck(
+          healthCheckEndpoint,
+          worker.protocol,
+          healthCheckTimeout,
+        );
+
+        // Update worker status
+        await this.update(id, {
+          status: {
+            active: isHealthy,
+            lastSeen: isHealthy ? Date.now() : worker.status.lastSeen,
+          },
+        });
+
+        return isHealthy;
+      }
+
+      // For other protocols, we'll need to implement specific health checks
+      // For now, just return false for unsupported protocols
+      console.log(
+        `Health check for protocol '${worker.protocol}' not implemented.`,
+      );
+      return false;
+    } catch (error) {
+      console.error(`Error checking worker health:`, error);
+
+      // Update worker status to inactive
+      await this.update(id, {
+        status: {
+          active: false,
+          lastSeen: worker.status.lastSeen,
+        },
+      });
+
+      return false;
+    }
+  }
+
+  /**
+   * Generate a worker ID
+   */
+  private generateWorkerId(name: string): string {
+    const normalizedName = name.toLowerCase().replace(/[^a-z0-9]/g, '-');
+    const timestamp = Date.now().toString(36);
+    return `${normalizedName}-${timestamp}`;
+  }
+
+  /**
+   * Perform HTTP health check
+   */
+  private httpHealthCheck(
+    endpoint: string,
+    protocol: string,
+    timeout: number,
+  ): Promise<boolean> {
+    return new Promise(resolve => {
+      const client = protocol === 'https' ? https : http;
+      const req = client.get(endpoint, res => {
+        // Consider 2xx status codes as healthy
+        const isHealthy =
+          res.statusCode !== undefined &&
+          res.statusCode >= 200 &&
+          res.statusCode < 300;
+        resolve(isHealthy);
+      });
+
+      req.on('error', () => {
+        resolve(false);
+      });
+
+      req.setTimeout(timeout, () => {
+        req.destroy();
+        resolve(false);
+      });
+    });
+  }
+}

--- a/packages/cli/src/tonk.ts
+++ b/packages/cli/src/tonk.ts
@@ -7,6 +7,7 @@ import {startCommand} from './commands/start.js';
 import {killCommand} from './commands/kill.js';
 import {pushCommand} from './commands/push.js';
 import {proxyCommand} from './commands/proxy.js';
+import {workerCommand} from './commands/worker.js';
 import {createServer} from '@tonk/server';
 import chalk from 'chalk';
 import envPaths from 'env-paths';
@@ -34,6 +35,7 @@ program.addCommand(psCommand);
 program.addCommand(lsCommand);
 program.addCommand(killCommand);
 program.addCommand(proxyCommand);
+program.addCommand(workerCommand);
 
 const startServer = async () => {
   try {

--- a/packages/cli/src/types/worker.ts
+++ b/packages/cli/src/types/worker.ts
@@ -1,0 +1,108 @@
+/**
+ * Worker specification for Tonk
+ * 
+ * This file defines the standard format for worker definitions in Tonk.
+ */
+
+/**
+ * Worker status information
+ */
+export interface WorkerStatus {
+  /** Whether the worker is currently active */
+  active: boolean;
+  /** Timestamp of when the worker was last seen (null if never) */
+  lastSeen: number | null;
+}
+
+/**
+ * Worker health check configuration
+ */
+export interface WorkerHealthCheck {
+  /** Endpoint to ping for health check */
+  endpoint: string;
+  /** Method to use for health check (GET, POST, etc.) */
+  method: string;
+  /** Interval in milliseconds between health checks */
+  interval: number;
+  /** Timeout in milliseconds for health check */
+  timeout: number;
+}
+
+/**
+ * Worker definition
+ */
+export interface Worker {
+  /** Unique identifier for the worker */
+  id: string;
+  /** Human-readable name of the worker */
+  name: string;
+  /** Description of the worker's purpose */
+  description: string;
+  /** Endpoint URL/path where the worker can be reached */
+  endpoint: string;
+  /** Protocol used by the worker (http, ws, tcp, etc.) */
+  protocol: string;
+  /** Current status of the worker */
+  status: WorkerStatus;
+  /** Environment variables required by the worker */
+  env: Record<string, string>;
+  /** Additional configuration options for the worker */
+  config: {
+    /** Optional health check configuration */
+    healthCheck?: WorkerHealthCheck;
+    /** Optional worker type (e.g., "obsidian", "rag", "custom") */
+    type?: string;
+    /** Optional worker version */
+    version?: string;
+    /** Optional worker capabilities */
+    capabilities?: string[];
+    /** Any other configuration options */
+    [key: string]: any;
+  };
+  /** Timestamp of when the worker was created */
+  createdAt: number;
+  /** Timestamp of when the worker was last updated */
+  updatedAt: number;
+}
+
+/**
+ * Worker registration options
+ */
+export interface WorkerRegistrationOptions {
+  /** Name of the worker */
+  name: string;
+  /** Description of the worker */
+  description?: string;
+  /** Endpoint URL/path of the worker */
+  endpoint: string;
+  /** Protocol used by the worker */
+  protocol?: string;
+  /** Environment variables in KEY=VALUE format */
+  env?: string[];
+  /** Path to configuration file */
+  config?: string;
+  /** Worker type */
+  type?: string;
+}
+
+/**
+ * Worker manager interface
+ */
+export interface WorkerManager {
+  /** Register a new worker */
+  register(options: WorkerRegistrationOptions): Promise<Worker>;
+  /** Get a worker by ID */
+  get(id: string): Promise<Worker | null>;
+  /** List all registered workers */
+  list(): Promise<Worker[]>;
+  /** Update a worker */
+  update(id: string, updates: Partial<Worker>): Promise<Worker>;
+  /** Remove a worker */
+  remove(id: string): Promise<boolean>;
+  /** Start a worker */
+  start(id: string): Promise<boolean>;
+  /** Stop a worker */
+  stop(id: string): Promise<boolean>;
+  /** Check worker health */
+  checkHealth(id: string): Promise<boolean>;
+}

--- a/packages/cli/src/types/workerConfig.ts
+++ b/packages/cli/src/types/workerConfig.ts
@@ -1,0 +1,101 @@
+/**
+ * Worker YAML Configuration Schema
+ *
+ * This file defines the standard format for worker configuration YAML files in Tonk.
+ */
+import {z} from 'zod';
+
+/**
+ * Zod schema for worker health check configuration
+ */
+export const WorkerHealthCheckSchema = z.object({
+  endpoint: z.string().optional(),
+  method: z.string().default('GET'),
+  interval: z.number().default(30000),
+  timeout: z.number().default(5000),
+});
+
+/**
+ * Zod schema for worker configuration
+ */
+export const WorkerConfigSchema = z.object({
+  // Basic worker information
+  name: z.string(),
+  description: z.string().optional(),
+  version: z.string().optional(),
+
+  // Connection details
+  endpoint: z.string(),
+  protocol: z.string().default('http'),
+
+  // Worker type and capabilities
+  type: z.string().default('custom'),
+  capabilities: z.array(z.string()).optional(),
+
+  // Health check configuration
+  healthCheck: WorkerHealthCheckSchema.optional(),
+
+  // Process management
+  process: z.object({
+    script: z.string(),
+    cwd: z.string().optional(),
+    instances: z.number().default(1),
+    autorestart: z.boolean().default(true),
+    watch: z.boolean().default(false),
+    max_memory_restart: z.string().optional(),
+    env: z.record(z.string()).optional(),
+  }),
+
+  // Additional custom configuration
+  config: z.record(z.any()).optional(),
+});
+
+/**
+ * Type for worker configuration
+ */
+export type WorkerConfig = z.infer<typeof WorkerConfigSchema>;
+
+/**
+ * Example YAML configuration:
+ *
+ * ```yaml
+ * # Worker Information
+ * name: obsidian-worker
+ * description: Tonk worker for Obsidian integration
+ * version: 1.0.0
+ *
+ * # Connection Details
+ * endpoint: http://localhost:5555/tonk
+ * protocol: http
+ *
+ * # Worker Type and Capabilities
+ * type: obsidian
+ * capabilities:
+ *   - sync
+ *   - rag
+ *
+ * # Health Check Configuration
+ * healthCheck:
+ *   endpoint: http://localhost:5555/health
+ *   method: GET
+ *   interval: 30000
+ *   timeout: 5000
+ *
+ * # Process Management
+ * process:
+ *   script: ./dist/index.js
+ *   cwd: ./
+ *   instances: 1
+ *   autorestart: true
+ *   watch: false
+ *   max_memory_restart: 500M
+ *   env:
+ *     NODE_ENV: production
+ *     CHROMA_URL: http://localhost:8888
+ *
+ * # Additional Configuration
+ * config:
+ *   syncDirectory: notes
+ *   embedModel: all-MiniLM-L6-v2
+ * ```
+ */


### PR DESCRIPTION
### Description

- adds cli commands to register, start/stop, ping, and retrieve logs of tonk workers
- processes are managed by pm2, thereby avoiding custom clis for each worker

TODO:
- [ ] add notion of dependencies for multi-worker systems
- [ ] specify lexicons for data
- [ ] announce to tonk app somehow?
- [ ] worker template, possibly sdk

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1052

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `worker` command for managing Tonk workers, including functionalities for registering, starting, stopping, inspecting, and listing workers. It also adds configuration schemas and updates dependencies.

### Detailed summary
- Added `cli-table3` and `yaml` dependencies.
- Introduced `workerCommand` to manage Tonk workers.
- Implemented worker registration with YAML and JSON support.
- Created `WorkerConfigSchema` and `Worker` types for validation.
- Enhanced `TonkWorkerManager` for worker management and health checks.
- Added commands for inspecting, starting, stopping, and listing workers.
- Implemented logging functionality for workers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->