### PR TITLE
feat!(core): consolidate VFS into TonkCore bindings, remove repo

### DIFF
--- a/examples/tonk-core-template/src/index.tsx
+++ b/examples/tonk-core-template/src/index.tsx
@@ -6,28 +6,26 @@ import App from './App';
 import { TonkCore } from '@tonk/core';
 
 const tonk1 = await TonkCore.create({ storage: { type: 'indexeddb' } });
-const vfs1 = await tonk1.getVfs();
 
-const _watcher = vfs1.watchDirectory('/', docState => {
+const _watcher = tonk1.watchDirectory('/', docState => {
   console.log(`Directory changed: ${docState}`);
 });
 
-await vfs1.createFile('/hello.txt', 'Hello, World!');
+await tonk1.createFile('/hello.txt', 'Hello, World!');
 
-const _watcher2 = vfs1.watchFile('/hello.txt', docState => {
+const _watcher2 = tonk1.watchFile('/hello.txt', docState => {
   console.log(`File changed: ${docState}`);
 });
 
-const content1 = await vfs1.readFile('/hello.txt');
+const content1 = await tonk1.readFile('/hello.txt');
 console.log('Initial content:', content1);
 
-await vfs1.updateFile('/hello.txt', 'Goodbye, world!');
+await tonk1.updateFile('/hello.txt', 'Goodbye, world!');
 
 const data = await tonk1.toBytes();
 const tonk2 = await TonkCore.fromBytes(data);
-const vfs2 = await tonk2.getVfs();
 
-const content2 = await vfs2.readFile('/hello.txt');
+const content2 = await tonk2.readFile('/hello.txt');
 console.log('Retrieved content:', content2);
 
 const container = document.getElementById('root');

--- a/packages/core-js/src/index-slim.ts
+++ b/packages/core-js/src/index-slim.ts
@@ -27,8 +27,6 @@ export { initializeTonk, isInitialized } from './init.js';
 export {
   // Main classes
   TonkCore,
-  VirtualFileSystem,
-  Repository,
   Bundle,
 
   // Types

--- a/packages/core-js/src/index.ts
+++ b/packages/core-js/src/index.ts
@@ -3,8 +3,6 @@ import type { TonkConfig } from './core.js';
 import {
   // Main classes
   TonkCore,
-  VirtualFileSystem,
-  Repository,
   Bundle,
 
   // Types
@@ -63,8 +61,6 @@ export { isInitialized };
 export {
   // Main classes
   TonkCore,
-  VirtualFileSystem,
-  Repository,
   Bundle,
 
   // Types


### PR DESCRIPTION
### Description

- removed `Repository` and related bindings from `wasm.rs` and `core-js` (doesn't make sense to provide access to underlying automerge methods if they aren't fully reimplemented in the JS wrapper since they'll do nothing)
- the VFS class and its methods rolled entirely into main `TonkCore` class (no more `tonk.getVfs()`, just replace `vfs.<whateverMethod>()` with `tonk.<whateverMethod>()`

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1439

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Absolutely not

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the code by removing the `VirtualFileSystem` and `Repository` classes from the `TonkCore` interface and updating the usage of the virtual file system methods directly on `TonkCore`. It also cleans up the `WasmTonkCore` implementation.

### Detailed summary
- Removed `VirtualFileSystem` and `Repository` class exports.
- Updated methods in `examples/tonk-core-template/src/index.tsx` to call `TonkCore` directly.
- Refactored `WasmTonkCore` to eliminate `getVfs` and `getRepo` methods.
- Adjusted the implementation of file operations in `WasmVfs` to use `TonkCore` directly.
- Removed extensive documentation and examples related to `VirtualFileSystem` and `Repository` in `packages/core-js/src/core.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->