### PR TITLE
feat(cli): `tonk-auth` version bump

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@tonk/server": "^0.2.15",
-    "@tonk/tonk-auth": "^0.1.9",
+    "@tonk/tonk-auth": "^0.1.13",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^11.1.0",

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15(@types/node@22.15.32)(typescript@5.8.3)
       '@tonk/tonk-auth':
-        specifier: ^0.1.5
-        version: 0.1.5(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        specifier: ^0.1.13
+        version: 0.1.13(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
@@ -1233,9 +1233,9 @@ packages:
   '@tonk/server@0.2.15':
     resolution: {integrity: sha512-uGBXP0LztSqrTQ3JMuPesxXPZFBcXPZJggy0R1DhGXtKRhY7n+Y5jfCYRt2L6Oki0DzNwLef5QRfPqZzDmmhuw==}
 
-  '@tonk/tonk-auth@0.1.5':
-    resolution: {integrity: sha512-a18+n+LOGcX1I1tdNyE23/nQ9SvUA2So9NtPTD4uMNL2GLK40GQV89nhOecEExPFqiFNrHZuBntF1j2bYmlXhA==}
-    engines: {node: '>=18'}
+  '@tonk/tonk-auth@0.1.13':
+    resolution: {integrity: sha512-3DHuJG/IZjzm3GtVpEHvKF7cBb2dLjTACzCvcshy9cEsOMhZKI0qcHRYXlQD1sT1TKE7cgLAbY5PcS/1/8zJNw==}
+    engines: {node: '>=22'}
     peerDependencies:
       typescript: ^5
 
@@ -5663,7 +5663,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@tonk/tonk-auth@0.1.5(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@tonk/tonk-auth@0.1.13(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@clerk/clerk-js': 5.69.0(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
### Description

Updated `tonk-auth` to latest version

### Related issues

- closes #TON-1157

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

-
_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

-
_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `@tonk/tonk-auth` package in both `package.json` and `pnpm-lock.yaml` files.

### Detailed summary
- Updated `@tonk/tonk-auth` from version `^0.1.9` to `^0.1.13` in `packages/cli/package.json`.
- Updated the `specifier` for `@tonk/tonk-auth` from `^0.1.9` to `^0.1.13` in `packages/cli/pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->