### PR TITLE
chore(create): TON-1292: bump version

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/create",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Bootstrap apps on the Tonk stack",
   "type": "module",
   "bin": {
@@ -27,8 +27,7 @@
     "!templates/**/yarn.lock",
     "!templates/**/dist/**",
     "!templates/**/dev-dist/**",
-    "!templates/**/.DS_Store",
-    "!templates/workspace"
+    "!templates/**/.DS_Store"
   ],
   "scripts": {
     "build": "tsup && chmod +x ./dist/create.js",


### PR DESCRIPTION
### Description

- bump `@tonk/create` to include new workspace template and CLI options

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1292

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `version` of the `@tonk/create` package in the `package.json` file from `0.4.5` to `0.4.6`. It also removes a specific entry from the `.gitignore` list.

### Detailed summary
- Updated `version` from `0.4.5` to `0.4.6` in `package.json`
- Removed the entry `"!templates/workspace"` from the `.gitignore` list

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->