### PR TITLE
feat: improve output of inspect routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,6 +4282,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-wasm-macros",
+ "base58",
  "base64",
  "console_error_panic_hook",
  "dialog-artifacts",

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -330,6 +330,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         let branch = replica.branches.open(&branch_id).await?;
 
         let revision = branch.revision();
+        let base = format!("{}", branch.base());
         let upstream = branch.upstream().map(|u| UpstreamInfo {
             site: u.site().map(|s| s.to_string()),
             branch: u.id().to_string(),
@@ -339,6 +340,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         Ok(BranchInfo {
             name: branch_name.to_string(),
             revision,
+            base,
             upstream,
         })
     }
@@ -477,6 +479,8 @@ pub struct BranchInfo {
     pub name: String,
     /// Current revision
     pub revision: Revision,
+    /// Base tree hash (the tree we're based off for tracking local changes)
+    pub base: String,
     /// Upstream info if configured
     pub upstream: Option<UpstreamInfo>,
 }

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -12,6 +12,7 @@ web-integration-tests = []
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["json", "macros", "query"] }
+base58 = "0.2"
 base64 = { workspace = true }
 axum-wasm-macros = { workspace = true }
 console_error_panic_hook = { workspace = true }

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -3,23 +3,98 @@
 use ::axum::extract::Path;
 use ::axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
+use base58::ToBase58;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
+use tonk_space::Revision;
+
+/// Wrapper for displaying Edition as base58 hash.
+struct EditionHash<'a, T>(&'a T);
+
+impl<T: Hash> Display for EditionHash<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Use Hash trait to extract the underlying bytes
+        let mut hasher = ByteCaptureHasher::new();
+        self.0.hash(&mut hasher);
+        write!(f, "#{}", hasher.into_bytes().to_base58())
+    }
+}
+
+/// A hasher that captures the bytes being hashed.
+struct ByteCaptureHasher {
+    bytes: Vec<u8>,
+}
+
+impl ByteCaptureHasher {
+    fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl Hasher for ByteCaptureHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        0 // We don't care about the hash value
+    }
+}
 
 use super::super::AppState;
 use crate::TonkWorkerError;
 
+/// Serializable revision info with all fields.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RevisionResponse {
+    /// Period indicating when this revision was created.
+    pub period: usize,
+    /// Moment at which this revision was created.
+    pub moment: usize,
+    /// The issuer DID who created this revision.
+    pub issuer: String,
+    /// The tree root hash (base58 encoded).
+    pub tree: String,
+    /// Causal ancestor hashes (base58 encoded).
+    pub cause: Vec<String>,
+}
+
+impl RevisionResponse {
+    /// Create a RevisionResponse from a Revision.
+    pub fn from_revision(revision: &Revision) -> Self {
+        Self {
+            period: *revision.period(),
+            moment: *revision.moment(),
+            issuer: revision.issuer().did().to_string(),
+            tree: format!("{}", revision.tree()),
+            cause: revision
+                .cause()
+                .iter()
+                .map(|c| format!("{}", EditionHash(c)))
+                .collect(),
+        }
+    }
+}
+
 /// Response for branch status query.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BranchStatusResponse {
+    /// The subject DID (space DID).
+    pub subject: String,
     /// The branch name.
-    pub name: String,
-    /// Current revision period.
-    pub period: usize,
-    /// Current revision moment.
-    pub moment: usize,
+    pub branch: String,
+    /// Current revision with full details.
+    pub revision: RevisionResponse,
+    /// Base tree hash (the tree we're based off for tracking local changes).
+    pub base: String,
     /// Upstream info if configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream: Option<UpstreamStatusResponse>,
@@ -33,12 +108,9 @@ pub struct UpstreamStatusResponse {
     pub site: Option<String>,
     /// The branch name on the upstream.
     pub branch: String,
-    /// The upstream revision period if known.
+    /// The upstream revision with full details (if known).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub period: Option<usize>,
-    /// The upstream revision moment if known.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub moment: Option<usize>,
+    pub revision: Option<RevisionResponse>,
 }
 
 /// Returns the status of a specific branch.
