### PR TITLE
feat(core-api): TON-1433: api calls for loading/saving blob files

### DIFF
--- a/packages/tonk-core-browser/src/core.ts
+++ b/packages/tonk-core-browser/src/core.ts
@@ -209,7 +209,7 @@ export class VirtualFileSystem {
    * Read the contents of a blob file.
    *
    * @param path - Absolute path to the file
-   * @returns JSON representing the blob and its metadata
+   * @returns File contents as a string, which can be decoded to include both metadata and blob
    * @throws {FileSystemError} If the file doesn't exist, can't be read, or 
    * wasn't created using the `createBlobFile` function (resulting in incorrect structure)
    *
@@ -226,8 +226,9 @@ export class VirtualFileSystem {
         if (result === null) {
           throw new FileSystemError(`File not found: ${path}`);
         }
-        const result_parsed = JSON.parse(result);
-        if (!result_parsed.content.blob || !result_parsed.content.metadata) {
+        const result_parsed = JSON.parse(JSON.parse(JSON.parse(result).content));
+        console.log(`PARSED FILE: ${result_parsed}`);
+        if (!result_parsed.blob || !result_parsed.metadata) {
           throw new FileSystemError(`File not a blob type: ${path}. Try using readFile instead.`);
         }
         return result;


### PR DESCRIPTION
### Description

Standardise reading/writing to blob files. Although I think there is scope for improvement here? This method required a lot of complexity on the suer side in parsing JSON files etc. It could be nice if the API handles this.

### Tested

Changes have been tested! 

### Related issues

- TON-1433

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->
