### PR TITLE
feat(cli): resurrect tonk-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "any_spawner"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arbitrary"
@@ -60,9 +110,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
@@ -225,6 +275,8 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -236,6 +288,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -396,16 +449,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "bytes"
-version = "1.11.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"
@@ -439,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -476,8 +544,36 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -496,6 +592,46 @@ dependencies = [
  "serde_bytes",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cmake"
@@ -522,6 +658,12 @@ name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -553,6 +695,19 @@ dependencies = [
  "serde_core",
  "toml",
  "winnow",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -720,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
 ]
@@ -878,6 +1039,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "default-struct-builder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -939,6 +1121,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.2.17",
+ "js-sys",
  "leb128",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -951,6 +1134,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
+ "varsig",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -959,9 +1143,10 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "async-trait",
+ "convert_case 0.6.0",
  "dialog-common",
  "ipld-core",
  "serde",
@@ -972,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -981,28 +1166,32 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
 ]
 
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "async-trait",
  "dialog-capability",
  "dialog-common",
  "serde",
+ "serde_bytes",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "blake3",
  "proc-macro2",
@@ -1013,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1033,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "async-stream",
  "blake3",
@@ -1055,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "dialog-query-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "dialog-s3-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1082,6 +1271,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest 0.12.28",
  "serde",
+ "serde_bytes",
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2 0.10.9",
@@ -1089,15 +1279,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ucan",
  "url",
