### PR TITLE
feat(cli): TON-1916: adapt parser to spec

### DIFF
--- a/rust/tonk-cli/examples/cook.yaml
+++ b/rust/tonk-cli/examples/cook.yaml
@@ -1,38 +1,38 @@
 diy.cook:
   Recipe:
-    this:
-      the: Meal recipe
-    title:
-      the: The name of this recipe
-      as: Text
-    ingredient:
-      the: Ingredients of the recipe
-      cardinality: many
-    steps:
-      the: Steps of the cooking process
-      cardinality: many
-      as: RecipeStep
+    description: Meal recipe
+    with:
+      title:
+        description: The name of this recipe
+        as: Text
+      ingredient:
+        description: Ingredients of the recipe
+        cardinality: many
+      steps:
+        description: Steps of the cooking process
+        cardinality: many
+        as: .RecipeStep
 
   Ingredient:
-    this:
-      the: The meal ingredient
-    name:
-      the: Name of this ingredient
-      as: Text
-    quantity:
-      the: Quantity of the ingredient
-      as: Integer
-    unit:
-      the: The unit of measurement for the ingredient
-      as: [tsp, mls]
+    description: The meal ingredient
+    with:
+      name:
+        description: Name of this ingredient
+        as: Text
+      quantity:
+        description: Quantity of the ingredient
+        as: Integer
+      unit:
+        description: The unit of measurement for the ingredient
+        as: [":tsp", ":mls"]
 
   RecipeStep:
-    this:
-      the: The cooking step
-    after:
-      the: Step to perform this after
-      as: RecipeStep
-      optional:
-    instruction:
-      the: Instructions for this step
-      as: Text
+    description: The cooking step
+    with:
+      instruction:
+        description: Instructions for this step
+        as: Text
+    maybe:
+      after:
+        description: Step to perform this after
+        as: .RecipeStep

--- a/rust/tonk-cli/examples/minimal.yaml
+++ b/rust/tonk-cli/examples/minimal.yaml
@@ -1,14 +1,14 @@
 app:
   Task:
-    this:
-      the: A task to be completed
-    title:
-      the: Title of the task
-      as: Text
-    status:
-      the: Current status
-      as: [todo, in-progress, done]
-    priority:
-      the: Priority level
-      as: [low, medium, high]
-      optional:
+    description: A task to be completed
+    with:
+      title:
+        description: Title of the task
+        as: Text
+      status:
+        description: Current status
+        as: [":todo", ":in-progress", ":done"]
+    maybe:
+      priority:
+        description: Priority level
+        as: [":low", ":medium", ":high"]

--- a/rust/tonk-cli/examples/planner.yaml
+++ b/rust/tonk-cli/examples/planner.yaml
@@ -1,50 +1,84 @@
 diy.health:
   Allergy:
-    this:
-      the: The allergy person has
-    person:
-      the: Person having an allergy
-    substance:
-      the: Substance person has an allergy for
-      as: Text
+    description: The allergy person has
+    with:
+      person:
+        description: Person having an allergy
+      substance:
+        description: Substance person has an allergy for
+        as: Text
 
 diy.planner:
   Event:
-    this:
-      the: Event being planned
-    title:
-      the: Title of the event
-      as: Text
-    time:
-      the: Time of the event
-      as: Text
+    description: Event being planned
+    with:
+      title:
+        description: Title of the event
+        as: Text
+      time:
+        description: Time of the event
+        as: Text
 
   Meal:
-    this:
-      the: The plan for the meal
-    attendee:
-      the: The meal attendee
-    recipe:
-      the: The meal recipe
-    occasion:
-      the: The occasion for the meal
-      as: Event
+    description: The plan for the meal
+    with:
+      attendee:
+        description: The meal attendee
+      recipe:
+        description: The meal recipe
+      occasion:
+        description: The occasion for the meal
 
   SafeMeal:
-    this:
-      the: A meal that respects dietary restrictions
-    attendee:
-      the: The meal attendee
-    recipe:
-      the: The meal recipe
-    occasion:
-      the: The occasion for the meal
-      as: Event
+    description: A meal that respects dietary restrictions
+    with:
+      attendee:
+        description: The meal attendee
+      recipe:
+        description: The meal recipe
+      occasion:
+        description: The occasion for the meal
 
   AllergyConflict:
-    this:
-      the: A conflict between a recipe ingredient and an allergy
-    person:
-      the: The person with the allergy
-    recipe:
-      the: The recipe containing an allergenic ingredient
+    description: A conflict between a recipe ingredient and an allergy
+    with:
+      person:
+        description: The person with the allergy
+      recipe:
+        description: The recipe containing an allergenic ingredient
+
+  find-allergy-conflicts:
+    description: Find conflicts between recipe ingredients and allergies
+    deduce:
+      AllergyConflict:
+        person: ?person
+        recipe: ?recipe
+    when:
+      - diy.cook/Recipe:
+          this: ?recipe
+          ingredient: ?ingredient
+      - diy.cook/Ingredient:
+          this: ?ingredient
+          name: ?substance
+      - diy.health/Allergy:
+          this: ?allergy
+          person: ?person
+          substance: ?substance
+
+  respect-dietary-restrictions:
+    description: A meal that respects dietary restrictions
+    deduce:
+      SafeMeal:
+        attendee: ?person
+        recipe: ?recipe
+        occasion: ?occasion
+    when:
+      - diy.planner/Meal:
+          this: ?meal
+          attendee: ?person
+          recipe: ?recipe
+          occasion: ?occasion
+    unless:
+      - diy.planner/AllergyConflict:
+          person: ?person
+          recipe: ?recipe

--- a/rust/tonk-cli/examples/rules.yaml
+++ b/rust/tonk-cli/examples/rules.yaml
@@ -1,34 +1,34 @@
 user.rules:
-  find-allergy-conflicts:
-    assert:
-      diy.planner/AllergyConflict:
-        person: ?person
+  plan-event-meal:
+    description: Suggest a meal for an event attendee using an available recipe
+    deduce:
+      diy.planner/Meal:
+        attendee: ?person
         recipe: ?recipe
+        occasion: ?event
     when:
+      - diy.planner/Event:
+          this: ?event
+          title: ?title
+      - diy.planner/Meal:
+          this: ?existing
+          attendee: ?person
       - diy.cook/Recipe:
           this: ?recipe
-          ingredient: ?ingredient
-      - diy.cook/Ingredient:
-          this: ?ingredient
-          name: ?substance
-      - diy.health/Allergy:
-          this: ?allergy
-          person: ?person
-          substance: ?substance
+          title: ?recipe-name
 
-  respect-dietary-restrictions:
-    assert:
+  infer-safe-event-meal:
+    description: A safe meal for an event — combines event context with dietary safety
+    deduce:
       diy.planner/SafeMeal:
         attendee: ?person
         recipe: ?recipe
-        occasion: ?occasion
+        occasion: ?event
     when:
-      - diy.planner/Meal:
-          this: ?meal
+      - diy.planner/Event:
+          this: ?event
+          title: ?title
+      - diy.planner/SafeMeal:
+          this: ?safe
           attendee: ?person
-          recipe: ?recipe
-          occasion: ?occasion
-    unless:
-      - diy.planner/AllergyConflict:
-          person: ?person
           recipe: ?recipe

