### PR TITLE
fix(server): TON-1311: fix requests to tonk server

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Server package for Tonk applications",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -807,7 +807,7 @@ export class TonkServer {
         changeOrigin: true,
         pathRewrite: {'^/api': ''}, // Strip /api prefix before forwarding to nginx
         on: {
-          proxyReq: (proxyReq, req, res) => {
+          proxyReq: (_proxyReq, req, _res) => {
             // Log every request that comes through the proxy
             const timestamp = new Date().toISOString();
             const method = req.method;
@@ -829,7 +829,7 @@ export class TonkServer {
               logger.debug(`  Body: [Body will be forwarded to target]`);
             }
           },
-          proxyRes: (proxyRes, req, res) => {
+          proxyRes: (proxyRes, req, _res) => {
             // Log response details
             const timestamp = new Date().toISOString();
             const method = req.method;
@@ -861,8 +861,6 @@ export class TonkServer {
         },
       }),
     );
-
-
   }
 
   private async startBundleServer(


### PR DESCRIPTION
### Description

- first start `nginxManager`, then setup express middleware to properly handle all requests

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1311

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `@tonk/server` package version and refines the server initialization process, enhancing error handling and restructuring the server's start logic.

### Detailed summary
- Updated `version` in `package.json` from `0.3.1` to `0.3.2`.
- Replaced `this.setupExpressMiddleware()`, `this.initRoot()`, and `this.restorePersistedBundles()` with `this.initializeServer()`.
- Added `initializeServer()` method to handle server startup and error logging.
- Moved JSON body parsing to occur for all non-API routes.
- Simplified the `start()` method to improve readability and maintainability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->