### PR TITLE
chore: Use cachix for binary caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wimpysworld/nothing-but-nix@main
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: mshick/add-pr-comment@v2
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wimpysworld/nothing-but-nix@main
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: DeterminateSystems/flake-checker-action@main
         with:
           send-statistics: false
@@ -40,7 +47,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - uses: wimpysworld/nothing-but-nix@main
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: 'Run tests'
         shell: bash
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
 
         # Include the Rust toolchain in build inputs for dev shells
         devShellBuildInputs = commonBuildInputs ++ [
+          pkgs.cachix
           wrangler
           rustToolchain
           wasm-bindgen-cli
@@ -268,9 +269,11 @@
   # SEE: https://github.com/emrldnix/wrangler?tab=readme-ov-file#using-the-nar-cache
   nixConfig = {
     extra-substituters = [
+      "https://tonk-test-cache.cachix.org"
       "https://wrangler.cachix.org"
     ];
     extra-trusted-public-keys = [
+      "tonk-test-cache.cachix.org-1:H6CaKCO7CeGEq3NTQsHDPuC0+aaxwI1sDXZWloIWqEo="
       "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
     ];
   };

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod api;
 /// UI components for the Tonk application.
 pub mod components;
+
 /// Error types for the Tonk UI.
 pub mod error;
 


### PR DESCRIPTION
This change implements cachix-based binary caching for builds. The binary cache should be transparently shared between CI and local development environments, with the caveat that MacOS produces its own binaries (so it won't overlap with CI at this time).

The improvement in build times is significant:

<table>
    <thead>
        <tr>
            <th><b>Last stable build</b></th>
            <th><b>With this change</b></th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <img width="488" height="379" alt="image" src="https://github.com/user-attachments/assets/2a577408-e69b-48cd-8e01-d61feed7920d">
            </td>
            <td>
                <img width="507" height="388" alt="image" src="https://github.com/user-attachments/assets/be6dce2d-dbcf-4f46-ac25-cdcf3bf2f590">
            </td>
        </tr>
        <tr>
            <td>
                <img width="978" height="586" alt="image" src="https://github.com/user-attachments/assets/a3069113-87b0-41da-93a0-6ea9f357e391">
            </td>
            <td>
                <img width="992" height="591" alt="image" src="https://github.com/user-attachments/assets/a9e925c9-60a7-4735-9e4d-d12b6d32f6a9">
            </td>
        </tr>
    </tbody>
</table>

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the CI/CD configuration and Nix build setup for the Tonk application, enhancing dependency management and cache usage.

### Detailed summary
- Updated `publish.yml` to use `cachix/install-nix-action@v31` and `cachix/cachix-action@v16`.
- Added `nix_path` for `nixpkgs` in `publish.yml`.
- Included `pkgs.cachix` in `flake.nix` build inputs.
- Added new `extra-substituters` and `extra-trusted-public-keys` in `flake.nix`.
- Updated `test.yml` to mirror changes in `publish.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->