### PR TITLE
feat(cli): update version to use package.json version

### DIFF
--- a/packages/cli/src/tonk.ts
+++ b/packages/cli/src/tonk.ts
@@ -13,15 +13,15 @@ import chalk from 'chalk';
 import envPaths from 'env-paths';
 import fs from 'node:fs';
 import path from 'node:path';
+import pkg from '../package.json' with { type: 'json' };
 import {shutdownAnalytics, trackCommand, trackCommandError, trackCommandSuccess} from './utils/analytics.js';
 
 const program = new Command();
-
 // Main program setup
 program
   .name('tonk')
   .description('The tonk cli helps you to manage your tonk stack and apps.')
-  .version('0.1.2')
+  .version(pkg.version)
   .option('-d', 'Run the Tonk daemon')
   .on('--help', () => {
     console.log('\nWork in progress!');


### PR DESCRIPTION
### Description

Version was hardcoded. Now it grabbed from package json directly.

### Other changes

N/A

### Tested

Build
```bash
pnpm run build
```

Run 
```bash
node dist/tonk.js --version
```

### Related issues

N/A

### Backwards compatibility

Fully

### Documentation

N/A

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the versioning mechanism in the `tonk` CLI tool to use the version specified in `package.json` instead of a hardcoded string.

### Detailed summary
- Added import of `pkg` from `../package.json` with `{ type: 'json' }`.
- Changed the version method call from a hardcoded string `'0.1.2'` to `pkg.version`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->