### PR TITLE
feat(worker, ui): multispace support

### DIFF
--- a/rust/tonk-space/src/lib.rs
+++ b/rust/tonk-space/src/lib.rs
@@ -19,6 +19,7 @@ pub use dialog_artifacts::PlatformBackend;
 pub use dialog_query::claim::Transaction;
 pub use dialog_query::{ArtifactAttribute as Attribute, Entity, Fact, Relation, Value};
 pub use ownership::Ownership;
+pub use schema::space::{Description, Name};
 pub use space::{
     BranchInfo, CredentialsInfo, MemoryBackend, MemoryStorageBackend, RemoteBranchInfo,
     RemoteState, Revision, SiteInfo, Space, SpaceError, UpstreamInfo,

--- a/rust/tonk-space/src/schema/space.rs
+++ b/rust/tonk-space/src/schema/space.rs
@@ -7,3 +7,11 @@ use dialog_query::{Attribute, Entity};
 /// Links a space DID to the ownership delegation CID.
 #[derive(Attribute, Clone, PartialEq)]
 pub struct Owner(pub Entity);
+
+/// Human-readable name for a space.
+#[derive(Attribute, Clone, PartialEq)]
+pub struct Name(pub String);
+
+/// Human-readable description for a space.
+#[derive(Attribute, Clone, PartialEq)]
+pub struct Description(pub String);

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -463,6 +463,88 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
             .collect()
     }
 
+    /// Set the name of this space.
+    ///
+    /// The name is stored as a fact on the space's DID entity.
+    pub async fn set_name(&mut self, name: &str) -> Result<(), SpaceError> {
+        use crate::schema::space::Name;
+        use dialog_query::With;
+
+        let space_entity: Entity = self
+            .did
+            .parse()
+            .map_err(|e| SpaceError::InvalidEntity(format!("{:?}", e)))?;
+
+        let mut transaction = self.edit();
+        transaction.assert(With {
+            this: space_entity,
+            has: Name(name.to_string()),
+        });
+        self.commit(transaction).await
+    }
+
+    /// Set the description of this space.
+    ///
+    /// The description is stored as a fact on the space's DID entity.
+    pub async fn set_description(&mut self, description: &str) -> Result<(), SpaceError> {
+        use crate::schema::space::Description;
+        use dialog_query::With;
+
+        let space_entity: Entity = self
+            .did
+            .parse()
+            .map_err(|e| SpaceError::InvalidEntity(format!("{:?}", e)))?;
+
+        let mut transaction = self.edit();
+        transaction.assert(With {
+            this: space_entity,
+            has: Description(description.to_string()),
+        });
+        self.commit(transaction).await
+    }
+
+    /// Get the name of this space, if set.
+    pub async fn get_name(&self) -> Result<Option<String>, SpaceError> {
+        use crate::schema::space::Name;
+        use dialog_query::concept::Match as _;
+        use dialog_query::{Match, Term, With};
+        use futures_util::TryStreamExt;
+
+        let space_entity: Entity = self
+            .did
+            .parse()
+            .map_err(|e| SpaceError::InvalidEntity(format!("{:?}", e)))?;
+
+        let query = Match::<With<Name>> {
+            this: Term::from(space_entity),
+            has: Term::var("name"),
+        };
+
+        let results: Vec<_> = query.query(self.clone()).try_collect().await?;
+        Ok(results.into_iter().next().map(|r| r.has.0))
+    }
+
+    /// Get the description of this space, if set.
+    pub async fn get_description(&self) -> Result<Option<String>, SpaceError> {
+        use crate::schema::space::Description;
+        use dialog_query::concept::Match as _;
+        use dialog_query::{Match, Term, With};
+        use futures_util::TryStreamExt;
+
+        let space_entity: Entity = self
+            .did
+            .parse()
+            .map_err(|e| SpaceError::InvalidEntity(format!("{:?}", e)))?;
+
+        let query = Match::<With<Description>> {
+            this: Term::from(space_entity),
+            has: Term::var("description"),
+        };
+
+        let results: Vec<_> = query.query(self.clone()).try_collect().await?;
+        Ok(results.into_iter().next().map(|r| r.has.0))
+    }
+
     /// Fetch a raw block from a remote site's archive by its blake3 hash.
     ///
     /// # Arguments

--- a/rust/tonk-ui/Trunk.toml
+++ b/rust/tonk-ui/Trunk.toml
@@ -1,5 +1,5 @@
 [build]
-public_url = "./"
+public_url = "/"
 offline = true
 
 [serve]

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -1,98 +1,140 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
+  <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="title" content="Tonk">
-    <meta name="description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta name="robots" content="index, follow">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="title" content="Tonk" />
+    <meta
+      name="description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta name="robots" content="index, follow" />
 
     <title>Tonk</title>
 
-    <meta property="og:title" content="Tonk is impossible software">
-    <meta property="og:description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta property="og:url" content="https://tonk.xyz">
-    <meta property="og:site_name" content="Tonk">
-    <meta property="og:locale" content="en_US">
-    <meta property="og:image" content="https://tonk.xyz/preview.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Tonk is impossible software">
-    <meta property="og:type" content="website">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Tonk is impossible software">
-    <meta name="twitter:description"
-        content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-    <meta name="twitter:image" content="https://tonk.xyz/preview.png">
+    <meta property="og:title" content="Tonk is impossible software" />
+    <meta
+      property="og:description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta property="og:url" content="https://tonk.xyz" />
+    <meta property="og:site_name" content="Tonk" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:image" content="https://tonk.xyz/preview.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Tonk is impossible software" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tonk is impossible software" />
+    <meta
+      name="twitter:description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta name="twitter:image" content="https://tonk.xyz/preview.png" />
 
-    <link rel="shortcut icon" href="/images/mark-white.svg">
-    <link rel="apple-touch-icon" href="/images/mark-white.svg">
+    <link rel="shortcut icon" href="/images/mark-white.svg" />
+    <link rel="apple-touch-icon" href="/images/mark-white.svg" />
 
-    <!-- We need to include this before the snippet that loads the UI so that
-         the `serviceWorkerActivates` function is available when the Wasm blob
-         initializes; the promise is resolved later on. -->
+    <!-- Set up the serviceWorkerActivates promise that the UI Wasm will await.
+         This must be defined before the UI script loads. -->
     <script type="module">
-        const serviceWorkerActivatesPromise = new Promise((resolve, reject) => {
-            self.resolveServiceWorkerActivates = resolve;
-            self.rejectServiceWorkerActivates = reject;
-        });
+      const serviceWorkerActivatesPromise = new Promise((resolve, reject) => {
+        self.resolveServiceWorkerActivates = resolve;
+        self.rejectServiceWorkerActivates = reject;
+      });
 
