### PR TITLE
feat(keepsync, create): listenToDoc now includes patch information

### DIFF
--- a/examples/store-viewer/server/.cursorrules
+++ b/examples/store-viewer/server/.cursorrules
@@ -9,14 +9,12 @@ This Express server provides API proxy functionality for your Tonk application.
 All requests to `/api/:endpoint` are automatically proxied from the frontend to this server running on port 8080.
 
 ### Benefits of using the API proxy:
-
 1. **CORS handling** - Make cross-origin requests without browser restrictions
 2. **Security** - Store API keys and sensitive credentials server-side
 3. **Local resource access** - Access local file system or other local resources
 4. **Request transformation** - Modify requests or responses before forwarding
 
 ## How it works:
-
 - Your frontend makes requests to `/api/your-endpoint`
 - The webpack dev server proxies these to `http://localhost:8080/api/your-endpoint`
 - Your Express server handles the request, makes any needed external calls, and returns the response
@@ -27,15 +25,15 @@ You can create new API endpoints in the server directory. For example:
 
 ```javascript
 // Example endpoint in server/index.js
-app.get("/api/data", async (req, res) => {
+app.get('/api/data', async (req, res) => {
   // Access API keys from environment variables (not exposed to client)
   const API_KEY = process.env.MY_SECRET_API_KEY;
-
+  
   // Make requests to external services
-  const response = await fetch("https://external-api.com/data", {
-    headers: { Authorization: `Bearer ${API_KEY}` },
+  const response = await fetch('https://external-api.com/data', {
+    headers: { 'Authorization': `Bearer ${API_KEY}` }
   });
-
+  
   // Return the data to the client
   const data = await response.json();
   res.json(data);
@@ -49,7 +47,6 @@ app.get("/api/data", async (req, res) => {
 Returns a simple hello world message.
 
 Example response:
-
 ```
 Hello World Api!
 ```
@@ -59,17 +56,15 @@ Hello World Api!
 ⚠️ **IMPORTANT**: Your server MUST include a `/ping` endpoint that returns a 200 OK response. This endpoint is used for health checks and service discovery. Without this endpoint, your application will not function properly.
 
 Example implementation:
-
 ```javascript