--- a/rust/tonk-cli/src/attribute.rs
+++ b/rust/tonk-cli/src/attribute.rs
@@ -1,0 +1,592 @@
+//! Attribute introspection: list and inspect attribute metadata.
+//!
+//! Attributes are the fields of a concept schema. Each attribute has a qualified
+//! name (e.g. `recipe/title`) and optional metadata — description, type,
+//! cardinality, and optional flag — written by `tonk import`.
+//!
+//! This module reads that metadata back for schema discoverability.
+
+use crate::schema::*;
+use anyhow::{Context, Result};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single attribute, fetched from EAV triples.
+struct AttrMeta {
+    short_name: String,
+    qualified_name: String,
+    description: Option<String>,
+    type_str: Option<String>,
+    cardinality: Option<String>,
+    optional: bool,
+}
+
+/// Format a type string for human display.
+///
+/// If the stored value is a JSON array (e.g. `["tsp","mls"]`), display it as
+/// `tsp | mls`. Otherwise return the string as-is (e.g. `Text`, `Integer`).
+fn format_type_display(type_str: &str) -> String {
+    if let Ok(items) = serde_json::from_str::<Vec<String>>(type_str) {
+        items.join(" | ")
+    } else {
+        type_str.to_string()
+    }
+}
+
+/// Build a compact annotation string for human output.
+///
+/// Combines cardinality, type, and optional into a parenthetical like
+/// `(many, Text, optional)` or just `(Text)`.
+fn format_annotation(meta: &AttrMeta) -> String {
+    let mut parts = Vec::new();
+
+    if meta.cardinality.as_deref() == Some("many") {
+        parts.push("many".to_string());
+    }
+
+    if let Some(t) = &meta.type_str {
+        parts.push(format_type_display(t));
+    }
+
+    if meta.optional {
+        parts.push("optional".to_string());
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    }
+}
+
+/// Convert an AttrMeta to a JSON value.
+fn meta_to_json(meta: &AttrMeta) -> serde_json::Value {
+    serde_json::json!({
+        "name": meta.short_name,
+        "qualified_name": meta.qualified_name,
+        "description": meta.description,
+        "type": meta.type_str,
+        "cardinality": meta.cardinality,
+        "optional": meta.optional,
+    })
+}
+
+/// Collected info about a single concept and its attributes.
+struct ConceptAttrs {
+    name: String,
+    namespace: Option<String>,
+    attrs: Vec<AttrMeta>,
+}
+
+/// Fetch attribute metadata for a single qualified attribute name.
+async fn fetch_attr_meta<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    concept_name: &ConceptName,
+    qualified_name: &str,
+) -> Result<AttrMeta> {
+    let meta_entity = attribute_meta_entity(space_did, concept_name, qualified_name)?;
+
+    let description = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_DESCRIPTION).await?;
+    let type_str = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_TYPE).await?;
+    let cardinality = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_CARDINALITY).await?;
+    let optional_str = fetch_string(store, &meta_entity, ATTR_ATTRIBUTE_OPTIONAL).await?;
+    let optional = optional_str.as_deref() == Some("true");
+
+    Ok(AttrMeta {
+        short_name: short_attribute(concept_name, qualified_name),
+        qualified_name: qualified_name.to_string(),
+        description,
+        type_str,
+        cardinality,
+        optional,
+    })
+}
+
+/// Load all concepts and their attribute metadata from the space.
+async fn load_all_concepts<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+) -> Result<Vec<ConceptAttrs>> {
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    let mut concepts = Vec::new();
+
+    for entity in &concept_entities {
+        let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Concept entity '{}' is missing its 'concept/name' attribute",
+                    entity
+                )
+            })?;
+        let concept_name = ConceptName::from_stored(name.clone());
+        let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+        let qualified_attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+        let mut attrs = Vec::new();
+        for qname in &qualified_attrs {
+            let meta = fetch_attr_meta(store, space_did, &concept_name, qname).await?;
+            attrs.push(meta);
+        }
+
+        concepts.push(ConceptAttrs {
+            name,
+            namespace,
+            attrs,
+        });
+    }
+
+    Ok(concepts)
+}
+
+// ---------------------------------------------------------------------------
+// List all attributes
+// ---------------------------------------------------------------------------
+
+/// List all attributes in the active space, grouped by concept.
+pub async fn list(json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    let concepts = load_all_concepts(&branch, &ctx.space_did).await?;
+
+    if concepts.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!(
+                "No concepts defined. Use 'tonk concept define <name>' or 'tonk import <file>' to create one."
+            );
+        }
+        return Ok(());
+    }
+
+    if json {
+        let items: Vec<serde_json::Value> = concepts
+            .iter()
+            .map(|c| {
+                let attrs_json: Vec<serde_json::Value> = c.attrs.iter().map(meta_to_json).collect();
+                serde_json::json!({
+                    "concept": c.name,
+                    "namespace": c.namespace,
+                    "attributes": attrs_json,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&items)?);
+    } else {
+        let total_concepts = concepts.len();
+        let total_attrs: usize = concepts.iter().map(|c| c.attrs.len()).sum();
+
+        println!("Attributes:\n");
+        for c in &concepts {
+            let ns_str = c
+                .namespace
+                .as_ref()
+                .map(|ns| format!(" ({})", ns))
+                .unwrap_or_default();
+            println!("  {}{}:", c.name, ns_str);
+
+            if c.attrs.is_empty() {
+                println!("    (no attributes)");
+            } else {
+                // Calculate padding for aligned descriptions
+                let max_name_len = c
+                    .attrs
+                    .iter()
+                    .map(|a| a.short_name.len())
+                    .max()
+                    .unwrap_or(0);
+
+                for attr in &c.attrs {
+                    let padding = " ".repeat(max_name_len - attr.short_name.len());
+                    let desc_str = attr
+                        .description
+                        .as_ref()
+                        .map(|d| format!(" - {}", d))
+                        .unwrap_or_default();
+                    let annotation = format_annotation(attr);
+                    println!(
+                        "    {}{}{}{}",
+                        attr.short_name, padding, desc_str, annotation
+                    );
+                }
+            }
+
+            println!();
+        }
+
+        let concept_word = if total_concepts == 1 {
+            "concept"
+        } else {
+            "concepts"
+        };
+        let attr_word = if total_attrs == 1 {
+            "attribute"
+        } else {
+            "attributes"
+        };
+        println!(
+            "{} {}, {} {}",
+            total_concepts, concept_word, total_attrs, attr_word
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Show a single attribute
+// ---------------------------------------------------------------------------
+
+/// Show details of a specific attribute.
+///
+/// The attribute can be specified as a qualified name (e.g. `recipe/title`) or
+/// as a short name with `--concept` (e.g. `title --concept Recipe`).
+pub async fn show(name: String, concept: Option<String>, json: bool) -> Result<()> {
+    let ctx = get_space_context()?;
+    let branch = open_branch(&ctx).await?;
+
+    // Resolve the qualified name and owning concept
+    let (concept_name, namespace, qualified_name) = if name.contains('/') {
+        // Qualified name: split to find the concept prefix, then walk concepts
+        // to find the match.
+        resolve_qualified(&branch, &ctx.space_did, &name).await?
+    } else if let Some(c) = concept {
+        // Short name + --concept flag
+        resolve_short(&branch, &ctx.space_did, &name, &c).await?
+    } else {
+        // Try to find by short name across all concepts
+        resolve_unqualified(&branch, &ctx.space_did, &name).await?
+    };
+
+    let meta = fetch_attr_meta(&branch, &ctx.space_did, &concept_name, &qualified_name).await?;
+
+    if json {
+        let mut obj = meta_to_json(&meta);
+        obj.as_object_mut().unwrap().insert(
+            "concept".to_string(),
+            serde_json::json!(concept_name.as_str()),
+        );
+        if let Some(ns) = &namespace {
+            obj.as_object_mut()
+                .unwrap()
+                .insert("namespace".to_string(), serde_json::json!(ns));
+        }
+        println!("{}", serde_json::to_string(&obj)?);
+    } else {
+        println!("Attribute: {}", qualified_name);
+        println!("  Concept:     {}", concept_name);
+        if let Some(ns) = &namespace {
+            println!("  Namespace:   {}", ns);
+        }
+        if let Some(desc) = &meta.description {
+            println!("  Description: {}", desc);
+        }
+        let type_display = meta
+            .type_str
+            .as_ref()
+            .map(|t| format_type_display(t))
+            .unwrap_or_else(|| "(untyped)".to_string());
+        println!("  Type:        {}", type_display);
+        let card = if meta.cardinality.as_deref() == Some("many") {
+            "many"
+        } else {
+            "single"
+        };
+        println!("  Cardinality: {}", card);
+        println!(
+            "  Optional:    {}",
+            if meta.optional { "yes" } else { "no" }
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Name resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a qualified attribute name (e.g. `recipe/title`) to its concept.
+///
+/// Walks all concepts in the registry to find one whose `concept/attribute`
+/// list contains the given qualified name.
+async fn resolve_qualified<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    qualified_name: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let normalized = if let Some((prefix, attr)) = qualified_name.split_once('/') {
+        format!("{}/{}", prefix.to_lowercase(), attr)
+    } else {
+        qualified_name.to_string()
+    };
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    for entity in &concept_entities {
+        let attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+        if attrs.iter().any(|a| a == &normalized) {
+            let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Concept entity missing concept/name"))?;
+            let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+            return Ok((ConceptName::from_stored(name), namespace, normalized));
+        }
+    }
+
+    anyhow::bail!(
+        "Attribute '{}' not found. Run 'tonk attribute' to list available attributes.",
+        qualified_name
+    );
+}
+
+/// Resolve a short attribute name given a concept name.
+async fn resolve_short<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    short_name: &str,
+    concept_str: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let concept_name = ConceptName::new(concept_str)?;
+    let concept = concept_entity(space_did, &concept_name)?;
+
+    // Verify concept exists
+    let stored_name = fetch_string(store, &concept, ATTR_CONCEPT_NAME)
+        .await?
+        .context(format!("Concept '{}' not found", concept_name))?;
+    let stored_name = ConceptName::from_stored(stored_name);
+
+    let namespace = fetch_string(store, &concept, ATTR_CONCEPT_NAMESPACE).await?;
+    let qualified = qualify_attribute(&stored_name, short_name)?;
+
+    // Verify the attribute actually exists on this concept
+    let attrs = fetch_string_values(store, &concept, ATTR_CONCEPT_ATTRIBUTE).await?;
+    if !attrs.contains(&qualified) {
+        anyhow::bail!(
+            "Attribute '{}' not found on concept '{}'. Available attributes: {}",
+            short_name,
+            stored_name,
+            attrs
+                .iter()
+                .map(|a| short_attribute(&stored_name, a))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    Ok((stored_name, namespace, qualified))
+}
+
+/// Resolve a short attribute name without a concept — search all concepts.
+///
+/// If exactly one concept has an attribute with this short name, return it.
+/// If multiple concepts have it, bail with a disambiguation message.
+async fn resolve_unqualified<S: dialog_artifacts::ArtifactStore>(
+    store: &S,
+    space_did: &str,
+    short_name: &str,
+) -> Result<(ConceptName, Option<String>, String)> {
+    let registry = registry_entity(space_did)?;
+    let concept_entities = fetch_entity_values(store, &registry, ATTR_REGISTRY_CONCEPT).await?;
+
+    let mut matches: Vec<(ConceptName, Option<String>, String)> = Vec::new();
+
+    for entity in &concept_entities {
+        let name = fetch_string(store, entity, ATTR_CONCEPT_NAME)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Concept entity missing concept/name"))?;
+        let concept_name = ConceptName::from_stored(name);
+        let namespace = fetch_string(store, entity, ATTR_CONCEPT_NAMESPACE).await?;
+        let attrs = fetch_string_values(store, entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+        for qname in &attrs {
+            if short_attribute(&concept_name, qname) == short_name {
+                matches.push((concept_name.clone(), namespace.clone(), qname.clone()));
+                break;
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => {
+            anyhow::bail!(
+                "Attribute '{}' not found in any concept. Run 'tonk attribute' to list available attributes.",
+                short_name
+            );
+        }
+        1 => Ok(matches.into_iter().next().unwrap()),
+        _ => {
+            let concept_list: Vec<String> = matches
+                .iter()
+                .map(|(c, _, q)| format!("  {} ({})", c, q))
+                .collect();
+            anyhow::bail!(
+                "Attribute '{}' exists in multiple concepts. Use --concept to disambiguate:\n{}",
+                short_name,
+                concept_list.join("\n")
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- format_type_display -------------------------------------------------
+
+    #[test]
+    fn format_type_display_simple_string() {
+        assert_eq!(format_type_display("Text"), "Text");
+        assert_eq!(format_type_display("Integer"), "Integer");
+        assert_eq!(format_type_display("RecipeStep"), "RecipeStep");
+    }
+
+    #[test]
+    fn format_type_display_json_array_enum() {
+        assert_eq!(format_type_display(r#"["tsp","mls"]"#), "tsp | mls");
+    }
+
+    #[test]
+    fn format_type_display_single_element_array() {
+        assert_eq!(format_type_display(r#"["only"]"#), "only");
+    }
+
+    #[test]
+    fn format_type_display_empty_array() {
+        assert_eq!(format_type_display("[]"), "");
+    }
+
+    #[test]
+    fn format_type_display_invalid_json_passthrough() {
+        // Malformed JSON should be returned as-is
+        assert_eq!(format_type_display("[not json"), "[not json");
+    }
+
+    // -- format_annotation ---------------------------------------------------
+
+    fn make_meta(cardinality: Option<&str>, type_str: Option<&str>, optional: bool) -> AttrMeta {
+        AttrMeta {
+            short_name: "test".to_string(),
+            qualified_name: "concept/test".to_string(),
+            description: None,
+            type_str: type_str.map(|s| s.to_string()),
+            cardinality: cardinality.map(|s| s.to_string()),
+            optional,
+        }
+    }
+
+    #[test]
+    fn annotation_empty_when_no_metadata() {
+        let meta = make_meta(None, None, false);
+        assert_eq!(format_annotation(&meta), "");
+    }
+
+    #[test]
+    fn annotation_type_only() {
+        let meta = make_meta(None, Some("Text"), false);
+        assert_eq!(format_annotation(&meta), " (Text)");
+    }
+
+    #[test]
+    fn annotation_many_and_type() {
+        let meta = make_meta(Some("many"), Some("RecipeStep"), false);
+        assert_eq!(format_annotation(&meta), " (many, RecipeStep)");
+    }
+
+    #[test]
+    fn annotation_many_only() {
+        let meta = make_meta(Some("many"), None, false);
+        assert_eq!(format_annotation(&meta), " (many)");
+    }
+
+    #[test]
+    fn annotation_optional_only() {
+        let meta = make_meta(None, None, true);
+        assert_eq!(format_annotation(&meta), " (optional)");
+    }
+
+    #[test]
+    fn annotation_all_three() {
+        let meta = make_meta(Some("many"), Some("Text"), true);
+        assert_eq!(format_annotation(&meta), " (many, Text, optional)");
+    }
+
+    #[test]
+    fn annotation_enum_type() {
+        let meta = make_meta(None, Some(r#"["tsp","mls"]"#), false);
+        assert_eq!(format_annotation(&meta), " (tsp | mls)");
+    }
+
+    #[test]
+    fn annotation_single_cardinality_ignored() {
+        // Only "many" gets shown; other cardinality values are ignored
+        let meta = make_meta(Some("single"), Some("Text"), false);
+        assert_eq!(format_annotation(&meta), " (Text)");
+    }
+
+    // -- meta_to_json --------------------------------------------------------
+
+    #[test]
+    fn meta_to_json_with_all_fields() {
+        let meta = AttrMeta {
+            short_name: "title".to_string(),
+            qualified_name: "recipe/title".to_string(),
+            description: Some("The name of this recipe".to_string()),
+            type_str: Some("Text".to_string()),
+            cardinality: None,
+            optional: false,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["name"], "title");
+        assert_eq!(json["qualified_name"], "recipe/title");
+        assert_eq!(json["description"], "The name of this recipe");
+        assert_eq!(json["type"], "Text");
+        assert!(json["cardinality"].is_null());
+        assert_eq!(json["optional"], false);
+    }
+
+    #[test]
+    fn meta_to_json_minimal() {
+        let meta = AttrMeta {
+            short_name: "tag".to_string(),
+            qualified_name: "task/tag".to_string(),
+            description: None,
+            type_str: None,
+            cardinality: None,
+            optional: false,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["name"], "tag");
+        assert!(json["description"].is_null());
+        assert!(json["type"].is_null());
+        assert_eq!(json["optional"], false);
+    }
+
+    #[test]
+    fn meta_to_json_optional_many() {
+        let meta = AttrMeta {
+            short_name: "step".to_string(),
+            qualified_name: "recipe/step".to_string(),
+            description: Some("A cooking step".to_string()),
+            type_str: Some("RecipeStep".to_string()),
+            cardinality: Some("many".to_string()),
+            optional: true,
+        };
+        let json = meta_to_json(&meta);
+        assert_eq!(json["cardinality"], "many");
+        assert_eq!(json["optional"], true);
+        assert_eq!(json["type"], "RecipeStep");
+    }
+}

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -49,6 +49,12 @@ mod inner {
             command: Option<ConceptCommands>,
         },
 
+        /// Inspect attribute definitions
+        Attribute {
+            #[command(subcommand)]
+            command: Option<AttributeCommands>,
+        },
+
         /// Manage deductive rules between concepts
         Rule {
             #[command(subcommand)]
@@ -275,6 +281,19 @@ mod inner {
             /// Also delete all instances of this concept
             #[arg(short, long)]
             force: bool,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum AttributeCommands {
+        /// Show details of a specific attribute
+        Show {
+            /// Attribute name (qualified like "recipe/title", or short like "title" with --concept)
+            name: String,
+
+            /// Concept name (required when using short attribute names)
+            #[arg(long, short)]
+            concept: Option<String>,
         },
     }
 
@@ -594,6 +613,14 @@ async fn main() -> anyhow::Result<()> {
             }
             Some(ConceptCommands::Delete { name, force }) => {
                 tonk_cli::concept::delete(name, force, json).await?;
+            }
+        },
+        Commands::Attribute { command } => match command {
+            None => {
+                tonk_cli::attribute::list(json).await?;
+            }
+            Some(AttributeCommands::Show { name, concept }) => {
+                tonk_cli::attribute::show(name, concept, json).await?;
             }
         },
         Commands::Rule { command } => match command {

--- a/rust/tonk-cli/src/import.rs
+++ b/rust/tonk-cli/src/import.rs
@@ -1,42 +1,63 @@
-//! YAML import for concepts and rules.
+//! YAML import for concepts, standalone attributes, and rules.
 //!
-//! Parses a YAML file and auto-detects whether it contains concept definitions
-//! or rule definitions, then imports them atomically into the active space.
+//! Parses a YAML file using the canonical abbreviated notation and auto-detects
+//! whether it contains concept definitions, rule definitions, or a mix of both.
+//! Imports are committed atomically into the active space.
 //!
 //! # Concept YAML format
 //!
 //! ```yaml
 //! diy.cook:
 //!   Recipe:
-//!     this:
-//!       the: Meal recipe
-//!     title:
-//!       the: The name of this recipe
-//!       as: Text
-//!     ingredient:
-//!       the: Ingredients of the recipe
-//!       cardinality: many
+//!     description: Meal recipe
+//!     with:
+//!       title:
+//!         description: The name of this recipe
+//!         as: Text
+//!       ingredient:
+//!         description: Ingredients of the recipe
+//!         cardinality: many
+//!     maybe:
+//!       notes:
+//!         description: Optional notes
+//!         as: Text
+//! ```
+//!
+//! # Standalone attribute format
+//!
+//! ```yaml
+//! diy.cook:
+//!   quantity:
+//!     description: Amount needed
+//!     as: Integer
+//!     cardinality: many
 //! ```
 //!
 //! # Rule YAML format
 //!
 //! ```yaml
-//! user.rules:
-//!   respect-dietary-restrictions:
-//!     assert:
-//!       diy.meal-planner/Meal:
+//! diy.planner:
+//!   safe-meal:
+//!     description: A meal that respects dietary restrictions
+//!     deduce:
+//!       SafeMeal:
 //!         attendee: ?person
 //!         recipe: ?recipe
 //!     when:
-//!       - diy.cook/Recipe:
-//!           this: ?recipe
-//!           ingredient: ?ingredient
+//!       - diy.planner/Meal:
+//!           this: ?meal
+//!           attendee: ?person
 //!     unless:
-//!       - diy.health/Allergy:
-//!           this: _
+//!       - diy.planner/AllergyConflict:
 //!           person: ?person
-//!           substance: ?substance
+//!           recipe: ?recipe
 //! ```
+//!
+//! # Mixed files
+//!
+//! A single file can contain standalone attributes, concepts, and rules
+//! all under one namespace key. The parser handles this — it does not
+//! require separate files for concepts vs rules.
 
 mod commit;
 mod concept_parse;
@@ -52,45 +73,72 @@ use std::collections::BTreeMap;
 /// The type of content in a YAML import file.
 #[derive(Debug, PartialEq, Eq)]
 enum YamlFileType {
+    /// Only concepts and/or standalone attributes (no rules).
     Concepts,
+    /// Only rules (no concepts or standalone attributes).
     Rules,
+    /// A mix of concepts, standalone attributes, and rules.
+    Mixed,
 }
 
-/// Detect whether a YAML string contains concept or rule definitions.
+/// Detect what kind of entries a YAML string contains.
 ///
-/// Inspects the second-level values: if any contains `assert` or `when`
-/// keys, it's a rule file. Otherwise it's a concept file.
+/// Inspects the second-level values:
+/// - A value with `deduce` + `when` keys → rule
+/// - A value with `with` key (no `deduce`) → concept
+/// - Otherwise → standalone attribute
+///
+/// If both rules and concepts/attributes are found, returns `Mixed`.
 fn detect_yaml_type(yaml_str: &str) -> Result<YamlFileType> {
     let root: BTreeMap<String, BTreeMap<String, serde_yaml::Value>> =
         serde_yaml::from_str(yaml_str).context("Failed to parse YAML")?;
 
+    let mut has_rules = false;
+    let mut has_concepts_or_attrs = false;
+
     for entries in root.values() {
         for value in entries.values() {
             if let serde_yaml::Value::Mapping(map) = value {
-                let has_assert = map.contains_key(serde_yaml::Value::String("assert".into()));
-                let has_when = map.contains_key(serde_yaml::Value::String("when".into()));
-                if has_assert || has_when {
-                    return Ok(YamlFileType::Rules);
+                let has_deduce = map.contains_key(serde_yaml::Value::String("deduce".into()));
+                let has_with = map.contains_key(serde_yaml::Value::String("with".into()));
+
+                if has_deduce {
+                    has_rules = true;
+                } else if has_with {
+                    has_concepts_or_attrs = true;
+                } else {
+                    // Standalone attribute or other non-rule, non-concept entry
+                    has_concepts_or_attrs = true;
                 }
+            } else {
+                // Scalar or null value → standalone attribute (e.g. `quantity: Integer`)
+                has_concepts_or_attrs = true;
             }
         }
     }
 
-    Ok(YamlFileType::Concepts)
+    if has_rules && has_concepts_or_attrs {
+        Ok(YamlFileType::Mixed)
+    } else if has_rules {
+        Ok(YamlFileType::Rules)
+    } else {
+        Ok(YamlFileType::Concepts)
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Import command (entry point)
 // ---------------------------------------------------------------------------
 
-/// Import concepts or rules from a YAML file into the active space.
+/// Import concepts, standalone attributes, and/or rules from a YAML file
+/// into the active space.
 ///
 /// Auto-detects the file type based on the YAML structure, then dispatches
 /// to the appropriate import handler.
 ///
-/// All concepts in the file are validated first, then committed atomically.
-/// If `force` is true, existing concepts are overwritten (retracted then
-/// re-created); otherwise any collision fails the entire import.
+/// All entries in the file are validated first, then committed atomically.
+/// If `force` is true, existing concepts/rules are overwritten (retracted
+/// then re-created); otherwise any collision fails the entire import.
 pub async fn import(file: String, force: bool, json: bool) -> Result<()> {
     let yaml_str =
         std::fs::read_to_string(&file).context(format!("Failed to read file: {}", file))?;
@@ -98,6 +146,7 @@ pub async fn import(file: String, force: bool, json: bool) -> Result<()> {
     match detect_yaml_type(&yaml_str)? {
         YamlFileType::Concepts => commit::import_concepts(&yaml_str, &file, force, json).await,
         YamlFileType::Rules => commit::import_rules(&yaml_str, &file, force, json).await,
+        YamlFileType::Mixed => commit::import_mixed(&yaml_str, &file, force, json).await,
     }
 }
 
@@ -114,11 +163,11 @@ mod tests {
         let yaml = r#"
 diy.cook:
   Recipe:
-    this:
-      the: Meal recipe
-    title:
-      the: The name
-      as: Text
+    description: Meal recipe
+    with:
+      title:
+        description: The name
+        as: Text
 "#;
         assert_eq!(detect_yaml_type(yaml).unwrap(), YamlFileType::Concepts);
     }
@@ -128,7 +177,8 @@ diy.cook:
         let yaml = r#"
 user.rules:
   my-rule:
-    assert:
+    description: A rule
+    deduce:
       ns/Meal:
         attendee: ?person
     when:
@@ -137,5 +187,40 @@ user.rules:
           title: _
 "#;
         assert_eq!(detect_yaml_type(yaml).unwrap(), YamlFileType::Rules);
+    }
+
+    #[test]
+    fn detect_mixed_file() {
+        let yaml = r#"
+diy.cook:
+  Recipe:
+    description: Meal recipe
+    with:
+      title:
+        description: The name
+        as: Text
+
+  find-something:
+    description: A rule
+    deduce:
+      Recipe:
+        title: ?t
+    when:
+      - diy.cook/Recipe:
+          this: ?r
+          title: ?t
+"#;
+        assert_eq!(detect_yaml_type(yaml).unwrap(), YamlFileType::Mixed);
+    }
+
+    #[test]
+    fn detect_standalone_attribute_file() {
+        let yaml = r#"
+diy.cook:
+  quantity:
+    description: Amount needed
+    as: Integer
+"#;
+        assert_eq!(detect_yaml_type(yaml).unwrap(), YamlFileType::Concepts);
     }
 }

--- a/rust/tonk-cli/src/import/commit.rs
+++ b/rust/tonk-cli/src/import/commit.rs
@@ -1,10 +1,12 @@
 //! Import orchestration: validation, retraction, assertion, and atomic commit.
 //!
-//! Contains the async functions that take parsed concepts or rules, validate
-//! them against the active space, build retract/assert instruction lists, and
-//! commit them atomically.
+//! Contains the async functions that take parsed concepts, standalone
+//! attributes, or rules, validate them against the active space, build
+//! retract/assert instruction lists, and commit them atomically.
 
-use super::concept_parse::{ParsedAttribute, ParsedConcept};
+use super::concept_parse::{
+    ParsedAttribute, ParsedConcept, ParsedEntry, ParsedStandaloneAttribute,
+};
 use super::rule_parse::{ParsedRule, lower_rule};
 use crate::rule::RuleDefinition;
 use crate::schema::*;
@@ -28,9 +30,30 @@ pub(super) async fn import_concepts(
     force: bool,
     json: bool,
 ) -> Result<()> {
-    let concepts = super::concept_parse::parse_yaml(yaml_str)?;
+    let entries = super::concept_parse::parse_yaml(yaml_str)?;
 
-    if concepts.is_empty() {
+    // Separate concepts and standalone attributes
+    let mut concepts = Vec::new();
+    let mut standalone_attrs = Vec::new();
+
+    for entry in entries {
+        match entry {
+            ParsedEntry::Concept(c) => concepts.push(c),
+            ParsedEntry::Attribute(a) => standalone_attrs.push(a),
+            ParsedEntry::Rule {
+                name, namespace, ..
+            } => {
+                anyhow::bail!(
+                    "Unexpected rule '{}' in namespace '{}'. \
+                     Use a mixed-format file or a separate rules file.",
+                    name,
+                    namespace
+                );
+            }
+        }
+    }
+
+    if concepts.is_empty() && standalone_attrs.is_empty() {
         if json {
             println!(
                 "{}",
@@ -81,6 +104,11 @@ pub(super) async fn import_concepts(
         validated.push((cname, concept));
     }
 
+    // Validate standalone attributes
+    for attr in &standalone_attrs {
+        validate_safe_name(&attr.short_name, "Attribute")?;
+    }
+
     let ctx = get_space_context()?;
     let mut branch = open_branch(&ctx).await?;
     let registry = registry_entity(&ctx.space_did)?;
@@ -88,84 +116,26 @@ pub(super) async fn import_concepts(
     let mut retract_instructions: Vec<Instruction> = Vec::new();
 
     for (cname, _concept) in &validated {
-        let entity = concept_entity(&ctx.space_did, cname)?;
-        let existing = fetch_string(&branch, &entity, ATTR_CONCEPT_NAME).await?;
+        retract_concept_if_exists(
+            &branch,
+            &ctx.space_did,
+            cname,
+            &registry,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
+    }
 
-        if existing.is_some() {
-            if force {
-                let existing_attrs =
-                    fetch_string_values(&branch, &entity, ATTR_CONCEPT_ATTRIBUTE).await?;
-
-                for attr_name in &existing_attrs {
-                    let meta_entity = attribute_meta_entity(&ctx.space_did, cname, attr_name)?;
-
-                    for meta_attr in &[
-                        ATTR_ATTRIBUTE_DESCRIPTION,
-                        ATTR_ATTRIBUTE_TYPE,
-                        ATTR_ATTRIBUTE_CARDINALITY,
-                        ATTR_ATTRIBUTE_OPTIONAL,
-                    ] {
-                        if let Some(val) = fetch_string(&branch, &meta_entity, meta_attr).await? {
-                            retract_instructions.push(Instruction::Retract(Artifact {
-                                the: Attribute::from_str(meta_attr)?,
-                                of: meta_entity.clone(),
-                                is: Value::String(val),
-                                cause: None,
-                            }));
-                        }
-                    }
-
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_CONCEPT_ATTRIBUTE)?,
-                        of: entity.clone(),
-                        is: Value::String(attr_name.clone()),
-                        cause: None,
-                    }));
-                }
-
-                if let Some(name) = fetch_string(&branch, &entity, ATTR_CONCEPT_NAME).await? {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_CONCEPT_NAME)?,
-                        of: entity.clone(),
-                        is: Value::String(name),
-                        cause: None,
-                    }));
-                }
-
-                if let Some(desc) = fetch_string(&branch, &entity, ATTR_CONCEPT_DESCRIPTION).await?
-                {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_CONCEPT_DESCRIPTION)?,
-                        of: entity.clone(),
-                        is: Value::String(desc),
-                        cause: None,
-                    }));
-                }
-
-                if let Some(ns) = fetch_string(&branch, &entity, ATTR_CONCEPT_NAMESPACE).await? {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_CONCEPT_NAMESPACE)?,
-                        of: entity.clone(),
-                        is: Value::String(ns),
-                        cause: None,
-                    }));
-                }
-
-                retract_instructions.push(Instruction::Retract(Artifact {
-                    the: Attribute::from_str(ATTR_REGISTRY_CONCEPT)?,
-                    of: registry.clone(),
-                    is: Value::Entity(entity.clone()),
-                    cause: None,
-                }));
-            } else {
-                anyhow::bail!(
-                    "Concept '{}' already exists. Use --force to overwrite, \
-                     or delete it first with 'tonk concept delete {}'.",
-                    cname,
-                    cname
-                );
-            }
-        }
+    for attr in &standalone_attrs {
+        retract_standalone_attr_if_exists(
+            &branch,
+            &ctx.space_did,
+            attr,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
     }
 
     // --- Build assert instructions ---
@@ -174,97 +144,19 @@ pub(super) async fn import_concepts(
     let mut import_summary: Vec<serde_json::Value> = Vec::new();
 
     for (cname, concept) in &validated {
-        let entity = concept_entity(&ctx.space_did, cname)?;
+        build_concept_assertions(
+            &ctx.space_did,
+            cname,
+            concept,
+            &registry,
+            &mut assert_instructions,
+            &mut import_summary,
+        )?;
+    }
 
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_REGISTRY_CONCEPT)?,
-            of: registry.clone(),
-            is: Value::Entity(entity.clone()),
-            cause: None,
-        }));
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_CONCEPT_NAME)?,
-            of: entity.clone(),
-            is: Value::String(cname.to_string()),
-            cause: None,
-        }));
-
-        if let Some(desc) = &concept.description {
-            assert_instructions.push(Instruction::Assert(Artifact {
-                the: Attribute::from_str(ATTR_CONCEPT_DESCRIPTION)?,
-                of: entity.clone(),
-                is: Value::String(desc.clone()),
-                cause: None,
-            }));
-        }
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_CONCEPT_NAMESPACE)?,
-            of: entity.clone(),
-            is: Value::String(concept.namespace.clone()),
-            cause: None,
-        }));
-
-        let mut attr_summaries: Vec<String> = Vec::new();
-
-        for attr in &concept.attributes {
-            let qualified = qualify_attribute(cname, &attr.short_name)?;
-
-            assert_instructions.push(Instruction::Assert(Artifact {
-                the: Attribute::from_str(ATTR_CONCEPT_ATTRIBUTE)?,
-                of: entity.clone(),
-                is: Value::String(qualified.clone()),
-                cause: None,
-            }));
-
-            let meta_entity = attribute_meta_entity(&ctx.space_did, cname, &qualified)?;
-
-            if let Some(desc) = &attr.description {
-                assert_instructions.push(Instruction::Assert(Artifact {
-                    the: Attribute::from_str(ATTR_ATTRIBUTE_DESCRIPTION)?,
-                    of: meta_entity.clone(),
-                    is: Value::String(desc.clone()),
-                    cause: None,
-                }));
-            }
-
-            if let Some(type_str) = &attr.type_str {
-                assert_instructions.push(Instruction::Assert(Artifact {
-                    the: Attribute::from_str(ATTR_ATTRIBUTE_TYPE)?,
-                    of: meta_entity.clone(),
-                    is: Value::String(type_str.clone()),
-                    cause: None,
-                }));
-            }
-
-            if let Some(cardinality) = &attr.cardinality {
-                assert_instructions.push(Instruction::Assert(Artifact {
-                    the: Attribute::from_str(ATTR_ATTRIBUTE_CARDINALITY)?,
-                    of: meta_entity.clone(),
-                    is: Value::String(cardinality.clone()),
-                    cause: None,
-                }));
-            }
-
-            if attr.optional {
-                assert_instructions.push(Instruction::Assert(Artifact {
-                    the: Attribute::from_str(ATTR_ATTRIBUTE_OPTIONAL)?,
-                    of: meta_entity.clone(),
-                    is: Value::String("true".to_string()),
-                    cause: None,
-                }));
-            }
-
-            attr_summaries.push(attr.short_name.clone());
-        }
-
-        import_summary.push(serde_json::json!({
-            "name": cname.as_str(),
-            "namespace": concept.namespace,
-            "attributes": attr_summaries,
-            "description": concept.description,
-        }));
+    // Build standalone attribute assertions
+    for attr in &standalone_attrs {
+        build_standalone_attr_assertions(&ctx.space_did, attr, &mut assert_instructions)?;
     }
 
     // --- Atomic commit ---
@@ -286,7 +178,8 @@ pub(super) async fn import_concepts(
         });
         println!("{}", serde_json::to_string(&output)?);
     } else {
-        println!("Imported {} concept(s) from '{}':\n", concepts.len(), file);
+        let total = concepts.len() + standalone_attrs.len();
+        println!("Imported {} item(s) from '{}':\n", total, file);
         for (cname, concept) in &validated {
             let desc_str = concept
                 .description
@@ -297,6 +190,12 @@ pub(super) async fn import_concepts(
             for attr in &concept.attributes {
                 print_attribute_summary(attr);
             }
+        }
+        for attr in &standalone_attrs {
+            println!(
+                "  {}/{} (standalone attribute)",
+                attr.namespace, attr.short_name
+            );
         }
     }
 
@@ -390,91 +289,17 @@ pub(super) async fn import_rules(
     let mut retract_instructions: Vec<Instruction> = Vec::new();
 
     for (parsed, definition) in &lowered {
-        // Check if rule already exists
-        let rule_ent = rule_entity(&ctx.space_did, &parsed.name)?;
-        let existing = fetch_string(&branch, &rule_ent, ATTR_RULE_NAME).await?;
+        retract_rule_if_exists(
+            &branch,
+            &ctx.space_did,
+            parsed,
+            &registry,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
 
-        if existing.is_some() {
-            if force {
-                // Retract existing rule
-                if let Some(name) = fetch_string(&branch, &rule_ent, ATTR_RULE_NAME).await? {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_RULE_NAME)?,
-                        of: rule_ent.clone(),
-                        is: Value::String(name),
-                        cause: None,
-                    }));
-                }
-                if let Some(conclusion) =
-                    fetch_string(&branch, &rule_ent, ATTR_RULE_CONCLUSION).await?
-                {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
-                        of: rule_ent.clone(),
-                        is: Value::String(conclusion),
-                        cause: None,
-                    }));
-                }
-                if let Some(def) = fetch_string(&branch, &rule_ent, ATTR_RULE_DEFINITION).await? {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
-                        of: rule_ent.clone(),
-                        is: Value::String(def),
-                        cause: None,
-                    }));
-                }
-                if let Some(desc) = fetch_string(&branch, &rule_ent, ATTR_RULE_DESCRIPTION).await? {
-                    retract_instructions.push(Instruction::Retract(Artifact {
-                        the: Attribute::from_str(ATTR_RULE_DESCRIPTION)?,
-                        of: rule_ent.clone(),
-                        is: Value::String(desc),
-                        cause: None,
-                    }));
-                }
-                retract_instructions.push(Instruction::Retract(Artifact {
-                    the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
-                    of: registry.clone(),
-                    is: Value::Entity(rule_ent.clone()),
-                    cause: None,
-                }));
-            } else {
-                anyhow::bail!(
-                    "Rule '{}' already exists. Use --force to overwrite, \
-                     or delete it first with 'tonk rule delete {}'.",
-                    parsed.name,
-                    parsed.name
-                );
-            }
-        }
-
-        // Validate the conclusion concept exists
-        let conclusion_concept = ConceptName::new(&definition.conclusion.concept)?;
-        let concept_ent = concept_entity(&ctx.space_did, &conclusion_concept)?;
-        let concept_name = fetch_string(&branch, &concept_ent, ATTR_CONCEPT_NAME)
-            .await?
-            .context(format!(
-                "Conclusion concept '{}' for rule '{}' not found. Define it first.",
-                definition.conclusion.concept, parsed.name
-            ))?;
-        let concept_name = ConceptName::from_stored(concept_name);
-
-        let concept_attrs =
-            fetch_string_values(&branch, &concept_ent, ATTR_CONCEPT_ATTRIBUTE).await?;
-
-        // Validate bindings match concept schema
-        crate::rule::validate_definition(definition, &concept_attrs, &concept_name)
-            .with_context(|| format!("Rule '{}' validation failed", parsed.name))?;
-
-        // Trial-compile
-        crate::rule::compile_rule(definition, &concept_name, &concept_attrs).with_context(
-            || {
-                format!(
-                    "Rule '{}' failed to compile. Check variable names match between \
-                     conclusion bindings and premises.",
-                    parsed.name
-                )
-            },
-        )?;
+        validate_rule_against_space(&branch, &ctx.space_did, parsed, definition).await?;
     }
 
     // --- Build assert instructions ---
