### PR TITLE
patch(instructions): update the instructions to use the tonk cli flags

### DIFF
--- a/packages/create/templates/workspace/.cursor/rules/root-rules.mdc
+++ b/packages/create/templates/workspace/.cursor/rules/root-rules.mdc
@@ -1,6 +1,7 @@
 ---
 description: Rules and guidelines for root
 globs: */**/*.js, */**/*.ts, */**/*.tsx
+alwaysApply: false
 ---
 
 # What is a Workspace?
@@ -15,15 +16,15 @@ A workspace follows a specific organizational structure with four main directori
 
 - **`/instructions`** — Contains instructions and guidelines for coding agents. Instructions are co-located with functionality: project-level instructions in `/instructions/`, view-specific guidance in `/views/llms.txt`, worker patterns in `/workers/llms.txt`, etc.
 
-- **`/views`** — Storage location for Tonk apps (or views) created using `tonk create`. These are interactive React applications that visualize data and provide user interfaces
+- **`/views`** — Storage location for Tonk apps (or views) created using `tonk-create -t react -n <name> -d <description>`. These are interactive React applications that visualize data and provide user interfaces
 
-- **`/workers`** — Contains Tonk workers created with `tonk create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
+- **`/workers`** — Contains Tonk workers created with `tonk-create -t worker -n <name> -d <description>`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
 
 ## Agent Interaction Model
 
 **Command-Line Assistant**: The agent interacts through command-line tool use, acting as a conversational assistant that helps users build data processing pipelines. The agent should:
 
-- Guide users through `tonk create` CLI flows (interactive selection of component type and naming)
+- Help users create views and workers via `tonk-create` commands 
 - **Vibecode** implementations (generate actual code on behalf of the user)
 - Suggest specific parsing libraries and technical approaches
 - Ask clarifying questions to disambiguate user intent
@@ -50,12 +51,12 @@ This creates **flows of data and visualizations over the flows** - an iterative 
 ## Agent Guidelines
 
 **File Format Handling**: If a file format isn't currently handled, guide the user to:
-1. Create a worker using `tonk create`
+1. Create a worker using `tonk-create -t worker -n <name> -d <description>`, using a name and description given by the user
 2. Vibecode the worker to parse the file format (suggest specific parsing libraries)
 3. Store parsed data in keepsync
 4. Create a view to visualize the data
 
-**Scaffolding Process**: When running `tonk create`, help users navigate the interactive CLI:
+**Scaffolding Process**: When running `tonk-create`, help users navigate the interactive CLI:
 - Select component type (worker/view)
 - Choose meaningful names based on stated goals
 - Provide context-aware suggestions during the flow

--- a/packages/create/templates/workspace/.cursorrules
+++ b/packages/create/templates/workspace/.cursorrules
@@ -10,15 +10,15 @@ A workspace follows a specific organizational structure with four main directori
 
 - **`/instructions`** — Contains instructions and guidelines for coding agents. Instructions are co-located with functionality: project-level instructions in `/instructions/`, view-specific guidance in `/views/llms.txt`, worker patterns in `/workers/llms.txt`, etc.
 
-- **`/views`** — Storage location for Tonk apps (or views) created using `tonk create`. These are interactive React applications that visualize data and provide user interfaces
+- **`/views`** — Storage location for Tonk apps (or views) created using `tonk-create`. These are interactive React applications that visualize data and provide user interfaces
 
-- **`/workers`** — Contains Tonk workers created with `tonk create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
+- **`/workers`** — Contains Tonk workers created with `tonk-create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
 
 ## Agent Interaction Model
 
 **Command-Line Assistant**: The agent interacts through command-line tool use, acting as a conversational assistant that helps users build data processing pipelines. The agent should:
 
-- Guide users through `tonk create` CLI flows (interactive selection of component type and naming)
+- Guide users through the process of creating views and workers
 - **Vibecode** implementations (generate actual code on behalf of the user)
 - Suggest specific parsing libraries and technical approaches
 - Ask clarifying questions to disambiguate user intent
@@ -45,15 +45,10 @@ This creates **flows of data and visualizations over the flows** - an iterative 
 ## Agent Guidelines
 
 **File Format Handling**: If a file format isn't currently handled, guide the user to:
-1. Create a worker using `tonk create`
+1. Create a worker using `tonk-create -t worker -n <name> -d <description of the worker>`
 2. Vibecode the worker to parse the file format (suggest specific parsing libraries)
 3. Store parsed data in keepsync
 4. Create a view to visualize the data
-
-**Scaffolding Process**: When running `tonk create`, help users navigate the interactive CLI:
-- Select component type (worker/view)
-- Choose meaningful names based on stated goals
-- Provide context-aware suggestions during the flow
 
 ## File Listening Pattern - IMPORTANT
 
@@ -96,6 +91,100 @@ const fileListener = await createAndStartFileListener(
 
 
 **Instructions Reference**: Always check relevant `llms.txt` files for component-specific patterns and guidelines before vibecoding implementations.
+
+## Tonk CLI Commands
+
+The Tonk CLI provides essential commands for managing your workspace and applications:
+
+### Main CLI (`tonk`)
+- **`tonk -d`** — Run the Tonk daemon (background server for managing bundles and stores)
+- **`tonk hello`** — Say hello to start and launch the tonk daemon
+- **`tonk auth`** — Log in to your Tonk account
+- **`tonk deploy`** — Deploy a Tonk bundle to an existing server
+- **`tonk server`** — Manage Tonk servers
+
+### Bundle Management
+- **`tonk push`** — Package, upload, build and start a bundle on the Tonk server
+- **`tonk start <bundleName>`** — Start a bundle on a route
+- **`tonk ps`** — List running bundles
+- **`tonk ls`** — List available bundles on the Tonk server
+- **`tonk kill <serverId>`** — Stop a running bundle server
+- **`tonk delete <bundleName>`** — Delete a bundle from the server (alias: `rm`)
+- **`tonk proxy <bundleName>`** — Create a reverse proxy to access a Tonk bundle
+
+### Worker Management (`tonk worker`)
+- **`tonk worker ls`** — List all registered workers
+- **`tonk worker inspect <nameOrId>`** — Inspect a specific worker
+- **`tonk worker start <nameOrId>`** — Start a worker
+- **`tonk worker stop <nameOrId>`** — Stop a worker
+- **`tonk worker rm <nameOrId>`** — Remove a registered worker
+- **`tonk worker ping <nameOrId>`** — Ping a worker to check its status
+- **`tonk worker logs <nameOrId>`** — View logs for a worker
+- **`tonk worker register [dir]`** — Register a worker with Tonk
+- **`tonk worker install <package>`** — Install and start a worker from npm
+- **`tonk worker init`** — Initialize a new worker configuration file
+
+### Create Command (`tonk-create`)
+
+The create command scaffolds code for your Tonk projects:
+
+**Usage**: `tonk-create [options]`
+
+**Options**:
+- `-v, --version` — Output the current version
+- `-i, --init` — Initialize in the current folder (instead of creating new directory)
+- `-t, --template <type>` — Template type: `react`, `worker`, or `workspace`
+- `-n, --name <name>` — Project name
+- `-d, --description <description>` — Project description
+
+**Template Types**:
+- **`react`** — "Create apps with your data" - Interactive React applications for data visualization
+- **`worker`** — "Retrieve data to use later" - Background processing and data ingestion
+- **`workspace`** — "Organize multiple projects" - Complete development environment structure
+
+**Examples**:
+```bash
+# Non-interactive mode
+tonk-create -t react -n my-dashboard -d "Sales data visualization"
+tonk-create --init -t workspace  # Initialize workspace in current directory
+```
+
+### Daemon Mode and Server Functionality
+
+The daemon (`tonk -d`) provides the core infrastructure:
+- **Bundle Storage**: Manages code bundles and their lifecycle
+- **Data Stores**: Maintains keepsync stores for data synchronization
+- **Process Coordination**: Handles running workers and serving React apps
+- **Worker Registry**: Manages registered workers and their states
+- **Server Infrastructure**: Runs TonkServer for handling requests
+
+## LLM Agent Workspace Navigation
+
+When working within a Tonk workspace, the LLM should understand these interaction patterns:
+
+### Project Creation Workflow
+1. **Understand Requirements**: Determine if user needs data ingestion (worker), visualization (react), or full environment (workspace)
+2. **Guide CLI Usage**: Use `tonk-create` with appropriate template and meaningful names
+3. **Implement Logic**: Vibecode the functionality using established patterns and libraries
+4. **Register and Start**: For workers, use `tonk worker register` and `tonk worker start` to activate them
+
+### Worker Management Patterns
+- **Development Cycle**: Create with `tonk-create -t worker -n <name> -d <description>`, register with `tonk worker register`, start with `tonk worker start`
+- **Debugging**: Use `tonk worker logs <worker>` to view output and `tonk worker ping <worker>` to check status
+- **Monitoring**: Check `tonk worker ls` to see all registered workers and their states
+- **Cleanup**: Use `tonk worker stop <worker>` and `tonk worker rm <worker>` to remove unused workers
+
+### Development Best Practices
+- **Check Existing Patterns**: Look at `/workers/` and `/views/` for similar implementations
+- **Follow Conventions**: Use established libraries and coding patterns from the workspace
+- **Reference Instructions**: Always check relevant `llms.txt` files for component-specific guidance
+- **Use FileListener Pattern**: For file watching, always use the existing FileListener from `src/listeners/fileListener.ts`
+
+### Troubleshooting and Debugging
+- **Daemon Status**: Ensure `tonk -d` is running for all workspace operations
+- **Worker Status**: Use `tonk worker ls` and `tonk worker ping <worker>` to monitor worker health
+- **Logs**: Check `tonk worker logs <worker>` for error messages and debugging information
+- **Data Flow**: Verify keepsync stores through the console app for data debugging
 
 ## Core Philosophy
 

--- a/packages/create/templates/workspace/.windsurfrules
+++ b/packages/create/templates/workspace/.windsurfrules
@@ -10,15 +10,15 @@ A workspace follows a specific organizational structure with four main directori
 
 - **`/instructions`** — Contains instructions and guidelines for coding agents. Instructions are co-located with functionality: project-level instructions in `/instructions/`, view-specific guidance in `/views/llms.txt`, worker patterns in `/workers/llms.txt`, etc.
 
-- **`/views`** — Storage location for Tonk apps (or views) created using `tonk create`. These are interactive React applications that visualize data and provide user interfaces
+- **`/views`** — Storage location for Tonk apps (or views) created using `tonk-create`. These are interactive React applications that visualize data and provide user interfaces
 
-- **`/workers`** — Contains Tonk workers created with `tonk create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
+- **`/workers`** — Contains Tonk workers created with `tonk-create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
 
 ## Agent Interaction Model
 
 **Command-Line Assistant**: The agent interacts through command-line tool use, acting as a conversational assistant that helps users build data processing pipelines. The agent should:
 
-- Guide users through `tonk create` CLI flows (interactive selection of component type and naming)
+- Guide users through the process of creating views and workers
 - **Vibecode** implementations (generate actual code on behalf of the user)
 - Suggest specific parsing libraries and technical approaches
 - Ask clarifying questions to disambiguate user intent
@@ -45,15 +45,10 @@ This creates **flows of data and visualizations over the flows** - an iterative 
 ## Agent Guidelines
 
 **File Format Handling**: If a file format isn't currently handled, guide the user to:
-1. Create a worker using `tonk create`
+1. Create a worker using `tonk-create -t worker -n <name> -d <description of the worker>`
 2. Vibecode the worker to parse the file format (suggest specific parsing libraries)
 3. Store parsed data in keepsync
 4. Create a view to visualize the data
-
-**Scaffolding Process**: When running `tonk create`, help users navigate the interactive CLI:
-- Select component type (worker/view)
-- Choose meaningful names based on stated goals
-- Provide context-aware suggestions during the flow
 
 ## File Listening Pattern - IMPORTANT
 
@@ -96,6 +91,100 @@ const fileListener = await createAndStartFileListener(
 
 
 **Instructions Reference**: Always check relevant `llms.txt` files for component-specific patterns and guidelines before vibecoding implementations.
+
+## Tonk CLI Commands
+
+The Tonk CLI provides essential commands for managing your workspace and applications:
+
+### Main CLI (`tonk`)
+- **`tonk -d`** — Run the Tonk daemon (background server for managing bundles and stores)
+- **`tonk hello`** — Say hello to start and launch the tonk daemon
+- **`tonk auth`** — Log in to your Tonk account
+- **`tonk deploy`** — Deploy a Tonk bundle to an existing server
+- **`tonk server`** — Manage Tonk servers
+
+### Bundle Management
+- **`tonk push`** — Package, upload, build and start a bundle on the Tonk server
+- **`tonk start <bundleName>`** — Start a bundle on a route
+- **`tonk ps`** — List running bundles
+- **`tonk ls`** — List available bundles on the Tonk server
+- **`tonk kill <serverId>`** — Stop a running bundle server
+- **`tonk delete <bundleName>`** — Delete a bundle from the server (alias: `rm`)
+- **`tonk proxy <bundleName>`** — Create a reverse proxy to access a Tonk bundle
+
+### Worker Management (`tonk worker`)
+- **`tonk worker ls`** — List all registered workers
+- **`tonk worker inspect <nameOrId>`** — Inspect a specific worker
+- **`tonk worker start <nameOrId>`** — Start a worker
+- **`tonk worker stop <nameOrId>`** — Stop a worker
+- **`tonk worker rm <nameOrId>`** — Remove a registered worker
+- **`tonk worker ping <nameOrId>`** — Ping a worker to check its status
+- **`tonk worker logs <nameOrId>`** — View logs for a worker
+- **`tonk worker register [dir]`** — Register a worker with Tonk
+- **`tonk worker install <package>`** — Install and start a worker from npm
+- **`tonk worker init`** — Initialize a new worker configuration file
+
+### Create Command (`tonk-create`)
+
+The create command scaffolds code for your Tonk projects:
+
+**Usage**: `tonk-create [options]`
+
+**Options**:
+- `-v, --version` — Output the current version
+- `-i, --init` — Initialize in the current folder (instead of creating new directory)
+- `-t, --template <type>` — Template type: `react`, `worker`, or `workspace`
+- `-n, --name <name>` — Project name
+- `-d, --description <description>` — Project description
+
+**Template Types**:
+- **`react`** — "Create apps with your data" - Interactive React applications for data visualization
+- **`worker`** — "Retrieve data to use later" - Background processing and data ingestion
+- **`workspace`** — "Organize multiple projects" - Complete development environment structure
+
+**Examples**:
+```bash
+# Non-interactive mode
+tonk-create -t react -n my-dashboard -d "Sales data visualization"
+tonk-create --init -t workspace  # Initialize workspace in current directory
+```
+
+### Daemon Mode and Server Functionality
+
+The daemon (`tonk -d`) provides the core infrastructure:
+- **Bundle Storage**: Manages code bundles and their lifecycle
+- **Data Stores**: Maintains keepsync stores for data synchronization
+- **Process Coordination**: Handles running workers and serving React apps
+- **Worker Registry**: Manages registered workers and their states
+- **Server Infrastructure**: Runs TonkServer for handling requests
+
+## LLM Agent Workspace Navigation
+
+When working within a Tonk workspace, the LLM should understand these interaction patterns:
+
+### Project Creation Workflow
+1. **Understand Requirements**: Determine if user needs data ingestion (worker), visualization (react), or full environment (workspace)
+2. **Guide CLI Usage**: Use `tonk-create` with appropriate template and meaningful names
+3. **Implement Logic**: Vibecode the functionality using established patterns and libraries
+4. **Register and Start**: For workers, use `tonk worker register` and `tonk worker start` to activate them
+
+### Worker Management Patterns
+- **Development Cycle**: Create with `tonk-create -t worker -n <name> -d <description>`, register with `tonk worker register`, start with `tonk worker start`
+- **Debugging**: Use `tonk worker logs <worker>` to view output and `tonk worker ping <worker>` to check status
+- **Monitoring**: Check `tonk worker ls` to see all registered workers and their states
+- **Cleanup**: Use `tonk worker stop <worker>` and `tonk worker rm <worker>` to remove unused workers
+
+### Development Best Practices
+- **Check Existing Patterns**: Look at `/workers/` and `/views/` for similar implementations
+- **Follow Conventions**: Use established libraries and coding patterns from the workspace
+- **Reference Instructions**: Always check relevant `llms.txt` files for component-specific guidance
+- **Use FileListener Pattern**: For file watching, always use the existing FileListener from `src/listeners/fileListener.ts`
+
+### Troubleshooting and Debugging
+- **Daemon Status**: Ensure `tonk -d` is running for all workspace operations
+- **Worker Status**: Use `tonk worker ls` and `tonk worker ping <worker>` to monitor worker health
+- **Logs**: Check `tonk worker logs <worker>` for error messages and debugging information
+- **Data Flow**: Verify keepsync stores through the console app for data debugging
 
 ## Core Philosophy
 

--- a/packages/create/templates/workspace/CLAUDE.md
+++ b/packages/create/templates/workspace/CLAUDE.md
@@ -10,15 +10,15 @@ A workspace follows a specific organizational structure with four main directori
 
 - **`/instructions`** — Contains instructions and guidelines for coding agents. Instructions are co-located with functionality: project-level instructions in `/instructions/`, view-specific guidance in `/views/llms.txt`, worker patterns in `/workers/llms.txt`, etc.
 
-- **`/views`** — Storage location for Tonk apps (or views) created using `tonk create`. These are interactive React applications that visualize data and provide user interfaces
+- **`/views`** — Storage location for Tonk apps (or views) created using `tonk-create`. These are interactive React applications that visualize data and provide user interfaces
 
-- **`/workers`** — Contains Tonk workers created with `tonk create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
+- **`/workers`** — Contains Tonk workers created with `tonk-create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
 
 ## Agent Interaction Model
 
 **Command-Line Assistant**: The agent interacts through command-line tool use, acting as a conversational assistant that helps users build data processing pipelines. The agent should:
 
-- Guide users through `tonk create` CLI flows (interactive selection of component type and naming)
+- Guide users through the process of creating views and workers
 - **Vibecode** implementations (generate actual code on behalf of the user)
 - Suggest specific parsing libraries and technical approaches
 - Ask clarifying questions to disambiguate user intent
@@ -45,15 +45,10 @@ This creates **flows of data and visualizations over the flows** - an iterative 
 ## Agent Guidelines
 
 **File Format Handling**: If a file format isn't currently handled, guide the user to:
-1. Create a worker using `tonk create`
+1. Create a worker using `tonk-create -t worker -n <name> -d <description of the worker>`
 2. Vibecode the worker to parse the file format (suggest specific parsing libraries)
 3. Store parsed data in keepsync
 4. Create a view to visualize the data
-
-**Scaffolding Process**: When running `tonk create`, help users navigate the interactive CLI:
-- Select component type (worker/view)
-- Choose meaningful names based on stated goals
-- Provide context-aware suggestions during the flow
 
 ## File Listening Pattern - IMPORTANT
 
@@ -105,7 +100,6 @@ The Tonk CLI provides essential commands for managing your workspace and applica
 - **`tonk -d`** — Run the Tonk daemon (background server for managing bundles and stores)
 - **`tonk hello`** — Say hello to start and launch the tonk daemon
 - **`tonk auth`** — Log in to your Tonk account
-- **`tonk create`** — Create a new tonk application or component
 - **`tonk deploy`** — Deploy a Tonk bundle to an existing server
 - **`tonk server`** — Manage Tonk servers
 
@@ -130,11 +124,11 @@ The Tonk CLI provides essential commands for managing your workspace and applica
 - **`tonk worker install <package>`** — Install and start a worker from npm
 - **`tonk worker init`** — Initialize a new worker configuration file
 
-### Create Command (`tonk create`)
+### Create Command (`tonk-create`)
 
 The create command scaffolds code for your Tonk projects:
 
-**Usage**: `tonk create [options]`
+**Usage**: `tonk-create [options]`
 
 **Options**:
 - `-v, --version` — Output the current version
@@ -150,12 +144,9 @@ The create command scaffolds code for your Tonk projects:
 
 **Examples**:
 ```bash
