### PR TITLE
fix(host-web): TON-1496: make BIOS screen mobile friendly

### DIFF
--- a/packages/host-web/src/index.html
+++ b/packages/host-web/src/index.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TONK BIOS</title>
     <style>
       @font-face {
@@ -133,7 +134,8 @@
         background: #000;
         border: 2px solid #666;
         padding: 20px;
-        min-width: 400px;
+        width: 90%;
+        max-width: 400px;
         display: none;
         z-index: 1000;
       }
@@ -206,7 +208,8 @@
         background: #000;
         border: 2px solid #666;
         padding: 20px;
-        min-width: 400px;
+        width: 90%;
+        max-width: 400px;
         display: none;
         z-index: 1000;
       }
@@ -283,7 +286,8 @@
         background: #000;
         border: 2px solid #666;
         padding: 20px;
-        min-width: 400px;
+        width: 90%;
+        max-width: 400px;
         display: none;
         z-index: 1000;
       }
@@ -337,7 +341,8 @@
         background: #000;
         border: 2px solid #666;
         padding: 30px;
-        min-width: 300px;
+        width: 90%;
+        max-width: 300px;
         display: none;
         z-index: 1001;
         text-align: center;
@@ -345,6 +350,64 @@
 
       .download-spinner-dialog.active {
         display: block;
+      }
+
+      @media (max-width: 768px) {
+        body {
+          padding: 15px;
+          font-size: 18px;
+        }
+
+        .bios-container {
+          max-width: 100%;
+        }
+
+        .version-text {
+          font-size: 16px;
+        }
+
+        .boot-menu {
+          padding: 12px;
+        }
+
+        .boot-menu-title {
+          font-size: 16px;
+        }
+
+        .app-item {
+          padding: 12px 10px;
+          font-size: 16px;
+        }
+
+        .app-status {
+          font-size: 14px;
+        }
+
+        .instructions {
+          font-size: 14px;
+        }
+
+        .btn {
+          padding: 12px 20px;
+          font-size: 16px;
+          min-height: 44px;
+        }
+
+        .confirmation-title,
+        .share-title,
+        .name-title {
+          font-size: 16px;
+        }
+
+        .confirmation-message,
+        .name-message {
+          font-size: 14px;
+        }
+
+        .name-input-container input {
+          padding: 12px;
+          font-size: 16px;
+        }
       }
     </style>
     <script>
@@ -462,9 +525,8 @@
         const app = availableApps[selectedAppIndex];
         const appName = typeof app === 'string' ? app : app.name;
 
-        document.getElementById(
-          'confirmation-message'
-        ).textContent = `Are you sure you want to boot "${appName}"?`;
+        document.getElementById('confirmation-message').textContent =
+          `Are you sure you want to boot "${appName}"?`;
         document.getElementById('confirmation-dialog').classList.add('active');
         document.getElementById('overlay').classList.add('active');
         isConfirmationOpen = true;


### PR DESCRIPTION
### Description

- improves font size and layout for mobile screens

### Other changes

None

### Tested

Yes

<img width="980" height="1874" alt="CleanShot 2025-10-02 at 17 55 38@2x" src="https://github.com/user-attachments/assets/1aa47db4-31ef-400e-a232-52c23a8832e2" />
<img width="910" height="1836" alt="CleanShot 2025-10-02 at 17 55 43@2x" src="https://github.com/user-attachments/assets/a0049969-dc5e-45cd-8806-bdc2ce04ed66" />

### Related issues

- closes TON-1496

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None