### PR TITLE
feat: Universal content-addressed blob storage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.wasm32-unknown-unknown]
 runner = "wasm-bindgen-test-runner"
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '--cfg', 'web_sys_unstable_apis']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1737,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1849,15 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2138,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idb"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2223,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2326,6 +2364,12 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leptos"
@@ -4520,7 +4564,7 @@ dependencies = [
  "dialog-storage",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4533,6 +4577,41 @@ dependencies = [
  "varsig",
  "worker",
  "worker-macros",
+]
+
+[[package]]
+name = "tonk-blobs"
+version = "0.1.0"
+dependencies = [
+ "base58",
+ "blake3",
+ "bytes",
+ "dialog-artifacts",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-query",
+ "dialog-s3-credentials",
+ "dialog-storage",
+ "dirs",
+ "futures-core",
+ "futures-util",
+ "getrandom 0.4.1",
+ "js-sys",
+ "serde",
+ "serde_ipld_dagcbor",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonk-common",
+ "ucan",
+ "ulid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -4633,7 +4712,7 @@ dependencies = [
  "console_error_panic_hook",
  "dialog-common",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "leptos",
  "leptos-use",
@@ -4673,7 +4752,7 @@ dependencies = [
  "dialog-s3-credentials",
  "dialog-storage",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "idb",
  "js-sys",
  "rand 0.9.2",
@@ -4866,6 +4945,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,6 +5127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,6 +5234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5168,6 +5288,18 @@ dependencies = [
  "quote",
  "sha2 0.10.9",
  "syn",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -5614,6 +5746,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "worker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "rust/tonk-access-service",
+    "rust/tonk-blobs",
     "rust/tonk-cli",
     "rust/tonk-core",
     "rust/tonk-common",
@@ -50,7 +51,8 @@ futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
 getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom_0_3 = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 hex = "0.4"
 hkdf = "0.12"
 idb = "0.6"
@@ -73,6 +75,8 @@ tempfile = "3"
 thirtyfour = "0.36"
 thiserror = "2"
 tokio = "1"
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 tower-service = "0.3"
 hyper = "1"
@@ -80,6 +84,7 @@ hyper-util = "0.1"
 bytes = "1"
 http-body-util = "0.1"
 url = "2"
+ulid = "1"
 wasm-streams = "0.4"
 web-time = "1"
 webbrowser = "1.0"
@@ -97,7 +102,7 @@ web-sys = { version = "0.3" }
 dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git",  branch = "tonk" }
 dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk" }
 dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "tonk", features = ["ucan"] }
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1768319649,
-        "narHash": "sha256-VFkNyxHxkqGp8gf8kfFMW1j6XeBy609kv6TE9uF/0Js=",
+        "lastModified": 1770419512,
+        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4b6527687cfd20da3c2ef8287e01b74c2d6c705b",
+        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
         "type": "github"
       },
       "original": {
@@ -91,8 +91,8 @@
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "wrangler-flake": "wrangler-flake",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "wrangler-flake": "wrangler-flake"
       }
     },
     "rust-overlay": {
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768359079,
-        "narHash": "sha256-a016mOfKconYrYo3fZLN6c2cnmqYYd44g2bUrBZAsQc=",
+        "lastModified": 1770779462,
+        "narHash": "sha256-ykcXTKtV+dOaKlOidAj6dpewBHjni9/oy/6VKcqfzfY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0357d1826057686637e41147545402cbbda420ce",
+        "rev": "8a53b3ade61914cdb10387db991b90a3a6f3c441",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768514153,
-        "narHash": "sha256-RqThQsJzlqdnC5s9DhZa93LD+5aoaf+dRcH3kBjgb7A=",
+        "lastModified": 1770743455,
+        "narHash": "sha256-E+h3LZEgMzlCs9I/CRpxfZ9bAE1LasJATYR6c3zZAio=",
         "owner": "emrldnix",
         "repo": "wrangler",
-        "rev": "c16f4ffb19d8e3de357a971efbdf2f68fc9ded72",
+        "rev": "913f6447be08bb1b60ac68f6c96091960af1655e",
         "type": "github"
       },
       "original": {

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -29,6 +29,7 @@ let
   rustSource = filter {
     root = workspaceRoot;
     include = [
+      ".cargo"
       "Cargo.lock"
       "Cargo.toml"
       "rust-toolchain.toml"

--- a/rust/tonk-blobs/Cargo.toml
+++ b/rust/tonk-blobs/Cargo.toml
@@ -1,0 +1,69 @@
+[package]
+name = "tonk-blobs"
+description = "File storage for Tonks"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+dialog-artifacts = { workspace = true, features = ["ucan"] }
+dialog-capability = { workspace = true }
+dialog-common = { workspace = true, features = ["helpers"] }
+dialog-query = { workspace = true }
+dialog-s3-credentials = { workspace = true }
+dialog-storage = { workspace = true }
+futures-util = { workspace = true }
+futures-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_ipld_dagcbor = { workspace = true }
+thiserror = { workspace = true }
+tonk-common = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+ucan = { workspace = true }
+bytes = { workspace = true }
+blake3 = { workspace = true }
+base58 = { workspace = true }
+ulid = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+js-sys = { workspace = true }
+wasm-streams = { workspace = true }
+getrandom = { workspace = true }
+# getrandom_0_2 = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
+web-sys = { workspace = true, features = [
+    "Crypto", "SubtleCrypto", "CryptoKey", "HkdfParams",
+    "Window", "Navigator", "StorageManager",
+    "FileSystemDirectoryHandle", "FileSystemFileHandle",
+    "FileSystemGetFileOptions", "FileSystemGetDirectoryOptions",
+    "FileSystemCreateWritableOptions", "FileSystemWritableFileStream",
+    "Blob", "File", "ReadableStream",
+    "LockManager",
+] }
+
+[dev-dependencies]
+tempfile = { workspace = true } 
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+[lints.rust]
+# The dialog_common::test macro uses cfg conditions that originate from the macro crate.
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(dialog_test_native_integration)',
+    'cfg(dialog_test_wasm_integration)',
+    'cfg(feature, values("web-integration-tests"))',
+] }

--- a/rust/tonk-blobs/src/blob_storage.rs
+++ b/rust/tonk-blobs/src/blob_storage.rs
@@ -1,0 +1,377 @@
+use base58::ToBase58;
+use dialog_common::Blake3Hash;
+use futures_core::Stream;
+use futures_util::StreamExt;
+use tokio::io::AsyncWriteExt;
+
+use crate::{FileReader, TonkBlobsError, Vfs};
+
+/// Derives the content-addressed path for a blob from its Blake3 hash.
+fn hash_to_path(hash: &Blake3Hash) -> String {
+    let b58 = hash.as_bytes().to_base58();
+    format!("{}/{}/{}/{}", &b58[0..2], &b58[2..4], &b58[4..6], b58)
+}
+
+/// High-level abstraction over platform-specific content-addressed blob
+/// storage.
+///
+/// Blobs are stored in a sharded directory tree derived from the base58
+/// encoding of their hash. Given a hash that encodes to `AbCdEfGh...`:
+///
+/// ```text
+/// <vfs root>/
+///   Ab/
+///     Cd/
+///       Ef/
+///         AbCdEfGh...   <- full base58 hash as filename
+/// ```
+///
+/// On native targets, native file system APIs are used. On the web, the
+/// origin-private file system is used.
+pub struct BlobStorage {
+    fs: Vfs,
+}
+
+impl BlobStorage {
+    /// Creates a new [`BlobStorage`] backed by the given [`Vfs`].
+    pub fn new(fs: Vfs) -> Self {
+        Self { fs }
+    }
+
+    /// Stores a blob from a stream of bytes.
+    /// Returns the Blake3 hash of the stored blob.
+    pub async fn put<S>(&mut self, mut bytes: S) -> Result<Blake3Hash, TonkBlobsError>
+    where
+        S: Stream<Item = Vec<u8>> + Unpin,
+    {
+        let mut hasher = blake3::Hasher::new();
+
+        // Each writer gets a unique temp file (ULID), so concurrent writes
+        // never interfere during the streaming phase.
+        let temp_name = format!(".tmp-{}", ulid::Ulid::new());
+        let mut writer = self.fs.write_to(&temp_name).await?;
+
+        while let Some(chunk) = bytes.next().await {
+            hasher.update(&chunk);
+            writer
+                .write_all(&chunk)
+                .await
+                .map_err(|error| TonkBlobsError::Put(format!("Write failed: {error}")))?;
+        }
+
+        writer
+            .shutdown()
+            .await
+            .map_err(|error| TonkBlobsError::Put(format!("Shutdown failed: {error}")))?;
+
+        let hash = Blake3Hash::from(*hasher.finalize().as_bytes());
+        let path = hash_to_path(&hash);
+
+        // Concurrent moves to the same content-addressed path are safe:
+        //
+        // - Native: rename(2) is atomic, so the last writer wins
+        //   harmlessly (content is identical by definition).
+        // - Web (Chromium): the non-standard FileSystemFileHandle.move()
+        //   is atomic, same as native rename.
+        // - Web (Firefox, Safari): no atomic move exists, so
+        //   Vfs::move_file serializes moves to the same destination
+        //   via the Web Locks API.
+        //
+        // In all cases the worst outcome is redundant I/O, never
+        // corruption or partial reads.
+        self.fs.move_file(&temp_name, &path).await?;
+
+        Ok(hash)
+    }
+
+    /// Retrieves a blob by its Blake3 hash.
+    ///
+    /// Returns `Ok(None)` when the blob cannot be read (e.g. it was never
+    /// stored or the underlying file is inaccessible).
+    pub async fn get(&self, hash: Blake3Hash) -> Result<Option<FileReader>, TonkBlobsError> {
+        let path = hash_to_path(&hash);
+
+        match self.fs.read_from(&path).await {
+            Ok(reader) => Ok(Some(reader)),
+            Err(_) => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    struct TestHarness {
+        storage: BlobStorage,
+        _dir: tempfile::TempDir,
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    impl TestHarness {
+        fn make_storage(&self) -> BlobStorage {
+            BlobStorage::new(Vfs::new(self._dir.path().to_path_buf()))
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn harness() -> TestHarness {
+        let dir = tempfile::tempdir().unwrap();
+        let vfs = Vfs::new(dir.path().to_path_buf());
+        TestHarness {
+            storage: BlobStorage::new(vfs),
+            _dir: dir,
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    struct TestHarness {
+        storage: BlobStorage,
+        root: String,
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    impl TestHarness {
+        fn make_storage(&self) -> BlobStorage {
+            BlobStorage::new(Vfs::new(self.root.clone()))
+        }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    fn harness() -> TestHarness {
+        let root = format!("test/{}", ulid::Ulid::new());
+        let vfs = Vfs::new(root.clone());
+        TestHarness {
+            storage: BlobStorage::new(vfs),
+            root,
+        }
+    }
+
+    async fn collect_reader(mut reader: FileReader) -> Vec<u8> {
+        let mut buf = Vec::new();
+        while let Some(chunk) = reader.next().await {
+            buf.extend_from_slice(&chunk.unwrap());
+        }
+        buf
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_and_retrieves_a_blob() {
+        let mut h = harness();
+        let data = b"hello world";
+
+        let hash = h
+            .storage
+            .put(stream::iter(vec![data.to_vec()]))
+            .await
+            .unwrap();
+        let reader = h
+            .storage
+            .get(hash)
+            .await
+            .unwrap()
+            .expect("blob should exist");
+        assert_eq!(collect_reader(reader).await, data);
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_the_correct_hash() {
+        let mut h = harness();
+        let data = b"test content";
+
+        let hash = h
+            .storage
+            .put(stream::iter(vec![data.to_vec()]))
+            .await
+            .unwrap();
+        let expected = Blake3Hash::hash(data);
+        assert_eq!(hash, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_handles_multiple_chunks() {
+        let mut h = harness();
+        let chunks = vec![b"chunk1".to_vec(), b"chunk2".to_vec(), b"chunk3".to_vec()];
+        let full_data: Vec<u8> = chunks.iter().flatten().copied().collect();
+
+        let hash = h.storage.put(stream::iter(chunks)).await.unwrap();
+        let reader = h
+            .storage
+            .get(hash)
+            .await
+            .unwrap()
+            .expect("blob should exist");
+        assert_eq!(collect_reader(reader).await, full_data);
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_none_for_nonexistent_blob() {
+        let h = harness();
+        let fake_hash = Blake3Hash::from([0u8; 32]);
+        assert!(h.storage.get(fake_hash).await.unwrap().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_consistent_hashes_for_identical_content() {
+        let mut h = harness();
+        let data = b"deterministic";
+
+        let hash1 = h
+            .storage
+            .put(stream::iter(vec![data.to_vec()]))
+            .await
+            .unwrap();
+        let hash2 = h
+            .storage
+            .put(stream::iter(vec![data.to_vec()]))
+            .await
+            .unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_and_retrieves_many_blobs() {
+        let mut h = harness();
+        let mut hashes = Vec::new();
+
+        for i in 0..20 {
+            let data = format!("blob number {i}");
+            let hash = h
+                .storage
+                .put(stream::iter(vec![data.into_bytes()]))
+                .await
+                .unwrap();
+            hashes.push(hash);
+        }
+
+        for (i, hash) in hashes.into_iter().enumerate() {
+            let expected = format!("blob number {i}");
+            let reader = h
+                .storage
+                .get(hash)
+                .await
+                .unwrap()
+                .expect("blob should exist");
+            assert_eq!(collect_reader(reader).await, expected.into_bytes());
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_multiple_blobs_concurrently() {
+        let mut h = harness();
+        let mut hashes = Vec::new();
+
+        for i in 0..10 {
+            let data = format!("concurrent read {i}");
+            let hash = h
+                .storage
+                .put(stream::iter(vec![data.into_bytes()]))
+                .await
+                .unwrap();
+            hashes.push(hash);
+        }
+
+        let reads: Vec<_> = hashes
+            .iter()
+            .map(|hash| h.storage.get(hash.clone()))
+            .collect();
+
+        let results = futures_util::future::join_all(reads).await;
+
+        for (i, result) in results.into_iter().enumerate() {
+            let expected = format!("concurrent read {i}");
+            let reader = result.unwrap().expect("blob should exist");
+            assert_eq!(collect_reader(reader).await, expected.into_bytes());
+        }
+    }
+
+    /// Returns a stream that yields each chunk with an explicit
+    /// `yield_now` between items, forcing the async runtime to
+    /// interleave concurrent tasks at every chunk boundary.
+    fn yielding_stream(chunks: Vec<Vec<u8>>) -> impl Stream<Item = Vec<u8>> + Unpin {
+        Box::pin(stream::iter(chunks).then(|chunk| async {
+            tokio::task::yield_now().await;
+            chunk
+        }))
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_identical_blobs_concurrently() {
+        let h = harness();
+
+        // Two writers produce identical multi-chunk content. The
+        // yielding stream forces the runtime to interleave execution
+        // at every chunk boundary. Each put() streams to a unique temp
+        // file (safe), then moves it to the same content-addressed
+        // destination. On the web slow path, without the Web Lock,
+        // both moves would stream-copy to the destination concurrently,
+        // interleaving their writes and corrupting the blob.
+        let chunks: Vec<Vec<u8>> = (0..8).map(|i| format!("chunk-{i}-").into_bytes()).collect();
+        let full_data: Vec<u8> = chunks.iter().flatten().copied().collect();
+
+        let mut writer_a = h.make_storage();
+        let mut writer_b = h.make_storage();
+
+        let (result_a, result_b) = futures_util::future::join(
+            writer_a.put(yielding_stream(chunks.clone())),
+            writer_b.put(yielding_stream(chunks.clone())),
+        )
+        .await;
+
+        let hash_a = result_a.unwrap();
+        let hash_b = result_b.unwrap();
+
+        assert_eq!(
+            hash_a, hash_b,
+            "identical content must produce identical hashes"
+        );
+
+        let reader = h
+            .storage
+            .get(hash_a)
+            .await
+            .unwrap()
+            .expect("blob should exist");
+        assert_eq!(collect_reader(reader).await, full_data);
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_blobs_concurrently_across_instances() {
+        let h = harness();
+
+        let futs: Vec<_> = (0..10)
+            .map(|i| {
+                let mut storage = h.make_storage();
+                async move {
+                    let data = format!("parallel write {i}");
+                    let hash = storage
+                        .put(stream::iter(vec![data.into_bytes()]))
+                        .await
+                        .unwrap();
+                    (i, hash)
+                }
+            })
+            .collect();
+
+        let results = futures_util::future::join_all(futs).await;
+
+        for (i, hash) in results {
+            let expected = format!("parallel write {i}");
+            let reader = h
+                .storage
+                .get(hash)
+                .await
+                .unwrap()
+                .expect("blob should exist");
+            assert_eq!(collect_reader(reader).await, expected.into_bytes());
+        }
+    }
+}

--- a/rust/tonk-blobs/src/error.rs
+++ b/rust/tonk-blobs/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+/// Errors produced by blob storage operations.
+#[derive(Error, Debug)]
+pub enum TonkBlobsError {
+    /// A write or move operation failed.
+    #[error("Failed to put blob bytes: {0}")]
+    Put(String),
+    /// A read operation failed.
+    #[error("Failed to get blob bytes: {0}")]
+    Get(String),
+    /// The storage backend could not be set up (e.g. missing data directory).
+    #[error("Failed to initialize blob storage: {0}")]
+    Initialization(String),
+    /// A caller-supplied path could not be resolved within the root directory.
+    #[error("Could not resolve path: {0}")]
+    Path(String),
+}

--- a/rust/tonk-blobs/src/lib.rs
+++ b/rust/tonk-blobs/src/lib.rs
@@ -1,0 +1,72 @@
+//! Local blob storage backed by the filesystem.
+//!
+//! # Examples
+//!
+//! Store a blob and read it back:
+//!
+//! ```
+//! use tonk_blobs::{BlobStorage, Vfs};
+//! use futures_util::stream;
+//! use futures_util::StreamExt;
+//!
+//! # async fn run() {
+//! #     #[cfg(not(target_arch = "wasm32"))]
+//! #     let _dir = tempfile::tempdir().unwrap();
+//! #     #[cfg(not(target_arch = "wasm32"))]
+//! #     let vfs = Vfs::new(_dir.path().to_path_buf());
+//! #     #[cfg(target_arch = "wasm32")]
+//! #     let vfs = Vfs::new(format!("doctest/{}", ulid::Ulid::new()));
+//! let mut storage = BlobStorage::new(vfs);
+//!
+//! // Store a blob from a stream of byte chunks
+//! let hash = storage
+//!     .put(stream::iter(vec![b"hello world".to_vec()]))
+//!     .await
+//!     .unwrap();
+//!
+//! // Retrieve it by hash
+//! let mut reader = storage.get(hash).await.unwrap().expect("blob exists");
+//! let mut buf = Vec::new();
+//! while let Some(chunk) = reader.next().await {
+//!     buf.extend_from_slice(&chunk.unwrap());
+//! }
+//! assert_eq!(buf, b"hello world");
+//! # }
+//! # #[cfg(not(target_arch = "wasm32"))]
+//! # tokio::runtime::Runtime::new().unwrap().block_on(run());
+//! # #[cfg(target_arch = "wasm32")]
+//! # wasm_bindgen_futures::spawn_local(run());
+//! ```
+//!
+//! A missing blob returns `None`:
+//!
+//! ```
+//! use tonk_blobs::{BlobStorage, Vfs};
+//! use dialog_common::Blake3Hash;
+//!
+//! # async fn run() {
+//! #     #[cfg(not(target_arch = "wasm32"))]
+//! #     let _dir = tempfile::tempdir().unwrap();
+//! #     #[cfg(not(target_arch = "wasm32"))]
+//! #     let vfs = Vfs::new(_dir.path().to_path_buf());
+//! #     #[cfg(target_arch = "wasm32")]
+//! #     let vfs = Vfs::new(format!("doctest/{}", ulid::Ulid::new()));
+//! let storage = BlobStorage::new(vfs);
+//!
+//! let missing = Blake3Hash::from([0u8; 32]);
+//! assert!(storage.get(missing).await.unwrap().is_none());
+//! # }
+//! # #[cfg(not(target_arch = "wasm32"))]
+//! # tokio::runtime::Runtime::new().unwrap().block_on(run());
+//! # #[cfg(target_arch = "wasm32")]
+//! # wasm_bindgen_futures::spawn_local(run());
+//! ```
+
+mod error;
+pub use error::*;
+
+mod vfs;
+pub use vfs::*;
+
+mod blob_storage;
+pub use blob_storage::*;

--- a/rust/tonk-blobs/src/vfs.rs
+++ b/rust/tonk-blobs/src/vfs.rs
@@ -1,0 +1,110 @@
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod web;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub use web::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    struct TestHarness {
+        vfs: Vfs,
+        _dir: tempfile::TempDir,
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn harness() -> TestHarness {
+        let dir = tempfile::tempdir().unwrap();
+        let vfs = Vfs::new(dir.path().to_path_buf());
+        TestHarness { vfs, _dir: dir }
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    struct TestHarness {
+        vfs: Vfs,
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    fn harness() -> TestHarness {
+        let vfs = Vfs::new(format!("test/{}", ulid::Ulid::new()));
+        TestHarness { vfs }
+    }
+
+    async fn collect_reader(mut reader: FileReader) -> Vec<u8> {
+        let mut buf = Vec::new();
+        while let Some(chunk) = reader.next().await {
+            buf.extend_from_slice(&chunk.unwrap());
+        }
+        buf
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_and_reads_back() {
+        let h = harness();
+        let data = b"hello world";
+
+        let mut w = h.vfs.write_to("test.txt").await.unwrap();
+        w.write_all(data).await.unwrap();
+        w.shutdown().await.unwrap();
+
+        let reader = h.vfs.read_from("test.txt").await.unwrap();
+        assert_eq!(collect_reader(reader).await, data);
+    }
+
+    #[dialog_common::test]
+    async fn it_writes_to_nested_path() {
+        let h = harness();
+        let data = b"nested content";
+
+        let mut w = h.vfs.write_to("a/b/c.txt").await.unwrap();
+        w.write_all(data).await.unwrap();
+        w.shutdown().await.unwrap();
+
+        let reader = h.vfs.read_from("a/b/c.txt").await.unwrap();
+        assert_eq!(collect_reader(reader).await, data);
+    }
+
+    #[dialog_common::test]
+    async fn it_moves_a_file() {
+        let h = harness();
+        let data = b"move me";
+
+        let mut w = h.vfs.write_to("src.txt").await.unwrap();
+        w.write_all(data).await.unwrap();
+        w.shutdown().await.unwrap();
+
+        h.vfs.move_file("src.txt", "dst/moved.txt").await.unwrap();
+
+        assert!(h.vfs.read_from("src.txt").await.is_err());
+
+        let reader = h.vfs.read_from("dst/moved.txt").await.unwrap();
+        assert_eq!(collect_reader(reader).await, data);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_path_traversal() {
+        let h = harness();
+        assert!(h.vfs.read_from("../../etc/passwd").await.is_err());
+        assert!(h.vfs.write_to("../escape.txt").await.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_nonexistent_file_as_error() {
+        let h = harness();
+        assert!(h.vfs.read_from("no_such_file.bin").await.is_err());
+    }
+}

--- a/rust/tonk-blobs/src/vfs/native.rs
+++ b/rust/tonk-blobs/src/vfs/native.rs
@@ -1,0 +1,258 @@
+use futures_core::Stream;
+use futures_util::TryFutureExt;
+use tokio::fs::File;
+use tokio::io::AsyncWrite;
+use tokio_util::io::ReaderStream;
+
+use std::{
+    path::{Path, PathBuf},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::TonkBlobsError;
+
+/// A sandboxed virtual filesystem rooted at a fixed directory.
+///
+/// Every path provided to [`Vfs`] methods is resolved relative to its root.
+/// Path components like `..` are normalized away, and any result that would
+/// escape the root is rejected with a [`TonkBlobsError::Path`] error.
+pub struct Vfs {
+    root: PathBuf,
+}
+
+impl From<PathBuf> for Vfs {
+    fn from(value: PathBuf) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Vfs {
+    /// Creates a new [`Vfs`] with the given directory as its root.
+    ///
+    /// The root path is used as-is; callers should ensure it is absolute and
+    /// already exists on disk before performing any I/O.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// Converts a given path into a normalized path rooted on the internal `root`.
+    /// Prevents path traversal by resolving `..` components and verifying
+    /// the result stays within the root directory.
+    fn local_path(&self, given_path: &str) -> Result<PathBuf, TonkBlobsError> {
+        let joined = self.root.join(given_path.trim_start_matches('/'));
+        let mut normalized = PathBuf::new();
+        for component in joined.components() {
+            match component {
+                std::path::Component::ParentDir => {
+                    normalized.pop();
+                }
+                other => {
+                    normalized.push(other.as_os_str());
+                }
+            }
+        }
+        if normalized.starts_with(&self.root) {
+            Ok(normalized)
+        } else {
+            Err(TonkBlobsError::Path(
+                "Resolved path does not fall inside of configured root".into(),
+            ))
+        }
+    }
+
+    /// Returns the parent directory of `path`, clamped to [`self.root`].
+    ///
+    /// If the path has no parent or its parent falls outside the root, the
+    /// root itself is returned.
+    fn parent_directory(&self, path: &Path) -> PathBuf {
+        path.parent()
+            .filter(|p| p.starts_with(&self.root))
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| self.root.clone())
+    }
+
+    /// Creates a [`Vfs`] rooted at the platform's data directory
+    /// (`<data_dir>/tonk/blobs`).
+    ///
+    /// Returns [`TonkBlobsError::Initialization`] if the platform data
+    /// directory cannot be determined.
+    pub fn with_default_root() -> Result<Self, TonkBlobsError> {
+        dirs::data_dir()
+            .map(|path| path.join("tonk").join("blobs").into())
+            .ok_or_else(|| {
+                TonkBlobsError::Initialization("Could not determine data directory".to_string())
+            })
+    }
+
+    /// Opens the file at `path` (relative to root) for reading and returns a
+    /// [`FileReader`] that streams its contents as [`bytes::Bytes`] chunks.
+    pub async fn read_from(&self, path: &str) -> Result<FileReader, TonkBlobsError> {
+        self.local_path(path)
+            .map(|path| {
+                File::open(path)
+                    .map_err(|error| TonkBlobsError::Get(format!("Could not open file: {error}")))
+                    .map_ok(FileReader::new)
+            })?
+            .await
+    }
+
+    /// Creates a file at the given path (relative to root) and returns a handle for writing.
+    /// Intermediate directories are created as needed.
+    pub async fn write_to(&self, path: &str) -> Result<FileWriter, TonkBlobsError> {
+        self.local_path(path)
+            .map(|path| {
+                tokio::fs::create_dir_all(self.parent_directory(&path))
+                    .map_err(|error| {
+                        TonkBlobsError::Put(format!(
+                            "Could not create directory structure: {error}"
+                        ))
+                    })
+                    .and_then(|_| {
+                        File::create(path)
+                            .map_err(|error| {
+                                TonkBlobsError::Put(format!("Could not create file: {error}"))
+                            })
+                            .map_ok(FileWriter::new)
+                    })
+            })?
+            .await
+    }
+
+    /// Moves a file from one rooted path to another.
+    ///
+    /// Intermediate directories for the destination are created as needed.
+    /// Both `from` and `to` are resolved relative to root.
+    pub async fn move_file(&self, from: &str, to: &str) -> Result<(), TonkBlobsError> {
+        let from_full_path = self.local_path(from)?;
+        let to_full_path = self.local_path(to)?;
+
+        let destination_directory = self.parent_directory(&to_full_path);
+
+        tokio::fs::create_dir_all(&destination_directory)
+            .map_err(|error| {
+                TonkBlobsError::Put(format!("Could not create directory hierarchy: {error}"))
+            })
+            .and_then(|_| {
+                tokio::fs::rename(&from_full_path, &to_full_path)
+                    .map_err(|error| TonkBlobsError::Put(format!("Failed to move file: {}", error)))
+            })
+            .await
+    }
+
+    // fn ensure_path(&self, path: PathBuf)
+}
+
+/// A streaming reader for a file managed by [`Vfs`].
+///
+/// Implements [`Stream`]`<Item = Result<`[`bytes::Bytes`]`, `[`std::io::Error`]`>>`,
+/// yielding the file contents in chunks suitable for forwarding over a
+/// network or piping into another async sink.
+pub struct FileReader {
+    file: ReaderStream<File>,
+}
+
+impl FileReader {
+    fn new(file: File) -> Self {
+        Self {
+            file: ReaderStream::new(file),
+        }
+    }
+}
+
+impl Stream for FileReader {
+    type Item = Result<bytes::Bytes, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().file).poll_next(cx)
+    }
+}
+
+/// An async writer for a file managed by [`Vfs`].
+///
+/// Implements [`AsyncWrite`], delegating all operations to the underlying
+/// tokio [`File`] handle.
+pub struct FileWriter {
+    file: File,
+}
+
+impl FileWriter {
+    fn new(file: File) -> Self {
+        Self { file }
+    }
+}
+
+impl AsyncWrite for FileWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().file).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().file).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().file).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vfs(root: &str) -> Vfs {
+        Vfs::new(PathBuf::from(root))
+    }
+
+    #[test]
+    fn it_resolves_a_simple_filename_under_root() {
+        let v = vfs("/data/blobs");
+        assert_eq!(
+            v.local_path("foo.txt").unwrap(),
+            PathBuf::from("/data/blobs/foo.txt")
+        );
+    }
+
+    #[test]
+    fn it_strips_a_leading_slash_from_the_given_path() {
+        let v = vfs("/data/blobs");
+        assert_eq!(
+            v.local_path("/sub/file.bin").unwrap(),
+            PathBuf::from("/data/blobs/sub/file.bin")
+        );
+    }
+
+    #[test]
+    fn it_resolves_nested_paths() {
+        let v = vfs("/data/blobs");
+        assert_eq!(
+            v.local_path("a/b/c.txt").unwrap(),
+            PathBuf::from("/data/blobs/a/b/c.txt")
+        );
+    }
+
+    #[test]
+    fn it_rejects_traversal_above_root() {
+        let v = vfs("/data/blobs");
+        assert!(v.local_path("../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn it_allows_parent_traversal_that_stays_within_root() {
+        let v = vfs("/data/blobs");
+        assert_eq!(
+            v.local_path("a/b/../c.txt").unwrap(),
+            PathBuf::from("/data/blobs/a/c.txt")
+        );
+    }
+
+    #[test]
+    fn it_rejects_a_path_that_escapes_to_roots_sibling() {
+        let v = vfs("/data/blobs");
+        assert!(v.local_path("../secret").is_err());
+    }
+}

--- a/rust/tonk-blobs/src/vfs/web.rs
+++ b/rust/tonk-blobs/src/vfs/web.rs
@@ -1,0 +1,536 @@
+use futures_core::Stream;
+use futures_util::StreamExt;
+use futures_util::io::AsyncWrite as FuturesAsyncWrite;
+use js_sys::Uint8Array;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetDirectoryOptions,
+    FileSystemGetFileOptions, FileSystemWritableFileStream,
+};
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::TonkBlobsError;
+
+/// Extracts a human-readable message from a [`JsValue`] error.
+///
+/// Tries the `message` property of a JS `Error` first, then a bare string
+/// value, and falls back to `Debug` formatting for anything else.
+fn display_js_value(value: &JsValue) -> String {
+    if let Some(error) = value.dyn_ref::<js_sys::Error>() {
+        return String::from(error.message());
+    }
+    if let Some(s) = value.as_string() {
+        return s;
+    }
+    format!("{value:?}")
+}
+
+#[wasm_bindgen]
+extern "C" {
+    /// Extension type for `FileSystemFileHandle` that exposes the
+    /// Chromium-only `move()` method. Since `move` is a Rust keyword,
+    /// the Rust-side name is `move_to`.
+    #[wasm_bindgen(extends = web_sys::FileSystemFileHandle)]
+    type FileSystemFileHandleExt;
+
+    /// `fileHandle.move(destinationDir, newName)` — atomically moves
+    /// the file into `destination` with the given name. Returns a Promise.
+    /// Only available in Chromium-based browsers.
+    #[wasm_bindgen(method, structural, catch, js_name = move)]
+    fn move_to(
+        this: &FileSystemFileHandleExt,
+        destination: &web_sys::FileSystemDirectoryHandle,
+        name: &str,
+    ) -> Result<js_sys::Promise, JsValue>;
+}
+
+/// Returns `true` if the given file handle has a `move` method (Chromium-only).
+fn supports_native_move(handle: &web_sys::FileSystemFileHandle) -> bool {
+    js_sys::Reflect::has(handle, &"move".into()).unwrap_or(false)
+}
+
+/// Returns the `LockManager` from `navigator.locks`.
+fn lock_manager() -> Result<web_sys::LockManager, TonkBlobsError> {
+    let global = js_sys::global();
+    let navigator = js_sys::Reflect::get(&global, &"navigator".into()).map_err(|error| {
+        TonkBlobsError::Put(format!("No navigator: {}", display_js_value(&error)))
+    })?;
+    js_sys::Reflect::get(&navigator, &"locks".into())
+        .map_err(|error| {
+            TonkBlobsError::Put(format!("No lock manager: {}", display_js_value(&error)))
+        })?
+        .dyn_into()
+        .map_err(|_| TonkBlobsError::Put("Expected LockManager".into()))
+}
+
+/// Executes `f` while holding a Web Lock with the given `name`.
+///
+/// Uses the Web Locks API (`navigator.locks.request`) to coordinate
+/// across browser tabs, workers, and service workers. The lock is
+/// automatically released when `f` completes or when the execution
+/// context terminates.
+async fn with_web_lock<F, Fut, T>(name: &str, f: F) -> Result<T, TonkBlobsError>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T, TonkBlobsError>>,
+{
+    let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // The JS callback is invoked once the browser grants the lock. It
+    // signals acquisition via `acquired_tx`, then returns a Promise that
+    // stays pending until we send on `release_tx` — keeping the Web Lock
+    // held for the duration of the critical section.
+    let callback = Closure::once_into_js(move |_lock: JsValue| -> JsValue {
+        let _ = acquired_tx.send(());
+        wasm_bindgen_futures::future_to_promise(async move {
+            let _ = release_rx.await;
+            Ok(JsValue::UNDEFINED)
+        })
+        .into()
+    });
+
+    let mgr = lock_manager()?;
+    let outer_promise = mgr.request_with_callback(name, callback.unchecked_ref());
+
+    // Yield until the browser grants the lock and our callback fires.
+    acquired_rx
+        .await
+        .map_err(|_| TonkBlobsError::Put("Web Lock acquisition cancelled".into()))?;
+
+    // Critical section.
+    let result = f().await;
+
+    // Release the Web Lock (signal the inner promise to resolve).
+    // If `release_tx` is dropped without sending (e.g. on panic), the
+    // channel closes and `release_rx.await` returns Err — which we
+    // ignore in the callback, so the lock is still released.
+    let _ = release_tx.send(());
+    let outer = JsFuture::from(outer_promise).await;
+
+    // Prefer the critical-section error (more actionable); otherwise
+    // propagate any lock-manager rejection.
+    let value = result?;
+    outer.map_err(|error| {
+        TonkBlobsError::Put(format!(
+            "Web Lock request failed: {}",
+            display_js_value(&error)
+        ))
+    })?;
+    Ok(value)
+}
+
+/// A sandboxed virtual filesystem backed by the Origin Private File System (OPFS).
+///
+/// Every path provided to [`Vfs`] methods is resolved relative to a virtual root
+/// directory within OPFS. Path components like `..` are rejected to prevent
+/// traversal outside the root.
+pub struct Vfs {
+    root: String,
+}
+
+impl From<String> for Vfs {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Vfs {
+    /// Creates a new [`Vfs`] with the given path as its root within OPFS.
+    ///
+    /// The root is a `/`-separated virtual path (e.g. `"tonk/blobs"`) that will
+    /// be created as nested directories inside the OPFS root.
+    pub fn new(root: String) -> Self {
+        Self { root }
+    }
+
+    /// Creates a [`Vfs`] rooted at `tonk/blobs` within OPFS.
+    pub fn with_default_root() -> Result<Self, TonkBlobsError> {
+        Ok(Self::new("tonk/blobs".into()))
+    }
+
+    /// Obtains the OPFS root directory handle via `navigator.storage.getDirectory()`.
+    async fn opfs_root() -> Result<FileSystemDirectoryHandle, TonkBlobsError> {
+        let global = js_sys::global();
+        let navigator = js_sys::Reflect::get(&global, &"navigator".into()).map_err(|error| {
+            TonkBlobsError::Initialization(format!("No navigator: {}", display_js_value(&error)))
+        })?;
+        let storage: web_sys::StorageManager = js_sys::Reflect::get(&navigator, &"storage".into())
+            .map_err(|error| {
+                TonkBlobsError::Initialization(format!(
+                    "No storage manager: {}",
+                    display_js_value(&error)
+                ))
+            })?
+            .dyn_into()
+            .map_err(|_| TonkBlobsError::Initialization("Expected StorageManager".to_string()))?;
+        JsFuture::from(storage.get_directory())
+            .await
+            .map_err(|error| {
+                TonkBlobsError::Initialization(format!(
+                    "OPFS unavailable: {}",
+                    display_js_value(&error)
+                ))
+            })?
+            .dyn_into()
+            .map_err(|_| {
+                TonkBlobsError::Initialization("Expected FileSystemDirectoryHandle".to_string())
+            })
+    }
+
+    /// Splits a caller-supplied path into `(directory_segments, file_name)`.
+    ///
+    /// Rejects `..` and `.` components to prevent traversal.
+    fn split_path(path: &str) -> Result<(Vec<&str>, &str), TonkBlobsError> {
+        let segments: Vec<&str> = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if segments.is_empty() {
+            return Err(TonkBlobsError::Path("Empty path".into()));
+        }
+
+        if segments.iter().any(|s| *s == ".." || *s == ".") {
+            return Err(TonkBlobsError::Path(
+                "Resolved path does not fall inside of configured root".into(),
+            ));
+        }
+
+        let (dirs, file) = segments.split_at(segments.len() - 1);
+        Ok((dirs.to_vec(), file[0]))
+    }
+
+    /// Navigates from a starting directory through a chain of subdirectories,
+    /// optionally creating them along the way.
+    async fn navigate(
+        from: &FileSystemDirectoryHandle,
+        segments: &[&str],
+        create: bool,
+    ) -> Result<FileSystemDirectoryHandle, TonkBlobsError> {
+        let opts = FileSystemGetDirectoryOptions::new();
+        opts.set_create(create);
+
+        let mut current = from.clone();
+        for segment in segments {
+            current = JsFuture::from(current.get_directory_handle_with_options(segment, &opts))
+                .await
+                .map_err(|error| {
+                    TonkBlobsError::Path(format!(
+                        "Directory '{segment}': {}",
+                        display_js_value(&error)
+                    ))
+                })?
+                .dyn_into()
+                .map_err(|_| {
+                    TonkBlobsError::Path(format!("Failed to cast directory handle for '{segment}'"))
+                })?;
+        }
+
+        Ok(current)
+    }
+
+    /// Resolves the virtual root plus additional path segments into a directory handle.
+    async fn resolve_directory(
+        &self,
+        extra: &[&str],
+        create: bool,
+    ) -> Result<FileSystemDirectoryHandle, TonkBlobsError> {
+        let opfs = Self::opfs_root().await?;
+        let root_segments: Vec<&str> = self.root.split('/').filter(|s| !s.is_empty()).collect();
+        let all: Vec<&str> = root_segments.iter().chain(extra.iter()).copied().collect();
+        Self::navigate(&opfs, &all, create).await
+    }
+
+    /// Removes a file by name from the given parent directory.
+    async fn remove_entry(
+        dir: &FileSystemDirectoryHandle,
+        name: &str,
+    ) -> Result<(), TonkBlobsError> {
+        JsFuture::from(dir.remove_entry(name))
+            .await
+            .map_err(|error| {
+                TonkBlobsError::Put(format!(
+                    "Could not delete '{name}': {}",
+                    display_js_value(&error)
+                ))
+            })?;
+        Ok(())
+    }
+
+    /// Opens the file at `path` (relative to root) for reading and returns a
+    /// [`FileReader`] that streams its contents as [`bytes::Bytes`] chunks.
+    pub async fn read_from(&self, path: &str) -> Result<FileReader, TonkBlobsError> {
+        let (dirs, name) = Self::split_path(path)?;
+        let dir = self.resolve_directory(&dirs, false).await?;
+
+        let opts = FileSystemGetFileOptions::new();
+        opts.set_create(false);
+
+        let handle: FileSystemFileHandle =
+            JsFuture::from(dir.get_file_handle_with_options(name, &opts))
+                .await
+                .map_err(|error| {
+                    TonkBlobsError::Get(format!(
+                        "Could not open file: {}",
+                        display_js_value(&error)
+                    ))
+                })?
+                .dyn_into()
+                .map_err(|_| TonkBlobsError::Get("Expected FileSystemFileHandle".into()))?;
+
+        let file: web_sys::File = JsFuture::from(handle.get_file())
+            .await
+            .map_err(|error| {
+                TonkBlobsError::Get(format!("Could not get file: {}", display_js_value(&error)))
+            })?
+            .dyn_into()
+            .map_err(|_| TonkBlobsError::Get("Expected File".into()))?;
+
+        Ok(FileReader::new(file.stream()))
+    }
+
+    /// Creates a file at the given path (relative to root) and returns a handle for writing.
+    /// Intermediate directories are created as needed.
+    pub async fn write_to(&self, path: &str) -> Result<FileWriter, TonkBlobsError> {
+        let (dirs, name) = Self::split_path(path)?;
+        let dir = self.resolve_directory(&dirs, true).await?;
+
+        let opts = FileSystemGetFileOptions::new();
+        opts.set_create(true);
+
+        let handle: FileSystemFileHandle =
+            JsFuture::from(dir.get_file_handle_with_options(name, &opts))
+                .await
+                .map_err(|error| {
+                    TonkBlobsError::Put(format!(
+                        "Could not create file: {}",
+                        display_js_value(&error)
+                    ))
+                })?
+                .dyn_into()
+                .map_err(|_| TonkBlobsError::Put("Expected FileSystemFileHandle".into()))?;
+
+        let writable: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
+            .await
+            .map_err(|error| {
+                TonkBlobsError::Put(format!(
+                    "Could not create writable stream: {}",
+                    display_js_value(&error)
+                ))
+            })?
+            .dyn_into()
+            .map_err(|_| TonkBlobsError::Put("Expected FileSystemWritableFileStream".into()))?;
+
+        Ok(FileWriter::new(writable))
+    }
+
+    /// Moves a file from one rooted path to another.
+    ///
+    /// Intermediate directories for the destination are created as needed.
+    /// Both `from` and `to` are resolved relative to root. The data is
+    /// streamed from source to destination so that large files do not need
+    /// to be buffered entirely in memory.
+    pub async fn move_file(&self, from: &str, to: &str) -> Result<(), TonkBlobsError> {
+        let (from_dirs, from_name) = Self::split_path(from)?;
+        let (to_dirs, to_name) = Self::split_path(to)?;
+
+        // Resolve the source file handle
+        let from_dir = self.resolve_directory(&from_dirs, false).await?;
+        let opts = FileSystemGetFileOptions::new();
+        opts.set_create(false);
+        let handle: FileSystemFileHandle =
+            JsFuture::from(from_dir.get_file_handle_with_options(from_name, &opts))
+                .await
+                .map_err(|error| {
+                    TonkBlobsError::Get(format!(
+                        "Source file not found: {}",
+                        display_js_value(&error)
+                    ))
+                })?
+                .dyn_into()
+                .map_err(|_| TonkBlobsError::Get("Expected FileSystemFileHandle".into()))?;
+
+        // Resolve (or create) the destination directory
+        let to_dir = self.resolve_directory(&to_dirs, true).await?;
+
+        // Fast path: use Chromium's native atomic move if available.
+        // If the move rejects (e.g. destination is locked by a concurrent
+        // writer), fall through to the slow path which serializes via Web Locks.
+        if supports_native_move(&handle) {
+            let ext: &FileSystemFileHandleExt = handle.unchecked_ref();
+            if let Ok(promise) = ext.move_to(&to_dir, to_name) {
+                if JsFuture::from(promise).await.is_ok() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Slow path: stream copy + delete (Firefox, Safari, etc.)
+        //
+        // This is not atomic, so two concurrent moves to the same
+        // destination would interleave writes and corrupt the file.
+        // A Web Lock keyed on the destination path serializes them.
+        let lock_name = format!("tonk-blob-move:{to}");
+        with_web_lock(&lock_name, || async {
+            let mut reader = self.read_from(from).await?;
+            let mut writer = self.write_to(to).await?;
+
+            while let Some(chunk) = reader.next().await {
+                let bytes =
+                    chunk.map_err(|error| TonkBlobsError::Put(format!("Read error: {error}")))?;
+                writer
+                    .write_all(&bytes)
+                    .await
+                    .map_err(|error| TonkBlobsError::Put(format!("Write error: {error}")))?;
+            }
+
+            writer
+                .shutdown()
+                .await
+                .map_err(|error| TonkBlobsError::Put(format!("Failed to finalize: {error}")))?;
+
+            Self::remove_entry(&from_dir, from_name).await
+        })
+        .await
+    }
+}
+
+/// A streaming reader for a file managed by [`Vfs`].
+///
+/// Implements [`Stream`]`<Item = Result<`[`bytes::Bytes`]`, `[`std::io::Error`]`>>`,
+/// yielding the file contents in chunks suitable for forwarding over a
+/// network or piping into another async sink.
+pub struct FileReader {
+    inner: wasm_streams::readable::IntoStream<'static>,
+}
+
+impl FileReader {
+    fn new(readable: web_sys::ReadableStream) -> Self {
+        let stream = wasm_streams::ReadableStream::from_raw(readable.unchecked_into());
+        Self {
+            inner: stream.into_stream(),
+        }
+    }
+}
+
+impl Stream for FileReader {
+    type Item = Result<bytes::Bytes, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(js_value))) => {
+                let array = Uint8Array::new(&js_value);
+                Poll::Ready(Some(Ok(bytes::Bytes::from(array.to_vec()))))
+            }
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Stream error: {}", display_js_value(&error)),
+            )))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// An async writer for a file managed by [`Vfs`].
+///
+/// Implements [`AsyncWrite`] by delegating to the [`wasm_streams`] async
+/// writer, which bridges tokio's poll-based interface with the Promise-based
+/// OPFS [`FileSystemWritableFileStream`].
+pub struct FileWriter {
+    inner: wasm_streams::writable::IntoAsyncWrite<'static>,
+}
+
+impl FileWriter {
+    fn new(writable: FileSystemWritableFileStream) -> Self {
+        let stream = wasm_streams::WritableStream::from_raw(writable.unchecked_into());
+        Self {
+            inner: stream.into_async_write(),
+        }
+    }
+}
+
+impl AsyncWrite for FileWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[wasm_bindgen_test]
+    fn it_resolves_a_simple_filename_under_root() {
+        let (dirs, name) = Vfs::split_path("foo.txt").unwrap();
+        assert!(dirs.is_empty());
+        assert_eq!(name, "foo.txt");
+    }
+
+    #[wasm_bindgen_test]
+    fn it_strips_a_leading_slash_from_the_given_path() {
+        let (dirs, name) = Vfs::split_path("/sub/file.bin").unwrap();
+        assert_eq!(dirs, vec!["sub"]);
+        assert_eq!(name, "file.bin");
+    }
+
+    #[wasm_bindgen_test]
+    fn it_resolves_nested_paths() {
+        let (dirs, name) = Vfs::split_path("a/b/c.txt").unwrap();
+        assert_eq!(dirs, vec!["a", "b"]);
+        assert_eq!(name, "c.txt");
+    }
+
+    #[wasm_bindgen_test]
+    fn it_rejects_traversal_above_root() {
+        assert!(Vfs::split_path("../../etc/passwd").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn it_rejects_parent_traversal_even_within_root() {
+        // Web VFS is stricter than native: all ".." components are rejected
+        // because OPFS does not support path normalization.
+        assert!(Vfs::split_path("a/b/../c.txt").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn it_rejects_a_path_that_escapes_to_roots_sibling() {
+        assert!(Vfs::split_path("../secret").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn it_rejects_dot_segments() {
+        assert!(Vfs::split_path("./foo.txt").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn it_rejects_empty_path() {
+        assert!(Vfs::split_path("").is_err());
+    }
+}

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/bin/tonk.rs"
 default = []
 
 [dependencies]
+
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # CLI
 clap = { workspace = true, features = ["derive"] }
 dialoguer = { workspace = true }
@@ -64,23 +67,22 @@ dirs = { workspace = true }
 
 # For opening browser
 webbrowser = { workspace = true }
-
 [dev-dependencies]
 tempfile = { workspace = true }
 
 # Platform-specific keyring backends
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), target_os = "macos"))'.dependencies]
 keyring = { workspace = true, features = ["apple-native"] }
 
-[target.'cfg(target_os = "ios")'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), target_os = "ios"))'.dependencies]
 keyring = { workspace = true, features = ["apple-native"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), target_os = "windows"))'.dependencies]
 keyring = { workspace = true, features = ["windows-native"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), target_os = "linux"))'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }
 
 # Fallback for other platforms (FreeBSD, etc.)
-[target.'cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows", target_os = "linux")))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "windows", target_os = "linux")))'.dependencies]
 keyring = { workspace = true }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1,268 +1,283 @@
-use clap::{Parser, Subcommand};
+#[cfg(target_arch = "wasm32")]
+mod inner {}
 
-#[derive(Parser)]
-#[command(name = "tonk")]
-#[command(about = "Tonk CLI - Authentication and management tool", long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
+#[cfg(not(target_arch = "wasm32"))]
+mod inner {
+    use clap::{Parser, Subcommand};
 
-#[derive(Subcommand)]
-enum Commands {
-    /// Authenticate and obtain delegated capabilities
-    Login {
-        /// Optional authentication URL (e.g., "https://auth.tonk.xyz").
-        /// If not provided, serves auth page locally.
-        #[arg(long)]
-        via: Option<String>,
-    },
-
-    /// Manage sessions (authority contexts)
-    Session {
+    #[derive(Parser)]
+    #[command(name = "tonk")]
+    #[command(about = "Tonk CLI - Authentication and management tool", long_about = None)]
+    pub struct Cli {
         #[command(subcommand)]
-        command: Option<SessionCommands>,
+        pub command: Commands,
+    }
 
-        /// Show verbose output including delegation chains
-        #[arg(short, long)]
-        verbose: bool,
-    },
+    #[derive(Subcommand)]
+    pub enum Commands {
+        /// Authenticate and obtain delegated capabilities
+        Login {
+            /// Optional authentication URL (e.g., "https://auth.tonk.xyz").
+            /// If not provided, serves auth page locally.
+            #[arg(long)]
+            via: Option<String>,
+        },
 
-    /// Manage spaces (collaboration units)
-    Space {
-        #[command(subcommand)]
-        command: Option<SpaceCommands>,
-    },
+        /// Manage sessions (authority contexts)
+        Session {
+            #[command(subcommand)]
+            command: Option<SessionCommands>,
 
-    /// Operator commands
-    Operator {
-        #[command(subcommand)]
-        command: OperatorCommands,
-    },
+            /// Show verbose output including delegation chains
+            #[arg(short, long)]
+            verbose: bool,
+        },
 
-    /// Inspect delegations and invites
-    Inspect {
-        #[command(subcommand)]
-        command: InspectCommands,
-    },
+        /// Manage spaces (collaboration units)
+        Space {
+            #[command(subcommand)]
+            command: Option<SpaceCommands>,
+        },
 
-    /// Manage facts in the active space
-    Fact {
-        #[command(subcommand)]
-        command: FactCommands,
-    },
+        /// Operator commands
+        Operator {
+            #[command(subcommand)]
+            command: OperatorCommands,
+        },
 
-    /// Manage remotes for syncing spaces
-    Remote {
-        #[command(subcommand)]
-        command: RemoteCommands,
-    },
+        /// Inspect delegations and invites
+        Inspect {
+            #[command(subcommand)]
+            command: InspectCommands,
+        },
 
-    /// Pull changes from the upstream remote
-    Pull,
+        /// Manage facts in the active space
+        Fact {
+            #[command(subcommand)]
+            command: FactCommands,
+        },
 
-    /// Push local changes to the upstream remote
-    Push,
+        /// Manage remotes for syncing spaces
+        Remote {
+            #[command(subcommand)]
+            command: RemoteCommands,
+        },
 
-    /// Sync with upstream (pull then push)
-    Sync,
+        /// Pull changes from the upstream remote
+        Pull,
+
+        /// Push local changes to the upstream remote
+        Push,
+
+        /// Sync with upstream (pull then push)
+        Sync,
+    }
+
+    #[derive(Subcommand)]
+    pub enum SessionCommands {
+        /// Show the current session DID
+        Current,
+
+        /// Switch to a different session
+        Set {
+            /// Authority DID to switch to
+            authority_did: String,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum SpaceCommands {
+        /// Show the current space DID
+        Current,
+
+        /// Switch to a different space
+        Set {
+            /// Space name or DID to switch to
+            space: String,
+        },
+
+        /// Create a new space
+        Create {
+            /// Name of the space
+            name: String,
+
+            /// Owner DIDs (did:key identifiers). If not provided, will prompt interactively.
+            /// The active authority is always included as an owner.
+            #[arg(short, long)]
+            owners: Option<Vec<String>>,
+
+            /// Optional description
+            #[arg(short, long)]
+            description: Option<String>,
+        },
+
+        /// Invite a collaborator to a space
+        Invite {
+            /// Email address of the invitee (e.g., alice@example.com)
+            email: String,
+
+            /// Name of the space (defaults to active space)
+            #[arg(short, long)]
+            space: Option<String>,
+        },
+
+        /// Join a space using an invitation file
+        Join {
+            /// Path to the invitation file
+            #[arg(short, long)]
+            invite: String,
+
+            /// Profile to join with (defaults to active profile)
+            #[arg(short, long)]
+            profile: Option<String>,
+        },
+
+        /// Delete a space
+        Delete {
+            /// Space name or DID to delete
+            space: String,
+
+            /// Skip confirmation prompt
+            #[arg(short, long)]
+            force: bool,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum OperatorCommands {
+        /// Generate a new operator key (base58btc encoded)
+        Generate,
+    }
+
+    #[derive(Subcommand)]
+    pub enum InspectCommands {
+        /// Inspect a delegation (base64-encoded CBOR or .cbor file)
+        Delegation {
+            /// Base64-encoded CBOR delegation string or path to .cbor file
+            input: String,
+        },
+
+        /// Inspect an invite file
+        Invite {
+            /// Path to .invite file
+            path: String,
+        },
+
+        /// Inspect CBOR data and display as JSON
+        Cbor {
+            /// Path to .cbor file or base64-encoded CBOR string
+            input: String,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum FactCommands {
+        /// Assert a fact into the active space
+        Assert {
+            /// The attribute (e.g., "user/name")
+            #[arg(long, allow_hyphen_values = true)]
+            the: String,
+
+            /// The entity identifier. Can be:
+            /// - ~/path - derives entity from operator signature
+            /// - URI (e.g., did:key:..., https://...) - used as-is
+            /// - any string - hashed to create entity
+            #[arg(long, allow_hyphen_values = true)]
+            of: String,
+
+            /// The value to assert (all remaining words joined with spaces)
+            #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
+            is: Vec<String>,
+        },
+
+        /// Retract a fact from the active space
+        Retract {
+            /// The attribute (e.g., "user/name")
+            #[arg(long, allow_hyphen_values = true)]
+            the: String,
+
+            /// The entity identifier
+            #[arg(long, allow_hyphen_values = true)]
+            of: String,
+
+            /// The value to retract (all remaining words joined with spaces)
+            #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
+            is: Vec<String>,
+        },
+
+        /// Find facts in the active space
+        Find {
+            /// Filter by attribute (e.g., "user/name")
+            #[arg(long, allow_hyphen_values = true)]
+            the: Option<String>,
+
+            /// Filter by entity identifier
+            #[arg(long, allow_hyphen_values = true)]
+            of: Option<String>,
+
+            /// Filter by value
+            #[arg(long, allow_hyphen_values = true)]
+            is: Option<String>,
+
+            /// Format for decoding byte values (cbor, json, text, ucan)
+            #[arg(long, short)]
+            format: Option<String>,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum RemoteCommands {
+        /// Add a remote for syncing the active space
+        Add {
+            /// Name for the remote (e.g., "origin")
+            name: String,
+
+            /// UCAN access service URL (e.g., https://access.tonk.xyz).
+            /// When provided, uses UCAN delegation instead of raw S3 credentials.
+            #[arg(long, conflicts_with_all = ["endpoint", "bucket", "region", "access_key_id", "secret_access_key"])]
+            service_url: Option<String>,
+
+            /// S3 endpoint URL (e.g., https://s3.amazonaws.com)
+            #[arg(long, visible_alias = "host")]
+            endpoint: Option<String>,
+
+            /// S3 bucket name
+            #[arg(long)]
+            bucket: Option<String>,
+
+            /// AWS region (default: us-east-1)
+            #[arg(long)]
+            region: Option<String>,
+
+            /// AWS Access Key ID
+            #[arg(long)]
+            access_key_id: Option<String>,
+
+            /// AWS Secret Access Key
+            #[arg(long)]
+            secret_access_key: Option<String>,
+        },
+
+        /// Show the current upstream remote configuration
+        Show,
+
+        /// Remove the upstream remote
+        Delete,
+
+        /// Edit the upstream remote configuration
+        Edit,
+    }
 }
 
-#[derive(Subcommand)]
-enum SessionCommands {
-    /// Show the current session DID
-    Current,
+use inner::*;
 
-    /// Switch to a different session
-    Set {
-        /// Authority DID to switch to
-        authority_did: String,
-    },
-}
+#[cfg(target_arch = "wasm32")]
+pub fn main() {}
 
-#[derive(Subcommand)]
-enum SpaceCommands {
-    /// Show the current space DID
-    Current,
+#[cfg(not(target_arch = "wasm32"))]
+use clap::Parser;
 
-    /// Switch to a different space
-    Set {
-        /// Space name or DID to switch to
-        space: String,
-    },
-
-    /// Create a new space
-    Create {
-        /// Name of the space
-        name: String,
-
-        /// Owner DIDs (did:key identifiers). If not provided, will prompt interactively.
-        /// The active authority is always included as an owner.
-        #[arg(short, long)]
-        owners: Option<Vec<String>>,
-
-        /// Optional description
-        #[arg(short, long)]
-        description: Option<String>,
-    },
-
-    /// Invite a collaborator to a space
-    Invite {
-        /// Email address of the invitee (e.g., alice@example.com)
-        email: String,
-
-        /// Name of the space (defaults to active space)
-        #[arg(short, long)]
-        space: Option<String>,
-    },
-
-    /// Join a space using an invitation file
-    Join {
-        /// Path to the invitation file
-        #[arg(short, long)]
-        invite: String,
-
-        /// Profile to join with (defaults to active profile)
-        #[arg(short, long)]
-        profile: Option<String>,
-    },
-
-    /// Delete a space
-    Delete {
-        /// Space name or DID to delete
-        space: String,
-
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        force: bool,
-    },
-}
-
-#[derive(Subcommand)]
-enum OperatorCommands {
-    /// Generate a new operator key (base58btc encoded)
-    Generate,
-}
-
-#[derive(Subcommand)]
-enum InspectCommands {
-    /// Inspect a delegation (base64-encoded CBOR or .cbor file)
-    Delegation {
-        /// Base64-encoded CBOR delegation string or path to .cbor file
-        input: String,
-    },
-
-    /// Inspect an invite file
-    Invite {
-        /// Path to .invite file
-        path: String,
-    },
-
-    /// Inspect CBOR data and display as JSON
-    Cbor {
-        /// Path to .cbor file or base64-encoded CBOR string
-        input: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum FactCommands {
-    /// Assert a fact into the active space
-    Assert {
-        /// The attribute (e.g., "user/name")
-        #[arg(long, allow_hyphen_values = true)]
-        the: String,
-
-        /// The entity identifier. Can be:
-        /// - ~/path - derives entity from operator signature
-        /// - URI (e.g., did:key:..., https://...) - used as-is
-        /// - any string - hashed to create entity
-        #[arg(long, allow_hyphen_values = true)]
-        of: String,
-
-        /// The value to assert (all remaining words joined with spaces)
-        #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
-        is: Vec<String>,
-    },
-
-    /// Retract a fact from the active space
-    Retract {
-        /// The attribute (e.g., "user/name")
-        #[arg(long, allow_hyphen_values = true)]
-        the: String,
-
-        /// The entity identifier
-        #[arg(long, allow_hyphen_values = true)]
-        of: String,
-
-        /// The value to retract (all remaining words joined with spaces)
-        #[arg(long, required = true, num_args = 1.., trailing_var_arg = true, allow_hyphen_values = true)]
-        is: Vec<String>,
-    },
-
-    /// Find facts in the active space
-    Find {
-        /// Filter by attribute (e.g., "user/name")
-        #[arg(long, allow_hyphen_values = true)]
-        the: Option<String>,
-
-        /// Filter by entity identifier
-        #[arg(long, allow_hyphen_values = true)]
-        of: Option<String>,
-
-        /// Filter by value
-        #[arg(long, allow_hyphen_values = true)]
-        is: Option<String>,
-
-        /// Format for decoding byte values (cbor, json, text, ucan)
-        #[arg(long, short)]
-        format: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum RemoteCommands {
-    /// Add a remote for syncing the active space
-    Add {
-        /// Name for the remote (e.g., "origin")
-        name: String,
-
-        /// UCAN access service URL (e.g., https://access.tonk.xyz).
-        /// When provided, uses UCAN delegation instead of raw S3 credentials.
-        #[arg(long, conflicts_with_all = ["endpoint", "bucket", "region", "access_key_id", "secret_access_key"])]
-        service_url: Option<String>,
-
-        /// S3 endpoint URL (e.g., https://s3.amazonaws.com)
-        #[arg(long, visible_alias = "host")]
-        endpoint: Option<String>,
-
-        /// S3 bucket name
-        #[arg(long)]
-        bucket: Option<String>,
-
-        /// AWS region (default: us-east-1)
-        #[arg(long)]
-        region: Option<String>,
-
-        /// AWS Access Key ID
-        #[arg(long)]
-        access_key_id: Option<String>,
-
-        /// AWS Secret Access Key
-        #[arg(long)]
-        secret_access_key: Option<String>,
-    },
-
-    /// Show the current upstream remote configuration
-    Show,
-
-    /// Remove the upstream remote
-    Delete,
-
-    /// Edit the upstream remote configuration
-    Edit,
-}
-
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 pub mod authority;
 pub mod crypto;
 pub mod delegation;


### PR DESCRIPTION
This change implements universal (as in, platform agnostic) content-addressed blob storage via a `BlobStorage` construct. It supports two operations: read by `Blake3Hash`, and write bytes (receiving the final `Blake3Hash`). It strives to be as efficient as possible, utilizing conventional async IO interfaces and enabling reads and writes without requiring that the whole file be held in memory.

On the web, `BlobStorage` uses the [origin-private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system). This was mostly painless to use, except: OPFS does not have a standard atomic "move," (which the current implementation relies on to enable hashing without holding the whole file in memory). Thankfully, [Chrome has a non-standard `move` that the WG is attempting to standardize](https://github.com/whatwg/fs/pull/180). So on Chromium browsers, we have the fast move and on other browsers we have a fallback that implements a comparatively glacial read-and-pipe-to-writer scheme. It's probably still better than reading a very large file into memory, though.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new module `tonk-blobs` for local blob storage, enhances the `tonk-cli` with improved command structures, and updates dependencies, particularly for WebAssembly support.

### Detailed summary
- Added `tonk-blobs` module for filesystem-backed blob storage.
- Introduced `TonkBlobsError` enum for error handling in blob operations.
- Updated `Cargo.toml` to include `tonk-blobs` and adjust dependencies.
- Enhanced `tonk-cli` command structure for better command handling.
- Improved WebAssembly support with updated `rustflags`.
- Added tests for blob storage functionality and VFS operations.

> The following files were skipped due to too many changes: `rust/tonk-blobs/src/vfs/web.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->