### PR TITLE
feat: Add URL-based routing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           nix --accept-flake-config develop .#ci -c lint
 
-  rust_crates:
-    name: 'Rust Crates'
+  tests:
+    name: 'Tests'
     needs: ['lints']
     runs-on: 'ubuntu-latest'
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.helix
 automerge-repo-data
 .direnv
 .wrangler

--- a/rust/tonk-ui/Trunk.toml
+++ b/rust/tonk-ui/Trunk.toml
@@ -1,5 +1,5 @@
 [build]
-public_url = "./"
+public_url = "/"
 offline = true
 
 [serve]

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -2,117 +2,116 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="title" content="Tonk">
-    <meta name="description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta name="robots" content="index, follow">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="title" content="Tonk">
+  <meta name="description"
+    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
+  <meta name="robots" content="index, follow">
 
-    <title>Tonk</title>
+  <title>Tonk</title>
 
-    <meta property="og:title" content="Tonk is impossible software">
-    <meta property="og:description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta property="og:url" content="https://tonk.xyz">
-    <meta property="og:site_name" content="Tonk">
-    <meta property="og:locale" content="en_US">
-    <meta property="og:image" content="https://tonk.xyz/preview.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Tonk is impossible software">
-    <meta property="og:type" content="website">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Tonk is impossible software">
-    <meta name="twitter:description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta name="twitter:image" content="https://tonk.xyz/preview.png">
+  <meta property="og:title" content="Tonk is impossible software">
+  <meta property="og:description"
+    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
+  <meta property="og:url" content="https://tonk.xyz">
+  <meta property="og:site_name" content="Tonk">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://tonk.xyz/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="Tonk is impossible software">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Tonk is impossible software">
+  <meta name="twitter:description"
+    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
+  <meta name="twitter:image" content="https://tonk.xyz/preview.png">
 
-    <link rel="shortcut icon" href="/images/mark-white.svg">
-    <link rel="apple-touch-icon" href="/images/mark-white.svg">
+  <link rel="shortcut icon" href="/images/mark-white.svg">
+  <link rel="apple-touch-icon" href="/images/mark-white.svg">
 
-    <!-- We need to include this before the snippet that loads the UI so that
+  <!-- We need to include this before the snippet that loads the UI so that
          the `serviceWorkerActivates` function is available when the Wasm blob
          initializes; the promise is resolved later on. -->
-    <script type="module">
-        const serviceWorkerActivatesPromise = new Promise((resolve, reject) => {
-            self.resolveServiceWorkerActivates = resolve;
-            self.rejectServiceWorkerActivates = reject;
-        });
+  <script type="module">
+    const serviceWorkerActivatesPromise = new Promise((resolve, reject) => {
+      self.resolveServiceWorkerActivates = resolve;
+      self.rejectServiceWorkerActivates = reject;
+    });
 
-        self.serviceWorkerActivates = () => {
-            return serviceWorkerActivatesPromise;
-        };
+    self.serviceWorkerActivates = () => {
+      return serviceWorkerActivatesPromise;
+    };
 
