### PR TITLE
feat(core api): TON-1433: API to read/write Uint8Array

### DIFF
--- a/packages/core-js/README.md
+++ b/packages/core-js/README.md
@@ -13,6 +13,7 @@ npm install @tonk/core
 
 - **TonkCore**: Main synchronization engine
 - **Virtual File System**: CRDT-based file system with hierarchical document management
+- **Byte Storage API**: Store and retrieve binary data alongside JSON metadata
 - **Bundle Operations**: ZIP-based data export/import
 - **WebSocket Sync**: Real-time peer-to-peer synchronization
 
@@ -28,14 +29,15 @@ const tonk = await createTonk();
 const peerId = await tonk.getPeerId();
 console.log('Peer ID:', peerId);
 
-// Get the virtual file system
-const vfs = await tonk.getVfs();
-
 // Create a file
-await vfs.createFile('/hello.txt', 'Hello, World!');
+await tonk.createFile('/hello.txt', 'Hello, World!');
+
+// Create a file with binary data
+const imageData = new Uint8Array([137, 80, 78, 71, /* ... more PNG bytes */]);
+await tonk.createFileWithBytes('/image.png', { mime: 'image/png', alt: 'Sample image' }, imageData);
 
 // Read the file
-const content = await vfs.readFile('/hello.txt');
+const content = await tonk.readFile('/hello.txt');
 console.log('File content:', content);
 ```
 
@@ -90,11 +92,41 @@ class TonkCore {
   // Connect to a WebSocket server
   connectWebsocket(url: string): Promise<void>;
 
-  // Get the virtual file system
-  getVfs(): Promise<VirtualFileSystem>;
+  // Create a file with content
+  createFile(path: string, content: any): Promise<void>;
 
-  // Get the repository (low-level CRDT access)
-  getRepo(): Promise<Repository>;
+  // Create a file with binary data
+  createFileWithBytes(path: string, content: any, bytes: Uint8Array): Promise<void>;
+
+  // Read a file
+  readFile(path: string): Promise<any>;
+
+  // Update an existing file
+  updateFile(path: string, content: any): Promise<boolean>;
+
+  // Update a file with binary data
+  updateFileWithBytes(path: string, content: any, bytes: Uint8Array): Promise<boolean>;
+
+  // Delete a file
+  deleteFile(path: string): Promise<boolean>;
+
+  // Check if a path exists
+  exists(path: string): Promise<boolean>;
+
+  // Create a directory
+  createDirectory(path: string): Promise<void>;
+
+  // List directory contents
+  listDirectory(path: string): Promise<DirectoryEntry[]>;
+
+  // Get file/directory metadata
+  getMetadata(path: string): Promise<NodeMetadata | null>;
+
+  // Watch a file for changes
+  watchFile(path: string, callback: Function): Promise<DocumentWatcher | null>;
+
+  // Watch a directory for changes
+  watchDirectory(path: string, callback: Function): Promise<DocumentWatcher | null>;
 
   // Export to bundle bytes
   toBytes(): Promise<Uint8Array>;


### PR DESCRIPTION
new api functionality to load and store byte arrays as atomic objects 

### Description

- integrates with samod, ensuring the byte array is never converted to string + always remains an automerge scalar value

new api features exposed:
- `createFileWithBytes(path: string, content: any, bytes: Uint8Array): Promise<void>`
- `updateFileWithBytes(path: string, content: any, bytes: Uint8Array): Promise<boolean>`

### Other changes

changed the`DocNode` to include an `Option` field `bytes`

### Tested

changes have been tested!

### Related issues

- closes TON-1433

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `TonkCore` library, including a new `Byte Storage API` for handling binary data, and updates to file operations for better functionality.

### Detailed summary
- Added `Byte Storage API` section to `README.md`.
- Replaced `getVfs()` method with `createFile()` and `createFileWithBytes()` in usage examples.
- Updated `TonkCore` class methods to include:
  - `createFileWithBytes()`
  - `updateFile()`
  - `updateFileWithBytes()`
  - `deleteFile()`
  - `exists()`
  - `createDirectory()`
  - `listDirectory()`
  - `getMetadata()`
  - `watchFile()`
  - `watchDirectory()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->