### PR TITLE
fix(host-web): new tonk always fetched from server

### DIFF
--- a/packages/host-web/src/index.html
+++ b/packages/host-web/src/index.html
@@ -845,10 +845,10 @@
         console.log('Creating new tonk...');
 
         // Check if we have any loaded bundles
-        const hasLoadedBundles = availableApps.length > 0;
+        const hasLoadedBundles = false;
 
         // Pre-populate with first app name if available, otherwise use 'new-tonk'
-        const defaultName = hasLoadedBundles ? availableApps[0] : 'new-tonk';
+        const defaultName = 'new-tonk';
 
         // Show name dialog
         showNameDialog(defaultName, hasLoadedBundles);
@@ -926,7 +926,10 @@
                 }
               };
 
-              navigator.serviceWorker.addEventListener('message', messageHandler);
+              navigator.serviceWorker.addEventListener(
+                'message',
+                messageHandler
+              );
 
               const arrayBuffer = blankBytes.buffer.slice(
                 blankBytes.byteOffset,
@@ -949,7 +952,9 @@
             });
 
             if (!tempLoadResponse.success) {
-              throw new Error(tempLoadResponse.error || 'Failed to load blank tonk');
+              throw new Error(
+                tempLoadResponse.error || 'Failed to load blank tonk'
+              );
             }
           }
 
@@ -971,10 +976,7 @@
               }
             };
 
-            navigator.serviceWorker.addEventListener(
-              'message',
-              messageHandler
-            );
+            navigator.serviceWorker.addEventListener('message', messageHandler);
 
             navigator.serviceWorker.controller.postMessage({
               type: 'forkToBytes',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the handling of loaded bundles and the default app name in the `index.html` file. It also includes formatting adjustments for event listener registration.

### Detailed summary
- Set `hasLoadedBundles` to `false` instead of checking `availableApps.length`.
- Changed `defaultName` to always be `'new-tonk'`.
- Reformatted `navigator.serviceWorker.addEventListener` calls for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->