### PR TITLE
feat(worker, space): TON-1823: WebCrypto keys with `SigningAuthority`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -939,6 +939,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.2.17",
+ "js-sys",
  "leb128",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -950,6 +951,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
+ "ucan",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -959,7 +961,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -972,7 +974,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -990,7 +992,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1002,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "blake3",
  "proc-macro2",
@@ -1013,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1033,7 +1035,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "async-stream",
  "blake3",
@@ -1055,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "dialog-query-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "dialog-s3-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fgeneric-replica#712e8a9ceeae61846aa1edff1cef8f5884d4997e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1151,13 +1153,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
 dependencies = [
  "block-buffer 0.11.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.0-rc.13",
+ "crypto-common 0.2.0-rc.15",
  "subtle",
 ]
 
@@ -1367,9 +1369,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1654,7 +1656,7 @@ version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.10",
 ]
 
 [[package]]
@@ -1776,14 +1778,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -2378,7 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64dd2c9099caf8e29b629305199dddb1c6d981562b62c089afea54b0b4b5c333"
 dependencies = [
  "cfg-if",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.10",
 ]
 
 [[package]]
@@ -3671,7 +3672,7 @@ checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.10",
 ]
 
 [[package]]
@@ -3693,7 +3694,7 @@ checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.10",
 ]
 
 [[package]]
@@ -3726,9 +3727,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -3859,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.4",
@@ -4817,7 +4818,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5294,18 +5295,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5375,6 +5376,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,12 @@ js-sys = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk", features = ["ucan"] }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica" }
+dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/generic-replica", features = ["ucan"] }
 
 # UCAN (using local path for development)
 ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "tonk", package = "ucan" }