@@ -483,45 +308,14 @@ pub(super) async fn import_rules(
     let mut import_summary: Vec<serde_json::Value> = Vec::new();
 
     for (parsed, definition) in &lowered {
-        let rule_ent = rule_entity(&ctx.space_did, &parsed.name)?;
-        let concept_name = &definition.conclusion.concept;
-        let definition_str = serde_json::to_string(definition)?;
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
-            of: registry.clone(),
-            is: Value::Entity(rule_ent.clone()),
-            cause: None,
-        }));
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_RULE_NAME)?,
-            of: rule_ent.clone(),
-            is: Value::String(parsed.name.clone()),
-            cause: None,
-        }));
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
-            of: rule_ent.clone(),
-            is: Value::String(concept_name.clone()),
-            cause: None,
-        }));
-
-        assert_instructions.push(Instruction::Assert(Artifact {
-            the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
-            of: rule_ent.clone(),
-            is: Value::String(definition_str),
-            cause: None,
-        }));
-
-        import_summary.push(serde_json::json!({
-            "name": parsed.name,
-            "namespace": parsed.namespace,
-            "conclusion": concept_name,
-            "when_count": definition.when.len(),
-            "unless_count": definition.unless.len(),
-        }));
+        build_rule_assertions(
+            &ctx.space_did,
+            parsed,
+            definition,
+            &registry,
+            &mut assert_instructions,
+            &mut import_summary,
+        )?;
     }
 
     // --- Atomic commit ---
@@ -556,6 +350,802 @@ pub(super) async fn import_rules(
             );
         }
     }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Mixed import (concepts + rules + standalone attributes in one file)