-# Interactive mode (prompts for choices)
-tonk create
-
 # Non-interactive mode
-tonk create -t react -n my-dashboard -d "Sales data visualization"
-tonk create --init -t workspace  # Initialize workspace in current directory
+tonk-create -t react -n my-dashboard -d "Sales data visualization"
+tonk-create --init -t workspace  # Initialize workspace in current directory
 ```
 
 ### Daemon Mode and Server Functionality
@@ -173,12 +164,12 @@ When working within a Tonk workspace, the LLM should understand these interactio
 
 ### Project Creation Workflow
 1. **Understand Requirements**: Determine if user needs data ingestion (worker), visualization (react), or full environment (workspace)
-2. **Guide CLI Usage**: Use `tonk create` with appropriate template and meaningful names
+2. **Guide CLI Usage**: Use `tonk-create` with appropriate template and meaningful names
 3. **Implement Logic**: Vibecode the functionality using established patterns and libraries
 4. **Register and Start**: For workers, use `tonk worker register` and `tonk worker start` to activate them
 
 ### Worker Management Patterns
-- **Development Cycle**: Create with `tonk create -t worker`, register with `tonk worker register`, start with `tonk worker start`
+- **Development Cycle**: Create with `tonk-create -t worker -n <name> -d <description>`, register with `tonk worker register`, start with `tonk worker start`
 - **Debugging**: Use `tonk worker logs <worker>` to view output and `tonk worker ping <worker>` to check status
 - **Monitoring**: Check `tonk worker ls` to see all registered workers and their states
 - **Cleanup**: Use `tonk worker stop <worker>` and `tonk worker rm <worker>` to remove unused workers

--- a/packages/create/templates/workspace/instructions/.cursor/rules/instructions-rules.mdc
+++ b/packages/create/templates/workspace/instructions/.cursor/rules/instructions-rules.mdc
@@ -1,6 +1,7 @@
 ---
 description: Rules and guidelines for root
 globs: */**/*.js, */**/*.ts, */**/*.tsx
+alwaysApply: false
 ---
 
 # Tonk Workspace Agent Instructions
@@ -32,12 +33,10 @@ When users ask what this workspace is for or what you can help them with, explai
 - If the user is experiencing issues with syncing, it might be because the Tonk daemon is not running
 - Starts the local Tonk daemon
 
-### 2. `tonk create`
+### 2. `tonk-create`
 Use this when users need functionality or data that doesn't already exist in the workspace.
-- Launches an interactive CLI form to guide setup
-  - Gives the user an option to create a new **view** (React applications for user interfaces)
-  - Gives the user an option to create a new **worker** (background processes for data fetching/storage)
-- Choose this when users request new features, data sources, or UI components
+- Ask the user for the name and escription of the worker they are creating
+- Choose this when users request data sources (tonk-create -t workers -n <name> -d <description>), or UI components (tonk-create -t react -n <name> -d <description>)
 
 ### 3. `tonk push`
 Use to prepare a view bundle for sharing (primarily for use with `tonk proxy`).
@@ -75,7 +74,7 @@ Creates a temporary reverse proxy for sharing (60-minute limit).
 ## Worker Management
 
 ### Worker Lifecycle Options
-After creating a worker with `tonk create`, you have two approaches:
+After creating a worker with `tonk-create`, you have two approaches:
 
 **Option A: Manual Development**
 - Run the worker manually using `pnpm dev` in the project directory
@@ -107,7 +106,7 @@ After creating a worker with `tonk create`, you have two approaches:
 
 When a user requests something, ask yourself:
 
-1. **Do they need new functionality?** → Use `tonk create`
+1. **Do they need new functionality?** → Use `tonk-create`
 2. **Do they want to share something temporarily?** → Use `tonk push`, then `tonk start`, then `tonk proxy`
 3. **Do they need to manage running services?** → You can use typical react commands for local development or for shareable bundles use `tonk ps`, `tonk start`, `tonk kill`
 4. **Do they need background data processing?** → Create and register workers
@@ -138,7 +137,7 @@ This workflow is ideal for:
 ## Common Workflows
 
 **New Feature Development:**
-2. `tonk create` → Create view/worker as needed
+2. `tonk-create` → Create view/worker as needed
 3. Develop and test locally
 4. Optionally use `tonk proxy` for mobile testing
 
@@ -148,7 +147,7 @@ This workflow is ideal for:
 3. `tonk proxy <bundle-name>` → Create 60-minute shareable link
 
 **Background Data Processing:**
-1. `tonk create` → Create worker
+1. `tonk-create` → Create worker
 2. `tonk worker register` → Register for background running
 3. `tonk worker start <nameOrId>` → Start the service
 

--- a/packages/create/templates/workspace/instructions/.cursorrules
+++ b/packages/create/templates/workspace/instructions/.cursorrules
@@ -27,12 +27,10 @@ When users ask what this workspace is for or what you can help them with, explai
 - If the user is experiencing issues with syncing, it might be because the Tonk daemon is not running
 - Starts the local Tonk daemon
 
-### 2. `tonk create`
+### 2. `tonk-create`
 Use this when users need functionality or data that doesn't already exist in the workspace.
-- Launches an interactive CLI form to guide setup
-  - Gives the user an option to create a new **view** (React applications for user interfaces)
-  - Gives the user an option to create a new **worker** (background processes for data fetching/storage)
-- Choose this when users request new features, data sources, or UI components
+- Ask the user for the name and escription of the worker they are creating
+- Choose this when users request data sources (tonk-create -t workers -n <name> -d <description>), or UI components (tonk-create -t react -n <name> -d <description>)
 
 ### 3. `tonk push`
 Use to prepare a view bundle for sharing (primarily for use with `tonk proxy`).
@@ -70,7 +68,7 @@ Creates a temporary reverse proxy for sharing (60-minute limit).
 ## Worker Management
 
 ### Worker Lifecycle Options
-After creating a worker with `tonk create`, you have two approaches:
+After creating a worker with `tonk-create`, you have two approaches:
 
 **Option A: Manual Development**
 - Run the worker manually using `pnpm dev` in the project directory
@@ -102,7 +100,7 @@ After creating a worker with `tonk create`, you have two approaches:
 
 When a user requests something, ask yourself:
 
-1. **Do they need new functionality?** → Use `tonk create`
+1. **Do they need new functionality?** → Use `tonk-create`
 2. **Do they want to share something temporarily?** → Use `tonk push`, then `tonk start`, then `tonk proxy`
 3. **Do they need to manage running services?** → You can use typical react commands for local development or for shareable bundles use `tonk ps`, `tonk start`, `tonk kill`
 4. **Do they need background data processing?** → Create and register workers
@@ -133,7 +131,7 @@ This workflow is ideal for:
 ## Common Workflows
 
 **New Feature Development:**
-2. `tonk create` → Create view/worker as needed
+2. `tonk-create` → Create view/worker as needed
 3. Develop and test locally
 4. Optionally use `tonk proxy` for mobile testing
 
@@ -143,7 +141,7 @@ This workflow is ideal for:
 3. `tonk proxy <bundle-name>` → Create 60-minute shareable link
 
 **Background Data Processing:**
-1. `tonk create` → Create worker
+1. `tonk-create` → Create worker
 2. `tonk worker register` → Register for background running
 3. `tonk worker start <nameOrId>` → Start the service
 

--- a/packages/create/templates/workspace/instructions/.windsurfrules
+++ b/packages/create/templates/workspace/instructions/.windsurfrules
@@ -27,12 +27,10 @@ When users ask what this workspace is for or what you can help them with, explai
 - If the user is experiencing issues with syncing, it might be because the Tonk daemon is not running
 - Starts the local Tonk daemon
 
-### 2. `tonk create`
+### 2. `tonk-create`
 Use this when users need functionality or data that doesn't already exist in the workspace.
-- Launches an interactive CLI form to guide setup
-  - Gives the user an option to create a new **view** (React applications for user interfaces)
-  - Gives the user an option to create a new **worker** (background processes for data fetching/storage)
-- Choose this when users request new features, data sources, or UI components
+- Ask the user for the name and escription of the worker they are creating
+- Choose this when users request data sources (tonk-create -t workers -n <name> -d <description>), or UI components (tonk-create -t react -n <name> -d <description>)
 
 ### 3. `tonk push`
 Use to prepare a view bundle for sharing (primarily for use with `tonk proxy`).
@@ -70,7 +68,7 @@ Creates a temporary reverse proxy for sharing (60-minute limit).
 ## Worker Management
 
 ### Worker Lifecycle Options
-After creating a worker with `tonk create`, you have two approaches:
+After creating a worker with `tonk-create`, you have two approaches:
 
 **Option A: Manual Development**
 - Run the worker manually using `pnpm dev` in the project directory
@@ -102,7 +100,7 @@ After creating a worker with `tonk create`, you have two approaches:
 
 When a user requests something, ask yourself:
 
-1. **Do they need new functionality?** → Use `tonk create`
+1. **Do they need new functionality?** → Use `tonk-create`
 2. **Do they want to share something temporarily?** → Use `tonk push`, then `tonk start`, then `tonk proxy`
 3. **Do they need to manage running services?** → You can use typical react commands for local development or for shareable bundles use `tonk ps`, `tonk start`, `tonk kill`
 4. **Do they need background data processing?** → Create and register workers
@@ -133,7 +131,7 @@ This workflow is ideal for:
 ## Common Workflows
 
 **New Feature Development:**
-2. `tonk create` → Create view/worker as needed
+2. `tonk-create` → Create view/worker as needed
 3. Develop and test locally
 4. Optionally use `tonk proxy` for mobile testing
 
@@ -143,7 +141,7 @@ This workflow is ideal for:
 3. `tonk proxy <bundle-name>` → Create 60-minute shareable link
 
 **Background Data Processing:**
-1. `tonk create` → Create worker
+1. `tonk-create` → Create worker
 2. `tonk worker register` → Register for background running
 3. `tonk worker start <nameOrId>` → Start the service
 

--- a/packages/create/templates/workspace/instructions/CLAUDE.md
+++ b/packages/create/templates/workspace/instructions/CLAUDE.md
@@ -27,12 +27,10 @@ When users ask what this workspace is for or what you can help them with, explai
 - If the user is experiencing issues with syncing, it might be because the Tonk daemon is not running
 - Starts the local Tonk daemon
 
-### 2. `tonk create`
+### 2. `tonk-create`
 Use this when users need functionality or data that doesn't already exist in the workspace.
-- Launches an interactive CLI form to guide setup
-  - Gives the user an option to create a new **view** (React applications for user interfaces)
-  - Gives the user an option to create a new **worker** (background processes for data fetching/storage)
-- Choose this when users request new features, data sources, or UI components
+- Ask the user for the name and escription of the worker they are creating
+- Choose this when users request data sources (tonk-create -t workers -n <name> -d <description>), or UI components (tonk-create -t react -n <name> -d <description>)
 
 ### 3. `tonk push`
 Use to prepare a view bundle for sharing (primarily for use with `tonk proxy`).
@@ -70,7 +68,7 @@ Creates a temporary reverse proxy for sharing (60-minute limit).
 ## Worker Management
 
 ### Worker Lifecycle Options
-After creating a worker with `tonk create`, you have two approaches:
+After creating a worker with `tonk-create`, you have two approaches:
 
 **Option A: Manual Development**
 - Run the worker manually using `pnpm dev` in the project directory
@@ -102,7 +100,7 @@ After creating a worker with `tonk create`, you have two approaches:
 
 When a user requests something, ask yourself:
 
-1. **Do they need new functionality?** → Use `tonk create`
+1. **Do they need new functionality?** → Use `tonk-create`
 2. **Do they want to share something temporarily?** → Use `tonk push`, then `tonk start`, then `tonk proxy`
 3. **Do they need to manage running services?** → You can use typical react commands for local development or for shareable bundles use `tonk ps`, `tonk start`, `tonk kill`
 4. **Do they need background data processing?** → Create and register workers
@@ -133,7 +131,7 @@ This workflow is ideal for:
 ## Common Workflows
 
 **New Feature Development:**
-2. `tonk create` → Create view/worker as needed
+2. `tonk-create` → Create view/worker as needed
 3. Develop and test locally
 4. Optionally use `tonk proxy` for mobile testing
 
@@ -143,7 +141,7 @@ This workflow is ideal for:
 3. `tonk proxy <bundle-name>` → Create 60-minute shareable link
 
 **Background Data Processing:**
-1. `tonk create` → Create worker
+1. `tonk-create` → Create worker
 2. `tonk worker register` → Register for background running
 3. `tonk worker start <nameOrId>` → Start the service
 

--- a/packages/create/templates/workspace/instructions/llms.txt
+++ b/packages/create/templates/workspace/instructions/llms.txt
@@ -27,12 +27,10 @@ When users ask what this workspace is for or what you can help them with, explai
 - If the user is experiencing issues with syncing, it might be because the Tonk daemon is not running
 - Starts the local Tonk daemon
 
-### 2. `tonk create`
+### 2. `tonk-create`
 Use this when users need functionality or data that doesn't already exist in the workspace.
-- Launches an interactive CLI form to guide setup
-  - Gives the user an option to create a new **view** (React applications for user interfaces)
-  - Gives the user an option to create a new **worker** (background processes for data fetching/storage)
-- Choose this when users request new features, data sources, or UI components
+- Ask the user for the name and escription of the worker they are creating
+- Choose this when users request data sources (tonk-create -t workers -n <name> -d <description>), or UI components (tonk-create -t react -n <name> -d <description>)
 
 ### 3. `tonk push`
 Use to prepare a view bundle for sharing (primarily for use with `tonk proxy`).
@@ -70,7 +68,7 @@ Creates a temporary reverse proxy for sharing (60-minute limit).
 ## Worker Management
 
 ### Worker Lifecycle Options
-After creating a worker with `tonk create`, you have two approaches:
+After creating a worker with `tonk-create`, you have two approaches:
 
 **Option A: Manual Development**
 - Run the worker manually using `pnpm dev` in the project directory
@@ -102,7 +100,7 @@ After creating a worker with `tonk create`, you have two approaches:
 
 When a user requests something, ask yourself:
 
-1. **Do they need new functionality?** → Use `tonk create`
+1. **Do they need new functionality?** → Use `tonk-create`
 2. **Do they want to share something temporarily?** → Use `tonk push`, then `tonk start`, then `tonk proxy`
 3. **Do they need to manage running services?** → You can use typical react commands for local development or for shareable bundles use `tonk ps`, `tonk start`, `tonk kill`
 4. **Do they need background data processing?** → Create and register workers
@@ -133,7 +131,7 @@ This workflow is ideal for:
 ## Common Workflows
 
 **New Feature Development:**
-2. `tonk create` → Create view/worker as needed
+2. `tonk-create` → Create view/worker as needed
 3. Develop and test locally
 4. Optionally use `tonk proxy` for mobile testing
 
@@ -143,7 +141,7 @@ This workflow is ideal for:
 3. `tonk proxy <bundle-name>` → Create 60-minute shareable link
 
 **Background Data Processing:**
-1. `tonk create` → Create worker
+1. `tonk-create` → Create worker
 2. `tonk worker register` → Register for background running
 3. `tonk worker start <nameOrId>` → Start the service
 

--- a/packages/create/templates/workspace/instructions/prompts/create-app-view.md
+++ b/packages/create/templates/workspace/instructions/prompts/create-app-view.md
@@ -8,8 +8,8 @@ This is a collaborative process. Ask questions before making assumptions. Always
 
 ## Before You Start
 
-1. **Location**: ALWAYS run `tonk create` from inside the `views/` directory
-2. **Creation**: Views are created using `tonk create` - this scaffolds the complete structure
+1. **Location**: ALWAYS run `tonk-create` from inside the `views/` directory
+2. **Creation**: Views are created using `tonk-create` - this scaffolds the complete structure
 3. **Directory**: Ensure the new view is created as a subdirectory within `views/`
 
 ## Key Architecture Patterns
@@ -43,7 +43,7 @@ A Tonk view includes:
 
 ```bash
 cd views/  # CRITICAL: Must be in views directory