-app.get("/ping", (req, res) => {
-  res.status(200).send("OK");
+app.get('/ping', (req, res) => {
+  res.status(200).send('OK');
 });
 ```
 
 ## Setup
 
 1. Install server dependencies in the server/ folder:
-
 ```
 cd server
 pnpm install
@@ -77,7 +72,6 @@ pnpm build
 ```
 
 2. Start the development server in the top-level app project:
-
 ```
 tonk dev
 ```

--- a/examples/store-viewer/server/.windsurfrules
+++ b/examples/store-viewer/server/.windsurfrules
@@ -9,14 +9,12 @@ This Express server provides API proxy functionality for your Tonk application.
 All requests to `/api/:endpoint` are automatically proxied from the frontend to this server running on port 8080.
 
 ### Benefits of using the API proxy:
-
 1. **CORS handling** - Make cross-origin requests without browser restrictions
 2. **Security** - Store API keys and sensitive credentials server-side
 3. **Local resource access** - Access local file system or other local resources
 4. **Request transformation** - Modify requests or responses before forwarding
 
 ## How it works:
-
 - Your frontend makes requests to `/api/your-endpoint`
 - The webpack dev server proxies these to `http://localhost:8080/api/your-endpoint`
 - Your Express server handles the request, makes any needed external calls, and returns the response
@@ -27,15 +25,15 @@ You can create new API endpoints in the server directory. For example:
 
 ```javascript
 // Example endpoint in server/index.js
-app.get("/api/data", async (req, res) => {
+app.get('/api/data', async (req, res) => {
   // Access API keys from environment variables (not exposed to client)
   const API_KEY = process.env.MY_SECRET_API_KEY;
-
+  
   // Make requests to external services
-  const response = await fetch("https://external-api.com/data", {
-    headers: { Authorization: `Bearer ${API_KEY}` },
+  const response = await fetch('https://external-api.com/data', {
+    headers: { 'Authorization': `Bearer ${API_KEY}` }
   });
-
+  
   // Return the data to the client
   const data = await response.json();
   res.json(data);
@@ -49,7 +47,6 @@ app.get("/api/data", async (req, res) => {
 Returns a simple hello world message.
 
 Example response:
-
 ```
 Hello World Api!
 ```
@@ -59,17 +56,15 @@ Hello World Api!
 ⚠️ **IMPORTANT**: Your server MUST include a `/ping` endpoint that returns a 200 OK response. This endpoint is used for health checks and service discovery. Without this endpoint, your application will not function properly.
 
 Example implementation:
-
 ```javascript
-app.get("/ping", (req, res) => {
-  res.status(200).send("OK");
+app.get('/ping', (req, res) => {
+  res.status(200).send('OK');
 });
 ```
 
 ## Setup
 
 1. Install server dependencies in the server/ folder:
-
 ```
 cd server
 pnpm install
@@ -77,7 +72,6 @@ pnpm build
 ```
 
 2. Start the development server in the top-level app project:
-
 ```
 tonk dev
 ```

--- a/examples/store-viewer/server/CLAUDE.md
+++ b/examples/store-viewer/server/CLAUDE.md
@@ -9,14 +9,12 @@ This Express server provides API proxy functionality for your Tonk application.
 All requests to `/api/:endpoint` are automatically proxied from the frontend to this server running on port 8080.
 
 ### Benefits of using the API proxy:
-
 1. **CORS handling** - Make cross-origin requests without browser restrictions
 2. **Security** - Store API keys and sensitive credentials server-side
 3. **Local resource access** - Access local file system or other local resources
 4. **Request transformation** - Modify requests or responses before forwarding
 
 ## How it works:
-
 - Your frontend makes requests to `/api/your-endpoint`
 - The webpack dev server proxies these to `http://localhost:8080/api/your-endpoint`
 - Your Express server handles the request, makes any needed external calls, and returns the response
@@ -27,15 +25,15 @@ You can create new API endpoints in the server directory. For example:
 
 ```javascript
 // Example endpoint in server/index.js
-app.get("/api/data", async (req, res) => {
+app.get('/api/data', async (req, res) => {
   // Access API keys from environment variables (not exposed to client)
   const API_KEY = process.env.MY_SECRET_API_KEY;
-
+  
   // Make requests to external services
-  const response = await fetch("https://external-api.com/data", {
-    headers: { Authorization: `Bearer ${API_KEY}` },
+  const response = await fetch('https://external-api.com/data', {
+    headers: { 'Authorization': `Bearer ${API_KEY}` }
   });
-
+  
   // Return the data to the client
   const data = await response.json();
   res.json(data);
@@ -49,7 +47,6 @@ app.get("/api/data", async (req, res) => {
 Returns a simple hello world message.
 
 Example response:
-
 ```
 Hello World Api!
 ```
@@ -59,17 +56,15 @@ Hello World Api!
 ⚠️ **IMPORTANT**: Your server MUST include a `/ping` endpoint that returns a 200 OK response. This endpoint is used for health checks and service discovery. Without this endpoint, your application will not function properly.
 
 Example implementation:
-
 ```javascript
-app.get("/ping", (req, res) => {
-  res.status(200).send("OK");
+app.get('/ping', (req, res) => {
+  res.status(200).send('OK');
 });
 ```
 
 ## Setup
 
 1. Install server dependencies in the server/ folder:
-
 ```
 cd server
 pnpm install
@@ -77,7 +72,6 @@ pnpm build
 ```
 
 2. Start the development server in the top-level app project:
-
 ```
 tonk dev
 ```

--- a/examples/store-viewer/src/instructions/keepsync/.cursorrules
+++ b/examples/store-viewer/src/instructions/keepsync/.cursorrules
@@ -94,3 +94,13 @@ export function Counter() {
   );
 }
 ```
+
+There is also a new super useful api that lets you fetch a store directly by ID and then use it.
+```
+import { getDocHandleById } from '@tonk/keepsync';
+
+const handle = getDocHandleById('my doc id');
+const doc = handle.docSync();
+
+//doc is just a normal JS object, you can now do whatever you want with it
+```

--- a/examples/store-viewer/src/instructions/keepsync/.windsurfrules
+++ b/examples/store-viewer/src/instructions/keepsync/.windsurfrules
@@ -94,3 +94,13 @@ export function Counter() {
   );
 }
 ```
+
+There is also a new super useful api that lets you fetch a store directly by ID and then use it.
+```
+import { getDocHandleById } from '@tonk/keepsync';
+
+const handle = getDocHandleById('my doc id');
+const doc = handle.docSync();
+
+//doc is just a normal JS object, you can now do whatever you want with it
+```

--- a/examples/store-viewer/src/instructions/keepsync/CLAUDE.md
+++ b/examples/store-viewer/src/instructions/keepsync/CLAUDE.md
@@ -6,14 +6,14 @@ Initialize the sync engine in your application entry point (or before using any 
 
 ```typescript
 // index.tsx
-import { configureSyncEngine } from "@tonk/keepsync";
+import { configureSyncEngine } from '@tonk/keepsync';
 
 // Initialize the sync engine
 configureSyncEngine({
-  url: "ws://localhost:7777",
-  name: "MySyncEngine",
+  url: 'ws://localhost:7777',
+  name: 'MySyncEngine',
   onSync: (docId) => console.log(`Document ${docId} synced`),
-  onError: (error) => console.error("Sync error:", error),
+  onError: (error) => console.error('Sync error:', error),
 });
 ```
 
@@ -23,8 +23,8 @@ Use the `sync` middleware to create stores that automatically synchronize with o
 
 ```typescript
 // stores/counterStore.ts
-import { create } from "zustand";
-import { sync } from "@tonk/keepsync";
+import { create } from 'zustand';
+import { sync } from '@tonk/keepsync';
 
 interface CounterState {
   count: number;
@@ -55,13 +55,12 @@ export const useCounterStore = create<CounterState>(
       },
     }),
     // Sync configuration
-    {
-      docId: "counter",
+    { 
+      docId: 'counter',
       // Optional: configure initialization timeout
       initTimeout: 30000,
       // Optional: handle initialization errors
-      onInitError: (error) =>
-        console.error("Sync initialization error:", error),
+      onInitError: (error) => console.error('Sync initialization error:', error) 
     }
   )
 );
@@ -71,8 +70,8 @@ export const useCounterStore = create<CounterState>(
 
 ```typescript
 // components/Counter.tsx
-import React from "react";
-import { useCounterStore } from "../stores/counterStore";
+import React from 'react';
+import { useCounterStore } from '../stores/counterStore';
 
 export function Counter() {
   // Use the store hook directly - sync is handled by the middleware
@@ -88,11 +87,20 @@ export function Counter() {
       </div>
       <p>
         <small>
-          Open this app in multiple windows to see real-time collaboration in
-          action.
+          Open this app in multiple windows to see real-time collaboration in action.
         </small>
       </p>
     </div>
   );
 }
+```
+
+There is also a new super useful api that lets you fetch a store directly by ID and then use it.
+```
+import { getDocHandleById } from '@tonk/keepsync';
+
+const handle = getDocHandleById('my doc id');
+const doc = handle.docSync();
+
+//doc is just a normal JS object, you can now do whatever you want with it
 ```

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "description": "Bootstrap apps on the Tonk stack",
   "type": "module",
   "bin": {

--- a/packages/create/templates/react/.cursor/rules/instructions-keepsync-rules.mdc
+++ b/packages/create/templates/react/.cursor/rules/instructions-keepsync-rules.mdc
@@ -117,9 +117,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -143,4 +144,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/react/instructions/keepsync/.windsurfrules
+++ b/packages/create/templates/react/instructions/keepsync/.windsurfrules
@@ -112,9 +112,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -138,4 +139,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/react/instructions/keepsync/CLAUDE.md
+++ b/packages/create/templates/react/instructions/keepsync/CLAUDE.md
@@ -179,14 +179,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -212,11 +212,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/create/templates/react/instructions/keepsync/llms.txt
+++ b/packages/create/templates/react/instructions/keepsync/llms.txt
@@ -179,14 +179,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -212,11 +212,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/create/templates/worker/.cursor/rules/instructions-keepsync-rules.mdc
+++ b/packages/create/templates/worker/.cursor/rules/instructions-keepsync-rules.mdc
@@ -1,3 +1,8 @@
+---
+description: Rules and guidelines for instructions/keepsync
+globs: instructions/keepsync/**/*.js, instructions/keepsync/**/*.ts, instructions/keepsync/**/*.tsx
+---
+
 ## Basic Usage
 
 ### 1. Set Up the Sync Provider
@@ -8,20 +13,13 @@ Initialize the sync engine in your application entry point (or before using any 
 // index.tsx
 import { configureSyncEngine } from "@tonk/keepsync";
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
-import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 
-const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-const wsUrl = `${wsProtocol}//${window.location.host}/sync`;
-const wsAdapter = new BrowserWebSocketClientAdapter(wsUrl);
-const storage = new IndexedDBStorageAdapter();
-
-const url =
-  window.location.host.indexOf("localhost") === 0
-    ? "http://localhost:7777"
-    : `${window.location.protocol}//${window.location.host}`;
+const wsAdapter = new BrowserWebSocketClientAdapter("ws://localhost:7777/sync);
+const storage = new NodeFSStorageAdapter();
 
 configureSyncEngine({
-  url,
+  url: "http://localhost:7777",
   network: [wsAdapter as any],
   storage,
 });
@@ -33,7 +31,7 @@ Use the `sync` middleware to create stores that automatically synchronize with o
 
 ```typescript
 // stores/counterStore.ts
-import { create } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 import { sync, DocumentId } from '@tonk/keepsync';
 
 interface CounterState {
@@ -43,7 +41,7 @@ interface CounterState {
   reset: () => void;
 }
 
-export const useCounterStore = create<CounterState>(
+export const counterStore = createStore<CounterState>(
   sync(
     // The store implementation
     (set) => ({
@@ -76,34 +74,47 @@ export const useCounterStore = create<CounterState>(
 );
 ```
 
-### 3. Use the Store in React Components
+### 3. Manually fetch the state
+
+Because this is a Node project, we need to use zustand in a different way as it is used in React components. Each time you want fresh state you will need to use the `getState()` function.
 
 ```typescript
-// components/Counter.tsx
-import React from 'react';
-import { useCounterStore } from '../stores/counterStore';
+  const counterStore = createStore<CounterState>(
+    sync(
+      // The store implementation
+      (set) => ({
+        count: 0,
 
-export function Counter() {
-  // Use the store hook directly - sync is handled by the middleware
-  const { count, increment, decrement, reset } = useCounterStore();
+        // Increment the counter
+        increment: () => {
+          set((state) => ({ count: state.count + 1 }));
+        },
 
-  return (
-    <div>
-      <h2>Collaborative Counter: {count}</h2>
-      <div>
-        <button onClick={decrement}>-</button>
-        <button onClick={increment}>+</button>
-        <button onClick={reset}>Reset</button>
-      </div>
-      <p>
-        <small>
-          Open this app in multiple windows to see real-time collaboration in action.
-        </small>
-      </p>
-    </div>
+        // Decrement the counter
+        decrement: () => {
+          set((state) => ({ count: Math.max(0, state.count - 1) }));
+        },
+
+        // Reset the counter
+        reset: () => {
+          set({ count: 0 });
+        },
+      }),
+      // Sync configuration
+      { 
+        docId: 'counter' as DocumentId,
+        // Optional: configure initialization timeout
+        initTimeout: 30000,
+        // Optional: handle initialization errors
+        onInitError: (error) => console.error('Sync initialization error:', error) 
+      }
+    )
   );
-}
 
+  const state = counterStore.getState();
+
+  state.increment(); 
+  console.log(`The current count is: ${store.getState().count}`);
 ```
 
 # Directly reading and writing documents

--- a/packages/create/templates/worker/.cursor/rules/worker-instructions-rules.mdc
+++ b/packages/create/templates/worker/.cursor/rules/worker-instructions-rules.mdc
@@ -1,0 +1,11 @@
+---
+description: Rules and guidelines for instructions
+globs: instructions/**/*.js, instructions/**/*.ts, instructions/**/*.tsx
+---
+
+# How to use instruction files
+The files in this directory include utils and helpers that would ordinarily be hidden within a Node module. For the sake of introspection by LLMs, they are surfaced here.
+
+Each file has explicit and verbose TypeScript interfaces with comprehensive JSDoc documentation. Be sure to follow the provided structure, best practices, and implementation suggestions precisely. Do not hallucinate capabilities that are not explicitly defined in a given file.
+
+Related utilities are grouped into descriptively named files and include an `index.ts` that explicitly exports everything with detailed type annotations.

--- a/packages/create/templates/worker/instructions/keepsync/.cursorrules
+++ b/packages/create/templates/worker/instructions/keepsync/.cursorrules
@@ -118,9 +118,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -144,4 +145,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/worker/instructions/keepsync/.windsurfrules
+++ b/packages/create/templates/worker/instructions/keepsync/.windsurfrules
@@ -118,9 +118,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -144,4 +145,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/worker/instructions/keepsync/CLAUDE.md
+++ b/packages/create/templates/worker/instructions/keepsync/CLAUDE.md
@@ -185,14 +185,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -218,11 +218,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/create/templates/worker/instructions/keepsync/llms.txt
+++ b/packages/create/templates/worker/instructions/keepsync/llms.txt
@@ -185,14 +185,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -218,11 +218,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/create/templates/workspace/console/instructions/keepsync/.cursorrules
+++ b/packages/create/templates/workspace/console/instructions/keepsync/.cursorrules
@@ -112,9 +112,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -138,4 +139,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/workspace/console/instructions/keepsync/.windsurfrules
+++ b/packages/create/templates/workspace/console/instructions/keepsync/.windsurfrules
@@ -112,9 +112,10 @@ You can also directly read and write documents and address them using paths simi
 a zustand store is too cumbersome (e.g. when you want each document to have its own space and be directly addressable);
 
 
-```
-import { readDoc, writeDoc } from "@tonk/keepsync";
+```typescript
+import { readDoc, writeDoc, ls, mkDir, rm, listenToDoc } from "@tonk/keepsync";
 
+/**
  * Reads a document from keepsync
  *
  * This function retrieves a document at the specified path in your sync engine.
@@ -138,4 +139,97 @@ readDoc = async <T>(path: string): Promise<T | undefined>;
  * @throws Error if the SyncEngine is not properly initialized
  */
 writeDoc = async <T>(path: string, content: T);
+
+/**
+ * Lists documents at a specified path
+ *
+ * This function retrieves a list of documents at the specified directory path.
+ * It returns an array of document names found at that path.
+ *
+ * @param path - The directory path to list documents from
+ * @returns Promise resolving to an array of document names
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+ls = async (path: string): Promise<string[]>;
+
+/**
+ * Creates a directory at the specified path
+ *
+ * This function creates a new directory at the specified path.
+ * If the directory already exists, it does nothing.
+ *
+ * @param path - The path where the directory should be created
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+mkDir = async (path: string): Promise<void>;
+
+/**
+ * Removes a document or directory at the specified path
+ *
+ * This function deletes a document or directory at the specified path.
+ * If removing a directory, it will remove all documents within it.
+ *
+ * @param path - The path of the document or directory to remove
+ * @param recursive - Whether to recursively remove directories (default: false)
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+rm = async (path: string, recursive?: boolean): Promise<void>;
+
+/**
+ * Listens for changes to a document
+ *
+ * This function sets up a listener for changes to a document at the specified path.
+ * The callback will be called whenever the document changes with detailed patch information.
+ *
+ * @param path - The path of the document to listen to
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
+ * @returns A function that can be called to stop listening
+ * @throws Error if the SyncEngine is not properly initialized
+ */
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
+```
+
+## File System Operations Example
+
+Here's an example of how to use the file system operations:
+
+```typescript
+import { ls, mkDir, rm, readDoc, writeDoc, listenToDoc } from "@tonk/keepsync";
+
+// Create a directory structure
+await mkDir("/users");
+
+// Write a document
+await writeDoc("/users/user1", { name: "Alice", age: 30 });
+await writeDoc("/users/user2", { name: "Bob", age: 25 });
+
+// List documents in a directory
+const users = await ls("/users");
+console.log(users); // ["user1", "user2"]
+
+// Read a document
+const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
+console.log(user1); // { name: "Alice", age: 30 }
+
+// Listen for changes to a document
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
+  if (user) {
+    console.log(`User updated: ${user.name}, ${user.age}`);
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
+  }
+});
+
+// Update the document (will trigger the listener)
+await writeDoc("/users/user1", { name: "Alice", age: 31 });
+
+// Stop listening when done
+unsubscribe();
+
+// Remove a document
+await rm("/users/user2");
+
+// Remove a directory and all its contents
+await rm("/users", true);
 ```

--- a/packages/create/templates/workspace/console/instructions/keepsync/CLAUDE.md
+++ b/packages/create/templates/workspace/console/instructions/keepsync/CLAUDE.md
@@ -179,14 +179,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -212,11 +212,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/create/templates/workspace/console/instructions/keepsync/llms.txt
+++ b/packages/create/templates/workspace/console/instructions/keepsync/llms.txt
@@ -179,14 +179,14 @@ rm = async (path: string, recursive?: boolean): Promise<void>;
  * Listens for changes to a document
  *
  * This function sets up a listener for changes to a document at the specified path.
- * The callback will be called whenever the document changes.
+ * The callback will be called whenever the document changes with detailed patch information.
  *
  * @param path - The path of the document to listen to
- * @param callback - Function to call when the document changes
+ * @param callback - Function to call when the document changes, receives payload with doc, patches, patchInfo, and handle
  * @returns A function that can be called to stop listening
  * @throws Error if the SyncEngine is not properly initialized
  */
-listenToDoc = <T>(path: string, callback: (doc: T | undefined) => void): () => void;
+listenToDoc = <T>(path: string, callback: (payload: { doc: T; patches: any[]; patchInfo: any; handle: DocHandle<T> }) => void): Promise<() => void>;
 ```
 
 ## File System Operations Example
@@ -212,11 +212,12 @@ const user1 = await readDoc<{ name: string, age: number }>("/users/user1");
 console.log(user1); // { name: "Alice", age: 30 }
 
 // Listen for changes to a document
-const unsubscribe = listenToDoc<{ name: string, age: number }>("/users/user1", (user) => {
+const unsubscribe = await listenToDoc<{ name: string, age: number }>("/users/user1", (payload) => {
+  const { doc: user, patches, patchInfo, handle } = payload;
   if (user) {
     console.log(`User updated: ${user.name}, ${user.age}`);
-  } else {
-    console.log("User document not found or deleted");
+    console.log("Patches:", patches);
+    console.log("Patch info:", patchInfo);
   }
 });
 

--- a/packages/keepsync/package.json
+++ b/packages/keepsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/keepsync",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "A reactive sync engine framework for use with Tonk apps",
   "type": "module",
   "main": "./dist/index.js",

--- a/utils/copy-llms.js
+++ b/utils/copy-llms.js
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename);
 const PROJECT_SUBDIRS = [
   'packages/create/templates/react',
   'packages/create/templates/node',
+  'packages/create/templates/worker'
 ];
 
 function generateMDCName(dirPath) {


### PR DESCRIPTION
### Description

I wanted to get more granular information about changes happening to docs. Formerly, we weren't passing that up the from the listener.

### Other changes

I bumped the version and updated LLMS.txt

### Tested

Going to test this in another branch over the next couple of hours. I'm relatively confident it's fine given no TS errors. However, let's not push to NPM quite yet. @jackddouglas lmk if you need to update for whatever reason, we can quickly unblock this.

### Related issues

- closes TON-1086

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `@tonk/keepsync` library by introducing new features, improving documentation, and updating version numbers across several packages. It emphasizes better handling of document changes with detailed patch information and expands the API functionality.

### Detailed summary
- Added support for a new `worker` template in `utils/copy-llms.js`.
- Updated version to `0.4.0` in `packages/create/package.json`.
- Updated version to `0.5.0` in `packages/keepsync/package.json`.
- Introduced a new API to fetch documents by ID in `keepsync` instructions.
- Enhanced `listenToDoc` function to include detailed payload with patches and patch info.
- Updated various documentation files to reflect new features and usage examples.
- Improved TypeScript interfaces and JSDoc comments for clarity.
- Added file system operation examples in multiple instruction files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->