### PR TITLE
feat(cli): TON-1288: protect privleged tonk subdomains

### DIFF
--- a/examples/my-world/src/components/MapView.tsx
+++ b/examples/my-world/src/components/MapView.tsx
@@ -32,7 +32,7 @@ declare global {
 
 const getMapKitToken = async (): Promise<string> => {
   const token =
-    "eyJraWQiOiI3VDU0M0RUWjIyIiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiI4V1ZLUzJGMjRDIiwiaWF0IjoxNzQ5MTE4NjQzLCJleHAiOjE3NDk3OTc5OTl9.DVld6WskUrlqbm2Cxqba_kbAzkezOihjhQT_RSc3fBGtNvovwxwIVGLnk0N3IPcpmXBTgEpoBZ5zi4y3omcI5A";
+    "eyJraWQiOiI3RlFUWllLS1k1IiwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJpc3MiOiI4V1ZLUzJGMjRDIiwiaWF0IjoxNzUyMTY0OTk2LCJvcmlnaW4iOiIqLnRvbmsueHl6In0.T2u2q3OGBXg1staBZZpmC9TISjH0G-G_-fvIDdfTUksz3S9kLrHFczwNIQEWD7igH_vz50MjpgizVV0TJF0Ljg";
 
   if (!token) {
     console.error("MapKit token not found in environment variables");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "The Tonk stack command line utility",
   "type": "module",
   "bin": {


### PR DESCRIPTION
### Description

- when creating a tonk server, reject names conflicting with tonk services

### Other changes

- updated my world with permanent domain-scoped API key

### Tested

Yes

### Related issues

- closes TON-1288

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@tonk/cli` package version and introduces a validation function for server names, ensuring they do not use privileged subdomains. It also refines error handling and improves code readability.

### Detailed summary
- Updated `version` from `0.2.27` to `0.2.28` in `packages/cli/package.json`.
- Added `PRIVILEGED_SUBDOMAINS` array to `packages/cli/src/commands/server.ts`.
- Implemented `validateServerName` function for server name validation.
- Replaced inline validation with `validateServerName` in several prompts.
- Simplified error handling in `createServer` and `deleteServer` functions.
- Reformatted console log statements for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->