-tonk create  # Select "react" when prompted
+tonk-create  # Select "react" when prompted
 cd view-name/
 pnpm install
 ```
@@ -177,6 +177,7 @@ I'm helping you set up a new Tonk View. To scaffold it properly, I need a few de
 
 After collecting this information, I'll:
 
-- Run tonk create in /views
+- Make sure I know the name and description of the view
+- Run tonk-create -t react -n <name> -d <description> in /views
 - Begin coding the view structure
 - Create the implementation checklist at root of workspace project /checklist.md

--- a/packages/create/templates/workspace/instructions/prompts/get-data.md
+++ b/packages/create/templates/workspace/instructions/prompts/get-data.md
@@ -8,8 +8,8 @@ This is a collaborative process. Ask questions before making assumptions. Always
 
 ## Before You Start
 
-1. **Location**: ALWAYS run `tonk create` from inside the `workers/` directory
-2. **Creation**: Workers are created using `tonk create` - this scaffolds the complete structure
+1. **Location**: ALWAYS run `tonk-create` from inside the `workers/` directory
+2. **Creation**: Workers are created using `tonk-create` - this scaffolds the complete structure
 3. **Directory**: Ensure the new worker is created as a subdirectory within `workers/`
 
 ## Key Architecture Patterns
@@ -34,7 +34,7 @@ A Tonk worker includes:
 
 ```bash
 cd workers/  # CRITICAL: Must be in workers directory
