### PR TITLE
feat(cli): TON-1867: integration tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,9 +40,38 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: result/bin/tonk
 
+  test-cli:
+    name: 'Integration Tests'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+      - uses: wimpysworld/nothing-but-nix@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: 'Run CLI integration tests'
+        run: |
+          nix build --accept-flake-config .#tests-cli-integration
+          TESTS_PATH=$(nix eval --accept-flake-config .#tests-cli-integration.outPath --raw)
+          nix develop \
+            --accept-flake-config \
+            --set-env-var TMPDIR $RUNNER_TEMP \
+            .#ci \
+            --command cargo nextest run \
+              --workspace-remap ./ \
+              --archive-file "$TESTS_PATH/tests-cli-integration.tar.zst"
+
   publish-cli:
     name: 'Publish CLI'
-    needs: ['build-cli']
+    needs: ['build-cli', 'test-cli']
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/stable'
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
       - uses: wimpysworld/nothing-but-nix@main
       - uses: cachix/install-nix-action@v31
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,6 +3766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,6 +3788,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -4006,6 +4021,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4688,6 +4729,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ web-time = "1"
 webbrowser = "1.0"
 worker = "0.7.4"
 worker-macros = "0.7.4"
+serial_test = "3"
 
 # Bindgen
 wasm-bindgen = "=0.2.108"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "ton
 
 [profile.dev]
 opt-level = 1
+strip = "debuginfo"
 
 [profile.dev.package."*"]
 opt-level = 3
@@ -120,6 +121,7 @@ opt-level = 3
 [profile.release]
 lto = "thin"
 codegen-units = 1
+strip = "debuginfo"
 
 [profile.wasm-release]
 opt-level = "s"

--- a/flake.nix
+++ b/flake.nix
@@ -194,12 +194,12 @@
         packages = rec {
           tests-native-debug = buildTestArchive {
             name = "native-debug";
-            args = "--features integration-tests";
+            args = "--workspace --exclude tonk-ui --exclude tonk-core --features integration-tests";
           };
 
           tests-native-release = buildTestArchive {
             name = "native-release";
-            args = "--features integration-tests";
+            args = "--workspace --exclude tonk-ui --exclude tonk-core --features integration-tests --release";
           };
 
           tests-web-debug = buildTestArchive {
@@ -210,6 +210,7 @@
           tests-web-release = buildTestArchive {
             name = "web-release";
             target = "wasm32-unknown-unknown";
+            args = "--release";
           };
 
           tests-cli-integration = buildTestArchive {

--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,11 @@
             target = "wasm32-unknown-unknown";
           };
 
+          tests-cli-integration = buildTestArchive {
+            name = "cli-integration";
+            args = "--package tonk-cli --test cli_integration";
+          };
+
           tests = pkgs.runCommand "tests-all" { } ''
             mkdir -p $out
             cp ${self.packages.${system}.tests-native-debug}/*.tar.zst $out/

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -71,6 +71,14 @@ dirs = { workspace = true }
 webbrowser = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
+serial_test = { workspace = true }
+bs58 = { workspace = true }
+dialog-ucan = { workspace = true }
+dialog-varsig = { workspace = true }
+dialog-credentials = { workspace = true }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 
 # Platform-specific keyring backends
 [target.'cfg(all(not(target_arch = "wasm32"), target_os = "macos"))'.dependencies]

--- a/rust/tonk-cli/src/authority.rs
+++ b/rust/tonk-cli/src/authority.rs
@@ -25,8 +25,9 @@ pub fn get_authorities() -> Result<Vec<Authority>> {
         .context("Failed to get operator keypair")?;
     let operator_did = operator.did().to_string();
 
-    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
-    let access_dir = tonk_dir.join("access").join(&operator_did);
+    let access_dir = crate::util::access_dir()
+        .context("Could not determine tonk directory")?
+        .join(&operator_did);
 
     if !access_dir.exists() {
         return Ok(Vec::new());

--- a/rust/tonk-cli/src/authority.rs
+++ b/rust/tonk-cli/src/authority.rs
@@ -25,8 +25,8 @@ pub fn get_authorities() -> Result<Vec<Authority>> {
         .context("Failed to get operator keypair")?;
     let operator_did = operator.did().to_string();
 
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let access_dir = home.join(".tonk").join("access").join(&operator_did);
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let access_dir = tonk_dir.join("access").join(&operator_did);
 
     if !access_dir.exists() {
         return Ok(Vec::new());

--- a/rust/tonk-cli/src/delegation.rs
+++ b/rust/tonk-cli/src/delegation.rs
@@ -139,7 +139,7 @@ impl Delegation {
 
     /// Get the delegation storage path based on delegation fields
     fn storage_path(&self) -> Result<PathBuf, DelegationError> {
-        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
+        let access_dir: PathBuf = crate::util::access_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "Could not determine tonk directory",
@@ -148,7 +148,7 @@ impl Delegation {
 
         // Build path: ~/.tonk/access/{aud}/{sub or iss}/{exp}-{hash}.cbor
         let audience = self.audience();
-        let access_dir = tonk_dir.join("access").join(&audience);
+        let access_dir = access_dir.join(&audience);
 
         let sub_dir = match self.subject() {
             Subject::Specific(did) => {
@@ -279,14 +279,14 @@ impl Delegation {
         exp: i64,
         hash: &str,
     ) -> Result<Self, DelegationError> {
-        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
+        let access_dir: PathBuf = crate::util::access_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "Could not determine tonk directory",
             ))
         })?;
 
-        let access_dir = tonk_dir.join("access").join(aud);
+        let access_dir = access_dir.join(aud);
         let sub_dir = if let Some(sub) = sub {
             access_dir.join(sub)
         } else {

--- a/rust/tonk-cli/src/delegation.rs
+++ b/rust/tonk-cli/src/delegation.rs
@@ -139,16 +139,16 @@ impl Delegation {
 
     /// Get the delegation storage path based on delegation fields
     fn storage_path(&self) -> Result<PathBuf, DelegationError> {
-        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
+                "Could not determine tonk directory",
             ))
         })?;
 
         // Build path: ~/.tonk/access/{aud}/{sub or iss}/{exp}-{hash}.cbor
         let audience = self.audience();
-        let access_dir = home.join(".tonk").join("access").join(&audience);
+        let access_dir = tonk_dir.join("access").join(&audience);
 
         let sub_dir = match self.subject() {
             Subject::Specific(did) => {
@@ -201,15 +201,15 @@ impl Delegation {
         self.save()?;
 
         // Save metadata
-        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
+                "Could not determine tonk directory",
             ))
         })?;
 
         let hash: String = self.hash()?;
-        let meta_dir = home.join(".tonk").join("meta").join(&hash);
+        let meta_dir = tonk_dir.join("meta").join(&hash);
         fs::create_dir_all(&meta_dir)?;
 
         let meta_path = meta_dir.join("site.json");
@@ -231,15 +231,15 @@ impl Delegation {
         self.save_raw(raw_cbor)?;
 
         // Save metadata
-        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
+                "Could not determine tonk directory",
             ))
         })?;
 
         let hash: String = self.hash()?;
-        let meta_dir = home.join(".tonk").join("meta").join(&hash);
+        let meta_dir = tonk_dir.join("meta").join(&hash);
         fs::create_dir_all(&meta_dir)?;
 
         let meta_path = meta_dir.join("site.json");
@@ -252,19 +252,15 @@ impl Delegation {
 
     /// Load metadata for this delegation
     pub fn load_metadata(&self) -> Result<Option<DelegationMetadata>, DelegationError> {
-        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
+                "Could not determine tonk directory",
             ))
         })?;
 
         let hash = self.hash()?;
-        let meta_path = home
-            .join(".tonk")
-            .join("meta")
-            .join(&hash)
-            .join("site.json");
+        let meta_path = tonk_dir.join("meta").join(&hash).join("site.json");
 
         if !meta_path.exists() {
             return Ok(None);
@@ -283,14 +279,14 @@ impl Delegation {
         exp: i64,
         hash: &str,
     ) -> Result<Self, DelegationError> {
-        let home: PathBuf = crate::util::home_dir().ok_or_else(|| {
+        let tonk_dir: PathBuf = crate::util::tonk_dir().ok_or_else(|| {
             DelegationError::IoError(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
+                "Could not determine tonk directory",
             ))
         })?;
 
-        let access_dir = home.join(".tonk").join("access").join(aud);
+        let access_dir = tonk_dir.join("access").join(aud);
         let sub_dir = if let Some(sub) = sub {
             access_dir.join(sub)
         } else {

--- a/rust/tonk-cli/src/fact.rs
+++ b/rust/tonk-cli/src/fact.rs
@@ -77,9 +77,8 @@ fn get_active_space_storage_path() -> Result<(PathBuf, String)> {
     let space_did = state::get_active_space(&authority.did)?
         .context("No active space. Please run 'tonk space create' or 'tonk space select' first")?;
 
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let path = home
-        .join(".tonk")
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let path = tonk_dir
         .join("operator")
         .join(&operator_did)
         .join("session")

--- a/rust/tonk-cli/src/metadata.rs
+++ b/rust/tonk-cli/src/metadata.rs
@@ -5,8 +5,7 @@ use std::path::PathBuf;
 
 /// Get the .tonk directory path
 fn tonk_dir() -> Result<PathBuf> {
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    Ok(home.join(".tonk"))
+    crate::util::tonk_dir().context("Could not determine tonk directory")
 }
 
 /// Session metadata stored in ~/.tonk/meta/{authority-did}/session.json

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -25,9 +25,8 @@ fn get_active_space_info() -> Result<(String, PathBuf, Operator)> {
     let space_did = state::get_active_space(&authority.did)?
         .context("No active space. Please run 'tonk space create' or 'tonk space set' first")?;
 
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let path = home
-        .join(".tonk")
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let path = tonk_dir
         .join("operator")
         .join(&operator_did)
         .join("session")

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -276,9 +276,8 @@ pub fn get_space_context() -> Result<SpaceContext> {
     let space_did = state::get_active_space(&authority.did)?
         .context("No active space. Run 'tonk space create' first")?;
 
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let storage_path = home
-        .join(".tonk")
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let storage_path = tonk_dir
         .join("operator")
         .join(&operator_did)
         .join("session")

--- a/rust/tonk-cli/src/session.rs
+++ b/rust/tonk-cli/src/session.rs
@@ -172,8 +172,8 @@ pub async fn list(verbose: bool, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Get home directory for chain building
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    // Get tonk directory for chain building
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
 
     // Sort authorities to show active one first
     let mut sorted_authorities = authorities.clone();
@@ -299,7 +299,7 @@ pub async fn list(verbose: bool, json: bool) -> Result<()> {
                             cmd,
                             &operator_did,
                             &auth.did,
-                            &home,
+                            &tonk_dir,
                         ) {
                             // Chain is built: [authority→operator, ..., space→authority]
                             // Display from operator (top) to space (bottom/root)
@@ -369,13 +369,13 @@ fn build_authorization_chain(
     cmd: &str,
     operator_did: &str,
     authority_did: &str,
-    home: &std::path::Path,
+    tonk_dir: &std::path::Path,
 ) -> Result<Vec<Delegation>> {
     let mut chain = Vec::new();
     let mut visited = HashSet::new();
 
     // Start by finding the delegation from authority to operator (powerline)
-    if let Some(auth_to_op) = find_delegation_for_chain(authority_did, operator_did, home)? {
+    if let Some(auth_to_op) = find_delegation_for_chain(authority_did, operator_did, tonk_dir)? {
         chain.push(auth_to_op);
     }
 
@@ -384,7 +384,7 @@ fn build_authorization_chain(
         space_did,
         cmd,
         authority_did,
-        home,
+        tonk_dir,
         &mut chain,
         &mut visited,
         0,
@@ -398,7 +398,7 @@ fn trace_to_space(
     space_did: &str,
     cmd: &str,
     current_did: &str,
-    home: &std::path::Path,
+    tonk_dir: &std::path::Path,
     chain: &mut Vec<Delegation>,
     visited: &mut HashSet<String>,
     depth: usize,
@@ -409,7 +409,7 @@ fn trace_to_space(
     visited.insert(current_did.to_string());
 
     // Look for delegations TO current_did
-    let access_dir = home.join(".tonk").join("access").join(current_did);
+    let access_dir = tonk_dir.join("access").join(current_did);
     if !access_dir.exists() {
         return Ok(());
     }
@@ -469,7 +469,7 @@ fn trace_to_space(
                             space_did,
                             cmd,
                             &actual_issuer,
-                            home,
+                            tonk_dir,
                             chain,
                             visited,
                             depth + 1,
@@ -489,13 +489,9 @@ fn trace_to_space(
 fn find_delegation_for_chain(
     issuer_did: &str,
     audience_did: &str,
-    home: &std::path::Path,
+    tonk_dir: &std::path::Path,
 ) -> Result<Option<Delegation>> {
-    let access_dir = home
-        .join(".tonk")
-        .join("access")
-        .join(audience_did)
-        .join(issuer_did);
+    let access_dir = tonk_dir.join("access").join(audience_did).join(issuer_did);
 
     if !access_dir.exists() {
         return Ok(None);
@@ -533,7 +529,7 @@ pub fn collect_spaces_for_authority(
     _operator_did: &str,
     authority_did: &str,
 ) -> Result<HashMap<String, SpaceAccess>> {
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
+    let home = crate::util::tonk_dir().context("Could not determine tonk directory")?;
 
     // First, collect what the authority has direct access to
     let mut spaces: HashMap<String, SpaceAccess> = HashMap::new();
@@ -550,7 +546,7 @@ pub fn collect_spaces_for_authority(
     );
 
     // Check authority's own access (this is what they've been delegated)
-    let authority_access_dir = home.join(".tonk").join("access").join(authority_did);
+    let authority_access_dir = home.join("access").join(authority_did);
 
     if authority_access_dir.exists() {
         for entry in fs::read_dir(&authority_access_dir)? {
@@ -648,7 +644,7 @@ pub fn collect_spaces_for_authority(
 fn collect_spaces_recursive(
     authority_did: &str,
     did: &str,
-    home: &std::path::PathBuf,
+    tonk_dir: &std::path::PathBuf,
     visited: &mut HashSet<String>,
     spaces: &mut HashMap<String, SpaceAccess>,
     depth: usize,
@@ -658,7 +654,7 @@ fn collect_spaces_recursive(
     }
     visited.insert(did.to_string());
 
-    let access_dir = home.join(".tonk").join("access").join(did);
+    let access_dir = tonk_dir.join("access").join(did);
     if !access_dir.exists() {
         return Ok(());
     }
@@ -696,7 +692,7 @@ fn collect_spaces_recursive(
                     collect_spaces_recursive(
                         authority_did,
                         &issuer,
-                        home,
+                        tonk_dir,
                         visited,
                         spaces,
                         depth + 1,

--- a/rust/tonk-cli/src/session.rs
+++ b/rust/tonk-cli/src/session.rs
@@ -172,8 +172,8 @@ pub async fn list(verbose: bool, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Get tonk directory for chain building
-    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    // Get access directory for chain building
+    let access_dir = crate::util::access_dir().context("Could not determine tonk directory")?;
 
     // Sort authorities to show active one first
     let mut sorted_authorities = authorities.clone();
@@ -299,7 +299,7 @@ pub async fn list(verbose: bool, json: bool) -> Result<()> {
                             cmd,
                             &operator_did,
                             &auth.did,
-                            &tonk_dir,
+                            &access_dir,
                         ) {
                             // Chain is built: [authority→operator, ..., space→authority]
                             // Display from operator (top) to space (bottom/root)
@@ -369,13 +369,13 @@ fn build_authorization_chain(
     cmd: &str,
     operator_did: &str,
     authority_did: &str,
-    tonk_dir: &std::path::Path,
+    access_dir: &std::path::Path,
 ) -> Result<Vec<Delegation>> {
     let mut chain = Vec::new();
     let mut visited = HashSet::new();
 
     // Start by finding the delegation from authority to operator (powerline)
-    if let Some(auth_to_op) = find_delegation_for_chain(authority_did, operator_did, tonk_dir)? {
+    if let Some(auth_to_op) = find_delegation_for_chain(authority_did, operator_did, access_dir)? {
         chain.push(auth_to_op);
     }
 
@@ -384,7 +384,7 @@ fn build_authorization_chain(
         space_did,
         cmd,
         authority_did,
-        tonk_dir,
+        access_dir,
         &mut chain,
         &mut visited,
         0,
@@ -398,7 +398,7 @@ fn trace_to_space(
     space_did: &str,
     cmd: &str,
     current_did: &str,
-    tonk_dir: &std::path::Path,
+    access_dir: &std::path::Path,
     chain: &mut Vec<Delegation>,
     visited: &mut HashSet<String>,
     depth: usize,
@@ -409,13 +409,13 @@ fn trace_to_space(
     visited.insert(current_did.to_string());
 
     // Look for delegations TO current_did
-    let access_dir = tonk_dir.join("access").join(current_did);
-    if !access_dir.exists() {
+    let did_access_dir = access_dir.join(current_did);
+    if !did_access_dir.exists() {
         return Ok(());
     }
 
     // Find delegations that grant access to this space/command
-    for entry in fs::read_dir(&access_dir)? {
+    for entry in fs::read_dir(&did_access_dir)? {
         let entry = entry?;
         let issuer_dir = entry.path();
 
@@ -469,7 +469,7 @@ fn trace_to_space(
                             space_did,
                             cmd,
                             &actual_issuer,
-                            tonk_dir,
+                            access_dir,
                             chain,
                             visited,
                             depth + 1,
@@ -489,9 +489,9 @@ fn trace_to_space(
 fn find_delegation_for_chain(
     issuer_did: &str,
     audience_did: &str,
-    tonk_dir: &std::path::Path,
+    access_dir: &std::path::Path,
 ) -> Result<Option<Delegation>> {
-    let access_dir = tonk_dir.join("access").join(audience_did).join(issuer_did);
+    let access_dir = access_dir.join(audience_did).join(issuer_did);
 
     if !access_dir.exists() {
         return Ok(None);
@@ -529,7 +529,7 @@ pub fn collect_spaces_for_authority(
     _operator_did: &str,
     authority_did: &str,
 ) -> Result<HashMap<String, SpaceAccess>> {
-    let home = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let access_dir = crate::util::access_dir().context("Could not determine tonk directory")?;
 
     // First, collect what the authority has direct access to
     let mut spaces: HashMap<String, SpaceAccess> = HashMap::new();
@@ -546,7 +546,7 @@ pub fn collect_spaces_for_authority(
     );
 
     // Check authority's own access (this is what they've been delegated)
-    let authority_access_dir = home.join("access").join(authority_did);
+    let authority_access_dir = access_dir.join(authority_did);
 
     if authority_access_dir.exists() {
         for entry in fs::read_dir(&authority_access_dir)? {
@@ -631,7 +631,7 @@ pub fn collect_spaces_for_authority(
     collect_spaces_recursive(
         authority_did,
         authority_did,
-        &home,
+        &access_dir,
         &mut visited,
         &mut spaces,
         0,
@@ -644,7 +644,7 @@ pub fn collect_spaces_for_authority(
 fn collect_spaces_recursive(
     authority_did: &str,
     did: &str,
-    tonk_dir: &std::path::PathBuf,
+    access_dir: &std::path::Path,
     visited: &mut HashSet<String>,
     spaces: &mut HashMap<String, SpaceAccess>,
     depth: usize,
@@ -654,12 +654,12 @@ fn collect_spaces_recursive(
     }
     visited.insert(did.to_string());
 
-    let access_dir = tonk_dir.join("access").join(did);
-    if !access_dir.exists() {
+    let did_access_dir = access_dir.join(did);
+    if !did_access_dir.exists() {
         return Ok(());
     }
 
-    for entry in fs::read_dir(&access_dir)? {
+    for entry in fs::read_dir(&did_access_dir)? {
         let entry = entry?;
         let subject_path = entry.path();
 
@@ -692,7 +692,7 @@ fn collect_spaces_recursive(
                     collect_spaces_recursive(
                         authority_did,
                         &issuer,
-                        tonk_dir,
+                        access_dir,
                         visited,
                         spaces,
                         depth + 1,

--- a/rust/tonk-cli/src/space.rs
+++ b/rust/tonk-cli/src/space.rs
@@ -616,9 +616,8 @@ pub async fn invite(email: String, space_name: Option<String>) -> Result<()> {
     let invitation_hash = hex::encode(invitation_hash_bytes);
 
     // Save to storage (in the operator's access directory for the invitee)
-    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
-    let access_dir = tonk_dir
-        .join("access")
+    let access_dir = crate::util::access_dir()
+        .context("Could not determine tonk directory")?
         .join(&invitee_did)
         .join(&operator_did);
     fs::create_dir_all(&access_dir)?;
@@ -787,8 +786,10 @@ pub fn inspect_invite(path: String) -> Result<()> {
 
 /// Find a delegation from issuer to audience for a specific subject
 fn find_delegation(issuer: &str, audience: &str) -> Result<Option<Delegation>> {
-    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
-    let access_dir = tonk_dir.join("access").join(audience).join(issuer);
+    let access_dir = crate::util::access_dir()
+        .context("Could not determine tonk directory")?
+        .join(audience)
+        .join(issuer);
 
     if !access_dir.exists() {
         return Ok(None);
@@ -1166,8 +1167,7 @@ pub async fn delete(space_identifier: String, force: bool) -> Result<()> {
     }
 
     // Delete delegations from this space (in access directory)
-    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
-    let access_dir = tonk_dir.join("access");
+    let access_dir = crate::util::access_dir().context("Could not determine tonk directory")?;
 
     if access_dir.exists() {
         let mut deleted_delegations = 0;

--- a/rust/tonk-cli/src/space.rs
+++ b/rust/tonk-cli/src/space.rs
@@ -477,9 +477,8 @@ fn get_space_storage_path(
     authority_did: &str,
     space_did: &str,
 ) -> Result<PathBuf> {
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let path = home
-        .join(".tonk")
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let path = tonk_dir
         .join("operator")
         .join(operator_did)
         .join("session")
@@ -617,9 +616,8 @@ pub async fn invite(email: String, space_name: Option<String>) -> Result<()> {
     let invitation_hash = hex::encode(invitation_hash_bytes);
 
     // Save to storage (in the operator's access directory for the invitee)
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let access_dir = home
-        .join(".tonk")
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let access_dir = tonk_dir
         .join("access")
         .join(&invitee_did)
         .join(&operator_did);
@@ -789,12 +787,8 @@ pub fn inspect_invite(path: String) -> Result<()> {
 
 /// Find a delegation from issuer to audience for a specific subject
 fn find_delegation(issuer: &str, audience: &str) -> Result<Option<Delegation>> {
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let access_dir = home
-        .join(".tonk")
-        .join("access")
-        .join(audience)
-        .join(issuer);
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let access_dir = tonk_dir.join("access").join(audience).join(issuer);
 
     if !access_dir.exists() {
         return Ok(None);
@@ -1172,8 +1166,8 @@ pub async fn delete(space_identifier: String, force: bool) -> Result<()> {
     }
 
     // Delete delegations from this space (in access directory)
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    let access_dir = home.join(".tonk").join("access");
+    let tonk_dir = crate::util::tonk_dir().context("Could not determine tonk directory")?;
+    let access_dir = tonk_dir.join("access");
 
     if access_dir.exists() {
         let mut deleted_delegations = 0;

--- a/rust/tonk-cli/src/state.rs
+++ b/rust/tonk-cli/src/state.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 /// Get the .tonk directory path
 fn tonk_dir() -> Result<PathBuf> {
-    let home = crate::util::home_dir().context("Could not determine home directory")?;
-    Ok(home.join(".tonk"))
+    crate::util::tonk_dir().context("Could not determine tonk directory")
 }
 
 /// Get the operator DID

--- a/rust/tonk-cli/src/util.rs
+++ b/rust/tonk-cli/src/util.rs
@@ -13,3 +13,11 @@ pub fn tonk_dir() -> Option<PathBuf> {
     }
     dirs::home_dir().map(|h| h.join(".tonk"))
 }
+
+/// Get the access directory (`~/.tonk/access`).
+///
+/// Delegations are stored under this directory, keyed by audience and issuer
+/// DIDs.
+pub fn access_dir() -> Option<PathBuf> {
+    tonk_dir().map(|d| d.join("access"))
+}

--- a/rust/tonk-cli/src/util.rs
+++ b/rust/tonk-cli/src/util.rs
@@ -1,6 +1,15 @@
 use std::path::PathBuf;
 
-/// Get the home directory
-pub fn home_dir() -> Option<PathBuf> {
-    dirs::home_dir()
+/// Get the tonk data directory (`~/.tonk`).
+///
+/// If the `TONK_HOME` environment variable is set, its value is used directly
+/// as the tonk data directory. When unset, defaults to `~/.tonk`.
+///
+/// This allows integration tests (or custom deployments) to redirect all CLI
+/// state to an arbitrary directory.
+pub fn tonk_dir() -> Option<PathBuf> {
+    if let Ok(tonk_home) = std::env::var("TONK_HOME") {
+        return Some(PathBuf::from(tonk_home));
+    }
+    dirs::home_dir().map(|h| h.join(".tonk"))
 }

--- a/rust/tonk-cli/tests/cli_integration.rs
+++ b/rust/tonk-cli/tests/cli_integration.rs
@@ -1,0 +1,1607 @@
+//! Integration tests for the tonk CLI.
+//!
+//! These tests exercise the CLI through its library API, using isolated
+//! filesystem environments for each test. Every test gets its own temporary
+//! directory set as `TONK_HOME` (the tonk data directory, equivalent to
+//! `~/.tonk/`) with a programmatically bootstrapped session.
+//!
+//! Tests are marked `#[serial]` because they modify process-global env vars
+//! (`TONK_HOME`, `TONK_OPERATOR_KEY`).
+
+mod common;
+
+use common::TestEnv;
+use serial_test::serial;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Bootstrap & Status
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_operator_generate_produces_valid_did() {
+    // operator::generate() just prints to stdout; test that Operator::generate
+    // produces a valid did:key DID.
+    let operator = tonk_cli::crypto::Operator::generate();
+    let did = operator.did().to_string();
+    assert!(
+        did.starts_with("did:key:z"),
+        "DID should start with did:key:z, got: {}",
+        did
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Delegation round-trip
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_delegation_roundtrip() {
+    // Verify that delegations built by TestEnv survive a CBOR serialization
+    // round-trip and are recognized as valid powerline delegations.
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan::Delegation as UcanDelegation;
+    use dialog_ucan::subject::Subject;
+    use dialog_varsig::Did;
+    use dialog_varsig::eddsa::Ed25519Signature;
+    use tonk_cli::delegation::Delegation;
+
+    let authority = tonk_cli::crypto::Operator::generate();
+    let operator = tonk_cli::crypto::Operator::generate();
+
+    let authority_signer = Ed25519Signer::from(&authority);
+    let operator_did: Did = operator.did().to_string().parse().unwrap();
+
+    let ucan: UcanDelegation<Ed25519Signature> = UcanDelegation::builder()
+        .issuer(authority_signer)
+        .audience(&operator_did)
+        .subject(Subject::Any)
+        .command(vec![]) // Empty = root access "/"
+        .try_build()
+        .await
+        .unwrap();
+
+    let delegation = Delegation::from_ucan(ucan);
+    assert!(delegation.is_powerline(), "Should be powerline");
+    assert!(delegation.is_valid(), "Should be valid");
+    assert_eq!(delegation.expiration(), None, "No expiration set");
+
+    // Verify CBOR round-trip
+    let cbor = delegation.to_cbor_bytes().expect("serialize");
+    let reparsed = Delegation::from_cbor_bytes(&cbor).expect("deserialize");
+    assert!(
+        reparsed.is_powerline(),
+        "Should be powerline after roundtrip"
+    );
+    assert!(reparsed.is_valid(), "Should be valid after roundtrip");
+    assert_eq!(reparsed.issuer(), delegation.issuer());
+    assert_eq!(reparsed.audience(), delegation.audience());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_bootstrap_creates_session() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+
+    // Verify active session is set
+    let session = tonk_cli::state::get_active_session().expect("Failed to get active session");
+    assert_eq!(session, Some(env.authority_did.clone()));
+
+    // Verify the keystore returns the same operator
+    let keystore = tonk_cli::keystore::Keystore::new().expect("keystore");
+    let op = keystore.get_or_create_keypair().expect("keypair");
+    assert_eq!(
+        op.did().to_string(),
+        env.operator_did,
+        "Keystore should return same operator"
+    );
+
+    // Verify the authority is discoverable
+    let authorities = tonk_cli::authority::get_authorities().expect("Failed to get authorities");
+    assert!(
+        !authorities.is_empty(),
+        "Should have at least one authority"
+    );
+    assert_eq!(authorities[0].did, env.authority_did);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_status_with_space() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space_did = env
+        .create_space("test-space")
+        .await
+        .expect("Failed to create space");
+
+    // status::execute should not error when a space is active
+    let result = tonk_cli::status::execute(true).await;
+    assert!(result.is_ok(), "status should succeed: {:?}", result.err());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_status_json_output() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space_did = env
+        .create_space("json-space")
+        .await
+        .expect("Failed to create space");
+
+    // JSON mode should not error
+    let result = tonk_cli::status::execute(true).await;
+    assert!(
+        result.is_ok(),
+        "status --json should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space Management
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_space_create_and_list() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let space_did = env
+        .create_space("my-space")
+        .await
+        .expect("Failed to create space");
+
+    assert!(
+        space_did.starts_with("did:key:"),
+        "Space DID should be a did:key"
+    );
+
+    // List spaces (JSON mode) — should contain our space
+    // We can verify via state
+    let spaces = tonk_cli::state::list_spaces_for_session(&env.authority_did)
+        .expect("Failed to list spaces");
+    assert!(
+        spaces.contains(&space_did),
+        "Space should be in session list"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_space_create_sets_active() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let space_did = env
+        .create_space("active-space")
+        .await
+        .expect("Failed to create space");
+
+    let active =
+        tonk_cli::state::get_active_space(&env.authority_did).expect("Failed to get active space");
+    assert_eq!(active, Some(space_did));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_space_create_multiple_and_switch() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let space1 = env
+        .create_space("space-one")
+        .await
+        .expect("Failed to create space 1");
+    let space2 = env
+        .create_space("space-two")
+        .await
+        .expect("Failed to create space 2");
+
+    // space-two should be active (most recently created)
+    let active =
+        tonk_cli::state::get_active_space(&env.authority_did).expect("Failed to get active space");
+    assert_eq!(active, Some(space2.clone()));
+
+    // Switch back to space-one by name
+    tonk_cli::space::set("space-one".to_string())
+        .await
+        .expect("Failed to set space");
+
+    let active =
+        tonk_cli::state::get_active_space(&env.authority_did).expect("Failed to get active space");
+    assert_eq!(active, Some(space1));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_space_current() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space_did = env
+        .create_space("current-space")
+        .await
+        .expect("Failed to create space");
+
+    // show_current should not error
+    let result = tonk_cli::space::show_current(true).await;
+    assert!(
+        result.is_ok(),
+        "space current should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_space_delete() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space1 = env
+        .create_space("keep-me")
+        .await
+        .expect("Failed to create space 1");
+    let space2 = env
+        .create_space("delete-me")
+        .await
+        .expect("Failed to create space 2");
+
+    // Switch to space 1 so we're deleting a non-active space
+    tonk_cli::space::set("keep-me".to_string())
+        .await
+        .expect("Failed to switch space");
+
+    // Delete space 2 with force (skip confirmation)
+    tonk_cli::space::delete("delete-me".to_string(), true)
+        .await
+        .expect("Failed to delete space");
+
+    let spaces = tonk_cli::state::list_spaces_for_session(&env.authority_did)
+        .expect("Failed to list spaces");
+    assert!(
+        !spaces.contains(&space2),
+        "Deleted space should not be in list"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_space_delete_active_clears_active() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let space_did = env
+        .create_space("doomed-space")
+        .await
+        .expect("Failed to create space");
+
+    // Verify it's active
+    let active =
+        tonk_cli::state::get_active_space(&env.authority_did).expect("Failed to get active space");
+    assert_eq!(active, Some(space_did.clone()));
+
+    // Delete the active space
+    tonk_cli::space::delete("doomed-space".to_string(), true)
+        .await
+        .expect("Failed to delete space");
+
+    // Active space should be cleared
+    let active =
+        tonk_cli::state::get_active_space(&env.authority_did).expect("Failed to get active space");
+    assert_eq!(active, None);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Concept Management
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_concept_define_and_list() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("concept-space")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        Some("A task to track".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // List concepts — should not error and should find our concept
+    let result = tonk_cli::concept::list(true).await;
+    assert!(
+        result.is_ok(),
+        "concept list should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_show() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("show-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Contact".to_string(),
+        vec!["name".to_string(), "email".to_string(), "phone".to_string()],
+        Some("A contact entry".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Show the concept
+    let result = tonk_cli::concept::show("Contact".to_string(), true).await;
+    assert!(
+        result.is_ok(),
+        "concept show should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_extend() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("extend-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("Note".to_string(), vec!["title".to_string()], None, true)
+        .await
+        .expect("Failed to define concept");
+
+    // Extend with new attributes
+    tonk_cli::concept::extend(
+        "Note".to_string(),
+        vec!["body".to_string(), "tags".to_string()],
+        true,
+    )
+    .await
+    .expect("Failed to extend concept");
+
+    // Show should succeed and include new attributes
+    let result = tonk_cli::concept::show("Note".to_string(), true).await;
+    assert!(result.is_ok(), "concept show after extend should succeed");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_delete() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("delete-concept-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Temporary".to_string(),
+        vec!["data".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Delete it
+    tonk_cli::concept::delete("Temporary".to_string(), false, true)
+        .await
+        .expect("Failed to delete concept");
+
+    // Show should fail (concept no longer exists)
+    let result = tonk_cli::concept::show("Temporary".to_string(), true).await;
+    assert!(result.is_err(), "concept show after delete should fail");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_name_validation() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("validation-space")
+        .await
+        .expect("Failed to create space");
+
+    // Invalid name with special characters
+    let result =
+        tonk_cli::concept::define("bad name!".to_string(), vec!["x".to_string()], None, true).await;
+    assert!(result.is_err(), "concept with special chars should fail");
+
+    // Empty name
+    let result = tonk_cli::concept::define("".to_string(), vec!["x".to_string()], None, true).await;
+    assert!(result.is_err(), "concept with empty name should fail");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_duplicate_rejected() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("dup-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("Unique".to_string(), vec!["a".to_string()], None, true)
+        .await
+        .expect("Failed to define first concept");
+
+    // Defining same concept again should fail
+    let result =
+        tonk_cli::concept::define("Unique".to_string(), vec!["b".to_string()], None, true).await;
+    assert!(result.is_err(), "duplicate concept definition should fail");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Import
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_import_minimal_yaml() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-minimal")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("minimal.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import minimal.yaml");
+
+    // Verify Task concept was created
+    let result = tonk_cli::concept::show("Task".to_string(), true).await;
+    assert!(result.is_ok(), "Task concept should exist after import");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_cook_yaml() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-cook")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Verify all 3 concepts were created
+    for name in &["Recipe", "Ingredient", "RecipeStep"] {
+        let result = tonk_cli::concept::show(name.to_string(), true).await;
+        assert!(result.is_ok(), "{} concept should exist after import", name);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_planner_yaml() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-planner")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("planner.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import planner.yaml");
+
+    // Verify concepts across both namespaces
+    for name in &["Allergy", "Event", "Meal", "SafeMeal", "AllergyConflict"] {
+        let result = tonk_cli::concept::show(name.to_string(), true).await;
+        assert!(result.is_ok(), "{} concept should exist after import", name);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_rules_yaml() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-rules")
+        .await
+        .expect("Failed to create space");
+
+    // Import prerequisite concepts first
+    let planner_file = TestEnv::example_file("planner.yaml");
+    tonk_cli::import::import(planner_file, false, true)
+        .await
+        .expect("Failed to import planner.yaml");
+
+    let cook_file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(cook_file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Now import rules
+    let rules_file = TestEnv::example_file("rules.yaml");
+    tonk_cli::import::import(rules_file, false, true)
+        .await
+        .expect("Failed to import rules.yaml");
+
+    // Verify rules were created
+    let result = tonk_cli::rule::list(true).await;
+    assert!(result.is_ok(), "rule list should succeed after import");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_force_overwrite() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-force")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("minimal.yaml");
+
+    // First import
+    tonk_cli::import::import(file.clone(), false, true)
+        .await
+        .expect("Failed to first import");
+
+    // Second import without force should fail
+    let result = tonk_cli::import::import(file.clone(), false, true).await;
+    assert!(result.is_err(), "re-import without --force should fail");
+
+    // Second import with force should succeed
+    tonk_cli::import::import(file, true, true)
+        .await
+        .expect("Failed to force re-import");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_nonexistent_file_errors() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("import-nofile")
+        .await
+        .expect("Failed to create space");
+
+    let result = tonk_cli::import::import("/nonexistent/path.yaml".to_string(), false, true).await;
+    assert!(result.is_err(), "importing nonexistent file should fail");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Instance CRUD
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_create_instance() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("instance-space")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept first
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Create an instance
+    let result = tonk_cli::instance::create(
+        "Task".to_string(),
+        vec!["title=Fix bug".to_string(), "status=todo".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "create instance should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_query_instances() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("query-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("Item".to_string(), vec!["name".to_string()], None, true)
+        .await
+        .expect("Failed to define concept");
+
+    // Create 3 instances
+    for name in &["Apple", "Banana", "Cherry"] {
+        tonk_cli::instance::create(
+            "Item".to_string(),
+            vec![format!("name={}", name)],
+            None,
+            false,
+            true,
+        )
+        .await
+        .expect("Failed to create instance");
+    }
+
+    // Query all instances
+    let result = tonk_cli::instance::query("Item".to_string(), vec![], true).await;
+    assert!(result.is_ok(), "query should succeed: {:?}", result.err());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_query_with_filter() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("filter-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Create tasks with different statuses
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec!["title=Task A".to_string(), "status=todo".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task A");
+
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec!["title=Task B".to_string(), "status=done".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task B");
+
+    // Query with filter
+    let result =
+        tonk_cli::instance::query("Task".to_string(), vec!["status=todo".to_string()], true).await;
+    assert!(
+        result.is_ok(),
+        "filtered query should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_update_instance() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("update-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Create an instance — we need to capture the ID.
+    // instance::create in JSON mode prints JSON with the ID to stdout.
+    // We'll use the fact layer to find it after creation.
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec!["title=Update me".to_string(), "status=todo".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task");
+
+    // Find the instance via query (we know there's exactly one)
+    // Use the schema module to query the instance entity
+    let ctx = tonk_cli::schema::get_space_context().expect("Failed to get space context");
+    let branch = tonk_cli::schema::open_branch(&ctx)
+        .await
+        .expect("Failed to open branch");
+    let concept_name = tonk_cli::schema::ConceptName::new("Task").unwrap();
+    let concept_entity = tonk_cli::schema::concept_entity(&ctx.space_did, &concept_name).unwrap();
+    let instances =
+        tonk_cli::schema::fetch_entity_values(&branch, &concept_entity, "concept/instance")
+            .await
+            .expect("Failed to fetch instances");
+
+    assert_eq!(instances.len(), 1, "Should have exactly 1 instance");
+    let instance_id = instances[0].to_string();
+
+    // Update the instance
+    let result =
+        tonk_cli::instance::update(instance_id.clone(), vec!["status=done".to_string()], true)
+            .await;
+    assert!(result.is_ok(), "update should succeed: {:?}", result.err());
+
+    // Show should reflect the update
+    let result = tonk_cli::instance::show(instance_id, true).await;
+    assert!(result.is_ok(), "show after update should succeed");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_delete_instance() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("delete-inst-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("Task".to_string(), vec!["title".to_string()], None, true)
+        .await
+        .expect("Failed to define concept");
+
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec!["title=Delete me".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task");
+
+    // Find the instance ID
+    let ctx = tonk_cli::schema::get_space_context().expect("Failed to get space context");
+    let branch = tonk_cli::schema::open_branch(&ctx)
+        .await
+        .expect("Failed to open branch");
+    let concept_name = tonk_cli::schema::ConceptName::new("Task").unwrap();
+    let concept_entity = tonk_cli::schema::concept_entity(&ctx.space_did, &concept_name).unwrap();
+    let instances =
+        tonk_cli::schema::fetch_entity_values(&branch, &concept_entity, "concept/instance")
+            .await
+            .expect("Failed to fetch instances");
+    let instance_id = instances[0].to_string();
+
+    // Delete it
+    tonk_cli::instance::delete(instance_id, true)
+        .await
+        .expect("Failed to delete instance");
+
+    // Query should return no instances
+    let result = tonk_cli::instance::query("Task".to_string(), vec![], true).await;
+    assert!(result.is_ok(), "query after delete should succeed");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_instance_from_json_file() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("json-file-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Create a temporary JSON file
+    let json_path = env.home_path.join("instance.json");
+    std::fs::write(&json_path, r#"{"title": "From file", "status": "todo"}"#)
+        .expect("Failed to write JSON file");
+
+    let result = tonk_cli::instance::create(
+        "Task".to_string(),
+        vec![],
+        Some(json_path.to_string_lossy().into_owned()),
+        false,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "create from JSON file should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Batch Operations
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_batch_create() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("batch-create-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // Create batch JSON file
+    let json_path = env.home_path.join("batch.json");
+    std::fs::write(
+        &json_path,
+        r#"[
+        {"title": "Task 1", "status": "todo"},
+        {"title": "Task 2", "status": "in-progress"},
+        {"title": "Task 3", "status": "done"}
+    ]"#,
+    )
+    .expect("Failed to write batch JSON");
+
+    let result = tonk_cli::batch::batch_create(
+        "Task".to_string(),
+        Some(json_path.to_string_lossy().into_owned()),
+        false,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "batch create should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_batch_delete() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("batch-del-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("Task".to_string(), vec!["title".to_string()], None, true)
+        .await
+        .expect("Failed to define concept");
+
+    // Create some instances first
+    let json_path = env.home_path.join("batch_create.json");
+    std::fs::write(
+        &json_path,
+        r#"[
+        {"title": "A"},
+        {"title": "B"}
+    ]"#,
+    )
+    .expect("Failed to write batch JSON");
+
+    tonk_cli::batch::batch_create(
+        "Task".to_string(),
+        Some(json_path.to_string_lossy().into_owned()),
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to batch create");
+
+    // Get instance IDs
+    let ctx = tonk_cli::schema::get_space_context().expect("Failed to get context");
+    let branch = tonk_cli::schema::open_branch(&ctx)
+        .await
+        .expect("Failed to open branch");
+    let concept_name = tonk_cli::schema::ConceptName::new("Task").unwrap();
+    let concept_entity = tonk_cli::schema::concept_entity(&ctx.space_did, &concept_name).unwrap();
+    let instances =
+        tonk_cli::schema::fetch_entity_values(&branch, &concept_entity, "concept/instance")
+            .await
+            .expect("Failed to fetch instances");
+
+    let ids: Vec<String> = instances.iter().map(|e| e.to_string()).collect();
+    let ids_json = serde_json::to_string(&ids).unwrap();
+
+    let del_path = env.home_path.join("batch_delete.json");
+    std::fs::write(&del_path, &ids_json).expect("Failed to write delete JSON");
+
+    let result = tonk_cli::batch::batch_delete(
+        "Task".to_string(),
+        Some(del_path.to_string_lossy().into_owned()),
+        false,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "batch delete should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Rule Management
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_rule_define_and_list() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("rule-space")
+        .await
+        .expect("Failed to create space");
+
+    // Define prerequisite concepts
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec![
+            "title".to_string(),
+            "status".to_string(),
+            "priority".to_string(),
+        ],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Task");
+
+    tonk_cli::concept::define(
+        "HighPriority".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define HighPriority");
+
+    // Create rule definition JSON (EAV-level premises with the/of/is)
+    let rule_json = serde_json::json!({
+        "conclusion": {
+            "concept": "HighPriority",
+            "bindings": {
+                "title": "?title",
+                "status": "?status"
+            }
+        },
+        "when": [
+            {"the": "task/title", "of": "?task", "is": "?title"},
+            {"the": "task/status", "of": "?task", "is": "?status"},
+            {"the": "task/priority", "of": "?task", "is": "high"}
+        ]
+    });
+
+    let rule_path = env.home_path.join("rule.json");
+    std::fs::write(
+        &rule_path,
+        serde_json::to_string_pretty(&rule_json).unwrap(),
+    )
+    .expect("Failed to write rule JSON");
+
+    tonk_cli::rule::define(
+        "high-priority-tasks".to_string(),
+        Some(rule_path.to_string_lossy().into_owned()),
+        false,
+        Some("Find high priority tasks".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define rule");
+
+    // List rules
+    let result = tonk_cli::rule::list(true).await;
+    assert!(
+        result.is_ok(),
+        "rule list should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_rule_show() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("rule-show-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("A".to_string(), vec!["x".to_string()], None, true)
+        .await
+        .unwrap();
+    tonk_cli::concept::define("B".to_string(), vec!["x".to_string()], None, true)
+        .await
+        .unwrap();
+
+    let rule_json = serde_json::json!({
+        "conclusion": { "concept": "B", "bindings": { "x": "?x" } },
+        "when": [{ "the": "a/x", "of": "?entity", "is": "?x" }]
+    });
+
+    let rule_path = env.home_path.join("rule.json");
+    std::fs::write(&rule_path, serde_json::to_string(&rule_json).unwrap()).unwrap();
+
+    tonk_cli::rule::define(
+        "a-to-b".to_string(),
+        Some(rule_path.to_string_lossy().into_owned()),
+        false,
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define rule");
+
+    let result = tonk_cli::rule::show("a-to-b".to_string(), true).await;
+    assert!(
+        result.is_ok(),
+        "rule show should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_rule_delete() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("rule-del-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::concept::define("X".to_string(), vec!["v".to_string()], None, true)
+        .await
+        .unwrap();
+    tonk_cli::concept::define("Y".to_string(), vec!["v".to_string()], None, true)
+        .await
+        .unwrap();
+
+    let rule_json = serde_json::json!({
+        "conclusion": { "concept": "Y", "bindings": { "v": "?v" } },
+        "when": [{ "the": "x/v", "of": "?entity", "is": "?v" }]
+    });
+
+    let rule_path = env.home_path.join("rule.json");
+    std::fs::write(&rule_path, serde_json::to_string(&rule_json).unwrap()).unwrap();
+
+    tonk_cli::rule::define(
+        "temp-rule".to_string(),
+        Some(rule_path.to_string_lossy().into_owned()),
+        false,
+        None,
+        true,
+    )
+    .await
+    .unwrap();
+
+    // Delete the rule
+    tonk_cli::rule::delete("temp-rule".to_string(), true)
+        .await
+        .expect("Failed to delete rule");
+
+    // Show should fail
+    let result = tonk_cli::rule::show("temp-rule".to_string(), true).await;
+    assert!(result.is_err(), "rule show after delete should fail");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_rule_validates_concept_exists() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("rule-validation-space")
+        .await
+        .expect("Failed to create space");
+
+    // Define only one concept, not both
+    tonk_cli::concept::define("Exists".to_string(), vec!["v".to_string()], None, true)
+        .await
+        .unwrap();
+
+    let rule_json = serde_json::json!({
+        "conclusion": { "concept": "DoesNotExist", "bindings": { "v": "?v" } },
+        "when": [{ "the": "exists/v", "of": "?entity", "is": "?v" }]
+    });
+
+    let rule_path = env.home_path.join("rule.json");
+    std::fs::write(&rule_path, serde_json::to_string(&rule_json).unwrap()).unwrap();
+
+    let result = tonk_cli::rule::define(
+        "bad-rule".to_string(),
+        Some(rule_path.to_string_lossy().into_owned()),
+        false,
+        None,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "rule referencing non-existent concept should fail"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Dev Fact Operations
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_fact_assert_and_find() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("fact-space")
+        .await
+        .expect("Failed to create space");
+
+    // Assert a fact
+    tonk_cli::fact::assert(
+        "user/name".to_string(),
+        "alice".to_string(),
+        "Alice Smith".to_string(),
+        true,
+    )
+    .await
+    .expect("Failed to assert fact");
+
+    // Find it
+    let result = tonk_cli::fact::find(Some("user/name".to_string()), None, None, None, true).await;
+    assert!(
+        result.is_ok(),
+        "fact find should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_fact_retract() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("retract-space")
+        .await
+        .expect("Failed to create space");
+
+    tonk_cli::fact::assert(
+        "user/name".to_string(),
+        "bob".to_string(),
+        "Bob Jones".to_string(),
+        true,
+    )
+    .await
+    .expect("Failed to assert fact");
+
+    // Retract it
+    let result = tonk_cli::fact::retract(
+        "user/name".to_string(),
+        "bob".to_string(),
+        "Bob Jones".to_string(),
+        true,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "fact retract should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_fact_find_with_entity_filter() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("fact-filter-space")
+        .await
+        .expect("Failed to create space");
+
+    // Assert multiple facts
+    tonk_cli::fact::assert(
+        "user/name".to_string(),
+        "alice".to_string(),
+        "Alice".to_string(),
+        true,
+    )
+    .await
+    .expect("Failed to assert fact 1");
+
+    tonk_cli::fact::assert(
+        "user/email".to_string(),
+        "alice".to_string(),
+        "alice@example.com".to_string(),
+        true,
+    )
+    .await
+    .expect("Failed to assert fact 2");
+
+    tonk_cli::fact::assert(
+        "user/name".to_string(),
+        "bob".to_string(),
+        "Bob".to_string(),
+        true,
+    )
+    .await
+    .expect("Failed to assert fact 3");
+
+    // Find by entity
+    let result = tonk_cli::fact::find(None, Some("alice".to_string()), None, None, true).await;
+    assert!(result.is_ok(), "fact find by entity should succeed");
+
+    // Find by attribute
+    let result = tonk_cli::fact::find(Some("user/name".to_string()), None, None, None, true).await;
+    assert!(result.is_ok(), "fact find by attribute should succeed");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Session Management
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_session_list() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+
+    let result = tonk_cli::session::list(false, true).await;
+    assert!(
+        result.is_ok(),
+        "session list should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_session_current() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+
+    let result = tonk_cli::session::show_current(true).await;
+    assert!(
+        result.is_ok(),
+        "session current should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Edge Cases & Error Handling
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_no_space_errors_gracefully() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+    // No space created — commands requiring a space should fail gracefully
+
+    let result = tonk_cli::concept::list(true).await;
+    assert!(result.is_err(), "concept list without space should fail");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_operations_require_space() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+
+    let result =
+        tonk_cli::concept::define("Task".to_string(), vec!["title".to_string()], None, true).await;
+    assert!(result.is_err(), "concept define without space should fail");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_instance_create_requires_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("no-concept-space")
+        .await
+        .expect("Failed to create space");
+
+    // Try to create an instance of a concept that doesn't exist
+    let result = tonk_cli::instance::create(
+        "NonExistent".to_string(),
+        vec!["title=Foo".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "creating instance of non-existent concept should fail"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// End-to-End Workflows
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_full_crud_workflow() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("workflow-space")
+        .await
+        .expect("Failed to create space");
+
+    // 1. Import concepts from YAML
+    let file = TestEnv::example_file("minimal.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import concepts");
+
+    // 2. Create instances
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec![
+            "title=Write tests".to_string(),
+            "status=todo".to_string(),
+            "priority=high".to_string(),
+        ],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task 1");
+
+    tonk_cli::instance::create(
+        "Task".to_string(),
+        vec![
+            "title=Review PR".to_string(),
+            "status=in-progress".to_string(),
+            "priority=medium".to_string(),
+        ],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create task 2");
+
+    // 3. Query all tasks
+    let result = tonk_cli::instance::query("Task".to_string(), vec![], true).await;
+    assert!(result.is_ok(), "query all tasks should succeed");
+
+    // 4. Query with filter
+    let result =
+        tonk_cli::instance::query("Task".to_string(), vec!["status=todo".to_string()], true).await;
+    assert!(result.is_ok(), "filtered query should succeed");
+
+    // 5. Find an instance and update it
+    let ctx = tonk_cli::schema::get_space_context().expect("Failed to get context");
+    let branch = tonk_cli::schema::open_branch(&ctx)
+        .await
+        .expect("Failed to open branch");
+    let concept_name = tonk_cli::schema::ConceptName::new("Task").unwrap();
+    let concept_entity = tonk_cli::schema::concept_entity(&ctx.space_did, &concept_name).unwrap();
+    let instances =
+        tonk_cli::schema::fetch_entity_values(&branch, &concept_entity, "concept/instance")
+            .await
+            .expect("Failed to fetch instances");
+    assert_eq!(instances.len(), 2, "Should have 2 instances");
+
+    let instance_id = instances[0].to_string();
+    tonk_cli::instance::update(instance_id.clone(), vec!["status=done".to_string()], true)
+        .await
+        .expect("Failed to update instance");
+
+    // 6. Show the updated instance
+    tonk_cli::instance::show(instance_id.clone(), true)
+        .await
+        .expect("Failed to show instance");
+
+    // 7. Delete the instance
+    tonk_cli::instance::delete(instance_id, true)
+        .await
+        .expect("Failed to delete instance");
+
+    // 8. Verify only 1 instance remains
+    let branch2 = tonk_cli::schema::open_branch(&ctx)
+        .await
+        .expect("Failed to re-open branch");
+    let remaining =
+        tonk_cli::schema::fetch_entity_values(&branch2, &concept_entity, "concept/instance")
+            .await
+            .expect("Failed to fetch remaining instances");
+    assert_eq!(remaining.len(), 1, "Should have 1 instance after deletion");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_import_concepts_and_rules_full_workflow() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("full-workflow")
+        .await
+        .expect("Failed to create space");
+
+    // 1. Import planner concepts (2 namespaces, 5 concepts)
+    let planner = TestEnv::example_file("planner.yaml");
+    tonk_cli::import::import(planner, false, true)
+        .await
+        .expect("Failed to import planner concepts");
+
+    // 2. Import cook concepts (1 namespace, 3 concepts)
+    let cook = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(cook, false, true)
+        .await
+        .expect("Failed to import cook concepts");
+
+    // 3. Verify all 8 concepts exist
+    for name in &[
+        "Allergy",
+        "Event",
+        "Meal",
+        "SafeMeal",
+        "AllergyConflict",
+        "Recipe",
+        "Ingredient",
+        "RecipeStep",
+    ] {
+        let result = tonk_cli::concept::show(name.to_string(), true).await;
+        assert!(result.is_ok(), "{} should exist after import", name);
+    }
+
+    // 4. Import rules
+    let rules = TestEnv::example_file("rules.yaml");
+    tonk_cli::import::import(rules, false, true)
+        .await
+        .expect("Failed to import rules");
+
+    // 5. Verify rules exist
+    let result = tonk_cli::rule::list(true).await;
+    assert!(result.is_ok(), "rule list should succeed after import");
+
+    // 6. Create some data
+    tonk_cli::instance::create(
+        "Recipe".to_string(),
+        vec!["title=Pasta".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create recipe");
+
+    tonk_cli::instance::create(
+        "Ingredient".to_string(),
+        vec!["name=Peanuts".to_string(), "quantity=100".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create ingredient");
+
+    // 7. Query instances
+    let result = tonk_cli::instance::query("Recipe".to_string(), vec![], true).await;
+    assert!(result.is_ok(), "recipe query should succeed");
+
+    let result = tonk_cli::instance::query("Ingredient".to_string(), vec![], true).await;
+    assert!(result.is_ok(), "ingredient query should succeed");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_concept_define_with_many_attributes() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("many-attrs-space")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept with many attributes
+    tonk_cli::concept::define(
+        "Person".to_string(),
+        vec![
+            "first-name".to_string(),
+            "last-name".to_string(),
+            "email".to_string(),
+            "phone".to_string(),
+            "address".to_string(),
+            "city".to_string(),
+            "country".to_string(),
+            "age".to_string(),
+        ],
+        Some("A person record".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define Person concept");
+
+    // Show should display all attributes
+    let result = tonk_cli::concept::show("Person".to_string(), true).await;
+    assert!(result.is_ok(), "show Person should succeed");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_multiple_concepts_same_space() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("multi-concept")
+        .await
+        .expect("Failed to create space");
+
+    // Define multiple concepts
+    tonk_cli::concept::define(
+        "User".to_string(),
+        vec!["name".to_string(), "email".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define User");
+    tonk_cli::concept::define(
+        "Post".to_string(),
+        vec!["title".to_string(), "body".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Post");
+    tonk_cli::concept::define("Comment".to_string(), vec!["text".to_string()], None, true)
+        .await
+        .expect("Failed to define Comment");
+
+    // List should show all 3
+    let result = tonk_cli::concept::list(true).await;
+    assert!(result.is_ok(), "concept list should succeed");
+
+    // Create instances of each
+    tonk_cli::instance::create(
+        "User".to_string(),
+        vec!["name=Alice".to_string(), "email=a@b.com".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create user");
+    tonk_cli::instance::create(
+        "Post".to_string(),
+        vec!["title=Hello".to_string(), "body=World".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create post");
+    tonk_cli::instance::create(
+        "Comment".to_string(),
+        vec!["text=Nice post".to_string()],
+        None,
+        false,
+        true,
+    )
+    .await
+    .expect("Failed to create comment");
+
+    // Query each concept independently
+    for concept in &["User", "Post", "Comment"] {
+        let result = tonk_cli::instance::query(concept.to_string(), vec![], true).await;
+        assert!(result.is_ok(), "{} query should succeed", concept);
+    }
+}

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -1,0 +1,162 @@
+//! Test harness for tonk-cli integration tests.
+//!
+//! Provides a `TestEnv` struct that creates an isolated filesystem environment
+//! for each test, with a bootstrapped operator, session (authority), and
+//! optionally a space — bypassing the browser-based login flow entirely.
+
+use anyhow::{Context, Result};
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan::Delegation as UcanDelegation;
+use dialog_ucan::subject::Subject;
+use dialog_varsig::Did;
+use dialog_varsig::eddsa::Ed25519Signature;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tonk_cli::crypto::Operator;
+use tonk_cli::delegation::Delegation;
+
+/// An isolated test environment backed by a temporary directory.
+///
+/// Sets `TONK_HOME` and `TONK_OPERATOR_KEY` env vars so that all tonk-cli
+/// functions use a fresh tempdir as the tonk data directory (equivalent to
+/// `~/.tonk/` in normal operation).
+///
+/// On drop the tempdir and its contents are deleted automatically.
+#[allow(dead_code)]
+pub struct TestEnv {
+    _temp_dir: TempDir,
+    pub home_path: PathBuf,
+    pub operator: Operator,
+    pub operator_did: String,
+    pub authority_operator: Operator,
+    pub authority_did: String,
+}
+
+impl TestEnv {
+    /// Create a new test environment with a bootstrapped session.
+    ///
+    /// This simulates the result of `tonk login` by:
+    /// 1. Generating a deterministic operator keypair
+    /// 2. Generating an "authority" keypair (simulating the auth service)
+    /// 3. Creating a powerline UCAN delegation: authority → operator
+    /// 4. Saving the delegation to the correct filesystem path
+    /// 5. Setting the active session
+    pub async fn new() -> Result<Self> {
+        let temp_dir = TempDir::new().context("Failed to create temp directory")?;
+        let home_path = temp_dir.path().to_path_buf();
+
+        // Generate operator keypair
+        let operator = Operator::generate();
+        let operator_did = operator.did().to_string();
+
+        // Encode operator secret as base58btc for TONK_OPERATOR_KEY
+        let operator_secret = operator.to_secret();
+        let operator_key_b58 = bs58::encode(&operator_secret).into_string();
+
+        // Set environment variables for isolation.
+        // SAFETY: Tests run serially (via #[serial]) so no concurrent env var access.
+        unsafe {
+            std::env::set_var("TONK_HOME", &home_path);
+            std::env::set_var("TONK_OPERATOR_KEY", &operator_key_b58);
+        }
+
+        // Generate authority keypair (simulates the auth service identity)
+        let authority_operator = Operator::generate();
+        let authority_did = authority_operator.did().to_string();
+
+        // Create powerline delegation: authority → operator (subject = *)
+        let authority_signer = Ed25519Signer::from(&authority_operator);
+        let operator_did_parsed: Did = operator_did
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Failed to parse operator DID: {:?}", e))?;
+
+        let ucan_delegation: UcanDelegation<Ed25519Signature> = UcanDelegation::builder()
+            .issuer(authority_signer)
+            .audience(&operator_did_parsed)
+            .subject(Subject::Any) // Powerline = "*"
+            .command(vec![]) // Empty = root access "/"
+            .try_build()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to build delegation: {}", e))?;
+
+        let delegation = Delegation::from_ucan(ucan_delegation);
+
+        // Save delegation to filesystem (this uses TONK_HOME via util::tonk_dir())
+        delegation.save()?;
+
+        // Set active session
+        tonk_cli::state::set_active_session(&authority_did)?;
+
+        // Save session metadata
+        let session_meta = tonk_cli::metadata::SessionMetadata::new(
+            "test-session".to_string(),
+            "test://local".to_string(),
+        );
+        session_meta.save(&authority_did)?;
+
+        Ok(Self {
+            _temp_dir: temp_dir,
+            home_path,
+            operator,
+            operator_did,
+            authority_operator,
+            authority_did,
+        })
+    }
+
+    /// Create a named space in this test environment.
+    ///
+    /// Calls `tonk_cli::space::create()` which creates the space, saves
+    /// delegations, metadata, initializes the dialog-db, and sets the
+    /// space as active.
+    pub async fn create_space(&self, name: &str) -> Result<String> {
+        // Use JSON mode to capture the space DID from output
+        // But space::create prints to stdout, so we call it and then
+        // read the active space from state.
+        tonk_cli::space::create(
+            name.to_string(),
+            Some(vec![]), // No additional owners (authority is always included)
+            None,         // No description
+            true,         // JSON mode (suppresses interactive prompts)
+        )
+        .await?;
+
+        // Read back the active space DID
+        let space_did = tonk_cli::state::get_active_space(&self.authority_did)?
+            .context("Space was not set as active after creation")?;
+
+        Ok(space_did)
+    }
+
+    /// Get the path to the examples directory.
+    ///
+    /// Uses the runtime `CARGO_MANIFEST_DIR` env var, which nextest
+    /// automatically sets to the remapped path when running from an
+    /// archive with `--workspace-remap`. Falls back to the compile-time
+    /// value for normal `cargo test` runs.
+    pub fn examples_dir() -> PathBuf {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+        manifest_dir.join("examples")
+    }
+
+    /// Get path to a specific example YAML file.
+    pub fn example_file(name: &str) -> String {
+        Self::examples_dir()
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        // Clean up env vars (best-effort, tests run serially anyway).
+        // SAFETY: Tests run serially (via #[serial]) so no concurrent env var access.
+        unsafe {
+            std::env::remove_var("TONK_HOME");
+            std::env::remove_var("TONK_OPERATOR_KEY");
+        }
+    }
+}


### PR DESCRIPTION
### Description

- adds comprehensive integration tests for each path through the Tonk CLI
- adds test harness that bypasses `tonk login` browser flow by generating keypairs and delegation manually, then saving to temporary directory
- adds integration test step to CI

### Related issues

- closes TON-1867

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk-cli` project by refactoring directory handling, adding integration tests, and updating workflows for better CI/CD practices.

### Detailed summary
- Replaced `home_dir` usage with `tonk_dir` for consistency in directory path handling.
- Introduced `access_dir` function to streamline access directory retrieval.
- Added integration tests for CLI functionalities.
- Updated GitHub Actions workflows for improved CI processes.
- Added new dependencies in `Cargo.toml` for testing and functionality.
- Enhanced error handling and context messages for directory-related operations.

> The following files were skipped due to too many changes: `rust/tonk-cli/tests/cli_integration.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->