- "web-time",
 ]
 
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af"
 dependencies = [
  "anyhow",
+ "async-signature",
  "async-stream",
  "async-trait",
  "base58",
@@ -1133,8 +1323,22 @@ dependencies = [
  "tower-http",
  "ucan",
  "url",
+ "varsig",
  "wasm-bindgen",
  "web-time",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -1151,13 +1355,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer 0.11.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.0-rc.13",
+ "crypto-common 0.2.0-rc.5",
  "subtle",
 ]
 
@@ -1282,6 +1486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,9 +1577,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1603,6 +1813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,10 +1836,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-simd"
@@ -1654,7 +1887,7 @@ version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -1713,9 +1946,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41fb3dc24fe72c2e3a4685eed55917c2fb228851257f4a8f2d985da9443c3e5"
+checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
 dependencies = [
  "typenum",
 ]
@@ -1776,14 +2009,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1992,6 +2224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2298,21 @@ dependencies = [
  "once_cell",
  "sha2 0.10.9",
  "signature",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.5.1",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -2271,6 +2524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,7 +2640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64dd2c9099caf8e29b629305199dddb1c6d981562b62c089afea54b0b4b5c333"
 dependencies = [
  "cfg-if",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -2389,9 +2651,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2445,6 +2707,12 @@ dependencies = [
  "serde",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "next_tuple"
@@ -2530,6 +2798,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2837,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -2704,6 +3003,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "port_check"
@@ -3058,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3070,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3081,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -3125,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -3265,7 +3570,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -3293,7 +3598,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3325,9 +3630,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3s"
@@ -3415,6 +3720,19 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -3671,7 +3989,7 @@ checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -3693,8 +4011,14 @@ checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.9",
+ "digest 0.11.0-rc.4",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3707,6 +4031,16 @@ name = "sieve-cache"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879e304c6ec8e95de2bc5425b546df072ee5812d0b2b8497b73f0b68b31ddbbb"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -3726,9 +4060,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -3859,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.4",
@@ -4015,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4036,9 +4370,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4079,7 +4413,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4200,6 +4536,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonk-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64",
+ "blake3",
+ "bs58",
+ "chrono",
+ "ciborium",
+ "clap",
+ "dialog-artifacts",
+ "dialog-common",
+ "dialog-query",
+ "dialog-s3-credentials",
+ "dialog-storage",
+ "dialoguer",
+ "dirs",
+ "ed25519-dalek",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "keyring",
+ "rand 0.8.5",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonk-space",
+ "tower",
+ "ucan",
+ "varsig",
+ "webbrowser",
+]
+
+[[package]]
 name = "tonk-common"
 version = "0.1.0"
 dependencies = [
@@ -4242,6 +4617,7 @@ dependencies = [
  "tokio",
  "tonk-common",
  "ucan",
+ "varsig",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -4264,7 +4640,7 @@ dependencies = [
  "leptos_router",
  "port_check",
  "rand 0.9.2",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thirtyfour",
@@ -4460,12 +4836,14 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "ucan"
 version = "0.5.0"
-source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1"
+source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=main#300a5635544855be4599581bffc8ad231e04eb76"
 dependencies = [
+ "async-signature",
  "base58",
  "ed25519-dalek",
  "futures",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "ipld-core",
  "js-sys",
  "leb128",
@@ -4507,15 +4885,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -4567,6 +4951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,11 +4970,13 @@ dependencies = [
 [[package]]
 name = "varsig"
 version = "0.1.0"
-source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1"
+source = "git+https://github.com/tonk-labs/rs-ucan.git?branch=main#300a5635544855be4599581bffc8ad231e04eb76"
 dependencies = [
  "async-signature",
  "ed25519-dalek",
+ "getrandom 0.2.17",
  "ipld-core",
+ "js-sys",
  "k256",
  "leb128",
  "p256",
@@ -4594,6 +4986,9 @@ dependencies = [
  "signature",
  "thiserror 1.0.69",
  "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4796,19 +5191,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.5"
+name = "webbrowser"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "3f00bb839c1cf1e3036066614cbdcd035ecf215206691ea646aa3c60a24f68f2"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4819,7 +5230,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4915,6 +5326,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5296,18 +5716,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5340,6 +5760,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5377,6 +5811,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "rust/tonk-access-service",
+    "rust/tonk-cli",
     "rust/tonk-core",
     "rust/tonk-common",
     "rust/tonk-space",
@@ -18,6 +19,7 @@ edition = "2024"
 
 [workspace.dependencies]
 tonk-access-service = { path = "./rust/tonk-access-service" }
+tonk-cli = { path = "./rust/tonk-cli" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-core = { path = "./rust/tonk-core" }
 tonk-space = { path = "./rust/tonk-space" }
@@ -31,12 +33,17 @@ axum-wasm-macros = "0.1"
 base58 = "0.2"
 base64 = "0.22"
 blake3 = "1.5"
+bs58 = "0.5"
+ciborium = "0.2"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "wasmbind",
 ] }
 clap = { version = "4", features = ["derive"] }
 console_error_panic_hook = "0.1"
+crypto-common = "=0.2.0-rc.5"
+dialoguer = "0.11"
+digest = "=0.11.0-rc.4"
 dirs = "5"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 futures = "0.3"
@@ -46,7 +53,9 @@ getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 hex = "0.4"
 hkdf = "0.12"
+idb = "0.6"
 ipld-core = { version = "0.4", features = ["serde"] }
+keyring = "3.6"
 leptos = "0.8"
 leptos-use = "0.17"
 leptos_router = "0.8"
@@ -59,7 +68,6 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 serde_ipld_dagcbor = "0.6"
-sha2 = "0.11.0-rc.3"
 sha2_0_10 = { package = "sha2", version = "0.10" }
 tempfile = "3"
 thirtyfour = "0.36"
@@ -74,6 +82,7 @@ http-body-util = "0.1"
 url = "2"
 wasm-streams = "0.4"
 web-time = "1"
+webbrowser = "1.0"
 worker = "0.7.4"
 worker-macros = "0.7.4"
 
@@ -92,9 +101,9 @@ dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "
 dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk", features = ["ucan"] }
 
-# UCAN (using local path for development)
-ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "tonk", package = "ucan" }
-varsig = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "tonk", package = "varsig" }
+# UCAN
+ucan = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", package = "ucan" }
+varsig = { git = "https://github.com/tonk-labs/rs-ucan.git", branch = "main", package = "varsig" }
 
 [profile.dev]
 opt-level = 1

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             # Linux-specific inputs
             openssl
             pkg-config
+            dbus
             chromium
             chromedriver
           ]

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -18,10 +18,10 @@ let
   # that the same dependencies can be used across all derivations that
   # need them. Crane expects the full git URL as the key.
   cargoGitDependencies = {
-    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#83a59a367b6b96f99b7ecb884f011c57fbe32c54" =
-      "sha256-s3DRRNklq+ZFAApSDuGHC0hJo9V9ry1ODGhN0rdwMtY=";
-    "git+https://github.com/tonk-labs/rs-ucan.git?branch=tonk#51d0ec8952ccaf3d95a767f0bb3d302064ac7aa1" =
-      "sha256-apwOaUuOLvYfqNGHOTnOeJx3DIOSPvJLFwXpc6p3UkA=";
+    "git+https://github.com/dialog-db/dialog-db.git?branch=tonk#8b05928053e6902fe79e92baa617bc56dd86f2af" =
+      "sha256-digyUYefGIu27fVraJIfA6lMOo/bKSFX4XQDrC3GWzg=";
+    "git+https://github.com/tonk-labs/rs-ucan.git?branch=main#300a5635544855be4599581bffc8ad231e04eb76" =
+      "sha256-mkZ6M7jOrRvlcVyBZ+mUPagD7/hJZ/HvoptDOIm90bs=";
   };
 
   # Filter source to only Rust-relevant files
@@ -80,6 +80,11 @@ let
     src = rustSource;
     strictDeps = true;
     inherit nativeBuildInputs;
+    buildInputs =
+      with pkgs;
+      lib.optionals stdenv.isLinux [
+        dbus
+      ];
 
     # Git dependencies with hashes for offline evaluation
     # Crane will automatically find Cargo.lock from src
@@ -96,8 +101,15 @@ let
   );
 
   # Build WASM dependencies separately (different target)
+  # Exclude native-only crates that can't compile for wasm32-unknown-unknown.
+  # tonk-cli requires tokio["full"] which pulls in mio, a crate that needs
+  # OS-level async I/O primitives (epoll/kqueue) unavailable in WASM.
+  # If you add a new native-only crate, add it to the --exclude list here.
+  wasmCargoExcludeArgs = "--workspace --exclude tonk-cli";
+
   wasmAttributes = commonAttributes // {
     CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
+    cargoExtraArgs = wasmCargoExcludeArgs;
   };
 
   wasmArtifacts = craneLib.buildDepsOnly (
@@ -173,6 +185,7 @@ let
         buildPhaseCargoCommand = ''
           cargo nextest archive \
             ${args} \
+            ${if target == "wasm32-unknown-unknown" then wasmCargoExcludeArgs else ""} \
             --archive-file ./tests-${name}.tar.zst
         '';
 

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -26,7 +26,7 @@ dialog-storage = { workspace = true }
 dialog-query = { workspace = true }
 dialog-artifacts = { workspace = true, features = ["ucan"] }
 dialog-common = { workspace = true }
-dialog-s3-credentials = { workspace = true }
+dialog-s3-credentials = { workspace = true, features = ["ucan"] }
 
 # Async
 futures-util = { workspace = true }

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name = "tonk-cli"
+description = "CLI tool for Tonk authentication and management"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "tonk"
+path = "src/bin/tonk.rs"
+
+[features]
+default = []
+
+[dependencies]
+# CLI
+clap = { workspace = true, features = ["derive"] }
+dialoguer = { workspace = true }
+
+# Tonk packages
+tonk-space = { workspace = true }
+
+# Dialog DB
+dialog-storage = { workspace = true }
+dialog-query = { workspace = true }
+dialog-artifacts = { workspace = true, features = ["ucan"] }
+dialog-common = { workspace = true }
+dialog-s3-credentials = { workspace = true }
+
+# Async
+futures-util = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+# Crypto
+ed25519-dalek = { workspace = true }
+rand_0_8 = { workspace = true }
+bs58 = { workspace = true }
+sha2_0_10 = { workspace = true }
+hex = { workspace = true }
+hkdf = { workspace = true }
+blake3 = { workspace = true }
+
+# Serialization
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
+ciborium = { workspace = true }
+
+# HTTP server
+axum = { workspace = true, features = ["tokio", "form", "http1"] }
+tower = { workspace = true }
+
+# UCAN
+ucan = { workspace = true }
+varsig = { workspace = true }
+
+# Utilities
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+dirs = { workspace = true }
+
+# For opening browser
+webbrowser = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+# Platform-specific keyring backends
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { workspace = true, features = ["sync-secret-service"] }
+
+# Fallback for other platforms (FreeBSD, etc.)
+[target.'cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows", target_os = "linux")))'.dependencies]
+keyring = { workspace = true }

--- a/rust/tonk-cli/auth.html
+++ b/rust/tonk-cli/auth.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tonk Authorization</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 600px;
+        margin: 50px auto;
+        padding: 20px;
+        background: #f5f5f5;
+      }
+      .container {
+        background: white;
+        border-radius: 8px;
+        padding: 30px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      }
+      h1 {
+        color: #333;
+        margin-top: 0;
+      }
+      .info {
+        background: #e3f2fd;
+        padding: 15px;
+        border-radius: 5px;
+        margin: 20px 0;
+        font-size: 14px;
+      }
+      .info code {
+        background: #fff;
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 12px;
+        word-break: break-all;
+      }
+      button {
+        background: #1976d2;
+        color: white;
+        border: none;
+        padding: 12px 24px;
+        border-radius: 5px;
+        font-size: 16px;
+        cursor: pointer;
+        width: 100%;
+        margin-top: 10px;
+      }
+      button:hover {
+        background: #1565c0;
+      }
+      button:disabled {
+        background: #ccc;
+        cursor: not-allowed;
+      }
+      button.deny {
+        background: #666;
+      }
+      button.deny:hover {
+        background: #555;
+      }
+      .status {
+        margin-top: 20px;
+        padding: 15px;
+        border-radius: 5px;
+        display: none;
+      }
+      .status.success {
+        background: #c8e6c9;
+        color: #2e7d32;
+        display: block;
+      }
+      .status.error {
+        background: #ffcdd2;
+        color: #c62828;
+        display: block;
+      }
+      .status.loading {
+        background: #fff3e0;
+        color: #e65100;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>🔐 Tonk Authorization</h1>
+
+      <div class="info">
+        <p>
+          <strong>Operator:</strong><br /><code id="operator">Loading...</code>
+        </p>
+        <p><strong>Command:</strong> <code id="command">Loading...</code></p>
+        <p><strong>Subject:</strong> <code id="subject">Loading...</code></p>
+      </div>
+
+      <button id="authorizeButton">Authorize with WebAuthn</button>
+
+      <button class="deny" id="denyButton">Deny</button>
+
+      <div id="status"></div>
+    </div>
+
+    <script type="module">
+      import { Delegation } from 'https://esm.sh/iso-ucan@0.4.2/delegation';
+      import { EdDSASigner } from 'https://esm.sh/iso-signatures@0.5.1/signers/eddsa';
+      import { tag } from 'https://esm.sh/iso-base/varint';
+      import { base64pad } from 'https://esm.sh/iso-base/rfc4648';
+
+      // Parse URL parameters
+      const params = new URLSearchParams(window.location.search);
+      const operator = params.get('as');
+      const command = params.get('cmd');
+      const subject = params.get('sub');
+      const callback = params.get('callback');
+
+      // Display parameters
+      document.getElementById('operator').textContent =
+        operator || 'Not provided';
+      document.getElementById('command').textContent =
+        command || 'Not provided';
+      document.getElementById('subject').textContent =
+        subject || 'Not provided';
+
+      // Check if parameters are valid
+      if (!operator || !command || !callback) {
+        showStatus(
+          'error',
+          'Missing required parameters. Please use the CLI to initiate authorization.'
+        );
+        document.getElementById('authorizeButton').disabled = true;
+        throw new Error('Missing parameters');
+      }
+
+      async function authorize() {
+        const authButton = document.getElementById('authorizeButton');
+        const denyButton = document.getElementById('denyButton');
+        authButton.disabled = true;
+        denyButton.disabled = true;
+
+        try {
+          showStatus('loading', 'Starting WebAuthn authentication...');
+
+          // Check WebAuthn support
+          if (!window.PublicKeyCredential) {
+            throw new Error('WebAuthn is not supported in this browser');
+          }
+
+          // Check PRF support
+          const prfSupported =
+            await PublicKeyCredential.isConditionalMediationAvailable();
+
+          const challenge = new Uint8Array(32);
+          crypto.getRandomValues(challenge);
+
+          // Try to get existing credential first, otherwise create new one
+          let credential;
+          let prfOutput;
+
+          try {
+            // Try to get existing credential
+            credential = await navigator.credentials.get({
+              publicKey: {
+                challenge: challenge,
+                timeout: 60000,
+                userVerification: 'preferred',
+                extensions: {
+                  prf: {
+                    eval: {
+                      first: new TextEncoder().encode('tonk-authority-v1'),
+                    },
+                  },
+                },
+              },
+            });
+
+            const results = credential.getClientExtensionResults();
+            if (results.prf && results.prf.results) {
+              prfOutput = results.prf.results.first;
+            } else {
+              throw new Error('PRF extension not supported or enabled');
+            }
+          } catch (e) {
+            // No existing credential, create new one
+            showStatus('loading', 'Creating new WebAuthn credential...');
+
+            credential = await navigator.credentials.create({
+              publicKey: {
+                challenge: challenge,
+                rp: {
+                  name: 'Tonk',
+                  id: window.location.hostname,
+                },
+                user: {
+                  id: crypto.getRandomValues(new Uint8Array(16)),
+                  name: 'tonk-user',
+                  displayName: 'Tonk User',
+                },
+                pubKeyCredParams: [
+                  { type: 'public-key', alg: -7 }, // ES256 (ECDSA with SHA-256, most widely supported)
+                  { type: 'public-key', alg: -257 }, // RS256 (RSA with SHA-256)
+                  { type: 'public-key', alg: -8 }, // EdDSA (if supported natively)
+                ],
+                authenticatorSelection: {
+                  userVerification: 'preferred',
+                  residentKey: 'preferred',
+                },
+                timeout: 60000,
+                extensions: {
+                  prf: {
+                    eval: {
+                      first: new TextEncoder().encode('tonk-authority-v1'),
+                    },
+                  },
+                },
+              },
+            });
+
+            const results = credential.getClientExtensionResults();
+            if (results.prf && results.prf.results) {
+              prfOutput = results.prf.results.first;
+            } else {
+              throw new Error(
+                'PRF extension not supported or enabled. Try Chrome/Edge with a platform authenticator.'
+              );
+            }
+          }
+
+          showStatus('loading', 'Deriving authority key from PRF...');
+
+          // Derive Ed25519 seed from PRF output using HKDF
+          const prfKey = await crypto.subtle.importKey(
+            'raw',
+            prfOutput,
+            'HKDF',
+            false,
+            ['deriveBits']
+          );
+
+          const authoritySeed = await crypto.subtle.deriveBits(
+            {
+              name: 'HKDF',
+              hash: 'SHA-256',
+              salt: new TextEncoder().encode('tonk-authority-v1'),
+              info: new TextEncoder().encode('ed25519'),
+            },
+            prfKey,
+            256 // 32 bytes
+          );
+
+          // Create Ed25519 signer from seed
+          const authorityPrivateKey = tag(
+            EdDSASigner.code,
+            new Uint8Array(authoritySeed)
+          );
+
+          // Convert to base64 for EdDSASigner.import()
+          const privateKeyBase64 = base64pad.encode(authorityPrivateKey);
+          const issuer = await EdDSASigner.import(privateKeyBase64);
+
+          showStatus('loading', 'Creating UCAN delegation...');
+
+          // activation time
+          const nowInSeconds = Math.floor(Date.now() / 1000);
+
+          // Create delegation using iso-ucan
+          const delegation = await Delegation.create({
+            iss: issuer,
+            aud: operator,
+            sub: subject === '*' ? null : subject,
+            cmd: command,
+            pol: [],
+            exp: null,
+            nbf: nowInSeconds,
+            meta: {},
+          });
+
+          // iso-ucan's Delegation.toString() returns base64-encoded token
+          const ucanBase64 = delegation.toString();
+
+          showStatus('loading', 'Submitting authorization...');
+
+          // Submit via form POST
+          const form = document.createElement('form');
+          form.method = 'POST';
+          form.action = callback;
+
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = 'authorize';
+          input.value = ucanBase64;
+
+          form.appendChild(input);
+          document.body.appendChild(form);
+          form.submit();
+        } catch (error) {
+          console.error('Authorization failed:', error);
+          showStatus('error', `❌ Authorization failed: ${error.message}`);
+          authButton.disabled = false;
+          denyButton.disabled = false;
+        }
+      }
+
+      function deny() {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = callback;
+
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'deny';
+        input.value = 'User denied authorization';
+
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+      }
+
+      function showStatus(type, message) {
+        const status = document.getElementById('status');
+        status.className = `status ${type}`;
+        status.textContent = message;
+      }
+
+      // Set up event listeners
+      document
+        .getElementById('authorizeButton')
+        .addEventListener('click', authorize);
+      document.getElementById('denyButton').addEventListener('click', deny);
+    </script>
+  </body>
+</html>

--- a/rust/tonk-cli/src/authority.rs
+++ b/rust/tonk-cli/src/authority.rs
@@ -1,0 +1,121 @@
+use crate::delegation::Delegation;
+use crate::keystore::Keystore;
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::fs;
+
+/// Information about an available authority (login session)
+#[derive(Debug, Clone)]
+pub struct Authority {
+    /// The authority's DID
+    pub did: String,
+
+    /// Commands the authority has delegated to operator (usually "/")
+    pub commands: Vec<String>,
+
+    /// Expiration timestamp of the delegation
+    pub expiration: i64,
+}
+
+/// Get all available authorities (issuers from powerline delegations)
+pub fn get_authorities() -> Result<Vec<Authority>> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let access_dir = home.join(".tonk").join("access").join(&operator_did);
+
+    if !access_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut authorities: HashMap<String, Authority> = HashMap::new();
+
+    // Walk through issuer directories
+    for entry in fs::read_dir(&access_dir).context("Failed to read access directory")? {
+        let entry = entry?;
+        let dir_path = entry.path();
+
+        if !dir_path.is_dir() {
+            continue;
+        }
+
+        // Read delegation files in this directory
+        for delegation_entry in fs::read_dir(&dir_path)? {
+            let delegation_entry = delegation_entry?;
+            let delegation_path = delegation_entry.path();
+
+            if !delegation_path.is_file()
+                || delegation_path.extension().and_then(|e| e.to_str()) != Some("cbor")
+            {
+                continue;
+            }
+
+            // Parse delegation
+            if let Ok(cbor_bytes) = fs::read(&delegation_path)
+                && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+            {
+                // Only consider valid powerline delegations
+                if !delegation.is_valid() {
+                    continue;
+                }
+
+                if !delegation.is_powerline() {
+                    continue;
+                }
+
+                let authority_did = delegation.issuer();
+
+                // Track this authority
+                authorities
+                    .entry(authority_did.clone())
+                    .or_insert_with(|| Authority {
+                        did: authority_did,
+                        commands: Vec::new(),
+                        expiration: delegation.expiration().unwrap_or(i64::MAX),
+                    })
+                    .commands
+                    .push(delegation.command_str());
+            }
+        }
+    }
+
+    // Sort authorities by DID for consistent ordering
+    let mut result: Vec<Authority> = authorities.into_values().collect();
+    result.sort_by(|a, b| a.did.cmp(&b.did));
+    Ok(result)
+}
+
+/// Get the currently active authority, or the first available one
+pub fn get_active_authority() -> Result<Option<Authority>> {
+    let authorities = get_authorities()?;
+
+    if authorities.is_empty() {
+        return Ok(None);
+    }
+
+    // Use state to get active session
+    let active_did = crate::state::get_active_session()?;
+
+    if let Some(active_did) = active_did {
+        // Try to find the active authority
+        if let Some(auth) = authorities.iter().find(|a| a.did == active_did) {
+            return Ok(Some(auth.clone()));
+        }
+    }
+
+    // Default to first authority if no active one is set or not found
+    Ok(Some(authorities[0].clone()))
+}
+
+/// Format authority DID for display (shortened)
+pub fn format_authority_did(did: &str) -> String {
+    if did.len() > 20 {
+        format!("{}...{}", &did[..15], &did[did.len() - 8..])
+    } else {
+        did.to_string()
+    }
+}

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -227,6 +227,11 @@ enum RemoteCommands {
         /// Name for the remote (e.g., "origin")
         name: String,
 
+        /// UCAN access service URL (e.g., https://access.tonk.xyz).
+        /// When provided, uses UCAN delegation instead of raw S3 credentials.
+        #[arg(long, conflicts_with_all = ["endpoint", "bucket", "region", "access_key_id", "secret_access_key"])]
+        service_url: Option<String>,
+
         /// S3 endpoint URL (e.g., https://s3.amazonaws.com)
         #[arg(long, visible_alias = "host")]
         endpoint: Option<String>,
@@ -341,6 +346,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Remote { command } => match command {
             RemoteCommands::Add {
                 name,
+                service_url,
                 endpoint,
                 bucket,
                 region,
@@ -349,6 +355,7 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 tonk_cli::remote::add(
                     name,
+                    service_url,
                     endpoint,
                     bucket,
                     region,

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1,0 +1,382 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "tonk")]
+#[command(about = "Tonk CLI - Authentication and management tool", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Authenticate and obtain delegated capabilities
+    Login {
+        /// Optional authentication URL (e.g., "https://auth.tonk.xyz").
+        /// If not provided, serves auth page locally.
+        #[arg(long)]
+        via: Option<String>,
+    },
+
+    /// Manage sessions (authority contexts)
+    Session {
+        #[command(subcommand)]
+        command: Option<SessionCommands>,
+
+        /// Show verbose output including delegation chains
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Manage spaces (collaboration units)
+    Space {
+        #[command(subcommand)]
+        command: Option<SpaceCommands>,
+    },
+
+    /// Operator commands
+    Operator {
+        #[command(subcommand)]
+        command: OperatorCommands,
+    },
+
+    /// Inspect delegations and invites
+    Inspect {
+        #[command(subcommand)]
+        command: InspectCommands,
+    },
+
+    /// Manage facts in the active space
+    Fact {
+        #[command(subcommand)]
+        command: FactCommands,
+    },
+
+    /// Manage remotes for syncing spaces
+    Remote {
+        #[command(subcommand)]
+        command: RemoteCommands,
+    },
+
+    /// Pull changes from the upstream remote
+    Pull,
+
+    /// Push local changes to the upstream remote
+    Push,
+
+    /// Sync with upstream (pull then push)
+    Sync,
+}
+
+#[derive(Subcommand)]
+enum SessionCommands {
+    /// Show the current session DID
+    Current,
+
+    /// Switch to a different session
+    Set {
+        /// Authority DID to switch to
+        authority_did: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum SpaceCommands {
+    /// Show the current space DID
+    Current,
+
+    /// Switch to a different space
+    Set {
+        /// Space name or DID to switch to
+        space: String,
+    },
+
+    /// Create a new space
+    Create {
+        /// Name of the space
+        name: String,
+
+        /// Owner DIDs (did:key identifiers). If not provided, will prompt interactively.
+        /// The active authority is always included as an owner.
+        #[arg(short, long)]
+        owners: Option<Vec<String>>,
+
+        /// Optional description
+        #[arg(short, long)]
+        description: Option<String>,
+    },
+
+    /// Invite a collaborator to a space
+    Invite {
+        /// Email address of the invitee (e.g., alice@example.com)
+        email: String,
+
+        /// Name of the space (defaults to active space)
+        #[arg(short, long)]
+        space: Option<String>,
+    },
+
+    /// Join a space using an invitation file
+    Join {
+        /// Path to the invitation file
+        #[arg(short, long)]
+        invite: String,
+
+        /// Profile to join with (defaults to active profile)
+        #[arg(short, long)]
+        profile: Option<String>,
+    },
+
+    /// Delete a space
+    Delete {
+        /// Space name or DID to delete
+        space: String,
+
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum OperatorCommands {
+    /// Generate a new operator key (base58btc encoded)
+    Generate,
+}
+
+#[derive(Subcommand)]
+enum InspectCommands {
+    /// Inspect a delegation (base64-encoded CBOR or .cbor file)
+    Delegation {
+        /// Base64-encoded CBOR delegation string or path to .cbor file
+        input: String,
+    },
+
+    /// Inspect an invite file
+    Invite {
+        /// Path to .invite file
+        path: String,
+    },
+
+    /// Inspect CBOR data and display as JSON
+    Cbor {
+        /// Path to .cbor file or base64-encoded CBOR string
+        input: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum FactCommands {
+    /// Assert a fact into the active space
+    Assert {
+        /// The attribute (e.g., "user/name")
+        #[arg(long, allow_hyphen_values = true)]
+        the: String,
+
+        /// The entity identifier. Can be:
+        /// - ~/path - derives entity from operator signature
+        /// - URI (e.g., did:key:..., https://...) - used as-is
+        /// - any string - hashed to create entity
+        #[arg(long, allow_hyphen_values = true)]
+        of: String,
+
+        /// The value to assert (all remaining words joined with spaces)
+        #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
+        is: Vec<String>,
+    },
+
+    /// Retract a fact from the active space
+    Retract {
+        /// The attribute (e.g., "user/name")
+        #[arg(long, allow_hyphen_values = true)]
+        the: String,
+
+        /// The entity identifier
+        #[arg(long, allow_hyphen_values = true)]
+        of: String,
+
+        /// The value to retract (all remaining words joined with spaces)
+        #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
+        is: Vec<String>,
+    },
+
+    /// Find facts in the active space
+    Find {
+        /// Filter by attribute (e.g., "user/name")
+        #[arg(long, allow_hyphen_values = true)]
+        the: Option<String>,
+
+        /// Filter by entity identifier
+        #[arg(long, allow_hyphen_values = true)]
+        of: Option<String>,
+
+        /// Filter by value
+        #[arg(long, allow_hyphen_values = true)]
+        is: Option<String>,
+
+        /// Format for decoding byte values (cbor, json, text, ucan)
+        #[arg(long, short)]
+        format: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum RemoteCommands {
+    /// Add a remote for syncing the active space
+    Add {
+        /// Name for the remote (e.g., "origin")
+        name: String,
+
+        /// S3 endpoint URL (e.g., https://s3.amazonaws.com)
+        #[arg(long, visible_alias = "host")]
+        endpoint: Option<String>,
+
+        /// S3 bucket name
+        #[arg(long)]
+        bucket: Option<String>,
+
+        /// AWS region (default: us-east-1)
+        #[arg(long)]
+        region: Option<String>,
+
+        /// AWS Access Key ID
+        #[arg(long)]
+        access_key_id: Option<String>,
+
+        /// AWS Secret Access Key
+        #[arg(long)]
+        secret_access_key: Option<String>,
+    },
+
+    /// Show the current upstream remote configuration
+    Show,
+
+    /// Remove the upstream remote
+    Delete,
+
+    /// Edit the upstream remote configuration
+    Edit,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Login { via } => {
+            tonk_cli::login::execute(via).await?;
+        }
+        Commands::Session { command, verbose } => match command {
+            None => {
+                tonk_cli::session::list(verbose).await?;
+            }
+            Some(SessionCommands::Current) => {
+                tonk_cli::session::show_current().await?;
+            }
+            Some(SessionCommands::Set { authority_did }) => {
+                tonk_cli::session::set(authority_did).await?;
+            }
+        },
+        Commands::Space { command } => match command {
+            None => {
+                tonk_cli::space::list().await?;
+            }
+            Some(SpaceCommands::Current) => {
+                tonk_cli::space::show_current().await?;
+            }
+            Some(SpaceCommands::Set { space }) => {
+                tonk_cli::space::set(space).await?;
+            }
+            Some(SpaceCommands::Create {
+                name,
+                owners,
+                description,
+            }) => {
+                tonk_cli::space::create(name, owners, description).await?;
+            }
+            Some(SpaceCommands::Invite { email, space }) => {
+                tonk_cli::space::invite(email, space).await?;
+            }
+            Some(SpaceCommands::Join { invite, profile }) => {
+                tonk_cli::space::join(invite, profile).await?;
+            }
+            Some(SpaceCommands::Delete { space, force }) => {
+                tonk_cli::space::delete(space, force).await?;
+            }
+        },
+        Commands::Operator { command } => match command {
+            OperatorCommands::Generate => {
+                tonk_cli::operator::generate()?;
+            }
+        },
+        Commands::Inspect { command } => match command {
+            InspectCommands::Delegation { input } => {
+                tonk_cli::delegation::inspect(input)?;
+            }
+            InspectCommands::Invite { path } => {
+                tonk_cli::space::inspect_invite(path)?;
+            }
+            InspectCommands::Cbor { input } => {
+                tonk_cli::inspect::cbor(input)?;
+            }
+        },
+        Commands::Fact { command } => match command {
+            FactCommands::Assert { the, of, is } => {
+                let is_value = is.join(" ").trim().to_string();
+                tonk_cli::fact::assert(the, of, is_value).await?;
+            }
+            FactCommands::Retract { the, of, is } => {
+                let is_value = is.join(" ").trim().to_string();
+                tonk_cli::fact::retract(the, of, is_value).await?;
+            }
+            FactCommands::Find {
+                the,
+                of,
+                is,
+                format,
+            } => {
+                tonk_cli::fact::find(the, of, is, format).await?;
+            }
+        },
+        Commands::Remote { command } => match command {
+            RemoteCommands::Add {
+                name,
+                endpoint,
+                bucket,
+                region,
+                access_key_id,
+                secret_access_key,
+            } => {
+                tonk_cli::remote::add(
+                    name,
+                    endpoint,
+                    bucket,
+                    region,
+                    access_key_id,
+                    secret_access_key,
+                )
+                .await?;
+            }
+            RemoteCommands::Show => {
+                tonk_cli::remote::show().await?;
+            }
+            RemoteCommands::Delete => {
+                tonk_cli::remote::delete().await?;
+            }
+            RemoteCommands::Edit => {
+                tonk_cli::remote::edit().await?;
+            }
+        },
+        Commands::Pull => {
+            tonk_cli::remote::pull().await?;
+        }
+        Commands::Push => {
+            tonk_cli::remote::push().await?;
+        }
+        Commands::Sync => {
+            tonk_cli::remote::sync().await?;
+        }
+    }
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/crypto.rs
+++ b/rust/tonk-cli/src/crypto.rs
@@ -1,0 +1,2 @@
+// Re-export from tonk-space
+pub use tonk_space::Operator;

--- a/rust/tonk-cli/src/delegation.rs
+++ b/rust/tonk-cli/src/delegation.rs
@@ -1,0 +1,642 @@
+use crate::crypto::Operator;
+use anyhow::Result;
+use base64::Engine as _;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_ipld_dagcbor::EncodeError;
+use sha2_0_10::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+use std::{collections::TryReserveError, convert::Infallible};
+use thiserror::Error;
+use ucan::did::{Ed25519Did, Ed25519Signer};
+use ucan::time::timestamp::Timestamp;
+use ucan::{Delegation as UcanDelegation, delegation::subject::DelegatedSubject};
+
+#[derive(Error, Debug)]
+pub enum DelegationError {
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("CBOR serialization error: {0}")]
+    CborError(#[from] serde_ipld_dagcbor::DecodeError<Infallible>),
+
+    #[error("CBOR encoding error: {0}")]
+    CborEncodeError(String),
+
+    #[error("Delegation not found")]
+    NotFound,
+
+    #[error("Invalid delegation: {0}")]
+    InvalidDelegation(String),
+
+    #[error("Delegation expired")]
+    Expired,
+
+    #[error("Delegation not yet valid (notBefore in future)")]
+    NotYetValid,
+
+    #[error("Base64 decode error: {0}")]
+    Base64Error(#[from] base64::DecodeError),
+}
+
+/// Metadata about how a delegation was obtained
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationMetadata {
+    /// URL of the site/service that issued the delegation
+    pub site: String,
+
+    /// Timestamp when the delegation was received
+    pub received_at: DateTime<Utc>,
+
+    /// Whether the site was local (served by CLI) or remote
+    pub is_local: bool,
+
+    /// Additional metadata
+    #[serde(default)]
+    pub extra: serde_json::Value,
+}
+
+/// Wrapper around ucan::Delegation with storage and validation methods
+#[derive(Debug, Clone)]
+pub struct Delegation(UcanDelegation<Ed25519Did>);
+
+impl Delegation {
+    /// Create from a UCAN delegation
+    pub fn from_ucan(delegation: UcanDelegation<Ed25519Did>) -> Self {
+        Self(delegation)
+    }
+
+    /// Get the inner UCAN delegation
+    pub fn inner(&self) -> &UcanDelegation<Ed25519Did> {
+        &self.0
+    }
+
+    /// Deserialize from DAG-CBOR bytes
+    pub fn from_cbor_bytes(bytes: &[u8]) -> Result<Self, DelegationError> {
+        let delegation: UcanDelegation<Ed25519Did> = serde_ipld_dagcbor::from_slice(bytes)?;
+        Ok(Self(delegation))
+    }
+
+    /// Serialize to DAG-CBOR bytes
+    pub fn to_cbor_bytes(&self) -> Result<Vec<u8>, DelegationError> {
+        serde_ipld_dagcbor::to_vec(&self.0).map_err(|e: EncodeError<TryReserveError>| {
+            DelegationError::CborEncodeError(e.to_string())
+        })
+    }
+
+    /// Check if the delegation is still valid (not expired and notBefore passed)
+    pub fn is_valid(&self) -> bool {
+        let now = chrono::Utc::now().timestamp() as u64;
+
+        // Check expiration
+        if let Some(exp) = self.0.expiration() {
+            let exp_secs = exp.to_unix();
+            if exp_secs <= now {
+                return false;
+            }
+        }
+
+        // Check notBefore
+        if let Some(nbf) = self.0.not_before() {
+            let nbf_secs = nbf.to_unix();
+            if nbf_secs > now {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Get the audience (operator DID)
+    pub fn audience(&self) -> String {
+        self.0.audience().to_string()
+    }
+
+    /// Get the issuer (authority DID)
+    pub fn issuer(&self) -> String {
+        self.0.issuer().to_string()
+    }
+
+    /// Get the subject
+    pub fn subject(&self) -> &DelegatedSubject<Ed25519Did> {
+        self.0.subject()
+    }
+
+    /// Check if this is a powerline delegation (subject is *)
+    pub fn is_powerline(&self) -> bool {
+        matches!(self.0.subject(), DelegatedSubject::Any)
+    }
+
+    /// Get the command as a slash-separated string
+    pub fn command_str(&self) -> String {
+        self.command().join("/")
+    }
+
+    /// Get the commands
+    pub fn command(&self) -> &Vec<String> {
+        self.0.command().segments()
+    }
+
+    /// Get expiration timestamp (Unix epoch seconds)
+    pub fn expiration(&self) -> Option<i64> {
+        self.0.expiration().map(|ts: Timestamp| ts.to_unix() as i64)
+    }
+
+    /// Calculate hash of the delegation (for storage path)
+    fn hash(&self) -> Result<String, DelegationError> {
+        let cbor_bytes = self.to_cbor_bytes()?;
+        let mut hasher = Sha256::new();
+        hasher.update(&cbor_bytes);
+        let result = hasher.finalize();
+        Ok(hex::encode(result))
+    }
+
+    /// Get the delegation storage path based on delegation fields
+    fn storage_path(&self) -> Result<PathBuf, DelegationError> {
+        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+            DelegationError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            ))
+        })?;
+
+        // Build path: ~/.tonk/access/{aud}/{sub or iss}/{exp}-{hash}.cbor
+        let audience = self.audience();
+        let access_dir = home.join(".tonk").join("access").join(&audience);
+
+        let sub_dir = match self.subject() {
+            DelegatedSubject::Specific(did) => {
+                // Specific subject
+                access_dir.join(did.to_string())
+            }
+            DelegatedSubject::Any => {
+                // Powerline delegation - use issuer as directory name
+                access_dir.join(self.issuer())
+            }
+        };
+
+        // Create directory structure
+        fs::create_dir_all(&sub_dir)?;
+
+        let hash = self.hash()?;
+        let exp = self.expiration().unwrap_or(0);
+        let filename = format!("{}-{}.cbor", exp, hash);
+
+        Ok(sub_dir.join(filename))
+    }
+
+    /// Save delegation to local storage
+    pub fn save(&self) -> Result<(), DelegationError> {
+        let cbor_path: PathBuf = self.storage_path()?;
+
+        // Save as DAG-CBOR
+        let cbor_bytes = self.to_cbor_bytes()?;
+        fs::write(&cbor_path, cbor_bytes)?;
+        println!("   Saved to: {}", cbor_path.display());
+
+        Ok(())
+    }
+
+    /// Save delegation to local storage using provided raw CBOR bytes
+    /// This preserves the exact bytes received without re-serialization
+    pub fn save_raw(&self, raw_cbor: &[u8]) -> Result<(), DelegationError> {
+        let cbor_path: PathBuf = self.storage_path()?;
+
+        // Save the original CBOR bytes without re-serialization
+        fs::write(&cbor_path, raw_cbor)?;
+        println!("   Saved to: {}", cbor_path.display());
+
+        Ok(())
+    }
+
+    /// Save delegation with metadata
+    pub fn save_with_metadata(&self, metadata: &DelegationMetadata) -> Result<(), DelegationError> {
+        // Save the delegation first
+        self.save()?;
+
+        // Save metadata
+        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+            DelegationError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            ))
+        })?;
+
+        let hash: String = self.hash()?;
+        let meta_dir = home.join(".tonk").join("meta").join(&hash);
+        fs::create_dir_all(&meta_dir)?;
+
+        let meta_path = meta_dir.join("site.json");
+        let meta_json = serde_json::to_string_pretty(metadata)?;
+        fs::write(&meta_path, meta_json)?;
+
+        println!("   Metadata saved to: {}", meta_path.display());
+        Ok(())
+    }
+
+    /// Save delegation with metadata using provided raw CBOR bytes
+    /// This preserves the exact bytes received without re-serialization
+    pub fn save_raw_with_metadata(
+        &self,
+        raw_cbor: &[u8],
+        metadata: &DelegationMetadata,
+    ) -> Result<(), DelegationError> {
+        // Save the delegation using raw bytes
+        self.save_raw(raw_cbor)?;
+
+        // Save metadata
+        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+            DelegationError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            ))
+        })?;
+
+        let hash: String = self.hash()?;
+        let meta_dir = home.join(".tonk").join("meta").join(&hash);
+        fs::create_dir_all(&meta_dir)?;
+
+        let meta_path = meta_dir.join("site.json");
+        let meta_json = serde_json::to_string_pretty(metadata)?;
+        fs::write(&meta_path, meta_json)?;
+
+        println!("   Metadata saved to: {}", meta_path.display());
+        Ok(())
+    }
+
+    /// Load metadata for this delegation
+    pub fn load_metadata(&self) -> Result<Option<DelegationMetadata>, DelegationError> {
+        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+            DelegationError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            ))
+        })?;
+
+        let hash = self.hash()?;
+        let meta_path = home
+            .join(".tonk")
+            .join("meta")
+            .join(&hash)
+            .join("site.json");
+
+        if !meta_path.exists() {
+            return Ok(None);
+        }
+
+        let json = fs::read_to_string(meta_path)?;
+        let metadata: DelegationMetadata = serde_json::from_str(&json)?;
+        Ok(Some(metadata))
+    }
+
+    /// Load delegation from CBOR file (for future use)
+    #[allow(dead_code)]
+    pub fn load(
+        aud: &str,
+        sub: Option<&str>,
+        exp: i64,
+        hash: &str,
+    ) -> Result<Self, DelegationError> {
+        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+            DelegationError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            ))
+        })?;
+
+        let access_dir = home.join(".tonk").join("access").join(aud);
+        let sub_dir = if let Some(sub) = sub {
+            access_dir.join(sub)
+        } else {
+            access_dir.join("*")
+        };
+
+        let filename = format!("{}-{}.cbor", exp, hash);
+        let path = sub_dir.join(filename);
+
+        if !path.exists() {
+            return Err(DelegationError::NotFound);
+        }
+
+        let cbor_bytes = fs::read(path)?;
+        Self::from_cbor_bytes(&cbor_bytes)
+    }
+
+    /// Delete the stored delegation (for future use)
+    #[allow(dead_code)]
+    pub fn delete(&self) -> Result<(), DelegationError> {
+        let cbor_path: PathBuf = self.storage_path()?;
+
+        if cbor_path.exists() {
+            fs::remove_file(cbor_path)?;
+        }
+        Ok(())
+    }
+
+    /// Get the delegation hash as bytes
+    /// This is used as a stable, deterministic identifier for the delegation
+    ///
+    /// Used for deriving membership keys from invitations
+    pub fn hash_bytes(&self) -> Result<Vec<u8>, DelegationError> {
+        let hash = self.hash()?;
+        Ok(hex::decode(&hash).expect("hash is valid hex"))
+    }
+}
+
+/// Convert an Operator to an Ed25519Signer (for signing delegations)
+pub fn keypair_to_signer(operator: &Operator) -> Ed25519Signer {
+    Ed25519Signer::from(operator)
+}
+
+/// Convert an Operator to an Ed25519Did (for audience/subject)
+pub fn keypair_to_did(operator: &Operator) -> Ed25519Did {
+    operator.did().clone()
+}
+
+/// Create an ownership delegation (full access to a space)
+/// This is used when creating a space: Space DID -> Profile DID
+pub async fn create_ownership_delegation(
+    issuer: &Operator,
+    audience_did: Ed25519Did,
+    subject_did: Ed25519Did,
+) -> Result<UcanDelegation<Ed25519Did>, DelegationError> {
+    let signer = Ed25519Signer::from(issuer);
+
+    UcanDelegation::builder()
+        .issuer(signer)
+        .audience(audience_did)
+        .subject(DelegatedSubject::Specific(subject_did))
+        .command(vec!["read".to_string(), "write".to_string()])
+        .try_build()
+        .await
+        .map_err(|e| DelegationError::InvalidDelegation(e.to_string()))
+}
+
+/// Create a capability delegation with specific permissions
+/// Commands: "read", "write", or both
+pub async fn create_capability_delegation(
+    issuer: &Operator,
+    audience_did: Ed25519Did,
+    subject_did: Ed25519Did,
+    capabilities: &[&str],
+) -> Result<UcanDelegation<Ed25519Did>, DelegationError> {
+    let signer = Ed25519Signer::from(issuer);
+    let command: Vec<String> = capabilities.iter().map(|s| s.to_string()).collect();
+
+    UcanDelegation::builder()
+        .issuer(signer)
+        .audience(audience_did)
+        .subject(DelegatedSubject::Specific(subject_did))
+        .command(command)
+        .try_build()
+        .await
+        .map_err(|e| DelegationError::InvalidDelegation(e.to_string()))
+}
+
+/// Create a read-only delegation
+pub async fn create_read_delegation(
+    issuer: &Operator,
+    audience_did: Ed25519Did,
+    subject_did: Ed25519Did,
+) -> Result<UcanDelegation<Ed25519Did>, DelegationError> {
+    create_capability_delegation(issuer, audience_did, subject_did, &["read"]).await
+}
+
+/// Create a read-write delegation
+pub async fn create_read_write_delegation(
+    issuer: &Operator,
+    audience_did: Ed25519Did,
+    subject_did: Ed25519Did,
+) -> Result<UcanDelegation<Ed25519Did>, DelegationError> {
+    create_capability_delegation(issuer, audience_did, subject_did, &["read", "write"]).await
+}
+
+// Implement Serialize/Deserialize by delegating to inner type
+impl Serialize for Delegation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Delegation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let delegation = UcanDelegation::<Ed25519Did>::deserialize(deserializer)?;
+        Ok(Self(delegation))
+    }
+}
+
+impl From<&Delegation> for tonk_space::Delegation {
+    fn from(delegation: &Delegation) -> Self {
+        tonk_space::Delegation::from(delegation.inner().clone())
+    }
+}
+
+/// Inspect a base64-encoded CBOR delegation or a delegation file and print detailed information
+pub fn inspect(input: String) -> Result<()> {
+    println!("🔍 Inspecting delegation...\n");
+
+    // Determine if input is a file path or base64 string
+    let decoded = if std::path::Path::new(&input).exists() {
+        // Read from file
+        println!("📂 Reading from file: {}", input);
+        fs::read(&input).map_err(|e| anyhow::anyhow!("Failed to read file: {}", e))?
+    } else {
+        // Decode base64
+        println!("📥 Decoding base64...");
+        base64::engine::general_purpose::STANDARD
+            .decode(&input)
+            .map_err(|e| anyhow::anyhow!("Failed to decode base64: {}", e))?
+    };
+
+    println!("   ✓ Loaded {} bytes", decoded.len());
+    println!(
+        "   Hex (first 200): {}\n",
+        hex::encode(&decoded[..decoded.len().min(200)])
+    );
+
+    // Try to parse as UCAN delegation
+    println!("🎫 Parsing as UCAN delegation...");
+    match Delegation::from_cbor_bytes(&decoded) {
+        Ok(delegation) => {
+            println!("   ✓ Valid UCAN delegation!\n");
+
+            println!("📋 Delegation Details:");
+            println!("   Issuer:   {}", delegation.issuer());
+            println!("   Audience: {}", delegation.audience());
+            println!("   Command:  {}", delegation.command_str());
+
+            match delegation.subject() {
+                DelegatedSubject::Any => {
+                    println!("   Subject:  * (powerline - any subject)");
+                }
+                DelegatedSubject::Specific(did) => {
+                    println!("   Subject:  {}", did);
+                }
+            }
+
+            if let Some(exp) = delegation.expiration() {
+                let exp_time = chrono::DateTime::from_timestamp(exp, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_else(|| "invalid timestamp".to_string());
+                println!("   Expires:  {} ({})", exp_time, exp);
+            } else {
+                println!("   Expires:  never");
+            }
+
+            if let Some(nbf) = delegation.0.not_before() {
+                let nbf_secs = nbf.to_unix() as i64;
+                let nbf_time = chrono::DateTime::from_timestamp(nbf_secs, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_else(|| "invalid timestamp".to_string());
+                println!("   Not before: {} ({})", nbf_time, nbf_secs);
+            }
+
+            println!("\n✅ Delegation is valid: {}", delegation.is_valid());
+
+            // Check serialization roundtrip
+            println!("\n🔄 Serialization roundtrip test:");
+            match delegation.to_cbor_bytes() {
+                Ok(reserialized) => {
+                    println!("   Original size:    {} bytes", decoded.len());
+                    println!("   Reserialized:     {} bytes", reserialized.len());
+                    if decoded == reserialized {
+                        println!("   ✓ Perfect roundtrip!");
+                    } else {
+                        println!("   ✗ Bytes differ after re-serialization");
+                        println!(
+                            "   Original (first 200):     {}",
+                            hex::encode(&decoded[..decoded.len().min(200)])
+                        );
+                        println!(
+                            "   Reserialized (first 200): {}",
+                            hex::encode(&reserialized[..reserialized.len().min(200)])
+                        );
+
+                        // Find first difference
+                        for (i, (a, b)) in decoded.iter().zip(reserialized.iter()).enumerate() {
+                            if a != b {
+                                println!("   First diff at byte {}: {:02x} -> {:02x}", i, a, b);
+                                break;
+                            }
+                        }
+
+                        // Try to parse the reserialized bytes
+                        println!("\n   🧪 Testing if reserialized bytes can be parsed:");
+                        match Delegation::from_cbor_bytes(&reserialized) {
+                            Ok(_) => {
+                                println!("   ✓ Reserialized bytes CAN be parsed!");
+                            }
+                            Err(e) => {
+                                println!("   ✗ Reserialized bytes CANNOT be parsed!");
+                                println!("   Error: {}", e);
+                            }
+                        }
+
+                        // Save both versions for external analysis
+                        println!("\n   💾 Saving versions for comparison:");
+                        let temp_orig = "/tmp/delegation_original.cbor";
+                        let temp_reser = "/tmp/delegation_reserialized.cbor";
+                        std::fs::write(temp_orig, &decoded).ok();
+                        std::fs::write(temp_reser, &reserialized).ok();
+                        println!("   Original:      {}", temp_orig);
+                        println!("   Reserialized:  {}", temp_reser);
+                        println!("\n   You can analyze with: cbor2diag.rb or similar tools");
+                        println!("   Or compare: xxd {} > /tmp/orig.txt", temp_orig);
+                        println!("              xxd {} > /tmp/reser.txt", temp_reser);
+                        println!("              diff /tmp/orig.txt /tmp/reser.txt")
+                    }
+                }
+                Err(e) => {
+                    println!("   ✗ Re-serialization failed: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("   ✗ Failed to parse as UCAN delegation");
+            println!("   Error: {}\n", e);
+
+            println!("❌ This delegation cannot be parsed by ucan");
+            println!("   This may indicate:");
+            println!("   - Incompatible UCAN library versions");
+            println!("   - Different serialization format");
+            println!("   - Corrupted or invalid data");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_query::Entity;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_delegation_claim_cid_is_valid_uri() {
+        // Create test operators
+        let issuer = crate::crypto::Operator::generate();
+        let audience = crate::crypto::Operator::generate();
+
+        let signer = Ed25519Signer::from(&issuer);
+        let audience_did = audience.did().clone();
+        let subject_did = issuer.did().clone();
+
+        let delegation: UcanDelegation<Ed25519Did> = UcanDelegation::builder()
+            .issuer(signer)
+            .audience(audience_did)
+            .subject(DelegatedSubject::Specific(subject_did))
+            .command(vec!["/".to_string()])
+            .try_build()
+            .await
+            .expect("Failed to build delegation");
+
+        let delegation = Delegation::from_ucan(delegation);
+
+        // Convert to tonk_space::Delegation
+        let space_delegation: tonk_space::Delegation = (&delegation).into();
+
+        // The CID should be a valid URI that Entity::from_str can parse
+        let entity_str = format!("ucan:{}", space_delegation.cid());
+        assert!(
+            entity_str.starts_with("ucan:"),
+            "CID should be formatted as ucan: URI: {}",
+            entity_str
+        );
+
+        // Verify Entity::from_str can parse it
+        let entity = Entity::from_str(&entity_str);
+        assert!(
+            entity.is_ok(),
+            "CID should be parseable as Entity: {}",
+            entity_str
+        );
+    }
+
+    #[test]
+    fn test_plain_hash_is_not_valid_entity() {
+        // This test documents why we need the ucan: prefix.
+        // A plain hash is NOT a valid URI and Entity::from_str will reject it.
+        let plain_hash = "abc123def456";
+        let result = Entity::from_str(plain_hash);
+        assert!(
+            result.is_err(),
+            "Plain hash should NOT be parseable as Entity"
+        );
+
+        // But with ucan: prefix it works
+        let ucan_uri = format!("ucan:{}", plain_hash);
+        let result = Entity::from_str(&ucan_uri);
+        assert!(result.is_ok(), "ucan: URI should be parseable as Entity");
+    }
+}

--- a/rust/tonk-cli/src/delegation.rs
+++ b/rust/tonk-cli/src/delegation.rs
@@ -596,7 +596,7 @@ mod tests {
             .issuer(signer)
             .audience(audience_did)
             .subject(DelegatedSubject::Specific(subject_did))
-            .command(vec!["/".to_string()])
+            .command(vec![]) // Empty = root access "/"
             .try_build()
             .await
             .expect("Failed to build delegation");

--- a/rust/tonk-cli/src/did.rs
+++ b/rust/tonk-cli/src/did.rs
@@ -1,0 +1,166 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use ucan::did::{Did, Ed25519Did};
+use varsig::curve::Edwards25519;
+use varsig::hash::Sha2_512;
+use varsig::signature::eddsa::EdDsa;
+use varsig::verify::Verify;
+
+/// A universal DID type that can be either Ed25519 or mailto.
+/// This allows us to use ucan's Delegation<D> with mixed DID types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UniversalDid {
+    Ed25519(Ed25519Did),
+    Mailto(String), // Just store the email directly
+}
+
+impl UniversalDid {
+    pub fn mailto(email: String) -> Self {
+        UniversalDid::Mailto(email)
+    }
+
+    pub fn ed25519(did: Ed25519Did) -> Self {
+        UniversalDid::Ed25519(did)
+    }
+}
+
+impl Did for UniversalDid {
+    type VarsigConfig = EdDsa<Edwards25519, Sha2_512>;
+
+    fn did_method(&self) -> &str {
+        match self {
+            UniversalDid::Ed25519(did) => did.did_method(),
+            UniversalDid::Mailto(_) => "mailto",
+        }
+    }
+
+    fn varsig_config(&self) -> &Self::VarsigConfig {
+        match self {
+            UniversalDid::Ed25519(did) => did.varsig_config(),
+            UniversalDid::Mailto(_) => {
+                // For mailto, we should never actually use varsig operations
+                // But we need to return something, so panic if this is ever called
+                panic!("Cannot perform cryptographic operations on did:mailto")
+            }
+        }
+    }
+
+    fn verifier(&self) -> <Self::VarsigConfig as Verify>::Verifier {
+        match self {
+            UniversalDid::Ed25519(did) => did.verifier(),
+            UniversalDid::Mailto(_) => {
+                panic!("Cannot perform cryptographic operations on did:mailto")
+            }
+        }
+    }
+}
+
+impl fmt::Display for UniversalDid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UniversalDid::Ed25519(did) => write!(f, "{}", did),
+            UniversalDid::Mailto(email) => write!(f, "did:mailto:{}", email),
+        }
+    }
+}
+
+impl FromStr for UniversalDid {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("did:mailto:") {
+            let email = s
+                .strip_prefix("did:mailto:")
+                .ok_or_else(|| anyhow!("Failed to parse did:mailto"))?
+                .to_string();
+
+            if email.is_empty() {
+                return Err(anyhow!("Email cannot be empty in did:mailto"));
+            }
+
+            Ok(UniversalDid::Mailto(email))
+        } else if s.starts_with("did:key:") {
+            let ed25519_did: Ed25519Did = s
+                .parse()
+                .map_err(|e| anyhow!("Failed to parse did:key: {:?}", e))?;
+            Ok(UniversalDid::Ed25519(ed25519_did))
+        } else {
+            Err(anyhow!(
+                "Unsupported DID method, expected did:key or did:mailto"
+            ))
+        }
+    }
+}
+
+impl Serialize for UniversalDid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for UniversalDid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse()
+            .map_err(|e| serde::de::Error::custom(format!("Unable to parse DID: {}", e)))
+    }
+}
+
+impl From<Ed25519Did> for UniversalDid {
+    fn from(did: Ed25519Did) -> Self {
+        UniversalDid::Ed25519(did)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ucan::did::Did;
+
+    #[test]
+    fn test_universal_did_mailto_creation() {
+        let did = UniversalDid::mailto("user@example.com".to_string());
+        assert_eq!(did.to_string(), "did:mailto:user@example.com");
+        assert_eq!(did.did_method(), "mailto");
+    }
+
+    #[test]
+    fn test_universal_did_mailto_parsing() {
+        let did: UniversalDid = "did:mailto:user@example.com".parse().unwrap();
+        assert_eq!(did.to_string(), "did:mailto:user@example.com");
+        assert_eq!(did.did_method(), "mailto");
+    }
+
+    #[test]
+    fn test_universal_did_invalid() {
+        assert!("not-a-did".parse::<UniversalDid>().is_err());
+        assert!("did:mailto:".parse::<UniversalDid>().is_err());
+    }
+
+    #[test]
+    fn test_universal_did_mailto_serialization() {
+        let did = UniversalDid::mailto("user@example.com".to_string());
+        let json = serde_json::to_string(&did).unwrap();
+        assert_eq!(json, r#""did:mailto:user@example.com""#);
+
+        let deserialized: UniversalDid = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, did);
+    }
+
+    #[test]
+    fn test_universal_did_ed25519_parsing() {
+        // Test that we can still parse did:key
+        let did_str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+        let did: UniversalDid = did_str.parse().unwrap();
+        assert_eq!(did.to_string(), did_str);
+        assert_eq!(did.did_method(), "key");
+    }
+}

--- a/rust/tonk-cli/src/fact.rs
+++ b/rust/tonk-cli/src/fact.rs
@@ -1,0 +1,372 @@
+use crate::authority;
+use crate::crypto::Operator;
+use crate::keystore::Keystore;
+use crate::state;
+use anyhow::{Context, Result};
+use dialog_artifacts::replica::{BranchId, Replica, SigningAuthority};
+use dialog_query::claim::{Attribute, Claim, Relation};
+use dialog_query::{Entity, Session, Value};
+use ed25519_dalek::Signer;
+use futures_util::TryStreamExt;
+use std::path::PathBuf;
+use std::str::FromStr;
+use tonk_space::FsBackend;
+
+/// Resolve an entity identifier to an Entity.
+///
+/// Rules:
+/// - If starts with `~/` - derive by signing path with operator key, then blake3 hash, format as did:key
+/// - If parses as a valid URI (Entity) - use as-is
+/// - Otherwise - blake3 hash the input and format as did:key
+fn resolve_entity(input: &str, operator: &Operator) -> Result<Entity> {
+    if input.starts_with("~/") {
+        // Sign the path with operator key, then hash
+        let path_bytes = input.as_bytes();
+        let signature = operator.signer().sign(path_bytes);
+        let hash = blake3::hash(signature.to_bytes().as_ref());
+        let hash_b58 = bs58::encode(hash.as_bytes()).into_string();
+        let uri = format!("did:key:z{}", hash_b58);
+        Entity::from_str(&uri).context(format!("Failed to create entity from path: {}", input))
+    } else if let Ok(entity) = Entity::from_str(input) {
+        // Valid URI, use as-is
+        Ok(entity)
+    } else {
+        // Hash the input and format as did:key
+        let hash = blake3::hash(input.as_bytes());
+        let hash_b58 = bs58::encode(hash.as_bytes()).into_string();
+        let uri = format!("did:key:z{}", hash_b58);
+        Entity::from_str(&uri).context(format!("Failed to create entity from: {}", input))
+    }
+}
+
+/// Parse a value from string input.
+/// Tries to detect type: numbers or strings.
+fn parse_value(input: &str) -> Value {
+    // Try parsing as integer
+    if let Ok(n) = input.parse::<i128>() {
+        if n >= 0 {
+            return Value::UnsignedInt(n as u128);
+        } else {
+            return Value::SignedInt(n);
+        }
+    }
+
+    // Try parsing as float
+    if let Ok(f) = input.parse::<f64>() {
+        return Value::Float(f);
+    }
+
+    // Default to string
+    Value::String(input.to_string())
+}
+
+/// Get the storage path and space DID for the active space's facts database
+fn get_active_space_storage_path() -> Result<(PathBuf, String)> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    let authority = authority::get_active_authority()?
+        .context("No active authority. Please run 'tonk login' first")?;
+
+    let space_did = state::get_active_space(&authority.did)?
+        .context("No active space. Please run 'tonk space create' or 'tonk space select' first")?;
+
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let path = home
+        .join(".tonk")
+        .join("operator")
+        .join(&operator_did)
+        .join("session")
+        .join(&authority.did)
+        .join("space")
+        .join(&space_did)
+        .join("facts");
+
+    Ok((path, space_did))
+}
+
+/// Assert a fact into the active space
+pub async fn assert(the: String, of: String, is: String) -> Result<()> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+
+    // Resolve entity
+    let entity = resolve_entity(&of, &operator)?;
+
+    // Parse attribute
+    let attribute =
+        Attribute::from_str(&the).context(format!("Invalid attribute format: {}", the))?;
+
+    // Parse value
+    let value = parse_value(&is);
+
+    // Get storage path and create session
+    let (storage_path, space_did) = get_active_space_storage_path()?;
+    let backend = FsBackend::new(&storage_path).await?;
+    let authority = SigningAuthority::from(&operator);
+    let replica = Replica::open(authority, space_did.into(), backend)?;
+
+    let branch_id = BranchId::new("main".to_string());
+    let branch = replica.branches.open(&branch_id).await?;
+
+    let mut session = Session::open(branch);
+
+    // Create and commit the fact
+    let mut transaction = session.edit();
+    let relation = Relation::new(attribute.clone(), entity.clone(), value.clone());
+    relation.assert(&mut transaction);
+    session.commit(transaction).await?;
+
+    println!("✓ Asserted fact:");
+    println!("  the: {}", the);
+    println!("  of:  {} ({})", entity, of);
+    println!("  is:  {:?}", value);
+
+    Ok(())
+}
+
+/// Retract a fact from the active space
+pub async fn retract(the: String, of: String, is: String) -> Result<()> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+
+    // Resolve entity
+    let entity = resolve_entity(&of, &operator)?;
+
+    // Parse attribute
+    let attribute =
+        Attribute::from_str(&the).context(format!("Invalid attribute format: {}", the))?;
+
+    // Parse value
+    let value = parse_value(&is);
+
+    // Get storage path and create session
+    let (storage_path, space_did) = get_active_space_storage_path()?;
+    let backend = FsBackend::new(&storage_path).await?;
+    let authority = SigningAuthority::from(&operator);
+    let replica = Replica::open(authority, space_did.into(), backend)?;
+
+    let branch_id = BranchId::new("main".to_string());
+    let branch = replica.branches.open(&branch_id).await?;
+
+    let mut session = Session::open(branch);
+
+    // Create and commit the retraction
+    let mut transaction = session.edit();
+    let relation = Relation::new(attribute.clone(), entity.clone(), value.clone());
+    relation.retract(&mut transaction);
+    session.commit(transaction).await?;
+
+    println!("✓ Retracted fact:");
+    println!("  the: {}", the);
+    println!("  of:  {} ({})", entity, of);
+    println!("  is:  {:?}", value);
+
+    Ok(())
+}
+
+/// Supported byte format types
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ByteFormat {
+    /// Show as <N bytes>
+    Default,
+    /// Decode as CBOR and pretty-print
+    Cbor,
+    /// Decode as JSON and pretty-print
+    Json,
+    /// Decode as UTF-8 text
+    Text,
+    /// Decode as UCAN delegation
+    Ucan,
+}
+
+impl ByteFormat {
+    fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "cbor" | "application/cbor" => ByteFormat::Cbor,
+            "json" | "application/json" => ByteFormat::Json,
+            "text" | "text/plain" => ByteFormat::Text,
+            "ucan" => ByteFormat::Ucan,
+            _ => ByteFormat::Default,
+        }
+    }
+}
+
+/// Find facts in the active space matching the given criteria
+pub async fn find(
+    the: Option<String>,
+    of: Option<String>,
+    is: Option<String>,
+    format: Option<String>,
+) -> Result<()> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+
+    // Parse format option
+    let byte_format = format
+        .as_ref()
+        .map(|f| ByteFormat::from_str(f))
+        .unwrap_or(ByteFormat::Default);
+
+    // Build the query using Fact::select()
+    let mut fact = dialog_query::Fact::<Value>::select();
+
+    // Set attribute constraint if provided
+    if let Some(the_str) = &the {
+        fact = fact.the(the_str.as_str());
+    }
+
+    // Set entity constraint if provided
+    if let Some(of_str) = &of {
+        let entity = resolve_entity(of_str, &operator)?;
+        fact = fact.of(entity);
+    }
+
+    // Set value constraint if provided
+    if let Some(is_str) = &is {
+        let value = parse_value(is_str);
+        fact = fact.is(value);
+    }
+
+    // Compile the query - this will fail if no constraints provided
+    let application = fact.compile().context(
+        "Failed to compile query. At least one of --the, --of, or --is must be provided",
+    )?;
+
+    // Get storage path and create session
+    let (storage_path, space_did) = get_active_space_storage_path()?;
+    let backend = FsBackend::new(&storage_path).await?;
+    let authority = SigningAuthority::from(&operator);
+    let replica = Replica::open(authority, space_did.into(), backend)?;
+
+    let branch_id = BranchId::new("main".to_string());
+    let branch = replica.branches.open(&branch_id).await?;
+
+    let session = Session::open(branch);
+
+    // Execute the query
+    let results: Vec<dialog_query::Fact<Value>> = application.query(&session).try_collect().await?;
+
+    if results.is_empty() {
+        println!("No facts found matching criteria.");
+        return Ok(());
+    }
+
+    println!("Found {} fact(s):\n", results.len());
+
+    for result in results {
+        // Extract fact fields based on variant
+        let (the_val, of_val, is_val) = match &result {
+            dialog_query::Fact::Assertion { the, of, is, .. } => (
+                the.to_string(),
+                of.to_string(),
+                format_value(is, byte_format),
+            ),
+            dialog_query::Fact::Retraction { the, of, is, .. } => (
+                format!("!{}", the),
+                of.to_string(),
+                format_value(is, byte_format),
+            ),
+        };
+
+        println!("  the: {}", the_val);
+        println!("  of:  {}", of_val);
+        println!("  is:  {}", is_val);
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Format a Value for display
+fn format_value(value: &Value, byte_format: ByteFormat) -> String {
+    match value {
+        Value::String(s) => format!("\"{}\"", s),
+        Value::UnsignedInt(n) => n.to_string(),
+        Value::SignedInt(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bytes(b) => format_bytes(b, byte_format),
+        Value::Entity(e) => e.to_string(),
+        Value::Symbol(s) => format!(":{}", s),
+        Value::Boolean(b) => b.to_string(),
+        Value::Record(r) => format_bytes(r, byte_format),
+    }
+}
+
+/// Format bytes according to the specified format
+fn format_bytes(bytes: &[u8], format: ByteFormat) -> String {
+    match format {
+        ByteFormat::Default => format!("<{} bytes>", bytes.len()),
+        ByteFormat::Text => match String::from_utf8(bytes.to_vec()) {
+            Ok(s) => format!("\"{}\"", s),
+            Err(_) => format!("<{} bytes, invalid UTF-8>", bytes.len()),
+        },
+        ByteFormat::Json => {
+            match String::from_utf8(bytes.to_vec()) {
+                Ok(s) => {
+                    // Try to parse and pretty-print JSON
+                    match serde_json::from_str::<serde_json::Value>(&s) {
+                        Ok(json) => serde_json::to_string_pretty(&json).unwrap_or(s),
+                        Err(_) => format!("<{} bytes, invalid JSON>", bytes.len()),
+                    }
+                }
+                Err(_) => format!("<{} bytes, invalid UTF-8>", bytes.len()),
+            }
+        }
+        ByteFormat::Cbor => {
+            // Try to decode CBOR and display as JSON
+            // First try generic serde_json::Value, then fall back to hex
+            match serde_ipld_dagcbor::from_slice::<serde_json::Value>(bytes) {
+                Ok(value) => {
+                    serde_json::to_string_pretty(&value).unwrap_or_else(|_| format!("{:?}", value))
+                }
+                Err(_) => {
+                    // CBOR with specialized types (like UCANs) can't be decoded to JSON
+                    // Show as hex which can be decoded with external tools
+                    format!("0x{}", hex::encode(bytes))
+                }
+            }
+        }
+        ByteFormat::Ucan => {
+            // Try to decode as UCAN delegation
+            match crate::delegation::Delegation::from_cbor_bytes(bytes) {
+                Ok(delegation) => {
+                    let subject = match delegation.subject() {
+                        ucan::delegation::subject::DelegatedSubject::Specific(did) => {
+                            did.to_string()
+                        }
+                        ucan::delegation::subject::DelegatedSubject::Any => "*".to_string(),
+                    };
+                    let exp = delegation
+                        .expiration()
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "never".to_string());
+                    let cmd = delegation.command().join("/");
+                    let cmd_display = if cmd.is_empty() {
+                        "/".to_string()
+                    } else {
+                        format!("/{}", cmd)
+                    };
+                    format!(
+                        "UCAN {{\n  iss: {},\n  aud: {},\n  sub: {},\n  cmd: {},\n  exp: {}\n}}",
+                        delegation.issuer(),
+                        delegation.audience(),
+                        subject,
+                        cmd_display,
+                        exp
+                    )
+                }
+                Err(_) => format!("<{} bytes, invalid UCAN>", bytes.len()),
+            }
+        }
+    }
+}

--- a/rust/tonk-cli/src/inspect.rs
+++ b/rust/tonk-cli/src/inspect.rs
@@ -1,0 +1,130 @@
+use anyhow::{Context, Result};
+use base64::Engine;
+use std::fs;
+use std::path::Path;
+
+/// Remove a field from a CBOR file
+pub fn remove_field(file_path: &str, field_name: &str) -> Result<()> {
+    let data = fs::read(file_path).context(format!("Failed to read file: {}", file_path))?;
+
+    // Decode CBOR
+    let mut value: ciborium::Value =
+        ciborium::from_reader(&data[..]).context("Failed to decode CBOR")?;
+
+    // Remove field
+    if let ciborium::Value::Map(ref mut map) = value {
+        let original_len = map.len();
+        map.retain(|(k, _)| {
+            if let ciborium::Value::Text(key) = k {
+                key != field_name
+            } else {
+                true
+            }
+        });
+
+        if map.len() < original_len {
+            // Write back
+            let mut output = Vec::new();
+            ciborium::into_writer(&value, &mut output).context("Failed to encode CBOR")?;
+            fs::write(file_path, output).context("Failed to write file")?;
+            println!("Removed '{}' field and saved file", field_name);
+        } else {
+            println!("No '{}' field found", field_name);
+        }
+    } else {
+        anyhow::bail!("CBOR root is not a map");
+    }
+
+    Ok(())
+}
+
+/// Inspect CBOR data and display as JSON
+pub fn cbor(input: String) -> Result<()> {
+    let bytes = if Path::new(&input).exists() {
+        // Read from file
+        fs::read(&input).context(format!("Failed to read file: {}", input))?
+    } else {
+        // Try to decode as base64
+        base64::engine::general_purpose::STANDARD
+            .decode(&input)
+            .or_else(|_| {
+                // Try URL-safe base64
+                base64::engine::general_purpose::URL_SAFE.decode(&input)
+            })
+            .or_else(|_| {
+                // Try base64 without padding
+                base64::engine::general_purpose::STANDARD_NO_PAD.decode(&input)
+            })
+            .context("Input is not a valid file path or base64-encoded data")?
+    };
+
+    // Decode CBOR to a generic value
+    let value: ciborium::Value =
+        ciborium::from_reader(&bytes[..]).context("Failed to decode CBOR data")?;
+
+    // Convert to JSON
+    let json = cbor_value_to_json(&value);
+
+    // Pretty print
+    let output = serde_json::to_string_pretty(&json).context("Failed to serialize to JSON")?;
+
+    println!("{}", output);
+
+    Ok(())
+}
+
+/// Convert a CBOR value to a JSON value
+fn cbor_value_to_json(value: &ciborium::Value) -> serde_json::Value {
+    use ciborium::Value;
+    use serde_json::json;
+
+    match value {
+        Value::Integer(i) => {
+            // Try to convert to i64 or u64
+            let n: i128 = (*i).into();
+            if n >= 0 && n <= u64::MAX as i128 {
+                json!(n as u64)
+            } else if n >= i64::MIN as i128 && n <= i64::MAX as i128 {
+                json!(n as i64)
+            } else {
+                // Fall back to string for very large integers
+                json!(n.to_string())
+            }
+        }
+        Value::Bytes(b) => {
+            // Try to decode as UTF-8 string, otherwise hex encode
+            if let Ok(s) = std::str::from_utf8(b) {
+                json!({ "__bytes_utf8": s })
+            } else {
+                json!({ "__bytes_hex": hex::encode(b) })
+            }
+        }
+        Value::Float(f) => json!(f),
+        Value::Text(s) => json!(s),
+        Value::Bool(b) => json!(b),
+        Value::Null => serde_json::Value::Null,
+        Value::Tag(tag, inner) => {
+            json!({
+                "__tag": tag,
+                "value": cbor_value_to_json(inner)
+            })
+        }
+        Value::Array(arr) => serde_json::Value::Array(arr.iter().map(cbor_value_to_json).collect()),
+        Value::Map(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                let key = match k {
+                    Value::Text(s) => s.clone(),
+                    Value::Integer(i) => {
+                        let n: i128 = (*i).into();
+                        n.to_string()
+                    }
+                    _ => format!("{:?}", k),
+                };
+                obj.insert(key, cbor_value_to_json(v));
+            }
+            serde_json::Value::Object(obj)
+        }
+        _ => json!(format!("{:?}", value)),
+    }
+}

