### PR TITLE
feat: handle background sync events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "thirtyfour",
  "thiserror 2.0.18",
  "tokio",
+ "tonk-access-service",
  "tonk-worker",
  "url",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,6 +4304,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tonk-access-service",
  "tonk-common",
  "tonk-space",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT"
 edition = "2024"
 
 [workspace.dependencies]
+tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-core = { path = "./rust/tonk-core" }
 tonk-space = { path = "./rust/tonk-space" }

--- a/flake.nix
+++ b/flake.nix
@@ -255,14 +255,31 @@
           };
 
           # This package is used by integration tests to run a web server
-          # over a local deployment of tonk-ui
+          # over a local deployment of tonk-ui with Caddy as reverse proxy
+          # to route /ucan/* to the access service
           tonk-ui-test-server =
             with pkgs;
             writeScriptBin "tonk-ui-test-server" ''
               #!${bash}/bin/bash
               PORT=''${1:-8080}
+              ACCESS_SERVICE_PORT=''${2:-8090}
+              CONFIG_FILE=$(mktemp)
+              trap 'rm -f "$CONFIG_FILE"' EXIT
+
+              cat > "$CONFIG_FILE" << EOF
+              :$PORT {
+                  handle /ucan/* {
+                      reverse_proxy localhost:$ACCESS_SERVICE_PORT
+                  }
+                  handle {
+                      root * ${self.packages.${system}.tonk-ui}
+                      file_server
+                  }
+              }
+              EOF
+
               echo "Test server live at http://127.0.0.1:$PORT"
-              ${static-web-server}/bin/static-web-server --port $PORT -d ${self.packages.${system}.tonk-ui}
+              ${caddy}/bin/caddy run --config "$CONFIG_FILE" --adapter caddyfile
             '';
         };
       }

--- a/rust/tonk-access-service/src/helpers.rs
+++ b/rust/tonk-access-service/src/helpers.rs
@@ -4,6 +4,29 @@
 //! It mirrors the behavior of the Cloudflare Worker but runs as a native HTTP
 //! server, allowing tests to run without deploying to Cloudflare.
 
+use serde::{Deserialize, Serialize};
+
+/// Connection info for the UCAN access service test server.
+///
+/// Contains all information needed to configure `ucan::Credentials` and
+/// connect to the backing S3 server for test verification.
+///
+/// This struct is available on all platforms so it can be used as a test
+/// parameter in WASM tests, even though the server only runs natively.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccessServiceAddress {
+    /// URL of the UCAN access service (e.g., "http://127.0.0.1:8080")
+    pub access_service_url: String,
+    /// URL of the backing S3 server (for test verification)
+    pub s3_endpoint: String,
+    /// The bucket name
+    pub bucket: String,
+    /// AWS access key ID (used by access service, exposed for verification)
+    pub access_key_id: String,
+    /// AWS secret access key (used by access service, exposed for verification)
+    pub secret_access_key: String,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -4,6 +4,7 @@
 //! It implements the same handler logic as the Cloudflare Worker but runs
 //! as a native HTTP server with CORS support for browser-based testing.
 
+use super::AccessServiceAddress;
 use dialog_common::helpers::{Provider, Service};
 use dialog_s3_credentials::ucan::UcanAuthorizer;
 use dialog_s3_credentials::{Address, s3};
@@ -16,28 +17,9 @@ use hyper::header::{
 use hyper::server::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
-
-/// Connection info for the UCAN access service test server.
-///
-/// Contains all information needed to configure `ucan::Credentials` and
-/// connect to the backing S3 server for test verification.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AccessServiceAddress {
-    /// URL of the UCAN access service (e.g., "http://127.0.0.1:8080")
-    pub access_service_url: String,
-    /// URL of the backing S3 server (for test verification)
-    pub s3_endpoint: String,
-    /// The bucket name
-    pub bucket: String,
-    /// AWS access key ID (used by access service, exposed for verification)
-    pub access_key_id: String,
-    /// AWS secret access key (used by access service, exposed for verification)
-    pub secret_access_key: String,
-}
 
 /// A running UCAN access service test server instance.
 pub struct AccessServer {

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -32,7 +32,6 @@ mod error;
 mod handlers;
 
 /// Test helpers for integration testing.
-/// Only available for non-WASM targets with the `helpers` feature.
 #[cfg(feature = "helpers")]
 pub mod helpers;
 

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -33,7 +33,7 @@ mod handlers;
 
 /// Test helpers for integration testing.
 /// Only available for non-WASM targets with the `helpers` feature.
-#[cfg(all(not(target_arch = "wasm32"), feature = "helpers"))]
+#[cfg(feature = "helpers")]
 pub mod helpers;
 
 /// Worker entrypoint

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -9,7 +9,12 @@ edition.workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-helpers = ["dialog-common/helpers", "dep:thirtyfour", "dep:port_check"]
+helpers = [
+    "dialog-common/helpers",
+    "dep:thirtyfour",
+    "dep:port_check",
+    "dep:tonk-access-service",
+]
 integration-tests = ["helpers", "dialog-common/integration-tests"]
 web-integration-tests = ["helpers", "dialog-common/integration-tests"]
 
@@ -36,6 +41,7 @@ url = { workspace = true }
 dialog-common = { workspace = true, optional = true }
 port_check = { workspace = true, optional = true }
 thirtyfour = { workspace = true, optional = true }
+tonk-access-service = { workspace = true, features = ["helpers"], optional = true }
 
 [dev-dependencies]
 dialog-common = { workspace = true, features = [
@@ -45,8 +51,10 @@ dialog-common = { workspace = true, features = [
 wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+anyhow = { workspace = true }
 port_check = { workspace = true }
 thirtyfour = { workspace = true }
+tonk-access-service = { workspace = true, features = ["helpers"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
@@ -54,3 +62,11 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 [dependencies.web-sys]
 workspace = true
 features = ["Window"]
+
+[lints.rust]
+# The dialog_common::test macro uses cfg conditions that originate from the macro crate.
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(dialog_test_native_integration)',
+    'cfg(dialog_test_wasm_integration)',
+    'cfg(feature, values("web-integration-tests"))',
+] }

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -37,3 +37,14 @@ self.onfetch = event => {
         );
     }
 };
+
+// Background Sync API event handler
+self.onsync = event => {
+    log("Background sync event:", event.tag);
+    event.waitUntil(
+        (async () => {
+            let worker = await activateWorker();
+            return worker.sync();
+        })()
+    );
+};

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -43,6 +43,26 @@
         self.serviceWorkerActivates = () => {
             return serviceWorkerActivatesPromise;
         };
+
+        // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
+        self.sync = async () => {
+            if ('serviceWorker' in navigator && 'SyncManager' in window) {
+                try {
+                    const registration = await navigator.serviceWorker.ready;
+                    await registration.sync.register('tonk-sync');
+                    console.log('[Tonk] Background sync registered');
+                    return;
+                } catch (e) {
+                    console.warn('[Tonk] Background sync registration failed, falling back:', e);
+                }
+            }
+            // Fallback to direct sync call
+            const response = await fetch('/api/sync', { method: 'POST' });
+            if (!response.ok) {
+                throw new Error(`Sync failed: ${response.status}`);
+            }
+            console.log('[Tonk] Direct sync completed');
+        };
     </script>
 
     <!-- The following are load-bearing configuration for the Trunk build tool

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -159,12 +159,7 @@ mod tests {
         // Wait for toolbar to become visible (indicates UI is ready and authorized)
         assert!(driver.query(By::Css(".toolbar.visible")).exists().await?);
 
-        // Call window.sync() which uses Background Sync API
-        // Note: Background Sync API may not be available in headless Chrome,
-        // in which case it falls back to direct /api/sync call
-        driver.execute("await window.sync();", vec![]).await?;
-
-        // Get the space_did from status to verify sync on remote
+        // Get the space_did from status (needed to verify sync on remote)
         let status_result = driver
             .execute(
                 r#"
@@ -177,8 +172,7 @@ mod tests {
         let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
         let space_did = status.space_did.clone();
 
-        // Verify data was pushed by checking the remote branch
-        // Note: space_did needs to be URL-encoded since it contains ':'
+        // Build the inspect URL (space_did needs URL-encoding since it contains ':')
         use url::form_urlencoded;
         let encoded_space_did: String =
             form_urlencoded::byte_serialize(space_did.as_bytes()).collect();
@@ -191,6 +185,30 @@ mod tests {
             encoded_space_did
         );
 
+        // Verify remote branch has no revision before sync
+        let inspect_result = driver.execute(&inspect_script, vec![]).await?;
+        let branch_status: serde_json::Value =
+            serde_json::from_value(inspect_result.json().clone())?;
+
+        assert!(
+            branch_status["revision"].is_null(),
+            "Remote branch should have no revision before sync: {:?}",
+            branch_status
+        );
+
+        // Register sync using the Background Sync API
+        // This triggers the service worker's sync event handler
+        driver
+            .execute(
+                r#"
+                const registration = await navigator.serviceWorker.ready;
+                await registration.sync.register('tonk-sync');
+                "#,
+                vec![],
+            )
+            .await?;
+
+        // Verify data was pushed by checking the remote branch now has a revision
         let inspect_result = driver.execute(&inspect_script, vec![]).await?;
         let branch_status: serde_json::Value =
             serde_json::from_value(inspect_result.json().clone())?;

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -85,3 +85,159 @@ pub fn TonkShell() -> impl IntoView {
         <TonkLauncher></TonkLauncher>
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::helpers::TestEnvironment;
+    use anyhow::Result;
+    use tonk_worker::{
+        AuthorizeRequest, AuthorizeResponse, RemoteBranchStatusResponse, StatusResponse,
+        SyncResponse,
+    };
+
+    /// Test that the UI loads and the service worker responds to status requests.
+    #[dialog_common::test]
+    async fn it_loads_ui_and_gets_status(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Wait for service worker to activate before making API calls
+        driver
+            .execute("await window.serviceWorkerActivates();", vec![])
+            .await?;
+
+        // Execute JavaScript to call the status API
+        let result = driver
+            .execute(
+                r#"
+                const response = await fetch('/api/status');
+                return await response.json();
+                "#,
+                vec![],
+            )
+            .await?;
+
+        let status: StatusResponse = serde_json::from_value(result.json().clone())?;
+
+        // Status should show no upstream configured initially
+        assert!(!status.has_upstream, "Expected no upstream initially");
+        assert!(!status.space_did.is_empty(), "Expected space_did to be set");
+        assert!(
+            !status.operator_did.is_empty(),
+            "Expected operator_did to be set"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// Test authorization flow through the browser with access service.
+    #[dialog_common::test]
+    async fn it_authorizes_via_browser(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Wait for service worker to activate before making API calls
+        driver
+            .execute("await window.serviceWorkerActivates();", vec![])
+            .await?;
+
+        // Build authorize request with access service URL
+        let authorize_request = AuthorizeRequest {
+            access_service_url: Some(env.access_service_url()),
+        };
+        let request_json = serde_json::to_string(&authorize_request)?;
+
+        // Execute authorization via browser
+        let script = format!(
+            r#"
+            const response = await fetch('/api/authorize', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: '{}'
+            }});
+            return await response.json();
+            "#,
+            request_json.replace('\'', "\\'")
+        );
+
+        let result = driver.execute(&script, vec![]).await?;
+        let auth_response: AuthorizeResponse = serde_json::from_value(result.json().clone())?;
+
+        assert!(auth_response.success, "Authorization should succeed");
+        assert!(
+            auth_response.error.is_none(),
+            "Authorization should not have error"
+        );
+
+        // Verify status now shows upstream configured
+        let status_result = driver
+            .execute(
+                r#"
+                const response = await fetch('/api/status');
+                return await response.json();
+                "#,
+                vec![],
+            )
+            .await?;
+
+        let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
+        assert!(
+            status.has_upstream,
+            "Expected upstream to be configured after authorization"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// Test full sync flow through the browser.
+    #[dialog_common::test]
+    async fn it_syncs_via_browser(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Wait for service worker to activate before making API calls
+        driver
+            .execute("await window.serviceWorkerActivates();", vec![])
+            .await?;
+
+        // First authorize with the access service
+        let authorize_request = AuthorizeRequest {
+            access_service_url: Some(env.access_service_url()),
+        };
+        let request_json = serde_json::to_string(&authorize_request)?;
+
+        let auth_script = format!(
+            r#"
+            const response = await fetch('/api/authorize', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: '{}'
+            }});
+            return await response.json();
+            "#,
+            request_json.replace('\'', "\\'")
+        );
+
+        let auth_result = driver.execute(&auth_script, vec![]).await?;
+        let auth_response: AuthorizeResponse = serde_json::from_value(auth_result.json().clone())?;
+        assert!(auth_response.success, "Authorization should succeed");
+
+        // Now perform sync
+        let sync_result = driver
+            .execute(
+                r#"
+                const response = await fetch('/api/sync', {
+                    method: 'POST'
+                });
+                return await response.json();
+                "#,
+                vec![],
+            )
+            .await?;
+
+        let sync_response: SyncResponse = serde_json::from_value(sync_result.json().clone())?;
+        assert!(sync_response.success, "Sync should succeed");
+
+        driver.quit().await?;
+        Ok(())
+    }
+}

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -90,14 +90,18 @@ pub fn TonkShell() -> impl IntoView {
 mod tests {
     use crate::helpers::TestEnvironment;
     use anyhow::Result;
-    use tonk_worker::{AuthorizeRequest, AuthorizeResponse, StatusResponse, SyncResponse};
+    use thirtyfour::prelude::*;
+    use tonk_worker::{StatusResponse, SyncResponse};
 
     /// Test that the UI loads and the service worker responds to status requests.
+    /// This test checks initial state before auto-authorization completes.
     #[dialog_common::test]
     async fn it_loads_ui_and_gets_status(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
         // Wait for service worker to activate before making API calls
+        // Note: We use serviceWorkerActivates here (not .toolbar.visible) to check
+        // the initial state before auto-authorization completes
         driver
             .execute("await window.serviceWorkerActivates();", vec![])
             .await?;
@@ -127,45 +131,16 @@ mod tests {
         Ok(())
     }
 
-    /// Test authorization flow through the browser with access service.
+    /// Test that the UI auto-authorizes on load via the access service.
+    /// The access service is available at /ucan/ via Caddy reverse proxy.
     #[dialog_common::test]
     async fn it_authorizes_via_browser(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for service worker to activate before making API calls
-        driver
-            .execute("await window.serviceWorkerActivates();", vec![])
-            .await?;
+        // Wait for toolbar to become visible (indicates UI is ready and authorized)
+        assert!(driver.query(By::Css(".toolbar.visible")).exists().await?);
 
-        // Build authorize request with access service URL
-        let authorize_request = AuthorizeRequest {
-            access_service_url: Some(env.access_service_url()),
-        };
-        let request_json = serde_json::to_string(&authorize_request)?;
-
-        // Execute authorization via browser
-        let script = format!(
-            r#"
-            const response = await fetch('/api/authorize', {{
-                method: 'POST',
-                headers: {{ 'Content-Type': 'application/json' }},
-                body: '{}'
-            }});
-            return await response.json();
-            "#,
-            request_json.replace('\'', "\\'")
-        );
-
-        let result = driver.execute(&script, vec![]).await?;
-        let auth_response: AuthorizeResponse = serde_json::from_value(result.json().clone())?;
-
-        assert!(auth_response.success, "Authorization should succeed");
-        assert!(
-            auth_response.error.is_none(),
-            "Authorization should not have error"
-        );
-
-        // Verify status now shows upstream configured
+        // Verify status shows upstream configured after auto-authorization
         let status_result = driver
             .execute(
                 r#"
@@ -179,7 +154,7 @@ mod tests {
         let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
         assert!(
             status.has_upstream,
-            "Expected upstream to be configured after authorization"
+            "Expected upstream to be configured after auto-authorization"
         );
 
         driver.quit().await?;
@@ -191,34 +166,10 @@ mod tests {
     async fn it_syncs_via_sync_route(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for service worker to activate before making API calls
-        driver
-            .execute("await window.serviceWorkerActivates();", vec![])
-            .await?;
+        // Wait for toolbar to become visible (indicates UI is ready and authorized)
+        assert!(driver.query(By::Css(".toolbar.visible")).exists().await?);
 
-        // First authorize with the access service
-        let authorize_request = AuthorizeRequest {
-            access_service_url: Some(env.access_service_url()),
-        };
-        let request_json = serde_json::to_string(&authorize_request)?;
-
-        let auth_script = format!(
-            r#"
-            const response = await fetch('/api/authorize', {{
-                method: 'POST',
-                headers: {{ 'Content-Type': 'application/json' }},
-                body: '{}'
-            }});
-            return await response.json();
-            "#,
-            request_json.replace('\'', "\\'")
-        );
-
-        let auth_result = driver.execute(&auth_script, vec![]).await?;
-        let auth_response: AuthorizeResponse = serde_json::from_value(auth_result.json().clone())?;
-        assert!(auth_response.success, "Authorization should succeed");
-
-        // Now perform sync
+        // Perform sync
         let sync_result = driver
             .execute(
                 r#"
@@ -243,34 +194,10 @@ mod tests {
     async fn it_syncs_via_background_sync_api(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for service worker to activate before making API calls
-        driver
-            .execute("await window.serviceWorkerActivates();", vec![])
-            .await?;
+        // Wait for toolbar to become visible (indicates UI is ready and authorized)
+        assert!(driver.query(By::Css(".toolbar.visible")).exists().await?);
 
-        // Authorize with the access service first (must happen before status call)
-        let authorize_request = AuthorizeRequest {
-            access_service_url: Some(env.access_service_url()),
-        };
-        let request_json = serde_json::to_string(&authorize_request)?;
-
-        let auth_script = format!(
-            r#"
-            const response = await fetch('/api/authorize', {{
-                method: 'POST',
-                headers: {{ 'Content-Type': 'application/json' }},
-                body: '{}'
-            }});
-            return await response.json();
-            "#,
-            request_json.replace('\'', "\\'")
-        );
-
-        let auth_result = driver.execute(&auth_script, vec![]).await?;
-        let auth_response: AuthorizeResponse = serde_json::from_value(auth_result.json().clone())?;
-        assert!(auth_response.success, "Authorization should succeed");
-
-        // Get status to learn the space_did (after authorization)
+        // Get status to learn the space_did
         let status_result = driver
             .execute(
                 r#"
@@ -286,9 +213,7 @@ mod tests {
         // Call window.sync() which uses Background Sync API
         // Note: Background Sync API may not be available in headless Chrome,
         // in which case it falls back to direct /api/sync call
-        driver
-            .execute("await window.sync();", vec![])
-            .await?;
+        driver.execute("await window.sync();", vec![]).await?;
 
         // Verify data was pushed by checking the remote branch
         // Note: space_did needs to be URL-encoded since it contains ':'

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -90,10 +90,7 @@ pub fn TonkShell() -> impl IntoView {
 mod tests {
     use crate::helpers::TestEnvironment;
     use anyhow::Result;
-    use tonk_worker::{
-        AuthorizeRequest, AuthorizeResponse, RemoteBranchStatusResponse, StatusResponse,
-        SyncResponse,
-    };
+    use tonk_worker::{AuthorizeRequest, AuthorizeResponse, StatusResponse, SyncResponse};
 
     /// Test that the UI loads and the service worker responds to status requests.
     #[dialog_common::test]
@@ -191,7 +188,7 @@ mod tests {
 
     /// Test full sync flow through the browser.
     #[dialog_common::test]
-    async fn it_syncs_via_browser(env: TestEnvironment) -> Result<()> {
+    async fn it_syncs_via_sync_route(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
         // Wait for service worker to activate before making API calls
@@ -236,6 +233,90 @@ mod tests {
 
         let sync_response: SyncResponse = serde_json::from_value(sync_result.json().clone())?;
         assert!(sync_response.success, "Sync should succeed");
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// Test sync via Background Sync API and verify data was pushed to remote.
+    #[dialog_common::test]
+    async fn it_syncs_via_background_sync_api(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Wait for service worker to activate before making API calls
+        driver
+            .execute("await window.serviceWorkerActivates();", vec![])
+            .await?;
+
+        // Authorize with the access service first (must happen before status call)
+        let authorize_request = AuthorizeRequest {
+            access_service_url: Some(env.access_service_url()),
+        };
+        let request_json = serde_json::to_string(&authorize_request)?;
+
+        let auth_script = format!(
+            r#"
+            const response = await fetch('/api/authorize', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: '{}'
+            }});
+            return await response.json();
+            "#,
+            request_json.replace('\'', "\\'")
+        );
+
+        let auth_result = driver.execute(&auth_script, vec![]).await?;
+        let auth_response: AuthorizeResponse = serde_json::from_value(auth_result.json().clone())?;
+        assert!(auth_response.success, "Authorization should succeed");
+
+        // Get status to learn the space_did (after authorization)
+        let status_result = driver
+            .execute(
+                r#"
+                const response = await fetch('/api/status');
+                return await response.json();
+                "#,
+                vec![],
+            )
+            .await?;
+        let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
+        let space_did = status.space_did.clone();
+
+        // Call window.sync() which uses Background Sync API
+        // Note: Background Sync API may not be available in headless Chrome,
+        // in which case it falls back to direct /api/sync call
+        driver
+            .execute("await window.sync();", vec![])
+            .await?;
+
+        // Verify data was pushed by checking the remote branch
+        // Note: space_did needs to be URL-encoded since it contains ':'
+        use url::form_urlencoded;
+        let encoded_space_did: String =
+            form_urlencoded::byte_serialize(space_did.as_bytes()).collect();
+
+        let inspect_script = format!(
+            r#"
+            const response = await fetch('/api/inspect/site/origin/{}/branch/main');
+            return await response.json();
+            "#,
+            encoded_space_did
+        );
+
+        let inspect_result = driver.execute(&inspect_script, vec![]).await?;
+        let branch_status: serde_json::Value =
+            serde_json::from_value(inspect_result.json().clone())?;
+
+        assert!(
+            branch_status["success"].as_bool().unwrap_or(false),
+            "Remote branch resolution should succeed after sync: {:?}",
+            branch_status
+        );
+        assert!(
+            branch_status.get("revision").is_some() && !branch_status["revision"].is_null(),
+            "Remote branch should have a revision after sync"
+        );
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -21,6 +21,11 @@ use space::*;
 extern "C" {
     #[wasm_bindgen(js_namespace = window, js_name = serviceWorkerActivates)]
     async fn service_worker_activates();
+
+    /// Triggers a sync operation.
+    /// Uses Background Sync API if available, otherwise falls back to /api/sync.
+    #[wasm_bindgen(js_namespace = window, catch)]
+    pub async fn sync() -> Result<(), JsValue>;
 }
 
 /// The current status of the application.

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -90,6 +90,7 @@ pub fn TonkShell() -> impl IntoView {
 mod tests {
     use crate::helpers::TestEnvironment;
     use anyhow::Result;
+    #[cfg(not(target_arch = "wasm32"))]
     use thirtyfour::prelude::*;
     use tonk_worker::{StatusResponse, SyncResponse};
 

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -93,48 +93,10 @@ mod tests {
     use thirtyfour::prelude::*;
     use tonk_worker::{StatusResponse, SyncResponse};
 
-    /// Test that the UI loads and the service worker responds to status requests.
-    /// This test checks initial state before auto-authorization completes.
-    #[dialog_common::test]
-    async fn it_loads_ui_and_gets_status(env: TestEnvironment) -> Result<()> {
-        let driver = env.driver().await?;
-
-        // Wait for service worker to activate before making API calls
-        // Note: We use serviceWorkerActivates here (not .toolbar.visible) to check
-        // the initial state before auto-authorization completes
-        driver
-            .execute("await window.serviceWorkerActivates();", vec![])
-            .await?;
-
-        // Execute JavaScript to call the status API
-        let result = driver
-            .execute(
-                r#"
-                const response = await fetch('/api/status');
-                return await response.json();
-                "#,
-                vec![],
-            )
-            .await?;
-
-        let status: StatusResponse = serde_json::from_value(result.json().clone())?;
-
-        // Status should show no upstream configured initially
-        assert!(!status.has_upstream, "Expected no upstream initially");
-        assert!(!status.space_did.is_empty(), "Expected space_did to be set");
-        assert!(
-            !status.operator_did.is_empty(),
-            "Expected operator_did to be set"
-        );
-
-        driver.quit().await?;
-        Ok(())
-    }
-
-    /// Test that the UI auto-authorizes on load via the access service.
+    /// Test that the UI auto-configures upstream on load via the access service.
     /// The access service is available at /ucan/ via Caddy reverse proxy.
     #[dialog_common::test]
-    async fn it_authorizes_via_browser(env: TestEnvironment) -> Result<()> {
+    async fn it_configures_upstream(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
         // Wait for toolbar to become visible (indicates UI is ready and authorized)
@@ -154,14 +116,14 @@ mod tests {
         let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
         assert!(
             status.has_upstream,
-            "Expected upstream to be configured after auto-authorization"
+            "Expected upstream to be configured after initialization"
         );
 
         driver.quit().await?;
         Ok(())
     }
 
-    /// Test full sync flow through the browser.
+    /// Test sync via /api/sync endpoint.
     #[dialog_common::test]
     async fn it_syncs_via_sync_route(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
@@ -197,7 +159,12 @@ mod tests {
         // Wait for toolbar to become visible (indicates UI is ready and authorized)
         assert!(driver.query(By::Css(".toolbar.visible")).exists().await?);
 
-        // Get status to learn the space_did
+        // Call window.sync() which uses Background Sync API
+        // Note: Background Sync API may not be available in headless Chrome,
+        // in which case it falls back to direct /api/sync call
+        driver.execute("await window.sync();", vec![]).await?;
+
+        // Get the space_did from status to verify sync on remote
         let status_result = driver
             .execute(
                 r#"
@@ -209,11 +176,6 @@ mod tests {
             .await?;
         let status: StatusResponse = serde_json::from_value(status_result.json().clone())?;
         let space_did = status.space_did.clone();
-
-        // Call window.sync() which uses Background Sync API
-        // Note: Background Sync API may not be available in headless Chrome,
-        // in which case it falls back to direct /api/sync call
-        driver.execute("await window.sync();", vec![]).await?;
 
         // Verify data was pushed by checking the remote branch
         // Note: space_did needs to be URL-encoded since it contains ':'

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -14,11 +14,11 @@ mod native {
     /// Test environment configuration for integration tests.
     #[derive(Deserialize, Serialize, Debug, Clone)]
     pub struct TestEnvironment {
-        /// URL of the Tonk web server.
+        /// URL of the Tonk web server (Caddy proxies /ucan/* to the access service).
         pub tonk_web: Url,
         /// URL of the ChromeDriver server.
         pub chromedriver: Url,
-        /// Access service connection info.
+        /// Access service connection info (for direct access if needed).
         pub access_service: AccessServiceAddress,
     }
 
@@ -44,11 +44,6 @@ mod native {
             driver.goto(&self.tonk_web.to_string()).await?;
             Ok(driver)
         }
-
-        /// Returns the access service URL with /ucan/ path appended.
-        pub fn access_service_url(&self) -> String {
-            format!("{}/ucan/", self.access_service.access_service_url)
-        }
     }
 
     /// Manages test server processes for integration testing.
@@ -60,11 +55,33 @@ mod native {
 
     impl TestServers {
         /// Starts the test servers and returns the server handles and environment configuration.
+        ///
+        /// Startup order:
+        /// 1. Start access service first to get its port
+        /// 2. Start Caddy web server with access service port (proxies /ucan/*)
+        /// 3. Start ChromeDriver
         pub async fn start() -> Result<(Self, TestEnvironment)> {
+            // Start the access service first to get its port
+            let settings = AccessServiceSettings::default();
+            let access_service = tonk_access_service::helpers::access_service(settings).await?;
+            let access_service_address = access_service.address.clone();
+
+            // Extract port from access service URL (e.g., "http://127.0.0.1:8090" -> "8090")
+            let access_service_port = Url::parse(&access_service_address.access_service_url)?
+                .port()
+                .ok_or_else(|| anyhow!("Access service URL has no port"))?;
+
+            // Start the web server (Caddy) with access service port for /ucan/* proxying
             let web_port =
                 free_local_port().expect("Could not get a free local port for test server");
             let mut web_server = std::process::Command::new("nix")
-                .args(["run", ".#tonk-ui-test-server", "--", &format!("{web_port}")])
+                .args([
+                    "run",
+                    ".#tonk-ui-test-server",
+                    "--",
+                    &format!("{web_port}"),
+                    &format!("{access_service_port}"),
+                ])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .spawn()?;
@@ -82,6 +99,7 @@ mod native {
                 }
             }
 
+            // Start ChromeDriver
             let chromedriver_port =
                 free_local_port().expect("Could not get a free local port for chromedriver");
             let mut chromedriver = std::process::Command::new("chromedriver")
@@ -102,12 +120,6 @@ mod native {
                     break;
                 }
             }
-
-            // Start the access service using tonk-access-service's provider
-            let settings = AccessServiceSettings::default();
-            let access_service = tonk_access_service::helpers::access_service(settings).await?;
-
-            let access_service_address = access_service.address.clone();
 
             Ok((
                 Self {

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -2,12 +2,13 @@
 mod native {
     use anyhow::{Result, anyhow};
     use async_trait::async_trait;
-    use dialog_common::helpers::Provider;
+    use dialog_common::helpers::{Provider, Service};
     use port_check::free_local_port;
     use serde::{Deserialize, Serialize};
     use std::io::{BufRead, BufReader};
     use std::process::{Child, Stdio};
     use thirtyfour::{ChromiumLikeCapabilities, DesiredCapabilities, WebDriver};
+    use tonk_access_service::helpers::{AccessServiceAddress, AccessServiceSettings};
     use url::Url;
 
     /// Test environment configuration for integration tests.
@@ -17,6 +18,8 @@ mod native {
         pub tonk_web: Url,
         /// URL of the ChromeDriver server.
         pub chromedriver: Url,
+        /// Access service connection info.
+        pub access_service: AccessServiceAddress,
     }
 
     impl TestEnvironment {
@@ -41,17 +44,23 @@ mod native {
             driver.goto(&self.tonk_web.to_string()).await?;
             Ok(driver)
         }
+
+        /// Returns the access service URL with /ucan/ path appended.
+        pub fn access_service_url(&self) -> String {
+            format!("{}/ucan/", self.access_service.access_service_url)
+        }
     }
 
     /// Manages test server processes for integration testing.
     pub struct TestServers {
         web_server: Child,
         chromedriver: Child,
+        access_service: Service<AccessServiceAddress, tonk_access_service::helpers::AccessServer>,
     }
 
     impl TestServers {
         /// Starts the test servers and returns the server handles and environment configuration.
-        pub fn start() -> Result<(Self, TestEnvironment)> {
+        pub async fn start() -> Result<(Self, TestEnvironment)> {
             let web_port =
                 free_local_port().expect("Could not get a free local port for test server");
             let mut web_server = std::process::Command::new("nix")
@@ -94,22 +103,31 @@ mod native {
                 }
             }
 
+            // Start the access service using tonk-access-service's provider
+            let settings = AccessServiceSettings::default();
+            let access_service = tonk_access_service::helpers::access_service(settings).await?;
+
+            let access_service_address = access_service.address.clone();
+
             Ok((
                 Self {
                     web_server,
                     chromedriver,
+                    access_service,
                 },
                 TestEnvironment {
                     tonk_web: Url::parse(&format!("http://127.0.0.1:{web_port}"))?,
                     chromedriver: Url::parse(&format!("http://127.0.0.1:{chromedriver_port}"))?,
+                    access_service: access_service_address,
                 },
             ))
         }
 
         /// Stops all test server processes.
-        pub fn stop(mut self) -> Result<()> {
+        pub async fn stop(mut self) -> Result<()> {
             self.web_server.kill()?;
             self.chromedriver.kill()?;
+            self.access_service.stop().await?;
             Ok(())
         }
     }
@@ -117,16 +135,14 @@ mod native {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl Provider for TestServers {
-        async fn stop(mut self) -> anyhow::Result<()> {
-            TestServers::stop(self)
+        async fn stop(self) -> anyhow::Result<()> {
+            TestServers::stop(self).await
         }
     }
 
     #[dialog_common::provider]
     async fn test_servers(_: ()) -> Result<Service<TestEnvironment, TestServers>> {
-        use dialog_common::helpers::Service;
-
-        let (server, address) = TestServers::start()?;
+        let (server, address) = TestServers::start().await?;
         Ok(Service::new(address, server))
     }
 }

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -1,26 +1,28 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Test environment configuration for integration tests.
+/// Available on all platforms, but can only be constructed on native.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TestEnvironment {
+    /// URL of the Tonk web server (Caddy proxies /ucan/* to the access service).
+    pub tonk_web: Url,
+    /// URL of the ChromeDriver server.
+    pub chromedriver: Url,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
+    use super::TestEnvironment;
     use anyhow::{Result, anyhow};
     use async_trait::async_trait;
     use dialog_common::helpers::{Provider, Service};
     use port_check::free_local_port;
-    use serde::{Deserialize, Serialize};
     use std::io::{BufRead, BufReader};
     use std::process::{Child, Stdio};
     use thirtyfour::{ChromiumLikeCapabilities, DesiredCapabilities, WebDriver};
     use tonk_access_service::helpers::{AccessServiceAddress, AccessServiceSettings};
     use url::Url;
-
-    /// Test environment configuration for integration tests.
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    pub struct TestEnvironment {
-        /// URL of the Tonk web server (Caddy proxies /ucan/* to the access service).
-        pub tonk_web: Url,
-        /// URL of the ChromeDriver server.
-        pub chromedriver: Url,
-        /// Access service connection info (for direct access if needed).
-        pub access_service: AccessServiceAddress,
-    }
 
     impl TestEnvironment {
         /// Creates a new WebDriver instance connected to the test environment.
@@ -130,7 +132,6 @@ mod native {
                 TestEnvironment {
                     tonk_web: Url::parse(&format!("http://127.0.0.1:{web_port}"))?,
                     chromedriver: Url::parse(&format!("http://127.0.0.1:{chromedriver_port}"))?,
-                    access_service: access_service_address,
                 },
             ))
         }
@@ -144,8 +145,7 @@ mod native {
         }
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[async_trait]
     impl Provider for TestServers {
         async fn stop(self) -> anyhow::Result<()> {
             TestServers::stop(self).await

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -56,8 +56,17 @@ idb = "0.6"
 [dev-dependencies]
 anyhow = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
+tonk-access-service = { workspace = true, features = ["helpers"] }
 tower = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
+
+[lints.rust]
+# The dialog_common::test macro uses cfg conditions that originate from the macro crate.
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(dialog_test_native_integration)',
+    'cfg(dialog_test_wasm_integration)',
+    'cfg(feature, values("web-integration-tests"))',
+] }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -8,7 +8,7 @@ use tokio::sync::RwLock;
 use crate::worker::TonkState;
 
 mod authorize;
-pub use authorize::{AuthorizeResponse, authorize};
+pub use authorize::{AuthorizeRequest, AuthorizeResponse, authorize};
 
 mod fact;
 pub use fact::{AssertResponse, FactQuery, FactResponse, QueryResponse, assert_fact, query_facts};
@@ -71,7 +71,8 @@ pub fn api_router(state: TonkState) -> Router {
         .with_state(state)
 }
 
-#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+/// Test utilities for router tests.
+#[cfg(test)]
 pub mod tests {
     use std::sync::Arc;
 
@@ -82,6 +83,7 @@ pub mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
+    /// Creates a test state with identity and session for testing routes.
     pub async fn test_state() -> TonkState {
         let mut identity = Identity::load_or_create()
             .await

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -8,7 +8,7 @@ use tokio::sync::RwLock;
 use crate::worker::TonkState;
 
 mod authorize;
-pub use authorize::{AuthorizeRequest, AuthorizeResponse, authorize};
+pub use authorize::{AuthorizeResponse, authorize};
 
 mod fact;
 pub use fact::{AssertResponse, FactQuery, FactResponse, QueryResponse, assert_fact, query_facts};

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -21,11 +21,12 @@ use crate::TonkWorkerError;
 /// Access service path (will be resolved to absolute URL at runtime).
 const ACCESS_SERVICE_PATH: &str = "/ucan/";
 
+/// Get the absolute URL for the access service.
 /// Get the default absolute URL for the access service.
 ///
 /// In WASM (service worker), we resolve against the current origin.
-/// In native, we return the default path.
-fn get_default_access_service_url() -> String {
+/// In native, we return the path as-is (for testing).
+fn get_access_service_url() -> String {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         use wasm_bindgen::JsCast;
@@ -42,15 +43,6 @@ fn get_default_access_service_url() -> String {
     {
         ACCESS_SERVICE_PATH.to_string()
     }
-}
-
-/// Request body for authorization.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct AuthorizeRequest {
-    /// Optional access service URL override.
-    /// If not provided, defaults to the origin-relative `/ucan/` path.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_service_url: Option<String>,
 }
 
 /// Authorization response indicating success.
@@ -82,7 +74,6 @@ pub struct StatusResponse {
 #[wasm_compat]
 pub async fn authorize(
     State(state): State<AppState>,
-    body: Option<Json<AuthorizeRequest>>,
 ) -> Result<Json<AuthorizeResponse>, TonkWorkerError> {
     log!("Authorizing with internal UCAN delegation...");
 
@@ -97,10 +88,7 @@ pub async fn authorize(
 
     let space_did = tonk_state.session.space_did().to_string();
 
-    // Use provided URL or fall back to default
-    let service_url = body
-        .and_then(|b| b.access_service_url.clone())
-        .unwrap_or_else(get_default_access_service_url);
+    let service_url = get_access_service_url();
     log!(
         "Setting up UCAN credentials for space: {} with URL: {}",
         space_did,
@@ -195,14 +183,11 @@ pub async fn status(
 #[cfg(test)]
 mod tests {
     use super::super::tests::test_state;
-    use super::AuthorizeRequest;
     use crate::StatusResponse;
     use crate::{AuthorizeResponse, SyncResponse, api_router};
 
-    use anyhow::Result;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use tonk_access_service::helpers::AccessServiceAddress;
     use tower::ServiceExt;
 
     #[dialog_common::test]
@@ -235,117 +220,7 @@ mod tests {
         assert!(!status_response.operator_did.is_empty());
     }
 
-    #[dialog_common::test]
-    async fn it_authorizes_with_access_service(env: AccessServiceAddress) -> Result<()> {
-        let state = test_state().await;
-        let app = api_router(state);
-
-        // Authorize with the test access service URL
-        let authorize_request = AuthorizeRequest {
-            access_service_url: Some(format!("{}/ucan/", env.access_service_url)),
-        };
-
-        let request = Request::builder()
-            .uri("/api/authorize")
-            .method("POST")
-            .header("content-type", "application/json")
-            .body(Body::from(
-                serde_json::to_string(&authorize_request).unwrap(),
-            ))
-            .expect("Failed to build request");
-
-        let response = app
-            .clone()
-            .oneshot(request)
-            .await
-            .expect("Failed to execute request");
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("Failed to read response body");
-
-        let authorize_response: AuthorizeResponse =
-            serde_json::from_slice(&body).expect("Failed to deserialize response");
-
-        assert!(authorize_response.success);
-        assert!(authorize_response.error.is_none());
-
-        // Verify status now shows upstream configured
-        let request = Request::builder()
-            .uri("/api/status")
-            .method("GET")
-            .body(Body::empty())
-            .expect("Failed to build request");
-
-        let response = app
-            .oneshot(request)
-            .await
-            .expect("Failed to execute request");
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("Failed to read response body");
-
-        let status_response: StatusResponse =
-            serde_json::from_slice(&body).expect("Failed to deserialize response");
-
-        assert!(status_response.has_upstream);
-        Ok(())
-    }
-
-    #[dialog_common::test]
-    async fn it_syncs_with_access_service(env: AccessServiceAddress) -> Result<()> {
-        let state = test_state().await;
-        let app = api_router(state);
-
-        // First authorize with the test access service
-        let authorize_request = AuthorizeRequest {
-            access_service_url: Some(format!("{}/ucan/", env.access_service_url)),
-        };
-
-        let request = Request::builder()
-            .uri("/api/authorize")
-            .method("POST")
-            .header("content-type", "application/json")
-            .body(Body::from(
-                serde_json::to_string(&authorize_request).unwrap(),
-            ))
-            .expect("Failed to build request");
-
-        let response = app
-            .clone()
-            .oneshot(request)
-            .await
-            .expect("Failed to execute request");
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        // Now perform sync
-        let request = Request::builder()
-            .uri("/api/sync")
-            .method("POST")
-            .body(Body::empty())
-            .expect("Failed to build request");
-
-        let response = app
-            .oneshot(request)
-            .await
-            .expect("Failed to execute request");
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("Failed to read response body");
-
-        let sync_response: SyncResponse =
-            serde_json::from_slice(&body).expect("Failed to deserialize response");
-
-        assert!(sync_response.success, "Sync should succeed");
-        Ok(())
-    }
+    // Note: it_authorizes_with_access_service and it_syncs_with_access_service
+    // tests have been moved to the browser integration tests in tonk-ui/src/components.rs
+    // since they require the /ucan/ proxy to be available (via Caddy in test environment).
 }

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -199,6 +199,7 @@ mod tests {
     use crate::StatusResponse;
     use crate::{AuthorizeResponse, SyncResponse, api_router};
 
+    use anyhow::Result;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use tonk_access_service::helpers::AccessServiceAddress;
@@ -235,7 +236,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_authorizes_with_access_service(env: AccessServiceAddress) {
+    async fn it_authorizes_with_access_service(env: AccessServiceAddress) -> Result<()> {
         let state = test_state().await;
         let app = api_router(state);
 
@@ -293,10 +294,11 @@ mod tests {
             serde_json::from_slice(&body).expect("Failed to deserialize response");
 
         assert!(status_response.has_upstream);
+        Ok(())
     }
 
     #[dialog_common::test]
-    async fn it_syncs_with_access_service(env: AccessServiceAddress) {
+    async fn it_syncs_with_access_service(env: AccessServiceAddress) -> Result<()> {
         let state = test_state().await;
         let app = api_router(state);
 
@@ -344,5 +346,6 @@ mod tests {
             serde_json::from_slice(&body).expect("Failed to deserialize response");
 
         assert!(sync_response.success, "Sync should succeed");
+        Ok(())
     }
 }

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -184,7 +184,7 @@ pub async fn status(
 mod tests {
     use super::super::tests::test_state;
     use crate::StatusResponse;
-    use crate::{AuthorizeResponse, SyncResponse, api_router};
+    use crate::api_router;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -1,8 +1,7 @@
 //! Authorization routes using UCAN-based authentication.
 //!
 //! The authorization endpoint uses the operator and delegation that were
-//! created when the service worker started. An optional access service URL
-//! can be provided for testing purposes.
+//! created when the service worker started. No external input is needed.
 
 use ::axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
@@ -70,7 +69,7 @@ pub struct StatusResponse {
 /// Handles authorization requests and configures the UCAN-based remote for the space.
 ///
 /// Uses the operator and delegation from the worker's state (created at startup).
-/// Optionally accepts an `access_service_url` in the request body for testing.
+// No external input is required - just call POST /api/authorize with an empty body.
 #[wasm_compat]
 pub async fn authorize(
     State(state): State<AppState>,
@@ -87,7 +86,6 @@ pub async fn authorize(
         .map_err(|e| TonkWorkerError::Internal(format!("Failed to query delegations: {}", e)))?;
 
     let space_did = tonk_state.session.space_did().to_string();
-
     let service_url = get_access_service_url();
     log!(
         "Setting up UCAN credentials for space: {} with URL: {}",

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -219,8 +219,4 @@ mod tests {
         assert!(!status_response.space_did.is_empty());
         assert!(!status_response.operator_did.is_empty());
     }
-
-    // Note: it_authorizes_with_access_service and it_syncs_with_access_service
-    // tests have been moved to the browser integration tests in tonk-ui/src/components.rs
-    // since they require the /ucan/ proxy to be available (via Caddy in test environment).
 }

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -1,7 +1,8 @@
 //! Authorization routes using UCAN-based authentication.
 //!
 //! The authorization endpoint uses the operator and delegation that were
-//! created when the service worker started. No external input is needed.
+//! created when the service worker started. An optional access service URL
+//! can be provided for testing purposes.
 
 use ::axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
@@ -20,11 +21,11 @@ use crate::TonkWorkerError;
 /// Access service path (will be resolved to absolute URL at runtime).
 const ACCESS_SERVICE_PATH: &str = "/ucan/";
 
-/// Get the absolute URL for the access service.
+/// Get the default absolute URL for the access service.
 ///
 /// In WASM (service worker), we resolve against the current origin.
-/// In native, we return the path as-is (for testing).
-fn get_access_service_url() -> String {
+/// In native, we return the default path.
+fn get_default_access_service_url() -> String {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         use wasm_bindgen::JsCast;
@@ -41,6 +42,15 @@ fn get_access_service_url() -> String {
     {
         ACCESS_SERVICE_PATH.to_string()
     }
+}
+
+/// Request body for authorization.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AuthorizeRequest {
+    /// Optional access service URL override.
+    /// If not provided, defaults to the origin-relative `/ucan/` path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_service_url: Option<String>,
 }
 
 /// Authorization response indicating success.
@@ -68,10 +78,11 @@ pub struct StatusResponse {
 /// Handles authorization requests and configures the UCAN-based remote for the space.
 ///
 /// Uses the operator and delegation from the worker's state (created at startup).
-/// No external input is required - just call POST /api/authorize with an empty body.
+/// Optionally accepts an `access_service_url` in the request body for testing.
 #[wasm_compat]
 pub async fn authorize(
     State(state): State<AppState>,
+    body: Option<Json<AuthorizeRequest>>,
 ) -> Result<Json<AuthorizeResponse>, TonkWorkerError> {
     log!("Authorizing with internal UCAN delegation...");
 
@@ -85,7 +96,11 @@ pub async fn authorize(
         .map_err(|e| TonkWorkerError::Internal(format!("Failed to query delegations: {}", e)))?;
 
     let space_did = tonk_state.session.space_did().to_string();
-    let service_url = get_access_service_url();
+
+    // Use provided URL or fall back to default
+    let service_url = body
+        .and_then(|b| b.access_service_url.clone())
+        .unwrap_or_else(get_default_access_service_url);
     log!(
         "Setting up UCAN credentials for space: {} with URL: {}",
         space_did,
@@ -177,14 +192,16 @@ pub async fn status(
     }))
 }
 
-#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(test)]
 mod tests {
     use super::super::tests::test_state;
+    use super::AuthorizeRequest;
     use crate::StatusResponse;
-    use crate::{AuthorizeResponse, api_router};
+    use crate::{AuthorizeResponse, SyncResponse, api_router};
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use tonk_access_service::helpers::AccessServiceAddress;
     use tower::ServiceExt;
 
     #[dialog_common::test]
@@ -215,5 +232,117 @@ mod tests {
         assert!(!status_response.has_upstream);
         assert!(!status_response.space_did.is_empty());
         assert!(!status_response.operator_did.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_with_access_service(env: AccessServiceAddress) {
+        let state = test_state().await;
+        let app = api_router(state);
+
+        // Authorize with the test access service URL
+        let authorize_request = AuthorizeRequest {
+            access_service_url: Some(format!("{}/ucan/", env.access_service_url)),
+        };
+
+        let request = Request::builder()
+            .uri("/api/authorize")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_string(&authorize_request).unwrap(),
+            ))
+            .expect("Failed to build request");
+
+        let response = app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let authorize_response: AuthorizeResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(authorize_response.success);
+        assert!(authorize_response.error.is_none());
+
+        // Verify status now shows upstream configured
+        let request = Request::builder()
+            .uri("/api/status")
+            .method("GET")
+            .body(Body::empty())
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let status_response: StatusResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(status_response.has_upstream);
+    }
+
+    #[dialog_common::test]
+    async fn it_syncs_with_access_service(env: AccessServiceAddress) {
+        let state = test_state().await;
+        let app = api_router(state);
+
+        // First authorize with the test access service
+        let authorize_request = AuthorizeRequest {
+            access_service_url: Some(format!("{}/ucan/", env.access_service_url)),
+        };
+
+        let request = Request::builder()
+            .uri("/api/authorize")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::to_string(&authorize_request).unwrap(),
+            ))
+            .expect("Failed to build request");
+
+        let response = app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Now perform sync
+        let request = Request::builder()
+            .uri("/api/sync")
+            .method("POST")
+            .body(Body::empty())
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let sync_response: SyncResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(sync_response.success, "Sync should succeed");
     }
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -134,4 +134,44 @@ impl TonkServiceWorker {
                 .map_err(JsValue::from)
         })
     }
+
+    /// Performs a full sync operation (pull then push) with the upstream remote.
+    ///
+    /// This method dispatches to the `/api/sync` route internally, so the sync
+    /// logic is not duplicated. It is intended to be called from the Background
+    /// Sync API event or as a polyfill.
+    ///
+    /// # Returns
+    ///
+    /// A JavaScript `Promise` that resolves to `undefined` on success, or
+    /// rejects with an error if the sync failed.
+    pub fn sync(&self) -> Promise {
+        log!("Background sync triggered, dispatching to /api/sync");
+
+        let router = self.router.clone();
+
+        future_to_promise(async move {
+            let request = axum::http::Request::builder()
+                .method("POST")
+                .uri("/api/sync")
+                .body(Body::empty())
+                .expect_throw("Failed to build sync request");
+
+            let response = router
+                .lock()
+                .await
+                .call(request)
+                .await
+                .expect_throw("Failed to handle sync request");
+
+            if response.status().is_success() {
+                Ok(JsValue::UNDEFINED)
+            } else {
+                Err(JsValue::from_str(&format!(
+                    "Sync failed with status: {}",
+                    response.status()
+                )))
+            }
+        })
+    }
 }


### PR DESCRIPTION
Integrates [background synchronization](https://developer.mozilla.org/en-US/docs/Web/API/Background_Synchronization_API) into service worker so changer across local/remote replicas are propagated.

Since browser support for this API seems sparse it falls back to posting to `/api/sync` endpoint to force synchronization.

Amends test infrastructure to spin up access service and mock s3 service so that synchronization can be tested end to end. 


<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the integration of the `tonk-access-service` into the project, adding support for background synchronization and improving testing utilities. It includes modifications to the service worker and various test setups to ensure smooth operation and verification of sync functionality.

### Detailed summary
- Added `tonk-access-service` as a dependency in `Cargo.toml`.
- Updated service worker in `rust/tonk-ui/assets/service_worker.js` to handle background sync events.
- Enhanced sync functionality in `rust/tonk-worker/src/worker.rs` with a new `sync` method.
- Simplified test utilities in `rust/tonk-worker/src/router.rs` and `rust/tonk-access-service/src/helpers.rs`.
- Improved integration test setup in `rust/tonk-ui/src/helpers.rs` to start the access service.
- Added new tests for sync operations in `rust/tonk-ui/src/components.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->