--- a/rust/tonk-space/src/delegation.rs
+++ b/rust/tonk-space/src/delegation.rs
@@ -262,9 +262,9 @@ mod tests {
 
     /// Create a test delegation with random operators.
     async fn make_test_delegation() -> Delegation {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
@@ -320,9 +320,9 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_serializes_transparently() {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
@@ -401,8 +401,8 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_creates_powerline_delegation() {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()

--- a/rust/tonk-space/src/operator.rs
+++ b/rust/tonk-space/src/operator.rs
@@ -2,9 +2,9 @@
 //!
 //! An `Operator` represents a principal that can sign UCAN delegations and
 //! dialog-db operations. It wraps an Ed25519 signing key and provides
-//! conversions to both `Ed25519Signer` (for UCAN) and dialog-db `Operator`.
+//! conversions to both `Ed25519Signer` (for UCAN) and `SigningAuthority`.
 
-use dialog_artifacts::replica::Operator as ReplicaOperator;
+use dialog_artifacts::replica::SigningAuthority;
 use ed25519_dalek::SigningKey;
 use rand_0_8::rngs::OsRng;
 use ucan::did::{Ed25519Did, Ed25519Signer};
@@ -14,13 +14,13 @@ use ucan::did::{Ed25519Did, Ed25519Signer};
 /// This is the primary identity type for tonk-space. It wraps an Ed25519 signing
 /// key and can be converted to:
 /// - `Ed25519Signer` for signing UCAN delegations
-/// - `ReplicaOperator` for signing dialog-db replica operations
+/// - `SigningAuthority` for signing dialog-db replica operations
 #[derive(Debug, Clone)]
 pub struct Operator(Ed25519Signer);
 
 impl Operator {
     /// Generate a new random operator identity.
-    pub fn generate() -> Self {
+    pub async fn generate() -> Self {
         let signing_key = SigningKey::generate(&mut OsRng);
         Self(Ed25519Signer::new(signing_key))
     }
@@ -72,15 +72,15 @@ impl From<&Operator> for Ed25519Signer {
     }
 }
 
-impl From<Operator> for ReplicaOperator {
+impl From<Operator> for SigningAuthority {
     fn from(operator: Operator) -> Self {
-        ReplicaOperator::from_secret(&operator.to_secret())
+        SigningAuthority::from_secret(&operator.to_secret())
     }
 }
 
-impl From<&Operator> for ReplicaOperator {
+impl From<&Operator> for SigningAuthority {
     fn from(operator: &Operator) -> Self {
-        ReplicaOperator::from_secret(&operator.to_secret())
+        SigningAuthority::from_secret(&operator.to_secret())
     }
 }
 
@@ -107,9 +107,9 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_generates_operator_with_valid_did() {
-        let operator = Operator::generate();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_generates_operator_with_valid_did() {
+        let operator = Operator::generate().await;
         let did = operator.did().to_string();
         assert!(did.starts_with("did:key:z"));
     }
@@ -132,43 +132,43 @@ mod tests {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_roundtrips_through_secret_bytes() {
-        let op1 = Operator::generate();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_roundtrips_through_secret_bytes() {
+        let op1 = Operator::generate().await;
         let secret = op1.to_secret();
         let op2 = Operator::from(SigningKey::from_bytes(&secret));
         assert_eq!(op1.did().to_string(), op2.did().to_string());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_roundtrips_through_from_secret() {
-        let op1 = Operator::generate();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_roundtrips_through_from_secret() {
+        let op1 = Operator::generate().await;
         let secret = op1.to_secret();
         let op2 = Operator::from_secret(secret);
         assert_eq!(op1.did().to_string(), op2.did().to_string());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_converts_to_ed25519_signer() {
-        let operator = Operator::generate();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_converts_to_ed25519_signer() {
+        let operator = Operator::generate().await;
         let did_before = operator.did().to_string();
         let signer: Ed25519Signer = operator.into();
         assert_eq!(signer.did().to_string(), did_before);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_converts_to_replica_operator() {
-        let operator = Operator::generate();
-        let _replica_op: ReplicaOperator = (&operator).into();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_converts_to_replica_operator() {
+        let operator = Operator::generate().await;
+        let _signing_authority: SigningAuthority = (&operator).into();
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_displays_as_did() {
-        let operator = Operator::generate();
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn it_displays_as_did() {
+        let operator = Operator::generate().await;
         let display = format!("{}", operator);
         assert!(display.starts_with("did:key:z"));
     }

--- a/rust/tonk-space/src/ownership.rs
+++ b/rust/tonk-space/src/ownership.rs
@@ -107,9 +107,9 @@ mod tests {
 
     /// Create a test delegation with random operators.
     async fn make_test_delegation() -> Delegation {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
@@ -158,9 +158,9 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_returns_specific_subject_as_space() {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let expected_space = *subject.did();
 
         let signer = Ed25519Signer::from(&issuer);
@@ -181,8 +181,8 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn it_returns_issuer_as_space_for_powerline() {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
         let expected_space = *issuer.did();
 
         let signer = Ed25519Signer::from(&issuer);

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -1,9 +1,7 @@
 use crate::delegation::Delegation;
 use crate::operator::Operator;
 use crate::ownership::Ownership;
-use dialog_artifacts::replica::{
-    Branch, BranchId, Operator as ReplicaOperator, RemoteSite, Remotes, Replica,
-};
+use dialog_artifacts::replica::{Branch, BranchId, RemoteSite, Remotes, Replica, SigningAuthority};
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, ArtifactStore, DialogArtifactsError, PlatformBackend,
@@ -108,8 +106,8 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         delegations: Vec<Delegation>,
     ) -> Result<Self, SpaceError> {
         // Open the replica with the operator and space DID as subject
-        let replica_operator = ReplicaOperator::from(operator);
-        let replica = Replica::open(replica_operator, space_did.clone().into(), backend)?;
+        let signing_authority = SigningAuthority::from(operator);
+        let replica = Replica::open(signing_authority, space_did.clone().into(), backend)?;
 
         // Create/open the "main" branch for this space
         let branch_id = BranchId::new("main".to_string());
@@ -144,7 +142,7 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
     ///
     /// # Arguments
     /// * `space_did` - The DID of the space
-    /// * `operator` - The operator that will sign operations
+    /// * `operator` - The operator that will sign operations (extractable keys)
     /// * `backend` - The storage backend to use
     ///
     /// # Returns
@@ -155,8 +153,28 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         backend: Backend,
     ) -> Result<Self, SpaceError> {
         // Open the replica with the operator and space DID as subject
-        let replica_operator = ReplicaOperator::from(operator);
-        let replica = Replica::open(replica_operator, space_did.clone().into(), backend)?;
+        let signing_authority = SigningAuthority::from(operator);
+        Self::open_with_authority(space_did, signing_authority, backend).await
+    }
+
+    /// Open an existing space with a `SigningAuthority`.
+    ///
+    /// This variant accepts a `SigningAuthority` directly, which is useful when
+    /// the authority may use WebCrypto non-extractable keys.
+    ///
+    /// # Arguments
+    /// * `space_did` - The DID of the space
+    /// * `authority` - The signing authority for signing operations
+    /// * `backend` - The storage backend to use
+    ///
+    /// # Returns
+    /// The Space instance with access to the branch
+    pub async fn open_with_authority(
+        space_did: String,
+        authority: SigningAuthority,
+        backend: Backend,
+    ) -> Result<Self, SpaceError> {
+        let replica = Replica::open(authority, space_did.clone().into(), backend)?;
 
         // Open the "main" branch (creates it if it doesn't exist)
         let branch_id = BranchId::new("main".to_string());
@@ -635,9 +653,9 @@ mod tests {
     }
 
     async fn make_test_delegation() -> Delegation {
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = Delegation::builder()
@@ -675,7 +693,7 @@ mod tests {
     async fn it_creates_empty_space() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
         let space = Space::create(space_did.clone(), &operator, backend, vec![])
             .await
@@ -689,7 +707,7 @@ mod tests {
     async fn it_creates_space_with_delegation() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
         let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did.clone(), &operator, backend, vec![delegation])
@@ -704,7 +722,7 @@ mod tests {
     async fn it_opens_space_after_create() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
         let delegation = make_test_delegation().await;
 
         // Create space first
@@ -730,7 +748,7 @@ mod tests {
     async fn it_tracks_revision() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
         let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])
@@ -747,7 +765,7 @@ mod tests {
     async fn it_has_no_upstream_by_default() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
         let space = Space::create(space_did, &operator, backend, vec![])
             .await
@@ -762,11 +780,11 @@ mod tests {
     async fn it_stores_delegation_issuer() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let delegation_entity = delegation.this();
         let expected_issuer = issuer.did().to_string();
@@ -791,11 +809,11 @@ mod tests {
     async fn it_stores_delegation_audience() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let expected_audience = audience.did().to_string();
@@ -820,11 +838,11 @@ mod tests {
     async fn it_stores_delegation_subject() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let expected_subject = subject.did().to_string();
@@ -849,11 +867,11 @@ mod tests {
     async fn it_stores_delegation_command() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
 
@@ -877,11 +895,11 @@ mod tests {
     async fn it_stores_space_owner() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let ucan = delegation.this();
         let space_entity = subject.did().to_string();
@@ -910,11 +928,11 @@ mod tests {
     async fn it_can_query_delegations_by_issuer() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let issuer_did = issuer.did().to_string();
 
@@ -942,11 +960,11 @@ mod tests {
     async fn it_queries_delegations_for_audience() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
 
-        let issuer = Operator::generate();
-        let audience = Operator::generate();
-        let subject = Operator::generate();
+        let issuer = Operator::generate().await;
+        let audience = Operator::generate().await;
+        let subject = Operator::generate().await;
         let delegation = make_delegation_with_parts(&issuer, &audience, &subject).await;
         let audience_did = audience.did().to_string();
 
@@ -965,7 +983,7 @@ mod tests {
     async fn it_returns_empty_for_unknown_audience() {
         let backend = MemoryBackend::default();
         let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
-        let operator = Operator::generate();
+        let operator = Operator::generate().await;
         let delegation = make_test_delegation().await;
 
         let space = Space::create(space_did, &operator, backend, vec![delegation])

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -17,7 +17,7 @@ base64 = { workspace = true }
 axum-wasm-macros = { workspace = true }
 console_error_panic_hook = { workspace = true }
 dialog-common = { workspace = true }
-dialog-artifacts = { workspace = true }
+dialog-artifacts = { workspace = true, features = ["webcrypto"] }
 dialog-query = { workspace = true }
 dialog-s3-credentials = { workspace = true, features = ["ucan"] }
 dialog-storage = { workspace = true, features = ["ucan"] }

--- a/rust/tonk-worker/src/account.rs
+++ b/rust/tonk-worker/src/account.rs
@@ -9,9 +9,10 @@
 //! of maintaining a separate list, we could query for delegations where the
 //! account is the audience to discover accessible spaces.
 
+use dialog_artifacts::replica::SigningAuthority;
 use dialog_query::{Attribute, Entity, With};
 use thiserror::Error;
-use tonk_space::{Operator, Space, SpaceError};
+use tonk_space::{Space, SpaceError};
 
 use crate::ServiceWorkerStorageBackend;
 
@@ -50,12 +51,13 @@ impl Account {
     ///
     /// # Arguments
     /// * `db_name` - The database name (should include tonk: prefix for debug clarity)
-    /// * `operator` - The operator for signing account operations
-    pub async fn open(db_name: &str, operator: &Operator) -> Result<Self, AccountError> {
+    /// * `authority` - The signing authority for signing account operations (may use WebCrypto)
+    pub async fn open(db_name: &str, authority: &SigningAuthority) -> Result<Self, AccountError> {
         let backend = ServiceWorkerStorageBackend::new(db_name).await;
 
         // Open the space (creates if doesn't exist)
-        let space = Space::open(db_name.to_string(), operator, backend).await?;
+        let space =
+            Space::open_with_authority(db_name.to_string(), authority.clone(), backend).await?;
 
         Ok(Self { space })
     }

--- a/rust/tonk-worker/src/identity.rs
+++ b/rust/tonk-worker/src/identity.rs
@@ -6,9 +6,9 @@
 use crate::account::{Account, AccountError};
 use crate::key_store::{KeyStore, KeyStoreError};
 use crate::session::{Session, SessionError};
+use dialog_artifacts::replica::SigningAuthority;
 use thiserror::Error;
 use tonk_space::Operator;
-use ucan::did::Ed25519Did;
 
 /// Errors that can occur when working with identity.
 #[derive(Debug, Error)]
@@ -27,18 +27,25 @@ pub enum IdentityError {
 /// There is exactly one Identity per device/browser. The identity is backed by
 /// an Ed25519 keypair that is generated on first use and persisted to storage.
 ///
+/// The user operator may use WebCrypto non-extractable keys for enhanced security,
+/// meaning the private key material never leaves the browser's secure environment.
+///
 /// The Identity provides access to:
 /// - The user's DID (decentralized identifier)
 /// - The user's operator (for signing operations)
 /// - Methods to open or create sessions
 #[derive(Clone)]
 pub struct Identity {
-    /// The user's operator keypair for this device.
-    /// Used to sign operations and establish identity.
-    /// TODO: In the future with powerline delegations, this will be the only key
+    /// The user's signing authority for this device.
+    ///
+    /// This is a `SigningAuthority` which may be either:
+    /// - `WebCrypto`: Non-extractable keys via browser's WebCrypto API
+    /// - `Fallback`: Extractable keys when WebCrypto Ed25519 is unavailable
+    ///
+    /// In the future with powerline delegations, this will be the only key
     /// needed - authority over spaces will come from UCAN delegation chains
     /// rather than holding space keys.
-    operator: Operator,
+    operator: SigningAuthority,
     /// Access to the key store for retrieving space operators.
     /// TODO: Once we switch to powerline delegations, space keys won't be stored
     /// and this field may no longer be needed.
@@ -50,6 +57,7 @@ impl Identity {
     /// Load an existing identity or create a new one.
     ///
     /// On first call, generates a new random Ed25519 keypair and persists it.
+    /// When WebCrypto Ed25519 is available, the key will be non-extractable.
     /// On subsequent calls, loads the existing keypair from storage.
     ///
     /// TODO: Consider passing storage as a parameter to make testing easier
@@ -77,13 +85,22 @@ impl Identity {
     /// Get the DID (decentralized identifier) for this identity.
     ///
     /// The DID is derived from the public key and has the format `did:key:z6Mk...`.
-    pub fn did(&self) -> &Ed25519Did {
+    pub fn did(&self) -> &str {
         self.operator.did()
     }
 
-    /// Get the operator for signing operations.
-    pub fn operator(&self) -> &Operator {
+    /// Get the signing authority for signing operations.
+    ///
+    /// This returns a `SigningAuthority` which supports async signing via the
+    /// `Authority` trait. For UCAN delegation signing, use the `AsyncDidSigner`
+    /// trait methods.
+    pub fn operator(&self) -> &SigningAuthority {
         &self.operator
+    }
+
+    /// Get a mutable reference to the signing authority for signing operations.
+    pub fn operator_mut(&mut self) -> &mut SigningAuthority {
+        &mut self.operator
     }
 
     /// Get access to the key store.
@@ -137,7 +154,7 @@ mod tests {
     #[tokio::test]
     async fn it_creates_identity_with_valid_did() {
         let identity = Identity::load_or_create().await.unwrap();
-        let did = identity.did().to_string();
+        let did = identity.did();
         assert!(did.starts_with("did:key:z"));
     }
 

--- a/rust/tonk-worker/src/key_store.rs
+++ b/rust/tonk-worker/src/key_store.rs
@@ -7,12 +7,13 @@
 //! ```text
 //! IndexedDB: "tonk-keys" (WASM) / In-memory HashMap (native)
 //! └── Object Store: "keys"
-//!     ├── "user"          → { secret: [u8; 32] }
-//!     └── "space:{did}"   → { secret: [u8; 32] }
+//!     ├── "user"          → { id, cryptoKey: CryptoKey, did: string } (WebCrypto)
+//!     │                   → { id, secret: Uint8Array }                (Fallback)
+//!     └── "space:{did}"   → { id, secret: Uint8Array }                (always extractable)
 //! ```
 //!
-//! Note: Plan A uses extractable keys stored as secret bytes. Plan B will
-//! re-introduce proper WebCrypto non-extractable keys for WASM.
+//! User identity keys use WebCrypto non-extractable keys when available.
+//! Space keys remain extractable (they'll be replaced by UCAN delegations).
 //!
 //! # Future Direction
 //!
@@ -21,21 +22,20 @@
 //! That way accounts have complete authority over spaces without managing keys.
 //! Unlike keys, those delegations can be kept public as they can't be exploited
 //! without account keys. See: https://github.com/ucan-wg/delegation#powerline
-//!
-//! TODO: Consider using the existing `IndexedDbStorageBackend` instead of this
-//! custom IDB implementation to reduce boilerplate.
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use dialog_artifacts::replica::{CryptoKey, SigningAuthority, WebCryptoEd25519Signer};
     use idb::{Database, DatabaseEvent, Factory, KeyPath, ObjectStoreParams, TransactionMode};
     use js_sys::{Object, Reflect, Uint8Array};
     use std::sync::Arc;
     use thiserror::Error;
     use tonk_space::Operator;
+    use ucan::did::Did as UcanDid;
     use wasm_bindgen::prelude::*;
 
     const DB_NAME: &str = "tonk-keys";
-    const DB_VERSION: u32 = 2; // Bump version for schema change
+    const DB_VERSION: u32 = 3; // Bump version for WebCrypto schema
     const STORE_NAME: &str = "keys";
 
     const USER_KEY: &str = "user";
@@ -55,6 +55,10 @@ mod wasm {
         /// Invalid data in storage.
         #[error("Invalid data: {0}")]
         InvalidData(String),
+
+        /// WebCrypto error.
+        #[error("WebCrypto error: {0}")]
+        WebCrypto(String),
     }
 
     impl From<idb::Error> for KeyStoreError {
@@ -65,9 +69,8 @@ mod wasm {
 
     /// Storage for operator keys in IndexedDB.
     ///
-    /// Keys are stored as 32-byte secret arrays. This is Plan A's temporary
-    /// approach using extractable keys; Plan B will use proper WebCrypto
-    /// non-extractable keys.
+    /// User identity keys use WebCrypto non-extractable keys when available.
+    /// Space keys are stored as extractable secret bytes.
     #[derive(Clone)]
     pub struct KeyStore {
         db: Arc<Database>,
@@ -103,35 +106,50 @@ mod wasm {
         }
 
         /// Get the user's operator if one exists.
-        pub async fn user_operator(&self) -> Result<Option<Operator>, KeyStoreError> {
-            self.get_operator(USER_KEY).await
+        ///
+        /// Returns a `SigningAuthority` which may be either WebCrypto or Fallback variant.
+        pub async fn user_operator(&self) -> Result<Option<SigningAuthority>, KeyStoreError> {
+            self.get_user_operator(USER_KEY).await
         }
 
-        /// Create a new user operator.
-        pub async fn create_user_operator(&self) -> Result<Operator, KeyStoreError> {
-            let operator = Operator::generate();
-            self.store_operator(USER_KEY, &operator).await?;
+        /// Create a new user operator using WebCrypto when available.
+        ///
+        /// This will attempt to use WebCrypto non-extractable keys. If WebCrypto
+        /// Ed25519 is not available, it falls back to extractable keys.
+        pub async fn create_user_operator(&self) -> Result<SigningAuthority, KeyStoreError> {
+            // Use SigningAuthority::generate() which handles WebCrypto fallback
+            let operator = SigningAuthority::generate()
+                .await
+                .map_err(|e| KeyStoreError::WebCrypto(e.to_string()))?;
+            self.store_user_operator(USER_KEY, &operator).await?;
             Ok(operator)
         }
 
         /// Get a space's operator if one exists.
+        ///
+        /// Space operators are always extractable (stored as secret bytes).
         pub async fn space_operator(
             &self,
             space_did: &str,
         ) -> Result<Option<Operator>, KeyStoreError> {
             let key = format!("{}{}", SPACE_KEY_PREFIX, space_did);
-            self.get_operator(&key).await
+            self.get_space_operator(&key).await
         }
 
         /// Store a space operator (for when you have an existing operator to store).
+        ///
+        /// Space operators are always stored as extractable secret bytes.
         pub async fn store_space_operator(&self, operator: &Operator) -> Result<(), KeyStoreError> {
             let space_did = operator.did().to_string();
             let key = format!("{}{}", SPACE_KEY_PREFIX, space_did);
-            self.store_operator(&key, operator).await
+            self.store_extractable_operator(&key, operator).await
         }
 
-        // Internal: Get an operator by key name
-        async fn get_operator(&self, key: &str) -> Result<Option<Operator>, KeyStoreError> {
+        /// Get a user operator (may be WebCrypto or Fallback).
+        async fn get_user_operator(
+            &self,
+            key: &str,
+        ) -> Result<Option<SigningAuthority>, KeyStoreError> {
             let transaction = self
                 .db
                 .transaction(&[STORE_NAME], TransactionMode::ReadOnly)?;
@@ -149,7 +167,134 @@ mod wasm {
             match result {
                 None => Ok(None),
                 Some(value) => {
-                    // Extract secret from the stored object
+                    // Check if this is a WebCrypto key (has cryptoKey field)
+                    let crypto_key_js = Reflect::get(&value, &"cryptoKey".into())
+                        .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+
+                    if !crypto_key_js.is_undefined() {
+                        // WebCrypto key: reconstruct from CryptoKey + DID
+                        let crypto_key: CryptoKey = crypto_key_js.unchecked_into();
+
+                        let did_js = Reflect::get(&value, &"did".into())
+                            .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+
+                        let did_str = did_js.as_string().ok_or_else(|| {
+                            KeyStoreError::InvalidData("did is not a string".into())
+                        })?;
+
+                        // Parse the DID to get public key bytes
+                        let ed25519_did: ucan::did::Ed25519Did = did_str.parse().map_err(|e| {
+                            KeyStoreError::InvalidData(format!("invalid DID: {:?}", e))
+                        })?;
+
+                        let public_key_bytes =
+                            <ucan::did::Ed25519Did as UcanDid>::verifier(&ed25519_did).to_bytes();
+
+                        // Reconstruct WebCryptoEd25519Signer
+                        let signer = WebCryptoEd25519Signer::from_key(crypto_key, public_key_bytes)
+                            .map_err(|e| KeyStoreError::WebCrypto(format!("{:?}", e)))?;
+
+                        Ok(Some(SigningAuthority::from_webcrypto_signer(signer)))
+                    } else {
+                        // Fallback key: reconstruct from secret bytes
+                        let secret_js = Reflect::get(&value, &"secret".into())
+                            .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+
+                        if secret_js.is_undefined() {
+                            return Err(KeyStoreError::InvalidData(
+                                "stored key has neither cryptoKey nor secret".into(),
+                            ));
+                        }
+
+                        let secret_array = Uint8Array::new(&secret_js);
+                        let mut secret_bytes = [0u8; 32];
+
+                        if secret_array.length() != 32 {
+                            return Err(KeyStoreError::InvalidData(format!(
+                                "expected 32-byte secret, got {}",
+                                secret_array.length()
+                            )));
+                        }
+
+                        secret_array.copy_to(&mut secret_bytes);
+
+                        Ok(Some(SigningAuthority::from_secret(&secret_bytes)))
+                    }
+                }
+            }
+        }
+
+        /// Store a user operator (handles both WebCrypto and Fallback).
+        async fn store_user_operator(
+            &self,
+            key: &str,
+            operator: &SigningAuthority,
+        ) -> Result<(), KeyStoreError> {
+            let transaction = self
+                .db
+                .transaction(&[STORE_NAME], TransactionMode::ReadWrite)?;
+            let store = transaction
+                .object_store(STORE_NAME)
+                .map_err(|e| KeyStoreError::Idb(format!("{:?}", e)))?;
+
+            let obj = Object::new();
+
+            Reflect::set(&obj, &"id".into(), &JsValue::from_str(key))
+                .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+
+            // Check if this is a WebCrypto operator
+            if let Some(signer) = operator.webcrypto_signer() {
+                // Store CryptoKey + DID
+                Reflect::set(&obj, &"cryptoKey".into(), signer.crypto_key())
+                    .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+
+                Reflect::set(
+                    &obj,
+                    &"did".into(),
+                    &JsValue::from_str(&signer.did().to_string()),
+                )
+                .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+            } else {
+                // Store secret bytes (Fallback or Native)
+                let secret_bytes = operator.secret_key_bytes().ok_or_else(|| {
+                    KeyStoreError::InvalidData("operator has no secret bytes".into())
+                })?;
+
+                let secret_array = Uint8Array::from(&secret_bytes[..]);
+
+                Reflect::set(&obj, &"secret".into(), &secret_array)
+                    .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
+            }
+
+            store
+                .put(&obj, None)
+                .map_err(|e| KeyStoreError::Idb(format!("{:?}", e)))?
+                .await?;
+
+            transaction.commit()?.await?;
+
+            Ok(())
+        }
+
+        /// Get a space operator (always extractable).
+        async fn get_space_operator(&self, key: &str) -> Result<Option<Operator>, KeyStoreError> {
+            let transaction = self
+                .db
+                .transaction(&[STORE_NAME], TransactionMode::ReadOnly)?;
+            let store = transaction
+                .object_store(STORE_NAME)
+                .map_err(|e| KeyStoreError::Idb(format!("{:?}", e)))?;
+
+            let result: Option<JsValue> = store
+                .get(JsValue::from_str(key))
+                .map_err(|e| KeyStoreError::Idb(format!("{:?}", e)))?
+                .await?;
+
+            transaction.await?;
+
+            match result {
+                None => Ok(None),
+                Some(value) => {
                     let secret_js = Reflect::get(&value, &"secret".into())
                         .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
 
@@ -165,14 +310,13 @@ mod wasm {
 
                     secret_array.copy_to(&mut secret_bytes);
 
-                    let operator = Operator::from_secret(secret_bytes);
-                    Ok(Some(operator))
+                    Ok(Some(Operator::from_secret(secret_bytes)))
                 }
             }
         }
 
-        // Internal: Store an operator by key name
-        async fn store_operator(
+        /// Store an extractable operator (for space keys).
+        async fn store_extractable_operator(
             &self,
             key: &str,
             operator: &Operator,
@@ -184,13 +328,11 @@ mod wasm {
                 .object_store(STORE_NAME)
                 .map_err(|e| KeyStoreError::Idb(format!("{:?}", e)))?;
 
-            // Create an object with id and secret
             let obj = Object::new();
 
             Reflect::set(&obj, &"id".into(), &JsValue::from_str(key))
                 .map_err(|e| KeyStoreError::JsError(format!("{:?}", e)))?;
 
-            // Store secret as Uint8Array
             let secret_bytes = operator.to_secret();
             let secret_array = Uint8Array::from(&secret_bytes[..]);
 
@@ -211,6 +353,7 @@ mod wasm {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
+    use dialog_artifacts::replica::SigningAuthority;
     use std::collections::HashMap;
     use std::sync::{Arc, RwLock};
     use thiserror::Error;
@@ -228,12 +371,20 @@ mod native {
         InvalidData(String),
     }
 
+    /// Storage for user operator (as SigningAuthority) and space operators (as tonk_space::Operator).
+    #[derive(Clone, Default)]
+    struct OperatorStorage {
+        user: Option<SigningAuthority>,
+        spaces: HashMap<String, Operator>,
+    }
+
     /// In-memory key store for testing (non-WASM targets).
     ///
-    /// This stores `Operator` instances for native testing purposes.
+    /// User operators are stored as `SigningAuthority` (matching WASM behavior).
+    /// Space operators are stored as `tonk_space::Operator` (extractable).
     #[derive(Clone, Default)]
     pub struct KeyStore {
-        operators: Arc<RwLock<HashMap<String, Operator>>>,
+        storage: Arc<RwLock<OperatorStorage>>,
     }
 
     impl KeyStore {
@@ -243,16 +394,18 @@ mod native {
         }
 
         /// Get the user's operator if one exists.
-        pub async fn user_operator(&self) -> Result<Option<Operator>, KeyStoreError> {
-            let ops = self.operators.read().unwrap();
-            Ok(ops.get("user").cloned())
+        pub async fn user_operator(&self) -> Result<Option<SigningAuthority>, KeyStoreError> {
+            let storage = self.storage.read().unwrap();
+            Ok(storage.user.clone())
         }
 
         /// Create a new user operator.
-        pub async fn create_user_operator(&self) -> Result<Operator, KeyStoreError> {
-            let operator = Operator::generate();
-            let mut ops = self.operators.write().unwrap();
-            ops.insert("user".to_string(), operator.clone());
+        pub async fn create_user_operator(&self) -> Result<SigningAuthority, KeyStoreError> {
+            let operator = SigningAuthority::generate()
+                .await
+                .map_err(|e| KeyStoreError::Storage(e.to_string()))?;
+            let mut storage = self.storage.write().unwrap();
+            storage.user = Some(operator.clone());
             Ok(operator)
         }
 
@@ -261,24 +414,28 @@ mod native {
             &self,
             space_did: &str,
         ) -> Result<Option<Operator>, KeyStoreError> {
-            let ops = self.operators.read().unwrap();
-            Ok(ops.get(&format!("space:{}", space_did)).cloned())
+            let storage = self.storage.read().unwrap();
+            Ok(storage.spaces.get(&format!("space:{}", space_did)).cloned())
         }
 
         /// Create a new space operator.
         pub async fn create_space_operator(&self) -> Result<Operator, KeyStoreError> {
-            let operator = Operator::generate();
+            let operator = Operator::generate().await;
             let space_did = operator.did().to_string();
-            let mut ops = self.operators.write().unwrap();
-            ops.insert(format!("space:{}", space_did), operator.clone());
+            let mut storage = self.storage.write().unwrap();
+            storage
+                .spaces
+                .insert(format!("space:{}", space_did), operator.clone());
             Ok(operator)
         }
 
         /// Store a space operator.
         pub async fn store_space_operator(&self, operator: &Operator) -> Result<(), KeyStoreError> {
             let space_did = operator.did();
-            let mut ops = self.operators.write().unwrap();
-            ops.insert(format!("space:{}", space_did), operator.clone());
+            let mut storage = self.storage.write().unwrap();
+            storage
+                .spaces
+                .insert(format!("space:{}", space_did), operator.clone());
             Ok(())
         }
     }

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -73,7 +73,7 @@ impl RevisionResponse {
         Self {
             period: *revision.period(),
             moment: *revision.moment(),
-            issuer: revision.issuer().did().to_string(),
+            issuer: revision.issuer().to_string(),
             tree: format!("{}", revision.tree()),
             cause: revision
                 .cause()

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -75,7 +75,9 @@ impl Session {
         // Prefix with "tonk:" for debug clarity when viewing IndexedDB in devtools
         let db_name = format!("tonk:{}", space_did);
         let backend = ServiceWorkerStorageBackend::new(&db_name).await;
-        let space = Space::open(space_did.to_string(), identity.operator(), backend).await?;
+        let space =
+            Space::open_with_authority(space_did.to_string(), identity.operator().clone(), backend)
+                .await?;
 
         Ok(Self {
             account: identity.did().to_string(),
@@ -90,7 +92,7 @@ impl Session {
     /// `.save(&mut storage)` method for persistence rather than doing it implicitly.
     pub(crate) async fn create(identity: &mut Identity) -> Result<Self, SessionError> {
         // Generate new keypair for the space and import it
-        Self::import(identity, Operator::generate()).await
+        Self::import(identity, Operator::generate().await).await
     }
 
     /// Imports a space by making this user an owner.
@@ -105,21 +107,18 @@ impl Session {
             .await?;
 
         // Create delegation: space -> user (space grants user full authority)
-        let delegation =
-            Self::create_ownership_delegation(&space_operator, identity.operator()).await?;
+        let delegation = Self::create_ownership_delegation(&space_operator, identity.did()).await?;
 
         // Update account with the new space
         let space_did = space_operator.did().to_string();
         identity.account_mut().add_known_space(&space_did).await?;
 
-        // Create the space database using the user's operator as the replica issuer.
-        // This ensures that when making remote requests, the claim.audience() matches
-        // the delegation.audience() (which is the user's operator DID).
+        // Create the space database using the space's operator for the initial creation.
+        // The user's identity DID is captured in the ownership delegation.
         // Prefix with "tonk:" for debug clarity when viewing IndexedDB in devtools
         let db_name = format!("tonk:{}", space_did);
         let backend = ServiceWorkerStorageBackend::new(&db_name).await;
-        let space =
-            Space::create(space_did, identity.operator(), backend, vec![delegation]).await?;
+        let space = Space::create(space_did, &space_operator, backend, vec![delegation]).await?;
 
         Ok(Self {
             account: identity.did().to_string(),
@@ -129,14 +128,23 @@ impl Session {
     }
 
     /// Create an ownership delegation from space to user.
+    ///
+    /// The space operator (extractable) signs a delegation granting the user
+    /// (identified by their DID) full authority over the space.
     async fn create_ownership_delegation(
         space_operator: &Operator,
-        user_operator: &Operator,
+        user_did: &str,
     ) -> Result<Delegation, SessionError> {
         let signer = Ed25519Signer::from(space_operator);
+
+        // Parse user DID to Ed25519Did
+        let user_ed25519_did: ucan::did::Ed25519Did = user_did
+            .parse()
+            .map_err(|e| SessionError::Delegation(format!("invalid user DID: {}", e)))?;
+
         let ucan_delegation = Delegation::builder()
             .issuer(signer.clone())
-            .audience(*user_operator.did())
+            .audience(user_ed25519_did)
             .subject(DelegatedSubject::Specific(*space_operator.did()))
             .command(vec![]) // Empty command = "/*" (all commands)
             .try_build(&signer)


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- closes [Linear ID, e.g. TON-123]

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `SigningAuthority` within the `tonk-worker` codebase, transitioning from using `Operator` to `SigningAuthority` for signing operations, and improving the integration with WebCrypto for better security.

### Detailed summary
- Updated `issuer` extraction in `branch.rs`.
- Modified `Cargo.toml` for `dialog-artifacts` to include `webcrypto` feature.
- Changed `open` function in `Account` to use `SigningAuthority`.
- Updated `Session` to utilize `SigningAuthority`.
- Adjusted tests to generate `Operator` asynchronously.
- Enhanced `KeyStore` to support `SigningAuthority` for user operators.
- Refactored `make_test_delegation` to use async `Operator` generation.
- Improved comments and documentation regarding key handling and `SigningAuthority`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->