-tonk create  # Select "worker" when prompted
+tonk-create  # Select "worker" when prompted
 cd worker-name/
 pnpm install
 ```
@@ -136,9 +136,8 @@ if (!complete) {
 const googleCreds = await credentialsManager.getCredentialByName(
   "Google Service Account"
 );
-const openaiKey = await credentialsManager.getCredentialByName(
-  "OpenAI API Key"
-);
+const openaiKey =
+  await credentialsManager.getCredentialByName("OpenAI API Key");
 ```
 
 ### Credential Types Supported

--- a/packages/create/templates/workspace/llms.txt
+++ b/packages/create/templates/workspace/llms.txt
@@ -10,15 +10,15 @@ A workspace follows a specific organizational structure with four main directori
 
 - **`/instructions`** — Contains instructions and guidelines for coding agents. Instructions are co-located with functionality: project-level instructions in `/instructions/`, view-specific guidance in `/views/llms.txt`, worker patterns in `/workers/llms.txt`, etc.
 
-- **`/views`** — Storage location for Tonk apps (or views) created using `tonk create`. These are interactive React applications that visualize data and provide user interfaces
+- **`/views`** — Storage location for Tonk apps (or views) created using `tonk-create`. These are interactive React applications that visualize data and provide user interfaces
 
-- **`/workers`** — Contains Tonk workers created with `tonk create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
+- **`/workers`** — Contains Tonk workers created with `tonk-create`. These handle background processing, data ingestion, transformation, and can listen to keepsync stores or file systems for automated workflows
 
 ## Agent Interaction Model
 
 **Command-Line Assistant**: The agent interacts through command-line tool use, acting as a conversational assistant that helps users build data processing pipelines. The agent should:
 
-- Guide users through `tonk create` CLI flows (interactive selection of component type and naming)
+- Guide users through the process of creating views and workers
 - **Vibecode** implementations (generate actual code on behalf of the user)
 - Suggest specific parsing libraries and technical approaches
 - Ask clarifying questions to disambiguate user intent
@@ -45,15 +45,10 @@ This creates **flows of data and visualizations over the flows** - an iterative 
 ## Agent Guidelines
 
 **File Format Handling**: If a file format isn't currently handled, guide the user to:
-1. Create a worker using `tonk create`
+1. Create a worker using `tonk-create -t worker -n <name> -d <description of the worker>`
 2. Vibecode the worker to parse the file format (suggest specific parsing libraries)
 3. Store parsed data in keepsync
 4. Create a view to visualize the data
-
-**Scaffolding Process**: When running `tonk create`, help users navigate the interactive CLI:
-- Select component type (worker/view)
-- Choose meaningful names based on stated goals
-- Provide context-aware suggestions during the flow
 
 ## File Listening Pattern - IMPORTANT
 
@@ -105,7 +100,6 @@ The Tonk CLI provides essential commands for managing your workspace and applica
 - **`tonk -d`** — Run the Tonk daemon (background server for managing bundles and stores)
 - **`tonk hello`** — Say hello to start and launch the tonk daemon
 - **`tonk auth`** — Log in to your Tonk account
-- **`tonk create`** — Create a new tonk application or component
 - **`tonk deploy`** — Deploy a Tonk bundle to an existing server
 - **`tonk server`** — Manage Tonk servers
 
@@ -130,11 +124,11 @@ The Tonk CLI provides essential commands for managing your workspace and applica
 - **`tonk worker install <package>`** — Install and start a worker from npm
 - **`tonk worker init`** — Initialize a new worker configuration file
 
-### Create Command (`tonk create`)
+### Create Command (`tonk-create`)
 
 The create command scaffolds code for your Tonk projects:
 
-**Usage**: `tonk create [options]`
+**Usage**: `tonk-create [options]`
 
 **Options**:
 - `-v, --version` — Output the current version
@@ -150,12 +144,9 @@ The create command scaffolds code for your Tonk projects:
 
 **Examples**:
 ```bash
