### PR TITLE
feat(core): TON-1463: update core API to be more consistent, switch t…

### DIFF
--- a/packages/core-js/src/core.ts
+++ b/packages/core-js/src/core.ts
@@ -13,11 +13,11 @@ export interface RefNode {
   timestamps: DocumentTimestamps;
 }
 
-export interface DirectoryUpdate {
+export interface DirectoryNode {
   /** Name of the file or directory */
   name: string;
   /** Type of the entry */
-  type: 'directory' | 'document';
+  type: 'directory';
   //the UUID of the automerge URL
   pointer: string;
   timestamps: DocumentTimestamps;
@@ -910,7 +910,7 @@ export class TonkCore {
    */
   async watchDirectory(
     path: string,
-    callback: (result: DirectoryUpdate) => void
+    callback: (result: DirectoryNode) => void
   ): Promise<DocumentWatcher> {
     try {
       const result = await this.#wasm.watchDirectory(path, callback);

--- a/packages/core-js/src/core.ts
+++ b/packages/core-js/src/core.ts
@@ -1,25 +1,28 @@
 import type { WasmTonkCore, WasmBundle } from './tonk_core.js';
 
 /**
- * Metadata for a file or directory node in the virtual file system
- */
-export interface NodeMetadata {
-  /** Type of the node - either 'directory' or 'document' */
-  nodeType: 'directory' | 'document';
-  /** Creation timestamp */
-  createdAt: Date;
-  /** Last modification timestamp */
-  modifiedAt: Date;
-}
-
-/**
  * Entry in a directory listing
  */
-export interface DirectoryEntry {
+export interface RefNode {
   /** Name of the file or directory */
   name: string;
   /** Type of the entry */
   type: 'directory' | 'document';
+  //the UUID of the automerge URL
+  pointer: string;
+  timestamps: DocumentTimestamps;
+}
+
+export interface DirectoryUpdate {
+  /** Name of the file or directory */
+  name: string;
+  /** Type of the entry */
+  type: 'directory' | 'document';
+  //the UUID of the automerge URL
+  pointer: string;
+  timestamps: DocumentTimestamps;
+  // if it's a directory this will be populated
+  children?: RefNode[];
 }
 
 /**
@@ -46,7 +49,7 @@ export interface DocumentWatcher {
   stop(): Promise<void>;
 }
 
-export interface DocumentTimestaps {
+export interface DocumentTimestamps {
   created: number;
   modified: number;
 }
@@ -62,8 +65,8 @@ export type JsonValue =
 export interface DocumentData {
   content: JsonValue;
   name: string;
-  timestamps: DocumentTimestaps;
-  type: 'doc' | 'dir';
+  timestamps: DocumentTimestamps;
+  type: 'document' | 'directory';
   bytes?: string; // Base64-encoded binary data when file was created with bytes
 }
 
@@ -83,10 +86,10 @@ export interface Manifest {
   manifestVersion: number;
   /** Tonk version */
   version: Version;
-  rootId: String;
-  entrypoints: String[];
-  networkUris: String[];
-  xNotes?: String;
+  rootId: string;
+  entrypoints: string[];
+  networkUris: string[];
+  xNotes?: string;
   xVendor?: Object;
 }
 
@@ -303,7 +306,7 @@ export class Bundle {
     try {
       return await this.#wasm.getManifest();
     } catch (error) {
-      throw new BundleError(`Failed to retrive manifest: ${error}`);
+      throw new BundleError(`Failed to retrieve manifest: ${error}`);
     }
   }
 
@@ -632,7 +635,7 @@ export class TonkCore {
    * const doc = await readFile('/notes/todo');
    * console.log(doc.content);   // string
    * console.log(doc.name);      // string
-   * console.log(doc.type);      // 'doc' | 'dir'
+   * console.log(doc.type);      // 'document' | 'directory'
    * console.log(doc.timestamps.created);   // number
    * console.log(doc.timestamps.modified);  // number
    * ```
@@ -648,25 +651,7 @@ export class TonkCore {
       // For some reason, we seem to get different return types in different environments
       let normalizedBytes;
       if (intermediary.bytes) {
-        // Normalize bytes to always be base64 string
-        if (typeof intermediary.bytes === 'string') {
-          // Already a base64 string
-          normalizedBytes = intermediary.bytes;
-        } else if (Array.isArray(intermediary.bytes)) {
-          // Convert array of char codes to base64 string
-          // Process in chunks to avoid maximum call stack exceeded errors
-          const chunkSize = 8192; // Safe chunk size for String.fromCharCode
-          let binaryString = '';
-          for (let i = 0; i < intermediary.bytes.length; i += chunkSize) {
-            const chunk = intermediary.bytes.slice(i, i + chunkSize);
-            binaryString += String.fromCharCode(...chunk);
-          }
-          normalizedBytes = btoa(binaryString);
-        } else {
-          throw new FileSystemError(
-            `Unrecognized bytes type in readFile ${typeof intermediary.bytes}`
-          );
-        }
+        normalizedBytes = normalizeBytes(intermediary.bytes);
       }
 
       return {
@@ -793,16 +778,18 @@ export class TonkCore {
    * ```typescript
    * const entries = await listDirectory('/projects');
    * for (const entry of entries) {
-   *   console.log(`${entry.type}: ${entry.name}`);
+   *   console.log(`${entry.type}: ${entry.name} ${entry.timestamps} ${entry.pointer}`);
    * }
    * ```
    */
-  async listDirectory(path: string): Promise<DirectoryEntry[]> {
+  async listDirectory(path: string): Promise<RefNode[]> {
     try {
       const entries = await this.#wasm.listDirectory(path);
       return entries.map((entry: any) => ({
         name: entry.name,
         type: entry.type as 'directory' | 'document',
+        timestamps: entry.timestamps,
+        pointer: entry.pointer,
       }));
     } catch (error) {
       throw new FileSystemError(
@@ -831,30 +818,33 @@ export class TonkCore {
    * Get metadata for a file or directory.
    *
    * @param path - Absolute path to the file or directory
-   * @returns Metadata object or null if the path doesn't exist
-   * @throws {FileSystemError} If the metadata can't be retrieved
+   * @returns Metadata object containing file/directory information
+   * @throws {FileSystemError} If the file or directory doesn't exist, or if the metadata can't be retrieved
    *
    * @example
    * ```typescript
-   * const metadata = await getMetadata('/notes/todo');
-   * if (metadata) {
+   * try {
+   *   const metadata = await getMetadata('/notes/todo');
    *   console.log(`Type: ${metadata.nodeType}`);
    *   console.log(`Created: ${metadata.createdAt}`);
    *   console.log(`Modified: ${metadata.modifiedAt}`);
+   * } catch (error) {
+   *   if (error instanceof FileSystemError) {
+   *     console.error('File not found or access error:', error.message);
+   *   }
    * }
    * ```
    */
-  async getMetadata(path: string): Promise<NodeMetadata | null> {
+  async getMetadata(path: string): Promise<RefNode> {
     try {
       const result = await this.#wasm.getMetadata(path);
-      if (result === null) return null;
+      if (result === null) {
+        throw new FileSystemError(`File or directory not found: ${path}`);
+      }
 
-      return {
-        nodeType: result.node_type as 'directory' | 'document',
-        createdAt: new Date(result.created_at * 1000),
-        modifiedAt: new Date(result.modified_at * 1000),
-      };
+      return result;
     } catch (error) {
+      if (error instanceof FileSystemError) throw error;
       throw new FileSystemError(`Failed to get metadata for ${path}: ${error}`);
     }
   }
@@ -875,14 +865,27 @@ export class TonkCore {
    */
   async watchFile(
     path: string,
-    callback: Function
-  ): Promise<DocumentWatcher | null> {
+    callback: (result: DocumentData) => void
+  ): Promise<DocumentWatcher> {
     try {
-      const result = await this.#wasm.watchDocument(path, callback);
-      if (result === null) return null;
+      const result = await this.#wasm.watchDocument(path, (doc: any) => {
+        let normalizedBytes;
+        if (doc.bytes) {
+          normalizedBytes = normalizeBytes(doc.bytes);
+        }
+        callback({
+          ...doc,
+          content: JSON.parse(doc.content),
+          bytes: normalizedBytes,
+        });
+      });
+      if (result === null) {
+        throw new FileSystemError(`File not found: ${path}`);
+      }
 
       return result;
     } catch (error) {
+      if (error instanceof FileSystemError) throw error;
       throw new FileSystemError(
         `Failed to watch file at path ${path}: ${error}`
       );
@@ -890,7 +893,9 @@ export class TonkCore {
   }
 
   /**
-   * Watch a directory for changes at the specified path
+   * Watch a directory will update only whenever it's direct descendents change.
+   * You will need to keep track of the timestamps in the children entries to discover
+   * which child has changed.
    *
    * @param path - Absolute path to the directory
    * @param callback - Callback to run on change events
@@ -898,21 +903,24 @@ export class TonkCore {
    *
    * @example
    * ```typescript
-   * const watcher = await watchDirecotry('/documents', docState => {
-   *   console.log('Directory changed:', docState);
+   * const watcher = await watchDirectory('/documents', dirEntry => {
+   *   console.log('Directory changed:', dirEntry);
    * });
    * ```
    */
   async watchDirectory(
     path: string,
-    callback: Function
-  ): Promise<DocumentWatcher | null> {
+    callback: (result: DirectoryUpdate) => void
+  ): Promise<DocumentWatcher> {
     try {
       const result = await this.#wasm.watchDirectory(path, callback);
-      if (result === null) return null;
+      if (result === null) {
+        throw new FileSystemError(`Directory not found: ${path}`);
+      }
 
       return result;
     } catch (error) {
+      if (error instanceof FileSystemError) throw error;
       throw new FileSystemError(
         `Failed to watch directory at path ${path}: ${error}`
       );
@@ -962,7 +970,7 @@ export function createFactoryFunctions(wasmModule?: any) {
 
     /**
      * Create a Tonk Core from bundle data
-     * @param bundle - The Bundle data from which to load
+     * @param data - The Bundle data from which to load
      * @returns A new TonkCore instance
      * @throws {Error} If Tonk creation fails or bundle is invalid
      */
@@ -990,4 +998,32 @@ const extractBytes = (bytes: string) => {
     barr[i] = binaryString.charCodeAt(i);
   }
   return barr;
+};
+
+/**
+ * Normalizes bytes from different formats to a base64 string
+ * @param bytes - The bytes to normalize (can be string, array, or other format)
+ * @returns A base64 encoded string
+ * @throws FileSystemError if the bytes format is unrecognized
+ */
+const normalizeBytes = (bytes: any): string => {
+  // Normalize bytes to always be base64 string
+  if (typeof bytes === 'string') {
+    // Already a base64 string
+    return bytes;
+  } else if (Array.isArray(bytes)) {
+    // Convert array of char codes to base64 string
+    // Process in chunks to avoid maximum call stack exceeded errors
+    const chunkSize = 8192; // Safe chunk size for String.fromCharCode
+    let binaryString = '';
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const chunk = bytes.slice(i, i + chunkSize);
+      binaryString += String.fromCharCode(...chunk);
+    }
+    return btoa(binaryString);
+  } else {
+    throw new FileSystemError(
+      `Unrecognized bytes type in readFile ${typeof bytes}`
+    );
+  }
 };

--- a/packages/core-js/src/index-slim.ts
+++ b/packages/core-js/src/index-slim.ts
@@ -33,7 +33,7 @@ export {
   type DocumentData,
   type Manifest,
   type RefNode,
-  type DirectoryUpdate,
+  type DirectoryNode,
   type DocumentTimestamps,
   type BundleEntry,
   type TonkConfig,

--- a/packages/core-js/src/index-slim.ts
+++ b/packages/core-js/src/index-slim.ts
@@ -32,8 +32,9 @@ export {
   // Types
   type DocumentData,
   type Manifest,
-  type NodeMetadata,
-  type DirectoryEntry,
+  type RefNode,
+  type DirectoryUpdate,
+  type DocumentTimestamps,
   type BundleEntry,
   type TonkConfig,
 

--- a/packages/core-js/src/index.ts
+++ b/packages/core-js/src/index.ts
@@ -9,7 +9,7 @@ import {
   // Types
   type DocumentData,
   type RefNode,
-  type DirectoryUpdate,
+  type DirectoryNode,
   type DocumentTimestamps,
   type BundleEntry,
 
@@ -73,7 +73,7 @@ export {
   type TonkConfig,
   type DocumentTimestamps,
   type RefNode,
-  type DirectoryUpdate,
+  type DirectoryNode,
 
   // Error classes
   TonkError,

--- a/packages/core-js/src/index.ts
+++ b/packages/core-js/src/index.ts
@@ -8,8 +8,9 @@ import {
 
   // Types
   type DocumentData,
-  type NodeMetadata,
-  type DirectoryEntry,
+  type RefNode,
+  type DirectoryUpdate,
+  type DocumentTimestamps,
   type BundleEntry,
 
   // Error classes
@@ -68,10 +69,11 @@ export {
   // Types
   type DocumentData,
   type Manifest,
-  type NodeMetadata,
-  type DirectoryEntry,
   type BundleEntry,
   type TonkConfig,
+  type DocumentTimestamps,
+  type RefNode,
+  type DirectoryUpdate,
 
   // Error classes
   TonkError,

--- a/packages/core-js/test/core.test.ts
+++ b/packages/core-js/test/core.test.ts
@@ -4,8 +4,10 @@ import {
   TonkCore,
   TonkError,
   FileSystemError,
+  DocumentData,
   BundleError,
   ConnectionError,
+  DocumentTimestamps,
 } from '../dist/index.js';
 import { pngBytes } from './data.js';
 
@@ -38,7 +40,7 @@ describe('TonkCore', () => {
     const retrieved = await tonk.readFile('/hello.txt');
     assert.strictEqual((retrieved.content as any).sampleString, sampleString);
     assert.strictEqual(retrieved.name, 'hello.txt');
-    assert.strictEqual(retrieved.type, 'doc');
+    assert.strictEqual(retrieved.type, 'document');
   });
 
   test('should create and read a file with array content', async () => {
@@ -48,12 +50,10 @@ describe('TonkCore', () => {
     const retrieved = await tonk.readFile('/data.json');
     assert.deepStrictEqual(retrieved.content, content);
     assert.strictEqual(retrieved.name, 'data.json');
-    assert.strictEqual(retrieved.type, 'doc');
+    assert.strictEqual(retrieved.type, 'document');
   });
 
-  // Add your tests here...
   test('should read and write bytes', async () => {
-    // Your test code here...
     await tonk.createFileWithBytes(
       '/test.png',
       { mime: 'image/png' },
@@ -74,10 +74,496 @@ describe('TonkCore', () => {
       'Retrieved bytes should match original'
     );
   });
-});
 
-describe('Bundle', () => {
-  // Add your Bundle tests here...
+  test('watchFile callback should match readFile format for regular files', async () => {
+    // Create a regular file
+    const content = { message: 'Hello, World!', count: 42 };
+    await tonk.createFile('/regular.txt', content);
+
+    // Get baseline from readFile
+    const readResult = await tonk.readFile('/regular.txt');
+
+    let callbackResult: any = null;
+    const watcher = await tonk.watchFile(
+      '/regular.txt',
+      (result: DocumentData) => {
+        callbackResult = result;
+      }
+    );
+
+    // Update the file to trigger the callback
+    const updatedContent = { message: 'Updated!', count: 100 };
+    await tonk.updateFile('/regular.txt', updatedContent);
+
+    // Wait for callback
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Verify callback result matches readFile structure
+    assert.ok(callbackResult, 'Callback should have been called');
+    assert.strictEqual(
+      callbackResult.name,
+      readResult.name,
+      'Name should match readFile'
+    );
+    assert.strictEqual(
+      callbackResult.type,
+      readResult.type,
+      'Type should match readFile'
+    );
+    assert.ok(
+      callbackResult.timestamps,
+      'Should have timestamps like readFile'
+    );
+    assert.ok(
+      callbackResult.timestamps.created,
+      'Should have created timestamp'
+    );
+    assert.ok(
+      callbackResult.timestamps.modified,
+      'Should have modified timestamp'
+    );
+    assert.deepStrictEqual(
+      callbackResult.content,
+      updatedContent,
+      'Content should match update'
+    );
+
+    // For regular files, bytes should be undefined (same as readFile)
+    assert.strictEqual(
+      callbackResult.bytes,
+      undefined,
+      'Regular files should not have bytes field'
+    );
+
+    if (watcher) await watcher.stop();
+  });
+
+  test('watchFile callback should match readFile format for files with bytes', async () => {
+    // Create a file with bytes
+    const content = { mime: 'image/png', description: 'Test image' };
+    await tonk.createFileWithBytes('/image.png', content, pngBytes);
+
+    // Get baseline from readFile
+    const readResult = await tonk.readFile('/image.png');
+
+    let callbackResult: any = null;
+    const watcher = await tonk.watchFile('/image.png', doc => {
+      callbackResult = doc;
+    });
+
+    // Update the file to trigger the callback
+    const updatedContent = { mime: 'image/png', description: 'Updated image' };
+    await tonk.updateFileWithBytes('/image.png', updatedContent, pngBytes);
+
+    // Wait for callback
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Verify callback result matches readFile structure
+    assert.ok(callbackResult, 'Callback should have been called');
+    assert.strictEqual(
+      callbackResult.name,
+      readResult.name,
+      'Name should match readFile'
+    );
+    assert.strictEqual(
+      callbackResult.type,
+      readResult.type,
+      'Type should match readFile'
+    );
+    assert.ok(
+      callbackResult.timestamps,
+      'Should have timestamps like readFile'
+    );
+    assert.deepStrictEqual(
+      callbackResult.content,
+      updatedContent,
+      'Content should match update'
+    );
+
+    // Verify bytes are present and in correct format (base64 string)
+    assert.ok(callbackResult.bytes, 'Files with bytes should have bytes field');
+    assert.strictEqual(
+      typeof callbackResult.bytes,
+      'string',
+      'Bytes should be base64 string'
+    );
+    assert.strictEqual(
+      callbackResult.bytes,
+      readResult.bytes,
+      'Bytes should match readFile format'
+    );
+
+    // Verify bytes can be converted back to original
+    const retrievedBytes = new Uint8Array(
+      Buffer.from(callbackResult.bytes, 'base64')
+    );
+    assert.deepStrictEqual(
+      retrievedBytes,
+      pngBytes,
+      'Decoded bytes should match original'
+    );
+
+    if (watcher) await watcher.stop();
+  });
+
+  test('watchDirectory should return directory change data', async () => {
+    // Create a directory to watch
+    await tonk.createDirectory('/watched-dir');
+
+    let callbackResult: any = null;
+
+    const watcher = await tonk.watchDirectory('/watched-dir', result => {
+      callbackResult = result;
+      // console.log('Directory watcher callback received:', result);
+    });
+
+    // Verify watcher was created
+    assert.ok(watcher, 'Directory watcher should be created');
+    assert.ok(
+      typeof watcher.documentId === 'function',
+      'Watcher should have documentId method'
+    );
+    assert.ok(
+      typeof watcher.stop === 'function',
+      'Watcher should have stop method'
+    );
+
+    // Get the document ID
+    const docId = watcher.documentId();
+    assert.ok(typeof docId === 'string', 'Document ID should be a string');
+    assert.ok(docId.length > 0, 'Document ID should not be empty');
+
+    // First, add multiple files to the directory
+    await tonk.createFile('/watched-dir/file1.txt', {
+      message: 'First file content',
+    });
+    await tonk.createFile('/watched-dir/file2.txt', {
+      message: 'Second file content',
+    });
+    await tonk.createFile('/watched-dir/file3.txt', {
+      message: 'Third file content',
+    });
+
+    // Create nested directory and file for deeper testing
+    await tonk.createDirectory('/watched-dir/new-dir');
+    await tonk.createFile('/watched-dir/new-dir/test.txt', {
+      message: 'Nested file content',
+    });
+
+    // Wait for initial callbacks to settle
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    // Reset callback result to capture the next update
+    callbackResult = null;
+
+    // Now modify only one of the files to see what the directory update shows
+    await tonk.updateFile('/watched-dir/file2.txt', {
+      message: 'Second file content UPDATED',
+      timestamp: Date.now(),
+    });
+
+    // Wait for callback
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Verify that the callback was triggered and received data
+    assert.ok(
+      callbackResult,
+      'Directory watcher callback should have been triggered'
+    );
+
+    // Verify the structure of the directory change data
+    assert.ok(
+      typeof callbackResult === 'object',
+      'Callback result should be an object'
+    );
+
+    // Check if it has directory metadata structure
+    if ('name' in callbackResult) {
+      assert.strictEqual(
+        callbackResult.name,
+        'watched-dir',
+        'Directory name should match'
+      );
+    }
+
+    if ('type' in callbackResult) {
+      assert.strictEqual(
+        callbackResult.type,
+        'directory',
+        'Directory type should be dir'
+      );
+    }
+
+    // Verify timestamps are present for directory metadata
+    if ('timestamps' in callbackResult) {
+      assert.ok(callbackResult.timestamps, 'Should have timestamps');
+      assert.ok(
+        typeof callbackResult.timestamps.created === 'number',
+        'Should have created timestamp'
+      );
+      assert.ok(
+        typeof callbackResult.timestamps.modified === 'number',
+        'Should have modified timestamp'
+      );
+    }
+
+    // Reset and test another change to a different file
+    callbackResult = null;
+    await tonk.updateFile('/watched-dir/file1.txt', {
+      message: 'First file content UPDATED TOO',
+      newField: 'added field',
+    });
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Should still be receiving updates
+    assert.ok(callbackResult, 'Should continue receiving directory updates');
+
+    // Test deeply nested file change - should NOT fire callback
+    callbackResult = null;
+
+    await tonk.updateFile('/watched-dir/new-dir/test.txt', {
+      message: 'Deeply nested file UPDATED',
+      timestamp: Date.now(),
+      level: 'nested',
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 250));
+
+    // Directory watcher should NOT fire for deeply nested changes
+    assert.strictEqual(
+      callbackResult,
+      null,
+      'Directory watcher should NOT fire for deeply nested file changes'
+    );
+
+    // Test direct child change - SHOULD fire callback
+    callbackResult = null;
+    await tonk.updateFile('/watched-dir/file3.txt', {
+      message: 'Direct child file UPDATED',
+      timestamp: Date.now(),
+      level: 'direct',
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Directory watcher SHOULD fire for direct child changes
+    assert.ok(
+      callbackResult !== null,
+      'Directory watcher SHOULD fire for direct child changes'
+    );
+
+    // Clean up
+    if (watcher) await watcher.stop();
+  });
+
+  test('should list directory contents correctly', async () => {
+    // Create a test directory structure
+    await tonk.createDirectory('/test-listing');
+    await tonk.createFile('/test-listing/file1.txt', { content: 'First file' });
+    await tonk.createFile('/test-listing/file2.json', { data: [1, 2, 3] });
+    await tonk.createDirectory('/test-listing/subdir');
+    await tonk.createFile('/test-listing/subdir/nested.txt', { nested: true });
+
+    // List the main directory
+    const entries = await tonk.listDirectory('/test-listing');
+
+    // Should have 3 entries (2 files + 1 subdirectory)
+    assert.strictEqual(entries.length, 3, 'Should have exactly 3 entries');
+
+    // Find each entry by name
+    const file1 = entries.find(e => e.name === 'file1.txt');
+    const file2 = entries.find(e => e.name === 'file2.json');
+    const subdir = entries.find(e => e.name === 'subdir');
+
+    // Verify file1.txt
+    assert.ok(file1, 'Should find file1.txt');
+    assert.strictEqual(
+      file1.type,
+      'document',
+      'file1.txt should be a document'
+    );
+    assert.ok(file1.timestamps, 'file1.txt should have timestamps');
+    assert.ok(
+      file1.timestamps.created,
+      'file1.txt should have created timestamp'
+    );
+    assert.ok(
+      file1.timestamps.modified,
+      'file1.txt should have modified timestamp'
+    );
+    assert.ok(
+      typeof file1.pointer === 'string',
+      'file1.txt should have a pointer'
+    );
+
+    // Verify file2.json
+    assert.ok(file2, 'Should find file2.json');
+    assert.strictEqual(
+      file2.type,
+      'document',
+      'file2.json should be a document'
+    );
+    assert.ok(file2.timestamps, 'file2.json should have timestamps');
+    assert.ok(
+      typeof file2.pointer === 'string',
+      'file2.json should have a pointer'
+    );
+
+    // Verify subdirectory
+    assert.ok(subdir, 'Should find subdir');
+    assert.strictEqual(
+      subdir.type,
+      'directory',
+      'subdir should be a directory'
+    );
+    assert.ok(subdir.timestamps, 'subdir should have timestamps');
+    assert.ok(
+      typeof subdir.pointer === 'string',
+      'subdir should have a pointer'
+    );
+
+    // List the subdirectory
+    const subdirEntries = await tonk.listDirectory('/test-listing/subdir');
+    assert.strictEqual(
+      subdirEntries.length,
+      1,
+      'Subdirectory should have 1 entry'
+    );
+
+    const nestedFile = subdirEntries[0];
+    assert.strictEqual(nestedFile.name, 'nested.txt', 'Should find nested.txt');
+    assert.strictEqual(
+      nestedFile.type,
+      'document',
+      'nested.txt should be a document'
+    );
+    assert.ok(nestedFile.timestamps, 'nested.txt should have timestamps');
+
+    // Test listing empty directory
+    await tonk.createDirectory('/empty-dir');
+    const emptyEntries = await tonk.listDirectory('/empty-dir');
+    assert.strictEqual(
+      emptyEntries.length,
+      0,
+      'Empty directory should have no entries'
+    );
+
+    // Test listing non-existent directory should throw
+    try {
+      await tonk.listDirectory('/non-existent');
+      assert.fail('Should throw error for non-existent directory');
+    } catch (error) {
+      assert.ok(
+        error instanceof FileSystemError,
+        'Should throw FileSystemError'
+      );
+    }
+  });
+
+  test('should get metadata for files and directories', async () => {
+    // Create test files and directories
+    await tonk.createFile('/test-file.txt', { content: 'test content' });
+    await tonk.createDirectory('/test-dir');
+    await tonk.createFile('/test-dir/nested-file.json', { data: [1, 2, 3] });
+
+    // Test file metadata
+    const fileMetadata = await tonk.getMetadata('/test-file.txt');
+    assert.ok(fileMetadata, 'Should return metadata for existing file');
+    assert.strictEqual(
+      fileMetadata.name,
+      'test-file.txt',
+      'File name should match'
+    );
+    assert.strictEqual(
+      fileMetadata.type,
+      'document',
+      'File type should be document'
+    );
+    assert.ok(fileMetadata.timestamps, 'Should have timestamps');
+    assert.ok(
+      typeof fileMetadata.timestamps.created === 'number',
+      'Should have created timestamp'
+    );
+    assert.ok(
+      typeof fileMetadata.timestamps.modified === 'number',
+      'Should have modified timestamp'
+    );
+    assert.ok(typeof fileMetadata.pointer === 'string', 'Should have pointer');
+    assert.ok(fileMetadata.pointer.length > 0, 'Pointer should not be empty');
+
+    // Test directory metadata
+    const dirMetadata = await tonk.getMetadata('/test-dir');
+    assert.ok(dirMetadata, 'Should return metadata for existing directory');
+    assert.strictEqual(
+      dirMetadata.name,
+      'test-dir',
+      'Directory name should match'
+    );
+    assert.strictEqual(
+      dirMetadata.type,
+      'directory',
+      'Directory type should be directory'
+    );
+    assert.ok(dirMetadata.timestamps, 'Directory should have timestamps');
+    assert.ok(
+      typeof dirMetadata.timestamps.created === 'number',
+      'Directory should have created timestamp'
+    );
+    assert.ok(
+      typeof dirMetadata.timestamps.modified === 'number',
+      'Directory should have modified timestamp'
+    );
+    assert.ok(
+      typeof dirMetadata.pointer === 'string',
+      'Directory should have pointer'
+    );
+
+    // Test nested file metadata
+    const nestedMetadata = await tonk.getMetadata('/test-dir/nested-file.json');
+    assert.ok(nestedMetadata, 'Should return metadata for nested file');
+    assert.strictEqual(
+      nestedMetadata.name,
+      'nested-file.json',
+      'Nested file name should match'
+    );
+    assert.strictEqual(
+      nestedMetadata.type,
+      'document',
+      'Nested file type should be document'
+    );
+    assert.ok(nestedMetadata.timestamps, 'Nested file should have timestamps');
+
+    // Test non-existent path should throw error
+    try {
+      await tonk.getMetadata('/non-existent-file.txt');
+      assert.fail('Should throw error for non-existent file');
+    } catch (error) {
+      assert.ok(
+        error instanceof FileSystemError,
+        'Should throw FileSystemError for non-existent file'
+      );
+    }
+
+    // Test root directory metadata
+    const rootMetadata = await tonk.getMetadata('/');
+    assert.ok(rootMetadata, 'Should return metadata for root directory');
+    assert.strictEqual(
+      rootMetadata.type,
+      'directory',
+      'Root should be a directory'
+    );
+
+    // Test invalid path should throw error
+    try {
+      await tonk.getMetadata('invalid-path-without-slash');
+      assert.fail('Should throw error for invalid path');
+    } catch (error) {
+      assert.ok(
+        error instanceof FileSystemError,
+        'Should throw FileSystemError for invalid path'
+      );
+    }
+  });
 });
 
 describe('Error Classes', () => {

--- a/packages/core-js/test/core.test.ts
+++ b/packages/core-js/test/core.test.ts
@@ -7,7 +7,6 @@ import {
   DocumentData,
   BundleError,
   ConnectionError,
-  DocumentTimestamps,
 } from '../dist/index.js';
 import { pngBytes } from './data.js';
 

--- a/packages/core/src/tonk_core.rs
+++ b/packages/core/src/tonk_core.rs
@@ -765,7 +765,7 @@ mod tests {
         // use automerge::ReadDoc;
         // let (value, _) = root_doc.get(automerge::ROOT, "type").unwrap().unwrap();
         // let doc_type = value.to_str().unwrap();
-        // assert_eq!(doc_type, "dir");
+        // assert_eq!(doc_type, "directory");
 
         // Check that the root document has a name
         // let (name_value, _) = root_doc.get(automerge::ROOT, "name").unwrap().unwrap();

--- a/packages/core/src/vfs/backend.rs
+++ b/packages/core/src/vfs/backend.rs
@@ -12,7 +12,7 @@ impl AutomergeHelpers {
     pub fn init_as_directory(handle: &DocHandle, name: &str) -> Result<()> {
         handle.with_document(|doc| {
             let mut tx = doc.transaction();
-            tx.put(automerge::ROOT, "type", "dir")?;
+            tx.put(automerge::ROOT, "type", "directory")?;
             tx.put(automerge::ROOT, "name", name)?;
 
             let now = chrono::Utc::now().timestamp_millis();
@@ -36,11 +36,11 @@ impl AutomergeHelpers {
                 .get(automerge::ROOT, "type")
                 .map_err(VfsError::AutomergeError)?
                 .and_then(|(value, _)| Self::extract_string_value(&value))
-                .unwrap_or_else(|| "dir".to_string());
+                .unwrap_or_else(|| "directory".to_string());
 
-            if node_type != "dir" {
+            if node_type != "directory" {
                 return Err(VfsError::NodeTypeMismatch {
-                    expected: "dir".to_string(),
+                    expected: "directory".to_string(),
                     actual: node_type,
                 });
             }
@@ -170,7 +170,7 @@ impl AutomergeHelpers {
     {
         handle.with_document(|doc| {
             let mut tx = doc.transaction();
-            tx.put(automerge::ROOT, "type", "doc")?;
+            tx.put(automerge::ROOT, "type", "document")?;
             tx.put(automerge::ROOT, "name", name)?;
 
             let now = chrono::Utc::now().timestamp_millis();
@@ -196,7 +196,7 @@ impl AutomergeHelpers {
     {
         handle.with_document(|doc| {
             let mut tx = doc.transaction();
-            tx.put(automerge::ROOT, "type", "doc")?;
+            tx.put(automerge::ROOT, "type", "document")?;
             tx.put(automerge::ROOT, "name", name)?;
 
             let now = chrono::Utc::now().timestamp_millis();
@@ -358,10 +358,10 @@ impl AutomergeHelpers {
             .ok()
             .flatten()
             .and_then(|(value, _)| Self::extract_string_value(&value))
-            .unwrap_or_else(|| "doc".to_string());
+            .unwrap_or_else(|| "document".to_string());
 
         let node_type = match node_type_str.as_str() {
-            "dir" => NodeType::Directory,
+            "directory" => NodeType::Directory,
             _ => NodeType::Document,
         };
 
@@ -402,10 +402,10 @@ impl AutomergeHelpers {
             .ok()
             .flatten()
             .and_then(|(value, _)| Self::extract_string_value(&value))
-            .unwrap_or_else(|| "doc".to_string());
+            .unwrap_or_else(|| "document".to_string());
 
         let node_type = match node_type_str.as_str() {
-            "dir" => NodeType::Directory,
+            "directory" => NodeType::Directory,
             _ => NodeType::Document,
         };
 
@@ -437,8 +437,8 @@ impl AutomergeHelpers {
     ) -> Result<()> {
         tx.put(obj_id.clone(), "name", ref_node.name.clone())?;
         let type_str = match ref_node.node_type {
-            NodeType::Directory => "dir",
-            NodeType::Document => "doc",
+            NodeType::Directory => "directory",
+            NodeType::Document => "document",
         };
         tx.put(obj_id.clone(), "type", type_str)?;
         tx.put(obj_id.clone(), "pointer", ref_node.pointer.to_string())?;
@@ -479,11 +479,11 @@ impl AutomergeHelpers {
                 .get(automerge::ROOT, "type")
                 .map_err(VfsError::AutomergeError)?
                 .and_then(|(value, _)| Self::extract_string_value(&value))
-                .unwrap_or_else(|| "doc".to_string());
+                .unwrap_or_else(|| "document".to_string());
 
-            if node_type != "doc" {
+            if node_type != "document" {
                 return Err(VfsError::NodeTypeMismatch {
-                    expected: "doc".to_string(),
+                    expected: "document".to_string(),
                     actual: node_type,
                 });
             }
@@ -530,11 +530,11 @@ impl AutomergeHelpers {
                 .get(automerge::ROOT, "type")
                 .map_err(VfsError::AutomergeError)?
                 .and_then(|(value, _)| Self::extract_string_value(&value))
-                .unwrap_or_else(|| "doc".to_string());
+                .unwrap_or_else(|| "document".to_string());
 
-            if node_type != "doc" {
+            if node_type != "document" {
                 return Err(VfsError::NodeTypeMismatch {
-                    expected: "doc".to_string(),
+                    expected: "document".to_string(),
                     actual: node_type,
                 });
             }

--- a/packages/core/src/vfs/types.rs
+++ b/packages/core/src/vfs/types.rs
@@ -4,16 +4,29 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum NodeType {
-    #[serde(rename = "doc")]
+    #[serde(rename = "document")]
     Document,
-    #[serde(rename = "dir")]
+    #[serde(rename = "directory")]
     Directory,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Timestamps {
     pub created: DateTime<Utc>,
     pub modified: DateTime<Utc>,
+}
+
+impl Serialize for Timestamps {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Timestamps", 2)?;
+        state.serialize_field("created", &self.created.timestamp_millis())?;
+        state.serialize_field("modified", &self.modified.timestamp_millis())?;
+        state.end()
+    }
 }
 
 impl Timestamps {


### PR DESCRIPTION
…o err throwing for invalid inputs

### Description

This PR is meant to bring more explicit typing and more consistent method signatures across the entire core API.

### Other changes

I have updated the default for invalid or missing paths from returning none to throwing errors. This is more consistent with other similar FS libraries in the JS ecosystem.

### Tested

Added tests around signatures that were modified

### Related issues

- closes TON-1463

### Backwards compatibility

It is not backwards compatible

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming types and improving the structure of the virtual file system in the `tonk` project, with changes to type definitions, metadata handling, and error management.

### Detailed summary
- Renamed `NodeMetadata`, `DirectoryEntry`, and `doc` to `RefNode`, `DirectoryNode`, and `document` respectively.
- Updated type definitions in `packages/core-js/src/index.ts` and `packages/core/src/vfs/types.rs`.
- Enhanced `Timestamps` struct with serialization implementation.
- Modified metadata retrieval methods to return `RefNode` instead of tuples.
- Adjusted error handling for file and directory operations.
- Updated tests to reflect type changes and ensure correctness.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->