### PR TITLE
patch(create): add .npmignore and update whitelist to filter out node…

### DIFF
--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -1,0 +1,27 @@
+node_modules/
+
+# Exclude node_modules and workspace folders from templates (comprehensive patterns)
+templates/**/node_modules/
+templates/**/node_modules/**
+templates/**/workspace/
+templates/**/workspace/**
+templates/**/.pnpm/
+templates/**/.pnpm/**
+
+# Exclude lock files from templates
+templates/**/pnpm-lock.yaml
+templates/**/package-lock.json
+templates/**/yarn.lock
+
+# Exclude other build/dev artifacts from templates
+templates/**/.DS_Store
+templates/**/dist/
+templates/**/dist/**
+templates/**/dev-dist/
+templates/**/dev-dist/**
+templates/**/.next/
+templates/**/.next/**
+templates/**/coverage/
+templates/**/coverage/**
+templates/**/.nyc_output/
+templates/**/.nyc_output/**

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -19,7 +19,16 @@
   "files": [
     "bin",
     "dist",
-    "templates"
+    "templates",
+    "!templates/**/node_modules/**",
+    "!templates/**/.pnpm/**",
+    "!templates/**/pnpm-lock.yaml",
+    "!templates/**/package-lock.json",
+    "!templates/**/yarn.lock",
+    "!templates/**/dist/**",
+    "!templates/**/dev-dist/**",
+    "!templates/**/.DS_Store",
+    "!templates/workspace"
   ],
   "scripts": {
     "build": "tsup && chmod +x ./dist/create.js",


### PR DESCRIPTION
…_modules and unnecessary templates

### Description

The package.json was overly permissive in what it was trying to bring in on the templates side. So we're now explicitly whitelisting and blacklisting certain files in the templates for create project

### Tested

Testing with `npm pack --dry-run`


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `.npmignore` and `package.json` files to exclude various files and directories from being published, particularly within the `templates` directory. This helps in keeping the package lightweight and free from unnecessary files.

### Detailed summary
- Updated `package.json` to include exclusion patterns for:
  - `node_modules`, `.pnpm`, lock files, and various build artifacts in `templates`.
- Enhanced `.npmignore` with comprehensive patterns to exclude:
  - `node_modules/`, `workspace/`, lock files, `.DS_Store`, and build directories (`dist`, `dev-dist`, `.next`, `coverage`, `.nyc_output`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->