### PR TITLE
feat(latergram): TON-1494: give LLM context about current page

### DIFF
--- a/examples/latergram/src/App.tsx
+++ b/examples/latergram/src/App.tsx
@@ -23,10 +23,6 @@ const DynamicView: React.FC<{ viewName?: string }> = ({ viewName }) => {
 };
 
 const App: React.FC<{ viewName?: string }> = ({ viewName }) => {
-  const params = useParams();
-  const pathSegments = params['*'] || viewName || 'index';
-  const viewPath = `/src/views/${pathSegments}.tsx`;
-
   return (
     <AppInitializer>
       <Routes>
@@ -34,7 +30,7 @@ const App: React.FC<{ viewName?: string }> = ({ viewName }) => {
         <Route path="/editor/*" element={<Editor />} />
 
         {/* Page routes with persistent drawer overlay */}
-        <Route element={<PageLayout viewPath={viewPath} />}>
+        <Route element={<PageLayout />}>
           <Route path="/" element={<DynamicView viewName="index" />} />
           {/* Catch all route for dynamic views */}
           <Route path="/*" element={<DynamicView />} />

--- a/examples/latergram/src/components/PageLayout.tsx
+++ b/examples/latergram/src/components/PageLayout.tsx
@@ -1,18 +1,18 @@
 import { Code2Icon, MessageCircle } from 'lucide-react';
 import type React from 'react';
 import { createRef, useCallback, useEffect, useState } from 'react';
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet, useLocation } from 'react-router-dom';
 import { useAgentChat } from '../lib/agent/use-agent-chat';
 import { cn, isMobile } from '../lib/utils';
 import AgentChat from './chat/AgentChat';
 import { Drawer, DrawerContent, DrawerTrigger } from './ui/drawer';
 import { useVisualViewport } from './hooks/useVisualViewport';
 
-interface PageLayoutProps {
-  viewPath: string;
-}
-
-export const PageLayout: React.FC<PageLayoutProps> = ({ viewPath }) => {
+export const PageLayout: React.FC = () => {
+  const location = useLocation();
+  const pathname =
+    location.pathname === '/' ? 'index' : location.pathname.slice(1);
+  const viewPath = `/src/views/${pathname}.tsx`;
   const [open, setOpen] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
   const inputRef = createRef<HTMLTextAreaElement>();
@@ -132,7 +132,13 @@ export const PageLayout: React.FC<PageLayoutProps> = ({ viewPath }) => {
             touchAction: 'pan-y',
           }}
         >
-          <AgentChat inputRef={inputRef} onClose={() => handleOpen(false)} />
+          <AgentChat
+            inputRef={inputRef}
+            onClose={() => handleOpen(false)}
+            context={{
+              currentView: viewPath,
+            }}
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/examples/latergram/src/components/chat/AgentChat.tsx
+++ b/examples/latergram/src/components/chat/AgentChat.tsx
@@ -11,9 +11,18 @@ import ChatMessage from './ChatMessage';
 interface AgentChatProps {
   inputRef: React.RefObject<HTMLTextAreaElement>;
   onClose?: () => void;
+  context?: {
+    currentView?: string;
+    selectedFile?: string;
+    fileType?: 'component' | 'store' | 'page' | 'generic';
+  };
 }
 
-const AgentChat: React.FC<AgentChatProps> = ({ inputRef, onClose }) => {
+const AgentChat: React.FC<AgentChatProps> = ({
+  inputRef,
+  onClose,
+  context,
+}) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const {
     messages,
@@ -144,6 +153,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ inputRef, onClose }) => {
         inputRef={inputRef}
         onStop={stopGeneration}
         onClear={clearConversation}
+        context={context}
       />
     </div>
   );

--- a/examples/latergram/src/components/chat/ChatInputBar.tsx
+++ b/examples/latergram/src/components/chat/ChatInputBar.tsx
@@ -4,12 +4,24 @@ import { useCallback, useState } from 'react';
 import { useKeyboardSubmit } from './hooks';
 
 interface ChatInputBarProps {
-  onSendMessage: (text: string) => void;
+  onSendMessage: (
+    text: string,
+    context?: {
+      currentView?: string;
+      selectedFile?: string;
+      fileType?: 'component' | 'store' | 'page' | 'generic';
+    }
+  ) => void;
   isLoading: boolean;
   isReady: boolean;
   inputRef: React.RefObject<HTMLTextAreaElement>;
   onClear: () => Promise<void>;
   onStop: () => void;
+  context?: {
+    currentView?: string;
+    selectedFile?: string;
+    fileType?: 'component' | 'store' | 'page' | 'generic';
+  };
 }
 
 const ChatInputBar: React.FC<ChatInputBarProps> = ({
@@ -19,6 +31,7 @@ const ChatInputBar: React.FC<ChatInputBarProps> = ({
   inputRef,
   onClear,
   onStop,
+  context,
 }) => {
   const [prompt, setPrompt] = useState('');
 
@@ -27,10 +40,10 @@ const ChatInputBar: React.FC<ChatInputBarProps> = ({
       e?.preventDefault();
       // Allow typing but prevent sending while loading
       if (!prompt.trim() || !isReady || isLoading) return;
-      onSendMessage(prompt.trim());
+      onSendMessage(prompt.trim(), context);
       setPrompt('');
     },
-    [prompt, isReady, isLoading, onSendMessage]
+    [prompt, isReady, isLoading, onSendMessage, context]
   );
 
   const { handleKeyDown } = useKeyboardSubmit(handleSubmit);

--- a/examples/latergram/src/components/unified-editor/Editor.tsx
+++ b/examples/latergram/src/components/unified-editor/Editor.tsx
@@ -1,5 +1,5 @@
 import { Database, FileText, FolderOpen, House, Layers } from 'lucide-react';
-import { createRef, useCallback } from 'react';
+import { createRef, useCallback, useState } from 'react';
 import {
   Link,
   Route,
@@ -11,16 +11,29 @@ import {
 import AgentChat from '../chat/AgentChat';
 import { UnifiedEditor } from './UnifiedEditor';
 
+type FileType = 'component' | 'store' | 'page' | 'generic';
+
+const getFileType = (filePath: string): FileType => {
+  if (filePath.startsWith('/src/components/')) return 'component';
+  if (filePath.startsWith('/src/stores/')) return 'store';
+  if (filePath.startsWith('/src/views/')) return 'page';
+  return 'generic';
+};
+
 export default function Editor() {
   const chatInputRef = createRef<HTMLTextAreaElement>();
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fileParam = searchParams.get('file');
+  const [selectedFile, setSelectedFile] = useState<string | null>(
+    fileParam || null
+  );
 
   // Handle file change - update URL with the selected file
   const handleFileChange = useCallback(
     (filePath: string) => {
+      setSelectedFile(filePath);
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.set('file', filePath);
       navigate(`${location.pathname}?${newSearchParams.toString()}`, {
@@ -152,7 +165,17 @@ export default function Editor() {
           </Routes>
         </div>
         <div className="overflow-hidden col-span-2 border-l border-gray-200">
-          <AgentChat inputRef={chatInputRef} />
+          <AgentChat
+            inputRef={chatInputRef}
+            context={
+              selectedFile
+                ? {
+                    selectedFile,
+                    fileType: getFileType(selectedFile),
+                  }
+                : undefined
+            }
+          />
         </div>
       </div>
     </div>

--- a/examples/latergram/src/lib/agent/agent-chat-store.ts
+++ b/examples/latergram/src/lib/agent/agent-chat-store.ts
@@ -24,7 +24,14 @@ export interface AgentChatActions {
 
   // Public actions
   initialize: () => Promise<void>;
-  sendMessage: (text: string) => Promise<void>;
+  sendMessage: (
+    text: string,
+    context?: {
+      currentView?: string;
+      selectedFile?: string;
+      fileType?: 'component' | 'store' | 'page' | 'generic';
+    }
+  ) => Promise<void>;
   clearConversation: () => Promise<void>;
   stopGeneration: () => void;
   updateMessage: (messageId: string, newContent: string) => Promise<void>;
@@ -156,7 +163,7 @@ export const useAgentChatStore = create<AgentChatStore>((set, get) => ({
   },
 
   // Send a message
-  sendMessage: async text => {
+  sendMessage: async (text, context) => {
     const { isReady, isLoading } = get();
     if (!text.trim() || !isReady || isLoading) {
       return;
@@ -168,8 +175,8 @@ export const useAgentChatStore = create<AgentChatStore>((set, get) => ({
     try {
       let accumulatedContent = '';
 
-      // Stream the response
-      for await (const chunk of service.streamMessage(text)) {
+      // Stream the response with context
+      for await (const chunk of service.streamMessage(text, context)) {
         if (chunk.content) {
           accumulatedContent += chunk.content;
           set({ streamingContent: accumulatedContent });

--- a/examples/latergram/src/lib/agent/chat-history.ts
+++ b/examples/latergram/src/lib/agent/chat-history.ts
@@ -16,6 +16,11 @@ export interface ChatMessage {
   toolCallId?: string;
   hidden?: boolean;
   streaming?: boolean;
+  context?: {
+    currentView?: string;
+    selectedFile?: string;
+    fileType?: 'component' | 'store' | 'page' | 'generic';
+  };
 }
 
 export interface ChatHistoryData {

--- a/examples/latergram/src/services/vfs-service.ts
+++ b/examples/latergram/src/services/vfs-service.ts
@@ -286,7 +286,7 @@ export class VFSService {
             console.error('[VFSService] VFS initialization timeout');
             reject(new Error('VFS initialization timeout'));
           }
-        }, 10000);
+        }, 30000);
       });
     } catch (error) {
       throw new Error(

--- a/examples/latergram/src/tonk-worker.ts
+++ b/examples/latergram/src/tonk-worker.ts
@@ -10,7 +10,7 @@ import type { VFSWorkerMessage, VFSWorkerResponse } from './types';
 console.log('[Worker] Worker script loading...');
 
 // Debug logging flag - set to true to enable comprehensive logging
-const DEBUG_LOGGING = false;
+const DEBUG_LOGGING = true;
 
 // Logger utility
 function log(


### PR DESCRIPTION
### Description

- new context field passed to LLM from `AgentChat`
- LLM now knows what page/file a user is looking at, inside or outside the editor

### Other changes

- `viewPath` calculated from `useLocation` rather than passed through props

### Tested

Yes

### Related issues

- closes TON-1494

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None