--- a/rust/tonk-cli/src/keystore.rs
+++ b/rust/tonk-cli/src/keystore.rs
@@ -1,0 +1,130 @@
+use crate::crypto::Operator;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use keyring::Entry;
+use thiserror::Error;
+
+const SERVICE_NAME: &str = "tonk-cli";
+const KEY_NAME: &str = "operator-keypair";
+
+#[derive(Error, Debug)]
+pub enum KeystoreError {
+    #[error("Failed to access keyring: {0}")]
+    KeyringError(#[from] keyring::Error),
+
+    #[error("Invalid key data: {0}")]
+    InvalidKeyData(String),
+}
+
+pub struct Keystore {
+    entry: Entry,
+}
+
+impl Keystore {
+    /// Create a new keystore instance
+    pub fn new() -> Result<Self, KeystoreError> {
+        let entry = Entry::new(SERVICE_NAME, KEY_NAME)?;
+        Ok(Self { entry })
+    }
+
+    /// Get or create an operator from the keystore
+    /// If TONK_OPERATOR_KEY env var is set, uses that key (base58btc encoded)
+    /// Otherwise uses OS keyring
+    pub fn get_or_create_keypair(&self) -> Result<Operator, KeystoreError> {
+        // Check for TONK_OPERATOR_KEY environment variable first
+        if let Ok(operator_key) = std::env::var("TONK_OPERATOR_KEY") {
+            return self.operator_from_env_key(&operator_key);
+        }
+
+        // Fall back to OS keyring
+        match self.get_operator() {
+            Ok(operator) => Ok(operator),
+            Err(KeystoreError::KeyringError(keyring::Error::NoEntry)) => {
+                let operator = Operator::generate();
+                self.store_operator(&operator)?;
+                Ok(operator)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Load operator from base58btc-encoded key in TONK_OPERATOR_KEY
+    fn operator_from_env_key(&self, key_b58: &str) -> Result<Operator, KeystoreError> {
+        let key_bytes = bs58::decode(key_b58)
+            .into_vec()
+            .map_err(|e| KeystoreError::InvalidKeyData(format!("Invalid base58btc key: {}", e)))?;
+
+        if key_bytes.len() != 32 {
+            return Err(KeystoreError::InvalidKeyData(format!(
+                "TONK_OPERATOR_KEY must be 32 bytes, got {}",
+                key_bytes.len()
+            )));
+        }
+
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&key_bytes);
+
+        Ok(Operator::from_secret(bytes))
+    }
+
+    /// Get an existing operator from the keystore
+    fn get_operator(&self) -> Result<Operator, KeystoreError> {
+        let password = self.entry.get_password()?;
+        let bytes = STANDARD
+            .decode(&password)
+            .map_err(|e| KeystoreError::InvalidKeyData(e.to_string()))?;
+
+        if bytes.len() != 32 {
+            return Err(KeystoreError::InvalidKeyData(format!(
+                "Expected 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+
+        let mut key_bytes = [0u8; 32];
+        key_bytes.copy_from_slice(&bytes);
+
+        Ok(Operator::from_secret(key_bytes))
+    }
+
+    /// Store an operator in the keystore
+    fn store_operator(&self, operator: &Operator) -> Result<(), KeystoreError> {
+        let bytes = operator.to_secret();
+        let encoded = STANDARD.encode(bytes);
+        self.entry.set_password(&encoded)?;
+        Ok(())
+    }
+
+    /// Delete the stored operator (for logout/reset)
+    #[allow(dead_code)]
+    pub fn delete_keypair(&self) -> Result<(), KeystoreError> {
+        self.entry.delete_credential()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore] // Requires actual keyring access
+    fn test_keystore_roundtrip() {
+        let keystore = Keystore::new().unwrap();
+
+        // Clean up any existing key
+        let _ = keystore.delete_keypair();
+
+        // First call should generate a new operator
+        let op1 = keystore.get_or_create_keypair().unwrap();
+        let did1 = op1.did().to_string();
+
+        // Second call should retrieve the same operator
+        let op2 = keystore.get_or_create_keypair().unwrap();
+        let did2 = op2.did().to_string();
+
+        assert_eq!(did1, did2);
+
+        // Cleanup
+        keystore.delete_keypair().unwrap();
+    }
+}

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod authority;
+pub mod crypto;
+pub mod delegation;
+pub mod did;
+pub mod fact;
+pub mod inspect;
+pub mod keystore;
+pub mod login;
+pub mod metadata;
+pub mod operator;
+pub mod remote;
+pub mod session;
+pub mod space;
+pub mod state;
+pub mod util;

--- a/rust/tonk-cli/src/login.rs
+++ b/rust/tonk-cli/src/login.rs
@@ -1,0 +1,293 @@
+use crate::delegation::{Delegation, DelegationMetadata};
+use crate::keystore::Keystore;
+use anyhow::{Context, Result};
+use axum::{
+    Router,
+    extract::{Form, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+    routing::{get, post},
+};
+use base64::Engine as _;
+use serde::Deserialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+const AUTH_HTML: &str = include_str!("../auth.html");
+
+#[derive(Deserialize)]
+struct CallbackForm {
+    #[serde(default)]
+    authorize: Option<String>,
+    #[serde(default)]
+    deny: Option<String>,
+}
+
+#[derive(Clone)]
+struct AppState {
+    shutdown: Arc<Notify>,
+    operator_did: Arc<String>,
+    auth_url: Arc<String>,
+}
+
+/// Execute the login flow
+pub async fn execute(via: Option<String>) -> Result<()> {
+    println!("🔐 Login...\n");
+
+    // Get or create operator keypair
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+
+    // Generate operator DID
+    let operator_did = operator.did().to_string();
+    println!("🫆 Operator: {}\n", operator_did);
+
+    // Find available port for callback server
+    let callback_port = find_available_port(8089)?;
+    let callback_url = format!("http://localhost:{}", callback_port);
+
+    // Build auth URL and determine auth site URL
+    let (auth_url, auth_site_url) = match &via {
+        Some(base_url) => {
+            // Use provided auth URL
+            let url = format!(
+                "{}?as={}&cmd=/&sub=*&callback={}",
+                base_url, operator_did, callback_url
+            );
+            (url, base_url.clone())
+        }
+        None => {
+            // Start local auth server
+            let auth_port = find_available_port(8088)?;
+            let auth_addr = SocketAddr::from(([127, 0, 0, 1], auth_port));
+
+            println!("🌐 Starting local auth server on {}...", auth_addr);
+            tokio::spawn(async move {
+                let app = Router::new().route("/", get(serve_auth_html));
+                let listener = tokio::net::TcpListener::bind(auth_addr)
+                    .await
+                    .expect("Failed to bind auth server");
+                axum::serve(listener, app)
+                    .await
+                    .expect("Auth server failed");
+            });
+
+            let url = format!(
+                "http://localhost:{}?as={}&cmd=/&sub=*&callback={}",
+                auth_port, operator_did, callback_url
+            );
+            let site = format!("http://localhost:{}", auth_port);
+            (url, site)
+        }
+    };
+
+    // Start callback server
+    let shutdown_signal = Arc::new(Notify::new());
+    let state = AppState {
+        shutdown: shutdown_signal.clone(),
+        operator_did: Arc::new(operator_did.clone()),
+        auth_url: Arc::new(auth_site_url.clone()),
+    };
+
+    let callback_addr = SocketAddr::from(([127, 0, 0, 1], callback_port));
+    println!("📞 Starting callback server on {}...\n", callback_addr);
+
+    let app = Router::new()
+        .route("/", post(handle_callback))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(callback_addr)
+        .await
+        .context("Failed to bind callback server")?;
+
+    // Open browser
+    println!("🌐 Opening browser for authentication...");
+    println!("   URL: {}\n", auth_url);
+
+    if let Err(e) = webbrowser::open(&auth_url) {
+        println!("⚠ Failed to open browser automatically: {}", e);
+        println!("   Please open this URL manually: {}", auth_url);
+    }
+
+    // Serve callback endpoint with graceful shutdown
+    println!("⏳ Waiting for authorization (timeout: 5 minutes)...\n");
+
+    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+        shutdown_signal.notified().await;
+    });
+
+    // Run server with timeout
+    let result = tokio::time::timeout(std::time::Duration::from_secs(300), server).await;
+
+    match result {
+        Ok(Ok(_)) => {
+            println!("\n✅ Login complete!");
+        }
+        Ok(Err(e)) => {
+            anyhow::bail!("Server error: {}", e);
+        }
+        Err(_) => {
+            anyhow::bail!("Timeout waiting for authorization");
+        }
+    }
+
+    Ok(())
+}
+
+async fn serve_auth_html() -> Html<&'static str> {
+    Html(AUTH_HTML)
+}
+
+async fn handle_callback(
+    State(state): State<AppState>,
+    Form(form): Form<CallbackForm>,
+) -> impl IntoResponse {
+    if let Some(deny) = form.deny {
+        println!("❌ Authorization denied: {}", deny);
+        state.shutdown.notify_one();
+        return (
+            StatusCode::OK,
+            Html(
+                "<html><body><h1>Authorization Denied</h1><p>You can close this window.</p></body></html>",
+            ),
+        );
+    }
+
+    if let Some(authorize) = form.authorize {
+        // Decode base64-encoded UCAN
+        let decoded = match base64::engine::general_purpose::STANDARD.decode(&authorize) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                println!("❌ Failed to decode base64: {}", e);
+                state.shutdown.notify_one();
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Html("<html><body><h1>Error</h1><p>Invalid base64 encoding.</p></body></html>"),
+                );
+            }
+        };
+
+        // Parse DAG-CBOR encoded UCAN
+        match Delegation::from_cbor_bytes(&decoded) {
+            Ok(delegation) => {
+                println!("✅ Received delegation!");
+                println!("   Issuer: {}", delegation.issuer());
+                println!("   Audience: {}", delegation.audience());
+                println!("   Command: {}", delegation.command_str());
+
+                // Validate audience matches operator DID
+                if delegation.audience() != state.operator_did.as_str() {
+                    println!("❌ Delegation audience mismatch!");
+                    println!("   Expected: {}", state.operator_did);
+                    println!("   Got: {}", delegation.audience());
+                    state.shutdown.notify_one();
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Html(
+                            "<html><body><h1>Error</h1><p>Delegation audience mismatch.</p></body></html>",
+                        ),
+                    );
+                }
+
+                // Validate not expired
+                if !delegation.is_valid() {
+                    println!("❌ Delegation is already expired!");
+                    state.shutdown.notify_one();
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Html(
+                            "<html><body><h1>Error</h1><p>Delegation is expired.</p></body></html>",
+                        ),
+                    );
+                }
+
+                // Create metadata
+                let metadata = DelegationMetadata {
+                    site: state.auth_url.to_string(),
+                    received_at: chrono::Utc::now(),
+                    is_local: state.auth_url.starts_with("http://localhost")
+                        || state.auth_url.starts_with("http://127.0.0.1"),
+                    extra: serde_json::Value::Null,
+                };
+
+                // Save delegation with metadata using raw bytes to preserve exact format
+                if let Err(e) = delegation.save_raw_with_metadata(&decoded, &metadata) {
+                    println!("⚠ Failed to save delegation: {}", e);
+                    state.shutdown.notify_one();
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Html(
+                            "<html><body><h1>Error</h1><p>Failed to save delegation.</p></body></html>",
+                        ),
+                    );
+                }
+
+                // Create and save session metadata
+                let authority_did = delegation.issuer();
+                let session_meta = crate::metadata::SessionMetadata::new(
+                    authority_did.clone(),
+                    state.auth_url.to_string(),
+                );
+                if let Err(e) = session_meta.save(&authority_did) {
+                    println!("⚠ Failed to save session metadata: {}", e);
+                }
+
+                // Set as active session
+                if let Err(e) = crate::state::set_active_session(&authority_did) {
+                    println!("⚠ Failed to set active session: {}", e);
+                }
+
+                // Trigger shutdown
+                state.shutdown.notify_one();
+
+                (
+                    StatusCode::OK,
+                    Html(
+                        "<html><body><h1>✅ Authorization Successful!</h1><p>You can close this window and return to the CLI.</p></body></html>",
+                    ),
+                )
+            }
+            Err(e) => {
+                println!("❌ Failed to parse delegation: {}", e);
+                state.shutdown.notify_one();
+                (
+                    StatusCode::BAD_REQUEST,
+                    Html(
+                        "<html><body><h1>Error</h1><p>Failed to parse delegation.</p></body></html>",
+                    ),
+                )
+            }
+        }
+    } else {
+        state.shutdown.notify_one();
+        (
+            StatusCode::BAD_REQUEST,
+            Html(
+                "<html><body><h1>Error</h1><p>No authorization or denial received.</p></body></html>",
+            ),
+        )
+    }
+}
+
+fn find_available_port(preferred: u16) -> Result<u16> {
+    // Try preferred port first
+    if port_is_available(preferred) {
+        return Ok(preferred);
+    }
+
+    // Find any available port
+    for port in 8000..9000 {
+        if port_is_available(port) {
+            return Ok(port);
+        }
+    }
+
+    anyhow::bail!("No available ports found")
+}
+
+fn port_is_available(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}