+// ---------------------------------------------------------------------------
+
+/// Import a mixed YAML file containing concepts, standalone attributes,
+/// and rules into the active space.
+///
+/// Concepts, standalone attributes, and rules are validated first, then
+/// committed together atomically. Rules are validated against the effective
+/// schema (including concepts defined in the same file).
+pub(super) async fn import_mixed(
+    yaml_str: &str,
+    file: &str,
+    force: bool,
+    json: bool,
+) -> Result<()> {
+    let entries = super::concept_parse::parse_yaml(yaml_str)?;
+
+    // Separate into concepts, standalone attributes, and rules
+    let mut concepts = Vec::new();
+    let mut standalone_attrs = Vec::new();
+    let mut rule_entries: Vec<(String, String, serde_yaml::Value)> = Vec::new();
+
+    for entry in entries {
+        match entry {
+            ParsedEntry::Concept(c) => concepts.push(c),
+            ParsedEntry::Attribute(a) => standalone_attrs.push(a),
+            ParsedEntry::Rule {
+                name,
+                namespace,
+                value,
+            } => {
+                rule_entries.push((name, namespace, value));
+            }
+        }
+    }
+
+    // Parse the raw rule YAML values into ParsedRules
+    let mut parsed_rules = Vec::new();
+    for (name, namespace, value) in &rule_entries {
+        let parsed = super::rule_parse::parse_rule(namespace, name, value)
+            .with_context(|| format!("In rule '{}/{}'", namespace, name))?;
+        parsed_rules.push(parsed);
+    }
+
+    if concepts.is_empty() && standalone_attrs.is_empty() && parsed_rules.is_empty() {
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({"ok": true, "imported": []}))?
+            );
+        } else {
+            println!("No entries found in YAML file.");
+        }
+        return Ok(());
+    }
+
+    // --- Validate concepts ---
+
+    let mut validated_concepts: Vec<(ConceptName, &ParsedConcept)> = Vec::new();
+    let mut seen_concept_names: HashSet<String> = HashSet::new();
+
+    for concept in &concepts {
+        let cname = ConceptName::new(&concept.name)?;
+
+        let lower = cname.to_lowercase();
+        if !seen_concept_names.insert(lower.clone()) {
+            anyhow::bail!(
+                "Duplicate concept name '{}' in YAML file. \
+                 Concept names must be unique (case-insensitive).",
+                concept.name
+            );
+        }
+
+        if concept.attributes.is_empty() {
+            anyhow::bail!(
+                "Concept '{}' has no attributes. A concept must have at least one attribute.",
+                concept.name
+            );
+        }
+
+        for attr in &concept.attributes {
+            if attr.short_name.contains('/') {
+                anyhow::bail!(
+                    "Attribute name '{}' in concept '{}' must not contain '/'. \
+                     Use short names only (e.g. 'title', not 'recipe/title').",
+                    attr.short_name,
+                    concept.name,
+                );
+            }
+            validate_safe_name(&attr.short_name, "Attribute")?;
+        }
+
+        validated_concepts.push((cname, concept));
+    }
+
+    // Validate standalone attributes
+    for attr in &standalone_attrs {
+        validate_safe_name(&attr.short_name, "Attribute")?;
+    }
+
+    // --- Lower rules (structural validation only, no space validation yet) ---
+
+    let mut lowered_rules: Vec<(&ParsedRule, RuleDefinition)> = Vec::new();
+    let mut seen_rule_names: HashSet<String> = HashSet::new();
+
+    for rule in &parsed_rules {
+        validate_safe_name(&rule.name, "Rule")?;
+
+        let lower = rule.name.to_lowercase();
+        if !seen_rule_names.insert(lower) {
+            anyhow::bail!(
+                "Duplicate rule name '{}' in YAML file. \
+                 Rule names must be unique (case-insensitive).",
+                rule.name
+            );
+        }
+
+        let definition =
+            lower_rule(rule).with_context(|| format!("Failed to lower rule '{}'", rule.name))?;
+
+        lowered_rules.push((rule, definition));
+    }
+
+    // --- Build schema overrides for concepts defined in this file ---
+
+    let mut concept_overrides: std::collections::HashMap<String, (ConceptName, Vec<String>)> =
+        std::collections::HashMap::new();
+    for (cname, concept) in &validated_concepts {
+        let attrs = build_concept_attr_list(cname, concept)?;
+        concept_overrides.insert(cname.to_lowercase(), (cname.clone(), attrs));
+    }
+
+    // --- Validate rules against the effective schema ---
+
+    let ctx = get_space_context()?;
+    let mut branch = open_branch(&ctx).await?;
+    let registry = registry_entity(&ctx.space_did)?;
+
+    for (parsed, definition) in &lowered_rules {
+        let conclusion_concept = ConceptName::new(&definition.conclusion.concept)?;
+        let key = conclusion_concept.to_lowercase();
+        let (concept_name, concept_attrs) = if let Some((name, attrs)) = concept_overrides.get(&key)
+        {
+            (name.clone(), attrs.clone())
+        } else {
+            let concept_ent = concept_entity(&ctx.space_did, &conclusion_concept)?;
+            let concept_name = fetch_string(&branch, &concept_ent, ATTR_CONCEPT_NAME)
+                .await?
+                .context(format!(
+                    "Conclusion concept '{}' for rule '{}' not found. Define it first.",
+                    definition.conclusion.concept, parsed.name
+                ))?;
+            let concept_name = ConceptName::from_stored(concept_name);
+            let concept_attrs =
+                fetch_string_values(&branch, &concept_ent, ATTR_CONCEPT_ATTRIBUTE).await?;
+            (concept_name, concept_attrs)
+        };
+
+        validate_rule_against_schema(parsed, definition, &concept_name, &concept_attrs)?;
+    }
+
+    // --- Build all instructions and commit atomically ---
+
+    let mut retract_instructions: Vec<Instruction> = Vec::new();
+    let mut assert_instructions: Vec<Instruction> = Vec::new();
+    let mut import_summary: Vec<serde_json::Value> = Vec::new();
+
+    for (cname, _concept) in &validated_concepts {
+        retract_concept_if_exists(
+            &branch,
+            &ctx.space_did,
+            cname,
+            &registry,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
+    }
+
+    for attr in &standalone_attrs {
+        retract_standalone_attr_if_exists(
+            &branch,
+            &ctx.space_did,
+            attr,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
+    }
+
+    for (parsed, _definition) in &lowered_rules {
+        retract_rule_if_exists(
+            &branch,
+            &ctx.space_did,
+            parsed,
+            &registry,
+            force,
+            &mut retract_instructions,
+        )
+        .await?;
+    }
+
+    for (cname, concept) in &validated_concepts {
+        build_concept_assertions(
+            &ctx.space_did,
+            cname,
+            concept,
+            &registry,
+            &mut assert_instructions,
+            &mut import_summary,
+        )?;
+    }
+
+    for attr in &standalone_attrs {
+        build_standalone_attr_assertions(&ctx.space_did, attr, &mut assert_instructions)?;
+    }
+
+    for (parsed, definition) in &lowered_rules {
+        build_rule_assertions(
+            &ctx.space_did,
+            parsed,
+            definition,
+            &registry,
+            &mut assert_instructions,
+            &mut import_summary,
+        )?;
+    }
+
+    let mut all_instructions = retract_instructions;
+    all_instructions.extend(assert_instructions);
+
+    branch
+        .commit(futures_util::stream::iter(all_instructions))
+        .await?;
+
+    // --- Output ---
+
+    if json {
+        let output = serde_json::json!({
+            "ok": true,
+            "type": "mixed",
+            "imported": import_summary,
+        });
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        let total = concepts.len() + standalone_attrs.len() + parsed_rules.len();
+        println!(
+            "Imported {} item(s) from '{}' ({} concept(s), {} attribute(s), {} rule(s)):\n",
+            total,
+            file,
+            concepts.len(),
+            standalone_attrs.len(),
+            parsed_rules.len()
+        );
+        for (cname, concept) in &validated_concepts {
+            let desc_str = concept
+                .description
+                .as_ref()
+                .map(|d| format!(" - {}", d))
+                .unwrap_or_default();
+            println!("  {} [{}]{}", cname, concept.namespace, desc_str);
+            for attr in &concept.attributes {
+                print_attribute_summary(attr);
+            }
+        }
+        for attr in &standalone_attrs {
+            println!(
+                "  {}/{} (standalone attribute)",
+                attr.namespace, attr.short_name
+            );
+        }
+        for (parsed, definition) in &lowered_rules {
+            println!(
+                "  {} [{}] -> {}",
+                parsed.name, parsed.namespace, definition.conclusion.concept
+            );
+            println!(
+                "    {} when, {} unless",
+                definition.when.len(),
+                definition.unless.len()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers: concept retraction and assertion
+// ---------------------------------------------------------------------------
+
+/// Check if a concept already exists and build retract instructions if `force` is true.
+async fn retract_concept_if_exists<S: dialog_artifacts::ArtifactStore + ArtifactStoreMut>(
+    branch: &S,
+    space_did: &str,
+    cname: &ConceptName,
+    registry: &dialog_query::Entity,
+    force: bool,
+    retract_instructions: &mut Vec<Instruction>,
+) -> Result<()> {
+    let entity = concept_entity(space_did, cname)?;
+    let existing = fetch_string(branch, &entity, ATTR_CONCEPT_NAME).await?;
+
+    if existing.is_some() {
+        if force {
+            let existing_attrs =
+                fetch_string_values(branch, &entity, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+            for attr_name in &existing_attrs {
+                let meta_entity = attribute_meta_entity(space_did, cname, attr_name)?;
+
+                for meta_attr in &[
+                    ATTR_ATTRIBUTE_DESCRIPTION,
+                    ATTR_ATTRIBUTE_TYPE,
+                    ATTR_ATTRIBUTE_CARDINALITY,
+                    ATTR_ATTRIBUTE_OPTIONAL,
+                ] {
+                    if let Some(val) = fetch_string(branch, &meta_entity, meta_attr).await? {
+                        retract_instructions.push(Instruction::Retract(Artifact {
+                            the: Attribute::from_str(meta_attr)?,
+                            of: meta_entity.clone(),
+                            is: Value::String(val),
+                            cause: None,
+                        }));
+                    }
+                }
+
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_CONCEPT_ATTRIBUTE)?,
+                    of: entity.clone(),
+                    is: Value::String(attr_name.clone()),
+                    cause: None,
+                }));
+            }
+
+            if let Some(name) = fetch_string(branch, &entity, ATTR_CONCEPT_NAME).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_CONCEPT_NAME)?,
+                    of: entity.clone(),
+                    is: Value::String(name),
+                    cause: None,
+                }));
+            }
+
+            if let Some(desc) = fetch_string(branch, &entity, ATTR_CONCEPT_DESCRIPTION).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_CONCEPT_DESCRIPTION)?,
+                    of: entity.clone(),
+                    is: Value::String(desc),
+                    cause: None,
+                }));
+            }
+
+            if let Some(ns) = fetch_string(branch, &entity, ATTR_CONCEPT_NAMESPACE).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_CONCEPT_NAMESPACE)?,
+                    of: entity.clone(),
+                    is: Value::String(ns),
+                    cause: None,
+                }));
+            }
+
+            retract_instructions.push(Instruction::Retract(Artifact {
+                the: Attribute::from_str(ATTR_REGISTRY_CONCEPT)?,
+                of: registry.clone(),
+                is: Value::Entity(entity.clone()),
+                cause: None,
+            }));
+        } else {
+            anyhow::bail!(
+                "Concept '{}' already exists. Use --force to overwrite, \
+                 or delete it first with 'tonk concept delete {}'.",
+                cname,
+                cname
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Build assert instructions for a single concept.
+fn build_concept_assertions(
+    space_did: &str,
+    cname: &ConceptName,
+    concept: &ParsedConcept,
+    registry: &dialog_query::Entity,
+    assert_instructions: &mut Vec<Instruction>,
+    import_summary: &mut Vec<serde_json::Value>,
+) -> Result<()> {
+    let entity = concept_entity(space_did, cname)?;
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_REGISTRY_CONCEPT)?,
+        of: registry.clone(),
+        is: Value::Entity(entity.clone()),
+        cause: None,
+    }));
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_CONCEPT_NAME)?,
+        of: entity.clone(),
+        is: Value::String(cname.to_string()),
+        cause: None,
+    }));
+
+    if let Some(desc) = &concept.description {
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_CONCEPT_DESCRIPTION)?,
+            of: entity.clone(),
+            is: Value::String(desc.clone()),
+            cause: None,
+        }));
+    }
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_CONCEPT_NAMESPACE)?,
+        of: entity.clone(),
+        is: Value::String(concept.namespace.clone()),
+        cause: None,
+    }));
+
+    let mut attr_summaries: Vec<String> = Vec::new();
+
+    for attr in &concept.attributes {
+        // Use the explicit qualified reference if one was provided in the YAML
+        // (e.g., `handle: carry.links/handle`). Otherwise fall back to
+        // generating the path from the concept name (e.g., `member/handle`).
+        let qualified = if let Some(ref qr) = attr.qualified_ref {
+            if let Some(name) = qr.strip_prefix('.') {
+                // `.name` — concept-relative, resolve now
+                let prefix = cname.to_lowercase();
+                format!("{}/{}", prefix, name)
+            } else {
+                // Fully qualified — use as-is
+                qr.clone()
+            }
+        } else {
+            qualify_attribute(cname, &attr.short_name)?
+        };
+
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_CONCEPT_ATTRIBUTE)?,
+            of: entity.clone(),
+            is: Value::String(qualified.clone()),
+            cause: None,
+        }));
+
+        let meta_entity = attribute_meta_entity(space_did, cname, &qualified)?;
+
+        if let Some(desc) = &attr.description {
+            assert_instructions.push(Instruction::Assert(Artifact {
+                the: Attribute::from_str(ATTR_ATTRIBUTE_DESCRIPTION)?,
+                of: meta_entity.clone(),
+                is: Value::String(desc.clone()),
+                cause: None,
+            }));
+        }
+
+        if let Some(type_str) = &attr.type_str {
+            assert_instructions.push(Instruction::Assert(Artifact {
+                the: Attribute::from_str(ATTR_ATTRIBUTE_TYPE)?,
+                of: meta_entity.clone(),
+                is: Value::String(type_str.clone()),
+                cause: None,
+            }));
+        }
+
+        if let Some(cardinality) = &attr.cardinality {
+            assert_instructions.push(Instruction::Assert(Artifact {
+                the: Attribute::from_str(ATTR_ATTRIBUTE_CARDINALITY)?,
+                of: meta_entity.clone(),
+                is: Value::String(cardinality.clone()),
+                cause: None,
+            }));
+        }
+
+        if attr.optional {
+            assert_instructions.push(Instruction::Assert(Artifact {
+                the: Attribute::from_str(ATTR_ATTRIBUTE_OPTIONAL)?,
+                of: meta_entity.clone(),
+                is: Value::String("true".to_string()),
+                cause: None,
+            }));
+        }
+
+        attr_summaries.push(attr.short_name.clone());
+    }
+
+    import_summary.push(serde_json::json!({
+        "name": cname.as_str(),
+        "namespace": concept.namespace,
+        "attributes": attr_summaries,
+        "description": concept.description,
+    }));
+
+    Ok(())
+}
+
+/// Build a list of fully-qualified attribute names for a concept definition.
+fn build_concept_attr_list(cname: &ConceptName, concept: &ParsedConcept) -> Result<Vec<String>> {
+    let mut attrs = Vec::new();
+
+    for attr in &concept.attributes {
+        let qualified = if let Some(ref qr) = attr.qualified_ref {
+            if let Some(name) = qr.strip_prefix('.') {
+                // `.name` — concept-relative, resolve now
+                let prefix = cname.to_lowercase();
+                format!("{}/{}", prefix, name)
+            } else {
+                // Fully qualified — use as-is
+                qr.clone()
+            }
+        } else {
+            qualify_attribute(cname, &attr.short_name)?
+        };
+
+        attrs.push(qualified);
+    }
+
+    Ok(attrs)
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers: standalone attribute assertion
+// ---------------------------------------------------------------------------
+
+/// Build assert instructions for a standalone attribute.
+///
+/// Standalone attributes are stored as attribute metadata triples
+/// without a parent concept, using a deterministic entity derived
+/// from the namespace and attribute name.
+fn build_standalone_attr_assertions(
+    space_did: &str,
+    attr: &ParsedStandaloneAttribute,
+    assert_instructions: &mut Vec<Instruction>,
+) -> Result<()> {
+    // Use a deterministic entity for standalone attributes
+    let qualified = format!("{}/{}", attr.namespace, attr.short_name);
+    let entity_input = format!("{}\0standalone-attr\0{}", space_did, qualified);
+    let meta_entity = derive_entity(&entity_input)?;
+
+    if let Some(desc) = &attr.description {
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_ATTRIBUTE_DESCRIPTION)?,
+            of: meta_entity.clone(),
+            is: Value::String(desc.clone()),
+            cause: None,
+        }));
+    }
+
+    if let Some(type_str) = &attr.type_str {
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_ATTRIBUTE_TYPE)?,
+            of: meta_entity.clone(),
+            is: Value::String(type_str.clone()),
+            cause: None,
+        }));
+    }
+
+    if let Some(cardinality) = &attr.cardinality {
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_ATTRIBUTE_CARDINALITY)?,
+            of: meta_entity.clone(),
+            is: Value::String(cardinality.clone()),
+            cause: None,
+        }));
+    }
+
+    Ok(())
+}
+
+/// Check if a standalone attribute already exists and build retract instructions if `force` is true.
+async fn retract_standalone_attr_if_exists<
+    S: dialog_artifacts::ArtifactStore + ArtifactStoreMut,
+>(
+    branch: &S,
+    space_did: &str,
+    attr: &ParsedStandaloneAttribute,
+    force: bool,
+    retract_instructions: &mut Vec<Instruction>,
+) -> Result<()> {
+    let qualified = format!("{}/{}", attr.namespace, attr.short_name);
+    let entity_input = format!("{}\0standalone-attr\0{}", space_did, qualified);
+    let meta_entity = derive_entity(&entity_input)?;
+
+    let mut found_any = false;
+    for meta_attr in [
+        ATTR_ATTRIBUTE_DESCRIPTION,
+        ATTR_ATTRIBUTE_TYPE,
+        ATTR_ATTRIBUTE_CARDINALITY,
+        ATTR_ATTRIBUTE_OPTIONAL,
+    ] {
+        if let Some(val) = fetch_string(branch, &meta_entity, meta_attr).await? {
+            found_any = true;
+            if force {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(meta_attr)?,
+                    of: meta_entity.clone(),
+                    is: Value::String(val),
+                    cause: None,
+                }));
+            }
+        }
+    }
+
+    if found_any && !force {
+        anyhow::bail!(
+            "Standalone attribute '{}/{}' already exists. Use --force to overwrite.",
+            attr.namespace,
+            attr.short_name
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers: rule retraction, validation, and assertion
+// ---------------------------------------------------------------------------
+
+/// Check if a rule already exists and build retract instructions if `force` is true.
+async fn retract_rule_if_exists<S: dialog_artifacts::ArtifactStore + ArtifactStoreMut>(
+    branch: &S,
+    space_did: &str,
+    parsed: &ParsedRule,
+    registry: &dialog_query::Entity,
+    force: bool,
+    retract_instructions: &mut Vec<Instruction>,
+) -> Result<()> {
+    let rule_ent = rule_entity(space_did, &parsed.name)?;
+    let existing = fetch_string(branch, &rule_ent, ATTR_RULE_NAME).await?;
+
+    if existing.is_some() {
+        if force {
+            if let Some(name) = fetch_string(branch, &rule_ent, ATTR_RULE_NAME).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_RULE_NAME)?,
+                    of: rule_ent.clone(),
+                    is: Value::String(name),
+                    cause: None,
+                }));
+            }
+            if let Some(conclusion) = fetch_string(branch, &rule_ent, ATTR_RULE_CONCLUSION).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
+                    of: rule_ent.clone(),
+                    is: Value::String(conclusion),
+                    cause: None,
+                }));
+            }
+            if let Some(def) = fetch_string(branch, &rule_ent, ATTR_RULE_DEFINITION).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
+                    of: rule_ent.clone(),
+                    is: Value::String(def),
+                    cause: None,
+                }));
+            }
+            if let Some(desc) = fetch_string(branch, &rule_ent, ATTR_RULE_DESCRIPTION).await? {
+                retract_instructions.push(Instruction::Retract(Artifact {
+                    the: Attribute::from_str(ATTR_RULE_DESCRIPTION)?,
+                    of: rule_ent.clone(),
+                    is: Value::String(desc),
+                    cause: None,
+                }));
+            }
+            retract_instructions.push(Instruction::Retract(Artifact {
+                the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
+                of: registry.clone(),
+                is: Value::Entity(rule_ent.clone()),
+                cause: None,
+            }));
+        } else {
+            anyhow::bail!(
+                "Rule '{}' already exists. Use --force to overwrite, \
+                 or delete it first with 'tonk rule delete {}'.",
+                parsed.name,
+                parsed.name
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a rule against the space's concept schemas.
+async fn validate_rule_against_space<S: dialog_artifacts::ArtifactStore + ArtifactStoreMut>(
+    branch: &S,
+    space_did: &str,
+    parsed: &ParsedRule,
+    definition: &RuleDefinition,
+) -> Result<()> {
+    let conclusion_concept = ConceptName::new(&definition.conclusion.concept)?;
+    let concept_ent = concept_entity(space_did, &conclusion_concept)?;
+    let concept_name = fetch_string(branch, &concept_ent, ATTR_CONCEPT_NAME)
+        .await?
+        .context(format!(
+            "Conclusion concept '{}' for rule '{}' not found. Define it first.",
+            definition.conclusion.concept, parsed.name
+        ))?;
+    let concept_name = ConceptName::from_stored(concept_name);
+
+    let concept_attrs = fetch_string_values(branch, &concept_ent, ATTR_CONCEPT_ATTRIBUTE).await?;
+
+    validate_rule_against_schema(parsed, definition, &concept_name, &concept_attrs)?;
+
+    Ok(())
+}
+
+/// Validate a rule against a provided concept schema.
+fn validate_rule_against_schema(
+    parsed: &ParsedRule,
+    definition: &RuleDefinition,
+    concept_name: &ConceptName,
+    concept_attrs: &[String],
+) -> Result<()> {
+    // Validate bindings match concept schema
+    crate::rule::validate_definition(definition, concept_attrs, concept_name)
+        .with_context(|| format!("Rule '{}' validation failed", parsed.name))?;
+
+    // Trial-compile
+    crate::rule::compile_rule(definition, concept_name, concept_attrs).with_context(|| {
+        format!(
+            "Rule '{}' failed to compile. Check variable names match between \
+             conclusion bindings and premises.",
+            parsed.name
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Build assert instructions for a single rule.
+fn build_rule_assertions(
+    space_did: &str,
+    parsed: &ParsedRule,
+    definition: &RuleDefinition,
+    registry: &dialog_query::Entity,
+    assert_instructions: &mut Vec<Instruction>,
+    import_summary: &mut Vec<serde_json::Value>,
+) -> Result<()> {
+    let rule_ent = rule_entity(space_did, &parsed.name)?;
+    let concept_name = &definition.conclusion.concept;
+    let definition_str = serde_json::to_string(definition)?;
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_REGISTRY_RULE)?,
+        of: registry.clone(),
+        is: Value::Entity(rule_ent.clone()),
+        cause: None,
+    }));
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_RULE_NAME)?,
+        of: rule_ent.clone(),
+        is: Value::String(parsed.name.clone()),
+        cause: None,
+    }));
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_RULE_CONCLUSION)?,
+        of: rule_ent.clone(),
+        is: Value::String(concept_name.clone()),
+        cause: None,
+    }));
+
+    assert_instructions.push(Instruction::Assert(Artifact {
+        the: Attribute::from_str(ATTR_RULE_DEFINITION)?,
+        of: rule_ent.clone(),
+        is: Value::String(definition_str),
+        cause: None,
+    }));
+
+    // Assert rule description if present
+    if let Some(desc) = &parsed.description {
+        assert_instructions.push(Instruction::Assert(Artifact {
+            the: Attribute::from_str(ATTR_RULE_DESCRIPTION)?,
+            of: rule_ent.clone(),
+            is: Value::String(desc.clone()),
+            cause: None,
+        }));
+    }
+
+    import_summary.push(serde_json::json!({
+        "name": parsed.name,
+        "namespace": parsed.namespace,
+        "conclusion": concept_name,
+        "when_count": definition.when.len(),
+        "unless_count": definition.unless.len(),
+    }));
 
     Ok(())
 }

--- a/rust/tonk-cli/src/import/concept_parse.rs
+++ b/rust/tonk-cli/src/import/concept_parse.rs
@@ -1,154 +1,311 @@
-//! YAML parsing for concept definitions.
+//! YAML parsing for the canonical abbreviated notation.
 //!
-//! Parses a YAML file of the form:
+//! Parses a YAML file containing standalone attributes, concepts, and/or rules:
 //!
 //! ```yaml
 //! diy.cook:
