### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Tonk
+Copyright (c) 2026 Tonk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Annual copyright year update.

- Updated year: 2025 -> 2026
- Files affected: LICENSE

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the copyright year in the `LICENSE` file from 2025 to 2026.

### Detailed summary
- Updated copyright year from `2025` to `2026` in the `LICENSE` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->