### PR TITLE
fix: problematic column use on mac

### DIFF
--- a/nix/menu.nix
+++ b/nix/menu.nix
@@ -93,7 +93,7 @@ let
       menuLines = builtins.foldl' intoLines "echo ''" names;
 
       menu = ''
-        echo "$(${menuLines})" | column -t --s ';'
+        echo "$(${menuLines})" | column -t -s ';'
       '';
     in
     {


### PR DESCRIPTION
Addresses following errors on mac

```
column: illegal option -- -
usage: column [-tx] [-c columns] [-s sep] [file ...]
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor update in the `nix/menu.nix` file, specifically changing the syntax of the `column` command used in the `echo` statement.

### Detailed summary
- Changed the `column` command option from `--s` to `-s` for specifying the delimiter in `echo "$(${menuLines})" | column -t -s ';'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->