### PR TITLE
fix: Fallback navigation for SPA-style routing

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -35,6 +35,17 @@ self.onfetch = event => {
                 return (await activateWorker()).onfetch(request);
             })(),
         );
+    // NOTE: Only intercept navigate as candidates for serving
+    // the index.html (in order to provide SPA-style routing)
+    } else if (request.mode === 'navigate') {
+        event.respondWith(
+            fetch(request).then(response => {
+                if (response.status === 404) {
+                    return fetch("/index.html");
+                }
+                return response;
+            }),
+        );
     }
 };
 

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -97,6 +97,26 @@ mod tests {
     use thirtyfour::prelude::*;
     use tonk_worker::{StatusResponse, SyncResponse};
 
+    #[dialog_common::test]
+    async fn it_falls_back_to_index_for_unhandled_routes(env: TestEnvironment) -> Result<()> {
+        // 1. Navigate to the root to confirm that the page loads
+        let driver = env.driver().await?;
+        let space = driver.query(By::Css(".space")).first().await?;
+        assert!(space.text().await?.starts_with("did:key:"));
+
+        // 2. Navigate again to /unhandled/route
+        driver
+            .goto(&format!("{}/unhandled/route", env.tonk_web))
+            .await?;
+
+        // 3. Confirm that the page loads (DID text rendered in the .space element)
+        let space = driver.query(By::Css(".space")).first().await?;
+        assert!(space.text().await?.starts_with("did:key:"));
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     /// Test that the UI auto-configures upstream on load via the access service.
     /// The access service is available at /ucan/ via Caddy reverse proxy.
     #[dialog_common::test]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "tonk-access-service"
 main = "./result/tonk-access-service/worker/shim.mjs"
-compatibility_date = "2024-01-01"
+compatibility_date = "2026-01-01"
 compatibility_flags = ["nodejs_compat"]
 
 [build]


### PR DESCRIPTION
PR-Codex got it right this time.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the compatibility date in `wrangler.toml`, enhancing the service worker to handle SPA-style routing by serving `index.html` for unhandled routes, and adding a test in `components.rs` to verify this functionality.

### Detailed summary
- Updated `compatibility_date` in `wrangler.toml` from "2024-01-01" to "2026-01-01".
- Enhanced service worker in `rust/tonk-ui/assets/service_worker.js` to intercept navigation requests and serve `index.html` for 404 responses.
- Added a new test in `rust/tonk-ui/src/components.rs` to verify routing behavior for unhandled routes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->