### PR TITLE
feat(cli): TON-1915: `tonk attribute` command for discoverability

### DIFF
--- a/rust/tonk-cli/src/attribute.rs
+++ b/rust/tonk-cli/src/attribute.rs
@@ -1,0 +1,592 @@
+//! Attribute introspection: list and inspect attribute metadata.
+//!
+//! Attributes are the fields of a concept schema. Each attribute has a qualified
+//! name (e.g. `recipe/title`) and optional metadata — description, type,
+//! cardinality, and optional flag — written by `tonk import`.
+//!
+//! This module reads that metadata back for schema discoverability.
+
+use crate::schema::*;
+use anyhow::{Context, Result};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single attribute, fetched from EAV triples.
+struct AttrMeta {
+    short_name: String,
+    qualified_name: String,
+    description: Option<String>,
+    type_str: Option<String>,
+    cardinality: Option<String>,
+    optional: bool,
+}
+
+/// Format a type string for human display.
+///
+/// If the stored value is a JSON array (e.g. `["tsp","mls"]`), display it as
+/// `tsp | mls`. Otherwise return the string as-is (e.g. `Text`, `Integer`).
+fn format_type_display(type_str: &str) -> String {
+    if let Ok(items) = serde_json::from_str::<Vec<String>>(type_str) {
+        items.join(" | ")
+    } else {
+        type_str.to_string()
+    }
+}
+
+/// Build a compact annotation string for human output.
+///
+/// Combines cardinality, type, and optional into a parenthetical like
+/// `(many, Text, optional)` or just `(Text)`.
+fn format_annotation(meta: &AttrMeta) -> String {
+    let mut parts = Vec::new();
+
+    if meta.cardinality.as_deref() == Some("many") {
+        parts.push("many".to_string());
+    }
+
+    if let Some(t) = &meta.type_str {
+        parts.push(format_type_display(t));
+    }
+
+    if meta.optional {
+        parts.push("optional".to_string());
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    }
+}
+
+/// Convert an AttrMeta to a JSON value.
+fn meta_to_json(meta: &AttrMeta) -> serde_json::Value {
+    serde_json::json!({
+        "name": meta.short_name,
+        "qualified_name": meta.qualified_name,
+        "description": meta.description,
+        "type": meta.type_str,
+        "cardinality": meta.cardinality,
+        "optional": meta.optional,
+    })
+}
+
+/// Collected info about a single concept and its attributes.
+struct ConceptAttrs {
+    name: String,
+    namespace: Option<String>,
+    attrs: Vec<AttrMeta>,
+}
+
+/// Fetch attribute metadata for a single qualified attribute name.
+async fn fetch_attr_meta<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    concept_name: &ConceptName,
+    qualified_name: &str,
+) -> Result<AttrMeta> {
+    let meta_entity = attribute_meta_entity(space_did, concept_name, qualified_name)?;
+
+    let description = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_DESCRIPTION).await?;
+    let type_str = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_TYPE).await?;
+    let cardinality = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_CARDINALITY).await?;
+    let optional_str = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_OPTIONAL).await?;
+    let optional = optional_str.as_deref() == Some("true");
+
+    Ok(AttrMeta {
+        short_name: short_attribute(concept_name, qualified_name),
+        qualified_name: qualified_name.to_string(),
+        description,
+        type_str,
+        cardinality,
+        optional,
+    })
+}
+
+/// Load all concepts and their attribute metadata from the space.
+async fn load_all_concepts<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+) -> Result<Vec<ConceptAttrs>> {
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    let mut concepts = Vec::new();
+
+    for entity in &concept_entities {
+        let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Concept entity '{}' is missing its 'concept/name' attribute",
+                    entity
+                )
+            })?;
+        let concept_name = ConceptName::from_stored(name.clone());
+        let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+        let qualified_attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+        let mut attrs = Vec::new();
+        for qname in &qualified_attrs {
+            let meta = fetch_attr_meta(store, space_did, &concept_name, qname).await?;
+            attrs.push(meta);
+        }
+
+        concepts.push(ConceptAttrs {
+            name,
+            namespace,
+            attrs,
+        });
+    }
+
+    Ok(concepts)
+}
+
+// ---------------------------------------------------------------------------
+// List all attributes
+// ---------------------------------------------------------------------------
+
+/// List all attributes in the active space, grouped by concept.
+pub async fn list(json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    let concepts = load_all_concepts(&branch, &ctx.space_did).await?;
+
+    if concepts.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!(
+                "No concepts defined. Use 'tonk concept define <name>' or 'tonk import <file>' to create one."
+            );
+        }
+        return Ok(());
+    }
+
+    if json {
+        let items: Vec<serde_json::Value> = concepts
+            .iter()
+            .map(|c| {
+                let attrs_json: Vec<serde_json::Value> = c.attrs.iter().map(meta_to_json).collect();
+                serde_json::json!({
+                    "concept": c.name,
+                    "namespace": c.namespace,
+                    "attributes": attrs_json,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&items)?);
+    } else {
+        let total_concepts = concepts.len();
+        let total_attrs: usize = concepts.iter().map(|c| c.attrs.len()).sum();
+
+        println!("Attributes:\n");
+        for c in &concepts {
+            let ns_str = c
+                .namespace
+                .as_ref()
+                .map(|ns| format!(" ({})", ns))
+                .unwrap_or_default();
+            println!("  {}{}:", c.name, ns_str);
+
+            if c.attrs.is_empty() {
+                println!("    (no attributes)");
+            } else {
+                // Calculate padding for aligned descriptions
+                let max_name_len = c
+                    .attrs
+                    .iter()
+                    .map(|a| a.short_name.len())
+                    .max()
+                    .unwrap_or(0);
+
+                for attr in &c.attrs {
+                    let padding = " ".repeat(max_name_len - attr.short_name.len());
+                    let desc_str = attr
+                        .description
+                        .as_ref()
+                        .map(|d| format!(" - {}", d))
+                        .unwrap_or_default();
+                    let annotation = format_annotation(attr);
+                    println!(
+                        "    {}{}{}{}",
+                        attr.short_name, padding, desc_str, annotation
+                    );
+                }
+            }
+
+            println!();
+        }
+
+        let concept_word = if total_concepts == 1 {
+            "concept"
+        } else {
+            "concepts"
+        };
+        let attr_word = if total_attrs == 1 {
+            "attribute"
+        } else {
+            "attributes"
+        };
+        println!(
+            "{} {}, {} {}",
+            total_concepts, concept_word, total_attrs, attr_word
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Show a single attribute
+// ---------------------------------------------------------------------------
+
+/// Show details of a specific attribute.
+///
+/// The attribute can be specified as a qualified name (e.g. `recipe/title`) or
+/// as a short name with `--concept` (e.g. `title --concept Recipe`).
+pub async fn show(name: String, concept: Option<String>, json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    // Resolve the qualified name and owning concept
+    let (concept_name, namespace, qualified_name) = if name.contains('/') {
+        // Qualified name: split to find the concept prefix, then walk concepts
+        // to find the match.
+        resolve_qualified(&branch, &ctx.space_did, &name).await?
+    } else if let Some(c) = concept {
+        // Short name + --concept flag
+        resolve_short(&branch, &ctx.space_did, &name, &c).await?
+    } else {
+        // Try to find by short name across all concepts
+        resolve_unqualified(&branch, &ctx.space_did, &name).await?
+    };
+
+    let meta = fetch_attr_meta(&branch, &ctx.space_did, &concept_name, &qualified_name).await?;
+
+    if json {
+        let mut obj = meta_to_json(&meta);
+        obj.as_object_mut().unwrap().insert(
+            "concept".to_string(),
+            serde_json::json!(concept_name.as_str()),
+        );
+        if let Some(ns) = &namespace {
+            obj.as_object_mut()
+                .unwrap()
+                .insert("namespace".to_string(), serde_json::json!(ns));
+        }
+        println!("{}", serde_json::to_string(&obj)?);
+    } else {
+        println!("Attribute: {}", qualified_name);
+        println!("  Concept:     {}", concept_name);
+        if let Some(ns) = &namespace {
+            println!("  Namespace:   {}", ns);
+        }
+        if let Some(desc) = &meta.description {
+            println!("  Description: {}", desc);
+        }
+        let type_display = meta
+            .type_str
+            .as_ref()
+            .map(|t| format_type_display(t))
+            .unwrap_or_else(|| "(untyped)".to_string());
+        println!("  Type:        {}", type_display);
+        let card = if meta.cardinality.as_deref() == Some("many") {
+            "many"
+        } else {
+            "single"
+        };
+        println!("  Cardinality: {}", card);
+        println!(
+            "  Optional:    {}",
+            if meta.optional { "yes" } else { "no" }
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Name resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a qualified attribute name (e.g. `recipe/title`) to its concept.
+///
+/// Walks all concepts in the registry to find one whose `concept/attribute`
+/// list contains the given qualified name.
+async fn resolve_qualified<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    qualified_name: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let normalized = if let Some((prefix, attr)) = qualified_name.split_once('/') {
+        format!("{}/{}", prefix.to_lowercase(), attr)
+    } else {
+        qualified_name.to_string()
+    };
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    for entity in &concept_entities {
+        let attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+        if attrs.iter().any(|a| a == &normalized) {
+            let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Concept entity missing concept/name"))?;
+            let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+            return Ok((ConceptName::from_stored(name), namespace, normalized));
+        }
+    }
+
+    anyhow::bail!(
+        "Attribute '{}' not found. Run 'tonk attribute' to list available attributes.",
+        qualified_name
+    );
+}
+
+/// Resolve a short attribute name given a concept name.
+async fn resolve_short<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    short_name: &str,
+    concept_str: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let concept_name = ConceptName::new(concept_str)?;
+    let concept = concept_entity(space_did, &concept_name)?;
+
+    // Verify concept exists
+    let stored_name = fetch_string(store, &concept, ATTR_CONCEPT_NAME)
+        .await?
+        .context(format!("Concept '{}' not found", concept_name))?;
+    let stored_name = ConceptName::from_stored(stored_name);
+
+    let namespace = fetch_string(store, &concept, ATTR_CONCEPT_NAMESPACE).await?;
+    let qualified = qualify_attribute(&stored_name, short_name)?;
+
+    // Verify the attribute actually exists on this concept
+    let attrs = fetch_string_values(store, &concept, ATTR_CONCEPT_ATTRIBUTE).await?;
+    if !attrs.contains(&qualified) {
+        anyhow::bail!(
+            "Attribute '{}' not found on concept '{}'. Available attributes: {}",
+            short_name,
+            stored_name,
+            attrs
+                .iter()
+                .map(|a| short_attribute(&stored_name, a))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    Ok((stored_name, namespace, qualified))
+}
+
+/// Resolve a short attribute name without a concept — search all concepts.
+///
+/// If exactly one concept has an attribute with this short name, return it.
+/// If multiple concepts have it, bail with a disambiguation message.
+async fn resolve_unqualified<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    short_name: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    let mut matches: Vec<(ConceptName, Option<String>, String)> = Vec::new();
+
+    for entity in &concept_entities {
+        let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Concept entity missing concept/name"))?;
+        let concept_name = ConceptName::from_stored(name);
+        let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+        let attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+        for qname in &attrs {
+            if short_attribute(&concept_name, qname) == short_name {
+                matches.push((concept_name.clone(), namespace.clone(), qname.clone()));
+                break;
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => {
+            anyhow::bail!(
+                "Attribute '{}' not found in any concept. Run 'tonk attribute' to list available attributes.",
+                short_name
+            );
+        }
+        1 => Ok(matches.into_iter().next().unwrap()),
+        _ => {
+            let concept_list: Vec<String> = matches
+                .iter()
+                .map(|(c, _, q)| format!("  {} ({})", c, q))
+                .collect();
+            anyhow::bail!(
+                "Attribute '{}' exists in multiple concepts. Use --concept to disambiguate:\n{}",
+                short_name,
+                concept_list.join("\n")
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- format_type_display -------------------------------------------------
+
+    #[test]
+    fn format_type_display_simple_string() {
+        assert_eq!(format_type_display("Text"), "Text");
+        assert_eq!(format_type_display("Integer"), "Integer");
+        assert_eq!(format_type_display("RecipeStep"), "RecipeStep");
+    }
+
+    #[test]
+    fn format_type_display_json_array_enum() {
+        assert_eq!(format_type_display(r#"["tsp","mls"]"#), "tsp | mls");
+    }
+
+    #[test]
+    fn format_type_display_single_element_array() {
+        assert_eq!(format_type_display(r#"["only"]"#), "only");
+    }
+
+    #[test]
+    fn format_type_display_empty_array() {
+        assert_eq!(format_type_display("[]"), "");
+    }
+
+    #[test]
+    fn format_type_display_invalid_json_passthrough() {
+        // Malformed JSON should be returned as-is
+        assert_eq!(format_type_display("[not json"), "[not json");
+    }
+
+    // -- format_annotation ---------------------------------------------------
+
+    fn make_meta(cardinality: Option<&str>, type_str: Option<&str>, optional: bool) -> AttrMeta {
+        AttrMeta {
+            short_name: "test".to_string(),
+            qualified_name: "concept/test".to_string(),
+            description: None,
+            type_str: type_str.map(|s| s.to_string()),
+            cardinality: cardinality.map(|s| s.to_string()),
+            optional,
+        }
+    }
+
+    #[test]
+    fn annotation_empty_when_no_metadata() {
+        let meta = make_meta(None, None, false);
+        assert_eq!(format_annotation(&meta), "");
+    }
+
+    #[test]
+    fn annotation_type_only() {
+        let meta = make_meta(None, Some("Text"), false);
+        assert_eq!(format_annotation(&meta), " (Text)");
+    }
+
+    #[test]
+    fn annotation_many_and_type() {
+        let meta = make_meta(Some("many"), Some("RecipeStep"), false);
+        assert_eq!(format_annotation(&meta), " (many, RecipeStep)");
+    }
+
+    #[test]
+    fn annotation_many_only() {
+        let meta = make_meta(Some("many"), None, false);
+        assert_eq!(format_annotation(&meta), " (many)");
+    }
+
+    #[test]
+    fn annotation_optional_only() {
+        let meta = make_meta(None, None, true);
+        assert_eq!(format_annotation(&meta), " (optional)");
+    }
+
+    #[test]
+    fn annotation_all_three() {
+        let meta = make_meta(Some("many"), Some("Text"), true);
+        assert_eq!(format_annotation(&meta), " (many, Text, optional)");
+    }
+
+    #[test]
+    fn annotation_enum_type() {
+        let meta = make_meta(None, Some(r#"["tsp","mls"]"#), false);
+        assert_eq!(format_annotation(&meta), " (tsp | mls)");
+    }
+
+    #[test]
+    fn annotation_single_cardinality_ignored() {
+        // Only "many" gets shown; other cardinality values are ignored
+        let meta = make_meta(Some("single"), Some("Text"), false);
+        assert_eq!(format_annotation(&meta), " (Text)");
+    }
+
+    // -- meta_to_json --------------------------------------------------------
+
+    #[test]
+    fn meta_to_json_with_all_fields() {
+        let meta = AttrMeta {
+            short_name: "title".to_string(),
+            qualified_name: "recipe/title".to_string(),
+            description: Some("The name of this recipe".to_string()),
+            type_str: Some("Text".to_string()),
+            cardinality: None,
+            optional: false,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["name"], "title");
+        assert_eq!(json["qualified_name"], "recipe/title");
+        assert_eq!(json["description"], "The name of this recipe");
+        assert_eq!(json["type"], "Text");
+        assert!(json["cardinality"].is_null());
+        assert_eq!(json["optional"], false);
+    }
+
+    #[test]
+    fn meta_to_json_minimal() {
+        let meta = AttrMeta {
+            short_name: "tag".to_string(),
+            qualified_name: "task/tag".to_string(),
+            description: None,
+            type_str: None,
+            cardinality: None,
+            optional: false,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["name"], "tag");
+        assert!(json["description"].is_null());
+        assert!(json["type"].is_null());
+        assert_eq!(json["optional"], false);
+    }
+
+    #[test]
+    fn meta_to_json_optional_many() {
+        let meta = AttrMeta {
+            short_name: "step".to_string(),
+            qualified_name: "recipe/step".to_string(),
+            description: Some("A cooking step".to_string()),
+            type_str: Some("RecipeStep".to_string()),
+            cardinality: Some("many".to_string()),
+            optional: true,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["cardinality"], "many");
+        assert_eq!(json["optional"], true);
+        assert_eq!(json["type"], "RecipeStep");
+    }
+}

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -49,6 +49,12 @@ mod inner {
             command: Option<ConceptCommands>,
         },
 
+        /// Inspect attribute definitions
+        Attribute {
+            #[command(subcommand)]
+            command: Option<AttributeCommands>,
+        },
+
         /// Manage deductive rules between concepts
         Rule {
             #[command(subcommand)]
@@ -275,6 +281,19 @@ mod inner {
             /// Also delete all instances of this concept
             #[arg(short, long)]
             force: bool,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum AttributeCommands {
+        /// Show details of a specific attribute
+        Show {
+            /// Attribute name (qualified like "recipe/title", or short like "title" with --concept)
+            name: String,
+
+            /// Concept name (required when using short attribute names)
+            #[arg(long, short)]
+            concept: Option<String>,
         },
     }
 
@@ -594,6 +613,14 @@ async fn main() -> anyhow::Result<()> {
             }
             Some(ConceptCommands::Delete { name, force }) => {
                 tonk_cli::concept::delete(name, force, json).await?;
+            }
+        },
+        Commands::Attribute { command } => match command {
+            None => {
+                tonk_cli::attribute::list(json).await?;
+            }
+            Some(AttributeCommands::Show { name, concept }) => {
+                tonk_cli::attribute::show(name, concept, json).await?;
             }
         },
         Commands::Rule { command } => match command {

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+pub mod attribute;
 pub mod authority;
 pub mod batch;
 pub mod concept;

--- a/rust/tonk-cli/tests/cli_integration.rs
+++ b/rust/tonk-cli/tests/cli_integration.rs
@@ -1743,3 +1743,501 @@ async fn test_multiple_concepts_same_space() {
         assert!(result.is_ok(), "{} query should succeed", concept);
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Attribute Introspection
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_empty_space() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-empty")
+        .await
+        .expect("Failed to create space");
+
+    // List attributes in an empty space — should succeed (prints empty message)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list on empty space should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode should also succeed
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON on empty space should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_concept_define() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-define")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept (no metadata — just attribute names)
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // List attributes — should show Task with title and status (no metadata)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_import_with_metadata() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-import")
+        .await
+        .expect("Failed to create space");
+
+    // Import cook.yaml which has full attribute metadata
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // List attributes — should show Recipe, Ingredient, RecipeStep with metadata
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list after import should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON after import should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_qualified_name() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-qual")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Show by qualified name
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show by qualified name should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON by qualified name should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_short_name_with_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-short")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Show by short name with --concept
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Recipe".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show with --concept should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Recipe".to_string()), true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON with --concept should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_unambiguous_short_name() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-unambig")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "steps" only exists on Recipe, so it should resolve unambiguously
+    let result = tonk_cli::attribute::show("steps".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show unambiguous short name should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_ambiguous_short_name_errors() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-ambig")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "name" exists on both Ingredient and possibly others — check if it's ambiguous
+    // Actually in cook.yaml, "name" only exists on Ingredient.
+    // Let's use a concept where we know there's overlap. Define a second concept
+    // with a "name" attribute to create ambiguity.
+    tonk_cli::concept::define(
+        "Person".to_string(),
+        vec!["name".to_string(), "age".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Person concept");
+
+    // Now "name" exists on both Ingredient and Person
+    let result = tonk_cli::attribute::show("name".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with ambiguous name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_qualified() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-noexist")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Nonexistent qualified name
+    let result = tonk_cli::attribute::show("recipe/nonexistent".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent qualified name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_short() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-noexist-short")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Nonexistent short name
+    let result = tonk_cli::attribute::show("zzz_nonexistent".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent short name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_wrong_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-wrongconcept")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "title" belongs to Recipe, not Ingredient
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Ingredient".to_string()), false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with wrong concept should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-badconcept")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Concept doesn't exist
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Nonexistent".to_string()), false)
+            .await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent concept should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_enum_type() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-enum")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "unit" on Ingredient has enum type ["tsp","mls"]
+    let result =
+        tonk_cli::attribute::show("unit".to_string(), Some("Ingredient".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show for enum type should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result =
+        tonk_cli::attribute::show("unit".to_string(), Some("Ingredient".to_string()), true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON for enum type should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_many_cardinality() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-many")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "ingredient" on Recipe has cardinality: many
+    let result =
+        tonk_cli::attribute::show("ingredient".to_string(), Some("Recipe".to_string()), false)
+            .await;
+    assert!(
+        result.is_ok(),
+        "attribute show for many-cardinality should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_optional_attribute() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-optional")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "after" on RecipeStep has optional: true
+    let result =
+        tonk_cli::attribute::show("after".to_string(), Some("RecipeStep".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show for optional attribute should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_no_space_errors() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+    // No space created — should fail gracefully
+
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_err(),
+        "attribute list without a space should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_no_space_errors() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+    // No space created — should fail gracefully
+
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show without a space should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_import_and_define_mixed() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-mixed")
+        .await
+        .expect("Failed to create space");
+
+    // Import cook.yaml (has metadata)
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Also define a concept manually (no metadata)
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        Some("A task".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define Task");
+
+    // List should show both imported (with metadata) and defined (without)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list with mixed concepts should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON with mixed concepts should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_defined_concept_no_metadata() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-nometa")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept without importing (no metadata)
+    tonk_cli::concept::define(
+        "Note".to_string(),
+        vec!["body".to_string(), "tags".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Note");
+
+    // Show should work, just without metadata
+    let result =
+        tonk_cli::attribute::show("body".to_string(), Some("Note".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show without metadata should succeed: {:?}",
+        result.err()
+    );
+
+    // Qualified form too
+    let result = tonk_cli::attribute::show("note/body".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show by qualified name without metadata should succeed: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `Attribute` module in the `tonk-cli`, enabling the inspection and management of attribute definitions, including commands for listing and showing attributes. It also adds tests for various scenarios related to attributes.

### Detailed summary
- Added `Attribute` module with subcommands for managing attributes.
- Implemented `list` and `show` commands for attributes.
- Created tests for:
  - Listing attributes in empty and populated spaces.
  - Showing attributes by qualified and short names.
  - Handling errors for non-existent attributes and concepts.
- Enhanced metadata handling for attributes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->