### PR TITLE
feat(cli): space subcommand, aliases

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact-name: carry-cli-linux-x86_64
+            artifact-name: carry-linux-x86_64
           - os: macos-latest
-            artifact-name: carry-cli-macos-arm64
+            artifact-name: carry-macos-arm64
     steps:
       - uses: actions/checkout@v4
       - uses: wimpysworld/nothing-but-nix@main
@@ -33,8 +33,8 @@ jobs:
         with:
           name: tonk-test-cache
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: 'Build carry-cli'
-        run: nix build --accept-flake-config .#carry-cli
+      - name: 'Build carry'
+        run: nix build --accept-flake-config .#carry
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
@@ -79,11 +79,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: carry-cli-macos-arm64
+          name: carry-macos-arm64
           path: artifacts/macos-arm64
       - uses: actions/download-artifact@v4
         with:
-          name: carry-cli-linux-x86_64
+          name: carry-linux-x86_64
           path: artifacts/linux-x86_64
       - name: Prepare release assets
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ automerge-repo-data
 .direnv
 .wrangler
 result
+.carry
 
 # Node dependencies
 node_modules

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -19,6 +19,10 @@ mod inner {
         #[arg(long, global = true)]
         pub site: Option<String>,
 
+        /// Target a specific space by DID or label (overrides active space)
+        #[arg(long, global = true)]
+        pub space: Option<String>,
+
         /// Output format for query results
         #[arg(long, global = true, default_value = "yaml", value_parser = ["yaml", "json"])]
         pub format: String,
@@ -45,11 +49,7 @@ mod inner {
 
             /// Fields to output or filter. Use 'field' to include in output,
             /// 'field=value' to filter results.
-            #[arg(
-                trailing_var_arg = true,
-                allow_hyphen_values = true,
-                value_name = "FIELD[=VALUE]"
-            )]
+            #[arg(value_name = "FIELD[=VALUE]")]
             fields: Vec<String>,
         },
 
@@ -63,11 +63,7 @@ mod inner {
 
             /// Claims to assert. Use 'this=<DID>' to target existing entity,
             /// otherwise a new entity is created.
-            #[arg(
-                trailing_var_arg = true,
-                allow_hyphen_values = true,
-                value_name = "FIELD=VALUE"
-            )]
+            #[arg(value_name = "FIELD=VALUE")]
             fields: Vec<String>,
         },
 
@@ -81,11 +77,7 @@ mod inner {
 
             /// Claims to retract. Use 'this=<DID>' to specify entity.
             /// 'field' retracts any value; 'field=value' retracts exact match only.
-            #[arg(
-                trailing_var_arg = true,
-                allow_hyphen_values = true,
-                value_name = "FIELD[=VALUE]"
-            )]
+            #[arg(value_name = "FIELD[=VALUE]")]
             fields: Vec<String>,
         },
 
@@ -93,14 +85,48 @@ mod inner {
         #[command(long_about = help::STATUS_LONG_ABOUT)]
         #[command(after_help = help::STATUS_AFTER_HELP)]
         Status,
-        // TODO: Add `Space` subcommand with nested commands:
-        //   - `carry space list` - list all spaces in the site
-        //   - `carry space create [LABEL]` - create a new space
-        //   - `carry space switch <DID|LABEL>` - switch active space
-        //   - `carry space active` - show current active space
-        //   - `carry space delete <DID>` - delete a space (with confirmation)
-        // Infrastructure already exists in site.rs: list_spaces(), create_space(),
-        // set_active_space(), active_space_did(), etc.
+
+        /// Manage spaces within a .carry/ repository
+        #[command(long_about = help::SPACE_LONG_ABOUT)]
+        #[command(after_help = help::SPACE_AFTER_HELP)]
+        Space {
+            #[command(subcommand)]
+            command: SpaceCommands,
+        },
+    }
+
+    #[derive(Subcommand)]
+    pub enum SpaceCommands {
+        /// List all spaces in the site
+        List,
+
+        /// Create a new space
+        Create {
+            /// Label for the new space
+            #[arg(value_name = "LABEL")]
+            label: Option<String>,
+        },
+
+        /// Switch active space
+        Switch {
+            /// DID or label of the space to switch to
+            #[arg(value_name = "DID|LABEL")]
+            target: String,
+        },
+
+        /// Show current active space
+        Active,
+
+        /// Delete a space (cannot delete the active space)
+        Delete {
+            /// DID or label of the space to delete
+            #[arg(value_name = "DID|LABEL")]
+            target: String,
+
+            /// Skip confirmation prompt
+            #[arg(long, short)]
+            yes: bool,
+        },
     }
 }
 
