### PR TITLE
fix: missing block on pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -990,7 +990,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "blake3",
  "proc-macro2",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "async-stream",
  "blake3",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "dialog-query-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "dialog-s3-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fweb-crypto#ec8da47e9568f7f4764c938614da144faaaefd12"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4456,7 +4456,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "ucan"
 version = "0.5.0"
-source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#69ffde436a9d8373a2d0bc6e285860137e9131b0"
+source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1"
 dependencies = [
  "base58",
  "ed25519-dalek",
@@ -4576,7 +4576,7 @@ dependencies = [
 [[package]]
 name = "varsig"
 version = "0.1.0"
-source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#69ffde436a9d8373a2d0bc6e285860137e9131b0"
+source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1"
 dependencies = [
  "async-signature",
  "ed25519-dalek",
@@ -4815,7 +4815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -990,7 +990,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "blake3",
  "proc-macro2",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "async-stream",
  "blake3",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "dialog-query-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "dialog-s3-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4221,6 +4221,7 @@ name = "tonk-space"
 version = "0.1.0"
 dependencies = [
  "dialog-artifacts",
+ "dialog-capability",
  "dialog-common",
  "dialog-query",
  "dialog-s3-credentials",
@@ -4239,6 +4240,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tonk-common",
  "ucan",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = 
 dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk", features = ["ucan"] }
 
 # UCAN (using local path for development)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,11 +76,11 @@ js-sys = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/web-crypto" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/web-crypto" }
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/web-crypto" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/web-crypto" }
-dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/web-crypto", features = ["ucan"] }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk", features = ["ucan"] }
 
 # UCAN (using local path for development)
 ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "tonk", package = "ucan" }

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -18,8 +18,8 @@ let
   # that the same dependencies can be used across all derivations that
   # need them. Crane expects the full git URL as the key.
   cargoGitDependencies = {
-    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa" =
-      "sha256-sqf2/pAMBNMoqzNuK/5LxdUiriIn58tpU8nyUop9rok=";
+    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54" =
+      "sha256-s3DRRNklq+ZFAApSDuGHC0hJo9V9ry1ODGhN0rdwMtY=";
     "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1" =
       "sha256-apwOaUuOLvYfqNGHOTnOeJx3DIOSPvJLFwXpc6p3UkA=";
   };

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -18,10 +18,10 @@ let
   # that the same dependencies can be used across all derivations that
   # need them. Crane expects the full git URL as the key.
   cargoGitDependencies = {
-    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#e88a5dce82136459771965be80ed82218a5c3d54" =
-      "sha256-bUWiJ/5jimXakkChIUwoP7Wbq/wmFlXAnkeYul7VrwQ=";
-    "git+https://github.com/tonk-labs/rs-ucan.git?branch=jackddouglas/feat/check#671a0256621eb4656b42d9e631108da3ec18158b" =
-      "sha256-5KQ7wIXv7PHgd6y1pq0+aUU/VFW7BLxECmVUNk1JfGw=";
+    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#c363f189a3e82ecd3e013906cc797645b42b41aa" =
+      "sha256-sqf2/pAMBNMoqzNuK/5LxdUiriIn58tpU8nyUop9rok=";
+    "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1" =
+      "sha256-apwOaUuOLvYfqNGHOTnOeJx3DIOSPvJLFwXpc6p3UkA=";
   };
 
   # Filter source to only Rust-relevant files

--- a/rust/tonk-access-service/tests/ucan_integration.rs
+++ b/rust/tonk-access-service/tests/ucan_integration.rs
@@ -19,13 +19,14 @@ use dialog_storage::s3::{Bucket, Credentials, S3};
 use tonk_access_service::helpers::{AccessServiceAddress, Operator};
 
 /// Helper to create a test delegation chain from subject to operator.
-fn create_test_delegation_chain(
+async fn create_test_delegation_chain(
     subject_signer: &ucan::did::Ed25519Signer,
     operator_did: &ucan::did::Ed25519Did,
     can: &[&str],
 ) -> DelegationChain {
     let subject_did = subject_signer.did();
     let delegation = create_delegation(subject_signer, operator_did, subject_did, can)
+        .await
         .expect("Failed to create test delegation");
     DelegationChain::new(delegation)
 }
@@ -54,7 +55,8 @@ async fn it_performs_storage_get_and_set_via_ucan(env: AccessServiceAddress) -> 
     let operator = Operator::generate();
 
     let delegation =
-        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"]);
+        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"])
+            .await;
 
     let mut bucket = create_ucan_bucket(&env, operator, delegation, "test-store");
 
@@ -77,7 +79,8 @@ async fn it_isolates_stores_via_ucan(env: AccessServiceAddress) -> anyhow::Resul
     let operator = Operator::generate();
 
     let delegation =
-        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"]);
+        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"])
+            .await;
 
     let mut bucket_a = create_ucan_bucket(&env, operator.clone(), delegation.clone(), "store-a");
     let mut bucket_b = create_ucan_bucket(&env, operator, delegation, "store-b");
@@ -108,7 +111,8 @@ async fn it_returns_none_for_nonexistent_key_via_ucan(
     let operator = Operator::generate();
 
     let delegation =
-        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"]);
+        create_test_delegation_chain(operator.signer(), operator.signer().did(), &["storage"])
+            .await;
 
     let bucket = create_ucan_bucket(&env, operator, delegation, "test-nonexistent");
 

--- a/rust/tonk-space/Cargo.toml
+++ b/rust/tonk-space/Cargo.toml
@@ -15,6 +15,7 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 js-sys = { workspace = true }
 web-sys = { workspace = true, features = ["Crypto", "SubtleCrypto", "CryptoKey", "HkdfParams"] }
+tonk-common = { workspace = true }
 
 # Error handling
 thiserror = "2"
@@ -33,6 +34,7 @@ dialog-query = { workspace = true }
 dialog-artifacts = { workspace = true, features = ["ucan"] }
 dialog-common = { workspace = true }
 dialog-s3-credentials = { workspace = true }
+dialog-capability = { workspace = true }
 
 # UCAN
 ucan = { workspace = true }

--- a/rust/tonk-space/src/delegation.rs
+++ b/rust/tonk-space/src/delegation.rs
@@ -261,26 +261,28 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     /// Create a test delegation with random operators.
-    fn make_test_delegation() -> Delegation {
+    async fn make_test_delegation() -> Delegation {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         Delegation::from(ucan_delegation)
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_exposes_delegation_fields() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_exposes_delegation_fields() {
+        let delegation = make_test_delegation().await;
 
         assert!(delegation.issuer().to_string().starts_with("did:key:"));
         assert!(delegation.audience().to_string().starts_with("did:key:"));
@@ -294,9 +296,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_roundtrips_through_serde() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_roundtrips_through_serde() {
+        let delegation = make_test_delegation().await;
 
         let bytes = serde_ipld_dagcbor::to_vec(&delegation).expect("Failed to encode");
         let decoded: Delegation = serde_ipld_dagcbor::from_slice(&bytes).expect("Failed to decode");
@@ -316,18 +318,20 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_serializes_transparently() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_serializes_transparently() {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         let ucan_bytes =
@@ -351,9 +355,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_produces_valid_cid() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_produces_valid_cid() {
+        let delegation = make_test_delegation().await;
 
         let cid = delegation.cid();
         let cid_str = format!("ucan:{}", cid);
@@ -363,9 +367,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_returns_entity_from_this() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_returns_entity_from_this() {
+        let delegation = make_test_delegation().await;
 
         let entity = delegation.this();
         assert!(
@@ -375,9 +379,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_produces_deterministic_cid() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_produces_deterministic_cid() {
+        let delegation = make_test_delegation().await;
 
         let cid1 = delegation.cid();
         let cid2 = delegation.cid();
@@ -386,26 +390,28 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_validates_delegation_without_expiration() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_validates_delegation_without_expiration() {
+        let delegation = make_test_delegation().await;
         let now = Timestamp::now();
 
         assert!(delegation.validate(now).is_ok());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_creates_powerline_delegation() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_creates_powerline_delegation() {
         let issuer = Operator::generate();
         let audience = Operator::generate();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Any)
             .command(vec!["read".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         let delegation = Delegation::from(ucan_delegation);
@@ -415,9 +421,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_provides_access_to_inner() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_provides_access_to_inner() {
+        let delegation = make_test_delegation().await;
 
         let inner = delegation.inner();
         assert_eq!(inner.issuer().to_string(), delegation.issuer().to_string());

--- a/rust/tonk-space/src/ownership.rs
+++ b/rust/tonk-space/src/ownership.rs
@@ -106,26 +106,28 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     /// Create a test delegation with random operators.
-    fn make_test_delegation() -> Delegation {
+    async fn make_test_delegation() -> Delegation {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         Delegation::from(ucan_delegation)
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_creates_ownership_from_delegation() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_creates_ownership_from_delegation() {
+        let delegation = make_test_delegation().await;
         let expected_subject = delegation.subject().clone();
         let ownership = Ownership::from(delegation);
 
@@ -133,9 +135,9 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_provides_access_to_underlying_delegation() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_provides_access_to_underlying_delegation() {
+        let delegation = make_test_delegation().await;
         let expected_issuer = delegation.issuer().to_string();
         let ownership = Ownership::from(delegation);
 
@@ -145,28 +147,30 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_matches_subject_with_delegation() {
-        let delegation = make_test_delegation();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_matches_subject_with_delegation() {
+        let delegation = make_test_delegation().await;
         let ownership = Ownership::from(delegation);
 
         assert_eq!(ownership.subject(), ownership.delegation().subject());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_returns_specific_subject_as_space() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_returns_specific_subject_as_space() {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
         let expected_space = *subject.did();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         let ownership = Ownership::from(Delegation::from(ucan_delegation));
@@ -175,18 +179,20 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_returns_issuer_as_space_for_powerline() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_returns_issuer_as_space_for_powerline() {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let expected_space = *issuer.did();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Any)
             .command(vec!["read".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         let ownership = Ownership::from(Delegation::from(ucan_delegation));

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -11,6 +11,7 @@ use dialog_artifacts::{
 use dialog_query::claim::{Transaction, TransactionError};
 use dialog_query::query::Source;
 use dialog_query::{Concept, DeductiveRule, Entity, Session};
+use dialog_storage::StorageBackend;
 use futures_core::Stream;
 use std::sync::Arc;
 use thiserror::Error;
@@ -280,9 +281,12 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
     /// Get upstream info if configured.
     ///
     /// # Returns
-    /// - `Some((site_name, branch_id, revision))` for remote upstream
+    /// - `Some((site_name, branch_id))` if upstream is configured
     /// - `None` if no upstream is configured
-    pub async fn upstream_info(&self) -> Option<(String, String, Option<Revision>)> {
+    ///
+    /// Note: Revision is not included because for remote upstreams it would
+    /// require connecting to the remote. Use `fetch()` to get the latest revision.
+    pub async fn upstream_info(&self) -> Option<(String, String)> {
         let branch = self.branch.read().await;
         if let Some(upstream) = branch.upstream() {
             let site = upstream
@@ -290,8 +294,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "local".to_string());
             let branch_id = upstream.id().to_string();
-            let revision = upstream.revision();
-            Some((site, branch_id, revision))
+            Some((site, branch_id))
         } else {
             None
         }
@@ -349,7 +352,6 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         let upstream = branch.upstream().map(|u| UpstreamInfo {
             site: u.site().map(|s| s.to_string()),
             branch: u.id().to_string(),
-            revision: u.revision(),
         });
 
         Ok(BranchInfo {
@@ -437,6 +439,55 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
                     .map_err(|e| SpaceError::InvalidEntity(e.to_string()))
             })
             .collect()
+    }
+
+    /// Fetch a raw block from a remote site's archive by its blake3 hash.
+    ///
+    /// # Arguments
+    /// * `site` - The remote site name
+    /// * `repo_did` - The repository DID (subject)
+    /// * `hash` - The blake3 hash bytes (32 bytes)
+    ///
+    /// # Returns
+    /// The raw bytes if found, None if not found.
+    pub async fn fetch_remote_archive_block(
+        &self,
+        site: &str,
+        repo_did: &str,
+        hash: &[u8; 32],
+    ) -> Result<Option<Vec<u8>>, SpaceError> {
+        let replica = self.replica.read().await;
+
+        // Load the remote site
+        let remote_site = RemoteSite::load(
+            &site.to_string(),
+            replica.issuer().clone(),
+            replica.storage().clone(),
+        )
+        .await?;
+
+        // Get a reference to a branch (we need to open a connection)
+        // Using "main" as default branch to establish the connection
+        let mut remote_branch = remote_site.repository(repo_did.to_string()).branch("main");
+
+        // Open the connection and get the archive connection
+        let connection = remote_branch.open().await?;
+        let archive = match connection.archive_connection() {
+            Some(archive) => archive,
+            None => {
+                return Err(SpaceError::Storage(
+                    dialog_storage::DialogStorageError::StorageBackend(
+                        "No archive connection available".to_string(),
+                    ),
+                ));
+            }
+        };
+
+        // Fetch the block by hash
+        let key = hash.to_vec();
+        let bytes = archive.get(&key).await.map_err(SpaceError::Storage)?;
+
+        Ok(bytes)
     }
 }
 
@@ -542,8 +593,6 @@ pub struct UpstreamInfo {
     pub site: Option<String>,
     /// The branch name on the upstream
     pub branch: String,
-    /// The upstream revision
-    pub revision: Option<Revision>,
 }
 
 /// Implement ArtifactStore for Space by delegating to the inner session

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -398,8 +398,9 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
             .repository(repo_did.to_string())
             .branch(branch_name);
 
-        // Resolve the remote branch - this actually connects to the remote
-        let revision = remote_branch.resolve().await?;
+        // Open the connection and resolve the remote branch
+        let connection = remote_branch.open().await?;
+        let revision = connection.resolve().await?;
 
         Ok(RemoteBranchInfo {
             site: site.to_string(),
@@ -473,18 +474,9 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         // Using "main" as default branch to establish the connection
         let mut remote_branch = remote_site.repository(repo_did.to_string()).branch("main");
 
-        // Open the connection and get the archive connection
+        // Open the connection and get the archive
         let connection = remote_branch.open().await?;
-        let archive = match connection.archive_connection() {
-            Some(archive) => archive,
-            None => {
-                return Err(SpaceError::Storage(
-                    dialog_storage::DialogStorageError::StorageBackend(
-                        "No archive connection available".to_string(),
-                    ),
-                ));
-            }
-        };
+        let archive = connection.archive();
 
         // Fetch the block by hash
         let key = hash.to_vec();
@@ -642,33 +634,37 @@ mod tests {
         blob: schema::ucan::Blob,
     }
 
-    fn make_test_delegation() -> Delegation {
+    async fn make_test_delegation() -> Delegation {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
 
+        let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = Delegation::builder()
-            .issuer(Ed25519Signer::from(&issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         Delegation::from(ucan_delegation)
     }
 
-    fn make_delegation_with_parts(
+    async fn make_delegation_with_parts(
         issuer: &Operator,
         audience: &Operator,
         subject: &Operator,
     ) -> Delegation {
+        let signer = Ed25519Signer::from(issuer);
         let ucan_delegation = Delegation::builder()
-            .issuer(Ed25519Signer::from(issuer))
+            .issuer(signer.clone())
             .audience(*audience.did())
             .subject(DelegatedSubject::Specific(*subject.did()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Failed to build delegation");
 
         Delegation::from(ucan_delegation)
@@ -694,7 +690,7 @@ mod tests {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
         let operator = Operator::generate();
-        let delegation = make_test_delegation();
+        let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did.clone(), &operator, backend, vec![delegation])
             .await
@@ -709,7 +705,7 @@ mod tests {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
         let operator = Operator::generate();
-        let delegation = make_test_delegation();
+        let delegation = make_test_delegation().await;
 
         // Create space first
         let _space = Space::create(
@@ -735,7 +731,7 @@ mod tests {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
         let operator = Operator::generate();
-        let delegation = make_test_delegation();
+        let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
             .await
@@ -771,7 +767,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let delegation_entity = delegation.this();
         let expected_issuer = issuer.did().to_string();
 
@@ -800,7 +796,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let expected_audience = audience.did().to_string();
 
@@ -829,7 +825,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let expected_subject = subject.did().to_string();
 
@@ -858,7 +854,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
@@ -886,7 +882,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let space_entity = subject.did().to_string();
 
@@ -919,7 +915,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let issuer_did = issuer.did().to_string();
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
@@ -951,7 +947,7 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let delegation = make_delegation_with_parts(&issuer, &audience, &subject);
+        let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let audience_did = audience.did().to_string();
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
@@ -970,7 +966,7 @@ mod tests {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
         let operator = Operator::generate();
-        let delegation = make_test_delegation();
+        let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
             .await

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -352,6 +352,9 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         let upstream = branch.upstream().map(|u| UpstreamInfo {
             site: u.site().map(|s| s.to_string()),
             branch: u.id().to_string(),
+            // TODO: Use u.subject().to_string() when dialog-db is updated with Upstream::subject() method
+            // See https://github.com/dialog-db/dialog-db/pull/156
+            subject: None,
         });
 
         Ok(BranchInfo {
@@ -593,6 +596,8 @@ pub struct UpstreamInfo {
     pub site: Option<String>,
     /// The branch name on the upstream
     pub branch: String,
+    /// The subject DID of the upstream repository (None for local upstream)
+    pub subject: Option<String>,
 }
 
 /// Implement ArtifactStore for Space by delegating to the inner session

--- a/rust/tonk-worker/src/identity.rs
+++ b/rust/tonk-worker/src/identity.rs
@@ -117,6 +117,11 @@ impl Identity {
     pub async fn create_session(&mut self) -> Result<Session, SessionError> {
         Session::create(self).await
     }
+
+    /// Join a space by making this user an owner and opens it as a session.
+    pub async fn join_session(&mut self, space: Operator) -> Result<Session, SessionError> {
+        Session::import(self, space).await
+    }
 }
 
 impl std::fmt::Display for Identity {

--- a/rust/tonk-worker/src/key_store.rs
+++ b/rust/tonk-worker/src/key_store.rs
@@ -123,23 +123,9 @@ mod wasm {
             self.get_operator(&key).await
         }
 
-        /// Create a new space operator.
-        ///
-        /// Returns the new operator. The space DID is derived from the generated public key.
-        pub async fn create_space_operator(&self) -> Result<Operator, KeyStoreError> {
-            let operator = Operator::generate();
-            let space_did = operator.did().to_string();
-            let key = format!("{}{}", SPACE_KEY_PREFIX, space_did);
-            self.store_operator(&key, &operator).await?;
-            Ok(operator)
-        }
-
         /// Store a space operator (for when you have an existing operator to store).
-        pub async fn store_space_operator(
-            &self,
-            space_did: &str,
-            operator: &Operator,
-        ) -> Result<(), KeyStoreError> {
+        pub async fn store_space_operator(&self, operator: &Operator) -> Result<(), KeyStoreError> {
+            let space_did = operator.did().to_string();
             let key = format!("{}{}", SPACE_KEY_PREFIX, space_did);
             self.store_operator(&key, operator).await
         }
@@ -289,11 +275,8 @@ mod native {
         }
 
         /// Store a space operator.
-        pub async fn store_space_operator(
-            &self,
-            space_did: &str,
-            operator: &Operator,
-        ) -> Result<(), KeyStoreError> {
+        pub async fn store_space_operator(&self, operator: &Operator) -> Result<(), KeyStoreError> {
+            let space_did = operator.did();
             let mut ops = self.operators.write().unwrap();
             ops.insert(format!("space:{}", space_did), operator.clone());
             Ok(())

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -57,6 +57,10 @@ pub fn api_router(state: TonkState) -> Router {
             get(inspect::site::branch),
         )
         .route(
+            "/api/inspect/site/{site}/{repo_did}/archive/index/{hash}",
+            get(inspect::site::archive_block),
+        )
+        .route(
             "/api/fact/assert/{entity}/{attribute_ns}/{attribute_name}",
             post(assert_fact),
         )

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_space::{RemoteState, SpaceError};
+use ucan::delegation::subject::DelegatedSubject;
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -83,11 +84,6 @@ pub async fn authorize(
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("Failed to query delegations: {}", e)))?;
 
-    let delegation = user_delegations
-        .into_iter()
-        .next()
-        .ok_or_else(|| TonkWorkerError::Internal("No delegations found for user".to_string()))?;
-
     let space_did = tonk_state.session.space_did().to_string();
     let service_url = get_access_service_url();
     log!(
@@ -95,6 +91,17 @@ pub async fn authorize(
         space_did,
         service_url
     );
+
+    // Find delegation where subject matches the space DID
+    let delegation = user_delegations
+        .into_iter()
+        .find(|d| match d.subject() {
+            DelegatedSubject::Specific(did) => did.to_string() == space_did,
+            DelegatedSubject::Any => true, // Powerline delegations apply to any subject
+        })
+        .ok_or_else(|| {
+            TonkWorkerError::Internal(format!("No delegation found for space {}", space_did))
+        })?;
 
     // Create delegation chain from the user's delegation
     let delegation_chain = DelegationChain::new(delegation.inner().clone());

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -125,11 +125,12 @@ pub async fn branch(
     match tonk_state.session.space().branch_info(&branch_name).await {
         Ok(branch_info) => {
             let upstream = branch_info.upstream.map(|u| {
-                let revision = u.revision.as_ref().map(RevisionResponse::from_revision);
                 UpstreamStatusResponse {
                     site: u.site,
                     branch: u.branch,
-                    revision,
+                    // Revision is not available without connecting to remote
+                    // Use the sync endpoints to get the latest revision
+                    revision: None,
                 }
             });
 

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -108,6 +108,9 @@ pub struct UpstreamStatusResponse {
     pub site: Option<String>,
     /// The branch name on the upstream.
     pub branch: String,
+    /// The subject DID of the upstream repository (None for local upstream).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     /// The upstream revision with full details (if known).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revision: Option<RevisionResponse>,
@@ -128,6 +131,7 @@ pub async fn branch(
                 UpstreamStatusResponse {
                     site: u.site,
                     branch: u.branch,
+                    subject: u.subject,
                     // Revision is not available without connecting to remote
                     // Use the sync endpoints to get the latest revision
                     revision: None,

--- a/rust/tonk-worker/src/router/inspect/site.rs
+++ b/rust/tonk-worker/src/router/inspect/site.rs
@@ -267,7 +267,8 @@ pub async fn archive_block(
     let tonk_state = state.read().await;
 
     match tonk_state
-        .space
+        .session
+        .space()
         .fetch_remote_archive_block(&params.site, &params.repo_did, &hash)
         .await
     {

--- a/rust/tonk-worker/src/router/inspect/site.rs
+++ b/rust/tonk-worker/src/router/inspect/site.rs
@@ -3,6 +3,7 @@
 use ::axum::extract::Path;
 use ::axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
+use base58::FromBase58;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
@@ -59,6 +60,14 @@ pub struct RemoteBranchPath {
     site: String,
     repo_did: String,
     branch: String,
+}
+
+/// Path parameters for archive block fetch.
+#[derive(Debug, Deserialize)]
+pub struct ArchiveBlockPath {
+    site: String,
+    repo_did: String,
+    hash: String,
 }
 
 /// Response for remote branch resolution.
@@ -180,6 +189,121 @@ pub async fn branch(
                 branch: params.branch,
                 success: false,
                 revision: None,
+                error: Some(format!("{}", e)),
+            }))
+        }
+    }
+}
+
+/// Response for archive block fetch.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ArchiveBlockResponse {
+    /// The site name.
+    pub site: String,
+    /// The subject DID.
+    pub subject: String,
+    /// The requested hash (base58).
+    pub hash: String,
+    /// Whether the block was found.
+    pub found: bool,
+    /// The block data as base64 (if found).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    /// The block size in bytes (if found).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<usize>,
+    /// Error message if fetch failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Fetches a block from a remote site's archive by its blake3 hash.
+///
+/// The hash should be provided as base58 encoded string.
+#[wasm_compat]
+pub async fn archive_block(
+    State(state): State<AppState>,
+    Path(params): Path<ArchiveBlockPath>,
+) -> Result<Json<ArchiveBlockResponse>, TonkWorkerError> {
+    log!(
+        "Fetching archive block: site={}, repo={}, hash={}",
+        params.site,
+        params.repo_did,
+        params.hash
+    );
+
+    // Decode the base58 hash
+    let hash_bytes = match params.hash.from_base58() {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return Ok(Json(ArchiveBlockResponse {
+                site: params.site,
+                subject: params.repo_did,
+                hash: params.hash,
+                found: false,
+                data: None,
+                size: None,
+                error: Some(format!("Invalid base58 hash: {:?}", e)),
+            }));
+        }
+    };
+
+    // Ensure it's exactly 32 bytes
+    let hash: [u8; 32] = match hash_bytes.try_into() {
+        Ok(h) => h,
+        Err(bytes) => {
+            return Ok(Json(ArchiveBlockResponse {
+                site: params.site,
+                subject: params.repo_did,
+                hash: params.hash,
+                found: false,
+                data: None,
+                size: None,
+                error: Some(format!("Hash must be 32 bytes, got {}", bytes.len())),
+            }));
+        }
+    };
+
+    let tonk_state = state.read().await;
+
+    match tonk_state
+        .space
+        .fetch_remote_archive_block(&params.site, &params.repo_did, &hash)
+        .await
+    {
+        Ok(Some(data)) => {
+            use base64::Engine;
+            let size = data.len();
+            let data_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
+
+            Ok(Json(ArchiveBlockResponse {
+                site: params.site,
+                subject: params.repo_did,
+                hash: params.hash,
+                found: true,
+                data: Some(data_base64),
+                size: Some(size),
+                error: None,
+            }))
+        }
+        Ok(None) => Ok(Json(ArchiveBlockResponse {
+            site: params.site,
+            subject: params.repo_did,
+            hash: params.hash,
+            found: false,
+            data: None,
+            size: None,
+            error: None,
+        })),
+        Err(e) => {
+            log!("Error fetching archive block: {:?}", e);
+            Ok(Json(ArchiveBlockResponse {
+                site: params.site,
+                subject: params.repo_did,
+                hash: params.hash,
+                found: false,
+                data: None,
+                size: None,
                 error: Some(format!("{}", e)),
             }))
         }

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -100,7 +100,7 @@ impl Session {
             .await?;
 
         // Create delegation: space -> user (space grants user full authority)
-        let delegation = Self::create_ownership_delegation(&operator, identity.operator())?;
+        let delegation = Self::create_ownership_delegation(&operator, identity.operator()).await?;
 
         // Update account with the new space
         identity.account_mut().add_known_space(&space_did).await?;
@@ -119,16 +119,18 @@ impl Session {
     }
 
     /// Create an ownership delegation from space to user.
-    fn create_ownership_delegation(
+    async fn create_ownership_delegation(
         space_operator: &Operator,
         user_operator: &Operator,
     ) -> Result<Delegation, SessionError> {
+        let signer = Ed25519Signer::from(space_operator);
         let ucan_delegation = Delegation::builder()
-            .issuer(Ed25519Signer::from(space_operator))
+            .issuer(signer.clone())
             .audience(*user_operator.did())
             .subject(DelegatedSubject::Specific(*space_operator.did()))
             .command(vec![]) // Empty command = "/*" (all commands)
-            .try_build()
+            .try_build(&signer)
+            .await
             .expect("Delegation builder should not fail with valid inputs");
 
         Ok(Delegation::from(ucan_delegation))

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -69,11 +69,13 @@ impl Session {
             .await?
             .ok_or_else(|| SessionError::SpaceNotFound(space_did.to_string()))?;
 
-        // Open the space database
+        // Open the space database using the user's operator as the replica issuer.
+        // This ensures that when making remote requests, the claim.audience() matches
+        // the delegation.audience() (which is the user's operator DID).
         // Prefix with "tonk:" for debug clarity when viewing IndexedDB in devtools
         let db_name = format!("tonk:{}", space_did);
         let backend = ServiceWorkerStorageBackend::new(&db_name).await;
-        let space = Space::open(space_did.to_string(), &operator, backend).await?;
+        let space = Space::open(space_did.to_string(), identity.operator(), backend).await?;
 
         Ok(Self {
             account: identity.did().to_string(),
@@ -87,34 +89,42 @@ impl Session {
     /// TODO: Decouple creation from saving - consider having a separate
     /// `.save(&mut storage)` method for persistence rather than doing it implicitly.
     pub(crate) async fn create(identity: &mut Identity) -> Result<Self, SessionError> {
-        // Generate a new keypair for the space
-        // TODO: Once we switch to powerline delegations, we may not need to store
-        // space keys at all - just the delegation from space to account.
-        let operator = identity.key_store().create_space_operator().await?;
-        let space_did = operator.did().to_string();
+        // Generate new keypair for the space and import it
+        Self::import(identity, Operator::generate()).await
+    }
 
+    /// Imports a space by making this user an owner.
+    pub(crate) async fn import(
+        identity: &mut Identity,
+        space_operator: Operator,
+    ) -> Result<Self, SessionError> {
         // Store space operator in key store
         identity
             .key_store()
-            .store_space_operator(&space_did, &operator)
+            .store_space_operator(&space_operator)
             .await?;
 
         // Create delegation: space -> user (space grants user full authority)
-        let delegation = Self::create_ownership_delegation(&operator, identity.operator()).await?;
+        let delegation =
+            Self::create_ownership_delegation(&space_operator, identity.operator()).await?;
 
         // Update account with the new space
+        let space_did = space_operator.did().to_string();
         identity.account_mut().add_known_space(&space_did).await?;
 
-        // Create the space database and space with ownership delegation
+        // Create the space database using the user's operator as the replica issuer.
+        // This ensures that when making remote requests, the claim.audience() matches
+        // the delegation.audience() (which is the user's operator DID).
         // Prefix with "tonk:" for debug clarity when viewing IndexedDB in devtools
         let db_name = format!("tonk:{}", space_did);
         let backend = ServiceWorkerStorageBackend::new(&db_name).await;
-        let space = Space::create(space_did, &operator, backend, vec![delegation]).await?;
+        let space =
+            Space::create(space_did, identity.operator(), backend, vec![delegation]).await?;
 
         Ok(Self {
             account: identity.did().to_string(),
             space,
-            operator,
+            operator: space_operator,
         })
     }
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -12,6 +12,7 @@ use axum::{Router, body::Body};
 use js_sys::Promise;
 use tokio::sync::Mutex;
 use tonk_common::log;
+use tonk_space::Operator;
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -81,9 +82,10 @@ impl TonkServiceWorker {
                 .await
                 .expect_throw("Could not open session")
         } else {
-            log!("No known spaces, creating...");
+            log!("No known spaces, join publish shared space");
+            let shared_space = Operator::from_passphrase("public tonk space").await;
             identity
-                .create_session()
+                .join_session(shared_space)
                 .await
                 .expect_throw("Could not create session")
         };


### PR DESCRIPTION
This does #384 on top of new stable as I failed to rebase and ended up cherry-picking instead

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `tonk-worker` and `tonk-space` modules, primarily focusing on session management, delegation handling, and the addition of new API routes for fetching archive blocks.

### Detailed summary
- Added a new route for fetching archive blocks in `router.rs`.
- Introduced `join_session` method in `identity.rs`.
- Updated session creation to use imported space operators.
- Modified `fetch_remote_archive_block` method in `space.rs`.
- Enhanced delegation creation and validation methods to be asynchronous.
- Updated test functions to be asynchronous and adjusted delegation handling in tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->