### PR TITLE
Revert "feat: wiring up space with UI"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,7 +3915,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tonk-common",
- "tonk-space",
  "tower",
  "tower-service",
  "url",

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
             --archive-file "$TESTS_PATH/${target}.tar.zst" \
         '';
 
-        menuTestEnv = with pkgs; lib.optionalAttrs stdenv.isLinux {
+        menuTestEnv = with pkgs; lib.optionals stdenv.isLinux {
           "CHROME" = "${chromium}/bin/chromium";
           "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
         };
@@ -193,7 +193,7 @@
           default = mkShell {
             buildInputs = commonBuildInputs;
             nativeBuildInputs = menu.commands;
-            env = lib.optionalAttrs stdenv.isLinux {
+            env = lib.optionals stdenv.isLinux {
               "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
             };
             shellHook = ''
@@ -211,7 +211,7 @@
           ci = mkShell {
             buildInputs = commonBuildInputs;
             nativeBuildInputs = menu.commands;
-            env = lib.optionalAttrs stdenv.isLinux {
+            env = lib.optionals stdenv.isLinux {
               "CHROME" = "${chromium}/bin/chromium";
               "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
             };

--- a/rust/tonk-space/src/lib.rs
+++ b/rust/tonk-space/src/lib.rs
@@ -18,9 +18,7 @@ pub use ::ucan::time::timestamp::Timestamp;
 pub use dialog_artifacts::PlatformBackend;
 pub use dialog_query::claim::Transaction;
 pub use ownership::Ownership;
-pub use space::{
-    MemoryBackend, MemoryStorageBackend, RemoteConfig, RemoteState, Revision, Space, SpaceError,
-};
+pub use space::{MemoryBackend, MemoryStorageBackend, RemoteState, Revision, Space, SpaceError};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use space::{FileSystemStorageBackend, FsBackend};

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 // Re-export types for CLI use
-pub use dialog_artifacts::replica::{RemoteConfig, RemoteState, Revision, UpstreamState};
+pub use dialog_artifacts::replica::{RemoteState, Revision, UpstreamState};
 pub use dialog_storage::MemoryStorageBackend;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -115,7 +115,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         })
     }
 
-    /// Open an existing space, or create the branch if it doesn't exist.
+    /// Open an existing space.
     ///
     /// # Arguments
     /// * `space_did` - The DID of the space
@@ -123,7 +123,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
     /// * `backend` - The storage backend to use
     ///
     /// # Returns
-    /// The Space instance with access to the branch
+    /// The Space instance with access to the existing branch
     pub async fn open(
         space_did: String,
         operator: &Operator,
@@ -132,9 +132,9 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         // Open the replica with the operator as issuer
         let replica = Replica::open(Issuer::from(operator), backend)?;
 
-        // Open the "main" branch (creates it if it doesn't exist)
+        // Load the "main" branch
         let branch_id = BranchId::new("main".to_string());
-        let branch = replica.branches.open(&branch_id).await?;
+        let branch = replica.branches.load(&branch_id).await?;
 
         // Create session for the branch (clone branch since Session takes ownership)
         let session = Session::open(branch.clone());

--- a/rust/tonk-ui/assets/styles/elements/input.css
+++ b/rust/tonk-ui/assets/styles/elements/input.css
@@ -1,5 +1,4 @@
-input[type="text"],
-input[type="password"] {
+input[type="text"] {
     border: 1px solid var(--text-input-border-color, #E4E4E7);
     background-color: var(--text-input-background-color, #F4F4F580);
     border-radius: 6px;
@@ -12,26 +11,22 @@ input[type="password"] {
     outline: none;
 }
 
-input[type="text"][disabled],
-input[type="password"][disabled] {
+input[type="text"][disabled] {
     border-color: var(--text-input-disabled-border-color, #e4e4e7);
     background-color: var(--text-input-disabled-background-color, #F4F4F5);
     color: var(--text-input-disabled-text-color, #71717A);
     cursor: not-allowed;
 }
 
-input[type="text"]::placeholder,
-input[type="password"]::placeholder {
+input[type="text"]::placeholder {
     color: var(--text-input-placeholder-color, #71717A);
 }
 
 
-input[type="text"]:focus,
-input[type="password"]:focus {
+input[type="text"]:focus {
     outline: none;
 }
 
-input[type="text"]:focus-visible,
-input[type="password"]:focus-visible {
+input[type="text"]:focus-visible {
     outline: 2px solid var(--color-gray-900);
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -1,5 +1,5 @@
 use leptos::{logging::log, prelude::window};
-use tonk_worker::{AuthorizeRequest, AuthorizeResponse, StatusResponse};
+use tonk_worker::{AuthorizeRequest, AuthorizeResponse};
 
 use crate::error::TonkUiError;
 
@@ -15,19 +15,6 @@ fn origin() -> String {
         .location()
         .origin()
         .expect("Could not read window location")
-}
-
-/// Fetches the current status of the space from the service worker.
-pub async fn status() -> Result<StatusResponse, TonkUiError> {
-    log!("Fetching status...");
-
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/status", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-
-    response.json().await.map_err(into_api_error)
 }
 
 /// Authorizes the user with the Tonk service worker.

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -27,18 +27,8 @@ extern "C" {
     async fn service_worker_activates();
 }
 
-/// The current status of the application.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Status {
-    /// Service worker is still loading/activating.
-    Loading,
-    /// Service worker is ready but no upstream remote is configured.
-    Unauthorized,
-    /// Authorization request has been sent, waiting for response.
-    Authorizing,
-    /// Service worker is ready and upstream remote is configured.
-    Authorized,
-}
+/// A marker type to represent the activation status of a service worker
+pub struct ActiveServiceWorker;
 
 /// The root UI component for the Tonk application.
 ///
@@ -47,48 +37,23 @@ pub enum Status {
 #[component]
 pub fn TonkShell() -> impl IntoView {
     log!("Tonk shell initializing...");
-
-    // Fetch status after service worker is ready
-    let status_resource = LocalResource::new(|| async {
+    let active_service_worker = LocalResource::new(|| async {
         log!("Waiting for SW to activate...");
         service_worker_activates().await;
-        log!("SW is activated, fetching status...");
-        api::status().await
+        log!("SW is activated!");
+        ActiveServiceWorker
     });
 
     let authorize_action =
         Action::new_local(|request: &AuthorizeRequest| api::authorize(request.clone()));
-
-    // Derive the application status from status resource and authorize action
-    let status = Signal::derive_local(move || {
-        // Check if status has loaded
-        let response = match status_resource.get() {
-            Some(Ok(response)) => response,
-            _ => return Status::Loading,
-        };
-
-        // Check if already authorized (has upstream)
-        if response.has_upstream {
-            return Status::Authorized;
-        }
-
-        // Check if authorization is in progress
-        if authorize_action.pending().get() {
-            return Status::Authorizing;
-        }
-
-        // Check if authorization succeeded
-        if let Some(Ok(response)) = authorize_action.value().get()
-            && response.success
-        {
-            return Status::Authorized;
-        }
-
-        Status::Unauthorized
+    let authorization = Signal::derive_local(move || match authorize_action.value().get() {
+        Some(Ok(response)) => Some(response),
+        _ => None,
     });
 
-    provide_context(status);
+    provide_context(active_service_worker);
     provide_context(authorize_action);
+    provide_context(authorization);
 
     view! {
         <TonkAuth></TonkAuth>

--- a/rust/tonk-ui/src/components/auth.rs
+++ b/rust/tonk-ui/src/components/auth.rs
@@ -1,54 +1,62 @@
 use leptos::prelude::*;
 use tonk_worker::{AuthorizeRequest, AuthorizeResponse};
 
-use crate::{components::Status, error::TonkUiError};
+use crate::{components::ActiveServiceWorker, error::TonkUiError};
 
-/// Authentication form for user login with R2 credentials.
+/// Authentication form for user login with account credentials.
 #[component]
 pub fn TonkAuth() -> impl IntoView {
-    let (access_key_id, set_access_key_id) = signal_local(String::new());
-    let (secret_access_key, set_secret_access_key) = signal_local(String::new());
+    let (is_submitted, set_is_submitted) = signal_local(false);
+    let (account_id, set_account_id) = signal_local(String::new());
+    let (secret_key, set_secret_key) = signal_local(String::new());
 
-    let status = use_context::<Signal<Status, LocalStorage>>().expect("Missing status");
+    let service_worker = use_context::<LocalResource<ActiveServiceWorker>>()
+        .expect("Missing active service worker resource");
 
     let authorize_action =
         use_context::<Action<AuthorizeRequest, Result<AuthorizeResponse, TonkUiError>>>()
-            .expect("Missing authorize action");
+            .expect("Missing expected authorize action");
 
-    let is_authorizing = move || status.get() == Status::Authorizing;
+    let authorization = use_context::<Signal<Option<AuthorizeResponse>, LocalStorage>>()
+        .expect("Missing expected authorization signal");
 
     let ready_to_submit = move || {
-        status.get() == Status::Unauthorized
-            && !access_key_id.get().is_empty()
-            && !secret_access_key.get().is_empty()
+        service_worker.read().is_some()
+            && !account_id.get().is_empty()
+            && !secret_key.get().is_empty()
+            && !is_submitted.get()
     };
 
-    let submit = move |_| {
+    Effect::new(move |_| {
+        if !is_submitted.get() {
+            return;
+        }
+
+        let account_id = account_id.get();
+        let secret_key = secret_key.get();
+
         authorize_action.dispatch(AuthorizeRequest {
-            access_key_id: access_key_id.get(),
-            secret_access_key: secret_access_key.get(),
+            secret_key,
+            account_id,
         });
-    };
+    });
 
     let button_text = move || {
-        if is_authorizing() {
+        if is_submitted.get() {
             "Authorizing..."
         } else {
             "Authorize"
         }
     };
 
-    // Show form when unauthorized or authorizing
-    let show_form = move || matches!(status.get(), Status::Unauthorized | Status::Authorizing);
-
     view! {
         <section
             class="auth"
-            class:pending=show_form
+            class:pending=move || authorization.get().is_none()
         >
             <section
                 class="loading-indicator"
-                class:visible=is_authorizing
+                class:visible=move || is_submitted.get() && authorization.get().is_none()
             >
             </section>
             <section
@@ -56,26 +64,26 @@ pub fn TonkAuth() -> impl IntoView {
             >
                 <input
                     type="text"
-                    placeholder="Access Key ID"
-                    prop:value=access_key_id
-                    disabled=is_authorizing
+                    placeholder="Account ID"
+                    prop:value=account_id
+                    disabled=is_submitted
                     on:input=move |ev| {
-                        set_access_key_id.set(event_target_value(&ev));
+                        set_account_id.set(event_target_value(&ev));
                     }
                 />
                 <input
-                    type="password"
-                    placeholder="Secret Access Key"
-                    prop:value=secret_access_key
-                    disabled=is_authorizing
+                    type="text"
+                    placeholder="Secret Key"
+                    prop:value=secret_key
+                    disabled=is_submitted
                     on:input=move |ev| {
-                        set_secret_access_key.set(event_target_value(&ev));
+                        set_secret_key.set(event_target_value(&ev));
                     }
                 />
                 <button
                     aria-label=button_text
                     disabled=move || !ready_to_submit()
-                    on:click=submit
+                    on:click=move |_| set_is_submitted.set(true)
                 >{button_text}</button>
             </section>
         </section>
@@ -89,12 +97,15 @@ pub fn TonkAuth() -> impl IntoView {
 mod integration_tests {
     #![allow(unexpected_cfgs)]
 
+    use std::time::Duration;
+
     #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
     use crate::helpers::TestEnvironment;
     #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
     use anyhow::Result;
     #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
     use thirtyfour::prelude::*;
+    use tokio::time::sleep;
 
     #[dialog_common::test]
     async fn it_reaches_the_website(test_environment: TestEnvironment) -> Result<()> {
@@ -114,20 +125,16 @@ mod integration_tests {
     ) -> Result<()> {
         let driver = test_environment.driver().await?;
 
-        let access_key_id_input = driver
-            .query(By::Css("[placeholder='Access Key ID']"))
+        sleep(Duration::from_secs(3)).await;
+
+        let account_id_input = driver
+            .query(By::Css("[placeholder='Account ID']"))
             .first()
             .await?;
-        access_key_id_input
-            .send_keys("AKIAIOSFODNN7EXAMPLE")
-            .await?;
+        account_id_input.send_keys("abc123").await?;
 
-        let secret_access_key_input = driver
-            .find(By::Css("[placeholder='Secret Access Key']"))
-            .await?;
-        secret_access_key_input
-            .send_keys("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-            .await?;
+        let secret_key_input = driver.find(By::Css("[placeholder='Secret Key']")).await?;
+        secret_key_input.send_keys("123abc").await?;
 
         let authorize_button = driver
             .query(By::Css("[aria-label='Authorize']:not(:disabled)"))

--- a/rust/tonk-ui/src/components/toolbar.rs
+++ b/rust/tonk-ui/src/components/toolbar.rs
@@ -1,16 +1,16 @@
 use leptos::prelude::*;
-
-use crate::components::Status;
+use tonk_worker::AuthorizeResponse;
 
 /// Top navigation toolbar with app controls and user menu.
 #[component]
 pub fn TonkToolbar() -> impl IntoView {
-    let status = use_context::<Signal<Status, LocalStorage>>().expect("Missing status");
+    let authorization = use_context::<Signal<Option<AuthorizeResponse>, LocalStorage>>()
+        .expect("Missing expected authorization signal");
     // TODO(cdata): This is all placeholder for now
     view! {
         <section
             class="toolbar"
-            class:visible=move || status.get() == Status::Authorized
+            class:visible=move || authorization.get().is_some()
         >
             <img src="/images/tonk-logo.svg" />
             <img src="/images/circle-plus.svg" width="36"/>

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonk-common = { workspace = true }
-tonk-space = { workspace = true }
 tower-service = { workspace = true }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/rust/tonk-worker/src/error.rs
+++ b/rust/tonk-worker/src/error.rs
@@ -7,12 +7,9 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum TonkWorkerError {
     /// An error occurred in the router.
+
     #[error("Router error: {0}")]
     Router(String),
-
-    /// An internal error occurred.
-    #[error("Internal error: {0}")]
-    Internal(String),
 }
 
 impl IntoResponse for TonkWorkerError {

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1,34 +1,26 @@
 //! API router configuration and handlers.
 
-use std::sync::Arc;
-
 use ::axum::{Router, extract::State, routing::get, routing::post};
-use tokio::sync::RwLock;
-use tonk_space::Space;
+use dialog_artifacts::Artifacts;
 
 use crate::ServiceWorkerStorageBackend;
 
 mod authorize;
-pub use authorize::{AuthorizeRequest, AuthorizeResponse, StatusResponse, authorize, status};
-
-/// Shared application state containing the Space.
-pub type AppState = Arc<RwLock<Space<ServiceWorkerStorageBackend>>>;
+pub use authorize::*;
 
 /// Root handler that returns a welcome message.
-async fn root(State(_space): State<AppState>) -> &'static str {
+async fn root(State(_artifacts): State<Artifacts<ServiceWorkerStorageBackend>>) -> &'static str {
     "Hello, Tonk!"
 }
 
 /// Creates the API router with all configured routes.
 ///
-/// Sets up the routing tree with the space as shared state.
-pub fn api_router(space: Space<ServiceWorkerStorageBackend>) -> Router {
-    let state: AppState = Arc::new(RwLock::new(space));
+/// Sets up the routing tree with the artifacts storage as shared state.
+pub fn api_router(artifacts: Artifacts<ServiceWorkerStorageBackend>) -> Router {
     Router::new()
         .route("/api", get(root))
         .route("/api/authorize", post(authorize))
-        .route("/api/status", get(status))
-        .with_state(state)
+        .with_state(artifacts)
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
@@ -37,22 +29,20 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use tonk_space::{Operator, Space};
+    use dialog_artifacts::Artifacts;
     use tower::ServiceExt;
 
-    pub async fn test_space() -> Space<ServiceWorkerStorageBackend> {
-        let operator = Operator::from_passphrase("test tonk").await;
-        let space_did = operator.did().to_string();
-        let backend = ServiceWorkerStorageBackend::new(&space_did).await;
-        Space::open(space_did, &operator, backend)
+    pub async fn test_artifacts() -> Artifacts<ServiceWorkerStorageBackend> {
+        let backend = ServiceWorkerStorageBackend::new().await;
+        Artifacts::open("tonk-test".into(), backend)
             .await
-            .expect("Failed to create test space")
+            .expect("Failed to create test artifacts")
     }
 
     #[dialog_common::test]
     async fn it_responds_to_root_api_request() {
-        let space = test_space().await;
-        let app = api_router(space);
+        let artifacts = test_artifacts().await;
+        let app = api_router(artifacts);
 
         let request = Request::builder()
             .uri("/api")

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -1,114 +1,74 @@
-use ::axum::{Json, extract::State};
+use ::axum::Json;
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_space::{RemoteConfig, RemoteState};
+use url::Url;
+use web_time::Duration;
 
-use super::AppState;
 use crate::TonkWorkerError;
-
-/// R2 endpoint for Tonk spaces storage.
-const R2_ENDPOINT: &str = "https://5f20ca8a0de0a5ac52a14fa8bf9c90db.r2.cloudflarestorage.com";
-/// R2 bucket name for Tonk spaces.
-const R2_BUCKET: &str = "tonk-spaces";
 
 /// Authorization request with account credentials.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeRequest {
-    /// AWS access key ID.
-    pub access_key_id: String,
-    /// AWS secret access key.
-    pub secret_access_key: String,
+    /// Secret key for authentication.
+    pub secret_key: String,
+    /// Account identifier.
+    pub account_id: String,
 }
 
-/// Authorization response indicating success.
+/// Authorization response containing a presigned URL.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeResponse {
-    /// Whether the authorization and remote setup succeeded.
-    pub success: bool,
+    /// Presigned URL for accessing authorized resources.
+    pub presigned_url: Url,
 }
 
-/// Status response indicating the current space state.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StatusResponse {
-    /// The DID of the space.
-    pub space_did: String,
-    /// Whether the space has an upstream remote configured.
-    pub has_upstream: bool,
-}
-
-/// Handles authorization requests and configures the R2 remote for the space.
+/// Handles authorization requests for accessing cloud storage resources.
 #[wasm_compat]
 pub async fn authorize(
-    State(state): State<AppState>,
-    Json(body): Json<AuthorizeRequest>,
+    Json(_body): Json<AuthorizeRequest>,
 ) -> Result<Json<AuthorizeResponse>, TonkWorkerError> {
-    log!("Authorizing and configuring R2 remote...");
+    use crate::sleep;
 
-    let mut space = state.write().await;
+    log!("NOTE: Simulating S3/R2 API request latency of ~1 second...");
 
-    // Create remote config with R2 credentials
-    // Prefix is space DID followed by /
-    let prefix = format!("{}/", space.did);
+    if let Err(error) = sleep(Duration::from_secs(1)).await {
+        log!("{:?}", error);
+    }
 
-    let remote_config = RemoteConfig {
-        endpoint: R2_ENDPOINT.to_string(),
-        region: "auto".to_string(),
-        bucket: R2_BUCKET.to_string(),
-        prefix: Some(prefix),
-        access_key_id: Some(body.access_key_id),
-        secret_access_key: Some(body.secret_access_key),
-    };
-
-    let remote_state = RemoteState {
-        site: "r2".to_string(),
-        address: remote_config,
-    };
-
-    // Add the remote to the space
-    space.add_remote(remote_state).await.map_err(|e| {
-        log!("Failed to add remote: {:?}", e);
-        TonkWorkerError::Internal(format!("Failed to add remote: {}", e))
-    })?;
-
-    log!("R2 remote configured successfully");
-
-    Ok(Json(AuthorizeResponse { success: true }))
-}
-
-/// Returns the current status of the space.
-#[wasm_compat]
-pub async fn status(
-    State(state): State<AppState>,
-) -> Result<Json<StatusResponse>, TonkWorkerError> {
-    let space = state.read().await;
-
-    Ok(Json(StatusResponse {
-        space_did: space.did.clone(),
-        has_upstream: space.has_upstream().await,
+    Ok(Json(AuthorizeResponse {
+        presigned_url: Url::parse("https://www.example.com").unwrap(),
     }))
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
-    use super::super::tests::test_space;
-    use crate::{StatusResponse, api_router};
+    use super::super::tests::test_artifacts;
+    use crate::{AuthorizeRequest, AuthorizeResponse, api_router};
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
     #[dialog_common::test]
-    async fn it_returns_status_without_upstream() {
-        let space = test_space().await;
-        let app = api_router(space);
+    async fn it_authorizes_and_returns_presigned_url() {
+        let artifacts = test_artifacts().await;
+        let app = api_router(artifacts);
+
+        let auth_request = AuthorizeRequest {
+            secret_key: "test-secret".to_string(),
+            account_id: "test-account".to_string(),
+        };
 
         let request = Request::builder()
-            .uri("/api/status")
-            .method("GET")
-            .body(Body::empty())
+            .uri("/api/authorize")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_vec(&auth_request).expect("Failed to serialize request"),
+            ))
             .expect("Failed to build request");
 
         let response = app
@@ -122,10 +82,12 @@ mod tests {
             .await
             .expect("Failed to read response body");
 
-        let status_response: StatusResponse =
+        let auth_response: AuthorizeResponse =
             serde_json::from_slice(&body).expect("Failed to deserialize response");
 
-        assert!(!status_response.has_upstream);
-        assert!(!status_response.space_did.is_empty());
+        assert_eq!(
+            auth_response.presigned_url.as_str(),
+            "https://www.example.com/"
+        );
     }
 }

--- a/rust/tonk-worker/src/storage.rs
+++ b/rust/tonk-worker/src/storage.rs
@@ -6,48 +6,35 @@ mod inner {
     use std::sync::Arc;
     use wasm_bindgen::prelude::*;
 
-    use dialog_common::Blake3Hash;
     use dialog_storage::{
-        CompressedStorage, DialogStorageError, IndexedDbStorageBackend, StorageBackend,
-        StorageCache, TransactionalMemoryBackend,
+        Blake3Hash, CompressedStorage, DialogStorageError, IndexedDbStorageBackend, StorageBackend,
+        StorageCache, web::ObjectSafeStorageBackend,
     };
     use tokio::sync::Mutex;
-
-    /// Type alias for compressed and cached storage backend.
-    type CachedStorage =
-        StorageCache<CompressedStorage<3, IndexedDbStorageBackend<[u8; 32], Vec<u8>>>>;
 
     /// Storage backend for the service worker using IndexedDB with compression and caching.
     ///
     /// This wraps an IndexedDB backend with compression and caching layers to optimize
     /// storage performance in the browser environment.
     #[derive(Clone)]
-    pub struct ServiceWorkerStorageBackend {
-        /// Compressed and cached storage for blobs (StorageBackend).
-        /// Uses [u8; 32] keys internally for content-addressed storage.
-        storage: Arc<Mutex<CachedStorage>>,
-        /// Raw IndexedDB backend for transactional memory (branches, remotes).
-        memory: IndexedDbStorageBackend<Vec<u8>, Vec<u8>>,
-    }
+    pub struct ServiceWorkerStorageBackend(Arc<Mutex<dyn ObjectSafeStorageBackend>>);
 
     impl ServiceWorkerStorageBackend {
         /// Creates a new storage backend instance.
         ///
         /// Initializes an IndexedDB backend wrapped with compression (level 3) and
         /// a 64K-large in-memory cache for blocks.
-        pub async fn new(name: &str) -> Self {
-            let backend: IndexedDbStorageBackend<[u8; 32], Vec<u8>> =
-                IndexedDbStorageBackend::new(name).await.unwrap_throw();
-            let compressed = CompressedStorage::<3, _>::new(backend);
+        pub async fn new() -> Self {
+            let backend = IndexedDbStorageBackend::new("tonk-artifacts")
+                .await
+                .unwrap_throw();
+            let backend = CompressedStorage::<3, _>::new(backend);
             #[allow(clippy::arc_with_non_send_sync)]
-            let storage = Arc::new(Mutex::new(
-                StorageCache::new(compressed, 64_000).unwrap_throw(),
+            let backend: Arc<Mutex<dyn ObjectSafeStorageBackend>> = Arc::new(Mutex::new(
+                StorageCache::new(backend, 64_000).unwrap_throw(),
             ));
 
-            let memory: IndexedDbStorageBackend<Vec<u8>, Vec<u8>> =
-                IndexedDbStorageBackend::new(name).await.unwrap_throw();
-
-            Self { storage, memory }
+            Self(backend)
         }
     }
 
@@ -59,112 +46,50 @@ mod inner {
     unsafe impl Send for ServiceWorkerStorageBackend {}
     unsafe impl Sync for ServiceWorkerStorageBackend {}
 
-    /// Convert Vec<u8> to [u8; 32], assuming the vec contains exactly 32 bytes.
-    fn vec_to_hash(key: &[u8]) -> Result<[u8; 32], DialogStorageError> {
-        key.try_into().map_err(|_| {
-            DialogStorageError::StorageBackend(format!("Key must be 32 bytes, got {}", key.len()))
-        })
-    }
-
     #[async_trait(?Send)]
     impl StorageBackend for ServiceWorkerStorageBackend {
-        type Key = Vec<u8>;
+        type Key = Blake3Hash;
         type Value = Vec<u8>;
         type Error = DialogStorageError;
 
         async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
-            let hash = vec_to_hash(&key)?;
-            self.storage.lock().await.set(hash, value).await
+            StorageBackend::set(&mut self.0, key, value).await
         }
 
         async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
-            let hash = vec_to_hash(key)?;
-            self.storage.lock().await.get(&hash).await
-        }
-    }
-
-    #[async_trait(?Send)]
-    impl TransactionalMemoryBackend for ServiceWorkerStorageBackend {
-        type Address = Vec<u8>;
-        type Value = Vec<u8>;
-        type Error = DialogStorageError;
-        type Edition = Blake3Hash;
-
-        async fn resolve(
-            &self,
-            address: &Self::Address,
-        ) -> Result<Option<(Self::Value, Self::Edition)>, Self::Error> {
-            self.memory.resolve(address).await
-        }
-
-        async fn replace(
-            &self,
-            address: &Self::Address,
-            edition: Option<&Self::Edition>,
-            content: Option<Self::Value>,
-        ) -> Result<Option<Self::Edition>, Self::Error> {
-            self.memory.replace(address, edition, content).await
+            StorageBackend::get(&self.0, key).await
         }
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 mod inner {
-    use dialog_common::Blake3Hash;
-    use dialog_storage::{
-        DialogStorageError, MemoryStorageBackend, StorageBackend, TransactionalMemoryBackend,
-    };
+    use dialog_storage::{Blake3Hash, DialogStorageError, MemoryStorageBackend, StorageBackend};
 
     /// Storage backend for non-Wasm targets using in-memory storage.
     ///
     /// This is only a placeholder implementation for testing purposes. The worker
     /// has no use case for being used in non-wasm contexts at this time.
     #[derive(Clone)]
-    pub struct ServiceWorkerStorageBackend(MemoryStorageBackend<Vec<u8>, Vec<u8>>);
-
+    pub struct ServiceWorkerStorageBackend(MemoryStorageBackend<Blake3Hash, Vec<u8>>);
     impl ServiceWorkerStorageBackend {
         /// Creates a new in-memory storage backend instance.
-        pub async fn new(_name: &str) -> Self {
+        pub async fn new() -> Self {
             Self(MemoryStorageBackend::default())
         }
     }
-
     #[async_trait::async_trait]
     impl StorageBackend for ServiceWorkerStorageBackend {
-        type Key = Vec<u8>;
+        type Key = Blake3Hash;
         type Value = Vec<u8>;
         type Error = DialogStorageError;
 
         async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
-            self.0.set(key, value).await
+            StorageBackend::set(&mut self.0, key, value).await
         }
 
         async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
-            self.0.get(key).await
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl TransactionalMemoryBackend for ServiceWorkerStorageBackend {
-        type Address = Vec<u8>;
-        type Value = Vec<u8>;
-        type Error = DialogStorageError;
-        type Edition = Blake3Hash;
-
-        async fn resolve(
-            &self,
-            address: &Self::Address,
-        ) -> Result<Option<(Self::Value, Self::Edition)>, Self::Error> {
-            self.0.resolve(address).await
-        }
-
-        async fn replace(
-            &self,
-            address: &Self::Address,
-            edition: Option<&Self::Edition>,
-            content: Option<Self::Value>,
-        ) -> Result<Option<Self::Edition>, Self::Error> {
-            self.0.replace(address, edition, content).await
+            StorageBackend::get(&self.0, key).await
         }
     }
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -9,10 +9,10 @@ use crate::{
     axum::{RequestConversion, ResponseConversion},
 };
 use axum::{Router, body::Body};
+use dialog_artifacts::Artifacts;
 use js_sys::Promise;
 use tokio::sync::Mutex;
 use tonk_common::log;
-use tonk_space::{Operator, Space};
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -31,7 +31,7 @@ pub struct TonkServiceWorker {
 impl TonkServiceWorker {
     /// Creates a new service worker instance.
     ///
-    /// Initializes the storage backend, space, and API router.
+    /// Initializes the storage backend, artifacts system, and API router.
     ///
     /// # Errors
     ///
@@ -39,18 +39,13 @@ impl TonkServiceWorker {
     #[wasm_bindgen(constructor)]
     pub async fn new() -> Result<Self, JsError> {
         log!("Tonk worker initializing...");
+        let backend = ServiceWorkerStorageBackend::new().await;
+        let artifacts: Artifacts<ServiceWorkerStorageBackend> =
+            Artifacts::open("tonk".into(), backend)
+                .await
+                .expect_throw("Could not open artifacts");
 
-        let operator = Operator::from_passphrase("public tonk").await;
-        let space_did = operator.did().to_string();
-
-        log!("Opening space: {}", space_did);
-
-        let backend = ServiceWorkerStorageBackend::new(&space_did).await;
-        let space: Space<ServiceWorkerStorageBackend> = Space::open(space_did, &operator, backend)
-            .await
-            .expect_throw("Could not open space");
-
-        let router = Arc::new(Mutex::new(api_router(space)));
+        let router = Arc::new(Mutex::new(api_router(artifacts)));
 
         Ok(Self { router })
     }


### PR DESCRIPTION
Reverts tonk-labs/tonk#362

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `tonk-worker` and related components to improve code structure, enhance authorization handling, and streamline the use of artifacts for storage. It also updates the UI components for better integration with the new authorization flow.

### Detailed summary
- Removed `tonk-space` from `Cargo.toml` and `Cargo.lock`.
- Updated `TonkWorkerError` by removing the `Internal` variant.
- Simplified `pub use` statements in `lib.rs` files.
- Changed authorization handling in `TonkToolbar` and `TonkAuth` components.
- Replaced `Status` enum with `ActiveServiceWorker` struct.
- Updated API routes to use `Artifacts` instead of `Space`.
- Modified `authorize` function to handle new authorization request structure.
- Changed input types in CSS for better user experience.
- Adjusted storage backend implementations to use `Blake3Hash` for keys.
- Removed unnecessary comments and improved documentation on functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->