### PR TITLE
feat(cli): TON-1858: rules

### DIFF
--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -107,6 +107,93 @@ tonk space set "name-or-did"         # Switch active space
 
 Concepts and instances are scoped to the active space. Switching spaces gives you a different set of concepts and data.
 
+## Rules — deriving instances from patterns
+
+A rule defines how instances of a concept can be **derived** from patterns across existing facts. Rules use Datalog-style deduction: positive premises (`when`) that must hold, and negative premises (`unless`) that must NOT hold. Variables (prefixed with `?`) bind values and create implicit joins across premises.
+
+Multiple rules can derive the same concept — they act as **OR branches**. Each rule independently produces derived instances, and results are merged. This lets you evolve rules independently rather than maintaining one giant rule with many branches.
+
+When you query a concept that has rules, derived instances are transparently merged with stored instances.
+
+```bash
+# List all rules
+tonk --json rule
+# → [{"name":"safe-meals","conclusion":"SafeMeal"},...]
+
+# Define a rule from JSON (via file)
+tonk --json rule define safe-meals --file rule.json
+
+# Define a rule from JSON (via stdin)
+cat <<'EOF' | tonk --json rule define safe-meals --stdin
+{
+  "conclusion": {
+    "concept": "SafeMeal",
+    "this": "?allergy",
+    "bindings": {
+      "attendee": "?person",
+      "recipe": "?recipe_name"
+    }
+  },
+  "when": [
+    { "the": "allergy/person", "of": "?allergy", "is": "?person" },
+    { "the": "recipe/name", "of": "?recipe", "is": "?recipe_name" },
+    { "the": "recipe/ingredient", "of": "?recipe", "is": "?ingredient" }
+  ],
+  "unless": [
+    { "the": "allergy/substance", "of": "?allergy", "is": "?ingredient" }
+  ]
+}
+EOF
+# → {"ok":true,"name":"safe-meals","conclusion":"SafeMeal","when_count":3,"unless_count":1}
+
+# Show rule details
+tonk --json rule show safe-meals
+
+# Delete a rule
+tonk --json rule delete safe-meals
+
+# Query now includes derived instances transparently
+tonk --json query SafeMeal
+```
+
+### Rule definition JSON format
+
+```json
+{
+  "conclusion": {
+    "concept": "ConceptName",
+    "this": "?entity_var",
+    "bindings": { "attr_short_name": "?variable", ... }
+  },
+  "when": [
+    { "the": "namespace/attribute", "of": "?var_or_constant", "is": "?var_or_constant" },
+    ...
+  ],
+  "unless": [
+    { "the": "namespace/attribute", "of": "?var_or_constant", "is": "?var_or_constant" },
+    ...
+  ]
+}
+```
+
+**Conclusion fields:**
+- `concept` — the name of the concept being derived (must already be defined; referencing an undefined concept is an error)
+- `this` — which entity variable from the premises becomes the derived entity's identity. `this` is distinct from attribute bindings: it designates the *entity identity* of each derived instance, not an attribute value. If omitted, defaults to the first entity variable in the `when` premises.
+- `bindings` — maps concept attribute short names to premise variables (`"?var"`) or constant values (any string without `?` prefix). Not every premise variable needs to appear in bindings — variables can appear only in premises to serve as join variables (e.g. `?ingredient` in the example above joins `when` and `unless` premises without appearing in the conclusion). The rule compiler automatically renames variables to match the concept's operand names; if this would cause a collision with another variable, the conflicting variable is auto-renamed.
+
+**Premise terms:**
+- `"?name"` — variable (binds/joins by name across premises)
+- `"_"` — wildcard (matches anything, no binding)
+- any other string — constant (exact match filter)
+
+**Constraints:**
+- `the` is always a fully qualified attribute name (constant). Premise attributes reference existing data but are not validated against concept schemas — only the conclusion concept must be defined.
+- Every variable in conclusion `bindings` must appear in at least one positive (`when`) premise (appearing only in `unless` is not sufficient — this is a Datalog safety requirement)
+- The conclusion concept must already be defined
+- The `unless` section is optional (negation-as-failure)
+- Rule names are case-insensitive (stored and looked up in lowercase). Names serve as human-friendly identifiers for lookup and deletion.
+- Rules must have at least one positive premise in `when`
+
 ## Typical workflow
 
 ```bash
@@ -141,6 +228,11 @@ tonk sync
 | `tonk --json concept show <name>` | Show concept schema |
 | `tonk --json concept extend <name> <attrs...>` | Add attributes to a concept |
 | `tonk --json concept delete <name> [--force]` | Delete a concept |
+| `tonk --json rule` | List all rules in the active space |
+| `tonk --json rule define <name> --file <json>` | Define a rule from JSON file |
+| `tonk --json rule define <name> --stdin` | Define a rule from stdin JSON |
+| `tonk --json rule show <name>` | Show rule definition |
+| `tonk --json rule delete <name>` | Delete a rule |
 | `tonk --json create <concept> [key=val...]` | Create an instance |
 | `tonk --json query <concept> [key=val...]` | Query/filter instances |
 | `tonk --json show <id>` | Show instance details |

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -49,6 +49,12 @@ mod inner {
             command: Option<ConceptCommands>,
         },
 
+        /// Manage deductive rules between concepts
+        Rule {
+            #[command(subcommand)]
+            command: Option<RuleCommands>,
+        },
+
         /// Create a new instance of a concept
         Create {
             /// Concept name (e.g., "Task")
@@ -67,14 +73,14 @@ mod inner {
             stdin: bool,
         },
 
-        /// Query instances of a concept with optional filters
+        /// Query instances of a concept with optional selectors
         Query {
             /// Concept name (e.g., "Task")
             concept: String,
 
-            /// Filters as key=value pairs (e.g., status=todo priority=high)
+            /// Selectors as key=value pairs (e.g., status=todo priority=high)
             #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-            filters: Vec<String>,
+            selectors: Vec<String>,
         },
 
         /// Show details of an instance by ID
@@ -253,6 +259,39 @@ mod inner {
             /// Also delete all instances of this concept
             #[arg(short, long)]
             force: bool,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum RuleCommands {
+        /// Define a new deductive rule
+        Define {
+            /// Rule name (e.g., "safe-meals", "high-priority-tasks")
+            name: String,
+
+            /// Read rule definition from a JSON file
+            #[arg(long, short)]
+            file: Option<String>,
+
+            /// Read rule definition from stdin as JSON
+            #[arg(long)]
+            stdin: bool,
+
+            /// Optional description of the rule
+            #[arg(short, long)]
+            description: Option<String>,
+        },
+
+        /// Show details of a rule
+        Show {
+            /// Rule name
+            name: String,
+        },
+
+        /// Delete a rule
+        Delete {
+            /// Rule name
+            name: String,
         },
     }
 
@@ -492,6 +531,26 @@ async fn main() -> anyhow::Result<()> {
                 tonk_cli::concept::delete(name, force, json).await?;
             }
         },
+        Commands::Rule { command } => match command {
+            None => {
+                // `tonk rule` with no subcommand lists all rules
+                tonk_cli::rule::list(json).await?;
+            }
+            Some(RuleCommands::Define {
+                name,
+                file,
+                stdin,
+                description,
+            }) => {
+                tonk_cli::rule::define(name, file, stdin, description, json).await?;
+            }
+            Some(RuleCommands::Show { name }) => {
+                tonk_cli::rule::show(name, json).await?;
+            }
+            Some(RuleCommands::Delete { name }) => {
+                tonk_cli::rule::delete(name, json).await?;
+            }
+        },
         Commands::Create {
             concept,
             fields,
@@ -500,8 +559,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             tonk_cli::instance::create(concept, fields, file, stdin, json).await?;
         }
-        Commands::Query { concept, filters } => {
-            tonk_cli::instance::query(concept, filters, json).await?;
+        Commands::Query { concept, selectors } => {
+            tonk_cli::instance::query(concept, selectors, json).await?;
         }
         Commands::Show { id } => {
             tonk_cli::instance::show(id, json).await?;

--- a/rust/tonk-cli/src/instance.rs
+++ b/rust/tonk-cli/src/instance.rs
@@ -6,12 +6,22 @@
 
 use crate::schema::*;
 use anyhow::{Context, Result};
-use dialog_artifacts::{Artifact, ArtifactSelector, ArtifactStore, ArtifactStoreMut, Instruction};
+use dialog_artifacts::{Artifact, ArtifactStoreMut, Instruction};
 use dialog_query::claim::Attribute;
-use dialog_query::{Entity, Value};
-use futures_util::TryStreamExt;
+use dialog_query::{Entity, Term, Value};
 use std::io::Read;
 use std::str::FromStr;
+
+/// A schema attribute variable used during concept querying.
+struct AttrVar {
+    /// Fully qualified attribute name (e.g., `"person/name"`).
+    #[allow(dead_code)]
+    attribute_name: String,
+    /// Short/unqualified name used as the query parameter key (e.g., `"name"`).
+    param_name: String,
+    /// The query term variable bound to this attribute.
+    term: Term<Value>,
+}
 
 // ---------------------------------------------------------------------------
 // Create an instance
@@ -163,10 +173,13 @@ pub async fn create(
 // Query instances
 // ---------------------------------------------------------------------------
 
-/// Query instances of a concept, with optional filters.
+/// Query instances of a concept, with optional selectors.
 ///
-/// Filters are `key=value` pairs for exact matching.
-pub async fn query(concept_name: String, filters: Vec<String>, json: bool) -> Result<()> {
+/// Selectors are `key=value` pairs for exact matching.
+///
+/// Uses dialog-db's Session-based concept querying which automatically
+/// merges stored instances with rule-derived instances.
+pub async fn query(concept_name: String, selectors: Vec<String>, json: bool) -> Result<()> {
     let ctx = get_space_context()?;
     let branch = open_branch(&ctx).await?;
 
@@ -180,68 +193,141 @@ pub async fn query(concept_name: String, filters: Vec<String>, json: bool) -> Re
 
     let schema_attrs = fetch_string_values(&branch, &concept, ATTR_CONCEPT_ATTRIBUTE).await?;
 
-    // Parse filters
-    let filter_map = parse_kv_fields(&filters)?;
-    let mut qualified_filters: Vec<(String, Value)> = Vec::new();
-    for (key, value) in &filter_map {
+    // Parse selectors
+    let selector_map = parse_kv_fields(&selectors)?;
+    let mut qualified_selectors: Vec<(String, Value)> = Vec::new();
+    for (key, value) in &selector_map {
         let qualified = qualify_attribute(&stored_name, key)?;
-        qualified_filters.push((qualified, parse_value(value)));
+        qualified_selectors.push((qualified, parse_value(value)));
     }
 
-    // Get all instance entities for this concept
-    let instance_entities = fetch_entity_values(&branch, &concept, ATTR_CONCEPT_INSTANCE).await?;
+    // Load any rules targeting this concept (may be empty)
+    let rule_defs =
+        crate::rule::load_rules_for_concept(&branch, &ctx.space_did, &stored_name).await?;
 
-    if instance_entities.is_empty() {
-        if json {
-            println!("[]");
-        } else {
-            println!("No {} instances found.", stored_name);
-        }
-        return Ok(());
+    // Use Session-based querying which handles both stored instances
+    // and rule-derived instances in a single code path.
+    let rows = query_with_rules(
+        branch,
+        &schema_attrs,
+        &stored_name,
+        &qualified_selectors,
+        &rule_defs,
+    )
+    .await?;
+
+    display_rows(&rows, &stored_name, &schema_attrs, json);
+    Ok(())
+}
+
+/// Session-based query with rules. Compiles rules into DeductiveRules,
+/// registers them with a Session, and uses dialog-db's concept application
+/// to merge stored and derived instances.
+async fn query_with_rules(
+    branch: dialog_artifacts::repository::Branch<tonk_space::FsBackend>,
+    schema_attrs: &[String],
+    stored_name: &ConceptName,
+    qualified_selectors: &[(String, Value)],
+    rule_defs: &[crate::rule::RuleDefinition],
+) -> Result<Vec<(String, serde_json::Map<String, serde_json::Value>)>> {
+    use dialog_query::{Parameters, Session};
+    use futures_util::TryStreamExt;
+
+    // Compile rules
+    let compiled_rules: Vec<dialog_query::DeductiveRule> = rule_defs
+        .iter()
+        .map(|def| crate::rule::compile_rule(def, stored_name, schema_attrs))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Open a Session and register rules
+    let mut session = Session::open(branch);
+    for rule in compiled_rules {
+        session = session.register(rule);
     }
 
-    // Hybrid query strategy:
-    // If exactly one filter, use dialog's value index for fast lookup,
-    // then intersect with concept instances.
-    // Otherwise, enumerate all instances and filter client-side.
-    let matching_entities: Vec<Entity> = if qualified_filters.len() == 1 {
-        let (attr_name, filter_value) = &qualified_filters[0];
-        fast_filter_by_value(&branch, attr_name, filter_value, &instance_entities).await?
-    } else if qualified_filters.is_empty() {
-        instance_entities.clone()
-    } else {
-        // Multi-filter: fetch all, then filter client-side
-        let mut result = Vec::new();
-        for entity in &instance_entities {
-            let mut matches = true;
-            for (attr_name, filter_value) in &qualified_filters {
-                let val = fetch_value(&branch, entity, attr_name).await?;
-                if val.as_ref() != Some(filter_value) {
-                    matches = false;
-                    break;
+    // Build the dynamic concept
+    let dynamic_concept = build_dynamic_concept(schema_attrs)?;
+
+    // Build query parameters: named variables for each attribute
+    // plus "this" for the entity
+    let mut params = Parameters::new();
+    let this_var: Term<Value> = Term::var("this");
+    params.insert("this".to_string(), this_var.clone());
+
+    // Create a variable for each attribute
+    let mut attr_vars: Vec<AttrVar> = Vec::new();
+    for attr in schema_attrs {
+        let param_name = short_attribute(stored_name, attr);
+        let term: Term<Value> = Term::var(param_name.as_str());
+        params.insert(param_name.clone(), term.clone());
+        attr_vars.push(AttrVar {
+            attribute_name: attr.clone(),
+            param_name,
+            term,
+        });
+    }
+
+    // Apply selectors as constant terms
+    for (attr_name, selector_value) in qualified_selectors {
+        let short = short_attribute(stored_name, attr_name);
+        params.insert(short, Term::Constant(selector_value.clone()));
+    }
+
+    // Execute the concept query
+    let application = dynamic_concept
+        .apply(params)
+        .map_err(|e| anyhow::anyhow!("Failed to apply concept query: {}", e))?;
+
+    let answers: Vec<dialog_query::Answer> = application
+        .query(&session)
+        .try_collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("Query failed: {}", e))?;
+
+    // Convert answers to rows
+    let mut rows = Vec::new();
+    for answer in &answers {
+        let mut data = serde_json::Map::new();
+
+        // Resolve the entity (this)
+        let entity_str = match answer.resolve(&this_var) {
+            Ok(Value::Entity(e)) => e.to_string(),
+            Ok(v) => format_value(&v),
+            Err(e) => {
+                eprintln!("Warning: could not resolve entity for query answer: {}", e);
+                "???".to_string()
+            }
+        };
+
+        // Resolve each attribute value
+        for attr_var in &attr_vars {
+            match answer.resolve(&attr_var.term) {
+                Ok(val) => {
+                    data.insert(attr_var.param_name.clone(), value_to_json(&val));
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not resolve attribute '{}': {}",
+                        attr_var.param_name, e
+                    );
+                    data.insert(attr_var.param_name.clone(), serde_json::Value::Null);
                 }
             }
-            if matches {
-                result.push(entity.clone());
-            }
         }
-        result
-    };
 
-    // Fetch full data for matching instances
-    let mut rows: Vec<(String, serde_json::Map<String, serde_json::Value>)> = Vec::new();
-
-    for entity in &matching_entities {
-        let mut data = serde_json::Map::new();
-        for attr_name in &schema_attrs {
-            if let Some(val) = fetch_value(&branch, entity, attr_name).await? {
-                let short = short_attribute(&stored_name, attr_name);
-                data.insert(short, value_to_json(&val));
-            }
-        }
-        rows.push((entity.to_string(), data));
+        rows.push((entity_str, data));
     }
 
+    Ok(rows)
+}
+
+/// Display query result rows.
+fn display_rows(
+    rows: &[(String, serde_json::Map<String, serde_json::Value>)],
+    stored_name: &ConceptName,
+    schema_attrs: &[String],
+    json: bool,
+) {
     if json {
         let items: Vec<serde_json::Value> = rows
             .iter()
@@ -252,23 +338,27 @@ pub async fn query(concept_name: String, filters: Vec<String>, json: bool) -> Re
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string(&items)?);
+        match serde_json::to_string(&items) {
+            Ok(s) => println!("{}", s),
+            Err(e) => {
+                eprintln!("Error: failed to serialize query results: {}", e);
+                println!("[]");
+            }
+        }
     } else {
         if rows.is_empty() {
             println!("No matching {} instances found.", stored_name);
-            return Ok(());
+            return;
         }
 
-        // Collect all attribute short names for column headers
         let short_attrs: Vec<String> = schema_attrs
             .iter()
-            .map(|a| short_attribute(&stored_name, a))
+            .map(|a| short_attribute(stored_name, a))
             .collect();
 
-        // Print as table
         println!("{} ({} found)\n", stored_name, rows.len());
 
-        for (id, data) in &rows {
+        for (id, data) in rows {
             println!("  id: {}", id);
             for attr in &short_attrs {
                 if let Some(val) = data.get(attr) {
@@ -282,8 +372,6 @@ pub async fn query(concept_name: String, filters: Vec<String>, json: bool) -> Re
             println!();
         }
     }
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -591,31 +679,6 @@ fn parse_json_fields(input: &str) -> Result<Vec<(String, String)>> {
         result.push((key.clone(), value_str));
     }
     Ok(result)
-}
-
-/// Fast path: use dialog's value index to find entities matching a single
-/// attribute+value filter, then intersect with the known instance set.
-async fn fast_filter_by_value<S: ArtifactStore>(
-    store: &S,
-    attr_name: &str,
-    filter_value: &Value,
-    instance_set: &[Entity],
-) -> Result<Vec<Entity>> {
-    let attr = Attribute::from_str(attr_name).context("Invalid attribute")?;
-
-    // Query by attribute + value to get all matching entities
-    let results: Vec<_> = store
-        .select(ArtifactSelector::new().the(attr).is(filter_value.clone()))
-        .try_collect()
-        .await?;
-
-    let matching_entities: Vec<Entity> = results.into_iter().map(|a| a.of).collect();
-
-    // Intersect with instance set
-    Ok(matching_entities
-        .into_iter()
-        .filter(|e| instance_set.contains(e))
-        .collect())
 }
 
 fn format_ts(ts: i64) -> String {

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod login;
 pub mod metadata;
 pub mod operator;
 pub mod remote;
+pub mod rule;
 pub mod schema;
 pub mod session;
 pub mod space;

--- a/rust/tonk-cli/src/rule.rs
+++ b/rust/tonk-cli/src/rule.rs
@@ -1,0 +1,889 @@
+//! Rule management: define, list, show, and delete deductive rules.
+//!
+//! A rule derives instances of a conclusion concept from patterns across
+//! existing facts. Rules are stored as JSON blobs in dialog-db and compiled
+//! into `DeductiveRule`s at query time.
+
+use crate::schema::*;
+use anyhow::{Context, Result};
+use dialog_artifacts::{Artifact, ArtifactStore, ArtifactStoreMut, Instruction};
+use dialog_query::claim::Attribute;
+use dialog_query::{DeductiveRule, Premise, Term, Value};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Read;
+use std::str::FromStr;
+
+// ---------------------------------------------------------------------------
+// Rule definition JSON types
+// ---------------------------------------------------------------------------
+
+/// The complete rule definition, stored as JSON in `rule/definition`.
+///
+/// Use [`RuleDefinition::from_json`] to parse and structurally validate
+/// a definition from user-supplied JSON. Direct deserialization via `serde`
+/// is still available for loading from storage (already validated at write time).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleDefinition {
+    /// The concept being derived and its variable bindings.
+    pub conclusion: RuleConclusion,
+
+    /// Positive premises — fact patterns that must hold.
+    pub when: Vec<RulePremise>,
+
+    /// Negative premises — fact patterns that must NOT hold.
+    #[serde(default)]
+    pub unless: Vec<RulePremise>,
+}
+
+impl RuleDefinition {
+    /// Parse and structurally validate a rule definition from JSON.
+    ///
+    /// This performs structural checks that are independent of any
+    /// particular concept schema:
+    /// - The JSON must be a valid `RuleDefinition`
+    /// - There must be at least one positive premise in `when`
+    /// - The conclusion concept name must not be empty
+    pub fn from_json(json: &str) -> Result<Self> {
+        let def: Self =
+            serde_json::from_str(json).context("Failed to parse rule definition JSON")?;
+
+        if def.when.is_empty() {
+            anyhow::bail!(
+                "Rule must have at least one positive premise in 'when'. \
+                 Rules with no positive premises cannot derive any instances."
+            );
+        }
+
+        if def.conclusion.concept.is_empty() {
+            anyhow::bail!("Rule conclusion must specify a non-empty 'concept' name.");
+        }
+
+        Ok(def)
+    }
+}
+
+/// The conclusion of a rule: which concept is derived, and how its
+/// attributes map to variables.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleConclusion {
+    /// Name of the conclusion concept (e.g. "SafeMeal").
+    pub concept: String,
+
+    /// Maps concept attribute short names to variables.
+    /// e.g. `{"attendee": "?person", "recipe": "?recipe"}`
+    pub bindings: HashMap<String, String>,
+
+    /// Which entity variable in the premises should bind to the
+    /// concept's implicit `this` entity. e.g. `"?allergy"`.
+    ///
+    /// This is distinct from attribute `bindings`: it designates the
+    /// *identity* of each derived instance rather than an attribute value.
+    ///
+    /// If omitted, defaults to the first entity variable (`of` field)
+    /// found in the `when` premises.
+    #[serde(default)]
+    pub this: Option<String>,
+}
+
+/// A single fact-level premise: an EAV pattern with variables.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RulePremise {
+    /// Fully qualified attribute name (always a constant).
+    pub the: String,
+
+    /// Entity pattern: `"?variable"`, `"_"` (wildcard), or a constant.
+    pub of: String,
+
+    /// Value pattern: `"?variable"`, `"_"` (wildcard), or a constant.
+    pub is: String,
+}
+
+// ---------------------------------------------------------------------------
+// Premise term parsing
+// ---------------------------------------------------------------------------
+
+/// A parsed term from a rule premise string.
+///
+/// Provides type-safe representation of the three possible term forms,
+/// replacing ad-hoc `strip_prefix('?')` / `== "_"` checks throughout
+/// the codebase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PremiseTerm {
+    /// A variable binding: `"?name"` → `Variable("name")`.
+    Variable(String),
+    /// A wildcard: `"_"` — matches anything, no binding.
+    Wildcard,
+    /// A constant literal: any other string.
+    Constant(String),
+}
+
+impl PremiseTerm {
+    /// Parse a raw term string from a rule definition.
+    pub fn parse(s: &str) -> Self {
+        if let Some(var_name) = s.strip_prefix('?') {
+            Self::Variable(var_name.to_string())
+        } else if s == "_" {
+            Self::Wildcard
+        } else {
+            Self::Constant(s.to_string())
+        }
+    }
+
+    /// If this is a variable, return its name (without the `?` prefix).
+    pub fn variable_name(&self) -> Option<&str> {
+        match self {
+            Self::Variable(name) => Some(name),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rule compilation
+// ---------------------------------------------------------------------------
+
+/// Convert a `PremiseTerm` into a `Term<Value>`.
+fn term_to_value(pt: &PremiseTerm) -> Term<Value> {
+    match pt {
+        PremiseTerm::Variable(name) => Term::var(name.as_str()),
+        PremiseTerm::Wildcard => Term::blank(),
+        PremiseTerm::Constant(s) => Term::Constant(parse_value(s)),
+    }
+}
+
+/// Convert a `PremiseTerm` into a `Term<Entity>`.
+fn term_to_entity(pt: &PremiseTerm) -> Result<Term<dialog_query::Entity>> {
+    match pt {
+        PremiseTerm::Variable(name) => Ok(Term::var(name.as_str())),
+        PremiseTerm::Wildcard => Ok(Term::blank()),
+        PremiseTerm::Constant(s) => {
+            let entity = dialog_query::Entity::from_str(s)
+                .context(format!("Invalid entity in premise 'of' field: {}", s))?;
+            Ok(Term::Constant(entity))
+        }
+    }
+}
+
+/// Parse a term string from a rule definition into a `Term<Value>`.
+///
+/// - `"?name"` → `Term::var("name")`
+/// - `"_"` → `Term::blank()`
+/// - anything else → `Term::Constant(parse_value(s))`
+fn parse_term_value(s: &str) -> Term<Value> {
+    term_to_value(&PremiseTerm::parse(s))
+}
+
+/// Parse a term string into a `Term<Entity>`.
+///
+/// Delegates to [`PremiseTerm::parse`] then [`term_to_entity`].
+fn parse_term_entity(s: &str) -> Result<Term<dialog_query::Entity>> {
+    term_to_entity(&PremiseTerm::parse(s))
+}
+
+/// Collect all variable names used in the positive (`when`) premises (`of` and `is` fields).
+///
+/// Variables used only in `unless` premises are unsafe in Datalog (they have no
+/// grounding) so this intentionally excludes them. Use [`collect_all_premise_vars`]
+/// when you need variables from both `when` and `unless` (e.g. for collision detection).
+fn collect_when_vars(definition: &RuleDefinition) -> std::collections::HashSet<String> {
+    let mut vars = std::collections::HashSet::new();
+    for p in &definition.when {
+        if let Some(name) = PremiseTerm::parse(&p.of).variable_name() {
+            vars.insert(name.to_string());
+        }
+        if let Some(name) = PremiseTerm::parse(&p.is).variable_name() {
+            vars.insert(name.to_string());
+        }
+    }
+    vars
+}
+
+/// Collect all variable names used in all premises (both `when` and `unless`).
+///
+/// Used for rename-collision detection where we need the full variable universe.
+fn collect_all_premise_vars(definition: &RuleDefinition) -> std::collections::HashSet<String> {
+    let mut vars = std::collections::HashSet::new();
+    for p in definition.when.iter().chain(definition.unless.iter()) {
+        if let Some(name) = PremiseTerm::parse(&p.of).variable_name() {
+            vars.insert(name.to_string());
+        }
+        if let Some(name) = PremiseTerm::parse(&p.is).variable_name() {
+            vars.insert(name.to_string());
+        }
+    }
+    vars
+}
+
+/// Build a variable renaming map from the conclusion bindings.
+///
+/// The conclusion bindings map concept attribute short names to user
+/// variables: `{"attendee": "?person"}` means the premise variable
+/// `?person` should be renamed to `?attendee` (the concept operand name).
+///
+/// Additionally, the `this` field (or first entity variable) is mapped
+/// to `"this"` — the implicit entity operand every Concept has.
+///
+/// If renaming would collide with existing premise variables that are
+/// NOT themselves being renamed, those existing variables are also
+/// given new names (suffixed with `_0`, `_1`, etc.) to avoid clashes.
+///
+/// Returns a map from user variable name (without `?`) to new variable name.
+fn build_rename_map(
+    definition: &RuleDefinition,
+    concept_name: &ConceptName,
+) -> Result<HashMap<String, String>> {
+    let all_vars = collect_all_premise_vars(definition);
+    let mut rename: HashMap<String, String> = HashMap::new();
+
+    // Map each conclusion binding: user variable → attribute short name
+    for (attr_short, var_str) in &definition.conclusion.bindings {
+        if let PremiseTerm::Variable(var_name) = PremiseTerm::parse(var_str) {
+            // Validate the attribute is in the concept
+            let _qualified = qualify_attribute(concept_name, attr_short)?;
+            rename.insert(var_name, attr_short.clone());
+        }
+        // Constants in bindings are allowed — they don't need renaming
+    }
+
+    // Map `this`: find which entity variable should become "this"
+    let this_var = if let Some(ref this_str) = definition.conclusion.this {
+        match PremiseTerm::parse(this_str) {
+            PremiseTerm::Variable(name) => name,
+            _ => anyhow::bail!(
+                "Conclusion 'this' must be a variable (starting with '?'), got: {}",
+                this_str
+            ),
+        }
+    } else {
+        // Auto-detect: use the first entity variable from `when` premises
+        definition
+            .when
+            .iter()
+            .filter_map(|p| {
+                PremiseTerm::parse(&p.of)
+                    .variable_name()
+                    .map(|v| v.to_string())
+            })
+            .next()
+            .context(
+                "No entity variable found in 'when' premises. \
+                 Specify 'this' in the conclusion or use a ?variable in an 'of' field.",
+            )?
+    };
+
+    // Check that the this variable isn't already mapped to an attribute name
+    if rename.contains_key(&this_var) {
+        anyhow::bail!(
+            "Variable '?{}' is used both as 'this' and as a binding for attribute '{}'. \
+             Use separate variables.",
+            this_var,
+            rename[&this_var]
+        );
+    }
+
+    rename.insert(this_var, "this".to_string());
+
+    // Detect collisions: a rename target name might already be used by
+    // a different variable in the premises that is NOT being renamed.
+    // e.g. bindings map ?recipe_name → "recipe", but ?recipe is already
+    // used as an entity variable. We need to rename ?recipe to avoid clash.
+    let rename_targets: std::collections::HashSet<String> = rename.values().cloned().collect();
+    let renamed_sources: std::collections::HashSet<String> = rename.keys().cloned().collect();
+
+    let mut collision_renames: Vec<(String, String)> = Vec::new();
+    for target_name in &rename_targets {
+        // Is there a variable with the same name as a rename target,
+        // that is NOT itself being renamed?
+        if all_vars.contains(target_name) && !renamed_sources.contains(target_name) {
+            // This variable would collide. Generate a safe name.
+            let mut suffix = 0;
+            loop {
+                let candidate = format!("{}_{}", target_name, suffix);
+                if !all_vars.contains(&candidate)
+                    && !rename_targets.contains(&candidate)
+                    && !collision_renames.iter().any(|(_, t)| t == &candidate)
+                {
+                    collision_renames.push((target_name.clone(), candidate));
+                    break;
+                }
+                suffix += 1;
+            }
+        }
+    }
+
+    for (old_name, new_name) in collision_renames {
+        rename.insert(old_name, new_name);
+    }
+
+    Ok(rename)
+}
+
+/// Apply the variable renaming map to a term string.
+///
+/// If the string is `"?varname"` and `varname` is in the rename map,
+/// returns the renamed version `"?newname"`. Otherwise returns as-is.
+fn rename_var(s: &str, rename: &HashMap<String, String>) -> String {
+    match PremiseTerm::parse(s) {
+        PremiseTerm::Variable(ref var_name) => {
+            if let Some(new_name) = rename.get(var_name.as_str()) {
+                format!("?{}", new_name)
+            } else {
+                s.to_string()
+            }
+        }
+        _ => s.to_string(),
+    }
+}
+
+/// Compile a `RuleDefinition` into a `DeductiveRule` using the given
+/// concept attributes for the conclusion.
+pub fn compile_rule(
+    definition: &RuleDefinition,
+    concept_name: &ConceptName,
+    concept_attrs: &[String],
+) -> Result<DeductiveRule> {
+    // 1. Build dynamic Concept from conclusion concept's attributes
+    let concept = build_dynamic_concept(concept_attrs)?;
+
+    // 2. Build variable renaming map from conclusion bindings
+    let rename = build_rename_map(definition, concept_name)?;
+
+    // 3. Build positive premises (with renamed variables)
+    let mut premises: Vec<Premise> = Vec::new();
+
+    for p in &definition.when {
+        let renamed_of = rename_var(&p.of, &rename);
+        let renamed_is = rename_var(&p.is, &rename);
+
+        let of_term = parse_term_entity(&renamed_of)?;
+        let is_term = parse_term_value(&renamed_is);
+
+        let fact_app = dialog_query::predicate::Fact::select()
+            .the(p.the.as_str())
+            .of(of_term)
+            .is(is_term)
+            .compile()
+            .context(format!(
+                "Failed to compile premise: the={}, of={}, is={}",
+                p.the, p.of, p.is
+            ))?;
+        premises.push(fact_app.into());
+    }
+
+    // 4. Build negative premises (unless) with renamed variables
+    for p in &definition.unless {
+        let renamed_of = rename_var(&p.of, &rename);
+        let renamed_is = rename_var(&p.is, &rename);
+
+        let of_term = parse_term_entity(&renamed_of)?;
+        let is_term = parse_term_value(&renamed_is);
+
+        let fact_app = dialog_query::predicate::Fact::select()
+            .the(p.the.as_str())
+            .of(of_term)
+            .is(is_term)
+            .compile()
+            .context(format!(
+                "Failed to compile negated premise: the={}, of={}, is={}",
+                p.the, p.of, p.is
+            ))?;
+        premises.push(!fact_app); // negation via Not trait
+    }
+
+    // 5. Compile the DeductiveRule
+    let rule = DeductiveRule::new(concept, premises).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to compile rule for concept '{}': {}",
+            definition.conclusion.concept,
+            e
+        )
+    })?;
+
+    Ok(rule)
+}
+
+/// Validate a rule definition against the known concept schemas.
+///
+/// Checks:
+/// - Conclusion binding keys are valid attributes of the conclusion concept
+/// - All conclusion binding variables appear in at least one premise
+fn validate_definition(
+    definition: &RuleDefinition,
+    conclusion_attrs: &[String],
+    conclusion_name: &ConceptName,
+) -> Result<()> {
+    // Check that all binding keys are valid concept attributes
+    for short_name in definition.conclusion.bindings.keys() {
+        let qualified = qualify_attribute(conclusion_name, short_name)?;
+        if !conclusion_attrs.contains(&qualified) {
+            anyhow::bail!(
+                "Conclusion binding '{}' is not an attribute of concept '{}'. \
+                 Known attributes: {}",
+                short_name,
+                conclusion_name,
+                conclusion_attrs
+                    .iter()
+                    .map(|a| short_attribute(conclusion_name, a))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+
+    // Collect variables from positive (`when`) premises only.
+    // Variables must be grounded in at least one positive premise — appearing
+    // only in `unless` is unsafe (Datalog safety requirement).
+    let when_vars = collect_when_vars(definition);
+
+    // Check that all conclusion binding variables appear in at least one `when` premise
+    for (attr, var_str) in &definition.conclusion.bindings {
+        if let PremiseTerm::Variable(var_name) = PremiseTerm::parse(var_str)
+            && !when_vars.contains(&var_name)
+        {
+            anyhow::bail!(
+                "Variable '?{}' in conclusion binding '{}' does not appear in any positive \
+                 ('when') premise. All conclusion variables must be grounded in 'when' premises \
+                 (appearing only in 'unless' is not sufficient).",
+                var_name,
+                attr,
+            );
+        }
+    }
+
+    // Also validate that the `this` variable (if explicit) appears in a `when` premise
+    if let Some(ref this_str) = definition.conclusion.this
+        && let PremiseTerm::Variable(var_name) = PremiseTerm::parse(this_str)
+        && !when_vars.contains(&var_name)
+    {
+        anyhow::bail!(
+            "Variable '?{}' used as 'this' does not appear in any positive ('when') \
+             premise. The entity variable must be grounded in 'when' premises.",
+            var_name,
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// List all rules
+// ---------------------------------------------------------------------------
+
+/// List all rules in the active space.
+pub async fn list(json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    let registry = registry_entity(&ctx.space_did)?;
+    let rule_entities = fetch_entity_values(&branch, &registry, ATTR_REGISTRY_RULE).await?;
+
+    if rule_entities.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!("No rules defined. Use 'tonk rule define <name>' to create one.");
+        }
+        return Ok(());
+    }
+
+    let mut rules: Vec<(String, Option<String>, String)> = Vec::new();
+    for entity in &rule_entities {
+        let name = match fetch_string(&branch, entity, ATTR_RULE_NAME).await? {
+            Some(n) => n,
+            None => {
+                eprintln!(
+                    "Warning: rule entity '{}' is missing its 'rule/name' attribute — possible data corruption",
+                    entity
+                );
+                "???".to_string()
+            }
+        };
+        let description = fetch_string(&branch, entity, ATTR_RULE_DESCRIPTION).await?;
+        let conclusion = match fetch_string(&branch, entity, ATTR_RULE_CONCLUSION).await? {
+            Some(c) => c,
+            None => {
+                eprintln!(
+                    "Warning: rule '{}' is missing its 'rule/conclusion' attribute — possible data corruption",
+                    name
+                );
+                "???".to_string()
+            }
+        };
+        rules.push((name, description, conclusion));
+    }
+
+    if json {
+        let items: Vec<serde_json::Value> = rules
+            .iter()
+            .map(|(name, desc, conclusion)| {
+                let mut obj = serde_json::json!({
+                    "name": name,
+                    "conclusion": conclusion,
+                });
+                if let Some(d) = desc {
+                    obj.as_object_mut()
+                        .unwrap()
+                        .insert("description".to_string(), serde_json::json!(d));
+                }
+                obj
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&items)?);
+    } else {
+        println!("Rules:\n");
+        for (name, desc, conclusion) in &rules {
+            let desc_str = desc
+                .as_ref()
+                .map(|d| format!(" - {}", d))
+                .unwrap_or_default();
+            println!("  {} -> {}{}", name, conclusion, desc_str);
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Define a new rule
+// ---------------------------------------------------------------------------
+
+/// Define a new rule from a JSON definition.
+pub async fn define(
+    name: String,
+    file: Option<String>,
+    stdin: bool,
+    description: Option<String>,
+    json: bool,
+) -> Result<()> {
+    validate_safe_name(&name, "Rule")?;
+
+    if file.is_some() && stdin {
+        anyhow::bail!(
+            "Cannot use both --file and --stdin. Provide the rule definition via one source."
+        );
+    }
+
+    // Read JSON definition from file or stdin
+    let definition_json = if let Some(path) = &file {
+        std::fs::read_to_string(path).context(format!("Failed to read file: {}", path))?
+    } else if stdin {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("Failed to read from stdin")?;
+        buf
+    } else {
+        anyhow::bail!("Provide a rule definition via --file <path> or --stdin");
+    };
+
+    let definition = RuleDefinition::from_json(definition_json.trim())?;
+
+    let ctx = get_space_context()?;
+    let mut branch = open_branch(&ctx).await?;
+
+    let registry = registry_entity(&ctx.space_did)?;
+    let rule = rule_entity(&ctx.space_did, &name)?;
+
+    // Check if rule already exists
+    let existing = fetch_string(&branch, &rule, ATTR_RULE_NAME).await?;
+    if existing.is_some() {
+        anyhow::bail!(
+            "Rule '{}' already exists. Delete it first with 'tonk rule delete {}'.",
+            name,
+            name
+        );
+    }
+
+    // Verify the conclusion concept exists and get its attributes
+    let conclusion_concept = ConceptName::new(&definition.conclusion.concept)?;
+    let concept = concept_entity(&ctx.space_did, &conclusion_concept)?;
+    let concept_name = fetch_string(&branch, &concept, ATTR_CONCEPT_NAME)
+        .await?
+        .context(format!(
+            "Conclusion concept '{}' not found. Define it first.",
+            definition.conclusion.concept
+        ))?;
+    let concept_name = ConceptName::from_stored(concept_name);
+
+    let concept_attrs = fetch_string_values(&branch, &concept, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+    // Validate the definition
+    validate_definition(&definition, &concept_attrs, &concept_name)?;
+
+    // Try to compile the rule to catch errors early
+    compile_rule(&definition, &concept_name, &concept_attrs).context(
+        "Rule definition is invalid. Check that variable names match between \
+         conclusion bindings and premises.",
+    )?;
+
+    // Serialize definition back to canonical JSON for storage
+    let definition_str = serde_json::to_string(&definition)?;
+
+    // Build instructions
+    let mut instructions = vec![
+        // Register in registry
+        Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
+            of: registry.clone(),
+            is: Value::Entity(rule.clone()),
+            cause: None,
+        }),
+        // Rule name
+        Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_RULE_NAME)?,
+            of: rule.clone(),
+            is: Value::String(name.clone()),
+            cause: None,
+        }),
+        // Rule conclusion concept name
+        Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
+            of: rule.clone(),
+            is: Value::String(concept_name.to_string()),
+            cause: None,
+        }),
+        // Rule definition JSON
+        Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
+            of: rule.clone(),
+            is: Value::String(definition_str.clone()),
+            cause: None,
+        }),
+    ];
+
+    // Description (optional)
+    if let Some(desc) = &description {
+        instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_RULE_DESCRIPTION)?,
+            of: rule.clone(),
+            is: Value::String(desc.clone()),
+            cause: None,
+        }));
+    }
+
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    if json {
+        let output = serde_json::json!({
+            "ok": true,
+            "name": name,
+            "conclusion": concept_name.as_str(),
+            "when_count": definition.when.len(),
+            "unless_count": definition.unless.len(),
+        });
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("Defined rule '{}'", name);
+        println!("  Conclusion: {}", concept_name);
+        println!(
+            "  Premises: {} when, {} unless",
+            definition.when.len(),
+            definition.unless.len()
+        );
+        if let Some(desc) = &description {
+            println!("  Description: {}", desc);
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Show rule details
+// ---------------------------------------------------------------------------
+
+/// Show the full definition of a rule.
+pub async fn show(name: String, json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    let rule = rule_entity(&ctx.space_did, &name)?;
+
+    let stored_name = fetch_string(&branch, &rule, ATTR_RULE_NAME)
+        .await?
+        .context(format!("Rule '{}' not found", name))?;
+
+    let description = fetch_string(&branch, &rule, ATTR_RULE_DESCRIPTION).await?;
+    let conclusion = match fetch_string(&branch, &rule, ATTR_RULE_CONCLUSION).await? {
+        Some(c) => c,
+        None => {
+            eprintln!(
+                "Warning: rule '{}' is missing its 'rule/conclusion' attribute — possible data corruption",
+                name
+            );
+            "???".to_string()
+        }
+    };
+    let definition_str = fetch_string(&branch, &rule, ATTR_RULE_DEFINITION)
+        .await?
+        .context("Rule definition not found")?;
+
+    let definition: RuleDefinition =
+        serde_json::from_str(&definition_str).context("Failed to parse stored rule definition")?;
+
+    if json {
+        let mut output = serde_json::json!({
+            "name": stored_name,
+            "conclusion": conclusion,
+            "definition": definition,
+            "entity": rule.to_string(),
+        });
+        if let Some(desc) = &description {
+            output
+                .as_object_mut()
+                .unwrap()
+                .insert("description".to_string(), serde_json::json!(desc));
+        }
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("Rule: {}", stored_name);
+        if let Some(desc) = &description {
+            println!("  Description: {}", desc);
+        }
+        println!("  Conclusion: {}", conclusion);
+        println!("  Bindings:");
+        for (attr, var) in &definition.conclusion.bindings {
+            println!("    {} = {}", attr, var);
+        }
+        println!("  When:");
+        for (i, p) in definition.when.iter().enumerate() {
+            println!("    {}: the={}, of={}, is={}", i + 1, p.the, p.of, p.is);
+        }
+        if !definition.unless.is_empty() {
+            println!("  Unless:");
+            for (i, p) in definition.unless.iter().enumerate() {
+                println!("    {}: the={}, of={}, is={}", i + 1, p.the, p.of, p.is);
+            }
+        }
+        println!("  Entity: {}", rule);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Delete a rule
+// ---------------------------------------------------------------------------
+
+/// Delete a rule.
+pub async fn delete(name: String, json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let mut branch = open_branch(&ctx).await?;
+
+    let registry = registry_entity(&ctx.space_did)?;
+    let rule = rule_entity(&ctx.space_did, &name)?;
+
+    // Verify rule exists
+    let stored_name = fetch_string(&branch, &rule, ATTR_RULE_NAME)
+        .await?
+        .context(format!("Rule '{}' not found", name))?;
+
+    let mut instructions = Vec::new();
+
+    // Retract rule name
+    instructions.push(Instruction::Retract(Artifact {
+        the: Attribute::from_str(ATTR_RULE_NAME)?,
+        of: rule.clone(),
+        is: Value::String(stored_name),
+        cause: None,
+    }));
+
+    // Retract conclusion
+    if let Some(conclusion) = fetch_string(&branch, &rule, ATTR_RULE_CONCLUSION).await? {
+        instructions.push(Instruction::Retract(Artifact {
+            the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
+            of: rule.clone(),
+            is: Value::String(conclusion),
+            cause: None,
+        }));
+    }
+
+    // Retract definition
+    if let Some(def) = fetch_string(&branch, &rule, ATTR_RULE_DEFINITION).await? {
+        instructions.push(Instruction::Retract(Artifact {
+            the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
+            of: rule.clone(),
+            is: Value::String(def),
+            cause: None,
+        }));
+    }
+
+    // Retract description
+    if let Some(desc) = fetch_string(&branch, &rule, ATTR_RULE_DESCRIPTION).await? {
+        instructions.push(Instruction::Retract(Artifact {
+            the: Attribute::from_str(ATTR_RULE_DESCRIPTION)?,
+            of: rule.clone(),
+            is: Value::String(desc),
+            cause: None,
+        }));
+    }
+
+    // Retract registry entry
+    instructions.push(Instruction::Retract(Artifact {
+        the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
+        of: registry.clone(),
+        is: Value::Entity(rule.clone()),
+        cause: None,
+    }));
+
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    if json {
+        let output = serde_json::json!({
+            "ok": true,
+            "deleted": name,
+        });
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("Deleted rule '{}'", name);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Rule loading helpers (used by instance::query)
+// ---------------------------------------------------------------------------
+
+/// Load all rule definitions that conclude a given concept name.
+///
+/// Returns the parsed `RuleDefinition` for each matching rule.
+pub async fn load_rules_for_concept<S: ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    concept_name: &ConceptName,
+) -> Result<Vec<RuleDefinition>> {
+    let registry = registry_entity(space_did)?;
+    let rule_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_RULE).await?;
+
+    let mut rules = Vec::new();
+    for rule_entity in &rule_entities {
+        let conclusion = fetch_string(store, rule_entity, ATTR_RULE_CONCLUSION).await?;
+        if conclusion.as_deref() != Some(concept_name.as_str()) {
+            continue;
+        }
+        if let Some(def_str) = fetch_string(store, rule_entity, ATTR_RULE_DEFINITION).await? {
+            match serde_json::from_str::<RuleDefinition>(&def_str) {
+                Ok(def) => rules.push(def),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: skipping rule with malformed definition for concept '{}': {}",
+                        concept_name, e
+                    );
+                }
+            }
+        } else {
+            eprintln!(
+                "Warning: rule entity '{}' for concept '{}' has no definition attribute",
+                rule_entity, concept_name
+            );
+        }
+    }
+
+    Ok(rules)
+}

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -127,6 +127,21 @@ pub const ATTR_INSTANCE_CREATED: &str = "instance/created";
 /// Attribute metadata: human-readable description of the attribute.
 pub const ATTR_ATTRIBUTE_DESCRIPTION: &str = "attribute/description";
 
+/// Registry attribute: points from registry entity to rule entities.
+pub const ATTR_REGISTRY_RULE: &str = "registry/rule";
+
+/// Rule attribute: the human-readable name of the rule.
+pub const ATTR_RULE_NAME: &str = "rule/name";
+
+/// Rule attribute: optional description.
+pub const ATTR_RULE_DESCRIPTION: &str = "rule/description";
+
+/// Rule attribute: name of the conclusion concept.
+pub const ATTR_RULE_CONCLUSION: &str = "rule/conclusion";
+
+/// Rule attribute: JSON-serialized rule definition.
+pub const ATTR_RULE_DEFINITION: &str = "rule/definition";
+
 // ---------------------------------------------------------------------------
 // Deterministic entity derivation
 // ---------------------------------------------------------------------------
@@ -146,6 +161,17 @@ pub fn concept_entity(space_did: &str, concept_name: &ConceptName) -> Result<Ent
         "{}\0concept\0{}",
         space_did,
         concept_name.to_lowercase()
+    ))
+}
+
+/// Derive the rule entity for a given rule name within a space.
+///
+/// `rule_entity = did:key:z{base58(blake3(space_did + "\0rule\0" + lowercase_name))}`
+pub fn rule_entity(space_did: &str, rule_name: &str) -> Result<Entity> {
+    derive_entity(&format!(
+        "{}\0rule\0{}",
+        space_did,
+        rule_name.to_lowercase()
     ))
 }
 


### PR DESCRIPTION
### Description

Adds support for Dialog's deductive rule system.

When querying a concept that has associated rules, derived instances are transparently merged with stored instances via dialog-db's Session-based querying.

New CLI commands:
- `tonk rule`: list all rules
- `tonk rule define <name> --file <json> | --stdin`: define a rule from JSON
- `tonk rule show <name>`: show rule details
- `tonk rule delete <name>`: delete a rule

Details:
- rules are stored as JSON blobs in dialog-db with `rule/name`, `rule/conclusion`, `rule/definition`, and `rule/description` attributes
- rule entities are deterministically derived from `space_did + rule_name` (same pattern as concepts)
- at query time, rules targeting the queried concept are loaded, compiled into `DeductiveRule`s, registered with a `Session`, and executed via `Concept::apply`
- compiler automatically renames user variables to match concept operand names, with collision detection and auto-renaming for conflicting variables
- validation catches errors early: missing concepts, unbound variables, invalid attribute references

### Related issues

- closes TON-1858

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new module for managing rules in the `tonk-cli`, enabling the definition, listing, showing, and deletion of deductive rules. It enhances the schema and query functionalities to incorporate rules, allowing for more complex data derivation.

### Detailed summary
- Added `pub mod rule;` to `lib.rs`.
- Introduced new attributes related to rules in `schema.rs`.
- Implemented `rule_entity` function to derive rule entities.
- Added `RuleCommands` enum for rule management in the CLI.
- Updated command handling in `tonk.rs` to include rule commands.
- Enhanced `query` function to support selectors instead of filters.
- Created functions for defining, showing, listing, and deleting rules in `rule.rs`.
- Validated rule definitions to ensure they meet schema requirements.
- Added JSON serialization for rule definitions and responses.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->