### PR TITLE
fix(keepsync): fix initializeSync condition check

### DIFF
--- a/packages/keepsync/src/middleware/sync.ts
+++ b/packages/keepsync/src/middleware/sync.ts
@@ -8,6 +8,7 @@ import { StateCreator } from 'zustand';
  * Import Repo and related types from automerge-repo
  */
 import { Repo, DocHandle, DocumentId } from '@automerge/automerge-repo/slim';
+import { next as A } from "@automerge/automerge/slim"
 
 /**
  * Utility functions for state management:
@@ -270,7 +271,7 @@ export const sync =
         // Get the current document
         const currentDoc = docHandle?.doc();
 
-        if (currentDoc && Object.keys(currentDoc).length > 0) {
+        if (currentDoc && A.stats(currentDoc).numOps > 0) {
           // CASE 1: Document already exists and has some contents - update the Zustand store with its contents
           handleDocChange(currentDoc);
         } else {

--- a/packages/keepsync/src/middleware/sync.ts
+++ b/packages/keepsync/src/middleware/sync.ts
@@ -270,11 +270,11 @@ export const sync =
         // Get the current document
         const currentDoc = docHandle?.doc();
 
-        if (currentDoc) {
-          // CASE 1: Document already exists - update the Zustand store with its contents
+        if (currentDoc && Object.keys(currentDoc).length > 0) {
+          // CASE 1: Document already exists and has some contents - update the Zustand store with its contents
           handleDocChange(currentDoc);
         } else {
-          // CASE 2: Document doesn't exist yet - initialize it with current Zustand state
+          // CASE 2: Document doesn't exist yet or exists but empty - initialize it with current Zustand state
           const initialState = get();
           const serializableState = serializeForSync(initialState);
 

--- a/packages/keepsync/tests/middleware/init-sync.test.ts
+++ b/packages/keepsync/tests/middleware/init-sync.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { create } from 'zustand';
+import { sync } from '../../src/middleware/sync';
+import { configureSyncEngine, resetSyncEngine } from '../../src/core/syncConfig';
+import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb';
+import * as Automerge from '@automerge/automerge';
+import 'fake-indexeddb/auto';
+import { setIsSlim } from '../../src/utils/wasmState';
+import { readDoc } from '../../src/middleware/sync';
+
+describe('initializeSync empty document fix', () => {
+  beforeEach(async () => {
+    setIsSlim();
+    Automerge.init();
+    resetSyncEngine();
+    const engine = await configureSyncEngine({
+      url: '',
+      storage: new IndexedDBStorageAdapter('test-db'),
+    });
+    await engine.whenReady();
+  });
+
+  afterEach(async () => {
+    resetSyncEngine();
+    indexedDB.deleteDatabase('test-db');
+  });
+
+  it('initializes empty Automerge doc with Zustand state', async () => {
+    const INITIAL_STATE = { counter: 42, message: 'Hello' };
+    
+    const useStore = create(
+      sync(
+        (set) => ({
+          ...INITIAL_STATE,
+          increment: () => set(s => ({ counter: s.counter + 1 })),
+        }),
+        { docId: 'test-doc' }
+      )
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    const docFromAutomerge = await readDoc<any>('test-doc');
+    
+    // Bug: Without fix, docFromAutomerge would be undefined/empty
+    // Fix: With A.stats().numOps check, it contains Zustand state
+    expect(docFromAutomerge.counter).toBe(42);
+    expect(docFromAutomerge.message).toBe('Hello');
+  });
+});


### PR DESCRIPTION
# PR Update

## Rebased and Added Test Coverage

This PR has been rebased onto the latest main branch and a test has been added to verify the fix.

### Test Added
- `tests/middleware/init-sync.test.ts` - Verifies that empty Automerge documents are correctly initialized with Zustand state rather than overwriting it

### Test Verification
The test demonstrates the bug by checking that:
- **Without the fix**: Empty Automerge documents (`{}`) would incorrectly trigger CASE 1, overwriting Zustand state with undefined values
- **With the fix**: Using `A.stats(currentDoc).numOps > 0` correctly identifies empty documents, triggering CASE 2 to initialize them from Zustand state

closes #216

---

## Original PR Description

### Description
Fixed a bug where newly created Automerge documents were incorrectly treated as having existing data,
preventing proper initialization from Zustand state.

### The Problem:

When docHandle.docSync() is called on a new document, it returns an empty object {} (not
undefined)
The previous check if (currentDoc) always evaluated to true for empty documents
This caused CASE 1 (sync from Automerge to Zustand) to execute instead of CASE 2 (sync from Zustand to Automerge) at initialization

### The Solution:

Added A.stats(currentDoc).numOps > 0 check to see if document has actual data (but I'm not sure if this implementation is more readable/less hacky than Object.keys(currentDoc).length > 0 - please check the previous commit)
Documents with 0 operations should be initialized with local Zustand state

### Other changes
I've added the core automerge package because there were no useful APIs in the automerge-repo in version 1.2.1 to check whether the document actually has data. (Although metrics() is available from ~v2.0.0. )
Also, sidenote that docSync() is deprecated and has been removed from the 2.0 release.

### Tested
Verified the fix works correctly:

First time document creation → Goes to CASE 2 (initializes from Zustand)
Subsequent access (refresh/other users) → Goes to CASE 1 (syncs from Automerge)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the synchronization logic in the `sync` middleware by ensuring that an empty document is initialized properly with Zustand state. It adds a check for operations in the current document and includes tests to verify the fix.

### Detailed summary
- Updated the condition in the `sync` function to check if the current document has operations using `A.stats(currentDoc).numOps > 0`.
- Modified comments for clarity regarding document state.
- Added a test suite in `init-sync.test.ts` to verify the initialization of an empty `Automerge` document with Zustand state.
- Implemented setup and teardown logic for the test environment using `beforeEach` and `afterEach`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->