-# Interactive mode (prompts for choices)
-tonk create
-
 # Non-interactive mode
-tonk create -t react -n my-dashboard -d "Sales data visualization"
-tonk create --init -t workspace  # Initialize workspace in current directory
+tonk-create -t react -n my-dashboard -d "Sales data visualization"
+tonk-create --init -t workspace  # Initialize workspace in current directory
 ```
 
 ### Daemon Mode and Server Functionality
@@ -173,12 +164,12 @@ When working within a Tonk workspace, the LLM should understand these interactio
 
 ### Project Creation Workflow
 1. **Understand Requirements**: Determine if user needs data ingestion (worker), visualization (react), or full environment (workspace)
-2. **Guide CLI Usage**: Use `tonk create` with appropriate template and meaningful names
+2. **Guide CLI Usage**: Use `tonk-create` with appropriate template and meaningful names
 3. **Implement Logic**: Vibecode the functionality using established patterns and libraries
 4. **Register and Start**: For workers, use `tonk worker register` and `tonk worker start` to activate them
 
 ### Worker Management Patterns
-- **Development Cycle**: Create with `tonk create -t worker`, register with `tonk worker register`, start with `tonk worker start`
+- **Development Cycle**: Create with `tonk-create -t worker -n <name> -d <description>`, register with `tonk worker register`, start with `tonk worker start`
 - **Debugging**: Use `tonk worker logs <worker>` to view output and `tonk worker ping <worker>` to check status
 - **Monitoring**: Check `tonk worker ls` to see all registered workers and their states
 - **Cleanup**: Use `tonk worker stop <worker>` and `tonk worker rm <worker>` to remove unused workers

--- a/packages/create/templates/workspace/views/.cursor/rules/views-rules.mdc
+++ b/packages/create/templates/workspace/views/.cursor/rules/views-rules.mdc
@@ -1,6 +1,7 @@
 ---
 description: Rules and guidelines for root
 globs: */**/*.js, */**/*.ts, */**/*.tsx
+alwaysApply: false
 ---
 
 # Tonk View Architecture and Usage Guide
@@ -9,11 +10,11 @@ globs: */**/*.js, */**/*.ts, */**/*.tsx
 Tonk views are React-based frontend applications that integrate with the Tonk ecosystem for building local-first applications. They provide modern web UI/UX with real-time data synchronization using KeepSync and Automerge CRDTs, supporting offline-first collaborative experiences.
 
 ## Getting Started
-The view structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
+The view structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
 
 To create a new view:
 ```bash
