### PR TITLE
feat(cli): update deployment service url, improved error handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "The Tonk stack command line utility",
   "type": "module",
   "bin": {

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -1602,8 +1602,8 @@ packages:
   cbor-x@1.6.0:
     resolution: {integrity: sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==}
 
-  chai@5.2.1:
-    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+  chai@5.3.1:
+    resolution: {integrity: sha512-48af6xm9gQK8rhIcOxWwdGzIervm8BVTin+yRp9HEvU20BtVZ2lBywlIJBzwaDtvo0FvjeL7QdCADoUoqIbV3A==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -2445,8 +2445,8 @@ packages:
     resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
-  istanbul-reports@3.1.7:
-    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
   jackspeak@3.4.3:
@@ -5382,7 +5382,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
+      istanbul-reports: 3.2.0
       magic-string: 0.30.17
       magicast: 0.3.5
       std-env: 3.9.0
@@ -5397,7 +5397,7 @@ snapshots:
       '@types/chai': 5.2.2
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.1
+      chai: 5.3.1
       tinyrainbow: 2.0.0
 
   '@vitest/mocker@3.2.4(vite@5.4.19(@types/node@22.15.32))':
@@ -5673,7 +5673,7 @@ snapshots:
     optionalDependencies:
       cbor-extract: 2.2.0
 
-  chai@5.2.1:
+  chai@5.3.1:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -6588,7 +6588,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-reports@3.1.7:
+  istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
@@ -7683,7 +7683,7 @@ snapshots:
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.1
+      chai: 5.3.1
       debug: 4.4.1
       expect-type: 1.2.2
       magic-string: 0.30.17

--- a/packages/cli/src/commands/server.ts
+++ b/packages/cli/src/commands/server.ts
@@ -122,7 +122,20 @@ async function deleteServer(serverName: string): Promise<void> {
     body: formData,
   });
 
-  const result: any = await response.json();
+  // Get response text first to check if it's HTML
+  const responseText = await response.text();
+
+  // Try to parse as JSON
+  let result: any;
+  try {
+    result = JSON.parse(responseText);
+  } catch {
+    console.error('Failed to parse response as JSON');
+    console.error('Full response:', responseText);
+    throw new Error(
+      'Server returned HTML instead of JSON. This usually means authentication failed or wrong URL.'
+    );
+  }
 
   if (!response.ok || !result.success) {
     throw new Error(result.error || 'Failed to delete server');
@@ -151,21 +164,22 @@ async function createServer(
 
     // Prepare form data for server creation
     const formData = new FormData();
-    formData.append(
-      'serverData',
-      JSON.stringify({
-        serverName,
-        region: options.region || 'ord',
-        memory: options.memory || '1gb',
-        cpus: options.cpus || '1',
-        remote: options.remote || false,
-        deployType: 'server',
-      })
-    );
+    const serverData = {
+      serverName,
+      region: options.region || 'ord',
+      memory: options.memory || '1gb',
+      cpus: options.cpus || '1',
+      remote: options.remote || false,
+      deployType: 'server',
+    };
+
+    formData.append('serverData', JSON.stringify(serverData));
+
+    const url = `${getDeploymentServiceUrl()}/create-server`;
 
     // Send server creation request
     spinner.text = 'Creating server...';
-    const response = await fetch(`${getDeploymentServiceUrl()}/create-server`, {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${authToken}`,
@@ -173,7 +187,20 @@ async function createServer(
       body: formData,
     });
 
-    const result: any = await response.json();
+    // Get response text first to check if it's HTML
+    const responseText = await response.text();
+
+    // Try to parse as JSON
+    let result: any;
+    try {
+      result = JSON.parse(responseText);
+    } catch {
+      console.error('Failed to parse response as JSON');
+      console.error('Full response:', responseText);
+      throw new Error(
+        'Server returned HTML instead of JSON. This usually means authentication failed or wrong URL.'
+      );
+    }
 
     if (!response.ok || !result.success) {
       const errorMessage = result.error || 'Server creation failed';
@@ -237,7 +264,20 @@ async function listRemoteBundles(serverName: string): Promise<void> {
     body: formData,
   });
 
-  const result: any = await response.json();
+  // Get response text first to check if it's HTML
+  const responseText = await response.text();
+
+  // Try to parse as JSON
+  let result: any;
+  try {
+    result = JSON.parse(responseText);
+  } catch {
+    console.error('Failed to parse response as JSON');
+    console.error('Full response:', responseText);
+    throw new Error(
+      'Server returned HTML instead of JSON. This usually means authentication failed or wrong URL.'
+    );
+  }
 
   if (!response.ok || !result.success) {
     throw new Error(result.error || 'Failed to list bundles');
@@ -281,7 +321,20 @@ async function listRunningBundles(serverName: string): Promise<void> {
     body: formData,
   });
 
-  const result: any = await response.json();
+  // Get response text first to check if it's HTML
+  const responseText = await response.text();
+
+  // Try to parse as JSON
+  let result: any;
+  try {
+    result = JSON.parse(responseText);
+  } catch {
+    console.error('Failed to parse response as JSON');
+    console.error('Full response:', responseText);
+    throw new Error(
+      'Server returned HTML instead of JSON. This usually means authentication failed or wrong URL.'
+    );
+  }
 
   if (!response.ok || !result.success) {
     throw new Error(result.error || 'Failed to list running bundles');
@@ -335,7 +388,20 @@ async function deleteRemoteBundle(
     body: formData,
   });
 
-  const result: any = await response.json();
+  // Get response text first to check if it's HTML
+  const responseText = await response.text();
+
+  // Try to parse as JSON
+  let result: any;
+  try {
+    result = JSON.parse(responseText);
+  } catch {
+    console.error('Failed to parse response as JSON');
+    console.error('Full response:', responseText);
+    throw new Error(
+      'Server returned HTML instead of JSON. This usually means authentication failed or wrong URL.'
+    );
+  }
 
   if (!response.ok || !result.success) {
     throw new Error(result.error || 'Failed to delete bundle');


### PR DESCRIPTION
### Description

- updates deployment url to railway instance

### Other changes

- better error handling in `cli`

### Tested

Yes

### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and improving error handling in the `packages/cli/src/commands/server.ts` file. It raises the version of the package and some libraries, while also enhancing the response parsing mechanism to handle HTML responses appropriately.

### Detailed summary
- Updated `version` in `packages/cli/package.json` from `0.3.2` to `0.3.3`.
- Upgraded `chai` from `5.2.1` to `5.3.1` in `pnpm-lock.yaml`.
- Upgraded `istanbul-reports` from `3.1.7` to `3.2.0` in `pnpm-lock.yaml`.
- Enhanced error handling in `packages/cli/src/commands/server.ts`:
  - Added logic to check if the response is HTML before parsing it as JSON.
  - Implemented error logging for failed JSON parsing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->