### PR TITLE
fix(keepsync): fix initialize condition check

### DIFF
--- a/packages/keepsync/package.json
+++ b/packages/keepsync/package.json
@@ -57,6 +57,7 @@
     "vitest": "^3.0.7"
   },
   "dependencies": {
+    "@automerge/automerge": "^2.2.8",
     "@automerge/automerge-repo": "^1.2.1",
     "@automerge/automerge-repo-network-websocket": "^1.2.1",
     "@automerge/automerge-repo-storage-indexeddb": "^1.2.1",

--- a/packages/keepsync/src/middleware/sync.ts
+++ b/packages/keepsync/src/middleware/sync.ts
@@ -8,6 +8,7 @@ import { StateCreator } from 'zustand';
  * Import Repo and related types from automerge-repo
  */
 import { Repo, DocHandle, DocumentId } from '@automerge/automerge-repo';
+import { next as A } from "@automerge/automerge/slim"
 
 /**
  * Utility functions for state management:
@@ -270,7 +271,7 @@ export const sync =
         // Get the current document
         const currentDoc = docHandle?.docSync();
 
-        if (currentDoc && Object.keys(currentDoc).length > 0) {
+        if (currentDoc && A.stats(currentDoc).numOps > 0) {
           // CASE 1: Document already exists and has some contents - update the Zustand store with its contents
           handleDocChange(currentDoc);
         } else {


### PR DESCRIPTION
### Description

  Fixed a bug where newly created Automerge documents were incorrectly treated as having existing data,
  preventing proper initialization from Zustand state.

  **The Problem:**
  - When `docHandle.docSync()` is called on a new document, it returns an empty object `{}` (not
  `undefined`)
  - The previous check `if (currentDoc)` always evaluated to true for empty documents
  - This caused CASE 1 (sync from Automerge to Zustand) to execute instead of CASE 2 (sync from Zustand to Automerge) at initialization

  **The Solution:**
  - Added `A.stats(currentDoc).numOps > 0` check to see if document has actual data (but I'm not sure if this implementation is more readable/less hacky than `Object.keys(currentDoc).length > 0` - please check the previous commit)
  - Documents with 0 operations should be initialized with local Zustand state

### Other changes

I've added the core automerge package because there were no useful APIs in the `automerge-repo` in version 1.2.1 to check whether the document actually has data. (Although `metrics()` is available from ~v2.0.0. )
Also, sidenote that `docSync()` is deprecated and has been removed from the 2.0 release.

### Tested

Verified the fix works correctly:
  - First time document creation → Goes to CASE 2 (initializes from Zustand)
  - Subsequent access (refresh/other users) → Goes to CASE 1 (syncs from Automerge)

### Related issues

N/A
<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility
Yes


### Documentation
None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` to include a new dependency on `@automerge/automerge` and modifies the `sync` function in `sync.ts` to enhance the logic for handling the current document's state.

### Detailed summary
- Added dependency `@automerge/automerge` version `^2.2.8` in `package.json`.
- Updated the condition in the `sync` function to check if `currentDoc` has operations using `A.stats(currentDoc).numOps > 0`.
- Revised comments for clarity regarding document existence and initialization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->