### PR TITLE
chore: Enforce shared workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1"
 async-trait = "0.1"
 axum = { version = "0.8", default-features = false }
 axum-wasm-macros = "0.1"
+base58 = "0.2"
 base64 = "0.22"
 blake3 = "1.5"
 chrono = { version = "0.4", default-features = false, features = [
@@ -35,18 +36,22 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 clap = { version = "4", features = ["derive"] }
 console_error_panic_hook = "0.1"
+dirs = "5"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 futures = "0.3"
+futures-core = "0.3"
 futures-util = "0.3"
 getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 hex = "0.4"
+hkdf = "0.12"
 ipld-core = { version = "0.4", features = ["serde"] }
 leptos = "0.8"
 leptos-use = "0.17"
 leptos_router = "0.8"
 port_check = "0.3"
 rand = "0.9"
+rand_0_8 = { package = "rand", version = "0.8" }
 rand_core = "0.9"
 reqwest = "0.13"
 serde = "1"
@@ -54,9 +59,12 @@ serde_bytes = "0.11"
 serde_json = "1"
 serde_ipld_dagcbor = "0.6"
 sha2 = "0.11.0-rc.3"
+sha2_0_10 = { package = "sha2", version = "0.10" }
+tempfile = "3"
 thirtyfour = "0.36"
 thiserror = "2"
 tokio = "1"
+tower = "0.5"
 tower-service = "0.3"
 hyper = "1"
 hyper-util = "0.1"

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -55,6 +55,21 @@ let
       };
     };
 
+  enforce-workspace-deps =
+    with pkgs;
+    rustPlatform.buildRustPackage rec {
+      pname = "cargo-enforce-shared-workspace-deps";
+      version = "0.1.0";
+      buildInputs = [ rustToolchain ];
+
+      src = fetchCrate {
+        inherit pname version;
+        sha256 = "sha256-XOdKeg9tNt/HT+WO9QKtdX3fUMUssVTlXRV0LOIMMzc=";
+      };
+
+      cargoHash = "sha256-O6DQXK8/VVwTLuFlSyh8jtBJyAFMfAUNXnTeMWrXTCM=";
+    };
+
   nativeBuildInputs = buildInputs ++ [
     rustToolchain
   ];
@@ -184,6 +199,16 @@ let
     rustfmt = craneLib.cargoFmt {
       src = rustSource;
       pname = "tonk-fmt-check";
+    };
+
+    sharedWorkspaceDeps = buildCrate {
+      pname = "shared-workspace-deps-check";
+      buildPhase = ''
+        ${enforce-workspace-deps}/bin/cargo-enforce-shared-workspace-deps
+      '';
+      installPhase = ''
+        touch $out
+      '';
     };
   };
 

--- a/rust/tonk-space/Cargo.toml
+++ b/rust/tonk-space/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 
 [dependencies]
 # Crypto
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-rand = "0.8"
+ed25519-dalek = { workspace = true, features = ["rand_core"] }
+rand_0_8 = { workspace = true }
 
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -18,15 +18,15 @@ web-sys = { workspace = true, features = ["Crypto", "SubtleCrypto", "CryptoKey",
 tonk-common = { workspace = true }
 
 # Error handling
-thiserror = "2"
+thiserror = { workspace = true }
 
 # Filesystem
-dirs = "5"
+dirs = { workspace = true }
 
 # Async
-futures-util = "0.3"
-futures-core = "0.3"
-tokio = { version = "1", features = ["sync"] }
+futures-util = { workspace = true }
+futures-core = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 # Dialog DB
 dialog-storage = { workspace = true }
@@ -38,24 +38,24 @@ dialog-capability = { workspace = true }
 
 # UCAN
 ucan = { workspace = true }
-ipld-core = "0.4"
+ipld-core = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_ipld_dagcbor = "0.6"
+serde = { workspace = true, features = ["derive"] }
+serde_ipld_dagcbor = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hkdf = "0.12"
-sha2 = "0.10"
+hkdf = { workspace = true }
+sha2_0_10 = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true } 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3"
-tokio = { version = "1", features = ["sync"] }
+wasm-bindgen-test = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }

--- a/rust/tonk-space/src/operator.rs
+++ b/rust/tonk-space/src/operator.rs
@@ -6,7 +6,7 @@
 
 use dialog_artifacts::replica::Operator as ReplicaOperator;
 use ed25519_dalek::SigningKey;
-use rand::rngs::OsRng;
+use rand_0_8::rngs::OsRng;
 use ucan::did::{Ed25519Did, Ed25519Signer};
 
 /// An operator identity that can sign UCAN delegations and dialog-db operations.

--- a/rust/tonk-space/src/secret.rs
+++ b/rust/tonk-space/src/secret.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::SigningKey;
 #[cfg(not(target_arch = "wasm32"))]
 use hkdf::Hkdf;
 #[cfg(not(target_arch = "wasm32"))]
-use sha2::Sha256;
+use sha2_0_10::Sha256;
 
 pub struct Passphrase(String);
 

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -12,7 +12,7 @@ web-integration-tests = []
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["json", "macros", "query"] }
-base58 = "0.2"
+base58 = { workspace = true }
 base64 = { workspace = true }
 axum-wasm-macros = { workspace = true }
 console_error_panic_hook = { workspace = true }
@@ -56,7 +56,7 @@ idb = "0.6"
 [dev-dependencies]
 anyhow = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
-tower = "0.5"
+tower = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]


### PR DESCRIPTION
This change adds a check (lint) that fails if any Cargo dependencies are **not** inherited from the workspace Cargo.toml. Unfortunately it is unable to check target-specific dependencies, but this is a good start and would have caught several cases where we broke the spirit of the rule.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies to their latest versions, transitioning to a workspace structure for better dependency management, and making adjustments for compatibility with different target architectures.

### Detailed summary
- Changed `sha2` to `sha2_0_10` in `rust/tonk-space/src/secret.rs`.
- Updated `rand` to `rand_0_8` in `rust/tonk-space/src/operator.rs`.
- Modified `Cargo.toml` files to use workspace dependencies for various crates, including `base58`, `tower`, `ed25519-dalek`, `rand`, `thiserror`, `dirs`, `futures-util`, `futures-core`, `tokio`, `ipld-core`, and `serde`.
- Added a new `cargo-enforce-shared-workspace-deps` package in `nix/rust.nix`.
- Adjusted dependencies for `wasm32` architecture in `Cargo.toml` files.
- Updated `tempfile` dependency to use workspace structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->