### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,7 +20,7 @@ jobs:
       packages: ${{ steps.changes.outputs.packages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -71,7 +71,7 @@ jobs:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `actions/checkout` version from `v4` to `v5` in multiple workflow files to ensure compatibility and benefit from improvements in the latest version.

### Detailed summary
- Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/mdbook.yml`.
- Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/publish-packages.yml`.
- Updated `actions/checkout` from `v4` to `v5` in a job within `.github/workflows/publish-packages.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->