### PR TITLE
fix: Use GHA-specific temp directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,8 @@ jobs:
       - name: 'Run tests'
         shell: bash
         run: |
-          nix --accept-flake-config develop .#ci -c test:${{matrix.platform}}:${{matrix.profile}}
+          nix develop \
+            --accept-flake-config \
+            --set-env-var TMPDIR $RUNNER_TEMP \
+            .#ci \
+            --command test:${{matrix.platform}}:${{matrix.profile}}


### PR DESCRIPTION
This switches us to use a GHA-specific temporary directory when running tests. 

We were hitting unexpected disk space thresholds when running tests in a certain change. A clue to the problem was:

>   Extracting 11 binaries (including 2 non-test binaries) and 3 linked paths to **/mnt**/tmp.pZSm8YdmCJ/nix-shell.DyaOKq/nextest-archive-8E7xfm
> error: error extracting archive /nix/store/p9s958vi94zqxzxsgkjbmfssi87qx7rw-tests-native-release-0.1.0/tests-native-release.tar.zst

`nothing-but-nix` gives us some insight into the mount table:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   50G   23G  69% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G 1008K  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   32K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
/dev/sdb1        74G   69G  1.0G  99% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
/dev/loop0       65G  5.7M   64G   1% /nix
```

And sure enough `/mnt` only has ~1G of space available. This "fix" uses a different, [GHA runner-specific temp directory](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#runner-context:~:text=The%20path%20to%20a%20temporary%20directory%20on%20the%20runner.%20This%20directory%20is%20emptied%20at%20the%20beginning%20and%20end%20of%20each%20job.%20Note%20that%20files%20will%20not%20be%20removed%20if%20the%20runner%27s%20user%20account%20does%20not%20have%20permission%20to%20delete%20them.) (usually rooted in `/home` where there is plenty of space). I was tipped off to it when reading https://github.com/cachix/install-nix-action/pull/199

<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `test.yml` workflow file to improve the `nix develop` command used for testing, enhancing readability and functionality by adding options for environment variable settings.

### Detailed summary
- Replaced a single line command with a multi-line `nix develop` command.
- Added the `--set-env-var TMPDIR $RUNNER_TEMP` option to set the temporary directory for the runner.
- Improved command readability by breaking it into separate lines.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->