-        // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
-        self.sync = async () => {
-            if ('serviceWorker' in navigator && 'SyncManager' in window) {
-                try {
-                    const registration = await navigator.serviceWorker.ready;
-                    await registration.sync.register('tonk-sync');
-                    console.log('[Tonk] Background sync registered');
-                    return;
-                } catch (e) {
-                    console.warn('[Tonk] Background sync registration failed, falling back:', e);
-                }
-            }
-            // Fallback to direct sync call
-            const response = await fetch('/api/sync', { method: 'POST' });
-            if (!response.ok) {
-                throw new Error(`Sync failed: ${response.status}`);
-            }
-            console.log('[Tonk] Direct sync completed');
-        };
-    </script>
-
-    <!-- The following are load-bearing configuration for the Trunk build tool
+    // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
+    self.sync = async () => {
+      if ('serviceWorker' in navigator && 'SyncManager' in window) {
+        try {
+          const registration = await navigator.serviceWorker.ready;
+          await registration.sync.register('tonk-sync');
+          console.log('[Tonk] Background sync registered');
+          return;
+        } catch (e) {
+          console.warn('[Tonk] Background sync registration failed, falling back:', e);
+        }
+      }
+      // Fallback to direct sync call
+      const response = await fetch('/api/sync', {method: 'POST'});
+      if (!response.ok) {
+        throw new Error(`Sync failed: ${response.status}`);
+      }
+      console.log('[Tonk] Direct sync completed');
+    };
+  </script>
+  <!-- The following are load-bearing configuration for the Trunk build tool
          (https://trunkrs.dev/assets/); if you need to add build steps or copy
          static assets, you will want to modify this condiguration here. -->
-    <link data-trunk rel="rust" data-bin="ui" data-type="main" data-wasm-opt="z" />
-    <link data-trunk rel="rust" data-bin="worker" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
+  <link data-trunk rel="rust" data-bin="ui" data-type="main" data-wasm-opt="z" />
+  <link data-trunk rel="rust" data-bin="worker" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
 
-    <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
-    <link data-trunk rel="copy-dir" href="./assets/images" />
+  <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
+  <link data-trunk rel="copy-dir" href="./assets/images" />
 
-    <link data-trunk rel="tailwind-css" href="./styles.css" />
+  <link data-trunk rel="tailwind-css" href="./styles.css" />
 </head>
 
 <body>
-    <script type="module">
-        const resolveWhenActive = worker => {
-            const onStateChange = () => {
-                if (worker.state === 'activated') {
-                    resolveServiceWorkerActivates();
-                    worker.removeEventListener('statechange', onStateChange);
-                }
-            };
-
-            worker.addEventListener('statechange', onStateChange);
-            onStateChange();
-        };
-
-        if ("serviceWorker" in navigator) {
-            const registration = await navigator.serviceWorker.register("./service_worker.js", { type: "module" });
-            const worker = registration.installing || registration.waiting || registration.active;
-
-            if (worker != null) {
-                resolveWhenActive(worker);
-            } else {
-                registration.addEventListener('updatefound', () => {
-                    const worker = registration.installing;
-
-                    if (worker != null) {
-                        resolveWhenActive(worker);
-                    } else {
-                        rejectServiceWorkerActivates();
-                    }
-                }, { once: true })
-            }
-        } else {
-            console.error("Service workers not supported; Tonk will not work!");
-            rejectServiceWorkerActivates();
+  <script type="module">
+    const resolveWhenActive = worker => {
+      const onStateChange = () => {
+        if (worker.state === 'activated') {
+          resolveServiceWorkerActivates();
+          worker.removeEventListener('statechange', onStateChange);
         }
-    </script>
+      };
+
+      worker.addEventListener('statechange', onStateChange);
+      onStateChange();
+    };
+
+    if ("serviceWorker" in navigator) {
+      const registration = await navigator.serviceWorker.register("/service_worker.js", {type: "module"});
+      const worker = registration.installing || registration.waiting || registration.active;
+
+      if (worker != null) {
+        resolveWhenActive(worker);
+      } else {
+        registration.addEventListener('updatefound', () => {
+          const worker = registration.installing;
+
+          if (worker != null) {
+            resolveWhenActive(worker);
+          } else {
+            rejectServiceWorkerActivates();
+          }
+        }, {once: true})
+      }
+    } else {
+      console.error("Service workers not supported; Tonk will not work!");
+      rejectServiceWorkerActivates();
+    }
+  </script>
 </body>
 
 </html>

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -4,6 +4,7 @@
 //! It compiles to Wasm and runs in the browser.
 
 use leptos::{logging::log, prelude::*};
+use leptos_router::location::{BrowserUrl, LocationProvider};
 use wasm_bindgen::prelude::*;
 
 use crate::api;
@@ -62,6 +63,8 @@ pub fn TonkShell() -> impl IntoView {
             api::authorize().await?;
             log!("Remote added successfully");
         }
+
+        BrowserUrl::redirect(&format!("/space/{}", status.space_did));
 
         Ok::<_, crate::error::TonkUiError>(())
     });

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -38,8 +38,11 @@ mod integration_tests {
     async fn it_navigates_to_the_default_space(test_environment: TestEnvironment) -> Result<()> {
         let driver = test_environment.driver().await?;
 
-        let launcher = driver.query(By::Css(".launcher")).first().await?;
-        assert_eq!(launcher.text().await?, "Nothing here ¯\\_(ツ)_/¯");
+        let _launcher = driver
+            .query(By::Css(".launcher"))
+            .with_text("Nothing here ¯\\_(ツ)_/¯")
+            .first()
+            .await?;
 
         let space = driver.query(By::Css(".space")).first().await?;
 

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -1,13 +1,52 @@
 use crate::components::{TonkSpace, TonkToolbar};
 use leptos::prelude::*;
+use leptos_router::{
+    components::{Route, Router, Routes},
+    path,
+};
 
 /// Main launcher view that combines the toolbar and workspace.
 #[component]
 pub fn TonkLauncher() -> impl IntoView {
     view! {
-        <section class="launcher">
-            <TonkToolbar></TonkToolbar>
-            <TonkSpace></TonkSpace>
-        </section>
+        <Router>
+            <section class="launcher">
+                <TonkToolbar />
+                <Routes fallback=move || view!{ <section class="404">"Nothing here ¯\\_(ツ)_/¯"</section> }>
+                    <Route path=path!("space/:did?") view=TonkSpace />
+                </Routes>
+            </section>
+        </Router>
+    }
+}
+
+#[cfg(all(
+    test,
+    not(any(target_arch = "wasm32", feature = "web-integration-tests"))
+))]
+mod integration_tests {
+    #![allow(unexpected_cfgs)]
+
+    #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
+    use crate::helpers::TestEnvironment;
+    #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
+    use anyhow::Result;
+    #[cfg_attr(not(feature = "integration-tests"), allow(unused))]
+    use thirtyfour::prelude::*;
+
+    #[dialog_common::test]
+    async fn it_navigates_to_the_default_space(test_environment: TestEnvironment) -> Result<()> {
+        let driver = test_environment.driver().await?;
+
+        let launcher = driver.query(By::Css(".launcher")).first().await?;
+        assert_eq!(launcher.text().await?, "Nothing here ¯\\_(ツ)_/¯");
+
+        let space = driver.query(By::Css(".space")).first().await?;
+
+        assert!(space.text().await?.starts_with("did:key:"));
+
+        driver.quit().await?;
+
+        Ok(())
     }
 }

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -1,8 +1,36 @@
-use leptos::prelude::*;
+use leptos::{either::Either, prelude::*};
+use leptos_router::{hooks::use_params, params::Params};
+
+#[derive(Params, PartialEq, Clone, Debug)]
+pub struct TonkSpaceParams {
+    did: Option<String>,
+}
 
 /// Main workspace area for displaying Tonks.
 #[component]
 #[allow(clippy::unused_unit)]
 pub fn TonkSpace() -> impl IntoView {
-    view! {}
+    let params = use_params::<TonkSpaceParams>();
+    let did = Signal::derive_local(move || {
+        params
+            .get()
+            .map(|params| params.did)
+            .ok()
+            .unwrap_or_default()
+    });
+
+    view! {
+        <section class="space">
+        {
+            move || match did.get() {
+                Some(did) => Either::Left(view! {
+                    <span>{ did }</span>
+                }),
+                None => Either::Right(view! {
+                    <span>"No DID!"</span>
+                }),
+            }
+        }
+        </section>
+    }
 }


### PR DESCRIPTION
This adds minimum viable URL-based routing. It automatically redirects the app to the default created space (this may not be what we want to do in practice), but it is a reasonable, basic demonstration of how routing works in Leptos.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `Tonk` application by updating routing capabilities, adding new parameters for handling space identifiers, and improving the testing framework. It also updates the `index.html` structure while making minor adjustments to configuration files.

### Detailed summary
- Updated `public_url` in `.gitignore`.
- Added `BrowserUrl` and a redirect in `TonkShell` function.
- Introduced `TonkSpaceParams` struct in `space.rs` for handling parameters.
- Enhanced `TonkSpace` component to display the space identifier or a default message.
- Modified `TonkLauncher` to include routing with `Router` and `Routes`.
- Added integration tests for navigation in `launcher.rs`.
- Updated `index.html` to ensure proper service worker registration and meta tags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->