### PR TITLE
fix(core): copy src directory when forking

### DIFF
--- a/packages/core/src/tonk_core.rs
+++ b/packages/core/src/tonk_core.rs
@@ -456,6 +456,12 @@ impl TonkCore {
         self.copy_directory_recursive(&self.vfs, &copied_vfs, "/app")
             .await?;
 
+        // Also copy /src if it exists
+        if self.vfs.exists("/src").await? {
+            self.copy_directory_recursive(&self.vfs, &copied_vfs, "/src")
+                .await?;
+        }
+
         // Export the copied VFS to bytes
         copied_vfs.to_bytes(config).await
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a check to determine if a directory named `/src` exists in the virtual file system (`vfs`) before copying it recursively to another location. This ensures that the directory is only copied if it exists, preventing unnecessary operations.

### Detailed summary
- Added a check to see if the directory `/src` exists in `self.vfs`.
- If `/src` exists, it calls `self.copy_directory_recursive` to copy the directory to `copied_vfs`.
- Ensured that the copying operation is awaited.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->