--- a/rust/tonk-cli/src/metadata.rs
+++ b/rust/tonk-cli/src/metadata.rs
@@ -1,0 +1,132 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// Get the .tonk directory path
+fn tonk_dir() -> Result<PathBuf> {
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".tonk"))
+}
+
+/// Session metadata stored in ~/.tonk/meta/{authority-did}/session.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadata {
+    /// Display name (defaults to DID)
+    pub name: String,
+
+    /// Authentication service used (e.g., "https://auth.tonk.xyz" or "local")
+    pub via: String,
+
+    /// ISO 8601 timestamp when session was created
+    pub created_at: String,
+}
+
+impl SessionMetadata {
+    /// Create new session metadata
+    pub fn new(name: String, via: String) -> Self {
+        let created_at = chrono::Utc::now().to_rfc3339();
+        Self {
+            name,
+            via,
+            created_at,
+        }
+    }
+
+    /// Load session metadata from ~/.tonk/meta/{authority-did}/session.json
+    pub fn load(authority_did: &str) -> Result<Option<Self>> {
+        let meta_file = tonk_dir()?
+            .join("meta")
+            .join(authority_did)
+            .join("session.json");
+
+        if !meta_file.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&meta_file).context("Failed to read session metadata")?;
+
+        let metadata: SessionMetadata =
+            serde_json::from_str(&content).context("Failed to parse session metadata")?;
+
+        Ok(Some(metadata))
+    }
+
+    /// Save session metadata to ~/.tonk/meta/{authority-did}/session.json
+    pub fn save(&self, authority_did: &str) -> Result<()> {
+        let meta_dir = tonk_dir()?.join("meta").join(authority_did);
+        fs::create_dir_all(&meta_dir)?;
+
+        let meta_file = meta_dir.join("session.json");
+        let json = serde_json::to_string_pretty(self)?;
+
+        fs::write(&meta_file, json).context("Failed to write session metadata")?;
+
+        Ok(())
+    }
+}
+
+/// Space metadata stored in ~/.tonk/meta/{space-did}/space.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpaceMetadata {
+    /// Display name for the space
+    pub name: String,
+
+    /// ISO 8601 timestamp when space was created
+    pub created_at: String,
+
+    /// DIDs of space owners
+    pub owners: Vec<String>,
+}
+
+impl SpaceMetadata {
+    /// Create new space metadata
+    pub fn new(name: String, owners: Vec<String>) -> Self {
+        let created_at = chrono::Utc::now().to_rfc3339();
+        Self {
+            name,
+            created_at,
+            owners,
+        }
+    }
+
+    /// Load space metadata from ~/.tonk/meta/{space-did}/space.json
+    pub fn load(space_did: &str) -> Result<Option<Self>> {
+        let meta_file = tonk_dir()?.join("meta").join(space_did).join("space.json");
+
+        if !meta_file.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&meta_file).context("Failed to read space metadata")?;
+
+        let metadata: SpaceMetadata =
+            serde_json::from_str(&content).context("Failed to parse space metadata")?;
+
+        Ok(Some(metadata))
+    }
+
+    /// Save space metadata to ~/.tonk/meta/{space-did}/space.json
+    pub fn save(&self, space_did: &str) -> Result<()> {
+        let meta_dir = tonk_dir()?.join("meta").join(space_did);
+        fs::create_dir_all(&meta_dir)?;
+
+        let meta_file = meta_dir.join("space.json");
+        let json = serde_json::to_string_pretty(self)?;
+
+        fs::write(&meta_file, json).context("Failed to write space metadata")?;
+
+        Ok(())
+    }
+
+    /// Delete space metadata from ~/.tonk/meta/{space-did}/
+    pub fn delete(space_did: &str) -> Result<()> {
+        let meta_dir = tonk_dir()?.join("meta").join(space_did);
+
+        if meta_dir.exists() {
+            fs::remove_dir_all(&meta_dir).context("Failed to delete space metadata directory")?;
+        }
+
+        Ok(())
+    }
+}