-tonk create
+tonk-create -t worker -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "react" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/views/.cursorrules
+++ b/packages/create/templates/workspace/views/.cursorrules
@@ -4,11 +4,11 @@
 Tonk views are React-based frontend applications that integrate with the Tonk ecosystem for building local-first applications. They provide modern web UI/UX with real-time data synchronization using KeepSync and Automerge CRDTs, supporting offline-first collaborative experiences.
 
 ## Getting Started
-The view structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
+The view structure described in this guide is automatically created when you run `tonk-create -t react -n <name> -d <description>`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
 
 To create a new view:
 ```bash
-tonk create
+tonk-create -t react -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "react" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/views/.windsurfrules
+++ b/packages/create/templates/workspace/views/.windsurfrules
@@ -4,11 +4,11 @@
 Tonk views are React-based frontend applications that integrate with the Tonk ecosystem for building local-first applications. They provide modern web UI/UX with real-time data synchronization using KeepSync and Automerge CRDTs, supporting offline-first collaborative experiences.
 
 ## Getting Started
-The view structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
+The view structure described in this guide is automatically created when you run `tonk-create -t react -n <name> -d <description>`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
 
 To create a new view:
 ```bash
-tonk create
+tonk-create -t react -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "react" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/views/CLAUDE.md
+++ b/packages/create/templates/workspace/views/CLAUDE.md
@@ -4,11 +4,11 @@
 Tonk views are React-based frontend applications that integrate with the Tonk ecosystem for building local-first applications. They provide modern web UI/UX with real-time data synchronization using KeepSync and Automerge CRDTs, supporting offline-first collaborative experiences.
 
 ## Getting Started
