### PR TITLE
chore(host-web): TON-1495: more descriptive error message

### DIFF
--- a/packages/host-web/src/index.html
+++ b/packages/host-web/src/index.html
@@ -1514,7 +1514,9 @@
               .catch(err => {
                 console.log('ServiceWorker registration failed: ', err);
                 showError(
-                  "Service Worker failed to load. If you're on Firefox, check ES module support."
+                  'Service Worker registration failed.\n\n' +
+                    'Firefox does not yet support ES modules in Service Workers.\n\n' +
+                    'Please use Chrome or Safari to run Tonks.'
                 );
               });
 


### PR DESCRIPTION
### Description

- explains service worker import issue and tells users to use chrome or safari

### Other changes

None

### Tested

Yes

### Related issues

- closes TON-1495

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes

### Documentation

None

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the error message displayed when the `ServiceWorker` registration fails, specifically for Firefox users, providing clearer guidance on browser compatibility.

### Detailed summary
- Updated the error message in `showError` for `ServiceWorker` registration failure.
- Changed the message to inform users that Firefox does not support ES modules in `Service Workers`.
- Suggested using Chrome or Safari to run Tonks instead.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->