+//!   # Standalone attribute at namespace level
+//!   quantity:
+//!     description: Amount needed
+//!     as: Integer
+//!
+//!   # Concept with required and optional fields
 //!   Recipe:
-//!     this:
-//!       the: Meal recipe
-//!     title:
-//!       the: The name of this recipe
-//!       as: Text
-//!     ingredient:
-//!       the: Ingredients of the recipe
-//!       cardinality: many
+//!     description: Meal recipe
+//!     with:
+//!       title:
+//!         description: The name of this recipe
+//!         as: Text
+//!       ingredient:
+//!         description: Ingredients of the recipe
+//!         cardinality: many
+//!     maybe:
+//!       notes:
+//!         description: Optional notes
+//!         as: Text
+//!
+//!   # Rule with deduce/when/unless
+//!   safe-meal:
+//!     description: A meal that respects dietary restrictions
+//!     deduce:
+//!       SafeMeal:
+//!         attendee: ?person
+//!     when:
+//!       - diy.planner/Meal:
+//!           attendee: ?person
+//!     unless:
+//!       - diy.planner/AllergyConflict:
+//!           person: ?person
 //! ```
 
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 
 // ---------------------------------------------------------------------------
-// YAML deserialization types
+// Parsed intermediate representations
 // ---------------------------------------------------------------------------
 