-The view structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
+The view structure described in this guide is automatically created when you run `tonk-create -t react -n <name> -d <description>`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
 
 To create a new view:
 ```bash
-tonk create
+tonk-create -t react -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "react" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/views/llms.txt
+++ b/packages/create/templates/workspace/views/llms.txt
@@ -4,11 +4,11 @@
 Tonk views are React-based frontend applications that integrate with the Tonk ecosystem for building local-first applications. They provide modern web UI/UX with real-time data synchronization using KeepSync and Automerge CRDTs, supporting offline-first collaborative experiences.
 
 ## Getting Started
-The view structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
+The view structure described in this guide is automatically created when you run `tonk-create -t react -n <name> -d <description>`. This command will guide you through the process of creating a new view and scaffold a complete React application template folder with all the necessary files and configurations.
 
 To create a new view:
 ```bash
-tonk create
+tonk-create -t react -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "react" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/workers/.cursor/rules/workers-rules.mdc
+++ b/packages/create/templates/workspace/workers/.cursor/rules/workers-rules.mdc
@@ -1,6 +1,7 @@
 ---
 description: Rules and guidelines for root
 globs: */**/*.js, */**/*.ts, */**/*.tsx
+alwaysApply: false
 ---
 
 # Tonk Worker Architecture and Usage Guide