--- a/rust/tonk-cli/src/operator.rs
+++ b/rust/tonk-cli/src/operator.rs
@@ -1,0 +1,18 @@
+use crate::crypto::Operator;
+use anyhow::Result;
+
+/// Generate a new operator key
+pub fn generate() -> Result<()> {
+    let operator = Operator::generate();
+    let key_bytes = operator.to_secret();
+    let key_b58 = bs58::encode(&key_bytes).into_string();
+    let did = operator.did().to_string();
+
+    println!("Generated new operator key:\n");
+    println!("{}", did);
+    println!("{}", key_b58);
+    println!("\nTo use this operator:");
+    println!("  export TONK_OPERATOR_KEY={}", key_b58);
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result, bail};
+use dialog_artifacts::replica::RemoteCredentials;
+use dialog_s3_credentials::{Address, s3};
+use dialoguer::{Input, Password};
+use std::path::PathBuf;
+use tonk_space::{FsBackend, Operator, Revision, Space};
+
+use crate::authority;
+use crate::keystore::Keystore;
+use crate::state;
+
+/// Get the storage path for the active space's facts database
+fn get_active_space_info() -> Result<(String, PathBuf, Operator)> {
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    let authority = authority::get_active_authority()?
+        .context("No active authority. Please run 'tonk login' first")?;
+
+    let space_did = state::get_active_space(&authority.did)?
+        .context("No active space. Please run 'tonk space create' or 'tonk space set' first")?;
+
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let path = home
+        .join(".tonk")
+        .join("operator")
+        .join(&operator_did)
+        .join("session")
+        .join(&authority.did)
+        .join("space")
+        .join(&space_did)
+        .join("facts");
+
+    Ok((space_did, path, operator))
+}
+
+/// Add a remote to the active space
+pub async fn add(
+    name: String,
+    endpoint: Option<String>,
+    bucket: Option<String>,
+    region: Option<String>,
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+) -> Result<()> {
+    // Get active space info
+    let (space_did, storage_path, operator) = get_active_space_info()?;
+
+    // Prompt for missing values
+    let endpoint = match endpoint {
+        Some(e) => e,
+        None => Input::new()
+            .with_prompt("Endpoint (e.g., https://s3.amazonaws.com)")
+            .interact_text()?,
+    };
+
+    let bucket = match bucket {
+        Some(b) => b,
+        None => Input::new().with_prompt("Bucket name").interact_text()?,
+    };
+
+    let region = match region {
+        Some(r) => r,
+        None => Input::new()
+            .with_prompt("Region")
+            .default("us-east-1".to_string())
+            .interact_text()?,
+    };
+
+    let access_key_id = match access_key_id {
+        Some(k) => k,
+        None => Input::new().with_prompt("Access Key ID").interact_text()?,
+    };
+
+    let secret_access_key = match secret_access_key {
+        Some(s) => s,
+        None => Password::new()
+            .with_prompt("Secret Access Key")
+            .interact()?,
+    };
+
+    // Create S3 credentials
+    let address = Address::new(&endpoint, &region, &bucket);
+    let s3_credentials = s3::Credentials::private(address, access_key_id, secret_access_key)
+        .context("Failed to create S3 credentials")?;
+
+    // Create remote state
+    let remote_state = tonk_space::RemoteState {
+        site: name.clone(),
+        credentials: RemoteCredentials::S3(s3_credentials),
+    };
+
+    // Open the space and add remote
+    let backend = FsBackend::new(&storage_path).await?;
+    let mut space = Space::open(space_did.clone(), &operator, backend).await?;
+    let site = space.add_remote(remote_state).await?;
+
+    // Set the new remote as upstream
+    space.set_upstream(&site).await?;
+
+    println!("Remote '{}' added to space", name);
+    println!("Key prefix: {}", space_did);
+
+    Ok(())
+}
+
+/// Format a revision for display
+fn format_revision(rev: &Revision) -> String {
+    format!("{}:{}", rev.period, rev.moment)
+}
+
+/// Open the active space
+async fn open_active_space() -> Result<Space<FsBackend>> {
+    let (space_did, storage_path, operator) = get_active_space_info()?;
+
+    let backend = FsBackend::new(&storage_path).await?;
+    let space = Space::open(space_did, &operator, backend).await?;
+    Ok(space)
+}
+
+/// Pull changes from the upstream remote
+pub async fn pull() -> Result<()> {
+    let mut space = open_active_space().await?;
+
+    let before = space.revision().await;
+    println!("Current revision: {}", format_revision(&before));
+
+    match space.pull().await {
+        Ok(Some(_old_upstream)) => {
+            let after = space.revision().await;
+            println!(
+                "Pulled changes: {} -> {}",
+                format_revision(&before),
+                format_revision(&after)
+            );
+        }
+        Ok(None) => {
+            println!("Already up to date");
+        }
+        Err(e) => {
+            bail!("Pull failed: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Push local changes to the upstream remote
+pub async fn push() -> Result<()> {
+    let mut space = open_active_space().await?;
+
+    let before = space.revision().await;
+    println!("Current revision: {}", format_revision(&before));
+
+    match space.push().await {
+        Ok(Some(old_upstream)) => {
+            println!(
+                "Pushed changes: remote {} -> {}",
+                format_revision(&old_upstream),
+                format_revision(&before)
+            );
+        }
+        Ok(None) => {
+            println!("Nothing to push (already in sync)");
+        }
+        Err(e) => {
+            bail!("Push failed: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Sync with upstream (pull then push)
+pub async fn sync() -> Result<()> {
+    let mut space = open_active_space().await?;
+
+    let before = space.revision().await;
+    println!("Current revision: {}", format_revision(&before));
+
+    // Pull first
+    match space.pull().await {
+        Ok(Some(_)) => {
+            let after_pull = space.revision().await;
+            println!(
+                "Pulled: {} -> {}",
+                format_revision(&before),
+                format_revision(&after_pull)
+            );
+        }
+        Ok(None) => {
+            println!("Pull: already up to date");
+        }
+        Err(e) => {
+            bail!("Pull failed: {}", e);
+        }
+    }
+
+    // Then push
+    let current = space.revision().await;
+    match space.push().await {
+        Ok(Some(old_upstream)) => {
+            println!(
+                "Pushed: remote {} -> {}",
+                format_revision(&old_upstream),
+                format_revision(&current)
+            );
+        }
+        Ok(None) => {
+            println!("Push: nothing to push");
+        }
+        Err(e) => {
+            bail!("Push failed: {}", e);
+        }
+    }
+
+    let final_rev = space.revision().await;
+    println!("Final revision: {}", format_revision(&final_rev));
+
+    Ok(())
+}
+
+/// Show upstream remote information
+pub async fn show() -> Result<()> {
+    let space = open_active_space().await?;
+
+    match space.upstream_info().await {
+        Some((site, branch_id)) => {
+            println!("Upstream configured:");
+            println!("  Site:     {}", site);
+            println!("  Branch:   {}", branch_id);
+        }
+        None => {
+            println!("No upstream configured");
+            println!("Use 'tonk remote add <name>' to add a remote");
+        }
+    }
+
+    Ok(())
+}
+
+/// Remove the upstream remote (not yet implemented)
+pub async fn delete() -> Result<()> {
+    let space = open_active_space().await?;
+
+    if space.has_upstream().await {
+        bail!(
+            "Remote deletion is not yet supported by the underlying storage layer.\nPlease recreate the space without a remote if you need to remove it."
+        );
+    } else {
+        println!("No upstream configured - nothing to delete");
+    }
+
+    Ok(())
+}
+
+/// Edit the upstream remote configuration (not yet implemented)
+pub async fn edit() -> Result<()> {
+    let space = open_active_space().await?;
+
+    if space.has_upstream().await {
+        bail!(
+            "Remote editing is not yet supported.\nTo change remote configuration, you would need to delete and re-add the remote.\nHowever, remote deletion is also not yet supported by the underlying storage layer."
+        );
+    } else {
+        println!("No upstream configured - nothing to edit");
+        println!("Use 'tonk remote add <name>' to add a remote");
+    }
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -1,9 +1,11 @@
 use anyhow::{Context, Result, bail};
 use dialog_artifacts::replica::RemoteCredentials;
+use dialog_s3_credentials::ucan::{Credentials as UcanCredentials, DelegationChain};
 use dialog_s3_credentials::{Address, s3};
 use dialoguer::{Input, Password};
 use std::path::PathBuf;
 use tonk_space::{FsBackend, Operator, Revision, Space};
+use ucan::delegation::subject::DelegatedSubject;
 
 use crate::authority;
 use crate::keystore::Keystore;
@@ -40,6 +42,7 @@ fn get_active_space_info() -> Result<(String, PathBuf, Operator)> {
 /// Add a remote to the active space
 pub async fn add(
     name: String,
+    service_url: Option<String>,
     endpoint: Option<String>,
     bucket: Option<String>,
     region: Option<String>,
@@ -48,6 +51,48 @@ pub async fn add(
 ) -> Result<()> {
     // Get active space info
     let (space_did, storage_path, operator) = get_active_space_info()?;
+
+    // UCAN credential path: use access service instead of raw S3 credentials
+    if let Some(service_url) = service_url {
+        let backend = FsBackend::new(&storage_path).await?;
+        let mut space = Space::open(space_did.clone(), &operator, backend).await?;
+
+        // Find a delegation for this operator + space from the space database
+        let operator_did = operator.did().to_string();
+        let delegations = space
+            .delegations_for_audience(&operator_did)
+            .await
+            .context("Failed to query delegations for operator")?;
+
+        let delegation = delegations
+            .into_iter()
+            .find(|d| match d.subject() {
+                DelegatedSubject::Specific(did) => did.to_string() == space_did,
+                DelegatedSubject::Any => true,
+            })
+            .context(
+                "No delegation found for this space. \
+                 Ensure the space has delegated access to your operator.",
+            )?;
+
+        // Build UCAN credentials (mirrors tonk-worker/src/router/authorize.rs)
+        let delegation_chain = DelegationChain::new(delegation.inner().clone());
+        let ucan_credentials = UcanCredentials::new(service_url, delegation_chain);
+
+        let remote_state = tonk_space::RemoteState {
+            site: name.clone(),
+            credentials: RemoteCredentials::Ucan(ucan_credentials),
+        };
+
+        let site = space.add_remote(remote_state).await?;
+        space.set_upstream(&site).await?;
+
+        println!("Remote '{}' added to space (UCAN)", name);
+        println!("Key prefix: {}", space_did);
+        return Ok(());
+    }
+
+    // S3 credential path (existing behavior)
 
     // Prompt for missing values
     let endpoint = match endpoint {

--- a/rust/tonk-cli/src/session.rs
+++ b/rust/tonk-cli/src/session.rs
@@ -1,0 +1,678 @@
+use crate::authority;
+use crate::delegation::Delegation;
+use crate::keystore::Keystore;
+use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use ucan::delegation::subject::DelegatedSubject;
+
+/// Format time remaining until expiration
+fn format_time_remaining(exp: i64) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let remaining = exp - now;
+
+    if remaining < 0 {
+        return "EXPIRED".to_string();
+    }
+
+    if remaining == i64::MAX - now {
+        return "never".to_string();
+    }
+
+    let days = remaining / 86400;
+    let hours = (remaining % 86400) / 3600;
+    let mins = (remaining % 3600) / 60;
+
+    if days > 365 {
+        "never".to_string()
+    } else if days > 0 {
+        format!("{}d {}h", days, hours)
+    } else if hours > 0 {
+        format!("{}h {}m", hours, mins)
+    } else {
+        format!("{}m", mins)
+    }
+}
+
+/// Represents a space with its accessible commands
+#[derive(Debug, Clone)]
+pub struct SpaceAccess {
+    pub space_did: String,
+    pub commands: Vec<(String, i64)>, // (command, expiration)
+    pub is_auth_space: bool, // True if this is the authority's own DID (authorization space)
+    pub authorization_chains: HashMap<String, Vec<Delegation>>, // (command -> delegation chain to operator)
+}
+
+/// Get the active authority from the list based on state
+pub fn get_active_authority_from_list(
+    authorities: &[authority::Authority],
+) -> Result<authority::Authority> {
+    let active_did = crate::state::get_active_session()?;
+
+    if let Some(active_did) = active_did {
+        // Try to find the active authority
+        if let Some(auth) = authorities.iter().find(|a| a.did == active_did) {
+            return Ok(auth.clone());
+        }
+    }
+
+    // Default to first authority if no active one is set or not found
+    Ok(authorities[0].clone())
+}
+
+/// Show the current session DID
+pub async fn show_current() -> Result<()> {
+    let authorities = authority::get_authorities()?;
+
+    if authorities.is_empty() {
+        println!("🚏 No active sessions found");
+        println!("👤 Run 'tonk login' to create an authorization session\n");
+        return Ok(());
+    }
+
+    let active_authority = get_active_authority_from_list(&authorities)?;
+    println!("{}", active_authority.did);
+
+    Ok(())
+}
+
+/// Switch to a different session
+pub async fn set(authority_did: String) -> Result<()> {
+    let authorities = authority::get_authorities()?;
+
+    // Find the authority in the list
+    if !authorities.iter().any(|a| a.did == authority_did) {
+        anyhow::bail!(
+            "Authority not found: {}\n   Run 'tonk session' to see available sessions",
+            authority_did
+        );
+    }
+
+    // Set active session
+    crate::state::set_active_session(&authority_did)?;
+
+    println!("✅ Switched to session: {}", authority_did);
+
+    // Restore active space for this session (if any)
+    if let Some(active_space) = crate::state::get_active_space(&authority_did)? {
+        println!("   Active space: {}", active_space);
+    }
+
+    Ok(())
+}
+
+/// List all available sessions
+pub async fn list(verbose: bool) -> Result<()> {
+    // Get operator DID
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    // Get all available authorities/sessions
+    let authorities = authority::get_authorities()?;
+
+    if authorities.is_empty() {
+        println!("🫆 Operator: {}\n", operator_did);
+        println!("🚏 No active sessions found");
+        println!("👤 Run 'tonk login' to create an authorization session\n");
+        return Ok(());
+    }
+
+    // Get active authority
+    let active_authority = get_active_authority_from_list(&authorities)?;
+
+    // Get home directory for chain building
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+
+    // Sort authorities to show active one first
+    let mut sorted_authorities = authorities.clone();
+    sorted_authorities.sort_by(|a, b| {
+        if a.did == active_authority.did {
+            std::cmp::Ordering::Less
+        } else if b.did == active_authority.did {
+            std::cmp::Ordering::Greater
+        } else {
+            a.did.cmp(&b.did)
+        }
+    });
+
+    // Display each session as a separate block
+    for auth in &sorted_authorities {
+        let is_active = auth.did == active_authority.did;
+        let dim_start = if is_active { "" } else { "\x1b[2m" };
+        let dim_end = if is_active { "" } else { "\x1b[0m" };
+
+        // Top separator
+        if is_active {
+            println!("════════════════════════════════════════════════════════════════");
+        } else {
+            println!(
+                "{}────────────────────────────────────────────────────────────────{}",
+                dim_start, dim_end
+            );
+        }
+
+        // Authority and Operator
+        println!("{}👤 Authority: {}{}", dim_start, auth.did, dim_end);
+        println!("{}🫆 Operator:  {}{}", dim_start, operator_did, dim_end);
+
+        // Collect spaces for this authority
+        let spaces = collect_spaces_for_authority(&operator_did, &auth.did)?;
+
+        if spaces.is_empty() {
+            println!("{}🪪  Access: none{}", dim_start, dim_end);
+        } else {
+            println!("{}🪪  Access:{}", dim_start, dim_end);
+
+            // Sort spaces: auth space first, then alphabetically
+            let mut sorted_spaces: Vec<_> = spaces.values().collect();
+            sorted_spaces.sort_by(|a, b| match (a.is_auth_space, b.is_auth_space) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => a.space_did.cmp(&b.space_did),
+            });
+
+            for space in sorted_spaces {
+                // Try to load space metadata to get the name
+                let space_name = if let Ok(Some(meta)) =
+                    crate::metadata::SpaceMetadata::load(&space.space_did)
+                {
+                    Some(meta.name)
+                } else {
+                    None
+                };
+
+                let emoji = if space.is_auth_space { "🔐" } else { "🏠" };
+                if space.is_auth_space {
+                    if let Some(name) = &space_name {
+                        if name != &space.space_did {
+                            println!(
+                                "{}   {} {} ({}) (authorization space){}",
+                                dim_start, emoji, name, space.space_did, dim_end
+                            );
+                        } else {
+                            println!(
+                                "{}   {} {} (authorization space){}",
+                                dim_start, emoji, space.space_did, dim_end
+                            );
+                        }
+                    } else {
+                        println!(
+                            "{}   {} {} (authorization space){}",
+                            dim_start, emoji, space.space_did, dim_end
+                        );
+                    }
+                } else if let Some(name) = &space_name {
+                    if name != &space.space_did {
+                        println!(
+                            "{}   {} {} ({}){}",
+                            dim_start, emoji, name, space.space_did, dim_end
+                        );
+                    } else {
+                        println!("{}   {} {}{}", dim_start, emoji, space.space_did, dim_end);
+                    }
+                } else {
+                    println!("{}   {} {}{}", dim_start, emoji, space.space_did, dim_end);
+                }
+
+                // Group and deduplicate commands
+                let mut command_exps: HashMap<String, i64> = HashMap::new();
+                for (cmd, exp) in &space.commands {
+                    command_exps
+                        .entry(cmd.clone())
+                        .and_modify(|e| *e = (*e).max(*exp))
+                        .or_insert(*exp);
+                }
+
+                let mut commands: Vec<_> = command_exps.into_iter().collect();
+                commands.sort_by(|a, b| a.0.cmp(&b.0));
+
+                for (j, (cmd, exp)) in commands.iter().enumerate() {
+                    let is_last = j == commands.len() - 1;
+                    let prefix = if is_last { "└─" } else { "├─" };
+                    let time_str = format_time_remaining(*exp);
+                    if time_str == "never" {
+                        println!("{}      {} ⚙️  {}{}", dim_start, prefix, cmd, dim_end);
+                    } else {
+                        println!(
+                            "{}      {} ⚙️  {} (expires: {}){}",
+                            dim_start, prefix, cmd, time_str, dim_end
+                        );
+                    }
+
+                    // Show delegation chain in verbose mode
+                    if verbose {
+                        // Build the complete authorization chain for this command
+                        if let Ok(chain) = build_authorization_chain(
+                            &space.space_did,
+                            cmd,
+                            &operator_did,
+                            &auth.did,
+                            &home,
+                        ) {
+                            // Chain is built: [authority→operator, ..., space→authority]
+                            // Display from operator (top) to space (bottom/root)
+                            let mut shown_dids = HashSet::new();
+                            let mut chain_dids = Vec::new();
+
+                            // Collect all DIDs in the chain in order: operator → ... → space
+                            // Start with operator (audience of first delegation)
+                            if !chain.is_empty() {
+                                let first_del = &chain[0];
+                                let aud = first_del.audience();
+                                if !shown_dids.contains(&aud) {
+                                    chain_dids.push((aud.clone(), first_del.is_powerline()));
+                                    shown_dids.insert(aud);
+                                }
+                            }
+
+                            // Add each issuer in the chain
+                            for delegation in chain.iter() {
+                                let iss = delegation.issuer();
+                                if !shown_dids.contains(&iss) {
+                                    chain_dids.push((iss.clone(), delegation.is_powerline()));
+                                    shown_dids.insert(iss);
+                                }
+                            }
+
+                            // Add the final subject (space) if different
+                            if let Some(last_del) = chain.last()
+                                && let DelegatedSubject::Specific(sub_did) = last_del.subject()
+                            {
+                                let sub = sub_did.to_string();
+                                if !shown_dids.contains(&sub) {
+                                    chain_dids.push((sub, false));
+                                }
+                            }
+
+                            // Display the chain with tree nesting
+                            for (idx, (did, is_powerline)) in chain_dids.iter().enumerate() {
+                                let emoji = if *is_powerline { "🎫" } else { "🎟️ " };
+                                let indent = "         ".to_string() + &"   ".repeat(idx);
+                                println!("{}{}└─{} {}{}", dim_start, indent, emoji, did, dim_end);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Bottom separator
+        if is_active {
+            println!("════════════════════════════════════════════════════════════════\n");
+        } else {
+            println!(
+                "{}────────────────────────────────────────────────────────────────{}\n",
+                dim_start, dim_end
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Build the complete authorization chain from space to operator
+/// Returns the chain in order: [delegation closest to operator, ..., delegation from space]
+fn build_authorization_chain(
+    space_did: &str,
+    cmd: &str,
+    operator_did: &str,
+    authority_did: &str,
+    home: &std::path::Path,
+) -> Result<Vec<Delegation>> {
+    let mut chain = Vec::new();
+    let mut visited = HashSet::new();
+
+    // Start by finding the delegation from authority to operator (powerline)
+    if let Some(auth_to_op) = find_delegation_for_chain(authority_did, operator_did, home)? {
+        chain.push(auth_to_op);
+    }
+
+    // Now trace backwards from authority to space
+    trace_to_space(
+        space_did,
+        cmd,
+        authority_did,
+        home,
+        &mut chain,
+        &mut visited,
+        0,
+    )?;
+
+    Ok(chain)
+}
+
+/// Trace backwards from current DID to the space
+fn trace_to_space(
+    space_did: &str,
+    cmd: &str,
+    current_did: &str,
+    home: &std::path::Path,
+    chain: &mut Vec<Delegation>,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) -> Result<()> {
+    if depth > 10 || visited.contains(current_did) {
+        return Ok(());
+    }
+    visited.insert(current_did.to_string());
+
+    // Look for delegations TO current_did
+    let access_dir = home.join(".tonk").join("access").join(current_did);
+    if !access_dir.exists() {
+        return Ok(());
+    }
+
+    // Find delegations that grant access to this space/command
+    for entry in fs::read_dir(&access_dir)? {
+        let entry = entry?;
+        let issuer_dir = entry.path();
+
+        if !issuer_dir.is_dir() {
+            continue;
+        }
+
+        // Note: directory name is either issuer (for powerline) or subject (for specific subject)
+        // We need to read the delegation to get the actual issuer
+
+        // Look for delegation files
+        for del_entry in fs::read_dir(&issuer_dir)? {
+            let del_entry = del_entry?;
+            let del_path = del_entry.path();
+
+            if !del_path.is_file() || del_path.extension().and_then(|e| e.to_str()) != Some("cbor")
+            {
+                continue;
+            }
+
+            if let Ok(cbor_bytes) = fs::read(&del_path)
+                && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+            {
+                if !delegation.is_valid() {
+                    continue;
+                }
+
+                let cmd_str = delegation.command_str();
+                let actual_issuer = delegation.issuer(); // Get the real issuer from the delegation
+
+                // Check if this delegation is relevant
+                let is_relevant = match delegation.subject() {
+                    DelegatedSubject::Specific(sub_did) => {
+                        // Regular delegation - must be for our space and command
+                        let sub = sub_did.to_string();
+                        sub == space_did
+                            && (cmd_str == cmd || cmd_str == "/" || cmd.starts_with(&cmd_str))
+                    }
+                    DelegatedSubject::Any => {
+                        // Powerline - must be for the right command
+                        cmd_str == cmd || cmd_str == "/" || cmd.starts_with(&cmd_str)
+                    }
+                };
+
+                if is_relevant {
+                    chain.push(delegation.clone());
+
+                    // If issuer is not the space itself, keep tracing
+                    if actual_issuer != space_did {
+                        trace_to_space(
+                            space_did,
+                            cmd,
+                            &actual_issuer,
+                            home,
+                            chain,
+                            visited,
+                            depth + 1,
+                        )?;
+                    }
+
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Find a delegation from issuer to audience
+fn find_delegation_for_chain(
+    issuer_did: &str,
+    audience_did: &str,
+    home: &std::path::Path,
+) -> Result<Option<Delegation>> {
+    let access_dir = home
+        .join(".tonk")
+        .join("access")
+        .join(audience_did)
+        .join(issuer_did);
+
+    if !access_dir.exists() {
+        return Ok(None);
+    }
+
+    // Find the most recent valid delegation
+    let mut delegations = Vec::new();
+    for entry in fs::read_dir(&access_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("cbor") {
+            continue;
+        }
+
+        if let Ok(cbor_bytes) = fs::read(&path)
+            && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+            && delegation.is_valid()
+        {
+            delegations.push(delegation);
+        }
+    }
+
+    // Return the one with the latest expiration
+    delegations.sort_by(|a, b| {
+        let exp_a = a.expiration().unwrap_or(0);
+        let exp_b = b.expiration().unwrap_or(0);
+        exp_b.cmp(&exp_a)
+    });
+    Ok(delegations.into_iter().next())
+}
+
+/// Collect all spaces accessible under a specific authority
+pub fn collect_spaces_for_authority(
+    _operator_did: &str,
+    authority_did: &str,
+) -> Result<HashMap<String, SpaceAccess>> {
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+
+    // First, collect what the authority has direct access to
+    let mut spaces: HashMap<String, SpaceAccess> = HashMap::new();
+
+    // The authority itself is always an authorization space (self-access)
+    spaces.insert(
+        authority_did.to_string(),
+        SpaceAccess {
+            space_did: authority_did.to_string(),
+            commands: vec![("/".to_string(), i64::MAX)], // Full self-access, never expires
+            is_auth_space: true,
+            authorization_chains: HashMap::new(), // Self-access has no chain
+        },
+    );
+
+    // Check authority's own access (this is what they've been delegated)
+    let authority_access_dir = home.join(".tonk").join("access").join(authority_did);
+
+    if authority_access_dir.exists() {
+        for entry in fs::read_dir(&authority_access_dir)? {
+            let entry = entry?;
+            let subject_path = entry.path();
+
+            if !subject_path.is_dir() {
+                continue;
+            }
+
+            let issuer_did = subject_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+
+            // Skip if not a did:key
+            if !issuer_did.starts_with("did:key:") {
+                continue;
+            }
+
+            // Read delegations from this issuer
+            for delegation_entry in fs::read_dir(&subject_path)? {
+                let delegation_entry = delegation_entry?;
+                let delegation_path = delegation_entry.path();
+
+                if !delegation_path.is_file()
+                    || delegation_path.extension().and_then(|e| e.to_str()) != Some("cbor")
+                {
+                    continue;
+                }
+
+                if let Ok(cbor_bytes) = fs::read(&delegation_path)
+                    && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+                {
+                    // Only consider valid delegations
+                    if !delegation.is_valid() {
+                        continue;
+                    }
+
+                    let exp = delegation.expiration().unwrap_or(i64::MAX);
+                    let cmd = delegation.command_str();
+
+                    // Check if this is a powerline delegation
+                    match delegation.subject() {
+                        DelegatedSubject::Any => {
+                            // Powerline: issuer becomes an authorization space
+                            spaces
+                                .entry(issuer_did.clone())
+                                .or_insert_with(|| SpaceAccess {
+                                    space_did: issuer_did.clone(),
+                                    commands: Vec::new(),
+                                    is_auth_space: true, // Issuer of powerline is always auth space
+                                    authorization_chains: HashMap::new(),
+                                })
+                                .commands
+                                .push((cmd, exp));
+                        }
+                        DelegatedSubject::Specific(subject_did_ref) => {
+                            // Regular delegation to a space
+                            let subject_did = subject_did_ref.to_string();
+                            let is_auth_space = subject_did == authority_did;
+                            spaces
+                                .entry(subject_did.clone())
+                                .or_insert_with(|| SpaceAccess {
+                                    space_did: subject_did.clone(),
+                                    commands: Vec::new(),
+                                    is_auth_space,
+                                    authorization_chains: HashMap::new(),
+                                })
+                                .commands
+                                .push((cmd, exp));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Also recursively check for spaces the authority can access via powerline delegations
+    let mut visited = HashSet::new();
+    collect_spaces_recursive(
+        authority_did,
+        authority_did,
+        &home,
+        &mut visited,
+        &mut spaces,
+        0,
+    )?;
+
+    Ok(spaces)
+}
+
+/// Recursively collect spaces through powerline delegation chains
+fn collect_spaces_recursive(
+    authority_did: &str,
+    did: &str,
+    home: &std::path::PathBuf,
+    visited: &mut HashSet<String>,
+    spaces: &mut HashMap<String, SpaceAccess>,
+    depth: usize,
+) -> Result<()> {
+    if depth > 10 || visited.contains(did) {
+        return Ok(());
+    }
+    visited.insert(did.to_string());
+
+    let access_dir = home.join(".tonk").join("access").join(did);
+    if !access_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(&access_dir)? {
+        let entry = entry?;
+        let subject_path = entry.path();
+
+        if !subject_path.is_dir() {
+            continue;
+        }
+
+        for delegation_entry in fs::read_dir(&subject_path)? {
+            let delegation_entry = delegation_entry?;
+            let delegation_path = delegation_entry.path();
+
+            if !delegation_path.is_file()
+                || delegation_path.extension().and_then(|e| e.to_str()) != Some("cbor")
+            {
+                continue;
+            }
+
+            if let Ok(cbor_bytes) = fs::read(&delegation_path)
+                && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+            {
+                if !delegation.is_valid() {
+                    continue;
+                }
+
+                let is_powerline = delegation.is_powerline();
+
+                if is_powerline {
+                    // Recurse into issuer's capabilities
+                    let issuer = delegation.issuer();
+                    collect_spaces_recursive(
+                        authority_did,
+                        &issuer,
+                        home,
+                        visited,
+                        spaces,
+                        depth + 1,
+                    )?;
+                } else if let DelegatedSubject::Specific(subject_did) = delegation.subject() {
+                    // Regular delegation to a space
+                    let subject = subject_did.to_string();
+                    if subject.starts_with("did:key:") {
+                        let exp = delegation.expiration().unwrap_or(i64::MAX);
+                        let cmd = delegation.command_str();
+                        spaces
+                            .entry(subject.clone())
+                            .or_insert_with(|| SpaceAccess {
+                                space_did: subject.clone(),
+                                commands: Vec::new(),
+                                is_auth_space: subject == authority_did,
+                                authorization_chains: HashMap::new(),
+                            })
+                            .commands
+                            .push((cmd, exp));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/space.rs
+++ b/rust/tonk-cli/src/space.rs
@@ -1,0 +1,1059 @@
+use crate::authority;
+use crate::crypto::Operator;
+use crate::delegation::Delegation;
+use crate::keystore::Keystore;
+use crate::session::collect_spaces_for_authority;
+use anyhow::{Context, Result};
+use ed25519_dalek::Signer;
+use serde::{Deserialize, Serialize};
+use sha2_0_10::Digest;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use tonk_space::{Delegation as SpaceDelegation, FsBackend, Space};
+use ucan::did::{Did, Ed25519Did, Ed25519Signer};
+use ucan::{Delegation as UcanDelegation, delegation::subject::DelegatedSubject};
+
+/// Format time remaining until expiration
+fn format_time_remaining(exp: i64) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let remaining = exp - now;
+
+    if remaining < 0 {
+        return "EXPIRED".to_string();
+    }
+
+    if remaining == i64::MAX - now {
+        return "never".to_string();
+    }
+
+    let days = remaining / 86400;
+    let hours = (remaining % 86400) / 3600;
+    let mins = (remaining % 3600) / 60;
+
+    if days > 365 {
+        "never".to_string()
+    } else if days > 0 {
+        format!("{}d {}h", days, hours)
+    } else if hours > 0 {
+        format!("{}h {}m", hours, mins)
+    } else {
+        format!("{}m", mins)
+    }
+}
+
+/// List all spaces accessible by the active authority
+pub async fn list() -> Result<()> {
+    // Get operator DID
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    // Get active authority
+    let authorities = authority::get_authorities()?;
+    if authorities.is_empty() {
+        println!("⚠  No active session");
+        println!("   Run 'tonk login' to authenticate\n");
+        return Ok(());
+    }
+
+    let active_authority = crate::session::get_active_authority_from_list(&authorities)?;
+
+    // Get active space from state
+    let active_space_did = crate::state::get_active_space(&active_authority.did)?;
+
+    // Collect spaces for active authority
+    let spaces =
+        crate::session::collect_spaces_for_authority(&operator_did, &active_authority.did)?;
+
+    if spaces.is_empty() {
+        println!("⚠  No accessible spaces\n");
+        return Ok(());
+    }
+
+    // Sort spaces: auth space first, then alphabetically
+    let mut sorted_spaces: Vec<_> = spaces.values().collect();
+    sorted_spaces.sort_by(|a, b| match (a.is_auth_space, b.is_auth_space) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.space_did.cmp(&b.space_did),
+    });
+
+    // Display each space
+    for space in sorted_spaces {
+        let is_active = active_space_did.as_ref() == Some(&space.space_did);
+        let dim_start = if is_active { "" } else { "\x1b[2m" };
+        let dim_end = if is_active { "" } else { "\x1b[0m" };
+
+        // Top separator
+        if is_active {
+            println!("════════════════════════════════════════════════════════════════");
+        } else {
+            println!(
+                "{}────────────────────────────────────────────────────────────────{}",
+                dim_start, dim_end
+            );
+        }
+
+        // Try to load space metadata to get the name
+        let space_name =
+            if let Ok(Some(meta)) = crate::metadata::SpaceMetadata::load(&space.space_did) {
+                Some(meta.name)
+            } else {
+                None
+            };
+
+        let emoji = if space.is_auth_space { "🔐" } else { "🏠" };
+        if space.is_auth_space {
+            if let Some(name) = &space_name {
+                if name != &space.space_did {
+                    println!(
+                        "{}{} {} ({}) (authorization space){}",
+                        dim_start, emoji, name, space.space_did, dim_end
+                    );
+                } else {
+                    println!(
+                        "{}{} {} (authorization space){}",
+                        dim_start, emoji, space.space_did, dim_end
+                    );
+                }
+            } else {
+                println!(
+                    "{}{} {} (authorization space){}",
+                    dim_start, emoji, space.space_did, dim_end
+                );
+            }
+        } else if let Some(name) = &space_name {
+            if name != &space.space_did {
+                println!(
+                    "{}{} {} ({}){}",
+                    dim_start, emoji, name, space.space_did, dim_end
+                );
+            } else {
+                println!("{}{} {}{}", dim_start, emoji, space.space_did, dim_end);
+            }
+        } else {
+            println!("{}{} {}{}", dim_start, emoji, space.space_did, dim_end);
+        }
+
+        // Group and deduplicate commands
+        let mut command_exps: HashMap<String, i64> = HashMap::new();
+        for (cmd, exp) in &space.commands {
+            command_exps
+                .entry(cmd.clone())
+                .and_modify(|e| *e = (*e).max(*exp))
+                .or_insert(*exp);
+        }
+
+        let mut commands: Vec<_> = command_exps.into_iter().collect();
+        commands.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for (j, (cmd, exp)) in commands.iter().enumerate() {
+            let is_last = j == commands.len() - 1;
+            let prefix = if is_last { "└─" } else { "├─" };
+            let time_str = format_time_remaining(*exp);
+            if time_str == "never" {
+                println!("{}   {} ⚙️  {}{}", dim_start, prefix, cmd, dim_end);
+            } else {
+                println!(
+                    "{}   {} ⚙️  {} (expires: {}){}",
+                    dim_start, prefix, cmd, time_str, dim_end
+                );
+            }
+        }
+
+        // Bottom separator
+        if is_active {
+            println!("════════════════════════════════════════════════════════════════\n");
+        } else {
+            println!(
+                "{}────────────────────────────────────────────────────────────────{}\n",
+                dim_start, dim_end
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Show the current space DID
+pub async fn show_current() -> Result<()> {
+    // Get active authority
+    let authority = crate::authority::get_active_authority()?
+        .context("No active session. Please run `tonk login` first.")?;
+
+    // Get active space
+    let active_space = crate::state::get_active_space(&authority.did)?;
+
+    match active_space {
+        Some(space_did) => {
+            // Try to load space metadata to show name
+            if let Ok(Some(metadata)) = crate::metadata::SpaceMetadata::load(&space_did) {
+                println!("🏠 {} ({})", metadata.name, space_did);
+            } else {
+                println!("🏠 {}", space_did);
+            }
+        }
+        None => {
+            println!("No active space set for current session.");
+            println!("Use `tonk space set <name-or-did>` to select a space.");
+        }
+    }
+
+    Ok(())
+}
+
+/// Switch to a different space (by name or DID)
+pub async fn set(space_identifier: String) -> Result<()> {
+    // Get operator and authority
+    let keystore = crate::keystore::Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    let authority = crate::authority::get_active_authority()?
+        .context("No active session. Please run `tonk login` first.")?;
+
+    // Collect available spaces
+    let spaces = collect_spaces_for_authority(&operator_did, &authority.did)?;
+
+    // Find space by name or DID
+    let space_did = if space_identifier.starts_with("did:key:") {
+        // Direct DID lookup
+        if spaces.contains_key(&space_identifier) {
+            space_identifier
+        } else {
+            anyhow::bail!("Space {} not found or not accessible", space_identifier);
+        }
+    } else {
+        // Name lookup
+        let matching_spaces: Vec<String> = spaces
+            .keys()
+            .filter(|space_did| {
+                if let Ok(Some(metadata)) = crate::metadata::SpaceMetadata::load(space_did) {
+                    metadata.name == space_identifier
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect();
+
+        if matching_spaces.is_empty() {
+            anyhow::bail!("No space found with name '{}'", space_identifier);
+        } else if matching_spaces.len() > 1 {
+            anyhow::bail!(
+                "Multiple spaces found with name '{}'. Use the DID instead.",
+                space_identifier
+            );
+        } else {
+            matching_spaces[0].clone()
+        }
+    };
+
+    // Set as active space
+    crate::state::set_active_space(&authority.did, &space_did)?;
+
+    // Show confirmation
+    if let Ok(Some(metadata)) = crate::metadata::SpaceMetadata::load(&space_did) {
+        println!("✅ Switched to space: {} ({})", metadata.name, space_did);
+    } else {
+        println!("✅ Switched to space: {}", space_did);
+    }
+
+    Ok(())
+}
+
+/// Create a new space
+pub async fn create(
+    name: String,
+    owners: Option<Vec<String>>,
+    _description: Option<String>,
+) -> Result<()> {
+    println!("🚀 Creating space: {}\n", name);
+
+    // Get operator
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    // Get active authority (required for space creation)
+    let authority = authority::get_active_authority()?
+        .context("No active authority. Please run 'tonk login' first")?;
+
+    println!(
+        "👤 Authority: {}\n",
+        authority::format_authority_did(&authority.did)
+    );
+
+    // Collect owner DIDs
+    let mut owner_dids = Vec::new();
+
+    // Always include the active authority as an owner
+    owner_dids.push(authority.did.clone());
+
+    // Handle additional owners
+    if let Some(provided_owners) = owners {
+        // Validate and add provided owners
+        for owner in &provided_owners {
+            if !owner.starts_with("did:key:") {
+                anyhow::bail!("Invalid owner DID: {}. Must be a did:key identifier", owner);
+            }
+            if owner != &authority.did && !owner_dids.contains(owner) {
+                owner_dids.push(owner.clone());
+            }
+        }
+    } else {
+        // Interactive mode: ask for additional owners
+        println!("Additional owners (did:key identifiers, one per line, empty line to finish):");
+        loop {
+            print!("> ");
+            io::stdout().flush()?;
+
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            let input = input.trim();
+
+            if input.is_empty() {
+                break;
+            }
+
+            if !input.starts_with("did:key:") {
+                println!("   ⚠  Invalid DID format. Must start with 'did:key:'");
+                continue;
+            }
+
+            if input == authority.did {
+                println!("   ℹ  Authority already included as owner");
+                continue;
+            }
+
+            if owner_dids.contains(&input.to_string()) {
+                println!("   ℹ  Already added");
+                continue;
+            }
+
+            owner_dids.push(input.to_string());
+            println!("   ✓ Added");
+        }
+        println!();
+    }
+
+    println!("👥 Owners ({}):", owner_dids.len());
+    for owner in &owner_dids {
+        println!("   • {}", authority::format_authority_did(owner));
+    }
+    println!();
+
+    // Generate space operator (temporary - used only for signing owner delegations)
+    let space_operator = Operator::generate();
+    let space_did = space_operator.did().to_string();
+
+    println!("🏠 Space DID: {}\n", space_did);
+
+    // Create delegations from space to each owner and collect for storage
+    println!("📜 Creating owner delegations...");
+    let mut delegations: Vec<SpaceDelegation> = Vec::new();
+    for owner_did in &owner_dids {
+        let delegation = create_owner_delegation(&space_operator, &space_did, owner_did).await?;
+
+        // Convert to tonk_space::Delegation for Space storage
+        let space_delegation = SpaceDelegation::from(delegation.inner().clone());
+        delegations.push(space_delegation);
+
+        // Also save to filesystem (existing behavior)
+        delegation.save()?;
+        println!("   ✓ {}", authority::format_authority_did(owner_did));
+    }
+
+    // Save space metadata
+    let space_metadata = crate::metadata::SpaceMetadata::new(name.clone(), owner_dids.clone());
+    space_metadata.save(&space_did)?;
+
+    // Add space to the current session (creates the space directory)
+    crate::state::add_space_to_session(&authority.did, &space_did)?;
+
+    // Create Space with dialog-db storage
+    println!("📦 Storing delegations in space database...");
+    let storage_path = get_space_storage_path(&operator_did, &authority.did, &space_did)?;
+    let backend = FsBackend::new(&storage_path).await?;
+
+    Space::create(space_did.clone(), &operator, backend, delegations)
+        .await
+        .context("Failed to create space database")?;
+    println!("   ✓ Delegations stored in main branch");
+
+    // Set this as the active space for the current session
+    crate::state::set_active_space(&authority.did, &space_did)?;
+
+    println!("✅ Space created and set as active!");
+    println!("   Operators under these authorities now have access to the space.\n");
+
+    Ok(())
+}
+
+/// Get the storage path for a space's facts database
+fn get_space_storage_path(
+    operator_did: &str,
+    authority_did: &str,
+    space_did: &str,
+) -> Result<PathBuf> {
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let path = home
+        .join(".tonk")
+        .join("operator")
+        .join(operator_did)
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join(space_did)
+        .join("facts");
+    Ok(path)
+}
+
+/// Create a delegation from space to an owner
+async fn create_owner_delegation(
+    space_operator: &Operator,
+    space_did: &str,
+    owner_did: &str,
+) -> Result<Delegation> {
+    // Parse owner DID
+    let owner_did_parsed: Ed25519Did = owner_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse owner DID: {:?}", e))?;
+
+    // Parse space DID for subject
+    let space_did_parsed: Ed25519Did = space_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse space DID: {:?}", e))?;
+
+    // Create delegation using ucan builder: Space → Owner with full access
+    let signer = Ed25519Signer::from(space_operator);
+
+    let ucan_delegation: UcanDelegation<Ed25519Did> = UcanDelegation::builder()
+        .issuer(signer)
+        .audience(owner_did_parsed)
+        .subject(DelegatedSubject::Specific(space_did_parsed))
+        .command(vec!["/".to_string()]) // Full access
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to build delegation: {}", e))?;
+
+    // Wrap in our Delegation type and return
+    Ok(Delegation::from_ucan(ucan_delegation))
+}
+
+/// Invitation file format
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InviteFile {
+    /// Secret - hash of the invitation delegation
+    secret: String,
+
+    /// Invite code - last 5 characters of signed hash (base58btc)
+    code: String,
+
+    /// Authorization chain: [space → authority, authority → operator, operator → membership]
+    authorization: Vec<Delegation>,
+}
+
+/// Invite a collaborator to a space
+pub async fn invite(email: String, space_name: Option<String>) -> Result<()> {
+    println!("🎫 Inviting {} to space\n", email);
+
+    // Get operator
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore.get_or_create_keypair()?;
+    let operator_did = operator.did().to_string();
+
+    // Get active authority
+    let authority = authority::get_active_authority()?
+        .context("No active authority. Please run 'tonk login' first")?;
+
+    // Get the space to invite to
+    let space_did = if let Some(name) = &space_name {
+        // Look up space by name from active session's spaces
+        let spaces = crate::state::list_spaces_for_session(&authority.did)?;
+
+        // Try to find space by looking up metadata
+        let mut found_did = None;
+        for space_did in &spaces {
+            if let Ok(Some(meta)) = crate::metadata::SpaceMetadata::load(space_did)
+                && &meta.name == name
+            {
+                found_did = Some(space_did.clone());
+                break;
+            }
+        }
+
+        found_did.context(format!("Space '{}' not found", name))?
+    } else if let Some(active_id) = crate::state::get_active_space(&authority.did)? {
+        active_id
+    } else {
+        anyhow::bail!("No active space. Create one with 'tonk space create' or specify --space");
+    };
+
+    // Load space metadata to get the name
+    let space_meta =
+        crate::metadata::SpaceMetadata::load(&space_did)?.context("Space metadata not found")?;
+
+    println!("📍 Space: {} ({})\n", space_meta.name, space_did);
+
+    // Convert email to did:mailto
+    let invitee_did = format!("did:mailto:{}", email);
+    println!("📧 Invitee: {}\n", invitee_did);
+
+    // Step 1: Create invitation delegation (operator → did:mailto)
+    println!("1️⃣  Creating invitation delegation...");
+
+    // Parse DIDs as UniversalDid
+    use crate::did::UniversalDid;
+    let operator_did_universal: UniversalDid = operator_did.parse()?;
+    let invitee_did_universal: UniversalDid = invitee_did.parse()?;
+    let space_did_universal: UniversalDid = space_did.parse()?;
+
+    // Create a signer from the operator
+    // We need to create a custom signer that works with UniversalDid
+    use ucan::did::DidSigner;
+
+    #[derive(Clone)]
+    struct UniversalDidSigner {
+        did: UniversalDid,
+        signer: Ed25519Signer,
+    }
+
+    impl DidSigner for UniversalDidSigner {
+        type Did = UniversalDid;
+
+        fn did(&self) -> &Self::Did {
+            &self.did
+        }
+
+        fn signer(&self) -> &<<Self::Did as Did>::VarsigConfig as varsig::signer::Sign>::Signer {
+            self.signer.signer()
+        }
+    }
+
+    let operator_signer_inner = Ed25519Signer::from(&operator);
+    let operator_universal_signer = UniversalDidSigner {
+        did: operator_did_universal.clone(),
+        signer: operator_signer_inner,
+    };
+
+    // Build invitation delegation using ucan
+    let invitation_ucan: UcanDelegation<UniversalDid> = UcanDelegation::builder()
+        .issuer(operator_universal_signer)
+        .audience(invitee_did_universal)
+        .subject(DelegatedSubject::Specific(space_did_universal))
+        .command(vec!["/".to_string()])
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to build invitation: {}", e))?;
+
+    // Step 2: Serialize and store invitation
+    println!("2️⃣  Storing invitation...");
+
+    // Serialize to CBOR
+    let invitation_cbor = serde_ipld_dagcbor::to_vec(&invitation_ucan)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize invitation: {}", e))?;
+
+    // Compute hash
+    let mut hasher = sha2_0_10::Sha256::new();
+    hasher.update(&invitation_cbor);
+    let invitation_hash_bytes = hasher.finalize();
+    let invitation_hash = hex::encode(invitation_hash_bytes);
+
+    // Save to storage (in the operator's access directory for the invitee)
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let access_dir = home
+        .join(".tonk")
+        .join("access")
+        .join(&invitee_did)
+        .join(&operator_did);
+    fs::create_dir_all(&access_dir)?;
+
+    let cbor_path = access_dir.join(format!("{}.cbor", invitation_hash));
+    fs::write(&cbor_path, &invitation_cbor)?;
+
+    println!("   ✓ Saved invitation");
+
+    // Step 3: Generate invite code - sign hash with operator key, take last 5 chars in base58btc
+    println!("3️⃣  Generating invite code...");
+    let hash_signature = operator.signer().sign(invitation_hash.as_bytes());
+    let hash_sig_bytes = hash_signature.to_bytes();
+    let hash_sig_b58 = bs58::encode(&hash_sig_bytes).into_string();
+    let invite_code = hash_sig_b58
+        .chars()
+        .rev()
+        .take(5)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>(); // Take last 5 chars
+    println!("   ✓ Code: {}", invite_code);
+
+    // Step 4: Derive membership keypair using HKDF(hash + code)
+    println!("4️⃣  Deriving membership principal...");
+    use hkdf::Hkdf;
+    use sha2_0_10::Sha256;
+
+    let ikm = format!("{}{}", invitation_hash, invite_code);
+    let hk = Hkdf::<Sha256>::new(None, ikm.as_bytes());
+    let mut okm = [0u8; 32];
+    hk.expand(b"tonk-membership-v1", &mut okm)
+        .map_err(|e| anyhow::anyhow!("HKDF expand failed: {:?}", e))?;
+
+    let membership_operator = Operator::from_secret(okm);
+    let membership_did = membership_operator.did().to_string();
+    println!("   ✓ Membership: {}", membership_did);
+
+    // Step 5: Create delegation from operator → membership
+    println!("5️⃣  Creating operator → membership delegation...");
+
+    // Parse DIDs
+    let space_did_parsed: Ed25519Did = space_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse space DID: {:?}", e))?;
+    let membership_did_parsed: Ed25519Did = membership_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse membership DID: {:?}", e))?;
+
+    // Build delegation using ucan
+    let operator_signer2 = Ed25519Signer::from(&operator);
+    let membership_ucan: UcanDelegation<Ed25519Did> = UcanDelegation::builder()
+        .issuer(operator_signer2)
+        .audience(membership_did_parsed)
+        .subject(DelegatedSubject::Specific(space_did_parsed))
+        .command(vec!["/".to_string()])
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to build membership delegation: {}", e))?;
+
+    let operator_to_membership = Delegation::from_ucan(membership_ucan);
+
+    // Step 6: Build delegation chain - we need space → authority and authority → operator
+    println!("6️⃣  Building delegation chain...");
+
+    // Find space → authority delegation
+    let space_to_authority = find_delegation(&space_did, &authority.did)?
+        .context("Space → authority delegation not found")?;
+
+    // Find authority → operator delegation
+    let authority_to_operator = find_delegation(&authority.did, &operator_did)?
+        .context("Authority → operator delegation not found")?;
+
+    let authorization_chain = vec![
+        space_to_authority,
+        authority_to_operator,
+        operator_to_membership,
+    ];
+    println!("   ✓ Chain: space → authority → operator → membership");
+
+    // Step 7: Create invite file (use CBOR encoding)
+    println!("7️⃣  Creating invite file...");
+    let invite_file = InviteFile {
+        secret: invitation_hash,
+        code: invite_code,
+        authorization: authorization_chain,
+    };
+
+    let invite_filename = format!("{}.invite", space_meta.name.replace(" ", "_"));
+    let invite_cbor = serde_ipld_dagcbor::to_vec(&invite_file)?;
+    fs::write(&invite_filename, invite_cbor)?;
+
+    println!("\n✅ Invitation created!");
+    println!("   File: {}", invite_filename);
+    println!("   Share this file with {} to grant them access\n", email);
+
+    Ok(())
+}
+
+/// Inspect an invite file and show its contents
+pub fn inspect_invite(path: String) -> Result<()> {
+    println!("🔍 Inspecting invite file...\n");
+
+    // Read and parse invite file (CBOR format)
+    println!("📂 Reading file: {}", path);
+    let invite_data = fs::read(&path).context("Failed to read invite file")?;
+
+    let invite: InviteFile = serde_ipld_dagcbor::from_slice(&invite_data)
+        .context("Failed to parse invite file (expected CBOR format)")?;
+
+    println!("   ✓ Loaded {} bytes\n", invite_data.len());
+
+    // Show invite details
+    println!("📋 Invite Details:");
+    println!("   Secret (hash): {}", invite.secret);
+    println!("   Invite code:   {}", invite.code);
+    println!(
+        "   Chain length:  {} delegations\n",
+        invite.authorization.len()
+    );
+
+    // Show each delegation in the authorization chain
+    println!("🔗 Authorization Chain:");
+    for (i, delegation) in invite.authorization.iter().enumerate() {
+        println!(
+            "\n   {}. Delegation {} → {}",
+            i + 1,
+            delegation.issuer(),
+            delegation.audience()
+        );
+        println!(
+            "      Subject:  {}",
+            match delegation.subject() {
+                DelegatedSubject::Specific(did) => did.to_string(),
+                DelegatedSubject::Any => "*".to_string(),
+            }
+        );
+        println!("      Command:  {}", delegation.command().join(", "));
+        println!("      Valid:    {}", delegation.is_valid());
+
+        if let Some(exp) = delegation.expiration() {
+            let exp_date = chrono::DateTime::from_timestamp(exp, 0)
+                .map(|d| d.to_rfc3339())
+                .unwrap_or_else(|| format!("Invalid timestamp: {}", exp));
+            println!("      Expires:  {}", exp_date);
+        } else {
+            println!("      Expires:  never");
+        }
+    }
+
+    // Extract space DID from first delegation
+    if let Some(first) = invite.authorization.first() {
+        println!("\n📍 Space DID: {}", first.issuer());
+    }
+
+    // Extract membership DID from last delegation
+    if let Some(last) = invite.authorization.last() {
+        println!("🎟️  Membership DID: {}", last.audience());
+    }
+
+    println!("\n✅ Invite file is valid!\n");
+
+    Ok(())
+}
+
+/// Find a delegation from issuer to audience for a specific subject
+fn find_delegation(issuer: &str, audience: &str) -> Result<Option<Delegation>> {
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let access_dir = home
+        .join(".tonk")
+        .join("access")
+        .join(audience)
+        .join(issuer);
+
+    if !access_dir.exists() {
+        return Ok(None);
+    }
+
+    // Find the most recent valid delegation
+    let mut delegations = Vec::new();
+    for entry in fs::read_dir(&access_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("cbor") {
+            continue;
+        }
+
+        if let Ok(cbor_bytes) = fs::read(&path)
+            && let Ok(delegation) = Delegation::from_cbor_bytes(&cbor_bytes)
+            && delegation.is_valid()
+        {
+            delegations.push(delegation);
+        }
+    }
+
+    // Return the one with the latest expiration
+    delegations.sort_by(|a, b| {
+        let exp_a = a.expiration().unwrap_or(0);
+        let exp_b = b.expiration().unwrap_or(0);
+        exp_b.cmp(&exp_a)
+    });
+    Ok(delegations.into_iter().next())
+}
+
+/// Join a space using an invitation file
+pub async fn join(invite_path: String, _profile_name: Option<String>) -> Result<()> {
+    println!("🔗 Joining space with invitation\n");
+
+    // Step 1: Read and parse invite file (CBOR format)
+    println!("1️⃣  Reading invite file...");
+    let invite_data = fs::read(&invite_path).context("Failed to read invite file")?;
+    let invite: InviteFile = serde_ipld_dagcbor::from_slice(&invite_data)
+        .context("Failed to parse invite file (expected CBOR format)")?;
+    println!("   ✓ Loaded invitation");
+
+    // Extract space DID from authorization chain
+    let space_did = invite
+        .authorization
+        .first()
+        .context("Authorization chain is empty")?
+        .issuer();
+
+    // Extract operator → membership delegation (last in chain)
+    let operator_to_membership = invite
+        .authorization
+        .last()
+        .context("Authorization chain is empty")?;
+
+    println!("   Space DID: {}", space_did);
+
+    // Step 2: Reconstruct membership keypair
+    println!("2️⃣  Reconstructing membership keypair...");
+    use hkdf::Hkdf;
+    use sha2_0_10::Sha256;
+
+    let ikm = format!("{}{}", invite.secret, invite.code);
+    let hk = Hkdf::<Sha256>::new(None, ikm.as_bytes());
+    let mut okm = [0u8; 32];
+    hk.expand(b"tonk-membership-v1", &mut okm)
+        .map_err(|e| anyhow::anyhow!("HKDF expand failed: {:?}", e))?;
+
+    let membership_operator = Operator::from_secret(okm);
+    let reconstructed_membership_did = membership_operator.did().to_string();
+    println!("   ✓ Reconstructed: {}", reconstructed_membership_did);
+
+    // Step 3: Verify membership DID matches authorization chain
+    println!("3️⃣  Verifying membership principal...");
+    let expected_membership_did = operator_to_membership.audience();
+
+    if reconstructed_membership_did != expected_membership_did {
+        anyhow::bail!(
+            "Membership verification failed!\n   Expected: {}\n   Got: {}",
+            expected_membership_did,
+            reconstructed_membership_did
+        );
+    }
+    println!("   ✓ Membership verified!");
+
+    // Step 4: Get active authority to delegate to
+    println!("4️⃣  Getting active authority...");
+    let authority = authority::get_active_authority()?
+        .context("No active authority. Please run 'tonk login' first")?;
+    println!("   ✓ Authority: {}", authority.did);
+
+    // Step 5: Create membership → authority delegation
+    println!("5️⃣  Creating membership → authority delegation...");
+
+    // Parse DIDs
+    let authority_did_parsed: Ed25519Did = authority
+        .did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse authority DID: {:?}", e))?;
+    let space_did_parsed: Ed25519Did = space_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse space DID: {:?}", e))?;
+
+    // Build delegation using ucan
+    let membership_signer = Ed25519Signer::from(&membership_operator);
+    let membership_to_authority_ucan: UcanDelegation<Ed25519Did> = UcanDelegation::builder()
+        .issuer(membership_signer)
+        .audience(authority_did_parsed)
+        .subject(DelegatedSubject::Specific(space_did_parsed))
+        .command(vec!["/".to_string()])
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to build membership delegation: {}", e))?;
+
+    let membership_to_authority = Delegation::from_ucan(membership_to_authority_ucan);
+    println!("   ✓ Delegation created");
+
+    // Note: We don't create authority → operator here because:
+    // 1. That delegation already exists from the login flow
+    // 2. We don't have the authority's keypair (it's derived from passkey in browser)
+    // The membership → authority delegation connects to the existing auth chain
+
+    // Get the local operator DID for verification
+    let keystore = Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    // Step 6: Import all delegations to local access directory
+    println!("6️⃣  Importing delegation chain...");
+
+    // Import each delegation in the authorization chain
+    for (i, delegation) in invite.authorization.iter().enumerate() {
+        delegation.save()?;
+        println!(
+            "   ✓ Imported delegation {} of {}",
+            i + 1,
+            invite.authorization.len()
+        );
+    }
+
+    // Import the membership → authority delegation
+    membership_to_authority.save()?;
+    println!("   ✓ Imported membership → authority delegation");
+
+    // Step 7: Verify the authority → operator delegation exists
+    println!("7️⃣  Verifying authority → operator delegation...");
+    let authority_to_operator_exists = find_delegation(&authority.did, &operator_did)?;
+
+    if authority_to_operator_exists.is_none() {
+        anyhow::bail!(
+            "Missing authority → operator delegation!\n   Authority: {}\n   Operator: {}\n   This should have been created during login.",
+            authority.did,
+            operator_did
+        );
+    }
+    println!("   ✓ Authority → operator delegation exists");
+
+    // Step 8: Add space to active session
+    println!("8️⃣  Adding space to session...");
+    crate::state::add_space_to_session(&authority.did, &space_did)?;
+    crate::state::set_active_space(&authority.did, &space_did)?;
+    println!("   ✓ Space added to session");
+
+    // Step 9: Initialize space database (replica and main branch)
+    println!("9️⃣  Initializing space database...");
+    let storage_path = get_space_storage_path(&operator_did, &authority.did, &space_did)?;
+    let backend = FsBackend::new(&storage_path).await?;
+
+    // Create space with empty delegations - this sets up the replica and main branch
+    Space::create(space_did.clone(), &operator, backend, vec![])
+        .await
+        .context("Failed to initialize space database")?;
+    println!("   ✓ Replica and main branch created");
+
+    // Load or create space metadata
+    if let Ok(Some(meta)) = crate::metadata::SpaceMetadata::load(&space_did) {
+        println!("\n✅ Successfully joined space!");
+        println!("   Space: {}", meta.name);
+        println!("   DID: {}", space_did);
+        println!("   Membership: {}", reconstructed_membership_did);
+        println!("   Authority: {}\n", authority.did);
+    } else {
+        println!("\n✅ Successfully joined space!");
+        println!("   DID: {}", space_did);
+        println!("   Membership: {}", reconstructed_membership_did);
+        println!("   Authority: {}\n", authority.did);
+    }
+
+    Ok(())
+}
+
+/// Delete a space
+pub async fn delete(space_identifier: String, force: bool) -> Result<()> {
+    // Get operator and authority
+    let keystore = crate::keystore::Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    let operator_did = operator.did().to_string();
+
+    let authority = crate::authority::get_active_authority()?
+        .context("No active session. Please run `tonk login` first.")?;
+
+    // Collect available spaces
+    let spaces = collect_spaces_for_authority(&operator_did, &authority.did)?;
+
+    // Find space by name or DID
+    let space_did = if space_identifier.starts_with("did:key:") {
+        // Direct DID lookup
+        if spaces.contains_key(&space_identifier) {
+            space_identifier.clone()
+        } else {
+            anyhow::bail!("Space {} not found or not accessible", space_identifier);
+        }
+    } else {
+        // Name lookup
+        let matching_spaces: Vec<String> = spaces
+            .keys()
+            .filter(|space_did| {
+                if let Ok(Some(metadata)) = crate::metadata::SpaceMetadata::load(space_did) {
+                    metadata.name == space_identifier
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect();
+
+        if matching_spaces.is_empty() {
+            anyhow::bail!("No space found with name '{}'", space_identifier);
+        } else if matching_spaces.len() > 1 {
+            anyhow::bail!(
+                "Multiple spaces found with name '{}'. Use the DID instead.",
+                space_identifier
+            );
+        } else {
+            matching_spaces[0].clone()
+        }
+    };
+
+    // Get space name for display
+    let space_name = if let Ok(Some(metadata)) = crate::metadata::SpaceMetadata::load(&space_did) {
+        metadata.name
+    } else {
+        space_did.clone()
+    };
+
+    // Confirm deletion unless --force
+    if !force {
+        println!("⚠️  About to delete space: {} ({})", space_name, space_did);
+        println!("   This will remove the space and all its data from this session.\n");
+
+        use dialoguer::Confirm;
+        let confirmed = Confirm::new()
+            .with_prompt("Are you sure you want to delete this space?")
+            .default(false)
+            .interact()?;
+
+        if !confirmed {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    println!("🗑️  Deleting space: {}\n", space_name);
+
+    // Remove space from session (this also clears active space if needed)
+    crate::state::remove_space_from_session(&authority.did, &space_did)?;
+    println!("   ✓ Removed from session");
+
+    // Delete space metadata
+    if crate::metadata::SpaceMetadata::delete(&space_did).is_ok() {
+        println!("   ✓ Deleted metadata");
+    }
+
+    // Delete delegations from this space (in access directory)
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let access_dir = home.join(".tonk").join("access");
+
+    if access_dir.exists() {
+        let mut deleted_delegations = 0;
+        // Look through all audience directories
+        for audience_entry in fs::read_dir(&access_dir)? {
+            let audience_entry = audience_entry?;
+            let audience_path = audience_entry.path();
+
+            if !audience_path.is_dir() {
+                continue;
+            }
+
+            // Look for directories named with the space_did (delegations from the space)
+            let space_delegation_dir = audience_path.join(&space_did);
+            if space_delegation_dir.exists() && space_delegation_dir.is_dir() {
+                fs::remove_dir_all(&space_delegation_dir)?;
+                deleted_delegations += 1;
+            }
+        }
+
+        if deleted_delegations > 0 {
+            println!("   ✓ Deleted {} delegation chain(s)", deleted_delegations);
+        }
+    }
+
+    println!("\n✅ Space deleted: {}", space_name);
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/space.rs
+++ b/rust/tonk-cli/src/space.rs
@@ -440,7 +440,7 @@ async fn create_owner_delegation(
         .issuer(signer)
         .audience(owner_did_parsed)
         .subject(DelegatedSubject::Specific(space_did_parsed))
-        .command(vec!["/".to_string()]) // Full access
+        .command(vec![]) // Empty = root access "/"
         .try_build()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to build delegation: {}", e))?;
@@ -550,7 +550,7 @@ pub async fn invite(email: String, space_name: Option<String>) -> Result<()> {
         .issuer(operator_universal_signer)
         .audience(invitee_did_universal)
         .subject(DelegatedSubject::Specific(space_did_universal))
-        .command(vec!["/".to_string()])
+        .command(vec![]) // Empty = root access "/"
         .try_build()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to build invitation: {}", e))?;
@@ -629,7 +629,7 @@ pub async fn invite(email: String, space_name: Option<String>) -> Result<()> {
         .issuer(operator_signer2)
         .audience(membership_did_parsed)
         .subject(DelegatedSubject::Specific(space_did_parsed))
-        .command(vec!["/".to_string()])
+        .command(vec![]) // Empty = root access "/"
         .try_build()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to build membership delegation: {}", e))?;
@@ -857,7 +857,7 @@ pub async fn join(invite_path: String, _profile_name: Option<String>) -> Result<
         .issuer(membership_signer)
         .audience(authority_did_parsed)
         .subject(DelegatedSubject::Specific(space_did_parsed))
-        .command(vec!["/".to_string()])
+        .command(vec![]) // Empty = root access "/"
         .try_build()
         .await
         .map_err(|e| anyhow::anyhow!("Failed to build membership delegation: {}", e))?;

--- a/rust/tonk-cli/src/state.rs
+++ b/rust/tonk-cli/src/state.rs
@@ -1,0 +1,206 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::PathBuf;
+
+/// Get the .tonk directory path
+fn tonk_dir() -> Result<PathBuf> {
+    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".tonk"))
+}
+
+/// Get the operator DID
+fn get_operator_did() -> Result<String> {
+    let keystore = crate::keystore::Keystore::new().context("Failed to initialize keystore")?;
+    let operator = keystore
+        .get_or_create_keypair()
+        .context("Failed to get operator keypair")?;
+    Ok(operator.did().to_string())
+}
+
+/// Get the operator directory path: ~/.tonk/operator/{operator-did}/
+fn operator_dir() -> Result<PathBuf> {
+    let operator_did = get_operator_did()?;
+    Ok(tonk_dir()?.join("operator").join(operator_did))
+}
+
+/// Get the active session DID from ~/.tonk/operator/{operator-did}/session/@active
+pub fn get_active_session() -> Result<Option<String>> {
+    let active_file = operator_dir()?.join("session").join("@active");
+
+    if !active_file.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&active_file).context("Failed to read active session file")?;
+
+    let did = content.trim().to_string();
+    if did.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(did))
+    }
+}
+
+/// Set the active session DID in ~/.tonk/operator/{operator-did}/session/@active
+pub fn set_active_session(authority_did: &str) -> Result<()> {
+    let active_file = operator_dir()?.join("session").join("@active");
+
+    // Ensure parent directory exists
+    if let Some(parent) = active_file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(&active_file, authority_did).context("Failed to write active session file")?;
+
+    Ok(())
+}
+
+/// Get all session DIDs (authorities) from ~/.tonk/operator/{operator-did}/session/
+pub fn list_sessions() -> Result<Vec<String>> {
+    let session_dir = operator_dir()?.join("session");
+
+    if !session_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::new();
+
+    for entry in fs::read_dir(&session_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.starts_with("did:key:")
+        {
+            sessions.push(name.to_string());
+        }
+    }
+
+    sessions.sort();
+    Ok(sessions)
+}
+
+/// Get the active space DID for a session from ~/.tonk/operator/{operator-did}/session/{authority}/space/@active
+pub fn get_active_space(authority_did: &str) -> Result<Option<String>> {
+    let active_file = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join("@active");
+
+    if !active_file.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&active_file).context("Failed to read active space file")?;
+
+    let did = content.trim().to_string();
+    if did.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(did))
+    }
+}
+
+/// Set the active space DID for a session in ~/.tonk/operator/{operator-did}/session/{authority}/space/@active
+pub fn set_active_space(authority_did: &str, space_did: &str) -> Result<()> {
+    let active_file = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join("@active");
+
+    // Ensure parent directory exists
+    if let Some(parent) = active_file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(&active_file, space_did).context("Failed to write active space file")?;
+
+    Ok(())
+}
+
+/// Add a space to a session by creating ~/.tonk/operator/{operator-did}/session/{authority}/space/{space-did}/
+pub fn add_space_to_session(authority_did: &str, space_did: &str) -> Result<()> {
+    let space_dir = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join(space_did);
+
+    fs::create_dir_all(&space_dir).context("Failed to create space directory")?;
+
+    Ok(())
+}
+
+/// List all space DIDs for a session from ~/.tonk/operator/{operator-did}/session/{authority}/space/
+pub fn list_spaces_for_session(authority_did: &str) -> Result<Vec<String>> {
+    let spaces_dir = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space");
+
+    if !spaces_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut spaces = Vec::new();
+
+    for entry in fs::read_dir(&spaces_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        // Skip the @active file (active space marker)
+        if path.is_file() {
+            continue;
+        }
+
+        if path.is_dir()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.starts_with("did:key:")
+        {
+            spaces.push(name.to_string());
+        }
+    }
+
+    spaces.sort();
+    Ok(spaces)
+}
+
+/// Remove a space from a session by deleting ~/.tonk/operator/{operator-did}/session/{authority}/space/{space-did}/
+pub fn remove_space_from_session(authority_did: &str, space_did: &str) -> Result<()> {
+    let space_dir = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join(space_did);
+
+    if space_dir.exists() {
+        fs::remove_dir_all(&space_dir).context("Failed to remove space directory")?;
+    }
+
+    // If this was the active space, clear it
+    if let Ok(Some(active)) = get_active_space(authority_did)
+        && active == space_did
+    {
+        clear_active_space(authority_did)?;
+    }
+
+    Ok(())
+}
+
+/// Clear the active space for a session
+pub fn clear_active_space(authority_did: &str) -> Result<()> {
+    let active_file = operator_dir()?
+        .join("session")
+        .join(authority_did)
+        .join("space")
+        .join("@active");
+
+    if active_file.exists() {
+        fs::remove_file(&active_file).context("Failed to remove active space file")?;
+    }
+
+    Ok(())
+}

--- a/rust/tonk-cli/src/util.rs
+++ b/rust/tonk-cli/src/util.rs
@@ -1,0 +1,6 @@
+use std::path::PathBuf;
+
+/// Get the home directory
+pub fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}

--- a/rust/tonk-space/Cargo.toml
+++ b/rust/tonk-space/Cargo.toml
@@ -38,6 +38,7 @@ dialog-capability = { workspace = true }
 
 # UCAN
 ucan = { workspace = true }
+varsig = { workspace = true }
 ipld-core = { workspace = true }
 
 # Serialization

--- a/rust/tonk-space/src/delegation.rs
+++ b/rust/tonk-space/src/delegation.rs
@@ -268,11 +268,11 @@ mod tests {
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -326,11 +326,11 @@ mod tests {
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -406,11 +406,11 @@ mod tests {
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
+            .issuer(signer)
+            .audience(audience.did().clone())
             .subject(DelegatedSubject::Any)
             .command(vec!["read".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 

--- a/rust/tonk-space/src/operator.rs
+++ b/rust/tonk-space/src/operator.rs
@@ -2,19 +2,20 @@
 //!
 //! An `Operator` represents a principal that can sign UCAN delegations and
 //! dialog-db operations. It wraps an Ed25519 signing key and provides
-//! conversions to both `Ed25519Signer` (for UCAN) and dialog-db `Operator`.
+//! conversions to both `Ed25519Signer` (for UCAN) and dialog-db `SigningAuthority`.
 
-use dialog_artifacts::replica::Operator as ReplicaOperator;
+use dialog_artifacts::replica::SigningAuthority;
 use ed25519_dalek::SigningKey;
 use rand_0_8::rngs::OsRng;
 use ucan::did::{Ed25519Did, Ed25519Signer};
+use varsig::signature::eddsa::Ed25519SigningKey;
 
 /// An operator identity that can sign UCAN delegations and dialog-db operations.
 ///
 /// This is the primary identity type for tonk-space. It wraps an Ed25519 signing
 /// key and can be converted to:
 /// - `Ed25519Signer` for signing UCAN delegations
-/// - `ReplicaOperator` for signing dialog-db replica operations
+/// - `SigningAuthority` for signing dialog-db replica operations
 #[derive(Debug, Clone)]
 pub struct Operator(Ed25519Signer);
 
@@ -22,7 +23,7 @@ impl Operator {
     /// Generate a new random operator identity.
     pub fn generate() -> Self {
         let signing_key = SigningKey::generate(&mut OsRng);
-        Self(Ed25519Signer::new(signing_key))
+        Self(Ed25519Signer::from(signing_key))
     }
 
     /// Create an operator from a passphrase using HKDF key derivation.
@@ -33,7 +34,7 @@ impl Operator {
     pub async fn from_passphrase(passphrase: &str) -> Self {
         let passphrase = crate::Passphrase::from(passphrase);
         let signing_key = passphrase.derive_signing_key(None).await;
-        Self(Ed25519Signer::new(signing_key))
+        Self(Ed25519Signer::from(signing_key))
     }
 
     /// Get the DID for this operator.
@@ -41,9 +42,23 @@ impl Operator {
         self.0.did()
     }
 
-    /// Get the underlying signing key.
+    /// Get the underlying signing key (native platforms only).
+    ///
+    /// On native, this extracts the `ed25519_dalek::SigningKey` from the
+    /// platform-abstracted `Ed25519SigningKey` enum.
     pub fn signer(&self) -> &SigningKey {
-        self.0.signer()
+        match self.0.signer() {
+            Ed25519SigningKey::Native(key) => key,
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            Ed25519SigningKey::WebCrypto(_) => {
+                panic!("Cannot get native signing key on WASM; use ucan_signer() instead")
+            }
+        }
+    }
+
+    /// Get the underlying `Ed25519Signer` for UCAN operations.
+    pub fn ucan_signer(&self) -> &Ed25519Signer {
+        &self.0
     }
 
     /// Get the secret key bytes.
@@ -56,7 +71,7 @@ impl Operator {
     /// This is the inverse of `to_secret()` - it allows reconstructing an
     /// operator from previously stored secret bytes.
     pub fn from_secret(secret: [u8; 32]) -> Self {
-        Self(Ed25519Signer::new(SigningKey::from_bytes(&secret)))
+        Self(Ed25519Signer::from(SigningKey::from_bytes(&secret)))
     }
 }
 
@@ -72,21 +87,21 @@ impl From<&Operator> for Ed25519Signer {
     }
 }
 
-impl From<Operator> for ReplicaOperator {
+impl From<Operator> for SigningAuthority {
     fn from(operator: Operator) -> Self {
-        ReplicaOperator::from_secret(&operator.to_secret())
+        SigningAuthority::from_secret(&operator.to_secret())
     }
 }
 
-impl From<&Operator> for ReplicaOperator {
+impl From<&Operator> for SigningAuthority {
     fn from(operator: &Operator) -> Self {
-        ReplicaOperator::from_secret(&operator.to_secret())
+        SigningAuthority::from_secret(&operator.to_secret())
     }
 }
 
 impl From<SigningKey> for Operator {
     fn from(signing_key: SigningKey) -> Self {
-        Self(Ed25519Signer::new(signing_key))
+        Self(Ed25519Signer::from(signing_key))
     }
 }
 
@@ -160,9 +175,9 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn it_converts_to_replica_operator() {
+    fn it_converts_to_signing_authority() {
         let operator = Operator::generate();
-        let _replica_op: ReplicaOperator = (&operator).into();
+        let _authority: SigningAuthority = (&operator).into();
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/rust/tonk-space/src/ownership.rs
+++ b/rust/tonk-space/src/ownership.rs
@@ -113,11 +113,11 @@ mod tests {
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -161,15 +161,15 @@ mod tests {
         let issuer = Operator::generate();
         let audience = Operator::generate();
         let subject = Operator::generate();
-        let expected_space = *subject.did();
+        let expected_space = subject.did().clone();
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -183,15 +183,15 @@ mod tests {
     async fn it_returns_issuer_as_space_for_powerline() {
         let issuer = Operator::generate();
         let audience = Operator::generate();
-        let expected_space = *issuer.did();
+        let expected_space = issuer.did().clone();
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = UcanDelegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
+            .issuer(signer)
+            .audience(audience.did().clone())
             .subject(DelegatedSubject::Any)
             .command(vec!["read".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 

--- a/rust/tonk-space/src/space.rs
+++ b/rust/tonk-space/src/space.rs
@@ -1,9 +1,7 @@
 use crate::delegation::Delegation;
 use crate::operator::Operator;
 use crate::ownership::Ownership;
-use dialog_artifacts::replica::{
-    Branch, BranchId, Operator as ReplicaOperator, RemoteSite, Remotes, Replica,
-};
+use dialog_artifacts::replica::{Branch, BranchId, RemoteSite, Remotes, Replica, SigningAuthority};
 use dialog_artifacts::selector::Constrained;
 use dialog_artifacts::{
     Artifact, ArtifactSelector, ArtifactStore, DialogArtifactsError, PlatformBackend,
@@ -108,8 +106,8 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         delegations: Vec<Delegation>,
     ) -> Result<Self, SpaceError> {
         // Open the replica with the operator and space DID as subject
-        let replica_operator = ReplicaOperator::from(operator);
-        let replica = Replica::open(replica_operator, space_did.clone().into(), backend)?;
+        let authority = SigningAuthority::from(operator);
+        let replica = Replica::open(authority, space_did.clone().into(), backend)?;
 
         // Create/open the "main" branch for this space
         let branch_id = BranchId::new("main".to_string());
@@ -131,7 +129,6 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         if !transaction.is_empty() {
             session.commit(transaction).await?;
         }
-
         Ok(Space {
             did: space_did,
             replica: Arc::new(RwLock::new(replica)),
@@ -155,8 +152,8 @@ impl<Backend: PlatformBackend + 'static> Space<Backend> {
         backend: Backend,
     ) -> Result<Self, SpaceError> {
         // Open the replica with the operator and space DID as subject
-        let replica_operator = ReplicaOperator::from(operator);
-        let replica = Replica::open(replica_operator, space_did.clone().into(), backend)?;
+        let authority = SigningAuthority::from(operator);
+        let replica = Replica::open(authority, space_did.clone().into(), backend)?;
 
         // Open the "main" branch (creates it if it doesn't exist)
         let branch_id = BranchId::new("main".to_string());
@@ -641,11 +638,11 @@ mod tests {
 
         let signer = Ed25519Signer::from(&issuer);
         let ucan_delegation = Delegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -659,11 +656,11 @@ mod tests {
     ) -> Delegation {
         let signer = Ed25519Signer::from(issuer);
         let ucan_delegation = Delegation::builder()
-            .issuer(signer.clone())
-            .audience(*audience.did())
-            .subject(DelegatedSubject::Specific(*subject.did()))
+            .issuer(signer)
+            .audience(audience.did().clone())
+            .subject(DelegatedSubject::Specific(subject.did().clone()))
             .command(vec!["read".to_string(), "write".to_string()])
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Failed to build delegation");
 
@@ -695,6 +692,22 @@ mod tests {
         let space = Space::create(space_did.clone(), &operator, backend, vec![delegation])
             .await
             .expect("Failed to create space");
+
+        assert_eq!(space.did, space_did);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn it_creates_space_with_delegation_on_fs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = FsBackend::new(tmp.path()).await.unwrap();
+        let space_did = "did:key:z6MktRgfR4aqompSzCHvmwCxERDjWyn2QDXURd1vdqBgMozV".to_string();
+        let operator = Operator::generate();
+        let delegation = make_test_delegation().await;
+
+        let space = Space::create(space_did.clone(), &operator, backend, vec![delegation])
+            .await
+            .expect("Failed to create space with FsBackend");
 
         assert_eq!(space.did, space_did);
     }

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -51,7 +51,7 @@ web-sys = { workspace = true, features = [
 web-time = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-idb = "0.6"
+idb = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/rust/tonk-worker/src/router/inspect/branch.rs
+++ b/rust/tonk-worker/src/router/inspect/branch.rs
@@ -73,7 +73,7 @@ impl RevisionResponse {
         Self {
             period: *revision.period(),
             moment: *revision.moment(),
-            issuer: revision.issuer().did().to_string(),
+            issuer: revision.issuer().to_string(),
             tree: format!("{}", revision.tree()),
             cause: revision
                 .cause()

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -135,11 +135,11 @@ impl Session {
     ) -> Result<Delegation, SessionError> {
         let signer = Ed25519Signer::from(space_operator);
         let ucan_delegation = Delegation::builder()
-            .issuer(signer.clone())
-            .audience(*user_operator.did())
-            .subject(DelegatedSubject::Specific(*space_operator.did()))
+            .issuer(signer)
+            .audience(user_operator.did().clone())
+            .subject(DelegatedSubject::Specific(space_operator.did().clone()))
             .command(vec![]) // Empty command = "/*" (all commands)
-            .try_build(&signer)
+            .try_build()
             .await
             .expect("Delegation builder should not fail with valid inputs");
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -26,6 +26,16 @@ pub struct TonkState {
     pub session: Session,
 }
 
+// SAFETY: Web browsers run Wasm in a single thread only. The interior types
+// (Operator, Space, Identity) contain `web_sys::CryptoKey` handles (via
+// Ed25519SigningKey::WebCrypto) which are !Send/!Sync, but cross-thread access
+// cannot occur in a single-threaded browser context. This follows the same
+// pattern used for ServiceWorkerStorageBackend and KeyStore in this crate.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for TonkState {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for TonkState {}
+
 /// The main Tonk service worker that handles browser fetch events.
 ///
 /// This struct bridges the browser's service worker API with an Axum router,


### PR DESCRIPTION
### Description

- reintroduces `tonk-cli` and refactors to use `tonk-space`
- broad refactor to accommodate breaking changes in `rs-ucan`/`dialog-db` APIs

### Related issues

- closes TON-1850

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the `tonk-cli` and `tonk-space` Rust projects by adding new features, improving existing functionality, and updating dependencies. It introduces new modules, modifies existing ones, and enhances the overall structure for better usability.

### Detailed summary
- Added `dbus` to `flake.nix`.
- Re-exported `Operator` from `tonk-space` in `crypto.rs`.
- Implemented `home_dir` function in `util.rs`.
- Updated `Cargo.toml` files to include new dependencies and workspace configurations.
- Modified `idb` dependency in `tonk-worker/Cargo.toml` to use workspace.
- Simplified issuer handling in `branch.rs` and `session.rs`.
- Introduced multiple new modules in `lib.rs` of `tonk-cli`.
- Created `generate` function in `operator.rs` to generate operator keys.
- Added authority management in `authority.rs`, including functions to get and format authorities.
- Implemented CBOR field removal and inspection functionalities in `inspect.rs`.
- Enhanced `keystore.rs` for better key management and error handling.
- Introduced session metadata handling in `metadata.rs`.
- Added functionality for managing spaces and sessions in `state.rs`.
- Developed login flow and HTML interface in `login.rs` and `auth.html`.
- Improved remote handling in `remote.rs` with support for UCAN credentials.
- Updated `Operator` struct in `operator.rs` to use `SigningAuthority`.
- Added a new `UniversalDid` type to manage different DID formats in `did.rs`.

> The following files were skipped due to too many changes: `rust/tonk-cli/src/remote.rs`, `rust/tonk-cli/src/bin/tonk.rs`, `rust/tonk-cli/src/fact.rs`, `rust/tonk-cli/src/session.rs`, `rust/tonk-cli/src/delegation.rs`, `rust/tonk-cli/src/space.rs`, `Cargo.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->