@@ -53,22 +125,19 @@ pub async fn branch(
     match tonk_state.space.branch_info(&branch_name).await {
         Ok(branch_info) => {
             let upstream = branch_info.upstream.map(|u| {
-                let (period, moment) = u
-                    .revision
-                    .map(|r| (Some(r.period), Some(r.moment)))
-                    .unwrap_or((None, None));
+                let revision = u.revision.as_ref().map(RevisionResponse::from_revision);
                 UpstreamStatusResponse {
                     site: u.site,
                     branch: u.branch,
-                    period,
-                    moment,
+                    revision,
                 }
             });
 
             Ok(Json(BranchStatusResponse {
-                name: branch_info.name,
-                period: branch_info.revision.period,
-                moment: branch_info.revision.moment,
+                subject: tonk_state.space.did.clone(),
+                branch: branch_info.name,
+                revision: RevisionResponse::from_revision(&branch_info.revision),
+                base: branch_info.base,
                 upstream,
             }))
         }

--- a/rust/tonk-worker/src/router/inspect/site.rs
+++ b/rust/tonk-worker/src/router/inspect/site.rs
@@ -10,6 +10,7 @@ use tonk_common::log;
 use tonk_space::SpaceError;
 
 use super::super::AppState;
+use super::branch::RevisionResponse;
 use crate::TonkWorkerError;
 
 /// Response for site status query.
@@ -65,18 +66,15 @@ pub struct RemoteBranchPath {
 pub struct RemoteBranchStatusResponse {
     /// The site name.
     pub site: String,
-    /// The repository DID.
-    pub repo_did: String,
+    /// The subject DID (repository/space DID).
+    pub subject: String,
     /// The branch name.
     pub branch: String,
     /// Whether the resolution succeeded.
     pub success: bool,
-    /// The resolved revision period (if successful).
+    /// The resolved revision with full details (if successful).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub period: Option<usize>,
-    /// The resolved revision moment (if successful).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub moment: Option<usize>,
+    pub revision: Option<RevisionResponse>,
     /// Error message if resolution failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -162,18 +160,14 @@ pub async fn branch(
         .await
     {
         Ok(info) => {
-            let (period, moment) = info
-                .revision
-                .map(|r| (Some(r.period), Some(r.moment)))
-                .unwrap_or((None, None));
+            let revision = info.revision.as_ref().map(RevisionResponse::from_revision);
 
             Ok(Json(RemoteBranchStatusResponse {
                 site: info.site,
-                repo_did: info.repo_did,
+                subject: info.repo_did,
                 branch: info.branch,
                 success: true,
-                period,
-                moment,
+                revision,
                 error: None,
             }))
         }
@@ -181,11 +175,10 @@ pub async fn branch(
             log!("Error resolving remote branch: {:?}", e);
             Ok(Json(RemoteBranchStatusResponse {
                 site: params.site,
-                repo_did: params.repo_did,
+                subject: params.repo_did,
                 branch: params.branch,
                 success: false,
-                period: None,
-                moment: None,
+                revision: None,
                 error: Some(format!("{}", e)),
             }))
         }


### PR DESCRIPTION
Updates `/inspect/*` routes to provide more details on the local / remote state. With this changes you get this kind of output 

<img width="1146" height="563" alt="image" src="https://github.com/user-attachments/assets/9605fac2-7943-459f-b601-70e08c2901bb" />




<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `base58` dependency and enhances branch-related data structures and responses in the `tonk-worker` project. It adds a `base` field to `BranchInfo`, refines the `RemoteBranchStatusResponse`, and introduces a new `RevisionResponse` struct for detailed revision information.

### Detailed summary
- Added `base58` dependency in `Cargo.toml`.
- Introduced `base` field in `BranchInfo` struct.
- Modified `RemoteBranchStatusResponse` to include `subject` instead of `repo_did` and added `revision`.
- Created `RevisionResponse` struct for detailed revision info.
- Updated branch handling to use `RevisionResponse` for better data representation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->