-/// An attribute definition in the YAML schema. Each key under a concept
-/// (other than `this`) is deserialized into this type.
-///
-/// All fields are optional — a bare key with no value is a valid attribute
-/// with no metadata.
-#[derive(Debug, Default)]
-struct YamlAttributeDef {
-    /// Human-readable description of the attribute.
-    the: Option<String>,
-
-    /// Type constraint. Can be a single string (`"Text"`, `"Integer"`,
-    /// a concept name like `"RecipeStep"`) or an array of strings for
-    /// enum-like constraints (`["tsp", "mls"]`).
-    as_type: Option<serde_yaml::Value>,
-
-    /// Cardinality: `"many"` for multi-valued attributes. Absent means single.
-    cardinality: Option<String>,
-
-    /// Whether the `optional` key was present (even with a null value).
-    optional_present: bool,
+/// A parsed entry from a YAML namespace — can be a standalone attribute,
+/// concept, or rule marker (rules are delegated to `rule_parse`).
+#[derive(Debug)]
+pub(super) enum ParsedEntry {
+    Attribute(ParsedStandaloneAttribute),
+    Concept(ParsedConcept),
+    /// A rule entry. Contains the rule name, namespace, and the raw YAML
+    /// value to be parsed by `rule_parse`.
+    Rule {
+        name: String,
+        namespace: String,
+        value: serde_yaml::Value,
+    },
 }
 
-// ---------------------------------------------------------------------------
-// Parsed intermediate representation
-// ---------------------------------------------------------------------------
+/// A standalone attribute defined at the namespace level (no parent concept).
+#[derive(Debug)]
+pub(super) struct ParsedStandaloneAttribute {
+    /// Short attribute name (e.g. "quantity").
+    pub short_name: String,
+    /// The namespace it was defined under (e.g. "diy.cook").
+    pub namespace: String,
+    /// Description from the `description` field.
+    pub description: Option<String>,
+    /// Type constraint from `as`, stored verbatim. Arrays are JSON-encoded.
+    pub type_str: Option<String>,
+    /// Cardinality string (e.g. "many").
+    pub cardinality: Option<String>,
+}
 
 /// A concept parsed from the YAML, ready for validation and import.
+#[derive(Debug)]
 pub(super) struct ParsedConcept {
     /// The concept name (e.g. "Recipe").
     pub name: String,
     /// The namespace it was defined under (e.g. "diy.cook").
     pub namespace: String,
-    /// Description from the `this.the` field.
+    /// Description from the `description` field.
     pub description: Option<String>,
     /// The concept's attributes with their metadata.
     pub attributes: Vec<ParsedAttribute>,
 }
 
 /// A single attribute of a parsed concept.
+#[derive(Debug)]
 pub(super) struct ParsedAttribute {
     /// Short attribute name (e.g. "title").
     pub short_name: String,
-    /// Description from the `the` field.
+    /// Fully qualified attribute reference, if provided explicitly in the YAML.
+    /// Set when a concept field uses a string reference like `carry.links/handle`
+    /// instead of an inline attribute definition. When set, this should be used
+    /// as the stored attribute path instead of generating one from the concept name.
+    pub qualified_ref: Option<String>,
+    /// Description from the `description` field.
     pub description: Option<String>,
     /// Type constraint from `as`, stored verbatim. Arrays are JSON-encoded.
     pub type_str: Option<String>,
     /// Cardinality string (e.g. "many").
     pub cardinality: Option<String>,
-    /// Whether this attribute is optional.
+    /// Whether this attribute is optional (defined in `maybe:` block).
     pub optional: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Entry classification
+// ---------------------------------------------------------------------------
+
+/// Determine what kind of entry a second-level YAML value represents.
+#[derive(Debug, PartialEq, Eq)]
+enum EntryKind {
+    /// Has `deduce:` key → rule
+    Rule,
+    /// Has `with:` key (no `deduce:`) → concept
+    Concept,
+    /// Otherwise → standalone attribute
+    StandaloneAttribute,
+}
+
+fn classify_entry(value: &serde_yaml::Value) -> EntryKind {
+    if let serde_yaml::Value::Mapping(map) = value {
+        let has_deduce = map.contains_key(serde_yaml::Value::String("deduce".into()));
+        let has_with = map.contains_key(serde_yaml::Value::String("with".into()));
+
+        if has_deduce {
+            return EntryKind::Rule;
+        }
+        if has_with {
+            return EntryKind::Concept;
+        }
+    }
+    EntryKind::StandaloneAttribute
 }
 
 // ---------------------------------------------------------------------------
 // YAML parsing
 // ---------------------------------------------------------------------------
 
-/// Parse a YAML string into a list of concepts.
+/// Parse a YAML string into a list of entries (attributes, concepts, rules).
 ///
-/// The YAML structure is: `namespace -> concept_name -> attr_name -> attr_def`.
-/// The `this` key is special and provides the concept-level description.
-pub(super) fn parse_yaml(yaml_str: &str) -> Result<Vec<ParsedConcept>> {
-    // Parse as a map of namespace -> concepts
+/// The YAML structure is: `namespace -> entry_name -> entry_def`.
+/// Entry classification is based on the presence of `deduce:` (rule),
+/// `with:` (concept), or neither (standalone attribute).
+pub(super) fn parse_yaml(yaml_str: &str) -> Result<Vec<ParsedEntry>> {
     let root: BTreeMap<String, BTreeMap<String, serde_yaml::Value>> =
         serde_yaml::from_str(yaml_str).context("Failed to parse YAML")?;
 
-    let mut concepts = Vec::new();
+    let mut entries = Vec::new();
 
-    for (namespace, concept_map) in root {
-        for (concept_name, attrs_value) in concept_map {
-            let parsed = parse_concept(&namespace, &concept_name, &attrs_value)
-                .with_context(|| format!("In concept '{}.{}'", namespace, concept_name))?;
-            concepts.push(parsed);
+    for (namespace, entry_map) in root {
+        for (entry_name, entry_value) in entry_map {
+            let kind = classify_entry(&entry_value);
+            match kind {
+                EntryKind::Rule => {
+                    entries.push(ParsedEntry::Rule {
+                        name: entry_name,
+                        namespace: namespace.clone(),
+                        value: entry_value,
+                    });
+                }
+                EntryKind::Concept => {
+                    let concept = parse_concept(&namespace, &entry_name, &entry_value)
+                        .with_context(|| format!("In concept '{}.{}'", namespace, entry_name))?;
+                    entries.push(ParsedEntry::Concept(concept));
+                }
+                EntryKind::StandaloneAttribute => {
+                    let attr = parse_standalone_attribute(&namespace, &entry_name, &entry_value)
+                        .with_context(|| {
+                            format!("In standalone attribute '{}/{}'", namespace, entry_name)
+                        })?;
+                    entries.push(ParsedEntry::Attribute(attr));
+                }
+            }
         }
     }
 
-    Ok(concepts)
+    Ok(entries)
 }
 
-/// Parse a single concept from its YAML value (the map of attribute names to defs).
+/// Convenience: parse a YAML string and return only the concepts.
+/// Used by tests and the concept-only import path.
+#[cfg(test)]
+fn parse_concepts(yaml_str: &str) -> Result<Vec<ParsedConcept>> {
+    let entries = parse_yaml(yaml_str)?;
+    Ok(entries
+        .into_iter()
+        .filter_map(|e| match e {
+            ParsedEntry::Concept(c) => Some(c),
+            _ => None,
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Standalone attribute parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a standalone attribute from its YAML value.
+///
+/// Handles three forms:
+/// - Null: bare key with no value (e.g. `quantity:`)
+/// - String: type shorthand (e.g. `quantity: Integer`)
+/// - Mapping: full definition with `description:`, `as:`, `cardinality:`
+fn parse_standalone_attribute(
+    namespace: &str,
+    name: &str,
+    value: &serde_yaml::Value,
+) -> Result<ParsedStandaloneAttribute> {
+    match value {
+        serde_yaml::Value::Null => Ok(ParsedStandaloneAttribute {
+            short_name: name.to_string(),
+            namespace: namespace.to_string(),
+            description: None,
+            type_str: None,
+            cardinality: None,
+        }),
+        serde_yaml::Value::String(s) => Ok(ParsedStandaloneAttribute {
+            short_name: name.to_string(),
+            namespace: namespace.to_string(),
+            description: None,
+            type_str: Some(s.clone()),
+            cardinality: None,
+        }),
+        serde_yaml::Value::Mapping(map) => {
+            let description = map
+                .get(serde_yaml::Value::String("description".into()))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let as_type = map.get(serde_yaml::Value::String("as".into())).cloned();
+            let type_str = resolve_as_type(&as_type)?;
+
+            let cardinality = map
+                .get(serde_yaml::Value::String("cardinality".into()))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            Ok(ParsedStandaloneAttribute {
+                short_name: name.to_string(),
+                namespace: namespace.to_string(),
+                description,
+                type_str,
+                cardinality,
+            })
+        }
+        other => anyhow::bail!(
+            "Unexpected value type for standalone attribute '{}': {:?}",
+            name,
+            other
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concept parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a single concept from its YAML value.
+///
+/// Expected structure:
+/// ```yaml
+/// ConceptName:
+///   description: Human-readable description
+///   with:
+///     field1:
+///       description: ...
+///       as: Text
+///     field2: .           # punning reference
+///   maybe:
+///     opt_field:
+///       description: ...
+///       as: Text
+/// ```
 fn parse_concept(
     namespace: &str,
     concept_name: &str,
     value: &serde_yaml::Value,
 ) -> Result<ParsedConcept> {
-    let attrs_map: BTreeMap<String, serde_yaml::Value> =
-        serde_yaml::from_value(value.clone()).context("Expected a mapping of attributes")?;
+    let map: &serde_yaml::Mapping = value
+        .as_mapping()
+        .ok_or_else(|| anyhow::anyhow!("Expected a mapping for concept '{}'", concept_name))?;
 
-    let mut description = None;
+    // Extract description
+    let description = map
+        .get(serde_yaml::Value::String("description".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
     let mut attributes = Vec::new();
 
-    for (key, attr_value) in attrs_map {
-        if key == "this" {
-            // `this` is not an attribute — it describes the entity itself
-            let def = parse_attr_def(&attr_value).context("Failed to parse 'this' definition")?;
-            description = def.the;
-            continue;
-        }
+    // Parse `with:` block (required fields)
+    if let Some(with_value) = map.get(serde_yaml::Value::String("with".into())) {
+        let with_attrs =
+            parse_field_block(with_value, false).context("Failed to parse 'with' block")?;
+        attributes.extend(with_attrs);
+    }
 
-        let def = parse_attr_def(&attr_value)
-            .with_context(|| format!("Failed to parse attribute '{}'", key))?;
-
-        let type_str = match &def.as_type {
-            None => None,
-            Some(serde_yaml::Value::String(s)) => Some(s.clone()),
-            Some(serde_yaml::Value::Sequence(seq)) => {
-                // Array of strings -> JSON array
-                let items: Vec<String> = seq
-                    .iter()
-                    .map(|v| match v {
-                        serde_yaml::Value::String(s) => Ok(s.clone()),
-                        other => Ok(format!("{:?}", other)),
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                Some(serde_json::to_string(&items)?)
-            }
-            Some(other) => Some(format!("{:?}", other)),
-        };
-
-        let optional = def.optional_present;
-
-        attributes.push(ParsedAttribute {
-            short_name: key,
-            description: def.the,
-            type_str,
-            cardinality: def.cardinality,
-            optional,
-        });
+    // Parse `maybe:` block (optional fields)
+    if let Some(maybe_value) = map.get(serde_yaml::Value::String("maybe".into())) {
+        let maybe_attrs =
+            parse_field_block(maybe_value, true).context("Failed to parse 'maybe' block")?;
+        attributes.extend(maybe_attrs);
     }
 
     Ok(ParsedConcept {
@@ -159,48 +316,149 @@ fn parse_concept(
     })
 }
 
-/// Parse an attribute definition value. Handles three forms:
-/// - A full mapping `{the: ..., as: ..., ...}`
-/// - A bare scalar (e.g. `title:` with no value -> null -> default)
-/// - A string shorthand (e.g. `title: Text` -> treated as type only)
-fn parse_attr_def(value: &serde_yaml::Value) -> Result<YamlAttributeDef> {
+/// Parse a `with:` or `maybe:` block into a list of attributes.
+///
+/// Each field in the block can be:
+/// - A string reference (`.`, `.name`, `domain/name`) — attribute by reference
+/// - A mapping — inline attribute definition with `description:`, `as:`, `cardinality:`
+/// - Null — bare key with no metadata
+fn parse_field_block(value: &serde_yaml::Value, optional: bool) -> Result<Vec<ParsedAttribute>> {
+    let fields: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_value(value.clone())
+        .context("Expected a mapping of field names to definitions")?;
+
+    let mut attributes = Vec::new();
+
+    for (field_name, field_value) in fields {
+        let attr = parse_field_entry(&field_name, &field_value, optional)
+            .with_context(|| format!("Failed to parse field '{}'", field_name))?;
+        attributes.push(attr);
+    }
+
+    Ok(attributes)
+}
+
+/// Parse a single field entry within a `with:` or `maybe:` block.
+///
+/// Three forms of field values:
+/// 1. String `.` — punning (resolves to concept-domain/field-name)
+/// 2. String `.name` — explicit name override (resolves to concept-domain/name)
+/// 3. String `domain/name` — fully qualified attribute reference
+/// 4. Mapping — inline attribute definition
+/// 5. Null — bare key with no metadata
+fn parse_field_entry(
+    field_name: &str,
+    value: &serde_yaml::Value,
+    optional: bool,
+) -> Result<ParsedAttribute> {
     match value {
-        serde_yaml::Value::Null => Ok(YamlAttributeDef::default()),
-        serde_yaml::Value::String(s) => {
-            // Bare string -> treat as type shorthand
-            Ok(YamlAttributeDef {
-                as_type: Some(serde_yaml::Value::String(s.clone())),
-                ..Default::default()
+        serde_yaml::Value::Null => {
+            // Bare key, no metadata
+            Ok(ParsedAttribute {
+                short_name: field_name.to_string(),
+                qualified_ref: None,
+                description: None,
+                type_str: None,
+                cardinality: None,
+                optional,
+            })
+        }
+        serde_yaml::Value::String(ref_str) => {
+            // Reference form: ".", ".name", or "domain/name"
+            // Resolve and store the fully qualified reference so commit.rs
+            // can use the correct attribute path.
+            let qualified = if ref_str == "." {
+                // Punning: will be resolved at commit time using concept domain
+                None
+            } else if let Some(name) = ref_str.strip_prefix('.') {
+                // `.name` — explicit name, concept domain (resolved at commit time)
+                // For now store as-is; commit.rs will prepend concept domain
+                Some(format!(".{}", name))
+            } else if ref_str.contains('/') {
+                // Fully qualified: `domain/name`
+                Some(ref_str.clone())
+            } else {
+                None
+            };
+
+            Ok(ParsedAttribute {
+                short_name: field_name.to_string(),
+                qualified_ref: qualified,
+                description: None,
+                type_str: None,
+                cardinality: None,
+                optional,
             })
         }
         serde_yaml::Value::Mapping(map) => {
-            // Manually extract fields so we can detect the *presence* of `optional:`
-            // (even when its value is null), which serde's Option<T> would swallow.
-            let the = map
-                .get(serde_yaml::Value::String("the".into()))
+            // Inline attribute definition
+            let description = map
+                .get(serde_yaml::Value::String("description".into()))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
             let as_type = map.get(serde_yaml::Value::String("as".into())).cloned();
+            let type_str = resolve_as_type(&as_type)?;
 
             let cardinality = map
                 .get(serde_yaml::Value::String("cardinality".into()))
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            let optional_present = map.contains_key(serde_yaml::Value::String("optional".into()));
-
-            Ok(YamlAttributeDef {
-                the,
-                as_type,
+            Ok(ParsedAttribute {
+                short_name: field_name.to_string(),
+                qualified_ref: None,
+                description,
+                type_str,
                 cardinality,
-                optional_present,
+                optional,
             })
         }
         other => anyhow::bail!(
-            "Unexpected value type for attribute definition: {:?}",
+            "Unexpected value type for field '{}': {:?}",
+            field_name,
             other
         ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type resolution helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the `as:` field value into a stored type string.
+///
+/// Handles:
+/// - `None` → `None`
+/// - `String("Text")` → `Some("Text")`
+/// - `String(".RecipeStep")` → `Some("RecipeStep")` (strip dot prefix)
+/// - `Sequence([:tsp, :mls])` → `Some(r#"["tsp","mls"]"#)` (strip colon, JSON array)
+/// - Other → debug format
+fn resolve_as_type(as_type: &Option<serde_yaml::Value>) -> Result<Option<String>> {
+    match as_type {
+        None => Ok(None),
+        Some(serde_yaml::Value::String(s)) => {
+            if let Some(stripped) = s.strip_prefix('.') {
+                // Concept type reference: `.RecipeStep` → `RecipeStep`
+                Ok(Some(stripped.to_string()))
+            } else {
+                Ok(Some(s.clone()))
+            }
+        }
+        Some(serde_yaml::Value::Sequence(seq)) => {
+            // Array of symbols: `[:tsp, :mls]` → JSON `["tsp", "mls"]`
+            let items: Vec<String> = seq
+                .iter()
+                .map(|v| match v {
+                    serde_yaml::Value::String(s) => {
+                        // Strip colon prefix from symbols
+                        Ok(s.strip_prefix(':').unwrap_or(s).to_string())
+                    }
+                    other => Ok(format!("{:?}", other)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Some(serde_json::to_string(&items)?))
+        }
+        Some(other) => Ok(Some(format!("{:?}", other))),
     }
 }
 
@@ -212,28 +470,57 @@ fn parse_attr_def(value: &serde_yaml::Value) -> Result<YamlAttributeDef> {
 mod tests {
     use super::*;
 
+    // Helper to extract only concepts from parsed entries
+    fn extract_concepts(entries: Vec<ParsedEntry>) -> Vec<ParsedConcept> {
+        entries
+            .into_iter()
+            .filter_map(|e| match e {
+                ParsedEntry::Concept(c) => Some(c),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Helper to extract only standalone attributes from parsed entries
+    fn extract_attributes(entries: Vec<ParsedEntry>) -> Vec<ParsedStandaloneAttribute> {
+        entries
+            .into_iter()
+            .filter_map(|e| match e {
+                ParsedEntry::Attribute(a) => Some(a),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Helper to count rules in parsed entries
+    fn count_rules(entries: &[ParsedEntry]) -> usize {
+        entries
+            .iter()
+            .filter(|e| matches!(e, ParsedEntry::Rule { .. }))
+            .count()
+    }
+
     #[test]
     fn parse_basic_concept() {
         let yaml = r#"
 diy.cook:
   Recipe:
-    this:
-      the: Meal recipe
-    title:
-      the: The name of this recipe
-      as: Text
-    ingredient:
-      the: Ingredients of the recipe
-      cardinality: many
+    description: Meal recipe
+    with:
+      title:
+        description: The name of this recipe
+        as: Text
+      ingredient:
+        description: Ingredients of the recipe
+        cardinality: many
 "#;
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         assert_eq!(concepts.len(), 1);
         assert_eq!(concepts[0].name, "Recipe");
         assert_eq!(concepts[0].namespace, "diy.cook");
         assert_eq!(concepts[0].description.as_deref(), Some("Meal recipe"));
         assert_eq!(concepts[0].attributes.len(), 2);
 
-        // BTreeMap sorts alphabetically: ingredient before title
         let ingredient = concepts[0]
             .attributes
             .iter()
@@ -264,14 +551,16 @@ diy.cook:
         let yaml = r#"
 ns:
   Thing:
-    unit:
-      the: Unit of measurement
-      as: [tsp, mls]
+    description: A thing
+    with:
+      unit:
+        description: Unit of measurement
+        as: [":tsp", ":mls"]
 "#;
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         let attr = &concepts[0].attributes[0];
         assert_eq!(attr.short_name, "unit");
-        // Stored as JSON array
+        // Stored as JSON array with colon-prefixed symbols stripped
         let parsed: Vec<String> = serde_json::from_str(attr.type_str.as_ref().unwrap()).unwrap();
         assert_eq!(parsed, vec!["tsp", "mls"]);
     }
@@ -281,15 +570,17 @@ ns:
         let yaml = r#"
 ns:
   Thing:
-    name:
-      the: The name
-      as: Text
-    after:
-      the: Step to perform this after
-      as: RecipeStep
-      optional:
+    description: A thing
+    with:
+      name:
+        description: The name
+        as: Text
+    maybe:
+      after:
+        description: Step to perform this after
+        as: .RecipeStep
 "#;
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         let name_attr = concepts[0]
             .attributes
             .iter()
@@ -297,13 +588,15 @@ ns:
             .unwrap();
         assert!(!name_attr.optional);
 
-        // `optional:` with null value -> true
+        // Fields in `maybe:` block are optional
         let after_attr = concepts[0]
             .attributes
             .iter()
             .find(|a| a.short_name == "after")
             .unwrap();
         assert!(after_attr.optional);
+        // `.RecipeStep` should have dot stripped
+        assert_eq!(after_attr.type_str.as_deref(), Some("RecipeStep"));
     }
 
     #[test]
@@ -311,23 +604,23 @@ ns:
         let yaml = r#"
 diy.cook:
   Recipe:
-    this:
-      the: Meal recipe
-    title:
-      the: The name
-      as: Text
+    description: Meal recipe
+    with:
+      title:
+        description: The name
+        as: Text
 
 diy.health:
   Allergy:
-    this:
-      the: The allergy person has
-    person:
-      the: Person having an allergy
-    substance:
-      the: Substance person has an allergy for
-      as: Text
+    description: The allergy person has
+    with:
+      person:
+        description: Person having an allergy
+      substance:
+        description: Substance person has an allergy for
+        as: Text
 "#;
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         assert_eq!(concepts.len(), 2);
 
         let names: Vec<&str> = concepts.iter().map(|c| c.name.as_str()).collect();
@@ -339,22 +632,21 @@ diy.health:
     fn parse_empty_yaml() {
         let yaml = "";
         // serde_yaml treats empty string as null, which fails to parse as BTreeMap
-        // Our parser should handle this gracefully
         let result = parse_yaml(yaml);
-        // Empty YAML is fine - just no concepts
         assert!(result.is_ok() || result.is_err());
     }
 
     #[test]
-    fn concept_with_no_this() {
+    fn concept_with_no_description() {
         let yaml = r#"
 ns:
   Simple:
-    name:
-      the: A name
-      as: Text
+    with:
+      name:
+        description: A name
+        as: Text
 "#;
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         assert_eq!(concepts[0].description, None);
         assert_eq!(concepts[0].attributes.len(), 1);
     }
@@ -362,7 +654,7 @@ ns:
     #[test]
     fn parse_cook_example() {
         let yaml = include_str!("../../examples/cook.yaml");
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         assert_eq!(concepts.len(), 3);
 
         let names: Vec<&str> = concepts.iter().map(|c| c.name.as_str()).collect();
@@ -386,6 +678,7 @@ ns:
             .find(|a| a.short_name == "steps")
             .unwrap();
         assert_eq!(steps.cardinality.as_deref(), Some("many"));
+        // `.RecipeStep` should have dot stripped to `RecipeStep`
         assert_eq!(steps.type_str.as_deref(), Some("RecipeStep"));
 
         // Ingredient has enum type on unit
@@ -398,7 +691,7 @@ ns:
         let parsed: Vec<String> = serde_json::from_str(unit.type_str.as_ref().unwrap()).unwrap();
         assert_eq!(parsed, vec!["tsp", "mls"]);
 
-        // RecipeStep.after is optional
+        // RecipeStep.after is optional (in maybe: block)
         let step = concepts.iter().find(|c| c.name == "RecipeStep").unwrap();
         let after = step
             .attributes
@@ -412,7 +705,16 @@ ns:
     #[test]
     fn parse_planner_example() {
         let yaml = include_str!("../../examples/planner.yaml");
-        let concepts = parse_yaml(yaml).unwrap();
+        let entries = parse_yaml(yaml).unwrap();
+
+        let concepts = extract_concepts(
+            entries
+                .into_iter()
+                .filter(|e| !matches!(e, ParsedEntry::Rule { .. }))
+                .collect(),
+        );
+        // planner.yaml now has 5 concepts + 2 rules
+        // We only look at concepts here
         assert_eq!(concepts.len(), 5);
 
         let names: Vec<&str> = concepts.iter().map(|c| c.name.as_str()).collect();
@@ -431,29 +733,21 @@ ns:
 
         let meal = concepts.iter().find(|c| c.name == "Meal").unwrap();
         assert_eq!(meal.namespace, "diy.planner");
-
-        let safe_meal = concepts.iter().find(|c| c.name == "SafeMeal").unwrap();
-        assert_eq!(safe_meal.namespace, "diy.planner");
-
-        let conflict = concepts
-            .iter()
-            .find(|c| c.name == "AllergyConflict")
-            .unwrap();
-        assert_eq!(conflict.namespace, "diy.planner");
         assert_eq!(meal.attributes.len(), 3);
+    }
 
-        let occasion = meal
-            .attributes
-            .iter()
-            .find(|a| a.short_name == "occasion")
-            .unwrap();
-        assert_eq!(occasion.type_str.as_deref(), Some("Event"));
+    #[test]
+    fn parse_planner_has_rules() {
+        let yaml = include_str!("../../examples/planner.yaml");
+        let entries = parse_yaml(yaml).unwrap();
+        let rule_count = count_rules(&entries);
+        assert_eq!(rule_count, 2);
     }
 
     #[test]
     fn parse_minimal_example() {
         let yaml = include_str!("../../examples/minimal.yaml");
-        let concepts = parse_yaml(yaml).unwrap();
+        let concepts = parse_concepts(yaml).unwrap();
         assert_eq!(concepts.len(), 1);
 
         let task = &concepts[0];
@@ -462,7 +756,7 @@ ns:
         assert_eq!(task.description.as_deref(), Some("A task to be completed"));
         assert_eq!(task.attributes.len(), 3);
 
-        // status is an enum
+        // status is an enum (colon-prefixed symbols)
         let status = task
             .attributes
             .iter()
@@ -472,7 +766,7 @@ ns:
         assert_eq!(parsed, vec!["todo", "in-progress", "done"]);
         assert!(!status.optional);
 
-        // priority is optional and an enum
+        // priority is optional (in maybe: block) and an enum
         let priority = task
             .attributes
             .iter()
@@ -482,5 +776,169 @@ ns:
         let parsed: Vec<String> =
             serde_json::from_str(priority.type_str.as_ref().unwrap()).unwrap();
         assert_eq!(parsed, vec!["low", "medium", "high"]);
+    }
+
+    #[test]
+    fn parse_standalone_attribute_basic() {
+        let yaml = r#"
+diy.cook:
+  quantity:
+    description: Amount needed
+    as: Integer
+    cardinality: many
+"#;
+        let entries = parse_yaml(yaml).unwrap();
+        let attrs = extract_attributes(entries);
+        assert_eq!(attrs.len(), 1);
+
+        let attr = &attrs[0];
+        assert_eq!(attr.short_name, "quantity");
+        assert_eq!(attr.namespace, "diy.cook");
+        assert_eq!(attr.description.as_deref(), Some("Amount needed"));
+        assert_eq!(attr.type_str.as_deref(), Some("Integer"));
+        assert_eq!(attr.cardinality.as_deref(), Some("many"));
+    }
+
+    #[test]
+    fn parse_standalone_attribute_with_symbol_enum() {
+        let yaml = r#"
+diy.cook:
+  unit:
+    description: The unit of measurement
+    as: [":tsp", ":mls"]
+"#;
+        let entries = parse_yaml(yaml).unwrap();
+        let attrs = extract_attributes(entries);
+        assert_eq!(attrs.len(), 1);
+
+        let attr = &attrs[0];
+        let parsed: Vec<String> = serde_json::from_str(attr.type_str.as_ref().unwrap()).unwrap();
+        assert_eq!(parsed, vec!["tsp", "mls"]);
+    }
+
+    #[test]
+    fn parse_concept_with_punning_ref() {
+        let yaml = r#"
+diy.cook:
+  Ingredient:
+    description: An ingredient
+    with:
+      quantity: .
+      name: .ingredient-name
+      person-name: io.gozala.person/name
+"#;
+        let concepts = parse_concepts(yaml).unwrap();
+        assert_eq!(concepts.len(), 1);
+        assert_eq!(concepts[0].attributes.len(), 3);
+
+        // String references should parse without error, stored as attrs with no type/description
+        let qty = concepts[0]
+            .attributes
+            .iter()
+            .find(|a| a.short_name == "quantity")
+            .unwrap();
+        assert!(qty.description.is_none());
+        assert!(qty.type_str.is_none());
+    }
+
+    #[test]
+    fn parse_mixed_file_classification() {
+        let yaml = r#"
+diy.cook:
+  quantity:
+    description: Amount needed
+    as: Integer
+
+  Recipe:
+    description: A recipe
+    with:
+      title:
+        description: Title
+        as: Text
+
+  find-something:
+    description: A rule
+    deduce:
+      Recipe:
+        title: ?t
+    when:
+      - diy.cook/Recipe:
+          this: ?r
+          title: ?t
+"#;
+        let entries = parse_yaml(yaml).unwrap();
+
+        let attrs = entries
+            .iter()
+            .filter(|e| matches!(e, ParsedEntry::Attribute(_)))
+            .count();
+        let concepts = entries
+            .iter()
+            .filter(|e| matches!(e, ParsedEntry::Concept(_)))
+            .count();
+        let rules = count_rules(&entries);
+
+        assert_eq!(attrs, 1);
+        assert_eq!(concepts, 1);
+        assert_eq!(rules, 1);
+    }
+
+    #[test]
+    fn classify_entry_rule() {
+        let yaml_val: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+deduce:
+  Foo:
+    bar: ?x
+when:
+  - ns/Baz:
+      this: ?x
+"#,
+        )
+        .unwrap();
+        assert_eq!(classify_entry(&yaml_val), EntryKind::Rule);
+    }
+
+    #[test]
+    fn classify_entry_concept() {
+        let yaml_val: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+description: A thing
+with:
+  name:
+    as: Text
+"#,
+        )
+        .unwrap();
+        assert_eq!(classify_entry(&yaml_val), EntryKind::Concept);
+    }
+
+    #[test]
+    fn classify_entry_standalone_attr() {
+        let yaml_val: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+description: Amount needed
+as: Integer
+"#,
+        )
+        .unwrap();
+        assert_eq!(classify_entry(&yaml_val), EntryKind::StandaloneAttribute);
+    }
+
+    #[test]
+    fn dot_prefix_type_stripped() {
+        let yaml = r#"
+ns:
+  Thing:
+    description: A thing
+    with:
+      ref:
+        description: Reference
+        as: .OtherThing
+"#;
+        let concepts = parse_concepts(yaml).unwrap();
+        let attr = &concepts[0].attributes[0];
+        // Dot prefix should be stripped
+        assert_eq!(attr.type_str.as_deref(), Some("OtherThing"));
     }
 }

--- a/rust/tonk-cli/src/import/rule_parse.rs
+++ b/rust/tonk-cli/src/import/rule_parse.rs
@@ -1,23 +1,34 @@
 //! YAML parsing and lowering for rule definitions.
 //!
-//! Parses a YAML file of the form:
+//! Parses rule definitions using the canonical abbreviated notation:
 //!
 //! ```yaml
-//! user.rules:
-//!   respect-dietary-restrictions:
-//!     assert:
-//!       diy.meal-planner/Meal:
+//! diy.planner:
+//!   safe-meal:
+//!     description: A meal that respects dietary restrictions
+//!     deduce:
+//!       SafeMeal:
 //!         attendee: ?person
 //!         recipe: ?recipe
 //!     when:
-//!       - diy.cook/Recipe:
-//!           this: ?recipe
-//!           ingredient: ?ingredient
+//!       - diy.planner/Meal:
+//!           this: ?meal
+//!           attendee: ?person
+//!           recipe: ?recipe
+//!       - diy.cook/ingredient-name:
+//!           this: ?entity
+//!           is: ?name
+//!       - ==:
+//!           this: ?name
+//!           is: Alice
+//!       - math/sum:
+//!           of: ?a
+//!           with: ?b
+//!           is: ?result
 //!     unless:
-//!       - diy.health/Allergy:
-//!           this: _
+//!       - diy.planner/AllergyConflict:
 //!           person: ?person
-//!           substance: ?substance
+//!           recipe: ?recipe
 //! ```
 //!
 //! After parsing, the concept-oriented representation is *lowered* into
@@ -28,6 +39,30 @@ use anyhow::{Context, Result};
 use std::collections::{BTreeMap, HashMap};
 
 // ---------------------------------------------------------------------------
+// Known formula and constraint references
+// ---------------------------------------------------------------------------
+
+/// Known formula references that are treated specially in premises.
+const FORMULA_REFS: &[&str] = &[
+    "math/sum",
+    "math/difference",
+    "math/product",
+    "math/quotient",
+    "math/modulo",
+    "text/concatenate",
+    "text/length",
+    "text/upper-case",
+    "text/lower-case",
+    "text/like",
+    "boolean/and",
+    "boolean/or",
+    "boolean/not",
+];
+
+/// Known constraint references.
+const CONSTRAINT_REFS: &[&str] = &["=="];
+
+// ---------------------------------------------------------------------------
 // Parsed intermediate representation
 // ---------------------------------------------------------------------------
 
@@ -36,9 +71,11 @@ use std::collections::{BTreeMap, HashMap};
 pub(super) struct ParsedRule {
     /// Rule name from the YAML key (e.g. "respect-dietary-restrictions").
     pub name: String,
-    /// Namespace from the top-level key (e.g. "user.rules").
+    /// Namespace from the top-level key (e.g. "diy.planner").
     pub namespace: String,
-    /// The conclusion: which concept is asserted and its bindings.
+    /// Description from the `description` field.
+    pub description: Option<String>,
+    /// The conclusion: which concept is deduced and its bindings.
     pub conclusion: ParsedRuleConclusion,
     /// Positive premises (must hold).
     pub when: Vec<ParsedRulePremise>,
@@ -49,7 +86,7 @@ pub(super) struct ParsedRule {
 /// The conclusion of a parsed rule.
 #[derive(Debug)]
 pub(super) struct ParsedRuleConclusion {
-    /// Concept name extracted from the reference (e.g. "Meal" from "diy.meal-planner/Meal").
+    /// Concept name extracted from the reference (e.g. "SafeMeal" from "diy.planner/SafeMeal").
     pub concept_name: String,
     /// Bindings: attribute short names to variables/wildcards/constants.
     /// The `this` key, if present, is stored separately.
@@ -58,16 +95,67 @@ pub(super) struct ParsedRuleConclusion {
     pub this: Option<String>,
 }
 
-/// A single concept-oriented premise from the YAML, before lowering to EAV.
+/// The kind of premise in a rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PremiseKind {
+    /// Concept premise: key is `namespace/ConceptName` (CamelCase after `/`).
+    Concept,
+    /// Raw attribute premise: key is `domain/attribute-name` (kebab-case after `/`).
+    RawAttribute,
+    /// Equality constraint: key is `==`.
+    Equality,
+    /// Formula: key is `math/sum`, `text/concatenate`, etc.
+    Formula,
+}
+
+/// A single premise from the YAML, before lowering to EAV.
 #[derive(Debug)]
 pub(super) struct ParsedRulePremise {
-    /// Concept name extracted from the reference (e.g. "Recipe" from "diy.cook/Recipe").
+    /// What kind of premise this is.
+    pub kind: PremiseKind,
+    /// The full reference key (e.g. "diy.cook/Recipe", "==", "math/sum").
+    pub reference: String,
+    /// For concept premises: the concept name extracted from the reference.
+    /// For others: the full reference.
     pub concept_name: String,
     /// The `this` value (entity binding). Defaults to `"_"` if absent.
     pub this_value: String,
     /// Attribute bindings: short name -> variable/wildcard/constant.
     /// Does not include `this`.
     pub attributes: Vec<(String, String)>,
+}
+
+// ---------------------------------------------------------------------------
+// Premise classification
+// ---------------------------------------------------------------------------
+
+/// Classify a premise reference key into its kind.
+fn classify_premise_ref(reference: &str) -> PremiseKind {
+    // Check for known constraints
+    if CONSTRAINT_REFS.contains(&reference) {
+        return PremiseKind::Equality;
+    }
+
+    // Check for known formulas
+    if FORMULA_REFS.contains(&reference) {
+        return PremiseKind::Formula;
+    }
+
+    // If it contains `/`, check whether the part after the last `/` starts
+    // with an uppercase letter (concept) or lowercase (raw attribute).
+    if let Some((_ns, name)) = reference.rsplit_once('/') {
+        if name.starts_with(|c: char| c.is_ascii_uppercase()) {
+            return PremiseKind::Concept;
+        }
+        return PremiseKind::RawAttribute;
+    }
+
+    // Bare name starting with uppercase → concept, else raw attribute
+    if reference.starts_with(|c: char| c.is_ascii_uppercase()) {
+        PremiseKind::Concept
+    } else {
+        PremiseKind::RawAttribute
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +175,7 @@ fn extract_concept_name(reference: &str) -> String {
 
 /// Parse a YAML string containing rule definitions.
 ///
-/// Structure: `namespace -> rule_name -> {assert, when, unless}`.
+/// Structure: `namespace -> rule_name -> {description, deduce, when, unless}`.
 pub(super) fn parse_rules_yaml(yaml_str: &str) -> Result<Vec<ParsedRule>> {
     let root: BTreeMap<String, BTreeMap<String, serde_yaml::Value>> =
         serde_yaml::from_str(yaml_str).context("Failed to parse YAML")?;
@@ -106,19 +194,32 @@ pub(super) fn parse_rules_yaml(yaml_str: &str) -> Result<Vec<ParsedRule>> {
 }
 
 /// Parse a single rule from its YAML value.
-fn parse_rule(namespace: &str, rule_name: &str, value: &serde_yaml::Value) -> Result<ParsedRule> {
+///
+/// Called both from `parse_rules_yaml` (standalone rules file) and from
+/// the mixed-file parser in `concept_parse`.
+pub(super) fn parse_rule(
+    namespace: &str,
+    rule_name: &str,
+    value: &serde_yaml::Value,
+) -> Result<ParsedRule> {
     let map: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_value(value.clone())
-        .context("Expected a mapping with assert/when/unless")?;
+        .context("Expected a mapping with deduce/when/unless")?;
 
-    // Parse `assert` (required)
-    let assert_value = map
-        .get("assert")
-        .ok_or_else(|| anyhow::anyhow!("Rule must have an 'assert' section"))?;
+    // Parse `description` (optional)
+    let description = map
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // Parse `deduce` (required)
+    let deduce_value = map
+        .get("deduce")
+        .ok_or_else(|| anyhow::anyhow!("Rule must have a 'deduce' section"))?;
 
     let conclusion =
-        parse_rule_conclusion(assert_value).context("Failed to parse 'assert' section")?;
+        parse_rule_conclusion(deduce_value).context("Failed to parse 'deduce' section")?;
 
-    // Parse `when` (required, list of concept premises)
+    // Parse `when` (required, list of premises)
     let when_value = map
         .get("when")
         .ok_or_else(|| anyhow::anyhow!("Rule must have a 'when' section"))?;
@@ -139,20 +240,21 @@ fn parse_rule(namespace: &str, rule_name: &str, value: &serde_yaml::Value) -> Re
     Ok(ParsedRule {
         name: rule_name.to_string(),
         namespace: namespace.to_string(),
+        description,
         conclusion,
         when,
         unless,
     })
 }
 
-/// Parse the `assert` section of a rule YAML.
+/// Parse the `deduce` section of a rule YAML.
 ///
 /// Expected shape: a single-key mapping where the key is a concept reference
 /// and the value is a mapping of attribute bindings.
 ///
 /// ```yaml
-/// assert:
-///   diy.meal-planner/Meal:
+/// deduce:
+///   SafeMeal:
 ///     attendee: ?person
 ///     recipe: ?recipe
 /// ```
@@ -162,7 +264,7 @@ fn parse_rule_conclusion(value: &serde_yaml::Value) -> Result<ParsedRuleConclusi
 
     if map.len() != 1 {
         anyhow::bail!(
-            "The 'assert' section must contain exactly one concept, found {}",
+            "The 'deduce' section must contain exactly one concept, found {}",
             map.len()
         );
     }
@@ -191,17 +293,13 @@ fn parse_rule_conclusion(value: &serde_yaml::Value) -> Result<ParsedRuleConclusi
     })
 }
 
-/// Parse the `when` or `unless` section (a list of concept premises).
+/// Parse the `when` or `unless` section (a list of premises).
 ///
-/// Each entry is a single-key mapping: concept reference -> attribute bindings.
-///
-/// ```yaml
-/// when:
-///   - diy.cook/Recipe:
-///       this: ?recipe
-///       title: _
-///       ingredient: ?ingredient
-/// ```
+/// Each entry is a single-key mapping. The key determines the premise type:
+/// - `namespace/ConceptName` (CamelCase) → concept premise
+/// - `domain/attribute-name` (kebab-case) → raw attribute premise
+/// - `==` → equality constraint
+/// - `math/sum`, etc. → formula premise
 fn parse_rule_premises(value: &serde_yaml::Value) -> Result<Vec<ParsedRulePremise>> {
     let list: Vec<serde_yaml::Value> =
         serde_yaml::from_value(value.clone()).context("Expected a list of premises")?;
@@ -210,25 +308,26 @@ fn parse_rule_premises(value: &serde_yaml::Value) -> Result<Vec<ParsedRulePremis
 
     for (i, entry) in list.iter().enumerate() {
         let map: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_value(entry.clone())
-            .with_context(|| format!("Premise {} must be a concept mapping", i + 1))?;
+            .with_context(|| format!("Premise {} must be a mapping", i + 1))?;
 
         if map.len() != 1 {
             anyhow::bail!(
-                "Premise {} must reference exactly one concept, found {}",
+                "Premise {} must reference exactly one concept/attribute/constraint/formula, found {}",
                 i + 1,
                 map.len()
             );
         }
 
-        let (concept_ref, attrs_value) = map.into_iter().next().unwrap();
-        let concept_name = extract_concept_name(&concept_ref);
+        let (reference, attrs_value) = map.into_iter().next().unwrap();
+        let kind = classify_premise_ref(&reference);
+        let concept_name = extract_concept_name(&reference);
 
         let attrs_map: BTreeMap<String, String> = serde_yaml::from_value(attrs_value)
             .with_context(|| {
                 format!(
-                    "Premise {} ({}) must have attribute bindings (e.g. this: ?var, name: _)",
+                    "Premise {} ({}) must have bindings (e.g. this: ?var, name: _)",
                     i + 1,
-                    concept_ref
+                    reference
                 )
             })?;
 
@@ -244,6 +343,8 @@ fn parse_rule_premises(value: &serde_yaml::Value) -> Result<Vec<ParsedRulePremis
         }
 
         premises.push(ParsedRulePremise {
+            kind,
+            reference: reference.clone(),
             concept_name,
             this_value,
             attributes,
@@ -260,9 +361,9 @@ fn parse_rule_premises(value: &serde_yaml::Value) -> Result<Vec<ParsedRulePremis
 /// Lower a `ParsedRule` into the internal `RuleDefinition` (EAV-based).
 ///
 /// Each concept-oriented premise is expanded into one EAV premise per
-/// attribute mentioned. The `this` key maps to the entity (`of`) field.
-/// Attributes are qualified using the concept name as namespace prefix
-/// (e.g. attribute `title` on concept `Recipe` becomes `recipe/title`).
+/// attribute mentioned. Raw attribute premises pass through as single EAV
+/// premises. Equality constraints and formulas are lowered to EAV premises
+/// using the reference as the `the` field.
 pub(super) fn lower_rule(parsed: &ParsedRule) -> Result<RuleDefinition> {
     // Lower the conclusion
     let conclusion = RuleConclusion {
@@ -284,25 +385,77 @@ pub(super) fn lower_rule(parsed: &ParsedRule) -> Result<RuleDefinition> {
     })
 }
 
-/// Lower a list of parsed concept-oriented premises into flat EAV triples.
+/// Lower a list of parsed premises into flat EAV triples.
 ///
-/// Each attribute mentioned in a premise produces one `RulePremise` with:
-/// - `the`: fully qualified attribute (`concept_name_lowercase/attr_name`)
-/// - `of`: the entity binding from `this` (or `"_"` wildcard)
-/// - `is`: the attribute's value binding
+/// - **Concept premises**: Each attribute produces one `RulePremise` with
+///   `the = concept_name_lowercase/attr_name`, `of = this_value`, `is = value`.
+/// - **Raw attribute premises**: A single `RulePremise` with `the = reference`,
+///   `of = this_value`, `is = is_value`.
+/// - **Equality constraints**: A single `RulePremise` with `the = "=="`,
+///   `of = this_value`, `is = is_value`.
+/// - **Formulas**: A single `RulePremise` per binding with `the = formula_ref`,
+///   `of = param_name`, `is = param_value`. Note: formula lowering is
+///   provisional — the rule engine does not yet support formulas.
 fn lower_premises(premises: &[ParsedRulePremise]) -> Result<Vec<RulePremise>> {
     let mut eav_premises = Vec::new();
 
     for premise in premises {
-        let prefix = premise.concept_name.to_lowercase();
+        match premise.kind {
+            PremiseKind::Concept => {
+                let prefix = premise.concept_name.to_lowercase();
+                for (attr_name, value) in &premise.attributes {
+                    let qualified = format!("{}/{}", prefix, attr_name);
+                    eav_premises.push(RulePremise {
+                        the: qualified,
+                        of: premise.this_value.clone(),
+                        is: value.clone(),
+                    });
+                }
+            }
+            PremiseKind::RawAttribute => {
+                // Raw attribute premise: pass through the fully qualified reference
+                // The `is` binding is stored in attributes under key "is"
+                let is_value = premise
+                    .attributes
+                    .iter()
+                    .find(|&(k, _)| k == "is")
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or_else(|| "_".to_string());
 
-        for (attr_name, value) in &premise.attributes {
-            let qualified = format!("{}/{}", prefix, attr_name);
-            eav_premises.push(RulePremise {
-                the: qualified,
-                of: premise.this_value.clone(),
-                is: value.clone(),
-            });
+                eav_premises.push(RulePremise {
+                    the: premise.reference.clone(),
+                    of: premise.this_value.clone(),
+                    is: is_value,
+                });
+            }
+            PremiseKind::Equality => {
+                // Equality constraint: `==: { this: ?x, is: ?y }`
+                let is_value = premise
+                    .attributes
+                    .iter()
+                    .find(|&(k, _)| k == "is")
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or_else(|| "_".to_string());
+
+                eav_premises.push(RulePremise {
+                    the: "==".to_string(),
+                    of: premise.this_value.clone(),
+                    is: is_value,
+                });
+            }
+            PremiseKind::Formula => {
+                // Formula premise: lower each parameter binding as a separate
+                // EAV premise with the formula reference as `the`.
+                // This is provisional — the rule engine does not yet support
+                // formulas natively. We store them for forward compatibility.
+                for (param_name, param_value) in &premise.attributes {
+                    eav_premises.push(RulePremise {
+                        the: premise.reference.clone(),
+                        of: param_name.clone(),
+                        is: param_value.clone(),
+                    });
+                }
+            }
         }
     }
 
@@ -325,11 +478,51 @@ mod tests {
     }
 
     #[test]
+    fn classify_concept_premise() {
+        assert_eq!(
+            classify_premise_ref("diy.cook/Recipe"),
+            PremiseKind::Concept
+        );
+        assert_eq!(
+            classify_premise_ref("diy.planner/SafeMeal"),
+            PremiseKind::Concept
+        );
+    }
+
+    #[test]
+    fn classify_raw_attribute_premise() {
+        assert_eq!(
+            classify_premise_ref("diy.cook/ingredient-name"),
+            PremiseKind::RawAttribute
+        );
+        assert_eq!(
+            classify_premise_ref("diy.cook/quantity"),
+            PremiseKind::RawAttribute
+        );
+    }
+
+    #[test]
+    fn classify_equality_premise() {
+        assert_eq!(classify_premise_ref("=="), PremiseKind::Equality);
+    }
+
+    #[test]
+    fn classify_formula_premise() {
+        assert_eq!(classify_premise_ref("math/sum"), PremiseKind::Formula);
+        assert_eq!(
+            classify_premise_ref("text/concatenate"),
+            PremiseKind::Formula
+        );
+        assert_eq!(classify_premise_ref("boolean/not"), PremiseKind::Formula);
+    }
+
+    #[test]
     fn parse_basic_rule() {
         let yaml = r#"
 user.rules:
   my-rule:
-    assert:
+    description: Test rule
+    deduce:
       diy.planner/Meal:
         attendee: ?person
         recipe: ?recipe
@@ -353,6 +546,7 @@ user.rules:
         let rule = &rules[0];
         assert_eq!(rule.name, "my-rule");
         assert_eq!(rule.namespace, "user.rules");
+        assert_eq!(rule.description.as_deref(), Some("Test rule"));
         assert_eq!(rule.conclusion.concept_name, "Meal");
         assert_eq!(rule.conclusion.bindings.len(), 2);
         assert_eq!(rule.conclusion.bindings["attendee"], "?person");
@@ -360,9 +554,9 @@ user.rules:
         assert!(rule.conclusion.this.is_none());
 
         assert_eq!(rule.when.len(), 2);
+        assert_eq!(rule.when[0].kind, PremiseKind::Concept);
         assert_eq!(rule.when[0].concept_name, "Recipe");
         assert_eq!(rule.when[0].this_value, "?recipe");
-        // title and ingredient (BTreeMap sorted: ingredient, title)
         assert_eq!(rule.when[0].attributes.len(), 2);
 
         assert_eq!(rule.when[1].concept_name, "Ingredient");
@@ -380,7 +574,7 @@ user.rules:
         let yaml = r#"
 ns:
   my-rule:
-    assert:
+    deduce:
       ns/Thing:
         this: ?entity
         name: ?n
@@ -401,7 +595,7 @@ ns:
         let yaml = r#"
 ns:
   simple-rule:
-    assert:
+    deduce:
       ns/Output:
         value: ?v
     when:
@@ -413,6 +607,102 @@ ns:
         assert!(rules[0].unless.is_empty());
     }
 
+    #[test]
+    fn parse_rule_with_description() {
+        let yaml = r#"
+ns:
+  my-rule:
+    description: This is a test rule
+    deduce:
+      ns/Output:
+        value: ?v
+    when:
+      - ns/Input:
+          this: ?x
+          data: ?v
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        assert_eq!(rules[0].description.as_deref(), Some("This is a test rule"));
+    }
+
+    #[test]
+    fn parse_raw_attribute_premise() {
+        let yaml = r#"
+ns:
+  my-rule:
+    deduce:
+      ns/Output:
+        name: ?n
+    when:
+      - diy.cook/ingredient-name:
+          this: ?entity
+          is: ?n
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        let premise = &rules[0].when[0];
+        assert_eq!(premise.kind, PremiseKind::RawAttribute);
+        assert_eq!(premise.reference, "diy.cook/ingredient-name");
+        assert_eq!(premise.this_value, "?entity");
+        assert_eq!(premise.attributes.len(), 1);
+        assert_eq!(premise.attributes[0], ("is".to_string(), "?n".to_string()));
+    }
+
+    #[test]
+    fn parse_equality_premise() {
+        let yaml = r#"
+ns:
+  my-rule:
+    deduce:
+      ns/Output:
+        name: ?name
+    when:
+      - ns/Person:
+          this: ?p
+          name: ?name
+      - ==:
+          this: ?name
+          is: Alice
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        assert_eq!(rules[0].when.len(), 2);
+
+        let eq_premise = &rules[0].when[1];
+        assert_eq!(eq_premise.kind, PremiseKind::Equality);
+        assert_eq!(eq_premise.reference, "==");
+        assert_eq!(eq_premise.this_value, "?name");
+        assert_eq!(
+            eq_premise.attributes[0],
+            ("is".to_string(), "Alice".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_formula_premise() {
+        let yaml = r#"
+ns:
+  my-rule:
+    deduce:
+      ns/Output:
+        total: ?result
+    when:
+      - ns/Input:
+          this: ?e
+          value: ?a
+      - math/sum:
+          of: ?a
+          with: ?a
+          is: ?result
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        assert_eq!(rules[0].when.len(), 2);
+
+        let formula = &rules[0].when[1];
+        assert_eq!(formula.kind, PremiseKind::Formula);
+        assert_eq!(formula.reference, "math/sum");
+        // Formula bindings: of, is, with (sorted by BTreeMap)
+        assert_eq!(formula.attributes.len(), 3);
+    }
+
     // -----------------------------------------------------------------------
     // Rule lowering tests
     // -----------------------------------------------------------------------
@@ -422,7 +712,7 @@ ns:
         let yaml = r#"
 user.rules:
   my-rule:
-    assert:
+    deduce:
       diy.planner/Meal:
         attendee: ?person
         recipe: ?recipe
@@ -447,7 +737,6 @@ user.rules:
         let rules = parse_rules_yaml(yaml).unwrap();
         let def = lower_rule(&rules[0]).unwrap();
 
-        // Lowering passes variables through as-is (no splitting)
         assert_eq!(def.conclusion.concept, "Meal");
         assert!(def.conclusion.this.is_none());
         assert_eq!(def.conclusion.bindings.len(), 2);
@@ -512,12 +801,10 @@ user.rules:
 
     #[test]
     fn lower_rule_with_this_in_conclusion_no_conflict() {
-        // When `this: ?entity` is in the conclusion and NO binding
-        // uses ?entity, there's no conflict — no splitting needed.
         let yaml = r#"
 ns:
   my-rule:
-    assert:
+    deduce:
       ns/Thing:
         this: ?entity
         name: ?n
@@ -529,24 +816,18 @@ ns:
         let rules = parse_rules_yaml(yaml).unwrap();
         let def = lower_rule(&rules[0]).unwrap();
 
-        // No conflict: ?entity is only in `this`, not in bindings
         assert_eq!(def.conclusion.this.as_deref(), Some("?entity"));
         assert_eq!(def.conclusion.bindings.len(), 1);
         assert_eq!(def.conclusion.bindings["name"], "?n");
-        // Premise entity stays as-is
         assert_eq!(def.when[0].of, "?entity");
     }
 
     #[test]
     fn lower_passes_through_conflicting_vars() {
-        // Lowering does NOT split variables. If a conclusion binding
-        // variable is also used as `this` in a premise, both keep the
-        // original variable. The conflict is handled later at compile time
-        // (build_rename_map will skip the entity var for auto-detection).
         let yaml = r#"
 ns:
   rule:
-    assert:
+    deduce:
       ns/Output:
         source: ?entity
         value: ?v
@@ -558,25 +839,19 @@ ns:
         let rules = parse_rules_yaml(yaml).unwrap();
         let def = lower_rule(&rules[0]).unwrap();
 
-        // Variables pass through as-is — no splitting
         assert!(def.conclusion.this.is_none());
         assert_eq!(def.conclusion.bindings.len(), 2);
         assert_eq!(def.conclusion.bindings["source"], "?entity");
         assert_eq!(def.conclusion.bindings["value"], "?v");
-
-        // Premise entity keeps original variable
         assert_eq!(def.when[0].of, "?entity");
     }
 
     #[test]
     fn lower_explicit_this_with_same_binding_passes_through() {
-        // Lowering passes variables through as-is. The explicit `this`
-        // and binding using the same variable will be caught later at
-        // compile time by build_rename_map.
         let yaml = r#"
 ns:
   rule:
-    assert:
+    deduce:
       ns/Output:
         this: ?entity
         source: ?entity
@@ -589,7 +864,6 @@ ns:
         let rules = parse_rules_yaml(yaml).unwrap();
         let def = lower_rule(&rules[0]).unwrap();
 
-        // Lowering just passes through; no splitting
         assert_eq!(def.conclusion.this.as_deref(), Some("?entity"));
         assert_eq!(def.conclusion.bindings["source"], "?entity");
         assert_eq!(def.conclusion.bindings["value"], "?v");
@@ -598,12 +872,10 @@ ns:
 
     #[test]
     fn lower_binding_var_not_entity() {
-        // Binding variable that is NOT a premise entity variable.
-        // Lowering passes it through as-is.
         let yaml = r#"
 ns:
   rule:
-    assert:
+    deduce:
       ns/Output:
         name: ?n
     when:
@@ -621,11 +893,10 @@ ns:
 
     #[test]
     fn lower_no_conflict() {
-        // When entity var and binding vars are different, simple pass-through.
         let yaml = r#"
 ns:
   rule:
-    assert:
+    deduce:
       ns/Output:
         value: ?v
     when:
@@ -636,7 +907,6 @@ ns:
         let rules = parse_rules_yaml(yaml).unwrap();
         let def = lower_rule(&rules[0]).unwrap();
 
-        // Lowering just passes through; conclusion.this is not set by lowering
         assert!(def.conclusion.this.is_none());
         assert_eq!(def.conclusion.bindings.len(), 1);
         assert_eq!(def.conclusion.bindings["value"], "?v");
@@ -645,11 +915,10 @@ ns:
 
     #[test]
     fn lower_premise_no_this_defaults_to_wildcard() {
-        // A premise with no `this` key should use "_" as entity
         let yaml = r#"
 ns:
   my-rule:
-    assert:
+    deduce:
       ns/Out:
         val: ?v
     when:
@@ -666,31 +935,80 @@ ns:
     }
 
     #[test]
+    fn lower_raw_attribute_premise() {
+        let yaml = r#"
+ns:
+  my-rule:
+    deduce:
+      ns/Output:
+        name: ?n
+    when:
+      - diy.cook/ingredient-name:
+          this: ?entity
+          is: ?n
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        let def = lower_rule(&rules[0]).unwrap();
+
+        assert_eq!(def.when.len(), 1);
+        assert_eq!(def.when[0].the, "diy.cook/ingredient-name");
+        assert_eq!(def.when[0].of, "?entity");
+        assert_eq!(def.when[0].is, "?n");
+    }
+
+    #[test]
+    fn lower_equality_constraint() {
+        let yaml = r#"
+ns:
+  my-rule:
+    deduce:
+      ns/Output:
+        name: ?name
+    when:
+      - ns/Person:
+          this: ?p
+          name: ?name
+      - ==:
+          this: ?name
+          is: Alice
+"#;
+        let rules = parse_rules_yaml(yaml).unwrap();
+        let def = lower_rule(&rules[0]).unwrap();
+
+        assert_eq!(def.when.len(), 2);
+        // First premise: concept
+        assert_eq!(def.when[0].the, "person/name");
+        // Second premise: equality constraint
+        assert_eq!(def.when[1].the, "==");
+        assert_eq!(def.when[1].of, "?name");
+        assert_eq!(def.when[1].is, "Alice");
+    }
+
+    #[test]
     fn parse_rules_example_file() {
         let yaml = include_str!("../../examples/rules.yaml");
         let rules = parse_rules_yaml(yaml).unwrap();
         assert_eq!(rules.len(), 2);
 
-        // First rule: find-allergy-conflicts -> AllergyConflict
-        let rule1 = rules
-            .iter()
-            .find(|r| r.name == "find-allergy-conflicts")
-            .unwrap();
-        assert_eq!(rule1.conclusion.concept_name, "AllergyConflict");
+        // First rule: plan-event-meal -> Meal
+        let rule1 = rules.iter().find(|r| r.name == "plan-event-meal").unwrap();
+        assert_eq!(rule1.conclusion.concept_name, "Meal");
+        assert!(rule1.description.is_some());
         let def1 = lower_rule(rule1).unwrap();
-        assert_eq!(def1.conclusion.concept, "AllergyConflict");
+        assert_eq!(def1.conclusion.concept, "Meal");
         assert!(!def1.when.is_empty());
         assert!(def1.unless.is_empty());
 
-        // Second rule: respect-dietary-restrictions -> SafeMeal
+        // Second rule: infer-safe-event-meal -> SafeMeal
         let rule2 = rules
             .iter()
-            .find(|r| r.name == "respect-dietary-restrictions")
+            .find(|r| r.name == "infer-safe-event-meal")
             .unwrap();
         assert_eq!(rule2.conclusion.concept_name, "SafeMeal");
+        assert!(rule2.description.is_some());
         let def2 = lower_rule(rule2).unwrap();
         assert_eq!(def2.conclusion.concept, "SafeMeal");
         assert!(!def2.when.is_empty());
-        assert!(!def2.unless.is_empty());
+        assert!(def2.unless.is_empty());
     }
 }

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+pub mod attribute;
 pub mod authority;
 pub mod batch;
 pub mod concept;

--- a/rust/tonk-cli/src/rule.rs
+++ b/rust/tonk-cli/src/rule.rs
@@ -478,20 +478,25 @@ pub fn validate_definition(
     conclusion_attrs: &[String],
     conclusion_name: &ConceptName,
 ) -> Result<()> {
-    // Check that all binding keys are valid concept attributes
+    // Check that all binding keys are valid concept attributes.
+    // A binding key like "comment" matches either the concept-derived path
+    // (e.g. "annotatedlink/comment") or any attribute whose short name
+    // matches (e.g. "carry.links/comment" where the part after "/" is "comment").
     for short_name in definition.conclusion.bindings.keys() {
-        let qualified = qualify_attribute(conclusion_name, short_name)?;
-        if !conclusion_attrs.contains(&qualified) {
+        if short_name == "this" {
+            continue; // `this` is the entity binding, not an attribute
+        }
+        let concept_qualified = qualify_attribute(conclusion_name, short_name)?;
+        let matches = conclusion_attrs.iter().any(|a| {
+            *a == concept_qualified || a.rsplit_once('/').is_some_and(|(_, n)| n == short_name)
+        });
+        if !matches {
             anyhow::bail!(
                 "Conclusion binding '{}' is not an attribute of concept '{}'. \
                  Known attributes: {}",
                 short_name,
                 conclusion_name,
-                conclusion_attrs
-                    .iter()
-                    .map(|a| short_attribute(conclusion_name, a))
-                    .collect::<Vec<_>>()
-                    .join(", ")
+                conclusion_attrs.join(", ")
             );
         }
     }

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -204,7 +204,7 @@ pub fn attribute_meta_entity(
 }
 
 /// Low-level: hash input to produce a deterministic `did:key` entity.
-fn derive_entity(input: &str) -> Result<Entity> {
+pub fn derive_entity(input: &str) -> Result<Entity> {
     let hash = blake3::hash(input.as_bytes());
     let b58 = bs58::encode(hash.as_bytes()).into_string();
     let uri = format!("did:key:z{}", b58);

--- a/rust/tonk-cli/tests/cli_integration.rs
+++ b/rust/tonk-cli/tests/cli_integration.rs
@@ -1743,3 +1743,501 @@ async fn test_multiple_concepts_same_space() {
         assert!(result.is_ok(), "{} query should succeed", concept);
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Attribute Introspection
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_empty_space() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-empty")
+        .await
+        .expect("Failed to create space");
+
+    // List attributes in an empty space — should succeed (prints empty message)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list on empty space should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode should also succeed
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON on empty space should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_concept_define() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-define")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept (no metadata — just attribute names)
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define concept");
+
+    // List attributes — should show Task with title and status (no metadata)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_import_with_metadata() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-import")
+        .await
+        .expect("Failed to create space");
+
+    // Import cook.yaml which has full attribute metadata
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // List attributes — should show Recipe, Ingredient, RecipeStep with metadata
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list after import should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON after import should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_qualified_name() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-qual")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Show by qualified name
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show by qualified name should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON by qualified name should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_short_name_with_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-short")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Show by short name with --concept
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Recipe".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show with --concept should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Recipe".to_string()), true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON with --concept should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_unambiguous_short_name() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-unambig")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "steps" only exists on Recipe, so it should resolve unambiguously
+    let result = tonk_cli::attribute::show("steps".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show unambiguous short name should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_ambiguous_short_name_errors() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-ambig")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "name" exists on both Ingredient and possibly others — check if it's ambiguous
+    // Actually in cook.yaml, "name" only exists on Ingredient.
+    // Let's use a concept where we know there's overlap. Define a second concept
+    // with a "name" attribute to create ambiguity.
+    tonk_cli::concept::define(
+        "Person".to_string(),
+        vec!["name".to_string(), "age".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Person concept");
+
+    // Now "name" exists on both Ingredient and Person
+    let result = tonk_cli::attribute::show("name".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with ambiguous name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_qualified() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-noexist")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Nonexistent qualified name
+    let result = tonk_cli::attribute::show("recipe/nonexistent".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent qualified name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_short() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-noexist-short")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Nonexistent short name
+    let result = tonk_cli::attribute::show("zzz_nonexistent".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent short name should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_wrong_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-wrongconcept")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "title" belongs to Recipe, not Ingredient
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Ingredient".to_string()), false).await;
+    assert!(
+        result.is_err(),
+        "attribute show with wrong concept should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_nonexistent_concept() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-badconcept")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Concept doesn't exist
+    let result =
+        tonk_cli::attribute::show("title".to_string(), Some("Nonexistent".to_string()), false)
+            .await;
+    assert!(
+        result.is_err(),
+        "attribute show with nonexistent concept should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_enum_type() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-enum")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "unit" on Ingredient has enum type ["tsp","mls"]
+    let result =
+        tonk_cli::attribute::show("unit".to_string(), Some("Ingredient".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show for enum type should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result =
+        tonk_cli::attribute::show("unit".to_string(), Some("Ingredient".to_string()), true).await;
+    assert!(
+        result.is_ok(),
+        "attribute show JSON for enum type should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_many_cardinality() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-many")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "ingredient" on Recipe has cardinality: many
+    let result =
+        tonk_cli::attribute::show("ingredient".to_string(), Some("Recipe".to_string()), false)
+            .await;
+    assert!(
+        result.is_ok(),
+        "attribute show for many-cardinality should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_optional_attribute() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-optional")
+        .await
+        .expect("Failed to create space");
+
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // "after" on RecipeStep has optional: true
+    let result =
+        tonk_cli::attribute::show("after".to_string(), Some("RecipeStep".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show for optional attribute should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_no_space_errors() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+    // No space created — should fail gracefully
+
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_err(),
+        "attribute list without a space should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_no_space_errors() {
+    let _env = TestEnv::new().await.expect("Failed to create test env");
+    // No space created — should fail gracefully
+
+    let result = tonk_cli::attribute::show("recipe/title".to_string(), None, false).await;
+    assert!(
+        result.is_err(),
+        "attribute show without a space should fail"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_list_after_import_and_define_mixed() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-mixed")
+        .await
+        .expect("Failed to create space");
+
+    // Import cook.yaml (has metadata)
+    let file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // Also define a concept manually (no metadata)
+    tonk_cli::concept::define(
+        "Task".to_string(),
+        vec!["title".to_string(), "status".to_string()],
+        Some("A task".to_string()),
+        true,
+    )
+    .await
+    .expect("Failed to define Task");
+
+    // List should show both imported (with metadata) and defined (without)
+    let result = tonk_cli::attribute::list(false).await;
+    assert!(
+        result.is_ok(),
+        "attribute list with mixed concepts should succeed: {:?}",
+        result.err()
+    );
+
+    // JSON mode
+    let result = tonk_cli::attribute::list(true).await;
+    assert!(
+        result.is_ok(),
+        "attribute list JSON with mixed concepts should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_attribute_show_defined_concept_no_metadata() {
+    let env = TestEnv::new().await.expect("Failed to create test env");
+    let _space = env
+        .create_space("attr-show-nometa")
+        .await
+        .expect("Failed to create space");
+
+    // Define a concept without importing (no metadata)
+    tonk_cli::concept::define(
+        "Note".to_string(),
+        vec!["body".to_string(), "tags".to_string()],
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to define Note");
+
+    // Show should work, just without metadata
+    let result =
+        tonk_cli::attribute::show("body".to_string(), Some("Note".to_string()), false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show without metadata should succeed: {:?}",
+        result.err()
+    );
+
+    // Qualified form too
+    let result = tonk_cli::attribute::show("note/body".to_string(), None, false).await;
+    assert!(
+        result.is_ok(),
+        "attribute show by qualified name without metadata should succeed: {:?}",
+        result.err()
+    );
+}

--- a/rust/tonk-cli/tests/cli_integration.rs
+++ b/rust/tonk-cli/tests/cli_integration.rs
@@ -487,6 +487,13 @@ async fn test_import_planner_yaml() {
         .await
         .expect("Failed to create space");
 
+    // Import cook.yaml first (planner rules reference cook concepts)
+    let cook_file = TestEnv::example_file("cook.yaml");
+    tonk_cli::import::import(cook_file, false, true)
+        .await
+        .expect("Failed to import cook.yaml");
+
+    // planner.yaml is a mixed file: concepts + rules
     let file = TestEnv::example_file("planner.yaml");
     tonk_cli::import::import(file, false, true)
         .await
@@ -508,18 +515,19 @@ async fn test_import_rules_yaml() {
         .await
         .expect("Failed to create space");
 
-    // Import prerequisite concepts first
-    let planner_file = TestEnv::example_file("planner.yaml");
-    tonk_cli::import::import(planner_file, false, true)
-        .await
-        .expect("Failed to import planner.yaml");
-
+    // Import prerequisite concepts first (cook before planner, since
+    // planner's rules reference cook concepts)
     let cook_file = TestEnv::example_file("cook.yaml");
     tonk_cli::import::import(cook_file, false, true)
         .await
         .expect("Failed to import cook.yaml");
 
-    // Now import rules
+    let planner_file = TestEnv::example_file("planner.yaml");
+    tonk_cli::import::import(planner_file, false, true)
+        .await
+        .expect("Failed to import planner.yaml");
+
+    // Now import rules (standalone rules file)
     let rules_file = TestEnv::example_file("rules.yaml");
     tonk_cli::import::import(rules_file, false, true)
         .await
@@ -1575,17 +1583,17 @@ async fn test_import_concepts_and_rules_full_workflow() {
         .await
         .expect("Failed to create space");
 
-    // 1. Import planner concepts (2 namespaces, 5 concepts)
-    let planner = TestEnv::example_file("planner.yaml");
-    tonk_cli::import::import(planner, false, true)
-        .await
-        .expect("Failed to import planner concepts");
-
-    // 2. Import cook concepts (1 namespace, 3 concepts)
+    // 1. Import cook concepts first (planner rules reference cook concepts)
     let cook = TestEnv::example_file("cook.yaml");
     tonk_cli::import::import(cook, false, true)
         .await
         .expect("Failed to import cook concepts");
+
+    // 2. Import planner (mixed: 5 concepts + 2 rules across 2 namespaces)
+    let planner = TestEnv::example_file("planner.yaml");
+    tonk_cli::import::import(planner, false, true)
+        .await
+        .expect("Failed to import planner");
 
     // 3. Verify all 8 concepts exist
     for name in &[
@@ -1602,7 +1610,7 @@ async fn test_import_concepts_and_rules_full_workflow() {
         assert!(result.is_ok(), "{} should exist after import", name);
     }
 
-    // 4. Import rules
+    // 4. Import standalone rules file (rules referencing existing concepts)
     let rules = TestEnv::example_file("rules.yaml");
     tonk_cli::import::import(rules, false, true)
         .await


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on refactoring YAML parsing for concepts and rules in the `tonk-cli` application. It enhances the structure and clarity of the YAML files, introduces new parsing logic for mixed entries, and updates various related tests.

### Detailed summary
- Changed `derive_entity` function to `pub fn derive_entity`.
- Updated YAML structure in `minimal.yaml`, `rules.yaml`, `cook.yaml`, and `planner.yaml` files.
- Introduced a new parsing method for mixed YAML entries.
- Enhanced error handling and validation in YAML parsing.
- Added tests for new parsing logic and entry classification.

> The following files were skipped due to too many changes: `rust/tonk-cli/src/import/concept_parse.rs`, `rust/tonk-cli/src/import/commit.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->