@@ -117,6 +143,7 @@ use clap::Parser;
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let site_path = cli.site.as_deref().map(std::path::Path::new);
+    let space_flag = cli.space.as_deref();
     let format = &cli.format;
 
     match cli.command {
@@ -126,7 +153,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Query { target, fields } => {
             let parsed_target = carry::target::Target::parse(&target)?;
             let (parsed_fields, _this_entity) = carry::target::parse_fields(&fields)?;
-            let ctx = carry::site::SiteContext::resolve(site_path)?;
+            let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
             carry::query_cmd::execute(&ctx, parsed_target, parsed_fields, format).await?;
         }
         Commands::Assert {
@@ -135,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
             let (parsed_fields, this_entity) = carry::target::parse_fields(&fields)?;
-            let ctx = carry::site::SiteContext::resolve(site_path)?;
+            let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
             carry::assert_cmd::execute(&ctx, first_arg, this_entity, parsed_fields, format).await?;
         }
         Commands::Retract {
@@ -144,14 +171,281 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
             let (parsed_fields, this_entity) = carry::target::parse_fields(&fields)?;
-            let ctx = carry::site::SiteContext::resolve(site_path)?;
+            let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
             carry::retract_cmd::execute(&ctx, first_arg, this_entity, parsed_fields, format)
                 .await?;
         }
         Commands::Status => {
             carry::status_cmd::execute(site_path, format).await?;
         }
+        Commands::Space { command } => {
+            let site = carry::space_cmd::resolve_site(site_path)?;
+            match command {
+                SpaceCommands::List => {
+                    carry::space_cmd::list(&site, format).await?;
+                }
+                SpaceCommands::Create { label } => {
+                    carry::space_cmd::create(&site, label, format).await?;
+                }
+                SpaceCommands::Switch { target } => {
+                    carry::space_cmd::switch(&site, &target).await?;
+                }
+                SpaceCommands::Active => {
+                    carry::space_cmd::active(&site, format).await?;
+                }
+                SpaceCommands::Delete { target, yes } => {
+                    carry::space_cmd::delete(&site, &target, yes).await?;
+                }
+            }
+        }
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests — clap argument parsing
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use super::inner::*;
+    use clap::Parser;
+
+    // -- Query: --space not consumed by fields ------------------------------
+
+    #[test]
+    fn query_space_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "age",
+            "--space",
+            "test",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("test"));
+        match cli.command {
+            Commands::Query {
+                ref target,
+                ref fields,
+            } => {
+                assert_eq!(target, "com.app.person");
+                assert_eq!(fields, &["name", "age"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    #[test]
+    fn query_space_flag_before_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "--space",
+            "test",
+            "query",
+            "com.app.person",
+            "name",
+            "age",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("test"));
+        match cli.command {
+            Commands::Query {
+                ref target,
+                ref fields,
+            } => {
+                assert_eq!(target, "com.app.person");
+                assert_eq!(fields, &["name", "age"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    #[test]
+    fn query_space_flag_with_did() {
+        let did = "did:key:z6MkvSLQtPtAraTvgQwjz3ps9JBuY8a41STNikZ9bJdShNr6";
+        let cli = Cli::try_parse_from(["carry", "query", "com.app.person", "name", "--space", did])
+            .unwrap();
+        assert_eq!(cli.space.as_deref(), Some(did));
+        match cli.command {
+            Commands::Query { ref fields, .. } => {
+                assert_eq!(fields, &["name"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    // -- Query: --format not consumed by fields -----------------------------
+
+    #[test]
+    fn query_format_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert_eq!(cli.format, "json");
+        match cli.command {
+            Commands::Query { ref fields, .. } => {
+                assert_eq!(fields, &["name"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    // -- Query: --space and --format together -------------------------------
+
+    #[test]
+    fn query_space_and_format_flags_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "age",
+            "--space",
+            "research",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("research"));
+        assert_eq!(cli.format, "json");
+        match cli.command {
+            Commands::Query {
+                ref target,
+                ref fields,
+            } => {
+                assert_eq!(target, "com.app.person");
+                assert_eq!(fields, &["name", "age"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    // -- Assert: --space not consumed by fields -----------------------------
+
+    #[test]
+    fn assert_space_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "assert",
+            "com.app.person",
+            "name=Alice",
+            "age=28",
+            "--space",
+            "test",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("test"));
+        match cli.command {
+            Commands::Assert {
+                ref target_or_file,
+                ref fields,
+            } => {
+                assert_eq!(target_or_file, "com.app.person");
+                assert_eq!(fields, &["name=Alice", "age=28"]);
+            }
+            _ => panic!("Expected Assert command"),
+        }
+    }
+
+    #[test]
+    fn assert_format_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "assert",
+            "com.app.person",
+            "name=Alice",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert_eq!(cli.format, "json");
+        match cli.command {
+            Commands::Assert { ref fields, .. } => {
+                assert_eq!(fields, &["name=Alice"]);
+            }
+            _ => panic!("Expected Assert command"),
+        }
+    }
+
+    // -- Retract: --space not consumed by fields ----------------------------
+
+    #[test]
+    fn retract_space_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "retract",
+            "com.app.person",
+            "this=did:key:zAlice",
+            "age",
+            "--space",
+            "test",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("test"));
+        match cli.command {
+            Commands::Retract {
+                ref target_or_file,
+                ref fields,
+            } => {
+                assert_eq!(target_or_file, "com.app.person");
+                assert_eq!(fields, &["this=did:key:zAlice", "age"]);
+            }
+            _ => panic!("Expected Retract command"),
+        }
+    }
+
+    #[test]
+    fn retract_format_flag_after_fields() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "retract",
+            "com.app.person",
+            "this=did:key:zAlice",
+            "name",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert_eq!(cli.format, "json");
+        match cli.command {
+            Commands::Retract { ref fields, .. } => {
+                assert_eq!(fields, &["this=did:key:zAlice", "name"]);
+            }
+            _ => panic!("Expected Retract command"),
+        }
+    }
+
+    // -- Fields with = values still parse correctly -------------------------
+
+    #[test]
+    fn query_filter_fields_with_space_flag() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name=Alice",
+            "age",
+            "--space",
+            "my-space",
+        ])
+        .unwrap();
+        assert_eq!(cli.space.as_deref(), Some("my-space"));
+        match cli.command {
+            Commands::Query { ref fields, .. } => {
+                assert_eq!(fields, &["name=Alice", "age"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
 }

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -31,6 +31,7 @@ mod inner {
     #[derive(Subcommand)]
     pub enum Commands {
         /// Create a new .carry/ repository
+        #[command(alias = "i")]
         #[command(long_about = help::INIT_LONG_ABOUT)]
         #[command(after_help = help::INIT_AFTER_HELP)]
         Init {
@@ -40,6 +41,7 @@ mod inner {
         },
 
         /// Query entities by domain or concept
+        #[command(alias = "q")]
         #[command(long_about = help::QUERY_LONG_ABOUT)]
         #[command(after_help = help::QUERY_AFTER_HELP)]
         Query {
@@ -54,6 +56,7 @@ mod inner {
         },
 
         /// Assert claims on entities
+        #[command(alias = "a")]
         #[command(long_about = help::ASSERT_LONG_ABOUT)]
         #[command(after_help = help::ASSERT_AFTER_HELP)]
         Assert {
@@ -68,6 +71,7 @@ mod inner {
         },
 
         /// Retract claims from entities
+        #[command(alias = "r")]
         #[command(long_about = help::RETRACT_LONG_ABOUT)]
         #[command(after_help = help::RETRACT_AFTER_HELP)]
         Retract {
@@ -82,11 +86,13 @@ mod inner {
         },
 
         /// Show current site and space information
+        #[command(alias = "st")]
         #[command(long_about = help::STATUS_LONG_ABOUT)]
         #[command(after_help = help::STATUS_AFTER_HELP)]
         Status,
 
         /// Manage spaces within a .carry/ repository
+        #[command(alias = "s")]
         #[command(long_about = help::SPACE_LONG_ABOUT)]
         #[command(after_help = help::SPACE_AFTER_HELP)]
         Space {
@@ -98,9 +104,11 @@ mod inner {
     #[derive(Subcommand)]
     pub enum SpaceCommands {
         /// List all spaces in the site
+        #[command(alias = "l")]
         List,
 
         /// Create a new space
+        #[command(alias = "c")]
         Create {
             /// Label for the new space
             #[arg(value_name = "LABEL")]
@@ -108,6 +116,7 @@ mod inner {
         },
 
         /// Switch active space
+        #[command(alias = "s")]
         Switch {
             /// DID or label of the space to switch to
             #[arg(value_name = "DID|LABEL")]
@@ -115,9 +124,11 @@ mod inner {
         },
 
         /// Show current active space
+        #[command(alias = "a")]
         Active,
 
         /// Delete a space (cannot delete the active space)
+        #[command(alias = "d")]
         Delete {
             /// DID or label of the space to delete
             #[arg(value_name = "DID|LABEL")]

--- a/rust/carry/src/help.rs
+++ b/rust/carry/src/help.rs
@@ -8,7 +8,8 @@ organized into domains (namespaced like 'com.myapp.person') and can be grouped
 into concepts (reusable schemas). All data lives in a .carry/ repository.
 
 KEY CONCEPTS:
-  Space       A .carry/ repository containing your data
+  Site        A .carry/ repository containing your data
+  Space       An isolated namespace within a site, with its own identity
   Entity      Anything with an identity (has a DID like did:key:z...)
   Claim       A single fact: the X of Y is Z
   Domain      A namespace for relations (e.g., 'com.myapp.person')
@@ -65,9 +66,12 @@ For detailed help on any command: carry help <command>";
 pub const INIT_LONG_ABOUT: &str = "\
 Creates a new Dialog DB repository at .carry/ in the target directory.
 
-If --site is not specified, the repository is created in $PWD. If a repository 
-already exists at that location and a name is provided, the name is asserted 
-as the space label.
+If --site is not specified, the repository is created in $PWD. A first space
+is created automatically. If a name is provided, it is asserted as the space
+label.
+
+If a repository already exists, reports its status without creating another
+space. Use `carry space create` to add more spaces after initialization.
 
 The command generates an Ed25519 keypair for the space, creating a unique 
 space DID (e.g., did:key:zSpace). The private key is stored in 
@@ -132,6 +136,9 @@ EXAMPLES:
   # Output as JSON
   carry query person --format json
 
+  # Query in a different space (by label or DID)
+  carry query com.app.person name age --space research
+
 OUTPUT FORMAT (asserted notation):
   did:key:zAlice:
     com.app.person:
@@ -178,6 +185,9 @@ EXAMPLES:
 
   # Update an existing entity
   carry assert person this=did:key:zAlice age=29
+
+  # Assert into a specific space
+  carry assert com.app.person name=Alice --space research
 
   # Assert from a YAML file
   carry assert schema.yaml
@@ -232,6 +242,9 @@ EXAMPLES:
   # Retract using domain
   carry retract com.app.person this=did:key:zAlice name age
 
+  # Retract from a specific space
+  carry retract person this=did:key:zAlice age --space research
+
   # Retract from file
   carry retract retractions.yaml
 
@@ -264,3 +277,50 @@ OUTPUT:
   Site: /path/to/project/.carry/did:key:zSpace
   Space: did:key:zSpace
   Label: my-project";
+
+// -----------------------------------------------------------------------------
+// Space
+// -----------------------------------------------------------------------------
+
+pub const SPACE_LONG_ABOUT: &str = "\
+Manage spaces within a .carry/ repository.
+
+Spaces are isolated namespaces within a single carry repo, each with its own
+Ed25519 identity and data store. Use spaces to keep workstreams separate
+within the same project.
+
+Each space has a unique DID (e.g., did:key:z...) and an optional human-readable
+label. The active space is the default target for query, assert, and retract
+commands. Use --space <DID|LABEL> on any command to target a specific space
+without switching.";
+
+pub const SPACE_AFTER_HELP: &str = "\
+EXAMPLES:
+  # List all spaces
+  carry space list
+
+  # Create a new space with a label
+  carry space create research
+
+  # Switch to a space by label
+  carry space switch research
+
+  # Switch to a space by DID
+  carry space switch did:key:zAbc123
+
+  # Show current active space
+  carry space active
+
+  # Delete a space (with confirmation)
+  carry space delete research
+
+  # Delete without confirmation
+  carry space delete research --yes
+
+  # Query in a specific space without switching
+  carry query person --space research
+
+SPACE RESOLUTION:
+  Commands accept either a DID or a label to identify a space.
+  If a label matches multiple spaces, an error is returned —
+  use the DID to be specific.";

--- a/rust/carry/src/init.rs
+++ b/rust/carry/src/init.rs
@@ -1,15 +1,9 @@
 //! `carry init` — create a new `.carry/` repository.
 //!
-//! Creates a `.carry/` directory, generates an Ed25519 keypair, and
-//! initializes a space directory. Optionally asserts a label claim.
-//!
-//! # TODO: Behavior when site already has spaces
-//!
-//! Currently `carry init` reuses the first/active space if one exists.
-//! With multispace support, consider:
-//! - `carry init` with existing spaces could warn or prompt
-//! - `carry space create` becomes the explicit way to add spaces
-//! - `carry init` might only create the site, not a space, if spaces exist
+//! Creates a `.carry/` directory and a first space. Optionally asserts a
+//! label claim on the space. If a repository already exists, reports its
+//! status without creating additional spaces — use `carry space create`
+//! for that.
 
 use crate::schema;
 use crate::site::Site;
@@ -26,31 +20,40 @@ pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<(
         std::env::current_dir()?
     };
 
-    // Create or open the .carry/ directory
-    let site = if parent.join(".carry").is_dir() {
-        Site::open(&parent)?
-    } else {
-        Site::init(&parent)?
-    };
+    // If a .carry/ directory already exists, report status and return
+    if parent.join(".carry").is_dir() {
+        let site = Site::open(&parent)?;
+        let spaces = site.list_spaces()?;
+        let active_did = site.active_space_did()?;
 
-    // Check if there's already a space
-    let existing_spaces = site.list_spaces()?;
-
-    let space = if existing_spaces.is_empty() {
-        // Create a new space
-        let space = site.create_space()?;
-        site.set_active_space(&space.did)?;
-        space
-    } else {
-        // Use existing active space or first space
-        if let Ok(active) = site.active_space() {
-            active
-        } else {
-            let space = &existing_spaces[0];
-            site.set_active_space(&space.did)?;
-            space.clone()
+        println!("Repository already exists at {}", site.root().display());
+        println!(
+            "{} space{}",
+            spaces.len(),
+            if spaces.len() == 1 { "" } else { "s" }
+        );
+        if let Some(ref did) = active_did {
+            if let Some(space) = site.space_by_did(did) {
+                let label = site.space_label(&space).await.unwrap_or(None);
+                let label_display = label
+                    .as_ref()
+                    .map(|l| format!(" ({})", l))
+                    .unwrap_or_default();
+                println!("Active: {}{}", did, label_display);
+            } else {
+                println!("Active: {}", did);
+            }
         }
-    };
+        println!("\nUse `carry space create` to add more spaces.");
+        return Ok(());
+    }
+
+    // Create the .carry/ directory
+    let site = Site::init(&parent)?;
+
+    // Create the first space
+    let space = site.create_space()?;
+    site.set_active_space(&space.did)?;
 
     // If a name is provided, assert it as a label claim
     if let Some(ref label) = name {

--- a/rust/carry/src/lib.rs
+++ b/rust/carry/src/lib.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod query_cmd;
 pub mod retract_cmd;
 pub mod site;
+pub mod space_cmd;
 pub mod status_cmd;
 pub mod target;
 

--- a/rust/carry/src/site.rs
+++ b/rust/carry/src/site.rs
@@ -13,26 +13,22 @@
 //! The active space is tracked in `.carry/@active` (a plain-text file
 //! containing the space DID).
 //!
-//! # TODO: Expose multi-space support in CLI
-//!
-//! The infrastructure here already supports multiple spaces per site:
-//! - [`Site::list_spaces`] - enumerate all spaces
-//! - [`Site::create_space`] - create additional spaces
-//! - [`Site::set_active_space`] / [`Site::active_space_did`] - switch between spaces
-//! - [`Site::space_by_did`] - lookup by DID
-//!
-//! What's needed:
-//! 1. Add `carry space` subcommand in `bin/carry.rs` (see TODO there)
-//! 2. Add label storage for spaces (currently only xyz.tonk.carry/label on init)
-//! 3. Consider: space_by_label() lookup for `carry space switch my-label`
-//! 4. Consider: delete_space() with safety checks (no active, confirm prompt)
+//! Multi-space support is exposed via `carry space` subcommands:
+//! - `carry space list` — enumerate all spaces with labels
+//! - `carry space create [LABEL]` — create additional spaces
+//! - `carry space switch <DID|LABEL>` — switch active space
+//! - `carry space active` — show current active space
+//! - `carry space delete <DID|LABEL>` — delete a space (with confirmation)
 
+use crate::schema;
 use anyhow::{Context, Result};
 use dialog_artifacts::repository::{BranchId, Credentials, Repository};
 use dialog_query::Session;
+use dialog_query::claim::Attribute as ClaimAttribute;
 use ed25519_dalek::SigningKey;
 use rand_0_8::rngs::OsRng;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use tonk_space::{FsBackend, Operator};
 
 /// Marker file for the active space within a `.carry/` directory.
@@ -213,6 +209,62 @@ impl Site {
             .with_context(|| format!("Active space {} not found on disk", did))
     }
 
+    /// Resolve a space by DID or label.
+    ///
+    /// If `id` starts with `did:key:`, looks up by DID directly.
+    /// Otherwise, treats `id` as a label and searches all spaces for a
+    /// matching `xyz.tonk.carry/label` claim.
+    pub async fn resolve_space(&self, id: &str) -> Result<SpaceRef> {
+        if id.starts_with("did:key:") {
+            return self
+                .space_by_did(id)
+                .with_context(|| format!("No space found with DID {}", id));
+        }
+        // Search by label
+        let spaces = self.list_spaces()?;
+        let mut matches = Vec::new();
+        for space in &spaces {
+            if let Some(label) = self.space_label(space).await?
+                && label == id
+            {
+                matches.push(space.clone());
+            }
+        }
+        match matches.len() {
+            0 => anyhow::bail!("No space found with label '{}'", id),
+            1 => Ok(matches.into_iter().next().unwrap()),
+            n => anyhow::bail!(
+                "Ambiguous: {} spaces match label '{}'. Use a DID to be specific.",
+                n,
+                id
+            ),
+        }
+    }
+
+    /// Read the label for a space from its `xyz.tonk.carry/label` claim.
+    ///
+    /// Opens the space's session, queries for the label on the well-known
+    /// `derive_entity("space")` entity. Returns `None` if no label is set.
+    pub async fn space_label(&self, space: &SpaceRef) -> Result<Option<String>> {
+        let entity = schema::derive_entity("space")?;
+        let attr = ClaimAttribute::from_str("xyz.tonk.carry/label")
+            .map_err(|e| anyhow::anyhow!("Invalid attribute: {:?}", e))?;
+        let session = space.open_session().await?;
+        let label = schema::fetch_string(&session, &entity, attr).await?;
+        Ok(label)
+    }
+
+    /// Delete a space directory from disk.
+    ///
+    /// Removes the entire space directory. Caller is responsible for
+    /// checking that this is not the active space and confirming with the
+    /// user before calling this method.
+    pub fn delete_space(&self, space: &SpaceRef) -> Result<()> {
+        std::fs::remove_dir_all(space.dir())
+            .with_context(|| format!("Failed to delete space at {}", space.dir().display()))?;
+        Ok(())
+    }
+
     /// Create a new space: generate an Ed25519 keypair, create the directory
     /// structure, and write the credentials file.
     ///
@@ -350,11 +402,17 @@ pub struct SiteContext {
 }
 
 impl SiteContext {
-    /// Resolve from an optional `--site` flag. Discovers the site, then
-    /// loads the active space.
-    pub fn resolve(site_flag: Option<&Path>) -> Result<Self> {
+    /// Resolve from optional `--site` and `--space` flags.
+    ///
+    /// If `space_flag` is provided, resolves the space by DID or label
+    /// (requires async for label lookup). Otherwise uses the active space.
+    pub async fn resolve(site_flag: Option<&Path>, space_flag: Option<&str>) -> Result<Self> {
         let site = Site::resolve(site_flag)?;
-        let space = site.active_space()?;
+        let space = if let Some(space_id) = space_flag {
+            site.resolve_space(space_id).await?
+        } else {
+            site.active_space()?
+        };
         Ok(Self { site, space })
     }
 
@@ -482,5 +540,130 @@ mod tests {
 
         // Should successfully open a session (creates the prolly tree storage)
         let _session = space.open_session().await.unwrap();
+    }
+
+    // -- Helper: assert a label claim on a space ----------------------------
+
+    async fn assert_label(space: &SpaceRef, label: &str) {
+        use dialog_query::claim::{Claim, Relation};
+        let mut session = space.open_session().await.unwrap();
+        let entity = crate::schema::derive_entity("space").unwrap();
+        let attr = ClaimAttribute::from_str("xyz.tonk.carry/label").unwrap();
+        let value = dialog_query::Value::String(label.to_string());
+        let relation = Relation::new(attr, entity, value);
+        let mut tx = session.edit();
+        relation.assert(&mut tx);
+        session.commit(tx).await.unwrap();
+    }
+
+    // -- resolve_space tests ------------------------------------------------
+
+    #[tokio::test]
+    async fn test_resolve_space_by_did() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space = site.create_space().unwrap();
+
+        let resolved = site.resolve_space(&space.did).await.unwrap();
+        assert_eq!(resolved.did, space.did);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_space_by_label() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space = site.create_space().unwrap();
+        assert_label(&space, "my-space").await;
+
+        let resolved = site.resolve_space("my-space").await.unwrap();
+        assert_eq!(resolved.did, space.did);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_space_ambiguous_label() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space1 = site.create_space().unwrap();
+        let space2 = site.create_space().unwrap();
+        assert_label(&space1, "shared-label").await;
+        assert_label(&space2, "shared-label").await;
+
+        let result = site.resolve_space("shared-label").await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Ambiguous"),
+            "Expected 'Ambiguous' in error, got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_space_nonexistent_did() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let _space = site.create_space().unwrap();
+
+        let result = site.resolve_space("did:key:zBogus").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_space_nonexistent_label() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let _space = site.create_space().unwrap();
+
+        let result = site.resolve_space("no-such-label").await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("No space found with label"),
+            "Expected label-not-found error, got: {}",
+            err_msg
+        );
+    }
+
+    // -- space_label tests --------------------------------------------------
+
+    #[tokio::test]
+    async fn test_space_label_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space = site.create_space().unwrap();
+        assert_label(&space, "test-label").await;
+
+        let label = site.space_label(&space).await.unwrap();
+        assert_eq!(label, Some("test-label".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_space_label_none() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space = site.create_space().unwrap();
+
+        let label = site.space_label(&space).await.unwrap();
+        assert_eq!(label, None);
+    }
+
+    // -- delete_space tests -------------------------------------------------
+
+    #[tokio::test]
+    async fn test_delete_space_removes_dir() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let space = site.create_space().unwrap();
+        let space_dir = space.dir().to_path_buf();
+
+        // Verify directory exists before delete
+        assert!(space_dir.exists());
+        assert_eq!(site.list_spaces().unwrap().len(), 1);
+
+        site.delete_space(&space).unwrap();
+
+        // Verify directory is gone
+        assert!(!space_dir.exists());
+        assert_eq!(site.list_spaces().unwrap().len(), 0);
     }
 }

--- a/rust/carry/src/space_cmd.rs
+++ b/rust/carry/src/space_cmd.rs
@@ -1,0 +1,220 @@
+//! `carry space` — manage spaces within a `.carry/` repository.
+//!
+//! Spaces are isolated namespaces within a single carry repo, each with
+//! its own Ed25519 identity and data store. Use spaces to keep workstreams
+//! separate within the same project.
+
+use crate::schema;
+use crate::site::Site;
+use anyhow::Result;
+use dialog_query::claim::{Attribute as ClaimAttribute, Claim, Relation};
+use std::io::{self, Write};
+use std::path::Path;
+use std::str::FromStr;
+
+/// Execute `carry space list`.
+pub async fn list(site: &Site, format: &str) -> Result<()> {
+    let spaces = site.list_spaces()?;
+    let active_did = site.active_space_did()?;
+
+    if spaces.is_empty() {
+        println!("No spaces. Run `carry space create` or `carry init` to create one.");
+        return Ok(());
+    }
+
+    // Collect labels for all spaces
+    let mut entries = Vec::new();
+    for space in &spaces {
+        let label = site.space_label(space).await.unwrap_or(None);
+        let is_active = active_did.as_deref() == Some(&space.did);
+        entries.push((space, label, is_active));
+    }
+
+    match format {
+        "json" => {
+            let space_list: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|(space, label, is_active)| {
+                    let mut obj = serde_json::json!({
+                        "did": space.did,
+                        "active": is_active,
+                    });
+                    if let Some(label) = label {
+                        obj["label"] = serde_json::Value::String(label.clone());
+                    }
+                    obj
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&space_list)?);
+        }
+        _ => {
+            for (space, label, is_active) in &entries {
+                let active_marker = if *is_active { "* " } else { "  " };
+                let label_display = label
+                    .as_ref()
+                    .map(|l| format!(" ({})", l))
+                    .unwrap_or_default();
+                println!("{}{}{}", active_marker, space.did, label_display);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `carry space create [LABEL]`.
+pub async fn create(site: &Site, label: Option<String>, format: &str) -> Result<()> {
+    let space = site.create_space()?;
+    site.set_active_space(&space.did)?;
+
+    // If a label is provided, assert it as a claim
+    if let Some(ref label_str) = label {
+        let mut session = space.open_session().await?;
+        let entity = schema::derive_entity("space")?;
+        let attr = ClaimAttribute::from_str("xyz.tonk.carry/label")
+            .map_err(|e| anyhow::anyhow!("Invalid attribute: {:?}", e))?;
+        let value = dialog_query::Value::String(label_str.clone());
+        let relation = Relation::new(attr, entity, value);
+        let mut transaction = session.edit();
+        relation.assert(&mut transaction);
+        session.commit(transaction).await?;
+    }
+
+    match format {
+        "json" => {
+            let mut obj = serde_json::json!({
+                "did": space.did,
+                "active": true,
+            });
+            if let Some(ref label_str) = label {
+                obj["label"] = serde_json::Value::String(label_str.clone());
+            }
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+        _ => {
+            let label_display = label
+                .as_ref()
+                .map(|l| format!(" ({})", l))
+                .unwrap_or_default();
+            println!("Created space {}{}", space.did, label_display);
+            println!("Switched to new space (now active)");
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `carry space switch <DID|LABEL>`.
+pub async fn switch(site: &Site, target: &str) -> Result<()> {
+    let space = site.resolve_space(target).await?;
+
+    // Check if already active
+    if let Some(current) = site.active_space_did()?
+        && current == space.did
+    {
+        let label = site.space_label(&space).await.unwrap_or(None);
+        let label_display = label
+            .as_ref()
+            .map(|l| format!(" ({})", l))
+            .unwrap_or_default();
+        println!("Already on space {}{}", space.did, label_display);
+        return Ok(());
+    }
+
+    site.set_active_space(&space.did)?;
+    let label = site.space_label(&space).await.unwrap_or(None);
+    let label_display = label
+        .as_ref()
+        .map(|l| format!(" ({})", l))
+        .unwrap_or_default();
+    println!("Switched to space {}{}", space.did, label_display);
+
+    Ok(())
+}
+
+/// Execute `carry space active`.
+pub async fn active(site: &Site, format: &str) -> Result<()> {
+    let active_did = site.active_space_did()?;
+
+    match active_did {
+        None => {
+            println!("No active space. Run `carry space create` or `carry init` to create one.");
+        }
+        Some(ref did) => {
+            let space = site
+                .space_by_did(did)
+                .with_context(|| format!("Active space {} not found on disk", did))?;
+            let label = site.space_label(&space).await.unwrap_or(None);
+
+            match format {
+                "json" => {
+                    let mut obj = serde_json::json!({
+                        "did": space.did,
+                    });
+                    if let Some(ref label_str) = label {
+                        obj["label"] = serde_json::Value::String(label_str.clone());
+                    }
+                    println!("{}", serde_json::to_string_pretty(&obj)?);
+                }
+                _ => {
+                    let label_display = label
+                        .as_ref()
+                        .map(|l| format!(" ({})", l))
+                        .unwrap_or_default();
+                    println!("{}{}", space.did, label_display);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `carry space delete <DID|LABEL> [--yes]`.
+pub async fn delete(site: &Site, target: &str, skip_confirm: bool) -> Result<()> {
+    let space = site.resolve_space(target).await?;
+
+    // Prevent deleting the active space
+    if let Some(active_did) = site.active_space_did()?
+        && active_did == space.did
+    {
+        anyhow::bail!(
+            "Cannot delete the active space. Switch to another space first:\n  carry space switch <DID|LABEL>"
+        );
+    }
+
+    let label = site.space_label(&space).await.unwrap_or(None);
+    let label_display = label
+        .as_ref()
+        .map(|l| format!(" ({})", l))
+        .unwrap_or_default();
+
+    if !skip_confirm {
+        print!(
+            "Delete space {}{}? This cannot be undone. [y/N] ",
+            space.did, label_display
+        );
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+        if input != "y" && input != "yes" {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    site.delete_space(&space)?;
+    println!("Deleted space {}{}", space.did, label_display);
+
+    Ok(())
+}
+
+use anyhow::Context as _;
+
+/// Resolve a `Site` from the optional `--site` flag, for space subcommands
+/// that only need site-level access (not a full `SiteContext`).
+pub fn resolve_site(site_flag: Option<&Path>) -> Result<Site> {
+    Site::resolve(site_flag)
+}

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the carry CLI.
+//! Integration tests for carry.
 //!
 //! These tests exercise the CLI through its library API, using isolated
 //! `.carry/` site directories for each test. Every test gets its own
@@ -75,7 +75,7 @@ async fn test_status_json() {
 #[tokio::test]
 async fn test_assert_and_query_domain() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Assert a person
     let target = FirstArg::Target(Target::Domain("io.test.person".to_string()));
@@ -113,7 +113,7 @@ async fn test_assert_and_query_domain() {
 #[tokio::test]
 async fn test_assert_multiple_entities() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Assert two different people
     let fields1 = vec![
@@ -174,7 +174,7 @@ async fn test_assert_multiple_entities() {
 #[tokio::test]
 async fn test_query_with_filter() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Assert two people
     for (name, age) in [("Alice", "28"), ("Bob", "35")] {
@@ -227,7 +227,7 @@ async fn test_query_with_filter() {
 #[tokio::test]
 async fn test_assert_with_this_entity() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // First assert to get an entity
     let fields = vec![Field {
@@ -274,7 +274,7 @@ async fn test_assert_with_this_entity() {
 #[tokio::test]
 async fn test_retract_specific_field() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Assert
     let fields = vec![
@@ -322,7 +322,7 @@ async fn test_retract_specific_field() {
 #[tokio::test]
 async fn test_retract_all_fields() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Assert
     let fields = vec![Field {
@@ -364,7 +364,7 @@ async fn test_retract_all_fields() {
 #[tokio::test]
 async fn test_assert_from_json_content() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     // Write a JSON file with triples
     let json_content = r#"[
@@ -400,7 +400,7 @@ async fn test_assert_from_json_content() {
 #[tokio::test]
 async fn test_assert_requires_fields() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     let result = carry::assert_cmd::execute(
         &ctx,
@@ -417,7 +417,7 @@ async fn test_assert_requires_fields() {
 #[tokio::test]
 async fn test_assert_requires_values() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     let result = carry::assert_cmd::execute(
         &ctx,
@@ -437,7 +437,7 @@ async fn test_assert_requires_values() {
 #[tokio::test]
 async fn test_retract_requires_this() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     let result = carry::retract_cmd::execute(
         &ctx,
@@ -461,7 +461,7 @@ async fn test_retract_requires_this() {
 #[tokio::test]
 async fn test_assert_json_format() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     let fields = vec![Field {
         name: "name".to_string(),
@@ -481,7 +481,7 @@ async fn test_assert_json_format() {
 #[tokio::test]
 async fn test_query_json_format() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = env.ctx();
+    let ctx = env.ctx().await;
 
     let fields = vec![Field {
         name: "name".to_string(),
@@ -534,6 +534,753 @@ async fn test_site_discovery() {
 #[tokio::test]
 async fn test_site_context_resolve() {
     let env = TestEnv::new().await.unwrap();
-    let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path())).unwrap();
+    let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), None)
+        .await
+        .unwrap();
     assert_eq!(ctx.space.did, env.space_did);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space — list
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_list_single() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Should list the single bootstrapped space without error
+    carry::space_cmd::list(&site, "yaml").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_space_list_multiple_with_labels() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create two more spaces with labels
+    carry::space_cmd::create(&site, Some("alpha".to_string()), "yaml")
+        .await
+        .unwrap();
+    carry::space_cmd::create(&site, Some("beta".to_string()), "yaml")
+        .await
+        .unwrap();
+
+    let spaces = site.list_spaces().unwrap();
+    assert_eq!(spaces.len(), 3, "Should have 3 spaces total");
+
+    // list should run without error
+    carry::space_cmd::list(&site, "yaml").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_space_list_json() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    carry::space_cmd::create(&site, Some("json-test".to_string()), "yaml")
+        .await
+        .unwrap();
+
+    // JSON list should run without error
+    carry::space_cmd::list(&site, "json").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_space_list_empty_site() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let site = carry::site::Site::init(tmp.path()).unwrap();
+
+    // No spaces created — list should run without error
+    carry::space_cmd::list(&site, "yaml").await.unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space — create
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_create_no_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+    let initial_count = site.list_spaces().unwrap().len();
+
+    carry::space_cmd::create(&site, None, "yaml").await.unwrap();
+
+    let spaces = site.list_spaces().unwrap();
+    assert_eq!(
+        spaces.len(),
+        initial_count + 1,
+        "Space count should increase by 1"
+    );
+}
+
+#[tokio::test]
+async fn test_space_create_with_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    carry::space_cmd::create(&site, Some("research".to_string()), "yaml")
+        .await
+        .unwrap();
+
+    // The new space is now active — retrieve it and check its label
+    let active = site.active_space().unwrap();
+    let label = site.space_label(&active).await.unwrap();
+    assert_eq!(label, Some("research".to_string()));
+}
+
+#[tokio::test]
+async fn test_space_create_switches_active() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+    let original_did = env.space_did.clone();
+
+    carry::space_cmd::create(&site, Some("new-space".to_string()), "yaml")
+        .await
+        .unwrap();
+
+    let active_did = site.active_space_did().unwrap().unwrap();
+    assert_ne!(
+        active_did, original_did,
+        "Active space should have changed to the newly created space"
+    );
+}
+
+#[tokio::test]
+async fn test_space_create_json() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // JSON create should run without error
+    carry::space_cmd::create(&site, Some("json-space".to_string()), "json")
+        .await
+        .unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space — switch
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_switch_by_did() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+    let original_did = env.space_did.clone();
+
+    // Create a second space (which becomes active)
+    carry::space_cmd::create(&site, None, "yaml").await.unwrap();
+    assert_ne!(site.active_space_did().unwrap().unwrap(), original_did);
+
+    // Switch back to original by DID
+    carry::space_cmd::switch(&site, &original_did)
+        .await
+        .unwrap();
+    assert_eq!(site.active_space_did().unwrap().unwrap(), original_did);
+}
+
+#[tokio::test]
+async fn test_space_switch_by_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+    let original_did = env.space_did.clone();
+
+    // Create a labeled space (becomes active)
+    carry::space_cmd::create(&site, Some("labeled".to_string()), "yaml")
+        .await
+        .unwrap();
+    let labeled_did = site.active_space_did().unwrap().unwrap();
+    assert_ne!(labeled_did, original_did);
+
+    // Switch back to original by DID
+    carry::space_cmd::switch(&site, &original_did)
+        .await
+        .unwrap();
+    assert_eq!(site.active_space_did().unwrap().unwrap(), original_did);
+
+    // Switch to labeled space by label
+    carry::space_cmd::switch(&site, "labeled").await.unwrap();
+    assert_eq!(site.active_space_did().unwrap().unwrap(), labeled_did);
+}
+
+#[tokio::test]
+async fn test_space_switch_already_active() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+    let original_did = env.space_did.clone();
+
+    // Switch to already-active space — should succeed (idempotent)
+    carry::space_cmd::switch(&site, &original_did)
+        .await
+        .unwrap();
+    assert_eq!(site.active_space_did().unwrap().unwrap(), original_did);
+}
+
+#[tokio::test]
+async fn test_space_switch_nonexistent() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    let result = carry::space_cmd::switch(&site, "no-such-space").await;
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space — active
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_active_shows_current() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Should run without error when active space exists
+    carry::space_cmd::active(&site, "yaml").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_space_active_json() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    carry::space_cmd::active(&site, "json").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_space_active_none() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let site = carry::site::Site::init(tmp.path()).unwrap();
+    let _space = site.create_space().unwrap();
+    // Don't set active — @active marker is absent
+
+    // Should run without error, printing a helpful message
+    carry::space_cmd::active(&site, "yaml").await.unwrap();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space — delete
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_delete_by_did() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a second space (becomes active)
+    carry::space_cmd::create(&site, None, "yaml").await.unwrap();
+    let new_active_did = site.active_space_did().unwrap().unwrap();
+    assert_eq!(site.list_spaces().unwrap().len(), 2);
+
+    // Switch back to original so we can delete the new one
+    carry::space_cmd::switch(&site, &env.space_did)
+        .await
+        .unwrap();
+
+    // Delete the second space by DID (skip confirmation)
+    carry::space_cmd::delete(&site, &new_active_did, true)
+        .await
+        .unwrap();
+
+    let spaces = site.list_spaces().unwrap();
+    assert_eq!(spaces.len(), 1);
+    assert_eq!(spaces[0].did, env.space_did);
+}
+
+#[tokio::test]
+async fn test_space_delete_by_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a labeled space (becomes active)
+    carry::space_cmd::create(&site, Some("to-delete".to_string()), "yaml")
+        .await
+        .unwrap();
+    assert_eq!(site.list_spaces().unwrap().len(), 2);
+
+    // Switch back to original
+    carry::space_cmd::switch(&site, &env.space_did)
+        .await
+        .unwrap();
+
+    // Delete by label (skip confirmation)
+    carry::space_cmd::delete(&site, "to-delete", true)
+        .await
+        .unwrap();
+
+    let spaces = site.list_spaces().unwrap();
+    assert_eq!(spaces.len(), 1);
+    assert_eq!(spaces[0].did, env.space_did);
+}
+
+#[tokio::test]
+async fn test_space_delete_active_fails() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Try to delete the active space — should fail
+    let result = carry::space_cmd::delete(&site, &env.space_did, true).await;
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Cannot delete the active space"),
+        "Expected 'Cannot delete the active space' error, got: {}",
+        err_msg
+    );
+
+    // Space should still exist
+    assert_eq!(site.list_spaces().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_space_delete_nonexistent() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    let result = carry::space_cmd::delete(&site, "no-such-space", true).await;
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// --space flag (SiteContext resolution)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_flag_resolve_by_did() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a second space
+    let space2 = site.create_space().unwrap();
+
+    let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&space2.did))
+        .await
+        .unwrap();
+    assert_eq!(ctx.space.did, space2.did);
+}
+
+#[tokio::test]
+async fn test_space_flag_resolve_by_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a labeled space via the create command
+    carry::space_cmd::create(&site, Some("flagged".to_string()), "yaml")
+        .await
+        .unwrap();
+    let labeled_did = site.active_space_did().unwrap().unwrap();
+
+    // Switch back to original
+    site.set_active_space(&env.space_did).unwrap();
+
+    // Resolve by label via --space flag
+    let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("flagged"))
+        .await
+        .unwrap();
+    assert_eq!(ctx.space.did, labeled_did);
+}
+
+#[tokio::test]
+async fn test_space_flag_overrides_active() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a second space
+    let space2 = site.create_space().unwrap();
+
+    // Active is still the original (TestEnv sets it)
+    assert_eq!(site.active_space_did().unwrap().unwrap(), env.space_did);
+
+    // Resolve with --space pointing to space2 — should override active
+    let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&space2.did))
+        .await
+        .unwrap();
+    assert_eq!(ctx.space.did, space2.did);
+    assert_ne!(ctx.space.did, env.space_did);
+
+    // Active should not have changed (--space is read-only, doesn't switch)
+    assert_eq!(site.active_space_did().unwrap().unwrap(), env.space_did);
+}
+
+#[tokio::test]
+async fn test_space_flag_nonexistent_errors() {
+    let env = TestEnv::new().await.unwrap();
+
+    let result =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("nonexistent-space"))
+            .await;
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Space data isolation
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_space_data_isolation() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Assert data in the original space
+    let ctx_a =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&env.space_did))
+            .await
+            .unwrap();
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("28".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx_a,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify data is visible in space A
+    let query_fields = vec![Field {
+        name: "name".to_string(),
+        value: None,
+    }];
+    // Query in space A should succeed (data exists)
+    carry::query_cmd::execute(
+        &ctx_a,
+        Target::Domain("io.test.person".to_string()),
+        query_fields.clone(),
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Create space B and resolve a context for it
+    carry::space_cmd::create(&site, Some("space-b".to_string()), "yaml")
+        .await
+        .unwrap();
+    let ctx_b = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("space-b"))
+        .await
+        .unwrap();
+    assert_ne!(ctx_b.space.did, ctx_a.space.did);
+
+    // Query the same domain in space B — should find no entities
+    // (query_cmd returns Ok even with no results, it just prints nothing)
+    carry::query_cmd::execute(
+        &ctx_b,
+        Target::Domain("io.test.person".to_string()),
+        query_fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify space B has no data by checking at the session level
+    let session_b = ctx_b.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let entities = carry::schema::find_entities_by_attribute(&session_b, attr)
+        .await
+        .unwrap();
+    assert!(
+        entities.is_empty(),
+        "Space B should have no io.test.person entities, but found {}",
+        entities.len()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cross-space query/assert/retract via --space flag (regression tests)
+//
+// These tests reproduce the bug where --space was silently consumed by
+// trailing_var_arg on the fields positional, so --space had no effect.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Assert data in one space, switch to another, then query with --space flag
+/// pointing back to the original. Verifies data is returned (not silently
+/// ignored).
+#[tokio::test]
+async fn test_space_flag_cross_space_query() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Assert data in the default space (space A)
+    let ctx_a = env.ctx().await;
+    let fields_a = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("30".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx_a,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        fields_a,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Create space B and switch to it (so space A is no longer active)
+    carry::space_cmd::create(&site, Some("space-b".to_string()), "yaml")
+        .await
+        .unwrap();
+    // space B is now active
+    let active = site.active_space_did().unwrap().unwrap();
+    assert_ne!(active, env.space_did, "Should have switched to space B");
+
+    // Query with --space pointing to space A by DID
+    let ctx_via_flag =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&env.space_did))
+            .await
+            .unwrap();
+    assert_eq!(
+        ctx_via_flag.space.did, env.space_did,
+        "--space flag should resolve to space A"
+    );
+
+    // Verify the data is actually accessible through this context
+    let session = ctx_via_flag.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let entities = carry::schema::find_entities_by_attribute(&session, attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        entities.len(),
+        1,
+        "Should find 1 entity in space A via --space flag, but found {}",
+        entities.len()
+    );
+}
+
+/// Assert data in one space, switch to another, then query with --space flag
+/// using a label (not DID). Verifies label-based resolution works.
+#[tokio::test]
+async fn test_space_flag_cross_space_query_by_label() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create a labeled space and assert data into it
+    carry::space_cmd::create(&site, Some("labeled".to_string()), "yaml")
+        .await
+        .unwrap();
+    let labeled_did = site.active_space_did().unwrap().unwrap();
+
+    let ctx_labeled =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("labeled"))
+            .await
+            .unwrap();
+    let fields = vec![Field {
+        name: "title".to_string(),
+        value: Some("Engineer".to_string()),
+    }];
+    carry::assert_cmd::execute(
+        &ctx_labeled,
+        FirstArg::Target(Target::Domain("io.test.role".to_string())),
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Switch back to the original space
+    site.set_active_space(&env.space_did).unwrap();
+    assert_eq!(
+        site.active_space_did().unwrap().unwrap(),
+        env.space_did,
+        "Should be back on original space"
+    );
+
+    // Query with --space "labeled" (by label, not DID)
+    let ctx_via_label =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("labeled"))
+            .await
+            .unwrap();
+    assert_eq!(ctx_via_label.space.did, labeled_did);
+
+    // Verify data is accessible
+    let session = ctx_via_label.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let attr = ClaimAttribute::from_str("io.test.role/title").unwrap();
+    let entities = carry::schema::find_entities_by_attribute(&session, attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        entities.len(),
+        1,
+        "Should find 1 entity in labeled space via --space flag"
+    );
+}
+
+/// Assert into a non-active space using --space flag, then verify the data
+/// landed in the correct space.
+#[tokio::test]
+async fn test_space_flag_cross_space_assert() {
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create space B
+    carry::space_cmd::create(&site, Some("target".to_string()), "yaml")
+        .await
+        .unwrap();
+    let target_did = site.active_space_did().unwrap().unwrap();
+
+    // Switch back to original space
+    site.set_active_space(&env.space_did).unwrap();
+
+    // Assert into space B via --space flag (while space A is active)
+    let ctx_target =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("target"))
+            .await
+            .unwrap();
+    assert_eq!(ctx_target.space.did, target_did);
+
+    let fields = vec![Field {
+        name: "color".to_string(),
+        value: Some("blue".to_string()),
+    }];
+    carry::assert_cmd::execute(
+        &ctx_target,
+        FirstArg::Target(Target::Domain("io.test.pref".to_string())),
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Active space should still be space A (--space doesn't switch)
+    assert_eq!(site.active_space_did().unwrap().unwrap(), env.space_did);
+
+    // Verify data is NOT in space A
+    let session_a = env.ctx().await.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let attr = ClaimAttribute::from_str("io.test.pref/color").unwrap();
+    let entities_a = carry::schema::find_entities_by_attribute(&session_a, attr.clone())
+        .await
+        .unwrap();
+    assert!(
+        entities_a.is_empty(),
+        "Space A should have no io.test.pref data"
+    );
+
+    // Verify data IS in space B
+    let session_b = ctx_target.open_session().await.unwrap();
+    let entities_b = carry::schema::find_entities_by_attribute(&session_b, attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        entities_b.len(),
+        1,
+        "Space B should have 1 entity via --space assert"
+    );
+}
+
+/// Retract from a non-active space using --space flag.
+#[tokio::test]
+async fn test_space_flag_cross_space_retract() {
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let env = TestEnv::new().await.unwrap();
+    let site = env.site();
+
+    // Create space B, assert data into it
+    carry::space_cmd::create(&site, Some("retract-target".to_string()), "yaml")
+        .await
+        .unwrap();
+    let target_did = site.active_space_did().unwrap().unwrap();
+
+    let ctx_b = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&target_did))
+        .await
+        .unwrap();
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Bob".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("40".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx_b,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Find the entity DID that was just created
+    let session_b = ctx_b.open_session().await.unwrap();
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let entities = carry::schema::find_entities_by_attribute(&session_b, name_attr.clone())
+        .await
+        .unwrap();
+    assert_eq!(entities.len(), 1);
+    let entity_did = entities[0].to_string();
+
+    // Switch to space A
+    site.set_active_space(&env.space_did).unwrap();
+
+    // Retract from space B via --space flag
+    let ctx_retract =
+        carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some("retract-target"))
+            .await
+            .unwrap();
+    assert_eq!(ctx_retract.space.did, target_did);
+
+    let retract_fields = vec![Field {
+        name: "age".to_string(),
+        value: None,
+    }];
+    carry::retract_cmd::execute(
+        &ctx_retract,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        Some(entity_did),
+        retract_fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify age was retracted in space B
+    let session_b2 = ctx_retract.open_session().await.unwrap();
+    let age_attr = ClaimAttribute::from_str("io.test.person/age").unwrap();
+    let age_entities = carry::schema::find_entities_by_attribute(&session_b2, age_attr)
+        .await
+        .unwrap();
+    assert!(
+        age_entities.is_empty(),
+        "Age should have been retracted from space B"
+    );
+
+    // But name should still exist
+    let name_entities = carry::schema::find_entities_by_attribute(&session_b2, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        name_entities.len(),
+        1,
+        "Name should still exist in space B after retracting age"
+    );
 }

--- a/rust/carry/tests/common.rs
+++ b/rust/carry/tests/common.rs
@@ -53,8 +53,10 @@ impl TestEnv {
     }
 
     /// Resolve a `SiteContext` for use in commands.
-    pub fn ctx(&self) -> carry::site::SiteContext {
-        carry::site::SiteContext::resolve(Some(self.site_path.as_path())).unwrap()
+    pub async fn ctx(&self) -> carry::site::SiteContext {
+        carry::site::SiteContext::resolve(Some(self.site_path.as_path()), None)
+            .await
+            .unwrap()
     }
 
     /// Get path to a specific example YAML file.


### PR DESCRIPTION
After streamlining the `carry` CLI, the backend maintained support for multiple spaces per `.carry` repository, but the CLI didn't surface this functionality.

This change exposes a `carry space` command that allows users to create, list, switch, and delete spaces within a repo.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces multi-space support in the `carry` CLI, enhancing the ability to manage separate workspaces within a `.carry/` repository. It adds new commands for creating, switching, and deleting spaces, while also updating related functions for asynchronous context resolution.

### Detailed summary
- Added `pub mod space_cmd;` to `rust/carry/src/lib.rs`.
- Updated `ctx` function in `rust/carry/tests/common.rs` to be asynchronous.
- Modified `.github/workflows/cli.yml` for artifact naming changes.
- Created `carry space` commands for managing spaces:
  - `list`, `create`, `switch`, `active`, and `delete`.
- Enhanced `SiteContext` to resolve spaces by DID or label.
- Updated documentation and help messages for clarity.
- Added integration tests for space management functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->