@@ -9,11 +10,11 @@ globs: */**/*.js, */**/*.ts, */**/*.tsx
 Tonk workers are Node.js-based services that integrate with the Tonk ecosystem for building local-first applications. They provide HTTP API endpoints and integrate with KeepSync for distributed data synchronization using Automerge CRDTs.
 
 ## Getting Started
-The worker structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
+The worker structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
 
 To create a new worker:
 ```bash
-tonk create
+tonk-create -t worker -n <name> -d <description>
 ```
 
 The CLI will prompt you to select "worker" as the project type and guide you through the setup process, generating the folder structure and files detailed below.

--- a/packages/create/templates/workspace/workers/.cursorrules
+++ b/packages/create/templates/workspace/workers/.cursorrules
@@ -4,14 +4,14 @@
 Tonk workers are Node.js-based services that integrate with the Tonk ecosystem for building local-first applications. They provide HTTP API endpoints and integrate with KeepSync for distributed data synchronization using Automerge CRDTs.
 
 ## Getting Started
-The worker structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
+The worker structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
 
-**IMPORTANT: Always run `tonk create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
+**IMPORTANT: Always run `tonk-create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
 
 To create a new worker:
 ```bash
 cd workers/
-tonk create
+tonk-create
 ```
 
 The CLI will prompt you to select "worker" as the project type and guide you through the setup process, generating the folder structure and files detailed below. The worker will be created as a subdirectory within `workers/`.

--- a/packages/create/templates/workspace/workers/.windsurfrules
+++ b/packages/create/templates/workspace/workers/.windsurfrules
@@ -4,14 +4,14 @@
 Tonk workers are Node.js-based services that integrate with the Tonk ecosystem for building local-first applications. They provide HTTP API endpoints and integrate with KeepSync for distributed data synchronization using Automerge CRDTs.
 
 ## Getting Started
-The worker structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
+The worker structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
 
-**IMPORTANT: Always run `tonk create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
+**IMPORTANT: Always run `tonk-create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
 
 To create a new worker:
 ```bash
 cd workers/
-tonk create
+tonk-create
 ```
 
 The CLI will prompt you to select "worker" as the project type and guide you through the setup process, generating the folder structure and files detailed below. The worker will be created as a subdirectory within `workers/`.

--- a/packages/create/templates/workspace/workers/CLAUDE.md
+++ b/packages/create/templates/workspace/workers/CLAUDE.md
@@ -4,14 +4,14 @@
 Tonk workers are Node.js-based services that integrate with the Tonk ecosystem for building local-first applications. They provide HTTP API endpoints and integrate with KeepSync for distributed data synchronization using Automerge CRDTs.
 
 ## Getting Started
-The worker structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
+The worker structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
 
-**IMPORTANT: Always run `tonk create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
+**IMPORTANT: Always run `tonk-create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
 
 To create a new worker:
 ```bash
 cd workers/
-tonk create
+tonk-create
 ```
 
 The CLI will prompt you to select "worker" as the project type and guide you through the setup process, generating the folder structure and files detailed below. The worker will be created as a subdirectory within `workers/`.

--- a/packages/create/templates/workspace/workers/llms.txt
+++ b/packages/create/templates/workspace/workers/llms.txt
@@ -4,14 +4,14 @@
 Tonk workers are Node.js-based services that integrate with the Tonk ecosystem for building local-first applications. They provide HTTP API endpoints and integrate with KeepSync for distributed data synchronization using Automerge CRDTs.
 
 ## Getting Started
-The worker structure described in this guide is automatically created when you run `tonk create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
+The worker structure described in this guide is automatically created when you run `tonk-create`. This command will guide you through the process of creating a new worker and scaffold a complete worker template folder with all the necessary files and configurations.
 
-**IMPORTANT: Always run `tonk create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
+**IMPORTANT: Always run `tonk-create` from inside the `workers/` directory to ensure the new worker is created in the correct location.**
 
 To create a new worker:
 ```bash
 cd workers/
-tonk create
+tonk-create
 ```
 
 The CLI will prompt you to select "worker" as the project type and guide you through the setup process, generating the folder structure and files detailed below. The worker will be created as a subdirectory within `workers/`.

--- a/utils/copy-llms.js
+++ b/utils/copy-llms.js
@@ -10,7 +10,6 @@ const __dirname = path.dirname(__filename);
 // Define project subdirectories that should get their own .cursor/rules
 const PROJECT_SUBDIRS = [
   'packages/create/templates/react',
-  'packages/create/templates/node',
   'packages/create/templates/worker'
 ];
 


### PR DESCRIPTION
### Description

This changes the CLI to use flags instead of the interactive CLI

### Tested

Manually tested

### Related issues

- closes TON-1297


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the command used for creating projects and components in the Tonk CLI from `tonk create` to `tonk-create`, enhancing clarity in documentation and ensuring users have the correct command syntax for various operations.

### Detailed summary
- Changed `tonk create` to `tonk-create` in multiple documentation files.
- Updated command usage examples to reflect the new syntax.
- Clarified instructions for creating views and workers with the new command format.
- Ensured consistency across all related documentation files regarding the command changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->