-        self.serviceWorkerActivates = () => {
-            return serviceWorkerActivatesPromise;
-        };
+      self.serviceWorkerActivates = () => {
+        return serviceWorkerActivatesPromise;
+      };
     </script>
 
     <!-- The following are load-bearing configuration for the Trunk build tool
          (https://trunkrs.dev/assets/); if you need to add build steps or copy
          static assets, you will want to modify this condiguration here. -->
-    <link data-trunk rel="rust" data-bin="ui" data-type="main" data-wasm-opt="z" />
-    <link data-trunk rel="rust" data-bin="worker" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="ui"
+      data-type="main"
+      data-wasm-opt="z"
+    />
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="worker"
+      data-type="worker"
+      data-bindgen-target="web"
+      data-wasm-opt="z"
+    />
 
     <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
     <link data-trunk rel="copy-dir" href="./assets/images" />
 
     <link data-trunk rel="tailwind-css" href="./styles.css" />
-</head>
+  </head>
 
-<body>
+  <body>
     <script type="module">
-        const resolveWhenActive = worker => {
-            const onStateChange = () => {
-                if (worker.state === 'activated') {
-                    resolveServiceWorkerActivates();
-                    worker.removeEventListener('statechange', onStateChange);
-                }
-            };
-
-            worker.addEventListener('statechange', onStateChange);
-            onStateChange();
-        };
-
-        if ("serviceWorker" in navigator) {
-            const registration = await navigator.serviceWorker.register("./service_worker.js", { type: "module" });
-            const worker = registration.installing || registration.waiting || registration.active;
-
-            if (worker != null) {
-                resolveWhenActive(worker);
-            } else {
-                registration.addEventListener('updatefound', () => {
-                    const worker = registration.installing;
-
-                    if (worker != null) {
-                        resolveWhenActive(worker);
-                    } else {
-                        rejectServiceWorkerActivates();
-                    }
-                }, { once: true })
-            }
-        } else {
-            console.error("Service workers not supported; Tonk will not work!");
-            rejectServiceWorkerActivates();
+      const resolveWhenActive = (worker) => {
+        if (worker.state === "activated") {
+          resolveServiceWorkerActivates();
+          return;
         }
-    </script>
-</body>
 
+        const onStateChange = () => {
+          if (worker.state === "activated") {
+            resolveServiceWorkerActivates();
+            worker.removeEventListener("statechange", onStateChange);
+          }
+        };
+        worker.addEventListener("statechange", onStateChange);
+      };
+
+      if ("serviceWorker" in navigator) {
+        try {
+          const registration = await navigator.serviceWorker.register(
+            "/service_worker.js",
+            { type: "module" },
+          );
+
+          // Check if SW is already controlling (on page reload)
+          if (navigator.serviceWorker.controller) {
+            resolveServiceWorkerActivates();
+          } else {
+            const worker =
+              registration.installing ||
+              registration.waiting ||
+              registration.active;
+            if (worker) {
+              resolveWhenActive(worker);
+            } else {
+              registration.addEventListener(
+                "updatefound",
+                () => {
+                  const worker = registration.installing;
+                  if (worker) {
+                    resolveWhenActive(worker);
+                  } else {
+                    rejectServiceWorkerActivates(
+                      new Error("No installing worker found"),
+                    );
+                  }
+                },
+                { once: true },
+              );
+            }
+          }
+        } catch (error) {
+          console.error("Service worker registration failed:", error);
+          rejectServiceWorkerActivates(error);
+        }
+      } else {
+        console.error("Service workers not supported; Tonk will not work!");
+        rejectServiceWorkerActivates(
+          new Error("Service workers not supported"),
+        );
+      }
+    </script>
+  </body>
 </html>

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -1,5 +1,7 @@
 use leptos::{logging::log, prelude::window};
-use tonk_worker::{AuthorizeResponse, DelegationsResponse, IdentifyResponse, StatusResponse};
+use tonk_worker::{
+    AuthorizeResponse, DelegationsResponse, IdentifyResponse, ListSpacesResponse, StatusResponse,
+};
 
 use crate::error::TonkUiError;
 
@@ -17,12 +19,34 @@ fn origin() -> String {
         .expect("Could not read window location")
 }
 
-/// Fetches the current status of the space from the service worker.
-pub async fn status() -> Result<StatusResponse, TonkUiError> {
-    log!("Fetching status...");
+/// Build a space-aware API URL.
+///
+/// The multikey is the `z6Mk...` portion of a DID.
+fn space_api_url(multikey: &str, path: &str) -> String {
+    format!("{}/api/{}{}", origin(), multikey, path)
+}
+
+/// Lists all spaces the user has access to.
+///
+/// This is a global endpoint that doesn't require a space context.
+pub async fn list_spaces() -> Result<ListSpacesResponse, TonkUiError> {
+    log!("Fetching space list...");
 
     let response = reqwest::Client::new()
-        .get(format!("{}/api/status", origin()))
+        .get(format!("{}/api/space/list", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+
+    response.json().await.map_err(into_api_error)
+}
+
+/// Fetches the current status of the space from the service worker.
+pub async fn status(multikey: &str) -> Result<StatusResponse, TonkUiError> {
+    log!("Fetching status for space {}...", multikey);
+
+    let response = reqwest::Client::new()
+        .get(space_api_url(multikey, "/status"))
         .send()
         .await
         .map_err(into_api_error)?;
@@ -34,11 +58,11 @@ pub async fn status() -> Result<StatusResponse, TonkUiError> {
 ///
 /// This no longer requires any input - the service worker uses its
 /// internal operator and delegation.
-pub async fn authorize() -> Result<AuthorizeResponse, TonkUiError> {
-    log!("Enabling sync...");
+pub async fn authorize(multikey: &str) -> Result<AuthorizeResponse, TonkUiError> {
+    log!("Enabling sync for space {}...", multikey);
 
     let response = reqwest::Client::new()
-        .post(format!("{}/api/authorize", origin()))
+        .post(space_api_url(multikey, "/authorize"))
         .send()
         .await
         .map_err(into_api_error)?;
@@ -47,6 +71,8 @@ pub async fn authorize() -> Result<AuthorizeResponse, TonkUiError> {
 }
 
 /// Fetches the current user's identity (DID) from the service worker.
+///
+/// This is a global endpoint that doesn't require a space context.
 pub async fn identify() -> Result<IdentifyResponse, TonkUiError> {
     log!("Fetching identity...");
 
@@ -59,12 +85,12 @@ pub async fn identify() -> Result<IdentifyResponse, TonkUiError> {
     response.json().await.map_err(into_api_error)
 }
 
-/// Fetches the user's delegations for the current space from the service worker.
-pub async fn delegations() -> Result<DelegationsResponse, TonkUiError> {
-    log!("Fetching delegations...");
+/// Fetches the user's delegations for the given space from the service worker.
+pub async fn delegations(multikey: &str) -> Result<DelegationsResponse, TonkUiError> {
+    log!("Fetching delegations for space {}...", multikey);
 
     let response = reqwest::Client::new()
-        .get(format!("{}/api/delegations", origin()))
+        .get(space_api_url(multikey, "/delegations"))
         .send()
         .await
         .map_err(into_api_error)?;

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -4,18 +4,22 @@
 //! It compiles to Wasm and runs in the browser.
 
 use leptos::{logging::log, prelude::*};
+use leptos_router::{components::*, path};
 use wasm_bindgen::prelude::*;
 
-use crate::api;
-
 mod launcher;
-use launcher::*;
 
 mod toolbar;
-use toolbar::*;
+pub use toolbar::*;
 
 mod space;
-use space::*;
+pub use space::*;
+
+mod space_redirect;
+pub use space_redirect::*;
+
+mod space_router;
+pub use space_router::*;
 
 #[wasm_bindgen]
 extern "C" {
@@ -26,9 +30,9 @@ extern "C" {
 /// The current status of the application.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Status {
-    /// Service worker is still loading/activating, or setting up upstream.
+    /// Service worker is still loading/activating.
     Loading,
-    /// Service worker is ready and upstream remote is configured.
+    /// Service worker is ready.
     Ready,
 }
 
@@ -37,46 +41,47 @@ pub enum Status {
 /// This component serves as the main entry point for the Tonk user interface,
 /// rendering the primary application view.
 ///
-/// On startup, it waits for the service worker to activate, then automatically
-/// sets up the upstream remote if not already configured.
+/// On startup, it waits for the service worker to activate before rendering
+/// the router. This ensures all API requests are intercepted by the SW.
+/// Space-specific initialization (like setting up upstream) is handled by the
+/// SpaceRouter component which has access to the current space context.
 #[component]
 pub fn TonkShell() -> impl IntoView {
     log!("Tonk shell initializing...");
 
-    // Initialize the space: wait for SW, check status, setup remote if needed
-    let init_resource = LocalResource::new(|| async {
+    // Wait for service worker to activate
+    let sw_ready = LocalResource::new(|| async {
         log!("Waiting for SW to activate...");
         service_worker_activates().await;
-        log!("SW is activated, fetching status...");
-
-        let status = api::status().await?;
-
-        // If no upstream configured, add the remote (but don't set as upstream yet)
-        if !status.has_upstream {
-            log!("No upstream configured, adding remote...");
-            api::authorize().await?;
-            log!("Remote added successfully");
-        }
-
+        log!("SW is activated");
         Ok::<_, crate::error::TonkUiError>(())
     });
 
-    // Derive the application status from init resource
-    let status = Signal::derive_local(move || {
-        match init_resource.get() {
-            Some(Ok(())) => Status::Ready,
-            Some(Err(e)) => {
-                log!("Initialization error: {:?}", e);
-                // Still show as loading on error - could add an Error state later
-                Status::Loading
-            }
-            None => Status::Loading,
+    // Derive the application status from SW ready state
+    let status = Signal::derive_local(move || match sw_ready.get() {
+        Some(Ok(())) => Status::Ready,
+        Some(Err(e)) => {
+            log!("Initialization error: {:?}", e);
+            Status::Loading
         }
+        None => Status::Loading,
     });
 
     provide_context(status);
 
     view! {
-        <TonkLauncher></TonkLauncher>
+        <Suspense fallback=move || view! { <div class="loading">"Initializing..."</div> }>
+            {move || sw_ready.get().map(|_| view! {
+                <Router>
+                    <Routes fallback=|| view! { <div>"Not found"</div> }>
+                        // Root path redirects to first space
+                        <Route path=path!("") view=SpaceRedirect />
+                        // Space-specific routes
+                        <Route path=path!(":multikey") view=SpaceRouter />
+                        <Route path=path!(":multikey/*any") view=SpaceRouter />
+                    </Routes>
+                </Router>
+            })}
+        </Suspense>
     }
 }

--- a/rust/tonk-ui/src/components/space_redirect.rs
+++ b/rust/tonk-ui/src/components/space_redirect.rs
@@ -17,16 +17,16 @@ pub fn SpaceRedirect() -> impl IntoView {
     let spaces = LocalResource::new(|| async { api::list_spaces().await });
 
     Effect::new(move |_| {
-        if let Some(Ok(list)) = spaces.get() {
-            if let Some(first) = list.spaces.first() {
-                // Extract multikey from did:key:z6Mk...
-                let multikey = first
-                    .did
-                    .strip_prefix("did:key:")
-                    .unwrap_or(&first.did)
-                    .to_string();
-                navigate(&format!("/{}/", multikey), Default::default());
-            }
+        if let Some(Ok(list)) = spaces.get()
+            && let Some(first) = list.spaces.first()
+        {
+            // Extract multikey from did:key:z6Mk...
+            let multikey = first
+                .did
+                .strip_prefix("did:key:")
+                .unwrap_or(&first.did)
+                .to_string();
+            navigate(&format!("/{}/", multikey), Default::default());
         }
     });
 

--- a/rust/tonk-ui/src/components/space_redirect.rs
+++ b/rust/tonk-ui/src/components/space_redirect.rs
@@ -1,0 +1,38 @@
+//! Space redirect component - redirects from / to the first space.
+
+use leptos::prelude::*;
+use leptos_router::hooks::use_navigate;
+
+use crate::api;
+
+/// Redirects from the root path to the first available space.
+///
+/// When the user navigates to `/`, this component fetches the list of spaces
+/// and redirects to the first one (sorted alphabetically by DID).
+#[component]
+pub fn SpaceRedirect() -> impl IntoView {
+    let navigate = use_navigate();
+
+    // Fetch space list and redirect to first
+    let spaces = LocalResource::new(|| async { api::list_spaces().await });
+
+    Effect::new(move |_| {
+        if let Some(Ok(list)) = spaces.get() {
+            if let Some(first) = list.spaces.first() {
+                // Extract multikey from did:key:z6Mk...
+                let multikey = first
+                    .did
+                    .strip_prefix("did:key:")
+                    .unwrap_or(&first.did)
+                    .to_string();
+                navigate(&format!("/{}/", multikey), Default::default());
+            }
+        }
+    });
+
+    view! {
+        <div class="space-redirect">
+            <p>"Loading spaces..."</p>
+        </div>
+    }
+}

--- a/rust/tonk-ui/src/components/space_router.rs
+++ b/rust/tonk-ui/src/components/space_router.rs
@@ -1,0 +1,94 @@
+//! Space router component - displays the currently selected space.
+
+use leptos::{logging::log, prelude::*};
+use leptos_router::hooks::use_params_map;
+
+use crate::api;
+use crate::components::{TonkSpace, TonkToolbar};
+
+/// The current space's multikey, provided via context.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CurrentSpace(pub String);
+
+impl CurrentSpace {
+    /// Get the multikey (z6Mk...).
+    pub fn multikey(&self) -> &str {
+        &self.0
+    }
+
+    /// Get the full DID (did:key:z6Mk...).
+    pub fn did(&self) -> String {
+        if self.0.starts_with("did:key:") {
+            self.0.clone()
+        } else {
+            format!("did:key:{}", self.0)
+        }
+    }
+}
+
+/// Space initialization status.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpaceStatus {
+    /// Space is being initialized.
+    Loading,
+    /// Space is ready.
+    Ready,
+    /// Space initialization failed.
+    Error(String),
+}
+
+/// Routes to a specific space based on the URL path.
+///
+/// Extracts the multikey from `/{multikey}/` and provides it as context
+/// to child components. Also handles space-specific initialization like
+/// setting up the upstream remote.
+#[component]
+pub fn SpaceRouter() -> impl IntoView {
+    let params = use_params_map();
+
+    // Get multikey from URL params
+    let multikey = Memo::new(move |_| params.read().get("multikey").unwrap_or_default());
+
+    // Initialize the space: check status, setup remote if needed
+    let space_init = LocalResource::new(move || {
+        let mk = multikey.get();
+        async move {
+            if mk.is_empty() {
+                return Err(crate::error::TonkUiError::ApiError(
+                    "No space selected".to_string(),
+                ));
+            }
+
+            log!("Initializing space: {}", mk);
+            let status = api::status(&mk).await?;
+
+            // If no upstream configured, add the remote
+            if !status.has_upstream {
+                log!("No upstream configured for {}, adding remote...", mk);
+                api::authorize(&mk).await?;
+                log!("Remote added successfully for {}", mk);
+            }
+
+            Ok::<_, crate::error::TonkUiError>(())
+        }
+    });
+
+    // Derive space status from init resource
+    let space_status = Signal::derive_local(move || match space_init.get() {
+        Some(Ok(())) => SpaceStatus::Ready,
+        Some(Err(e)) => SpaceStatus::Error(format!("{:?}", e)),
+        None => SpaceStatus::Loading,
+    });
+
+    // Provide space context to children
+    let current_space = Signal::derive(move || CurrentSpace(multikey.get()));
+    provide_context(current_space);
+    provide_context(space_status);
+
+    view! {
+        <section class="launcher">
+            <TonkToolbar />
+            <TonkSpace />
+        </section>
+    }
+}

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -38,7 +38,9 @@ mod space_create;
 pub use space_create::{CreateSpaceRequest, CreateSpaceResponse, create_space};
 
 mod space_metadata;
-pub use space_metadata::{SpaceMetadataResponse, UpdateMetadataRequest, get_metadata, update_metadata};
+pub use space_metadata::{
+    SpaceMetadataResponse, UpdateMetadataRequest, get_metadata, update_metadata,
+};
 
 /// Shared application state containing identity and session.
 pub type AppState = Arc<RwLock<TonkState>>;

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -90,7 +90,10 @@ pub fn api_router(state: TonkState) -> Router {
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 pub mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
+
+    use tokio::sync::RwLock;
 
     use crate::worker::TonkState;
     use crate::{Identity, api_router};
@@ -99,7 +102,9 @@ pub mod tests {
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    pub async fn test_state() -> TonkState {
+    /// Creates a test state with a single space.
+    /// Returns the state and the multikey of the test space.
+    pub async fn test_state() -> (TonkState, String) {
         let mut identity = Identity::load_or_create()
             .await
             .expect("Failed to create test identity");
@@ -123,15 +128,27 @@ pub mod tests {
                 .expect("Failed to create session")
         };
 
-        TonkState {
-            identity: Arc::new(identity),
-            session,
-        }
+        let space_did = session.space_did().to_string();
+        let multikey = space_did
+            .strip_prefix("did:key:")
+            .unwrap_or(&space_did)
+            .to_string();
+
+        // Pre-cache the session
+        let mut sessions = HashMap::new();
+        sessions.insert(space_did, session);
+
+        let state = TonkState {
+            identity: Arc::new(RwLock::new(identity)),
+            sessions: Arc::new(RwLock::new(sessions)),
+        };
+
+        (state, multikey)
     }
 
     #[dialog_common::test]
     async fn it_responds_to_root_api_request() {
-        let state = test_state().await;
+        let (state, _multikey) = test_state().await;
         let app = api_router(state);
 
         let request = Request::builder()

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -34,6 +34,12 @@ pub use delegations::{DelegationsResponse, delegations};
 mod space_list;
 pub use space_list::{ListSpacesResponse, SpaceInfo, list_spaces};
 
+mod space_create;
+pub use space_create::{CreateSpaceRequest, CreateSpaceResponse, create_space};
+
+mod space_metadata;
+pub use space_metadata::{SpaceMetadataResponse, UpdateMetadataRequest, get_metadata, update_metadata};
+
 /// Shared application state containing identity and session.
 pub type AppState = Arc<RwLock<TonkState>>;
 
@@ -57,10 +63,15 @@ pub fn api_router(state: TonkState) -> Router {
         .route("/api", get(root))
         .route("/api/identify", get(identify))
         .route("/api/space/list", get(list_spaces))
+        .route("/api/space/create", post(create_space))
         // Space-specific endpoints - prefixed with multikey
         .route("/api/{multikey}/authorize", post(authorize))
         .route("/api/{multikey}/status", get(status))
         .route("/api/{multikey}/delegations", get(delegations))
+        .route(
+            "/api/{multikey}/metadata",
+            get(get_metadata).put(update_metadata),
+        )
         .route(
             "/api/{multikey}/inspect/branch/{branch_name}",
             get(inspect::branch),

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -31,6 +31,9 @@ pub use identify::{IdentifyResponse, identify};
 mod delegations;
 pub use delegations::{DelegationsResponse, delegations};
 
+mod space_list;
+pub use space_list::{ListSpacesResponse, SpaceInfo, list_spaces};
+
 /// Shared application state containing identity and session.
 pub type AppState = Arc<RwLock<TonkState>>;
 
@@ -42,32 +45,46 @@ async fn root(State(_state): State<AppState>) -> &'static str {
 /// Creates the API router with all configured routes.
 ///
 /// Sets up the routing tree with the TonkState as shared state.
+/// Routes are organized into:
+/// - Global endpoints: `/api/*` - identity-level operations
+/// - Space endpoints: `/api/{multikey}/*` - space-specific operations
+///
+/// The `multikey` is the `z6Mk...` portion of a DID (`did:key:z6Mk...`).
 pub fn api_router(state: TonkState) -> Router {
     let state: AppState = Arc::new(RwLock::new(state));
     Router::new()
+        // Global endpoints (no space context required)
         .route("/api", get(root))
         .route("/api/identify", get(identify))
-        .route("/api/authorize", post(authorize))
-        .route("/api/status", get(status))
-        .route("/api/delegations", get(delegations))
-        .route("/api/inspect/branch/{branch_name}", get(inspect::branch))
-        .route("/api/inspect/site/{site_name}", get(inspect::site::site))
+        .route("/api/space/list", get(list_spaces))
+        // Space-specific endpoints - prefixed with multikey
+        .route("/api/{multikey}/authorize", post(authorize))
+        .route("/api/{multikey}/status", get(status))
+        .route("/api/{multikey}/delegations", get(delegations))
         .route(
-            "/api/inspect/site/{site}/{repo_did}/branch/{branch}",
+            "/api/{multikey}/inspect/branch/{branch_name}",
+            get(inspect::branch),
+        )
+        .route(
+            "/api/{multikey}/inspect/site/{site_name}",
+            get(inspect::site::site),
+        )
+        .route(
+            "/api/{multikey}/inspect/site/{site}/{repo_did}/branch/{branch}",
             get(inspect::site::branch),
         )
         .route(
-            "/api/inspect/site/{site}/{repo_did}/archive/index/{hash}",
+            "/api/{multikey}/inspect/site/{site}/{repo_did}/archive/index/{hash}",
             get(inspect::site::archive_block),
         )
         .route(
-            "/api/fact/assert/{entity}/{attribute_ns}/{attribute_name}",
+            "/api/{multikey}/fact/assert/{entity}/{attribute_ns}/{attribute_name}",
             post(assert_fact),
         )
-        .route("/api/fact/query", get(query_facts))
-        .route("/api/sync", post(sync::sync))
-        .route("/api/sync/pull", post(sync::pull))
-        .route("/api/sync/push", post(sync::push))
+        .route("/api/{multikey}/fact/query", get(query_facts))
+        .route("/api/{multikey}/sync", post(sync::sync))
+        .route("/api/{multikey}/sync/pull", post(sync::pull))
+        .route("/api/{multikey}/sync/push", post(sync::push))
         .with_state(state)
 }
 

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -3,7 +3,10 @@
 //! The authorization endpoint uses the operator and delegation that were
 //! created when the service worker started. No external input is needed.
 
-use ::axum::{Json, extract::{Path, State}};
+use ::axum::{
+    Json,
+    extract::{Path, State},
+};
 use axum_wasm_macros::wasm_compat;
 use dialog_artifacts::replica::RemoteCredentials;
 use dialog_s3_credentials::ucan::{Credentials as UcanCredentials, DelegationChain};

--- a/rust/tonk-worker/src/router/authorize.rs
+++ b/rust/tonk-worker/src/router/authorize.rs
@@ -3,7 +3,7 @@
 //! The authorization endpoint uses the operator and delegation that were
 //! created when the service worker started. No external input is needed.
 
-use ::axum::{Json, extract::State};
+use ::axum::{Json, extract::{Path, State}};
 use axum_wasm_macros::wasm_compat;
 use dialog_artifacts::replica::RemoteCredentials;
 use dialog_s3_credentials::ucan::{Credentials as UcanCredentials, DelegationChain};
@@ -16,6 +16,7 @@ use ucan::delegation::subject::DelegatedSubject;
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Access service path (will be resolved to absolute URL at runtime).
 const ACCESS_SERVICE_PATH: &str = "/ucan/";
@@ -53,38 +54,31 @@ pub struct AuthorizeResponse {
     pub error: Option<String>,
 }
 
-/// Status response indicating the current space state.
-#[allow(dead_code)] // Used in wasm builds via #[wasm_compat] macro
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StatusResponse {
-    /// The DID of the space.
-    pub space_did: String,
-    /// The DID of the operator.
-    pub operator_did: String,
-    /// Whether the space has an upstream remote configured.
-    pub has_upstream: bool,
-}
-
 /// Handles authorization requests and configures the UCAN-based remote for the space.
 ///
 /// Uses the operator and delegation from the worker's state (created at startup).
-/// No external input is required - just call POST /api/authorize with an empty body.
+/// No external input is required - just call POST /api/{multikey}/authorize with an empty body.
 #[wasm_compat]
 pub async fn authorize(
     State(state): State<AppState>,
+    Path(multikey): Path<String>,
 ) -> Result<Json<AuthorizeResponse>, TonkWorkerError> {
     log!("Authorizing with internal UCAN delegation...");
 
-    let mut tonk_state = state.write().await;
+    let space_did = TonkState::multikey_to_did(&multikey);
+    let tonk_state = state.read().await;
+
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
 
     // Get user's delegation for authorization
-    let user_delegations = tonk_state
-        .session
+    let user_delegations = session
         .account_delegations()
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("Failed to query delegations: {}", e)))?;
 
-    let space_did = tonk_state.session.space_did().to_string();
     let service_url = get_access_service_url();
     log!(
         "Setting up UCAN credentials for space: {} with URL: {}",
@@ -116,12 +110,7 @@ pub async fn authorize(
 
     // Add the remote to the space
     // If the remote already exists, that's fine - treat it as success
-    match tonk_state
-        .session
-        .space_mut()
-        .add_remote(remote_state)
-        .await
-    {
+    match session.space_mut().add_remote(remote_state).await {
         Ok(site) => {
             log!("Remote '{}' added successfully", site);
         }
@@ -138,9 +127,9 @@ pub async fn authorize(
     }
 
     // Set upstream on branch if not already configured
-    if !tonk_state.session.space().has_upstream().await {
+    if !session.space().has_upstream().await {
         log!("Setting 'origin' as upstream for main branch...");
-        match tonk_state.session.space_mut().set_upstream("origin").await {
+        match session.space_mut().set_upstream("origin").await {
             Ok(()) => {
                 log!("Upstream set successfully");
             }
@@ -156,31 +145,18 @@ pub async fn authorize(
         log!("Upstream already configured, skipping");
     }
 
+    // Update the cached session
+    tonk_state.update_session(session).await;
+
     Ok(Json(AuthorizeResponse {
         success: true,
         error: None,
     }))
 }
 
-/// Returns the current status of the space.
-#[wasm_compat]
-pub async fn status(
-    State(state): State<AppState>,
-) -> Result<Json<StatusResponse>, TonkWorkerError> {
-    let tonk_state = state.read().await;
-    let space = tonk_state.session.space();
-
-    Ok(Json(StatusResponse {
-        space_did: space.did.clone(),
-        operator_did: tonk_state.identity.operator().did().to_string(),
-        has_upstream: space.has_upstream().await,
-    }))
-}
-
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
     use super::super::tests::test_state;
-    use crate::StatusResponse;
     use crate::{AuthorizeResponse, api_router};
 
     use axum::body::Body;
@@ -188,13 +164,13 @@ mod tests {
     use tower::ServiceExt;
 
     #[dialog_common::test]
-    async fn it_returns_status_without_upstream() {
-        let state = test_state().await;
+    async fn it_authorizes_space() {
+        let (state, multikey) = test_state().await;
         let app = api_router(state);
 
         let request = Request::builder()
-            .uri("/api/status")
-            .method("GET")
+            .uri(format!("/api/{}/authorize", multikey))
+            .method("POST")
             .body(Body::empty())
             .expect("Failed to build request");
 
@@ -209,11 +185,9 @@ mod tests {
             .await
             .expect("Failed to read response body");
 
-        let status_response: StatusResponse =
+        let auth_response: AuthorizeResponse =
             serde_json::from_slice(&body).expect("Failed to deserialize response");
 
-        assert!(!status_response.has_upstream);
-        assert!(!status_response.space_did.is_empty());
-        assert!(!status_response.operator_did.is_empty());
+        assert!(auth_response.success);
     }
 }

--- a/rust/tonk-worker/src/router/delegations.rs
+++ b/rust/tonk-worker/src/router/delegations.rs
@@ -1,6 +1,6 @@
 //! Delegations endpoint for retrieving user's UCAN delegations.
 
-use ::axum::{Json, extract::State};
+use ::axum::{Json, extract::{Path, State}};
 use axum_wasm_macros::wasm_compat;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use tokio::sync::oneshot;
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Response containing the user's delegations.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -20,7 +21,7 @@ pub struct DelegationsResponse {
     pub delegations: Vec<String>,
 }
 
-/// Returns all delegations granted to the current user for the current space.
+/// Returns all delegations granted to the current user for the given space.
 ///
 /// This endpoint queries the space for UCAN delegations where the audience
 /// matches the current user's DID. The delegations are returned as base64-encoded
@@ -28,12 +29,18 @@ pub struct DelegationsResponse {
 #[wasm_compat]
 pub async fn delegations(
     State(state): State<AppState>,
+    Path(multikey): Path<String>,
 ) -> Result<Json<DelegationsResponse>, TonkWorkerError> {
+    let space_did = TonkState::multikey_to_did(&multikey);
     let tonk_state = state.read().await;
 
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
     // Query delegations where audience == user DID
-    let user_delegations = tonk_state
-        .session
+    let user_delegations = session
         .account_delegations()
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("Failed to query delegations: {}", e)))?;

--- a/rust/tonk-worker/src/router/delegations.rs
+++ b/rust/tonk-worker/src/router/delegations.rs
@@ -1,6 +1,9 @@
 //! Delegations endpoint for retrieving user's UCAN delegations.
 
-use ::axum::{Json, extract::{Path, State}};
+use ::axum::{
+    Json,
+    extract::{Path, State},
+};
 use axum_wasm_macros::wasm_compat;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};

--- a/rust/tonk-worker/src/router/fact.rs
+++ b/rust/tonk-worker/src/router/fact.rs
@@ -17,16 +17,26 @@ use tonk_space::{Attribute, Entity, Relation, Value};
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Path parameters for fact assertion.
 #[derive(Debug, Deserialize)]
 pub struct AssertPath {
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
     /// The entity identifier.
     pub entity: String,
     /// The attribute namespace.
     pub attribute_ns: String,
     /// The attribute name.
     pub attribute_name: String,
+}
+
+/// Path parameters for fact query.
+#[derive(Debug, Deserialize)]
+pub struct QueryPath {
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
 }
 
 /// Query parameters for fact queries.
@@ -161,7 +171,7 @@ fn value_to_json(value: &Value) -> serde_json::Value {
 
 /// Handles fact assertion requests.
 ///
-/// POST /api/fact/assert/:entity/:attribute-ns/:attribute-name
+/// POST /api/{multikey}/fact/assert/:entity/:attribute-ns/:attribute-name
 #[wasm_compat]
 pub async fn assert_fact(
     State(state): State<AppState>,
@@ -175,6 +185,14 @@ pub async fn assert_fact(
         path.entity,
         attribute_str
     );
+
+    let space_did = TonkState::multikey_to_did(&path.multikey);
+    let tonk_state = state.read().await;
+
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
 
     // Parse the entity identifier
     let entity: Entity = path.entity.parse().map_err(|e| {
@@ -196,18 +214,17 @@ pub async fn assert_fact(
     let relation = Relation::new(attribute, entity, value);
 
     // Transact the relation
-    {
-        let mut tonk_state = state.write().await;
-        tonk_state
-            .session
-            .space_mut()
-            .transact([relation])
-            .await
-            .map_err(|e| {
-                log!("Failed to assert fact: {:?}", e);
-                TonkWorkerError::Internal(format!("Failed to assert fact: {}", e))
-            })?;
-    }
+    session
+        .space_mut()
+        .transact([relation])
+        .await
+        .map_err(|e| {
+            log!("Failed to assert fact: {:?}", e);
+            TonkWorkerError::Internal(format!("Failed to assert fact: {}", e))
+        })?;
+
+    // Update the cached session
+    tonk_state.update_session(session).await;
 
     log!("Fact asserted successfully");
 
@@ -220,10 +237,11 @@ pub async fn assert_fact(
 
 /// Handles fact query requests.
 ///
-/// GET /api/fact/query?the=namespace/name&of=entity&is=value
+/// GET /api/{multikey}/fact/query?the=namespace/name&of=entity&is=value
 #[wasm_compat]
 pub async fn query_facts(
     State(state): State<AppState>,
+    Path(path): Path<QueryPath>,
     AxumQuery(query): AxumQuery<FactQuery>,
 ) -> Result<Json<QueryResponse>, TonkWorkerError> {
     use futures_util::TryStreamExt;
@@ -243,7 +261,13 @@ pub async fn query_facts(
         ));
     }
 
+    let space_did = TonkState::multikey_to_did(&path.multikey);
     let tonk_state = state.read().await;
+
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
 
     // Build the query using the Fact selector
     let mut selector = FactType::<Value>::select();
@@ -284,7 +308,7 @@ pub async fn query_facts(
         .map_err(|e| TonkWorkerError::Internal(format!("Query compilation error: {}", e)))?;
 
     let facts: Vec<FactType<Value>> = compiled
-        .query(tonk_state.session.space())
+        .query(session.space())
         .try_collect()
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("Query execution error: {}", e)))?;
@@ -321,12 +345,12 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_asserts_and_queries_fact() {
-        let state = test_state().await;
+        let (state, multikey) = test_state().await;
         let app = api_router(state);
 
         // Assert a fact
         let request = Request::builder()
-            .uri("/api/fact/assert/test:entity/test/name")
+            .uri(format!("/api/{}/fact/assert/test:entity/test/name", multikey))
             .method("POST")
             .header("content-type", "text/plain")
             .body(Body::from("Test Name"))
@@ -342,7 +366,7 @@ mod tests {
 
         // Query the fact
         let request = Request::builder()
-            .uri("/api/fact/query?the=test/name&of=test:entity")
+            .uri(format!("/api/{}/fact/query?the=test/name&of=test:entity", multikey))
             .method("GET")
             .body(Body::empty())
             .expect("Failed to build request");

--- a/rust/tonk-worker/src/router/fact.rs
+++ b/rust/tonk-worker/src/router/fact.rs
@@ -350,7 +350,10 @@ mod tests {
 
         // Assert a fact
         let request = Request::builder()
-            .uri(format!("/api/{}/fact/assert/test:entity/test/name", multikey))
+            .uri(format!(
+                "/api/{}/fact/assert/test:entity/test/name",
+                multikey
+            ))
             .method("POST")
             .header("content-type", "text/plain")
             .body(Body::from("Test Name"))
@@ -366,7 +369,10 @@ mod tests {
 
         // Query the fact
         let request = Request::builder()
-            .uri(format!("/api/{}/fact/query?the=test/name&of=test:entity", multikey))
+            .uri(format!(
+                "/api/{}/fact/query?the=test/name&of=test:entity",
+                multikey
+            ))
             .method("GET")
             .body(Body::empty())
             .expect("Failed to build request");

--- a/rust/tonk-worker/src/router/identify.rs
+++ b/rust/tonk-worker/src/router/identify.rs
@@ -25,8 +25,9 @@ pub async fn identify(
     State(state): State<AppState>,
 ) -> Result<Json<IdentifyResponse>, TonkWorkerError> {
     let tonk_state = state.read().await;
+    let identity = tonk_state.identity.read().await;
 
     Ok(Json(IdentifyResponse {
-        user_did: tonk_state.identity.did().to_string(),
+        user_did: identity.did().to_string(),
     }))
 }

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -51,6 +51,16 @@ impl Hasher for ByteCaptureHasher {
 
 use super::super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
+
+/// Path parameters for branch inspection.
+#[derive(Debug, Deserialize)]
+pub struct BranchPath {
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
+    /// The branch name.
+    pub branch_name: String,
+}
 
 /// Serializable revision info with all fields.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -120,26 +130,31 @@ pub struct UpstreamStatusResponse {
 #[wasm_compat]
 pub async fn branch(
     State(state): State<AppState>,
-    Path(branch_name): Path<String>,
+    Path(path): Path<BranchPath>,
 ) -> Result<Json<BranchStatusResponse>, TonkWorkerError> {
-    log!("Querying branch status for: {}", branch_name);
+    log!("Querying branch status for: {}", path.branch_name);
+
+    let space_did = TonkState::multikey_to_did(&path.multikey);
     let tonk_state = state.read().await;
 
-    match tonk_state.session.space().branch_info(&branch_name).await {
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    match session.space().branch_info(&path.branch_name).await {
         Ok(branch_info) => {
-            let upstream = branch_info.upstream.map(|u| {
-                UpstreamStatusResponse {
-                    site: u.site,
-                    branch: u.branch,
-                    subject: u.subject,
-                    // Revision is not available without connecting to remote
-                    // Use the sync endpoints to get the latest revision
-                    revision: None,
-                }
+            let upstream = branch_info.upstream.map(|u| UpstreamStatusResponse {
+                site: u.site,
+                branch: u.branch,
+                subject: u.subject,
+                // Revision is not available without connecting to remote
+                // Use the sync endpoints to get the latest revision
+                revision: None,
             });
 
             Ok(Json(BranchStatusResponse {
-                subject: tonk_state.session.space_did().to_string(),
+                subject: session.space_did().to_string(),
                 branch: branch_info.name,
                 revision: RevisionResponse::from_revision(&branch_info.revision),
                 base: branch_info.base,

--- a/rust/tonk-worker/src/router/inspect/site.rs
+++ b/rust/tonk-worker/src/router/inspect/site.rs
@@ -13,6 +13,7 @@ use tonk_space::SpaceError;
 use super::super::AppState;
 use super::branch::RevisionResponse;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Response for site status query.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -54,20 +55,33 @@ pub enum CredentialsResponse {
     },
 }
 
+/// Path parameters for site inspection.
+#[derive(Debug, Deserialize)]
+pub struct SitePath {
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
+    /// The site name.
+    pub site_name: String,
+}
+
 /// Path parameters for remote branch resolution.
 #[derive(Debug, Deserialize)]
 pub struct RemoteBranchPath {
-    site: String,
-    repo_did: String,
-    branch: String,
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
+    pub site: String,
+    pub repo_did: String,
+    pub branch: String,
 }
 
 /// Path parameters for archive block fetch.
 #[derive(Debug, Deserialize)]
 pub struct ArchiveBlockPath {
-    site: String,
-    repo_did: String,
-    hash: String,
+    /// The multikey (z6Mk...) from the URL path.
+    pub multikey: String,
+    pub site: String,
+    pub repo_did: String,
+    pub hash: String,
 }
 
 /// Response for remote branch resolution.
@@ -93,12 +107,19 @@ pub struct RemoteBranchStatusResponse {
 #[wasm_compat]
 pub async fn site(
     State(state): State<AppState>,
-    Path(site_name): Path<String>,
+    Path(path): Path<SitePath>,
 ) -> Result<Json<SiteStatusResponse>, TonkWorkerError> {
-    log!("Querying site status for: {}", site_name);
+    log!("Querying site status for: {}", path.site_name);
+
+    let space_did = TonkState::multikey_to_did(&path.multikey);
     let tonk_state = state.read().await;
 
-    match tonk_state.session.space().resolve_site(&site_name).await {
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    match session.space().resolve_site(&path.site_name).await {
         Ok(site_info) => {
             let credentials = site_info.credentials.map(|c| match c {
                 tonk_space::CredentialsInfo::S3 {
@@ -132,7 +153,7 @@ pub async fn site(
         Err(SpaceError::Replica(_)) => {
             // Site doesn't exist
             Ok(Json(SiteStatusResponse {
-                name: site_name,
+                name: path.site_name,
                 exists: false,
                 credentials: None,
             }))
@@ -161,10 +182,16 @@ pub async fn branch(
         params.repo_did,
         params.branch
     );
+
+    let space_did = TonkState::multikey_to_did(&params.multikey);
     let tonk_state = state.read().await;
 
-    match tonk_state
-        .session
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    match session
         .space()
         .resolve_remote_branch(&params.site, &params.repo_did, &params.branch)
         .await
@@ -264,10 +291,15 @@ pub async fn archive_block(
         }
     };
 
+    let space_did = TonkState::multikey_to_did(&params.multikey);
     let tonk_state = state.read().await;
 
-    match tonk_state
-        .session
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    match session
         .space()
         .fetch_remote_archive_block(&params.site, &params.repo_did, &hash)
         .await

--- a/rust/tonk-worker/src/router/inspect/site.rs
+++ b/rust/tonk-worker/src/router/inspect/site.rs
@@ -69,8 +69,11 @@ pub struct SitePath {
 pub struct RemoteBranchPath {
     /// The multikey (z6Mk...) from the URL path.
     pub multikey: String,
+    /// The site name.
     pub site: String,
+    /// The repository/space DID.
     pub repo_did: String,
+    /// The branch name.
     pub branch: String,
 }
 
@@ -79,8 +82,11 @@ pub struct RemoteBranchPath {
 pub struct ArchiveBlockPath {
     /// The multikey (z6Mk...) from the URL path.
     pub multikey: String,
+    /// The site name.
     pub site: String,
+    /// The repository/space DID.
     pub repo_did: String,
+    /// The block hash (base58 encoded).
     pub hash: String,
 }
 

--- a/rust/tonk-worker/src/router/space_create.rs
+++ b/rust/tonk-worker/src/router/space_create.rs
@@ -1,0 +1,167 @@
+//! Space creation endpoint - creates a new space with optional metadata.
+
+use axum::{Json, extract::State};
+use axum_wasm_macros::wasm_compat;
+use serde::{Deserialize, Serialize};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use crate::router::AppState;
+use crate::TonkWorkerError;
+
+/// Request body for creating a new space.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CreateSpaceRequest {
+    /// Optional human-readable name for the space.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Optional description of the space.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Response for space creation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateSpaceResponse {
+    /// The DID of the newly created space (e.g., "did:key:z6Mk...")
+    pub did: String,
+    /// The name of the space, if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The description of the space, if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Handler for POST /api/space/create
+///
+/// Creates a new space with optional name and description.
+/// The space is automatically added to the user's known spaces.
+#[wasm_compat]
+pub async fn create_space(
+    State(state): State<AppState>,
+    Json(request): Json<CreateSpaceRequest>,
+) -> Result<Json<CreateSpaceResponse>, TonkWorkerError> {
+    log!("Creating new space with name: {:?}", request.name);
+
+    let tonk_state = state.read().await;
+    let mut identity = tonk_state.identity.write().await;
+
+    // Create a new session (which creates a new space)
+    let mut session = identity
+        .create_session()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to create space: {}", e)))?;
+
+    let space_did = session.space_did().to_string();
+    log!("Created new space: {}", space_did);
+
+    // Set metadata if provided
+    if let Some(ref name) = request.name {
+        session
+            .space_mut()
+            .set_name(name)
+            .await
+            .map_err(|e| TonkWorkerError::Internal(format!("Failed to set space name: {}", e)))?;
+        log!("Set space name: {}", name);
+    }
+
+    if let Some(ref description) = request.description {
+        session
+            .space_mut()
+            .set_description(description)
+            .await
+            .map_err(|e| {
+                TonkWorkerError::Internal(format!("Failed to set space description: {}", e))
+            })?;
+        log!("Set space description: {}", description);
+    }
+
+    // Cache the session for future use
+    tonk_state.update_session(session).await;
+
+    Ok(Json(CreateSpaceResponse {
+        did: space_did,
+        name: request.name,
+        description: request.description,
+    }))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use crate::api_router;
+    use crate::router::tests::test_state;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[dialog_common::test]
+    async fn it_creates_space_without_metadata() {
+        let (state, _multikey) = test_state().await;
+        let app = api_router(state);
+
+        let request = Request::builder()
+            .uri("/api/space/create")
+            .method("POST")
+            .header("Content-Type", "application/json")
+            .body(Body::from("{}"))
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let create_response: CreateSpaceResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(create_response.did.starts_with("did:key:z6Mk"));
+        assert!(create_response.name.is_none());
+        assert!(create_response.description.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_creates_space_with_metadata() {
+        let (state, _multikey) = test_state().await;
+        let app = api_router(state);
+
+        let request_body = serde_json::json!({
+            "name": "Test Space",
+            "description": "A test space"
+        });
+
+        let request = Request::builder()
+            .uri("/api/space/create")
+            .method("POST")
+            .header("Content-Type", "application/json")
+            .body(Body::from(request_body.to_string()))
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let create_response: CreateSpaceResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(create_response.did.starts_with("did:key:z6Mk"));
+        assert_eq!(create_response.name, Some("Test Space".to_string()));
+        assert_eq!(create_response.description, Some("A test space".to_string()));
+    }
+}

--- a/rust/tonk-worker/src/router/space_create.rs
+++ b/rust/tonk-worker/src/router/space_create.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tonk_common::log;
 
-use crate::router::AppState;
 use crate::TonkWorkerError;
+use crate::router::AppState;
 
 /// Request body for creating a new space.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -162,6 +162,9 @@ mod tests {
 
         assert!(create_response.did.starts_with("did:key:z6Mk"));
         assert_eq!(create_response.name, Some("Test Space".to_string()));
-        assert_eq!(create_response.description, Some("A test space".to_string()));
+        assert_eq!(
+            create_response.description,
+            Some("A test space".to_string())
+        );
     }
 }

--- a/rust/tonk-worker/src/router/space_list.rs
+++ b/rust/tonk-worker/src/router/space_list.rs
@@ -1,0 +1,54 @@
+//! Space list endpoint - returns all known spaces for this identity.
+
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+
+use crate::router::AppState;
+
+/// Information about a single space.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpaceInfo {
+    /// The space's DID (e.g., "did:key:z6Mk...")
+    pub did: String,
+    /// Optional human-readable name for the space.
+    pub name: Option<String>,
+    /// Optional description of the space.
+    pub description: Option<String>,
+}
+
+/// Response for the space list endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListSpacesResponse {
+    /// List of spaces the user has access to, sorted alphabetically by DID.
+    pub spaces: Vec<SpaceInfo>,
+}
+
+/// Handler for GET /api/space/list
+///
+/// Returns all spaces known to this identity, sorted alphabetically by DID.
+pub async fn list_spaces(State(state): State<AppState>) -> Json<ListSpacesResponse> {
+    let state = state.read().await;
+
+    // Get known spaces from the account
+    let known_space_dids = state
+        .identity
+        .account()
+        .known_spaces()
+        .await
+        .unwrap_or_default();
+
+    // Convert to SpaceInfo and sort alphabetically
+    let mut spaces: Vec<SpaceInfo> = known_space_dids
+        .into_iter()
+        .map(|did| SpaceInfo {
+            did,
+            // TODO: In the future, fetch name/description from space metadata
+            name: None,
+            description: None,
+        })
+        .collect();
+
+    spaces.sort_by(|a, b| a.did.cmp(&b.did));
+
+    Json(ListSpacesResponse { spaces })
+}

--- a/rust/tonk-worker/src/router/space_list.rs
+++ b/rust/tonk-worker/src/router/space_list.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tonk_common::log;
 
-use crate::router::AppState;
 use crate::TonkWorkerError;
+use crate::router::AppState;
 
 /// Information about a single space.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,11 +42,7 @@ pub async fn list_spaces(
     let identity = tonk_state.identity.read().await;
 
     // Get known spaces from the account
-    let known_space_dids: Vec<String> = identity
-        .account()
-        .known_spaces()
-        .await
-        .unwrap_or_default();
+    let known_space_dids: Vec<String> = identity.account().known_spaces().await.unwrap_or_default();
 
     // Drop identity lock before fetching metadata (we need tonk_state for session_for_space)
     drop(identity);

--- a/rust/tonk-worker/src/router/space_list.rs
+++ b/rust/tonk-worker/src/router/space_list.rs
@@ -5,6 +5,7 @@ use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
+use tonk_common::log;
 
 use crate::router::AppState;
 use crate::TonkWorkerError;
@@ -15,8 +16,10 @@ pub struct SpaceInfo {
     /// The space's DID (e.g., "did:key:z6Mk...")
     pub did: String,
     /// Optional human-readable name for the space.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Optional description of the space.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -30,6 +33,7 @@ pub struct ListSpacesResponse {
 /// Handler for GET /api/space/list
 ///
 /// Returns all spaces known to this identity, sorted alphabetically by DID.
+/// Includes name and description metadata for each space.
 #[wasm_compat]
 pub async fn list_spaces(
     State(state): State<AppState>,
@@ -44,17 +48,34 @@ pub async fn list_spaces(
         .await
         .unwrap_or_default();
 
-    // Convert to SpaceInfo and sort alphabetically
-    let mut spaces: Vec<SpaceInfo> = known_space_dids
-        .into_iter()
-        .map(|did| SpaceInfo {
-            did,
-            // TODO: In the future, fetch name/description from space metadata
-            name: None,
-            description: None,
-        })
-        .collect();
+    // Drop identity lock before fetching metadata (we need tonk_state for session_for_space)
+    drop(identity);
 
+    // Fetch metadata for each space
+    let mut spaces: Vec<SpaceInfo> = Vec::with_capacity(known_space_dids.len());
+
+    for did in known_space_dids {
+        let (name, description) = match tonk_state.session_for_space(&did).await {
+            Ok(session) => {
+                let name = session.space().get_name().await.ok().flatten();
+                let description = session.space().get_description().await.ok().flatten();
+                (name, description)
+            }
+            Err(e) => {
+                // Log error but continue - return space without metadata
+                log!("Failed to fetch metadata for space {}: {:?}", did, e);
+                (None, None)
+            }
+        };
+
+        spaces.push(SpaceInfo {
+            did,
+            name,
+            description,
+        });
+    }
+
+    // Sort alphabetically by DID
     spaces.sort_by(|a, b| a.did.cmp(&b.did));
 
     Ok(Json(ListSpacesResponse { spaces }))

--- a/rust/tonk-worker/src/router/space_list.rs
+++ b/rust/tonk-worker/src/router/space_list.rs
@@ -1,9 +1,13 @@
 //! Space list endpoint - returns all known spaces for this identity.
 
 use axum::{Json, extract::State};
+use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
 
 use crate::router::AppState;
+use crate::TonkWorkerError;
 
 /// Information about a single space.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,12 +30,15 @@ pub struct ListSpacesResponse {
 /// Handler for GET /api/space/list
 ///
 /// Returns all spaces known to this identity, sorted alphabetically by DID.
-pub async fn list_spaces(State(state): State<AppState>) -> Json<ListSpacesResponse> {
-    let state = state.read().await;
+#[wasm_compat]
+pub async fn list_spaces(
+    State(state): State<AppState>,
+) -> Result<Json<ListSpacesResponse>, TonkWorkerError> {
+    let tonk_state = state.read().await;
+    let identity = tonk_state.identity.read().await;
 
     // Get known spaces from the account
-    let known_space_dids = state
-        .identity
+    let known_space_dids: Vec<String> = identity
         .account()
         .known_spaces()
         .await
@@ -50,5 +57,5 @@ pub async fn list_spaces(State(state): State<AppState>) -> Json<ListSpacesRespon
 
     spaces.sort_by(|a, b| a.did.cmp(&b.did));
 
-    Json(ListSpacesResponse { spaces })
+    Ok(Json(ListSpacesResponse { spaces }))
 }

--- a/rust/tonk-worker/src/router/space_metadata.rs
+++ b/rust/tonk-worker/src/router/space_metadata.rs
@@ -1,15 +1,18 @@
 //! Space metadata endpoints - get and update space name/description.
 
-use axum::{Json, extract::{Path, State}};
+use axum::{
+    Json,
+    extract::{Path, State},
+};
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
 
+use crate::TonkWorkerError;
 use crate::router::AppState;
 use crate::worker::TonkState;
-use crate::TonkWorkerError;
 
 /// Response for getting space metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,6 +206,9 @@ mod tests {
             serde_json::from_slice(&body).expect("Failed to deserialize response");
 
         assert_eq!(metadata.name, Some("Updated Name".to_string()));
-        assert_eq!(metadata.description, Some("Updated description".to_string()));
+        assert_eq!(
+            metadata.description,
+            Some("Updated description".to_string())
+        );
     }
 }

--- a/rust/tonk-worker/src/router/space_metadata.rs
+++ b/rust/tonk-worker/src/router/space_metadata.rs
@@ -1,0 +1,208 @@
+//! Space metadata endpoints - get and update space name/description.
+
+use axum::{Json, extract::{Path, State}};
+use axum_wasm_macros::wasm_compat;
+use serde::{Deserialize, Serialize};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use crate::router::AppState;
+use crate::worker::TonkState;
+use crate::TonkWorkerError;
+
+/// Response for getting space metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpaceMetadataResponse {
+    /// The space's DID.
+    pub did: String,
+    /// The human-readable name for the space, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The description of the space, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Request body for updating space metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UpdateMetadataRequest {
+    /// New name for the space. If provided, updates the name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New description for the space. If provided, updates the description.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Handler for GET /api/{multikey}/metadata
+///
+/// Returns the current metadata (name, description) for a space.
+#[wasm_compat]
+pub async fn get_metadata(
+    State(state): State<AppState>,
+    Path(multikey): Path<String>,
+) -> Result<Json<SpaceMetadataResponse>, TonkWorkerError> {
+    let space_did = TonkState::multikey_to_did(&multikey);
+    log!("Getting metadata for space: {}", space_did);
+
+    let tonk_state = state.read().await;
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    let name = session
+        .space()
+        .get_name()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to get name: {}", e)))?;
+
+    let description = session
+        .space()
+        .get_description()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to get description: {}", e)))?;
+
+    Ok(Json(SpaceMetadataResponse {
+        did: space_did,
+        name,
+        description,
+    }))
+}
+
+/// Handler for PUT /api/{multikey}/metadata
+///
+/// Updates the metadata (name, description) for a space.
+/// Only provided fields are updated; omitted fields remain unchanged.
+#[wasm_compat]
+pub async fn update_metadata(
+    State(state): State<AppState>,
+    Path(multikey): Path<String>,
+    Json(request): Json<UpdateMetadataRequest>,
+) -> Result<Json<SpaceMetadataResponse>, TonkWorkerError> {
+    let space_did = TonkState::multikey_to_did(&multikey);
+    log!("Updating metadata for space: {}", space_did);
+
+    let tonk_state = state.read().await;
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    // Update name if provided
+    if let Some(ref name) = request.name {
+        session
+            .space_mut()
+            .set_name(name)
+            .await
+            .map_err(|e| TonkWorkerError::Internal(format!("Failed to set name: {}", e)))?;
+        log!("Updated space name to: {}", name);
+    }
+
+    // Update description if provided
+    if let Some(ref description) = request.description {
+        session
+            .space_mut()
+            .set_description(description)
+            .await
+            .map_err(|e| TonkWorkerError::Internal(format!("Failed to set description: {}", e)))?;
+        log!("Updated space description to: {}", description);
+    }
+
+    // Get the current metadata (after updates)
+    let name = session
+        .space()
+        .get_name()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to get name: {}", e)))?;
+
+    let description = session
+        .space()
+        .get_description()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to get description: {}", e)))?;
+
+    // Update the cached session
+    tonk_state.update_session(session).await;
+
+    Ok(Json(SpaceMetadataResponse {
+        did: space_did,
+        name,
+        description,
+    }))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use crate::api_router;
+    use crate::router::tests::test_state;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[dialog_common::test]
+    async fn it_gets_metadata_for_space() {
+        let (state, multikey) = test_state().await;
+        let app = api_router(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/{}/metadata", multikey))
+            .method("GET")
+            .body(Body::empty())
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let metadata: SpaceMetadataResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert!(metadata.did.starts_with("did:key:z6Mk"));
+    }
+
+    #[dialog_common::test]
+    async fn it_updates_metadata_for_space() {
+        let (state, multikey) = test_state().await;
+        let app = api_router(state.clone());
+
+        let request_body = serde_json::json!({
+            "name": "Updated Name",
+            "description": "Updated description"
+        });
+
+        let request = Request::builder()
+            .uri(format!("/api/{}/metadata", multikey))
+            .method("PUT")
+            .header("Content-Type", "application/json")
+            .body(Body::from(request_body.to_string()))
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let metadata: SpaceMetadataResponse =
+            serde_json::from_slice(&body).expect("Failed to deserialize response");
+
+        assert_eq!(metadata.name, Some("Updated Name".to_string()));
+        assert_eq!(metadata.description, Some("Updated description".to_string()));
+    }
+}

--- a/rust/tonk-worker/src/router/status.rs
+++ b/rust/tonk-worker/src/router/status.rs
@@ -1,6 +1,6 @@
 //! Status route for querying current space state.
 
-use ::axum::{Json, extract::State};
+use ::axum::{Json, extract::{Path, State}};
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -8,6 +8,7 @@ use tokio::sync::oneshot;
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Status response indicating the current space state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -24,13 +25,22 @@ pub struct StatusResponse {
 #[wasm_compat]
 pub async fn status(
     State(state): State<AppState>,
+    Path(multikey): Path<String>,
 ) -> Result<Json<StatusResponse>, TonkWorkerError> {
+    let space_did = TonkState::multikey_to_did(&multikey);
     let tonk_state = state.read().await;
-    let space = tonk_state.session.space();
+
+    let session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    let space = session.space();
+    let identity = tonk_state.identity.read().await;
 
     Ok(Json(StatusResponse {
         space_did: space.did.clone(),
-        operator_did: tonk_state.identity.did().to_string(),
+        operator_did: identity.did().to_string(),
         has_upstream: space.has_upstream().await,
     }))
 }
@@ -47,11 +57,11 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_returns_status_without_upstream() {
-        let tonk_state = test_state().await;
+        let (tonk_state, multikey) = test_state().await;
         let app = api_router(tonk_state);
 
         let request = Request::builder()
-            .uri("/api/status")
+            .uri(format!("/api/{}/status", multikey))
             .method("GET")
             .body(Body::empty())
             .expect("Failed to build request");

--- a/rust/tonk-worker/src/router/status.rs
+++ b/rust/tonk-worker/src/router/status.rs
@@ -1,6 +1,9 @@
 //! Status route for querying current space state.
 
-use ::axum::{Json, extract::{Path, State}};
+use ::axum::{
+    Json,
+    extract::{Path, State},
+};
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -2,7 +2,7 @@
 //!
 //! These endpoints allow synchronizing the local space with the upstream remote.
 
-use ::axum::{Json, extract::State};
+use ::axum::{Json, extract::{Path, State}};
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -11,6 +11,7 @@ use tonk_common::log;
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::worker::TonkState;
 
 /// Response for sync operations.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -28,12 +29,21 @@ pub struct SyncResponse {
 ///
 /// Fetches changes from the remote and merges them into the local branch.
 #[wasm_compat]
-pub async fn pull(State(state): State<AppState>) -> Result<Json<SyncResponse>, TonkWorkerError> {
+pub async fn pull(
+    State(state): State<AppState>,
+    Path(multikey): Path<String>,
+) -> Result<Json<SyncResponse>, TonkWorkerError> {
     log!("Pulling from upstream...");
 
-    let mut tonk_state = state.write().await;
+    let space_did = TonkState::multikey_to_did(&multikey);
+    let tonk_state = state.read().await;
 
-    match tonk_state.session.space_mut().pull().await {
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    let result = match session.space_mut().pull().await {
         Ok(Some(_old_revision)) => {
             log!("Pull succeeded, changes applied");
             Ok(Json(SyncResponse {
@@ -58,19 +68,33 @@ pub async fn pull(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
                 error: Some(e.to_string()),
             }))
         }
-    }
+    };
+
+    // Update the cached session
+    tonk_state.update_session(session).await;
+
+    result
 }
 
 /// Push local changes to the upstream remote.
 ///
 /// Sends local changes to the remote.
 #[wasm_compat]
-pub async fn push(State(state): State<AppState>) -> Result<Json<SyncResponse>, TonkWorkerError> {
+pub async fn push(
+    State(state): State<AppState>,
+    Path(multikey): Path<String>,
+) -> Result<Json<SyncResponse>, TonkWorkerError> {
     log!("Pushing to upstream...");
 
-    let mut tonk_state = state.write().await;
+    let space_did = TonkState::multikey_to_did(&multikey);
+    let tonk_state = state.read().await;
 
-    match tonk_state.session.space_mut().push().await {
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
+
+    let result = match session.space_mut().push().await {
         Ok(Some(_old_revision)) => {
             log!("Push succeeded, changes sent");
             Ok(Json(SyncResponse {
@@ -95,20 +119,34 @@ pub async fn push(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
                 error: Some(e.to_string()),
             }))
         }
-    }
+    };
+
+    // Update the cached session
+    tonk_state.update_session(session).await;
+
+    result
 }
 
 /// Full sync: pull then push.
 ///
 /// First pulls changes from upstream, then pushes local changes.
 #[wasm_compat]
-pub async fn sync(State(state): State<AppState>) -> Result<Json<SyncResponse>, TonkWorkerError> {
+pub async fn sync(
+    State(state): State<AppState>,
+    Path(multikey): Path<String>,
+) -> Result<Json<SyncResponse>, TonkWorkerError> {
     log!("Syncing with upstream (pull + push)...");
 
-    let mut tonk_state = state.write().await;
+    let space_did = TonkState::multikey_to_did(&multikey);
+    let tonk_state = state.read().await;
+
+    let mut session = tonk_state
+        .session_for_space(&space_did)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open session: {}", e)))?;
 
     // First pull
-    let pull_changed = match tonk_state.session.space_mut().pull().await {
+    let pull_changed = match session.space_mut().pull().await {
         Ok(Some(_)) => {
             log!("Pull succeeded, changes applied");
             true
@@ -119,6 +157,7 @@ pub async fn sync(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
         }
         Err(e) => {
             log!("Pull failed: {:?}", e);
+            tonk_state.update_session(session).await;
             return Ok(Json(SyncResponse {
                 success: false,
                 changed: false,
@@ -128,7 +167,7 @@ pub async fn sync(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
     };
 
     // Then push
-    let push_changed = match tonk_state.session.space_mut().push().await {
+    let push_changed = match session.space_mut().push().await {
         Ok(Some(_)) => {
             log!("Push succeeded, changes sent");
             true
@@ -139,6 +178,7 @@ pub async fn sync(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
         }
         Err(e) => {
             log!("Push failed: {:?}", e);
+            tonk_state.update_session(session).await;
             return Ok(Json(SyncResponse {
                 success: false,
                 changed: pull_changed,
@@ -146,6 +186,9 @@ pub async fn sync(State(state): State<AppState>) -> Result<Json<SyncResponse>, T
             }));
         }
     };
+
+    // Update the cached session
+    tonk_state.update_session(session).await;
 
     Ok(Json(SyncResponse {
         success: true,

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -2,7 +2,10 @@
 //!
 //! These endpoints allow synchronizing the local space with the upstream remote.
 
-use ::axum::{Json, extract::{Path, State}};
+use ::axum::{
+    Json,
+    extract::{Path, State},
+};
 use axum_wasm_macros::wasm_compat;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -41,6 +41,7 @@ pub enum SessionError {
 }
 
 /// An active session - an operator authorized to act on behalf of an account in a space.
+#[derive(Clone)]
 pub struct Session {
     /// The account's DID (the identity that authorized this session).
     account: String,

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -2,15 +2,17 @@
 //!
 //! This module defines all JavaScript-visible bindings for the Tonk service worker.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
     Identity, Session, api_router,
     axum::{RequestConversion, ResponseConversion},
+    session::SessionError,
 };
 use axum::{Router, body::Body};
 use js_sys::Promise;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tonk_common::log;
 use tonk_space::Operator;
 use tower_service::Service;
@@ -18,12 +20,61 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 use web_sys::{Request, Response};
 
-/// Application state containing the user's identity and active session.
+/// Application state containing the user's identity and session cache.
 pub struct TonkState {
     /// The user's persistent identity.
-    pub identity: Arc<Identity>,
-    /// The currently active session.
-    pub session: Session,
+    pub identity: Arc<RwLock<Identity>>,
+    /// Cache of active sessions by space DID.
+    /// Sessions are lazily loaded when a space is first accessed.
+    pub sessions: Arc<RwLock<HashMap<String, Session>>>,
+}
+
+impl TonkState {
+    /// Convert a multikey (z6Mk...) to a full DID (did:key:z6Mk...).
+    pub fn multikey_to_did(multikey: &str) -> String {
+        if multikey.starts_with("did:key:") {
+            multikey.to_string()
+        } else {
+            format!("did:key:{}", multikey)
+        }
+    }
+
+    /// Get or create a session for the given space.
+    ///
+    /// If the session is already cached, returns a clone.
+    /// Otherwise, opens a new session and caches it.
+    pub async fn session_for_space(&self, space_did: &str) -> Result<Session, SessionError> {
+        // Check cache first
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(session) = sessions.get(space_did) {
+                return Ok(session.clone());
+            }
+        }
+
+        // Not cached, create new session
+        log!("Opening session for space: {}", space_did);
+        let identity = self.identity.read().await;
+        let session = identity.open_session(space_did).await?;
+
+        // Cache it
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.insert(space_did.to_string(), session.clone());
+        }
+
+        Ok(session)
+    }
+
+    /// Update a cached session after modification.
+    ///
+    /// This should be called after mutating a session to ensure the cache
+    /// reflects the current state.
+    pub async fn update_session(&self, session: Session) {
+        let space_did = session.space_did().to_string();
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(space_did, session);
+    }
 }
 
 /// The main Tonk service worker that handles browser fetch events.
@@ -68,33 +119,26 @@ impl TonkServiceWorker {
             .expect_throw("Could not initialize identity");
         log!("User DID: {}", identity.did());
 
-        // 2. Get known spaces, or create if none exist
+        // 2. Ensure at least one space exists (the shared space)
         let known_spaces = identity
             .account()
             .known_spaces()
             .await
             .expect_throw("Could not query known spaces");
 
-        let session = if let Some(space_did) = known_spaces.first() {
-            log!("Opening known space: {}", space_did);
-            identity
-                .open_session(space_did)
-                .await
-                .expect_throw("Could not open session")
-        } else {
-            log!("No known spaces, join publish shared space");
+        if known_spaces.is_empty() {
+            log!("No known spaces, joining shared space");
             let shared_space = Operator::from_passphrase("public tonk space").await;
             identity
                 .join_session(shared_space)
                 .await
-                .expect_throw("Could not create session")
-        };
-        log!("Space DID: {}", session.space_did());
+                .expect_throw("Could not join shared space");
+        }
 
-        // 3. Build state and router
+        // 3. Build state with empty session cache (sessions loaded on demand)
         let state = TonkState {
-            identity: Arc::new(identity),
-            session,
+            identity: Arc::new(RwLock::new(identity)),
+            sessions: Arc::new(RwLock::new(HashMap::new())),
         };
         let router = Arc::new(Mutex::new(api_router(state)));
 


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- closes [Linear ID, e.g. TON-123]

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `tonk` application by adding new features for managing spaces, including metadata handling, session management, and improved API routes for space operations.

### Detailed summary
- Updated `public_url` in `Trunk.toml`.
- Added `Name` and `Description` structs to `space.rs`.
- Implemented space metadata retrieval and update endpoints.
- Enhanced session management with caching in `TonkState`.
- Modified API routes to include multikey for space-specific operations.
- Added a `SpaceRedirect` component for navigation.
- Improved error handling for session and API interactions.
- Updated HTML and JavaScript for better service worker integration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->