### PR TITLE
feat(cli, create): reliable install flow

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "The Tonk stack command line utility",
   "type": "module",
   "bin": {

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15(@types/node@22.15.32)(typescript@5.8.3)
       '@tonk/tonk-auth':
-        specifier: ^0.1.5
-        version: 0.1.5(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        specifier: ^0.1.9
+        version: 0.1.13(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
@@ -1233,9 +1233,9 @@ packages:
   '@tonk/server@0.2.15':
     resolution: {integrity: sha512-uGBXP0LztSqrTQ3JMuPesxXPZFBcXPZJggy0R1DhGXtKRhY7n+Y5jfCYRt2L6Oki0DzNwLef5QRfPqZzDmmhuw==}
 
-  '@tonk/tonk-auth@0.1.5':
-    resolution: {integrity: sha512-a18+n+LOGcX1I1tdNyE23/nQ9SvUA2So9NtPTD4uMNL2GLK40GQV89nhOecEExPFqiFNrHZuBntF1j2bYmlXhA==}
-    engines: {node: '>=18'}
+  '@tonk/tonk-auth@0.1.13':
+    resolution: {integrity: sha512-3DHuJG/IZjzm3GtVpEHvKF7cBb2dLjTACzCvcshy9cEsOMhZKI0qcHRYXlQD1sT1TKE7cgLAbY5PcS/1/8zJNw==}
+    engines: {node: '>=22'}
     peerDependencies:
       typescript: ^5
 
@@ -5663,7 +5663,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@tonk/tonk-auth@0.1.5(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@tonk/tonk-auth@0.1.13(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@clerk/clerk-js': 5.69.0(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)

--- a/packages/cli/src/commands/hello.ts
+++ b/packages/cli/src/commands/hello.ts
@@ -48,8 +48,9 @@ export const helloCommand = new Command('hello')
             await execAsync('pm2 restart tonkserver');
           } else {
             // Start the tonk daemon with PM2
-            const {stdout: tonkPath} = await execAsync('which tonk');
-            await execAsync(`pm2 start --interpreter bash "${tonkPath.trim()}" --name tonkserver -- -d`);
+            const {stdout: whichTonk} = await execAsync('which tonk');
+            const tonkPath = whichTonk.trim();
+            await execAsync(`pm2 start ${tonkPath} --name tonkserver -- -d`);
           }
 
           console.log(chalk.green('Tonk daemon started successfully!'));

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Bootstrap apps on the Tonk stack",
   "type": "module",
   "bin": {

--- a/packages/create/templates/react/src/index.tsx
+++ b/packages/create/templates/react/src/index.tsx
@@ -27,7 +27,7 @@ const root = createRoot(container);
 
 const basename =
   import.meta.env.VITE_BASE_PATH !== "/"
-    ? import.meta.env.VITE_BASE_PATH.replace(/\/$/, "")
+    ? import.meta.env.VITE_BASE_PATH?.replace(/\/$/, "")
     : "";
 
 root.render(


### PR DESCRIPTION
### Description

- handle case where VITE_BASE_PATH isn't specified so react dev server runs reliably
- pm2 now runs the output of `$(which tonk)` rather than just `tonk`

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1166, TON-1167

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates version numbers across several packages, modifies a TypeScript file to handle optional chaining, and refines a command in the `hello.ts` file for starting the tonk daemon. Additionally, it updates the version of `@tonk/tonk-auth` in the lock file.

### Detailed summary
- Updated `@tonk/cli` version from `0.2.19` to `0.2.20`.
- Updated `@tonk/create` version from `0.4.2` to `0.4.3`.
- Modified optional chaining in `packages/create/templates/react/src/index.tsx`.
- Changed variable handling in `packages/cli/src/commands/hello.ts` for tonk daemon execution.
- Updated `@tonk/tonk-auth` version from `0.1.5` to `0.1.13` in `pnpm-lock.yaml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->