### PR TITLE
fix(ci): rewrite nix libiconv so cli works on native mac

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,6 @@
             dbus
             chromium
             chromedriver
-          ]
-          ++ lib.optionals stdenv.isDarwin [
-            # MacOS-specific inputs
           ];
 
         # Import rust helpers
@@ -226,6 +223,18 @@
           tonk-cli = buildCrate {
             pname = "tonk-cli";
             cargoExtraArgs = "--package tonk-cli";
+            # Rewrite Nix store libiconv to the macOS system equivalent
+            # so the binary works on machines without Nix installed
+            fixupPhase = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              for bin in $out/bin/*; do
+                if [ -f "$bin" ]; then
+                  NIX_ICONV=$(otool -L "$bin" | grep '/nix/store.*libiconv' | awk '{print $1}' || true)
+                  if [ -n "$NIX_ICONV" ]; then
+                    install_name_tool -change "$NIX_ICONV" /usr/lib/libiconv.2.dylib "$bin"
+                  fi
+                fi
+              done
+            '';
           };
 
           tonk-ui = buildTrunkCrate {


### PR DESCRIPTION
The built CLI artifact for macOS was failing due to `libiconv` dep dynamically linked to Nix store instead of the native equivalent. This change adds a fixup phase that rewrites the link to the macOS equivalent so the binary can run on native Macs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `fixupPhase` to the `tonk-cli` build process in `flake.nix`, specifically for macOS. It modifies the binary to link against the macOS system's `libiconv` instead of the Nix store version, ensuring compatibility on machines without Nix.

### Detailed summary
- Introduced a `fixupPhase` in the `tonk-cli` build.
- Added a script to change the binary's `libiconv` reference from the Nix store to `/usr/lib/libiconv.2.dylib` on macOS.
- Ensured that the modification only occurs if `stdenv.isDarwin` is true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->