### PR TITLE
fix(relay): server error handling

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -365,8 +365,9 @@ process.on('uncaughtException', error => {
 
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled rejection at:', promise, 'reason:', reason);
-  console.error('Process will exit and systemd will restart it');
-  process.exit(1);
+  console.error(
+    'This is likely an operational error (timeout, network issue, etc.)'
+  );
 });
 
 main().catch(error => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the error handling for unhandled promise rejections in the `process` event listener. It provides a more informative error message instead of indicating that the process will exit.

### Detailed summary
- Updated the error message for unhandled rejections in the `process.on('unhandledRejection')` handler.
- Removed the line that indicated the process would exit and systemd would restart it.
- Added a new message clarifying that the error is likely due to operational issues (timeout, network issue, etc.).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->