### PR TITLE
chore(cli): version bump tonk-auth

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@tonk/server": "^0.2.15",
-    "@tonk/tonk-auth": "^0.2.1",
+    "@tonk/tonk-auth": "^0.2.2",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^11.1.0",

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15(@types/node@22.15.32)(typescript@5.8.3)
       '@tonk/tonk-auth':
-        specifier: ^0.2.1
-        version: 0.2.1(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        specifier: ^0.2.2
+        version: 0.2.2(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
@@ -1243,8 +1243,8 @@ packages:
   '@tonk/server@0.2.15':
     resolution: {integrity: sha512-uGBXP0LztSqrTQ3JMuPesxXPZFBcXPZJggy0R1DhGXtKRhY7n+Y5jfCYRt2L6Oki0DzNwLef5QRfPqZzDmmhuw==}
 
-  '@tonk/tonk-auth@0.2.1':
-    resolution: {integrity: sha512-P2rdry1nkQWrox0S+wtgLQL5jNl8fkw9kvDx+Vzq64YvGNaGPXQPrd9ImIbQS9Wr45b0pRTW6HVlKH+8bYONug==}
+  '@tonk/tonk-auth@0.2.2':
+    resolution: {integrity: sha512-9ZcbNm81yZsxlAYz/H/TwWbFcGVeMK+oem0xGFtsLjJtXpWNXcJThxXEd0G98w2i9i1ol74mLkGqqrODKwkdnw==}
     engines: {node: '>=22'}
     peerDependencies:
       typescript: ^5
@@ -5681,7 +5681,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@tonk/tonk-auth@0.2.1(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@tonk/tonk-auth@0.2.2(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@clerk/clerk-js': 5.70.0(@types/react@18.3.23)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)

--- a/packages/cli/pnpm-workspace.yaml
+++ b/packages/cli/pnpm-workspace.yaml
@@ -1,7 +1,0 @@
-onlyBuiltDependencies:
-  - '@clerk/shared'
-  - browser-tabs-lock
-  - cbor-extract
-  - core-js
-  - esbuild
-  - keytar


### PR DESCRIPTION
### Description

Bumps `tonk-auth` to latest (0.2.2) to support new dashboard.tonk.xyz and Clerk production config.

### Other changes

No

### Tested

Yes

### Related issues

- closes TON-1254

### Backwards compatibility

Yes

### Documentation

No

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `@tonk/tonk-auth` from `0.2.1` to `0.2.2` in multiple files, reflecting changes in dependencies and lock files.

### Detailed summary
- Deleted `packages/cli/pnpm-workspace.yaml` and `packages/cli/package.json`.
- Updated `@tonk/tonk-auth` version from `0.2.1` to `0.2.2` in `packages/cli/package.json`.
- Updated `@tonk/tonk-auth` version in `packages/cli/pnpm-lock.yaml`.
- Updated integrity hash for `@tonk/tonk-auth` in the lock file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->