### PR TITLE
feat(cli): improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "blake3",
  "bs58",
  "clap",
+ "clap_complete",
  "dialog-artifacts",
  "dialog-query",
  "dialog-varsig",
@@ -580,8 +581,20 @@ checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.7",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -601,6 +614,12 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -2205,6 +2224,15 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "wasmbind",
 ] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = { version = "4", features = ["unstable-dynamic"] }
 console_error_panic_hook = "0.1"
 crypto-common = "=0.2.0-rc.5"
 dialoguer = "0.11"

--- a/rust/carry/Cargo.toml
+++ b/rust/carry/Cargo.toml
@@ -1,54 +1,54 @@
 [package]
 name = "carry"
-description = "Carry - interact with Dialog DB spaces"
 version.workspace = true
-edition.workspace = true
 authors.workspace = true
+edition.workspace = true
+description = "Carry - interact with Dialog DB spaces"
 license.workspace = true
 
 [[bin]]
 name = "carry"
 path = "src/bin/carry.rs"
 
-[features]
-default = []
-
 [dependencies]
 
+[dev-dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # CLI
 clap = { workspace = true, features = ["derive"] }
+clap_complete = { workspace = true }
 
 # Tonk packages
 tonk-space = { workspace = true }
 
+dialog-artifacts = { workspace = true }
 # Dialog DB
 dialog-query = { workspace = true }
-dialog-artifacts = { workspace = true }
 dialog-varsig = { workspace = true }
 
 # Async
 futures-util = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
+blake3 = { workspace = true }
+bs58 = { workspace = true }
 # Crypto
 ed25519-dalek = { workspace = true }
 rand_0_8 = { workspace = true }
-bs58 = { workspace = true }
-blake3 = { workspace = true }
 
+base64 = { workspace = true }
 # Serialization
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-base64 = { workspace = true }
 
 # Utilities
 anyhow = { workspace = true }
 dirs = { workspace = true }
 
-[dev-dependencies]
-tempfile = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-anyhow = { workspace = true }
-serde_json = { workspace = true }
+[features]
+default = []

--- a/rust/carry/src/assert_cmd.rs
+++ b/rust/carry/src/assert_cmd.rs
@@ -1,35 +1,35 @@
 //! `carry assert` — assert claims on entities.
 //!
-//! Supports domain targets, concept targets, file input, and stdin.
+//! Supports domain targets, concept targets (both builtin and user-defined),
+//! file input, and stdin.
 //!
-//! # TODO: Support asserted notation for file/stdin input
+//! ## Concept assertion sugar
 //!
-//! Currently file/stdin input requires formal triple format: `[{the, of, is}, ...]`
-//! The spec says asserted notation (entity -> context -> fields) should also work,
-//! enabling round-trip: `carry query ... | carry assert -`
+//! Builtin concepts (`attribute`, `concept`, `bookmark`) have special handling:
+//! - Fields are mapped through the builtin schema (e.g. `the` → `dialog.attribute/id`)
+//! - Variable-keyed fields (e.g. `with.name=...`) are expanded
+//! - `@name` asserts `dialog.meta/name` on the entity
 //!
-//! To implement:
-//! 1. Detect if input is asserted notation (map with entity keys) vs formal triples
-//! 2. If asserted notation, expand to triples:
-//!    - Level 1 key = entity (DID or `_` for anonymous)
-//!    - Level 2 key = context (domain if contains `.`, concept if not)
-//!    - Level 3 = field/value pairs -> expand to `{the: context/field, of: entity, is: value}`
-//! 3. Handle concept context by resolving bookmarked concept to get attribute relations
-//! 4. Handle nested entities (non-scalar values at level 3)
+//! User-defined concepts resolve via `dialog.meta/name` → concept entity →
+//! `dialog.concept.with/*` claims → attribute selectors.
 
 use crate::schema;
 use crate::site::SiteContext;
 use crate::target::{Field, FirstArg, Target};
 use anyhow::{Context, Result};
 use dialog_artifacts::{Artifact, ArtifactStoreMut, Instruction};
+use dialog_query::Attribute;
+use dialog_query::Value;
 use dialog_query::claim::{Claim, Relation};
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
-/// Execute `carry assert <TARGET>|<FILE>|- [this=<ENTITY>] [FIELD=VALUE...]`.
+/// Execute `carry assert <TARGET>|<FILE>|- [this=<ENTITY>] [@name] [FIELD=VALUE...]`.
 pub async fn execute(
     ctx: &SiteContext,
     first_arg: FirstArg,
     this_entity: Option<String>,
+    entity_name: Option<String>,
     fields: Vec<Field>,
     format: &str,
 ) -> Result<()> {
@@ -37,7 +37,7 @@ pub async fn execute(
         FirstArg::Stdin => assert_from_stdin(ctx, format).await,
         FirstArg::File(path) => assert_from_file(ctx, &path, format).await,
         FirstArg::Target(target) => {
-            assert_with_target(ctx, target, this_entity, fields, format).await
+            assert_with_target(ctx, target, this_entity, entity_name, fields, format).await
         }
     }
 }
@@ -47,6 +47,7 @@ async fn assert_with_target(
     ctx: &SiteContext,
     target: Target,
     this_entity: Option<String>,
+    entity_name: Option<String>,
     fields: Vec<Field>,
     format: &str,
 ) -> Result<()> {
@@ -54,8 +55,34 @@ async fn assert_with_target(
         anyhow::bail!("At least one FIELD=VALUE pair is required for assert");
     }
 
+    match target {
+        Target::Domain(ref domain) => {
+            assert_domain(ctx, domain, this_entity, entity_name, &fields, format).await
+        }
+        Target::Concept(ref concept_name) => {
+            // Check if it's a builtin concept first
+            if let Some(builtin) = schema::lookup_builtin(concept_name) {
+                assert_builtin_concept(ctx, builtin, this_entity, entity_name, &fields, format)
+                    .await
+            } else {
+                assert_user_concept(ctx, concept_name, this_entity, entity_name, &fields, format)
+                    .await
+            }
+        }
+    }
+}
+
+/// Assert claims using a domain target (open-ended, no schema).
+async fn assert_domain(
+    ctx: &SiteContext,
+    domain: &str,
+    this_entity: Option<String>,
+    entity_name: Option<String>,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
     // All fields must have values for assert
-    for f in &fields {
+    for f in fields {
         if f.value.is_none() {
             anyhow::bail!(
                 "Field '{}' requires a value (use {}=<VALUE>)",
@@ -65,19 +92,16 @@ async fn assert_with_target(
         }
     }
 
-    let namespace = target.namespace();
     let mut session = ctx.open_session().await?;
 
-    // Resolve or derive the entity
     let entity = if let Some(ref entity_str) = this_entity {
         resolve_entity(entity_str)?
     } else {
-        // Derive entity from the field values
         let field_pairs: Vec<(String, String)> = fields
             .iter()
             .map(|f| {
                 (
-                    f.qualified_name(namespace),
+                    f.qualified_name(domain),
                     f.value.clone().unwrap_or_default(),
                 )
             })
@@ -85,37 +109,340 @@ async fn assert_with_target(
         schema::derive_entity_from_fields(&field_pairs)?
     };
 
-    // Build transaction using Session's edit API
     let mut transaction = session.edit();
 
-    for f in &fields {
-        let attr_name = f.qualified_name(namespace);
+    for f in fields {
+        let attr_name = f.qualified_name(domain);
         let attr = dialog_query::claim::Attribute::from_str(&attr_name)
             .context(format!("Invalid attribute: {}", attr_name))?;
         let value = schema::parse_value(f.value.as_deref().unwrap());
-        let relation = Relation::new(attr, entity.clone(), value);
-        relation.assert(&mut transaction);
+        Relation::new(attr, entity.clone(), value).assert(&mut transaction);
+    }
+
+    // Assert entity name if @name was provided
+    if let Some(ref name) = entity_name {
+        let name_attr = schema::dialog_meta::Name::selector();
+        Relation::new(name_attr, entity.clone(), Value::String(name.clone()))
+            .assert(&mut transaction);
     }
 
     session.commit(transaction).await?;
+    print_assert_result(&entity, fields.len(), entity_name.as_deref(), format);
+    Ok(())
+}
 
+/// Assert claims using a builtin concept target (attribute, concept, bookmark).
+async fn assert_builtin_concept(
+    ctx: &SiteContext,
+    builtin: &schema::BuiltinConceptSchema,
+    this_entity: Option<String>,
+    entity_name: Option<String>,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
+    // All fields must have values
+    for f in fields {
+        if f.value.is_none() {
+            anyhow::bail!(
+                "Field '{}' requires a value (use {}=<VALUE>)",
+                f.name,
+                f.name
+            );
+        }
+    }
+
+    let mut session = ctx.open_session().await?;
+
+    // Apply defaults for attribute assertions: cardinality defaults to "one"
+    let mut fields_with_defaults;
+    let effective_fields: &[Field] = if builtin.name == "attribute" {
+        fields_with_defaults = fields.to_vec();
+        if !fields_with_defaults.iter().any(|f| f.name == "cardinality") {
+            fields_with_defaults.push(Field {
+                name: "cardinality".to_string(),
+                value: Some("one".to_string()),
+            });
+        }
+        &fields_with_defaults
+    } else {
+        fields
+    };
+
+    // Resolve each CLI field to its relation via the builtin schema
+    let mut resolved_claims: Vec<(String, Value)> = Vec::new();
+    let mut concept_with_fields: BTreeMap<String, dialog_query::Entity> = BTreeMap::new();
+
+    for f in effective_fields {
+        let value_str = f.value.as_deref().unwrap();
+
+        if let Some((relation, is_variable)) = schema::resolve_builtin_field(builtin, &f.name) {
+            if is_variable && builtin.name == "concept" {
+                // Variable-keyed field on concept: value is an attribute reference.
+                // If it contains '/', treat as a selector (look up or create attribute).
+                // Otherwise, treat as a bookmark reference to an existing attribute.
+                let attr_entity = if value_str.contains('/') {
+                    // Selector: look up or create attribute with defaults
+                    resolve_or_create_attribute(&mut session, value_str, "Text", "one").await?
+                } else {
+                    // Bookmark reference: look up by name
+                    schema::lookup_entity_by_name(&session, value_str)
+                        .await?
+                        .ok_or_else(|| anyhow::anyhow!("Attribute '{}' not found", value_str))?
+                };
+
+                // Extract the field key from the dotted name (e.g. "with.name" → "name")
+                let field_key = f.name.split_once('.').map(|(_, k)| k).unwrap_or(&f.name);
+                concept_with_fields.insert(field_key.to_string(), attr_entity.clone());
+                resolved_claims.push((relation, Value::Entity(attr_entity)));
+            } else {
+                resolved_claims.push((relation, schema::parse_value(value_str)));
+            }
+        } else {
+            anyhow::bail!(
+                "Unknown field '{}' for concept '{}'. Available fields: {}",
+                f.name,
+                builtin.name,
+                builtin
+                    .with_fields
+                    .iter()
+                    .chain(builtin.maybe_fields.iter())
+                    .map(|f| {
+                        if f.variable_keyed {
+                            format!("{}.{{name}}", f.cli_name)
+                        } else {
+                            f.cli_name.to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+
+    // Derive entity based on concept type
+    let entity = if let Some(ref entity_str) = this_entity {
+        resolve_entity(entity_str)?
+    } else {
+        match builtin.name {
+            "attribute" => {
+                // Attribute identity: hash(the, type, cardinality)
+                let selector = find_resolved_string(&resolved_claims, "dialog.attribute/id")
+                    .ok_or_else(|| anyhow::anyhow!("Attribute requires `the` field"))?;
+                let value_type = find_resolved_string(&resolved_claims, "dialog.attribute/type")
+                    .unwrap_or_else(|| "Text".to_string());
+                let cardinality =
+                    find_resolved_string(&resolved_claims, "dialog.attribute/cardinality")
+                        .unwrap_or_else(|| "one".to_string());
+                schema::derive_attribute_entity(&selector, &value_type, &cardinality)?
+            }
+            "concept" => {
+                // Concept identity: hash(sorted field→attribute pairs)
+                if concept_with_fields.is_empty() {
+                    anyhow::bail!("Concept requires at least one `with.{{name}}` field");
+                }
+                schema::derive_concept_entity(&concept_with_fields)?
+            }
+            _ => {
+                // Generic: derive from field content
+                let field_pairs: Vec<(String, String)> = resolved_claims
+                    .iter()
+                    .map(|(rel, val)| (rel.clone(), schema::format_value(val).to_string()))
+                    .collect();
+                schema::derive_entity_from_fields(&field_pairs)?
+            }
+        }
+    };
+
+    let mut transaction = session.edit();
+
+    for (relation, value) in &resolved_claims {
+        let attr = schema::parse_claim_attribute(relation)?;
+        Relation::new(attr, entity.clone(), value.clone()).assert(&mut transaction);
+    }
+
+    // Assert entity name if @name was provided
+    if let Some(ref name) = entity_name {
+        let name_attr = schema::dialog_meta::Name::selector();
+        Relation::new(name_attr, entity.clone(), Value::String(name.clone()))
+            .assert(&mut transaction);
+    }
+
+    session.commit(transaction).await?;
+    print_assert_result(
+        &entity,
+        resolved_claims.len(),
+        entity_name.as_deref(),
+        format,
+    );
+    Ok(())
+}
+
+/// Assert claims using a user-defined concept target.
+async fn assert_user_concept(
+    ctx: &SiteContext,
+    concept_name: &str,
+    this_entity: Option<String>,
+    entity_name: Option<String>,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
+    // All fields must have values
+    for f in fields {
+        if f.value.is_none() {
+            anyhow::bail!(
+                "Field '{}' requires a value (use {}=<VALUE>)",
+                f.name,
+                f.name
+            );
+        }
+    }
+
+    let session = ctx.open_session().await?;
+
+    // Resolve the concept from the database
+    let concept = schema::resolve_concept(&session, concept_name).await?;
+
+    // Map each field to its attribute selector
+    let mut qualified_fields: Vec<(String, String)> = Vec::new();
+    for f in fields {
+        let selector = schema::resolve_field_selector(&concept, &f.name)?;
+        qualified_fields.push((selector, f.value.clone().unwrap_or_default()));
+    }
+
+    drop(session);
+    let mut session = ctx.open_session().await?;
+
+    // Derive or resolve entity
+    let entity = if let Some(ref entity_str) = this_entity {
+        resolve_entity(entity_str)?
+    } else {
+        schema::derive_entity_from_fields(&qualified_fields)?
+    };
+
+    let mut transaction = session.edit();
+
+    for (attr_name, value_str) in &qualified_fields {
+        let attr = schema::parse_claim_attribute(attr_name)?;
+        let value = schema::parse_value(value_str);
+        Relation::new(attr, entity.clone(), value).assert(&mut transaction);
+    }
+
+    // Assert entity name if @name was provided
+    if let Some(ref name) = entity_name {
+        let name_attr = schema::dialog_meta::Name::selector();
+        Relation::new(name_attr, entity.clone(), Value::String(name.clone()))
+            .assert(&mut transaction);
+    }
+
+    session.commit(transaction).await?;
+    print_assert_result(
+        &entity,
+        qualified_fields.len(),
+        entity_name.as_deref(),
+        format,
+    );
+    Ok(())
+}
+
+/// Look up or create an attribute entity from its selector, with default type and cardinality.
+async fn resolve_or_create_attribute<S: dialog_query::Store>(
+    session: &mut dialog_query::Session<S>,
+    selector: &str,
+    default_type: &str,
+    default_cardinality: &str,
+) -> Result<dialog_query::Entity> {
+    let entity = schema::derive_attribute_entity(selector, default_type, default_cardinality)?;
+
+    // Check if it already exists
+    let existing =
+        schema::fetch_string(session, &entity, schema::dialog_attribute::Id::selector()).await?;
+
+    if existing.is_some() {
+        return Ok(entity);
+    }
+
+    // Create it with defaults
+    let mut transaction = session.edit();
+
+    let attr_id = schema::dialog_attribute::Id::selector();
+    let attr_type = schema::dialog_attribute::Type::selector();
+    let attr_card = schema::dialog_attribute::Cardinality::selector();
+
+    Relation::new(attr_id, entity.clone(), Value::String(selector.to_string()))
+        .assert(&mut transaction);
+
+    Relation::new(
+        attr_type,
+        entity.clone(),
+        Value::String(default_type.to_string()),
+    )
+    .assert(&mut transaction);
+
+    Relation::new(
+        attr_card,
+        entity.clone(),
+        Value::String(default_cardinality.to_string()),
+    )
+    .assert(&mut transaction);
+
+    session.commit(transaction).await?;
+
+    // Report the defaulting in non-interactive mode
+    if !atty_stdout() {
+        eprintln!(
+            "Note: created attribute '{}' with defaults (as={}, cardinality={}). \
+             Use `carry assert attribute the={} as=<TYPE> cardinality=<CARD>` to change.",
+            selector, default_type, default_cardinality, selector
+        );
+    }
+
+    Ok(entity)
+}
+
+/// Find a string value in resolved claims by relation name.
+fn find_resolved_string(claims: &[(String, Value)], relation: &str) -> Option<String> {
+    claims.iter().find_map(|(rel, val)| {
+        if rel == relation {
+            Some(schema::format_value(val))
+        } else {
+            None
+        }
+    })
+}
+
+/// Print assertion result.
+fn print_assert_result(
+    entity: &dialog_query::Entity,
+    count: usize,
+    name: Option<&str>,
+    format: &str,
+) {
     match format {
         "json" => {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "entity": entity.to_string(),
-                    "asserted": fields.len(),
-                })
-            );
+            let mut obj = serde_json::json!({
+                "entity": entity.to_string(),
+                "asserted": count,
+            });
+            if let Some(n) = name {
+                obj["name"] = serde_json::Value::String(n.to_string());
+            }
+            println!("{}", obj);
         }
         _ => {
             println!("{}", entity);
         }
     }
-
-    Ok(())
 }
+
+/// Check if stdout is a TTY (interactive mode).
+fn atty_stdout() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
+
+// ---------------------------------------------------------------------------
+// File/stdin input (retained, mostly unchanged)
+// ---------------------------------------------------------------------------
 
 /// Assert claims from a YAML/JSON file.
 async fn assert_from_file(ctx: &SiteContext, path: &str, format: &str) -> Result<()> {
@@ -136,7 +463,6 @@ async fn assert_from_content(
     source: &str,
     _format: &str,
 ) -> Result<()> {
-    // Detect format: JSON if starts with '{' or '[', otherwise YAML
     let trimmed = content.trim();
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
         assert_from_json(ctx, trimmed).await
@@ -147,8 +473,6 @@ async fn assert_from_content(
 }
 
 /// Assert claims from formal JSON content.
-///
-/// Expects an array of `{the, of, is}` triples.
 async fn assert_from_json(ctx: &SiteContext, content: &str) -> Result<()> {
     let triples: Vec<serde_json::Value> = serde_json::from_str(content)?;
     let mut branch = ctx.open_branch().await?;
@@ -185,8 +509,6 @@ async fn assert_from_json(ctx: &SiteContext, content: &str) -> Result<()> {
 }
 
 /// Assert claims from formal YAML content.
-///
-/// Expects a sequence of `{the, of, is}` mappings.
 async fn assert_from_yaml(ctx: &SiteContext, content: &str) -> Result<()> {
     let docs: Vec<serde_yaml::Value> = serde_yaml::from_str(content)?;
     let mut branch = ctx.open_branch().await?;
@@ -231,47 +553,47 @@ async fn assert_from_yaml(ctx: &SiteContext, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn json_to_value(v: &serde_json::Value) -> Result<dialog_query::Value> {
+fn json_to_value(v: &serde_json::Value) -> Result<Value> {
     match v {
         serde_json::Value::String(s) => Ok(schema::parse_value(s)),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 if i >= 0 {
-                    Ok(dialog_query::Value::UnsignedInt(i as u128))
+                    Ok(Value::UnsignedInt(i as u128))
                 } else {
-                    Ok(dialog_query::Value::SignedInt(i as i128))
+                    Ok(Value::SignedInt(i as i128))
                 }
             } else if let Some(f) = n.as_f64() {
-                Ok(dialog_query::Value::Float(f))
+                Ok(Value::Float(f))
             } else {
                 anyhow::bail!("Unsupported number: {}", n)
             }
         }
-        serde_json::Value::Bool(b) => Ok(dialog_query::Value::Boolean(*b)),
-        _ => Ok(dialog_query::Value::String(v.to_string())),
+        serde_json::Value::Bool(b) => Ok(Value::Boolean(*b)),
+        _ => Ok(Value::String(v.to_string())),
     }
 }
 
-fn yaml_to_value(v: &serde_yaml::Value) -> Result<dialog_query::Value> {
+fn yaml_to_value(v: &serde_yaml::Value) -> Result<Value> {
     match v {
         serde_yaml::Value::String(s) => Ok(schema::parse_value(s)),
         serde_yaml::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 if i >= 0 {
-                    Ok(dialog_query::Value::UnsignedInt(i as u128))
+                    Ok(Value::UnsignedInt(i as u128))
                 } else {
-                    Ok(dialog_query::Value::SignedInt(i as i128))
+                    Ok(Value::SignedInt(i as i128))
                 }
             } else if let Some(f) = n.as_f64() {
-                Ok(dialog_query::Value::Float(f))
+                Ok(Value::Float(f))
             } else {
                 anyhow::bail!("Unsupported number: {:?}", n)
             }
         }
-        serde_yaml::Value::Bool(b) => Ok(dialog_query::Value::Boolean(*b)),
+        serde_yaml::Value::Bool(b) => Ok(Value::Boolean(*b)),
         _ => {
             let s = serde_yaml::to_string(v)?;
-            Ok(dialog_query::Value::String(s.trim().to_string()))
+            Ok(Value::String(s.trim().to_string()))
         }
     }
 }

--- a/rust/carry/src/assert_cmd.rs
+++ b/rust/carry/src/assert_cmd.rs
@@ -22,6 +22,7 @@ use dialog_query::Attribute;
 use dialog_query::Value;
 use dialog_query::claim::{Claim, Relation};
 use std::collections::BTreeMap;
+use std::slice::from_ref;
 use std::str::FromStr;
 
 /// Execute `carry assert <TARGET>|<FILE>|- [this=<ENTITY>] [@name] [FIELD=VALUE...]`.
@@ -509,21 +510,47 @@ async fn assert_from_json(ctx: &SiteContext, content: &str) -> Result<()> {
 }
 
 /// Assert claims from formal YAML content.
+///
+/// Supports two formats:
+/// 1. EAV triple notation (sequence of `{the, of, is}` mappings)
+/// 2. Asserted notation (entity-grouped: `entity → namespace → field: value`)
 async fn assert_from_yaml(ctx: &SiteContext, content: &str) -> Result<()> {
-    let docs: Vec<serde_yaml::Value> = serde_yaml::from_str(content)?;
+    let doc: serde_yaml::Value = serde_yaml::from_str(content)?;
+
+    match &doc {
+        serde_yaml::Value::Sequence(seq) => {
+            // Sequence of EAV triples
+            assert_from_eav_yaml(ctx, seq).await
+        }
+        serde_yaml::Value::Mapping(map) => {
+            // Check if this looks like asserted notation (entity → namespace → fields)
+            // by seeing if any top-level key starts with "did:" and maps to a mapping.
+            let is_asserted = map
+                .iter()
+                .any(|(k, v)| k.as_str().is_some_and(|s| s.starts_with("did:")) && v.is_mapping());
+
+            if is_asserted {
+                assert_from_asserted_yaml(ctx, map).await
+            } else if map.get("the").is_some() {
+                // Single EAV triple (not wrapped in a sequence)
+                assert_from_eav_yaml(ctx, from_ref(&doc)).await
+            } else {
+                anyhow::bail!(
+                    "Unrecognized YAML format: expected EAV triples (sequence of {{the, of, is}}) \
+                     or asserted notation (entity → namespace → fields)"
+                )
+            }
+        }
+        _ => anyhow::bail!("Expected YAML sequence or mapping"),
+    }
+}
+
+/// Assert claims from EAV triple YAML (sequence of `{the, of, is}` mappings).
+async fn assert_from_eav_yaml(ctx: &SiteContext, triples: &[serde_yaml::Value]) -> Result<()> {
     let mut branch = ctx.open_branch().await?;
 
-    let triples = if docs.len() == 1 {
-        match &docs[0] {
-            serde_yaml::Value::Sequence(seq) => seq.clone(),
-            other => vec![other.clone()],
-        }
-    } else {
-        docs
-    };
-
     let mut instructions = Vec::new();
-    for triple in &triples {
+    for triple in triples {
         let the = triple["the"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing 'the' in triple"))?;
@@ -542,6 +569,85 @@ async fn assert_from_yaml(ctx: &SiteContext, content: &str) -> Result<()> {
             is: value,
             cause: None,
         }));
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    println!("Asserted {} claims", count);
+    Ok(())
+}
+
+/// Assert claims from asserted notation YAML (entity-grouped mapping).
+///
+/// Expected structure:
+/// ```yaml
+/// <entity_did>:
+///   <namespace>:
+///     <field>: <value>
+///     <multi_field>:
+///       - <value1>
+///       - <value2>
+/// ```
+async fn assert_from_asserted_yaml(ctx: &SiteContext, top_map: &serde_yaml::Mapping) -> Result<()> {
+    let mut branch = ctx.open_branch().await?;
+    let mut instructions = Vec::new();
+
+    for (entity_key, namespace_map) in top_map {
+        let entity_id = entity_key
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Expected entity key to be a string"))?;
+        let entity = resolve_entity(entity_id)?;
+
+        let ns_map = namespace_map.as_mapping().ok_or_else(|| {
+            anyhow::anyhow!("Expected namespace mapping for entity '{}'", entity_id)
+        })?;
+
+        for (ns_key, fields_val) in ns_map {
+            let namespace = ns_key
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Expected namespace key to be a string"))?;
+
+            let fields_map = fields_val.as_mapping().ok_or_else(|| {
+                anyhow::anyhow!("Expected fields mapping under namespace '{}'", namespace)
+            })?;
+
+            for (field_key, value) in fields_map {
+                let field_name = field_key
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("Expected field key to be a string"))?;
+
+                // Build the qualified attribute name: namespace/field
+                let qualified = format!("{}/{}", namespace, field_name);
+                let attr = schema::parse_claim_attribute(&qualified)?;
+
+                // Handle multi-valued fields (YAML sequences)
+                match value {
+                    serde_yaml::Value::Sequence(seq) => {
+                        for item in seq {
+                            let val = yaml_to_value(item)?;
+                            instructions.push(Instruction::Assert(Artifact {
+                                the: attr.clone(),
+                                of: entity.clone(),
+                                is: val,
+                                cause: None,
+                            }));
+                        }
+                    }
+                    _ => {
+                        let val = yaml_to_value(value)?;
+                        instructions.push(Instruction::Assert(Artifact {
+                            the: attr,
+                            of: entity.clone(),
+                            is: val,
+                            cause: None,
+                        }));
+                    }
+                }
+            }
+        }
     }
 
     let count = instructions.len();

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -147,11 +147,14 @@ use inner::*;
 pub fn main() {}
 
 #[cfg(not(target_arch = "wasm32"))]
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+#[cfg(not(target_arch = "wasm32"))]
+use clap_complete::env::CompleteEnv;
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    CompleteEnv::with_factory(Cli::command).complete();
     let cli = Cli::parse();
     let site_path = cli.site.as_deref().map(std::path::Path::new);
     let space_flag = cli.space.as_deref();

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -163,27 +163,35 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Query { target, fields } => {
             let parsed_target = carry::target::Target::parse(&target)?;
-            let (parsed_fields, _this_entity) = carry::target::parse_fields(&fields)?;
+            let parsed = carry::target::parse_fields(&fields)?;
             let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
-            carry::query_cmd::execute(&ctx, parsed_target, parsed_fields, format).await?;
+            carry::query_cmd::execute(&ctx, parsed_target, parsed.fields, format).await?;
         }
         Commands::Assert {
             target_or_file,
             fields,
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
-            let (parsed_fields, this_entity) = carry::target::parse_fields(&fields)?;
+            let parsed = carry::target::parse_fields(&fields)?;
             let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
-            carry::assert_cmd::execute(&ctx, first_arg, this_entity, parsed_fields, format).await?;
+            carry::assert_cmd::execute(
+                &ctx,
+                first_arg,
+                parsed.this_entity,
+                parsed.entity_name,
+                parsed.fields,
+                format,
+            )
+            .await?;
         }
         Commands::Retract {
             target_or_file,
             fields,
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
-            let (parsed_fields, this_entity) = carry::target::parse_fields(&fields)?;
+            let parsed = carry::target::parse_fields(&fields)?;
             let ctx = carry::site::SiteContext::resolve(site_path, space_flag).await?;
-            carry::retract_cmd::execute(&ctx, first_arg, this_entity, parsed_fields, format)
+            carry::retract_cmd::execute(&ctx, first_arg, parsed.this_entity, parsed.fields, format)
                 .await?;
         }
         Commands::Status => {

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -24,7 +24,7 @@ mod inner {
         pub space: Option<String>,
 
         /// Output format for query results
-        #[arg(long, global = true, default_value = "yaml", value_parser = ["yaml", "json"])]
+        #[arg(long, global = true, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
         pub format: String,
     }
 
@@ -466,5 +466,64 @@ mod tests {
             }
             _ => panic!("Expected Query command"),
         }
+    }
+
+    // -- --format triples ----------------------------------------------------
+
+    #[test]
+    fn query_format_triples() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "--format",
+            "triples",
+        ])
+        .unwrap();
+        assert_eq!(cli.format, "triples");
+        match cli.command {
+            Commands::Query { ref fields, .. } => {
+                assert_eq!(fields, &["name"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    #[test]
+    fn query_format_triples_with_space() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "age",
+            "--format",
+            "triples",
+            "--space",
+            "research",
+        ])
+        .unwrap();
+        assert_eq!(cli.format, "triples");
+        assert_eq!(cli.space.as_deref(), Some("research"));
+        match cli.command {
+            Commands::Query { ref fields, .. } => {
+                assert_eq!(fields, &["name", "age"]);
+            }
+            _ => panic!("Expected Query command"),
+        }
+    }
+
+    #[test]
+    fn format_invalid_value_rejected() {
+        let result = Cli::try_parse_from([
+            "carry",
+            "query",
+            "com.app.person",
+            "name",
+            "--format",
+            "csv",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/rust/carry/src/help.rs
+++ b/rust/carry/src/help.rs
@@ -22,18 +22,28 @@ ASSERTED NOTATION:
       <domain-or-concept>:
         <field>: <value>
 
-  This format is used for query output. File/stdin input currently requires
-  formal triple format (see 'carry help assert').";
+  This format is used for both query output and file/stdin input.
+
+NAMING:
+  Use @name in assert commands to give an entity a human-readable name.
+  Names assert dialog.meta/name on the entity and can be used as bookmarks.
+
+META-SCHEMA:
+  Domains starting with 'dialog.' are reserved for Dialog DB internals.
+  Pre-registered concepts: attribute, concept, bookmark.";
 
 pub const MAIN_AFTER_HELP: &str = "\
 QUICK START:
   # Initialize a new space
   carry init my-project
 
-  # Define a schema (concept with attributes)
-  carry assert concept description='A person' \\
-    with.name.the=com.app.person/name with.name.as=Text with.name.cardinality=one \\
-    with.age.the=com.app.person/age with.age.as=UnsignedInteger with.age.cardinality=one
+  # Define an attribute with a name
+  carry assert attribute @person-name \\
+    the=com.app.person/name as=Text cardinality=one
+
+  # Define a concept referencing named attributes
+  carry assert concept @person \\
+    description='A person' with.name=person-name with.age=person-age
 
   # Or define via YAML file
   carry assert schema.yaml
@@ -49,13 +59,16 @@ QUICK START:
 
 COMMON WORKFLOWS:
   # Update an existing entity
-  carry assert person this=did:key:zAlice age=29
+  carry assert com.app.person this=did:key:zAlice age=29
 
   # Retract a field
-  carry retract person this=did:key:zAlice age
+  carry retract com.app.person this=did:key:zAlice age
 
-  # Assert from a file (formal triple format)
+  # Assert from a file (asserted notation)
   carry assert claims.yaml
+
+  # Pipe query output back as assert input
+  carry query person name=\"Alice\" | carry assert -
 
 For detailed help on any command: carry help <command>";
 
@@ -75,7 +88,10 @@ space. Use `carry space create` to add more spaces after initialization.
 
 The command generates an Ed25519 keypair for the space, creating a unique 
 space DID (e.g., did:key:zSpace). The private key is stored in 
-.carry/<space-did>/credentials.";
+.carry/<space-did>/credentials.
+
+Pre-registered concepts (attribute, concept, bookmark) are bootstrapped during
+init so they can be queried and used immediately.";
 
 pub const INIT_AFTER_HELP: &str = "\
 EXAMPLES:
@@ -107,8 +123,8 @@ TARGET TYPES:
     to include in output.
     
   Concept query (target has no '.')
-    Resolves the named concept via bookmark and returns all fields the concept 
-    defines. Specify fields only to filter, not to select output.
+    Resolves the named concept via dialog.meta/name and returns all fields the
+    concept defines. Specify fields only to filter, not to select output.
 
 FIELD SYNTAX:
   name          Output field - include in results without filtering
@@ -158,7 +174,7 @@ pub const ASSERT_LONG_ABOUT: &str = "\
 Assert claims on entities. Claims are facts stored as (the: relation, of: entity, is: value).
 
 INPUT MODES:
-  Target mode     carry assert <domain-or-concept> field=value ...
+  Target mode     carry assert <domain-or-concept> [@name] [this=<ENTITY>] field=value ...
   File mode       carry assert <file.yaml>
   Stdin mode      carry assert -
 
@@ -166,13 +182,22 @@ TARGET SYNTAX:
   Contains '.'    Domain - fields expand to domain/field relations
   No '.'          Concept - fields are validated against the concept schema
 
+ENTITY NAMING:
+  @name           Asserts dialog.meta/name on the entity. Use to give entities
+                  human-readable names (e.g., @person-name, @person).
+
 ENTITY SELECTION:
   Without this=   Creates a new entity (DID printed to stdout)
   With this=      Targets an existing entity
 
+BUILTIN CONCEPTS:
+  attribute       the=<relation> as=<Type> cardinality=<one|many>
+  concept         with.<field>=<attr-name> [maybe.<field>=<attr-name>]
+  bookmark        this=<DID> name=<bookmark-name>
+
 FILE/STDIN FORMAT:
-  Accepts formal triple format: a YAML/JSON sequence of {the, of, is} objects.
-  Format is auto-detected for stdin (JSON if starts with '{' or '[').";
+  Accepts asserted notation: the same YAML/JSON three-level hierarchy used
+  by query output. File format is auto-detected by extension or content.";
 
 pub const ASSERT_AFTER_HELP: &str = "\
 EXAMPLES:
@@ -180,32 +205,40 @@ EXAMPLES:
   carry assert com.app.person name=Alice age=28
   # Output: did:key:zNewEntity
 
-  # Assert using a concept (creates new entity)
-  carry assert person name=Bob age=35
+  # Define an attribute with a name
+  carry assert attribute @person-name \\
+    the=com.app.person/name as=Text cardinality=one
+
+  # Define a concept referencing named attributes
+  carry assert concept @person \\
+    description='A person' with.name=person-name with.age=person-age
 
   # Update an existing entity
-  carry assert person this=did:key:zAlice age=29
+  carry assert com.app.person this=did:key:zAlice age=29
 
   # Assert into a specific space
   carry assert com.app.person name=Alice --space research
 
-  # Assert from a YAML file
+  # Assert from a YAML file (asserted notation)
   carry assert schema.yaml
 
-  # Assert from stdin (formal triple format)
-  cat claims.yaml | carry assert -
+  # Assert from stdin / pipe query output back
+  carry query person name=\"Alice\" | carry assert -
 
-YAML FILE FORMAT (formal triples):
-  File/stdin input uses formal triple format, NOT asserted notation.
-  Each triple is a {the, of, is} object:
+ATTRIBUTE FIELDS:
+  the             Relation identifier (e.g., com.app.person/name)
+  as              Value type (Text, UnsignedInteger, Boolean, Entity, etc.)
+  cardinality     one (default) or many
+  description     Human-readable description (optional)
 
-  - the: com.app.person/name
-    of: did:key:zAlice
-    is: Alice
+CONCEPT FIELDS:
+  with.<field>    Required field referencing an attribute by name or selector
+  maybe.<field>   Optional field referencing an attribute by name or selector
+  description     Human-readable description (optional)
 
-  - the: com.app.person/age
-    of: did:key:zAlice
-    is: 28
+  If a with/maybe value contains '/', it is treated as an attribute selector
+  (the attribute is looked up or auto-created). Without '/', it is treated
+  as an attribute bookmark name.
 
 FILE VS TARGET DETECTION:
   - '-' is always stdin

--- a/rust/carry/src/help.rs
+++ b/rust/carry/src/help.rs
@@ -24,6 +24,16 @@ ASSERTED NOTATION:
 
   This format is used for both query output and file/stdin input.
 
+EAV TRIPLE FORMAT:
+  Use --format triples for a flat, pipeable YAML format:
+    - the: <namespace/field>
+      of: <entity-did>
+      is: <value>
+
+  This format is used for piping between carry commands:
+    carry query person --format triples | carry assert -
+    carry query person --format triples | carry retract -
+
 NAMING:
   Use @name in assert commands to give an entity a human-readable name.
   Names assert dialog.meta/name on the entity and can be used as bookmarks.
@@ -67,8 +77,14 @@ COMMON WORKFLOWS:
   # Assert from a file (asserted notation)
   carry assert claims.yaml
 
-  # Pipe query output back as assert input
-  carry query person name=\"Alice\" | carry assert -
+  # Pipe query output back as assert input (EAV triples)
+  carry query person --format triples | carry assert -
+
+  # Pipe query output to retract matching claims
+  carry query person name=\"Alice\" --format triples | carry retract -
+
+  # Pipe default YAML output (asserted notation also accepted)
+  carry query com.app.person name age | carry assert -
 
 For detailed help on any command: carry help <command>";
 
@@ -152,19 +168,32 @@ EXAMPLES:
   # Output as JSON
   carry query person --format json
 
+  # Output as EAV triples (for piping into assert/retract)
+  carry query person --format triples
+
+  # Pipe query results into assert
+  carry query person --format triples | carry assert -
+
   # Query in a different space (by label or DID)
   carry query com.app.person name age --space research
 
-OUTPUT FORMAT (asserted notation):
-  did:key:zAlice:
-    com.app.person:
-      name: Alice
-      age: 28
+OUTPUT FORMATS:
+  --format yaml (default):
+    did:key:zAlice:
+      com.app.person:
+        name: Alice
+        age: 28
 
-  did:key:zBob:
-    com.app.person:
-      name: Bob
-      age: 35";
+  --format triples:
+    - the: com.app.person/name
+      of: did:key:zAlice
+      is: Alice
+    - the: com.app.person/age
+      of: did:key:zAlice
+      is: 28
+
+  --format json:
+    [{\"id\": \"did:key:zAlice\", \"name\": \"Alice\", \"age\": 28}]";
 
 // -----------------------------------------------------------------------------
 // Assert
@@ -196,8 +225,20 @@ BUILTIN CONCEPTS:
   bookmark        this=<DID> name=<bookmark-name>
 
 FILE/STDIN FORMAT:
-  Accepts asserted notation: the same YAML/JSON three-level hierarchy used
-  by query output. File format is auto-detected by extension or content.";
+  Accepts two YAML formats, auto-detected:
+  
+  EAV triples (from --format triples):
+    - the: <namespace/field>
+      of: <entity-did>
+      is: <value>
+  
+  Asserted notation (from default --format yaml):
+    <entity-did>:
+      <namespace>:
+        <field>: <value>
+  
+  Also accepts JSON EAV triples:
+    [{\"the\": \"...\", \"of\": \"...\", \"is\": ...}]";
 
 pub const ASSERT_AFTER_HELP: &str = "\
 EXAMPLES:
@@ -222,7 +263,10 @@ EXAMPLES:
   # Assert from a YAML file (asserted notation)
   carry assert schema.yaml
 
-  # Assert from stdin / pipe query output back
+  # Assert from stdin / pipe query output back (EAV triples)
+  carry query person --format triples | carry assert -
+
+  # Assert from stdin (asserted notation also works)
   carry query person name=\"Alice\" | carry assert -
 
 ATTRIBUTE FIELDS:

--- a/rust/carry/src/init.rs
+++ b/rust/carry/src/init.rs
@@ -7,6 +7,7 @@
 use crate::schema;
 use crate::site::Site;
 use anyhow::Result;
+use dialog_query::Attribute;
 use dialog_query::claim::{Claim, Relation};
 use std::path::Path;
 

--- a/rust/carry/src/init.rs
+++ b/rust/carry/src/init.rs
@@ -1,16 +1,14 @@
 //! `carry init` — create a new `.carry/` repository.
 //!
 //! Creates a `.carry/` directory and a first space. Optionally asserts a
-//! label claim on the space. If a repository already exists, reports its
-//! status without creating additional spaces — use `carry space create`
-//! for that.
+//! label claim on the space. Bootstraps pre-registered concepts (attribute,
+//! concept, bookmark) so they can be queried and used immediately.
 
 use crate::schema;
 use crate::site::Site;
 use anyhow::Result;
 use dialog_query::claim::{Claim, Relation};
 use std::path::Path;
-use std::str::FromStr;
 
 /// Execute `carry init [<name>] [--site <SITE>]`.
 pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<()> {
@@ -55,14 +53,18 @@ pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<(
     let space = site.create_space()?;
     site.set_active_space(&space.did)?;
 
+    // Open a session for bootstrapping
+    let mut session = space.open_session().await?;
+
+    // Bootstrap pre-registered concepts (attribute, concept, bookmark)
+    schema::bootstrap_builtins(&mut session).await?;
+
     // If a name is provided, assert it as a label claim
     if let Some(ref label) = name {
-        let mut session = space.open_session().await?;
         let entity = schema::derive_entity("space")?;
-        let attr = dialog_query::claim::Attribute::from_str("xyz.tonk.carry/label")
-            .map_err(|e| anyhow::anyhow!("Invalid attribute: {:?}", e))?;
+        let name_attr = schema::dialog_meta::Name::selector();
         let value = dialog_query::Value::String(label.clone());
-        let relation = Relation::new(attr, entity, value);
+        let relation = Relation::new(name_attr, entity, value);
         let mut transaction = session.edit();
         relation.assert(&mut transaction);
         session.commit(transaction).await?;
@@ -71,9 +73,9 @@ pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<(
     // Print result
     let dir_display = space.dir().display();
     if let Some(label) = name {
-        println!("Seeded {} repository in {}", label, dir_display);
+        println!("Initialized {} repository in {}", label, dir_display);
     } else {
-        println!("Seeded repository in {}", dir_display);
+        println!("Initialized repository in {}", dir_display);
     }
 
     Ok(())

--- a/rust/carry/src/query_cmd.rs
+++ b/rust/carry/src/query_cmd.rs
@@ -2,6 +2,10 @@
 //!
 //! Supports both domain queries (`carry query io.gozala.person name age`)
 //! and concept queries (`carry query person name="Alice"`).
+//!
+//! Concept queries resolve the concept via `dialog.meta/name`, fetch its
+//! `dialog.concept.with/*` attributes, and return all matching entities
+//! with output grouped under the concept's bookmark name.
 
 use crate::schema;
 use crate::site::SiteContext;
@@ -9,6 +13,18 @@ use crate::target::{Field, Target};
 use anyhow::Result;
 use dialog_query::Value;
 use std::collections::BTreeMap;
+
+/// A concept field name mapped to its attribute selector (for display).
+struct FieldMapping {
+    field_name: String,
+    selector: String,
+}
+
+/// An attribute selector with a required value (for filtering).
+struct FilterConstraint {
+    selector: String,
+    value: String,
+}
 
 /// Execute `carry query <TARGET> [FIELD[=VALUE]...]`.
 pub async fn execute(
@@ -50,7 +66,6 @@ async fn domain_query(
     let all_attr_names: Vec<&str> = qualified_fields.iter().map(|f| f.0.as_str()).collect();
 
     // Find entities that have ANY of the requested attributes
-    // (we start with the first attribute and filter down)
     let first_attr = schema::parse_claim_attribute(all_attr_names[0])?;
     let candidate_entities = schema::find_entities_by_attribute(&session, first_attr).await?;
 
@@ -104,54 +119,52 @@ async fn concept_query(
 ) -> Result<()> {
     let session = ctx.open_session().await?;
 
-    // Look up the concept by name
-    let cname = schema::ConceptName::new(concept_name)?;
-    let concept_entity = schema::lookup_concept_by_name(&session, &cname)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Concept '{}' not found", concept_name))?;
+    // Resolve the concept from the database
+    let concept = schema::resolve_concept(&session, concept_name).await?;
 
-    // Get schema attributes for this concept
-    let schema_attrs = schema::fetch_string_values(
-        &session,
-        &concept_entity,
-        schema::concept_attribute_selector(),
-    )
-    .await?;
+    // Get the attribute selectors for structural membership matching
+    let schema_attrs = schema::concept_attribute_selectors(&concept);
 
     if schema_attrs.is_empty() {
         anyhow::bail!("Concept '{}' has no attributes", concept_name);
     }
 
-    // Find entities belonging to this concept
+    // Find entities belonging to this concept (structural matching)
     let entities = schema::find_entities_by_concept(&session, &schema_attrs).await?;
 
-    // Determine which attributes to show
-    let namespace = schema::fetch_string_values(
-        &session,
-        &concept_entity,
-        schema::concept_namespace_selector(),
-    )
-    .await?
-    .into_iter()
-    .next()
-    .unwrap_or_else(|| concept_name.to_string());
-
-    // If fields are specified, use them as filters/projections
-    // Otherwise show all concept attributes
-    let (show_attrs, filter_pairs): (Vec<String>, Vec<(String, String)>) = if fields.is_empty() {
-        (schema_attrs.clone(), Vec::new())
-    } else {
-        let mut show = Vec::new();
-        let mut filters = Vec::new();
-        for f in fields {
-            let qname = f.qualified_name(&namespace);
-            show.push(qname.clone());
-            if let Some(ref v) = f.value {
-                filters.push((qname, v.clone()));
+    // Determine which attributes to show and which to filter by
+    let (show_attrs, filter_pairs): (Vec<FieldMapping>, Vec<FilterConstraint>) =
+        if fields.is_empty() {
+            // No fields specified: show all concept attributes
+            let show: Vec<FieldMapping> = concept
+                .with_fields
+                .iter()
+                .chain(concept.maybe_fields.iter())
+                .map(|(field_name, (_, selector))| FieldMapping {
+                    field_name: field_name.clone(),
+                    selector: selector.clone(),
+                })
+                .collect();
+            (show, Vec::new())
+        } else {
+            // Fields specified: use as filters/projections
+            let mut show = Vec::new();
+            let mut filters = Vec::new();
+            for f in fields {
+                let selector = schema::resolve_field_selector(&concept, &f.name)?;
+                show.push(FieldMapping {
+                    field_name: f.name.clone(),
+                    selector: selector.clone(),
+                });
+                if let Some(ref v) = f.value {
+                    filters.push(FilterConstraint {
+                        selector,
+                        value: v.clone(),
+                    });
+                }
             }
-        }
-        (show, filters)
-    };
+            (show, filters)
+        };
 
     let mut results: BTreeMap<String, BTreeMap<String, Vec<Value>>> = BTreeMap::new();
 
@@ -159,8 +172,8 @@ async fn concept_query(
         let mut entity_values: BTreeMap<String, Vec<Value>> = BTreeMap::new();
         let mut matches_filters = true;
 
-        for attr_name in &show_attrs {
-            let attr = schema::parse_claim_attribute(attr_name)?;
+        for mapping in &show_attrs {
+            let attr = schema::parse_claim_attribute(&mapping.selector)?;
             let values = schema::fetch_values(&session, entity, attr).await?;
 
             if values.is_empty() {
@@ -168,9 +181,9 @@ async fn concept_query(
             }
 
             // Check filters
-            for (filter_attr, filter_val) in &filter_pairs {
-                if filter_attr == attr_name {
-                    let expected = schema::parse_value(filter_val);
+            for filter in &filter_pairs {
+                if filter.selector == mapping.selector {
+                    let expected = schema::parse_value(&filter.value);
                     if !values.contains(&expected) {
                         matches_filters = false;
                         break;
@@ -182,7 +195,8 @@ async fn concept_query(
                 break;
             }
 
-            entity_values.insert(attr_name.clone(), values);
+            // Use the concept field name (not the qualified selector) as the key
+            entity_values.insert(mapping.field_name.clone(), values);
         }
 
         if matches_filters && !entity_values.is_empty() {
@@ -190,10 +204,11 @@ async fn concept_query(
         }
     }
 
-    output_results(&results, &namespace, format)
+    // Output under the concept name, with short field names
+    output_concept_results(&results, concept_name, format)
 }
 
-/// Format and print query results.
+/// Format and print domain query results (grouped under domain namespace).
 fn output_results(
     results: &BTreeMap<String, BTreeMap<String, Vec<Value>>>,
     namespace: &str,
@@ -232,7 +247,7 @@ fn output_results(
             println!("{}", serde_json::to_string_pretty(&json_results)?);
         }
         _ => {
-            // YAML output (default)
+            // YAML asserted notation output
             for (entity_id, attrs) in results {
                 println!("{}:", entity_id);
                 println!("  {}:", namespace);
@@ -242,6 +257,65 @@ fn output_results(
                         println!("    {}: {}", short, schema::format_value(&values[0]));
                     } else {
                         println!("    {}:", short);
+                        for v in values {
+                            println!("      - {}", schema::format_value(v));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Format and print concept query results (grouped under concept name).
+fn output_concept_results(
+    results: &BTreeMap<String, BTreeMap<String, Vec<Value>>>,
+    concept_name: &str,
+    format: &str,
+) -> Result<()> {
+    if results.is_empty() {
+        return Ok(());
+    }
+
+    match format {
+        "json" => {
+            let json_results: Vec<serde_json::Value> = results
+                .iter()
+                .map(|(entity_id, attrs)| {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert(
+                        "id".to_string(),
+                        serde_json::Value::String(entity_id.clone()),
+                    );
+                    for (field_name, values) in attrs {
+                        if values.len() == 1 {
+                            obj.insert(field_name.clone(), schema::value_to_json(&values[0]));
+                        } else {
+                            obj.insert(
+                                field_name.clone(),
+                                serde_json::Value::Array(
+                                    values.iter().map(schema::value_to_json).collect(),
+                                ),
+                            );
+                        }
+                    }
+                    serde_json::Value::Object(obj)
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&json_results)?);
+        }
+        _ => {
+            // YAML asserted notation output under concept name
+            for (entity_id, attrs) in results {
+                println!("{}:", entity_id);
+                println!("  {}:", concept_name);
+                for (field_name, values) in attrs {
+                    if values.len() == 1 {
+                        println!("    {}: {}", field_name, schema::format_value(&values[0]));
+                    } else {
+                        println!("    {}:", field_name);
                         for v in values {
                             println!("      - {}", schema::format_value(v));
                         }

--- a/rust/carry/src/query_cmd.rs
+++ b/rust/carry/src/query_cmd.rs
@@ -167,6 +167,7 @@ async fn concept_query(
         };
 
     let mut results: BTreeMap<String, BTreeMap<String, Vec<Value>>> = BTreeMap::new();
+    let use_selectors = format == "triples";
 
     for entity in &entities {
         let mut entity_values: BTreeMap<String, Vec<Value>> = BTreeMap::new();
@@ -195,8 +196,15 @@ async fn concept_query(
                 break;
             }
 
-            // Use the concept field name (not the qualified selector) as the key
-            entity_values.insert(mapping.field_name.clone(), values);
+            // For triples format, use the qualified selector as the key
+            // so that output_triples emits fully-qualified attribute names.
+            // For other formats, use the concept field name (short name).
+            let key = if use_selectors {
+                mapping.selector.clone()
+            } else {
+                mapping.field_name.clone()
+            };
+            entity_values.insert(key, values);
         }
 
         if matches_filters && !entity_values.is_empty() {
@@ -204,8 +212,12 @@ async fn concept_query(
         }
     }
 
-    // Output under the concept name, with short field names
-    output_concept_results(&results, concept_name, format)
+    if use_selectors {
+        output_triples(&results)
+    } else {
+        // Output under the concept name, with short field names
+        output_concept_results(&results, concept_name, format)
+    }
 }
 
 /// Format and print domain query results (grouped under domain namespace).
@@ -219,6 +231,7 @@ fn output_results(
     }
 
     match format {
+        "triples" => output_triples(results),
         "json" => {
             let json_results: Vec<serde_json::Value> = results
                 .iter()
@@ -245,28 +258,15 @@ fn output_results(
                 })
                 .collect();
             println!("{}", serde_json::to_string_pretty(&json_results)?);
+            Ok(())
         }
         _ => {
             // YAML asserted notation output
-            for (entity_id, attrs) in results {
-                println!("{}:", entity_id);
-                println!("  {}:", namespace);
-                for (attr, values) in attrs {
-                    let short = schema::short_attribute(namespace, attr);
-                    if values.len() == 1 {
-                        println!("    {}: {}", short, schema::format_value(&values[0]));
-                    } else {
-                        println!("    {}:", short);
-                        for v in values {
-                            println!("      - {}", schema::format_value(v));
-                        }
-                    }
-                }
-            }
+            let yaml = format_asserted_yaml(results, namespace);
+            print!("{}", yaml);
+            Ok(())
         }
     }
-
-    Ok(())
 }
 
 /// Format and print concept query results (grouped under concept name).
@@ -326,4 +326,125 @@ fn output_concept_results(
     }
 
     Ok(())
+}
+
+/// Format and print results as EAV triples in YAML.
+///
+/// Each attribute-value pair becomes a separate triple:
+/// ```yaml
+/// - the: <qualified_attribute>
+///   of: <entity_did>
+///   is: <value>
+/// ```
+///
+/// Multi-valued attributes expand into multiple triples.
+fn output_triples(results: &BTreeMap<String, BTreeMap<String, Vec<Value>>>) -> Result<()> {
+    let yaml = format_triples(results)?;
+    if !yaml.is_empty() {
+        print!("{}", yaml);
+    }
+    Ok(())
+}
+
+/// Format results as asserted notation YAML string (entity-grouped).
+///
+/// Returns a YAML string with the structure:
+/// ```yaml
+/// <entity_did>:
+///   <namespace>:
+///     <field>: <value>
+/// ```
+pub fn format_asserted_yaml(
+    results: &BTreeMap<String, BTreeMap<String, Vec<Value>>>,
+    namespace: &str,
+) -> String {
+    use std::fmt::Write;
+    let mut output = String::new();
+    for (entity_id, attrs) in results {
+        writeln!(output, "{}:", entity_id).unwrap();
+        writeln!(output, "  {}:", namespace).unwrap();
+        for (attr, values) in attrs {
+            let short = schema::short_attribute(namespace, attr);
+            if values.len() == 1 {
+                writeln!(
+                    output,
+                    "    {}: {}",
+                    short,
+                    schema::format_value(&values[0])
+                )
+                .unwrap();
+            } else {
+                writeln!(output, "    {}:", short).unwrap();
+                for v in values {
+                    writeln!(output, "      - {}", schema::format_value(v)).unwrap();
+                }
+            }
+        }
+    }
+    output
+}
+
+/// Format results as EAV triple YAML string.
+///
+/// Returns the YAML string (without printing). Used by `output_triples`
+/// and available for testing round-trips.
+pub fn format_triples(results: &BTreeMap<String, BTreeMap<String, Vec<Value>>>) -> Result<String> {
+    if results.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut triples: Vec<serde_yaml::Value> = Vec::new();
+
+    for (entity_id, attrs) in results {
+        for (attr_name, values) in attrs {
+            for value in values {
+                let mut map = serde_yaml::Mapping::new();
+                map.insert(
+                    serde_yaml::Value::String("the".to_string()),
+                    serde_yaml::Value::String(attr_name.clone()),
+                );
+                map.insert(
+                    serde_yaml::Value::String("of".to_string()),
+                    serde_yaml::Value::String(entity_id.clone()),
+                );
+                map.insert(
+                    serde_yaml::Value::String("is".to_string()),
+                    value_to_yaml(value),
+                );
+                triples.push(serde_yaml::Value::Mapping(map));
+            }
+        }
+    }
+
+    Ok(serde_yaml::to_string(&triples)?)
+}
+
+/// Convert a dialog_query::Value to a serde_yaml::Value.
+fn value_to_yaml(value: &Value) -> serde_yaml::Value {
+    match value {
+        Value::String(s) => serde_yaml::Value::String(s.clone()),
+        Value::UnsignedInt(n) => {
+            // serde_yaml::Value doesn't support u128, downcast if possible
+            if *n <= u64::MAX as u128 {
+                serde_yaml::Value::Number(serde_yaml::Number::from(*n as u64))
+            } else {
+                serde_yaml::Value::String(n.to_string())
+            }
+        }
+        Value::SignedInt(n) => {
+            if *n >= i64::MIN as i128 && *n <= i64::MAX as i128 {
+                serde_yaml::Value::Number(serde_yaml::Number::from(*n as i64))
+            } else {
+                serde_yaml::Value::String(n.to_string())
+            }
+        }
+        Value::Float(f) => {
+            serde_yaml::to_value(f).unwrap_or_else(|_| serde_yaml::Value::String(f.to_string()))
+        }
+        Value::Boolean(b) => serde_yaml::Value::Bool(*b),
+        Value::Entity(e) => serde_yaml::Value::String(e.to_string()),
+        Value::Symbol(s) => serde_yaml::Value::String(format!(":{}", s)),
+        Value::Bytes(b) => serde_yaml::Value::String(format!("<{} bytes>", b.len())),
+        Value::Record(r) => serde_yaml::Value::String(format!("<{} bytes record>", r.len())),
+    }
 }

--- a/rust/carry/src/retract_cmd.rs
+++ b/rust/carry/src/retract_cmd.rs
@@ -8,6 +8,7 @@ use crate::site::SiteContext;
 use crate::target::{Field, FirstArg, Target};
 use anyhow::{Context, Result};
 use dialog_artifacts::{Artifact, ArtifactStoreMut, Instruction};
+use std::slice::from_ref;
 
 /// Execute `carry retract <TARGET>|<FILE>|- [this=<ENTITY>] [FIELD[=VALUE]...]`.
 pub async fn execute(
@@ -21,9 +22,8 @@ pub async fn execute(
         FirstArg::Target(target) => {
             retract_with_target(ctx, target, this_entity, fields, format).await
         }
-        FirstArg::Stdin | FirstArg::File(_) => {
-            anyhow::bail!("File/stdin retract is not yet implemented")
-        }
+        FirstArg::Stdin => retract_from_stdin(ctx, format).await,
+        FirstArg::File(path) => retract_from_file(ctx, &path, format).await,
     }
 }
 
@@ -266,6 +266,265 @@ fn print_retract_result(entity: &dialog_query::Entity, count: usize, format: &st
         }
         _ => {
             println!("Retracted {} claims from {}", count, entity);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File/stdin input
+// ---------------------------------------------------------------------------
+
+/// Retract claims from a YAML/JSON file.
+async fn retract_from_file(ctx: &SiteContext, path: &str, format: &str) -> Result<()> {
+    let content = std::fs::read_to_string(path)?;
+    retract_from_content(ctx, &content, path, format).await
+}
+
+/// Retract claims from stdin.
+async fn retract_from_stdin(ctx: &SiteContext, format: &str) -> Result<()> {
+    let content = std::io::read_to_string(std::io::stdin())?;
+    retract_from_content(ctx, &content, "-", format).await
+}
+
+/// Retract claims from file/stdin content.
+async fn retract_from_content(
+    ctx: &SiteContext,
+    content: &str,
+    source: &str,
+    _format: &str,
+) -> Result<()> {
+    let trimmed = content.trim();
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        retract_from_json(ctx, trimmed).await
+    } else {
+        retract_from_yaml(ctx, trimmed).await
+    }
+    .with_context(|| format!("Failed to process {}", source))
+}
+
+/// Retract claims from formal JSON content (EAV triples).
+async fn retract_from_json(ctx: &SiteContext, content: &str) -> Result<()> {
+    let triples: Vec<serde_json::Value> = serde_json::from_str(content)?;
+    let mut branch = ctx.open_branch().await?;
+
+    let mut instructions = Vec::new();
+    for triple in &triples {
+        let the = triple["the"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing 'the' in triple"))?;
+        let of = triple["of"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing 'of' in triple"))?;
+        let is = &triple["is"];
+
+        let attr = schema::parse_claim_attribute(the)?;
+        let entity = resolve_entity(of)?;
+        let value = json_to_value(is)?;
+
+        instructions.push(Instruction::Retract(Artifact {
+            the: attr,
+            of: entity,
+            is: value,
+            cause: None,
+        }));
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    println!("Retracted {} claims", count);
+    Ok(())
+}
+
+/// Retract claims from YAML content.
+///
+/// Supports two formats:
+/// 1. EAV triple notation (sequence of `{the, of, is}` mappings)
+/// 2. Asserted notation (entity-grouped: `entity → namespace → field: value`)
+async fn retract_from_yaml(ctx: &SiteContext, content: &str) -> Result<()> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(content)?;
+
+    match &doc {
+        serde_yaml::Value::Sequence(seq) => retract_from_eav_yaml(ctx, seq).await,
+        serde_yaml::Value::Mapping(map) => {
+            let is_asserted = map
+                .iter()
+                .any(|(k, v)| k.as_str().is_some_and(|s| s.starts_with("did:")) && v.is_mapping());
+
+            if is_asserted {
+                retract_from_asserted_yaml(ctx, map).await
+            } else if map.get("the").is_some() {
+                retract_from_eav_yaml(ctx, from_ref(&doc)).await
+            } else {
+                anyhow::bail!(
+                    "Unrecognized YAML format: expected EAV triples (sequence of {{the, of, is}}) \
+                     or asserted notation (entity → namespace → fields)"
+                )
+            }
+        }
+        _ => anyhow::bail!("Expected YAML sequence or mapping"),
+    }
+}
+
+/// Retract claims from EAV triple YAML.
+async fn retract_from_eav_yaml(ctx: &SiteContext, triples: &[serde_yaml::Value]) -> Result<()> {
+    let mut branch = ctx.open_branch().await?;
+
+    let mut instructions = Vec::new();
+    for triple in triples {
+        let the = triple["the"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing 'the' in triple"))?;
+        let of = triple["of"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing 'of' in triple"))?;
+
+        let attr = schema::parse_claim_attribute(the)?;
+        let entity = resolve_entity(of)?;
+        let is = &triple["is"];
+        let value = yaml_to_value(is)?;
+
+        instructions.push(Instruction::Retract(Artifact {
+            the: attr,
+            of: entity,
+            is: value,
+            cause: None,
+        }));
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    println!("Retracted {} claims", count);
+    Ok(())
+}
+
+/// Retract claims from asserted notation YAML (entity-grouped mapping).
+async fn retract_from_asserted_yaml(
+    ctx: &SiteContext,
+    top_map: &serde_yaml::Mapping,
+) -> Result<()> {
+    let mut branch = ctx.open_branch().await?;
+    let mut instructions = Vec::new();
+
+    for (entity_key, namespace_map) in top_map {
+        let entity_id = entity_key
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Expected entity key to be a string"))?;
+        let entity = resolve_entity(entity_id)?;
+
+        let ns_map = namespace_map.as_mapping().ok_or_else(|| {
+            anyhow::anyhow!("Expected namespace mapping for entity '{}'", entity_id)
+        })?;
+
+        for (ns_key, fields_val) in ns_map {
+            let namespace = ns_key
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Expected namespace key to be a string"))?;
+
+            let fields_map = fields_val.as_mapping().ok_or_else(|| {
+                anyhow::anyhow!("Expected fields mapping under namespace '{}'", namespace)
+            })?;
+
+            for (field_key, value) in fields_map {
+                let field_name = field_key
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("Expected field key to be a string"))?;
+
+                let qualified = format!("{}/{}", namespace, field_name);
+                let attr = schema::parse_claim_attribute(&qualified)?;
+
+                match value {
+                    serde_yaml::Value::Sequence(seq) => {
+                        for item in seq {
+                            let val = yaml_to_value(item)?;
+                            instructions.push(Instruction::Retract(Artifact {
+                                the: attr.clone(),
+                                of: entity.clone(),
+                                is: val,
+                                cause: None,
+                            }));
+                        }
+                    }
+                    _ => {
+                        let val = yaml_to_value(value)?;
+                        instructions.push(Instruction::Retract(Artifact {
+                            the: attr,
+                            of: entity.clone(),
+                            is: val,
+                            cause: None,
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    println!("Retracted {} claims", count);
+    Ok(())
+}
+
+fn resolve_entity(s: &str) -> Result<dialog_query::Entity> {
+    if s.starts_with("did:") {
+        use std::str::FromStr;
+        dialog_query::Entity::from_str(s).context("Invalid entity DID")
+    } else {
+        schema::derive_entity(s)
+    }
+}
+
+fn json_to_value(v: &serde_json::Value) -> Result<dialog_query::Value> {
+    use dialog_query::Value;
+    match v {
+        serde_json::Value::String(s) => Ok(schema::parse_value(s)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i >= 0 {
+                    Ok(Value::UnsignedInt(i as u128))
+                } else {
+                    Ok(Value::SignedInt(i as i128))
+                }
+            } else if let Some(f) = n.as_f64() {
+                Ok(Value::Float(f))
+            } else {
+                anyhow::bail!("Unsupported number: {}", n)
+            }
+        }
+        serde_json::Value::Bool(b) => Ok(Value::Boolean(*b)),
+        _ => Ok(Value::String(v.to_string())),
+    }
+}
+
+fn yaml_to_value(v: &serde_yaml::Value) -> Result<dialog_query::Value> {
+    use dialog_query::Value;
+    match v {
+        serde_yaml::Value::String(s) => Ok(schema::parse_value(s)),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i >= 0 {
+                    Ok(Value::UnsignedInt(i as u128))
+                } else {
+                    Ok(Value::SignedInt(i as i128))
+                }
+            } else if let Some(f) = n.as_f64() {
+                Ok(Value::Float(f))
+            } else {
+                anyhow::bail!("Unsupported number: {:?}", n)
+            }
+        }
+        serde_yaml::Value::Bool(b) => Ok(Value::Boolean(*b)),
+        _ => {
+            let s = serde_yaml::to_string(v)?;
+            Ok(Value::String(s.trim().to_string()))
         }
     }
 }

--- a/rust/carry/src/retract_cmd.rs
+++ b/rust/carry/src/retract_cmd.rs
@@ -1,6 +1,7 @@
 //! `carry retract` — retract claims from entities.
 //!
-//! Supports domain targets, concept targets, file input, and stdin.
+//! Supports domain targets, concept targets (builtin and user-defined),
+//! file input, and stdin.
 
 use crate::schema;
 use crate::site::SiteContext;
@@ -45,12 +46,27 @@ async fn retract_with_target(
         schema::derive_entity(&entity_str)?
     };
 
-    let namespace = target.namespace();
+    match target {
+        Target::Domain(ref domain) => retract_domain(ctx, domain, &entity, &fields, format).await,
+        Target::Concept(ref concept_name) => {
+            retract_concept(ctx, concept_name, &entity, &fields, format).await
+        }
+    }
+}
+
+/// Retract claims using a domain target.
+async fn retract_domain(
+    ctx: &SiteContext,
+    domain: &str,
+    entity: &dialog_query::Entity,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
     let mut branch = ctx.open_branch().await?;
 
     if fields.is_empty() {
         // Retract ALL facts about this entity
-        let all_facts = schema::fetch_all_entity_facts(&branch, &entity).await?;
+        let all_facts = schema::fetch_all_entity_facts(&branch, entity).await?;
         if all_facts.is_empty() {
             anyhow::bail!("Entity '{}' not found (no facts to retract)", entity);
         }
@@ -72,75 +88,184 @@ async fn retract_with_target(
             .commit(futures_util::stream::iter(instructions))
             .await?;
 
-        match format {
-            "json" => {
-                println!(
-                    "{}",
-                    serde_json::json!({
-                        "entity": entity.to_string(),
-                        "retracted": count,
-                    })
-                );
-            }
-            _ => {
-                println!("Retracted {} claims from {}", count, entity);
-            }
-        }
+        print_retract_result(entity, count, format);
     } else {
-        // Retract specific fields
-        let mut instructions = Vec::new();
+        retract_specific_fields(&mut branch, entity, domain, fields, format).await?;
+    }
 
-        for f in &fields {
-            let attr_name = f.qualified_name(namespace);
-            let attr = schema::parse_claim_attribute(&attr_name)?;
+    Ok(())
+}
 
-            if let Some(ref val_str) = f.value {
-                // Retract a specific value
-                let value = schema::parse_value(val_str);
-                instructions.push(Instruction::Retract(Artifact {
-                    the: attr,
-                    of: entity.clone(),
-                    is: value,
-                    cause: None,
-                }));
-            } else {
-                // Retract all values for this attribute
-                let values = schema::fetch_values(&branch, &entity, attr.clone()).await?;
-                for value in values {
-                    instructions.push(Instruction::Retract(Artifact {
-                        the: attr.clone(),
-                        of: entity.clone(),
-                        is: value,
-                        cause: None,
-                    }));
-                }
-            }
+/// Retract claims using a concept target.
+async fn retract_concept(
+    ctx: &SiteContext,
+    concept_name: &str,
+    entity: &dialog_query::Entity,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
+    if fields.is_empty() {
+        // Retract all facts about this entity
+        let mut branch = ctx.open_branch().await?;
+        let all_facts = schema::fetch_all_entity_facts(&branch, entity).await?;
+        if all_facts.is_empty() {
+            anyhow::bail!("Entity '{}' not found (no facts to retract)", entity);
         }
 
-        if instructions.is_empty() {
-            anyhow::bail!("No matching claims found to retract");
-        }
+        let instructions: Vec<Instruction> = all_facts
+            .into_iter()
+            .map(|artifact| {
+                Instruction::Retract(Artifact {
+                    the: artifact.the,
+                    of: artifact.of,
+                    is: artifact.is,
+                    cause: artifact.cause,
+                })
+            })
+            .collect();
 
         let count = instructions.len();
         branch
             .commit(futures_util::stream::iter(instructions))
             .await?;
 
-        match format {
-            "json" => {
-                println!(
-                    "{}",
-                    serde_json::json!({
-                        "entity": entity.to_string(),
-                        "retracted": count,
-                    })
-                );
-            }
-            _ => {
-                println!("Retracted {} claims from {}", count, entity);
+        print_retract_result(entity, count, format);
+        return Ok(());
+    }
+
+    // Resolve the concept to get field→selector mappings
+    let session = ctx.open_session().await?;
+
+    // Try builtin first, then user-defined
+    let resolved_fields: Vec<(String, Option<String>)> = if let Some(builtin) =
+        schema::lookup_builtin(concept_name)
+    {
+        fields
+            .iter()
+            .map(|f| {
+                let (relation, _) =
+                    schema::resolve_builtin_field(builtin, &f.name).ok_or_else(|| {
+                        anyhow::anyhow!("Unknown field '{}' for concept '{}'", f.name, concept_name)
+                    })?;
+                Ok((relation, f.value.clone()))
+            })
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        let concept = schema::resolve_concept(&session, concept_name).await?;
+        fields
+            .iter()
+            .map(|f| {
+                let selector = schema::resolve_field_selector(&concept, &f.name)?;
+                Ok((selector, f.value.clone()))
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    drop(session);
+    let mut branch = ctx.open_branch().await?;
+
+    let mut instructions = Vec::new();
+
+    for (attr_name, value) in &resolved_fields {
+        let attr = schema::parse_claim_attribute(attr_name)?;
+
+        if let Some(val_str) = value {
+            // Retract a specific value
+            let value = schema::parse_value(val_str);
+            instructions.push(Instruction::Retract(Artifact {
+                the: attr,
+                of: entity.clone(),
+                is: value,
+                cause: None,
+            }));
+        } else {
+            // Retract all values for this attribute
+            let values = schema::fetch_values(&branch, entity, attr.clone()).await?;
+            for value in values {
+                instructions.push(Instruction::Retract(Artifact {
+                    the: attr.clone(),
+                    of: entity.clone(),
+                    is: value,
+                    cause: None,
+                }));
             }
         }
     }
 
+    if instructions.is_empty() {
+        anyhow::bail!("No matching claims found to retract");
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    print_retract_result(entity, count, format);
     Ok(())
+}
+
+/// Retract specific fields using domain-qualified names.
+async fn retract_specific_fields(
+    branch: &mut dialog_artifacts::repository::Branch<tonk_space::FsBackend>,
+    entity: &dialog_query::Entity,
+    namespace: &str,
+    fields: &[Field],
+    format: &str,
+) -> Result<()> {
+    let mut instructions = Vec::new();
+
+    for f in fields {
+        let attr_name = f.qualified_name(namespace);
+        let attr = schema::parse_claim_attribute(&attr_name)?;
+
+        if let Some(ref val_str) = f.value {
+            let value = schema::parse_value(val_str);
+            instructions.push(Instruction::Retract(Artifact {
+                the: attr,
+                of: entity.clone(),
+                is: value,
+                cause: None,
+            }));
+        } else {
+            let values = schema::fetch_values(branch, entity, attr.clone()).await?;
+            for value in values {
+                instructions.push(Instruction::Retract(Artifact {
+                    the: attr.clone(),
+                    of: entity.clone(),
+                    is: value,
+                    cause: None,
+                }));
+            }
+        }
+    }
+
+    if instructions.is_empty() {
+        anyhow::bail!("No matching claims found to retract");
+    }
+
+    let count = instructions.len();
+    branch
+        .commit(futures_util::stream::iter(instructions))
+        .await?;
+
+    print_retract_result(entity, count, format);
+    Ok(())
+}
+
+fn print_retract_result(entity: &dialog_query::Entity, count: usize, format: &str) {
+    match format {
+        "json" => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "entity": entity.to_string(),
+                    "retracted": count,
+                })
+            );
+        }
+        _ => {
+            println!("Retracted {} claims from {}", count, entity);
+        }
+    }
 }

--- a/rust/carry/src/schema.rs
+++ b/rust/carry/src/schema.rs
@@ -1,67 +1,261 @@
 //! Shared helpers for the concepts & facts system.
 //!
-//! Provides deterministic entity derivation, attribute name prefixing,
-//! and common storage access patterns.
+//! Provides typed meta-schema definitions using dialog-query derive macros,
+//! deterministic entity derivation, and common storage access patterns.
+//!
+//! ## Meta-schema domains (RFC)
+//!
+//! | Domain                  | Purpose                                          |
+//! |-------------------------|--------------------------------------------------|
+//! | `dialog.attribute`      | Attribute identity fields (id, type, cardinality) |
+//! | `dialog.concept.with`   | Required concept membership by field name         |
+//! | `dialog.concept.maybe`  | Optional concept membership by field name          |
+//! | `dialog.meta`           | Universal metadata: names and descriptions        |
 
 use anyhow::{Context, Result};
 use base64::Engine as _;
 use dialog_artifacts::{ArtifactSelector, ArtifactStore};
+use dialog_query::Attribute as _;
 pub use dialog_query::claim::Attribute as ClaimAttribute;
 use dialog_query::concept::Concept as _;
-use dialog_query::{Cardinality, Entity, Value};
+use dialog_query::{Entity, Value};
 use futures_util::TryStreamExt;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 // ---------------------------------------------------------------------------
-// Typed meta-schema for registered concepts
+// Typed primitive attributes (RFC §Appendix: Primitive domains)
 // ---------------------------------------------------------------------------
 
-/// Meta-schema attributes for registered concepts.
-///
-/// These model "the concept of a concept" as a typed schema using
-/// dialog-query's `#[derive(Attribute)]` system. The module name
-/// `concept` becomes the attribute namespace, producing selectors
-/// like `concept/name`, `concept/attribute`, etc.
-pub mod concept {
-    /// The human-readable name of the concept.
+/// Universal metadata attributes: names and descriptions for any entity.
+pub mod dialog_meta {
+    /// Human-readable name for any entity.
     #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.meta")]
     pub struct Name(pub String);
 
-    /// Description of the concept.
+    /// Human-readable description for any entity.
     #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.meta")]
     pub struct Description(pub String);
-
-    /// A fully-qualified attribute belonging to the concept (multi-valued).
-    #[derive(dialog_query::Attribute, Clone, PartialEq)]
-    #[cardinality(many)]
-    pub struct Attribute(pub String);
-
-    /// The namespace the concept belongs to.
-    #[derive(dialog_query::Attribute, Clone, PartialEq)]
-    pub struct Namespace(pub String);
-
-    /// Entity ID of the prior concept (for schema evolution tracking).
-    #[derive(dialog_query::Attribute, Clone, PartialEq)]
-    pub struct Prior(pub String);
-
-    /// Rationale for updating a concept.
-    #[derive(dialog_query::Attribute, Clone, PartialEq)]
-    pub struct UpdateRationale(pub String);
 }
 
-/// A registered concept in the space, modeled as a typed concept.
+/// Attribute identity fields.
+pub mod dialog_attribute {
+    /// Nominal identifier (selector) of the attribute, e.g. `io.gozala.person/name`.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    pub struct Id(pub String);
+
+    /// Value type of the attribute (e.g. Text, UnsignedInteger, Symbol).
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    #[dialog(rename = "type")]
+    pub struct Kind(pub String);
+
+    /// Cardinality: `one` or `many`.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    pub struct Cardinality(pub String);
+}
+
+// ---------------------------------------------------------------------------
+// Typed builtin concept structs
+// ---------------------------------------------------------------------------
+
+/// The `attribute` concept: models a typed relation.
 ///
-/// Because the `attribute` field has `Cardinality::Many`, querying
-/// `Match::<RegisteredConcept>` returns one row per attribute value
-/// (join semantics). Callers should deduplicate by entity.
+/// CLI field mapping:
+///   `the`         → `dialog.attribute/id`
+///   `as`          → `dialog.attribute/type`
+///   `cardinality` → `dialog.attribute/cardinality`
+///   `description` → `dialog.meta/description`
 #[derive(dialog_query::Concept, Debug, Clone)]
-#[allow(dead_code)]
-pub struct RegisteredConcept {
+pub struct AttributeDef {
     pub this: Entity,
-    pub name: concept::Name,
-    pub description: concept::Description,
-    pub namespace: concept::Namespace,
-    pub attribute: concept::Attribute,
+    pub description: dialog_meta::Description,
+    #[dialog(rename = "the")]
+    pub selector: dialog_attribute::Id,
+    #[dialog(rename = "as")]
+    pub value_type: dialog_attribute::Kind,
+    pub cardinality: dialog_attribute::Cardinality,
+}
+
+/// The `bookmark` concept: maps a name to any entity.
+///
+/// CLI field mapping:
+///   `name` → `dialog.meta/name`
+#[derive(dialog_query::Concept, Debug, Clone)]
+pub struct BookmarkDef {
+    pub this: Entity,
+    pub name: dialog_meta::Name,
+}
+
+// Note: The `concept` concept cannot be fully expressed with #[derive(Concept)]
+// because its `with` and `maybe` fields are variable-keyed (with.{?name}).
+// The fixed `description` field is captured here; variable-keyed fields are
+// handled dynamically.
+
+/// The `concept` concept (partial): captures the fixed `description` field.
+///
+/// Variable-keyed fields (`with.{name}`, `maybe.{name}`) are handled
+/// dynamically in assertion/query code.
+#[derive(dialog_query::Concept, Debug, Clone)]
+pub struct ConceptDef {
+    pub this: Entity,
+    pub description: dialog_meta::Description,
+}
+
+// ---------------------------------------------------------------------------
+// Builtin concept field mapping (CLI field name → attribute selector)
+// ---------------------------------------------------------------------------
+
+/// A field within a pre-registered concept's schema.
+#[derive(Debug, Clone)]
+pub struct BuiltinField {
+    /// The field name as exposed to the CLI (e.g. "the", "as", "name").
+    pub cli_name: &'static str,
+    /// The fully-qualified relation identifier this field maps to.
+    pub relation: &'static str,
+    /// The expected value type (for documentation/validation).
+    pub value_type: &'static str,
+    /// Default cardinality.
+    pub cardinality: &'static str,
+    /// Whether this is a variable-keyed field (e.g. `with` on the concept concept).
+    pub variable_keyed: bool,
+}
+
+/// Schema for a pre-registered concept.
+#[derive(Debug, Clone)]
+pub struct BuiltinConceptSchema {
+    /// The concept name (also its bookmark).
+    pub name: &'static str,
+    /// Human-readable description.
+    pub description: &'static str,
+    /// Required fields (`with`).
+    pub with_fields: &'static [BuiltinField],
+    /// Optional fields (`maybe`).
+    pub maybe_fields: &'static [BuiltinField],
+}
+
+/// The `attribute` concept schema.
+pub static BUILTIN_ATTRIBUTE: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "attribute",
+    description: "Built-in concept for modeling attributes",
+    with_fields: &[
+        BuiltinField {
+            cli_name: "description",
+            relation: "dialog.meta/description",
+            value_type: "Text",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "the",
+            relation: "dialog.attribute/id",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "as",
+            relation: "dialog.attribute/type",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "cardinality",
+            relation: "dialog.attribute/cardinality",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+    ],
+    maybe_fields: &[],
+};
+
+/// The `concept` concept schema.
+pub static BUILTIN_CONCEPT: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "concept",
+    description: "Built-in concept for composing attributes into a shape",
+    with_fields: &[
+        BuiltinField {
+            cli_name: "description",
+            relation: "dialog.meta/description",
+            value_type: "Text",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "with",
+            relation: "dialog.concept.with/",
+            value_type: "attribute",
+            cardinality: "one",
+            variable_keyed: true,
+        },
+    ],
+    maybe_fields: &[BuiltinField {
+        cli_name: "maybe",
+        relation: "dialog.concept.maybe/",
+        value_type: "attribute",
+        cardinality: "one",
+        variable_keyed: true,
+    }],
+};
+
+/// The `bookmark` concept schema.
+pub static BUILTIN_BOOKMARK: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "bookmark",
+    description: "Naming mechanism mapping a local name to any entity",
+    with_fields: &[BuiltinField {
+        cli_name: "name",
+        relation: "dialog.meta/name",
+        value_type: "Text",
+        cardinality: "one",
+        variable_keyed: false,
+    }],
+    maybe_fields: &[],
+};
+
+/// Look up a pre-registered (builtin) concept schema by name.
+pub fn lookup_builtin(name: &str) -> Option<&'static BuiltinConceptSchema> {
+    match name.to_lowercase().as_str() {
+        "attribute" => Some(&BUILTIN_ATTRIBUTE),
+        "concept" => Some(&BUILTIN_CONCEPT),
+        "bookmark" => Some(&BUILTIN_BOOKMARK),
+        _ => None,
+    }
+}
+
+/// Find the relation for a CLI field name within a builtin concept schema.
+///
+/// For variable-keyed fields, `cli_field` should be the dotted form (e.g. "with.name").
+/// Returns `(relation, is_variable_keyed)`.
+pub fn resolve_builtin_field(
+    schema: &BuiltinConceptSchema,
+    cli_field: &str,
+) -> Option<(String, bool)> {
+    // Check fixed fields first
+    for f in schema.with_fields.iter().chain(schema.maybe_fields.iter()) {
+        if !f.variable_keyed && f.cli_name == cli_field {
+            return Some((f.relation.to_string(), false));
+        }
+    }
+    // Check variable-keyed fields (e.g. "with.name" → prefix "with")
+    for f in schema.with_fields.iter().chain(schema.maybe_fields.iter()) {
+        if f.variable_keyed {
+            if let Some(key) = cli_field
+                .strip_prefix(f.cli_name)
+                .and_then(|s| s.strip_prefix('.'))
+            {
+                if !key.is_empty() {
+                    return Some((format!("{}{}", f.relation, key), true));
+                }
+            }
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +263,7 @@ pub struct RegisteredConcept {
 // ---------------------------------------------------------------------------
 
 /// Validate that a name contains only safe characters: letters, digits,
-/// hyphens, and underscores. Used for both concept and rule names.
+/// hyphens, and underscores.
 pub fn validate_safe_name(name: &str, kind: &str) -> Result<()> {
     if name.is_empty() {
         anyhow::bail!("{} name cannot be empty", kind);
@@ -92,38 +286,20 @@ pub fn validate_safe_name(name: &str, kind: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// A validated concept name (alphanumeric, hyphens, underscores only).
-///
-/// Concept names are labels for concepts — they are decoupled from attribute
-/// namespaces. This type guarantees the name contains only safe characters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConceptName(String);
 
 impl ConceptName {
-    /// Create a new `ConceptName`, validating that it contains only safe characters.
-    ///
-    /// The name is normalized to lowercase for consistent storage and
-    /// exact-match lookups. Use [`ConceptName::from_stored`] to load
-    /// names read back from the database without re-normalizing.
     pub fn new(s: impl Into<String>) -> Result<Self> {
         let s = s.into();
         validate_safe_name(&s, "Concept")?;
         Ok(Self(s.to_lowercase()))
     }
 
-    /// Create from a name already stored in the database (skips validation).
-    ///
-    /// Use this only for names read back from storage that were validated
-    /// at write time.
     pub fn from_stored(s: String) -> Self {
         Self(s)
     }
 
-    /// The lowercase form used for entity derivation and attribute namespacing.
-    pub fn to_lowercase(&self) -> String {
-        self.0.to_lowercase()
-    }
-
-    /// The original name as stored.
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -149,217 +325,45 @@ impl AsRef<str> for ConceptName {
 }
 
 // ---------------------------------------------------------------------------
-// Well-known attribute selectors
+// Entity derivation
 // ---------------------------------------------------------------------------
 
-// Concept meta-schema attributes are defined as typed newtypes in the
-// `concept` module above. These selector functions and string constants
-// provide access for low-level Instruction building and fetch_string
-// queries respectively.
-
-/// Get the artifact-level selector for `concept/name`.
-pub fn concept_name_selector() -> ClaimAttribute {
-    <concept::Name as dialog_query::Attribute>::selector()
-}
-
-/// Get the artifact-level selector for `concept/description`.
-pub fn concept_description_selector() -> ClaimAttribute {
-    <concept::Description as dialog_query::Attribute>::selector()
-}
-
-/// Get the artifact-level selector for `concept/attribute`.
-pub fn concept_attribute_selector() -> ClaimAttribute {
-    <concept::Attribute as dialog_query::Attribute>::selector()
-}
-
-/// Get the artifact-level selector for `concept/namespace`.
-pub fn concept_namespace_selector() -> ClaimAttribute {
-    <concept::Namespace as dialog_query::Attribute>::selector()
-}
-
-/// Get the artifact-level selector for `concept/prior`.
-pub fn concept_prior_selector() -> ClaimAttribute {
-    <concept::Prior as dialog_query::Attribute>::selector()
-}
-
-/// Get the artifact-level selector for `concept/update-rationale`.
-pub fn concept_update_rationale_selector() -> ClaimAttribute {
-    <concept::UpdateRationale as dialog_query::Attribute>::selector()
-}
-
-/// Attribute metadata: human-readable description of the attribute.
-pub const ATTR_ATTRIBUTE_DESCRIPTION: &str = "attribute/description";
-
-/// Attribute metadata: type constraint (e.g. "Text", "Integer", "RecipeStep", or JSON array for enums).
-pub const ATTR_ATTRIBUTE_TYPE: &str = "attribute/type";
-
-/// Attribute metadata: cardinality ("many" for multi-valued, absent for single).
-pub const ATTR_ATTRIBUTE_CARDINALITY: &str = "attribute/cardinality";
-
-/// Attribute metadata: whether the attribute is optional.
-pub const ATTR_ATTRIBUTE_OPTIONAL: &str = "attribute/optional";
-
-/// Rule attribute: the human-readable name of the rule.
-pub const ATTR_RULE_NAME: &str = "rule/name";
-
-/// Rule attribute: optional description.
-pub const ATTR_RULE_DESCRIPTION: &str = "rule/description";
-
-/// Rule attribute: name of the conclusion concept.
-pub const ATTR_RULE_CONCLUSION: &str = "rule/conclusion";
-
-/// Rule attribute: JSON-serialized rule definition.
-pub const ATTR_RULE_DEFINITION: &str = "rule/definition";
-
-// ---------------------------------------------------------------------------
-// Deterministic entity derivation
-// ---------------------------------------------------------------------------
-
-/// Derive a concept entity from its attribute set using dialog-db's
-/// structural identity.
+/// Derive an attribute entity from its identity fields.
 ///
-/// Builds a dynamic `Concept` from the attribute list, computes its
-/// `operator()` URI (a blake3 hash of the CBOR-encoded attribute set),
-/// then derives a deterministic `did:key` entity from that URI.
-///
-/// Two concepts with the same attributes (same namespace/name/cardinality/type
-/// per attribute) produce the same entity ID, regardless of concept name.
-pub fn concept_entity_from_attrs(
-    attributes: &[String],
-    cardinalities: &std::collections::HashMap<String, Cardinality>,
+/// Per the RFC: `entity = hash(the, type, cardinality)`.
+/// Description and name do NOT participate in identity.
+pub fn derive_attribute_entity(
+    selector: &str,
+    value_type: &str,
+    cardinality: &str,
 ) -> Result<Entity> {
-    let concept = build_dynamic_concept(attributes, cardinalities)?;
-    let operator_uri = concept.operator();
-    derive_entity(&operator_uri)
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"attribute\0");
+    hasher.update(selector.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(value_type.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(cardinality.as_bytes());
+    derive_entity_from_hash(&hasher.finalize())
 }
 
-/// Look up a concept entity by name.
+/// Derive a concept entity from its field→attribute mappings.
 ///
-/// Queries the AEV index using the typed `concept::Name` selector,
-/// with case-insensitive matching.
-pub async fn lookup_concept_by_name<S: ArtifactStore>(
-    store: &S,
-    name: &ConceptName,
-) -> Result<Option<Entity>> {
-    let concept_entities = find_entities_by_attribute(store, concept_name_selector()).await?;
-
-    for entity in concept_entities {
-        let stored_names = fetch_string_values(store, &entity, concept_name_selector()).await?;
-        if stored_names
-            .iter()
-            .any(|n| n.to_lowercase() == name.to_lowercase())
-        {
-            return Ok(Some(entity));
-        }
+/// Per the RFC: identity = hash(sorted (field_name, attribute_entity) pairs).
+/// Both field names and attribute entities participate. `maybe` fields do NOT.
+pub fn derive_concept_entity(with_fields: &BTreeMap<String, Entity>) -> Result<Entity> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"concept\0");
+    for (field_name, attr_entity) in with_fields {
+        hasher.update(field_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(attr_entity.to_string().as_bytes());
+        hasher.update(b"\0");
     }
-    Ok(None)
-}
-
-/// Find all named concept entities in the store.
-///
-/// Discovers concepts by querying the AEV index for entities with the
-/// typed `concept::Name` attribute. Returns `(entity, name)` pairs.
-pub async fn find_all_concepts<S: ArtifactStore>(store: &S) -> Result<Vec<(Entity, String)>> {
-    let entities = find_entities_by_attribute(store, concept_name_selector()).await?;
-    let mut result = Vec::new();
-    for entity in entities {
-        let names = fetch_string_values(store, &entity, concept_name_selector()).await?;
-        for name in names {
-            result.push((entity.clone(), name));
-        }
-    }
-    Ok(result)
-}
-
-/// Find all rule entities in the store (both named and unnamed).
-///
-/// Discovers rules by querying the AEV index for entities with a
-/// `rule/conclusion` attribute (which all rules have). Returns
-/// `(entity, Option<name>)` pairs.
-pub async fn find_all_rules<S: ArtifactStore>(store: &S) -> Result<Vec<(Entity, Option<String>)>> {
-    let conclusion_attr = parse_claim_attribute(ATTR_RULE_CONCLUSION)?;
-    let rule_name_attr = parse_claim_attribute(ATTR_RULE_NAME)?;
-    let entities = find_entities_by_attribute(store, conclusion_attr).await?;
-    let mut result = Vec::new();
-    for entity in entities {
-        let name = fetch_string(store, &entity, rule_name_attr.clone()).await?;
-        result.push((entity, name));
-    }
-    Ok(result)
-}
-
-/// Look up a rule entity by name.
-///
-/// Discovers rules structurally by querying the AEV index for all
-/// entities with a `rule/name` attribute, then matches by name
-/// (case-insensitive).
-pub async fn lookup_rule_by_name<S: ArtifactStore>(
-    store: &S,
-    name: &str,
-) -> Result<Option<Entity>> {
-    let rule_name_attr = parse_claim_attribute(ATTR_RULE_NAME)?;
-    let rule_entities = find_entities_by_attribute(store, rule_name_attr.clone()).await?;
-    for entity in rule_entities {
-        if let Some(stored_name) = fetch_string(store, &entity, rule_name_attr.clone()).await?
-            && stored_name.to_lowercase() == name.to_lowercase()
-        {
-            return Ok(Some(entity));
-        }
-    }
-    Ok(None)
-}
-
-/// Derive the rule entity for a given rule name within a space.
-///
-/// Deterministically derived as an Ed25519 `did:key` from the space DID and rule name.
-pub fn rule_entity(space_did: &str, rule_name: &str) -> Result<Entity> {
-    derive_entity(&format!(
-        "{}\0rule\0{}",
-        space_did,
-        rule_name.to_lowercase()
-    ))
-}
-
-/// Derive the rule entity from its definition content (for unnamed rules).
-///
-/// Deterministically derived as an Ed25519 `did:key` from the space DID and
-/// the blake3 hash of the canonical definition JSON. Same definition in the
-/// same space always produces the same entity, making unnamed defines idempotent.
-pub fn rule_entity_from_definition(space_did: &str, definition_json: &str) -> Result<Entity> {
-    let def_hash = blake3::hash(definition_json.as_bytes());
-    derive_entity(&format!("{}\0rule\0def:{}", space_did, def_hash.to_hex()))
-}
-
-/// Derive an attribute metadata entity from its structural identity.
-///
-/// Uses dialog-db's `AttributeSchema::to_uri()` to derive a deterministic
-/// entity ID from the attribute's namespace/name. This is concept-independent —
-/// the same attribute used in multiple concepts shares one metadata entity.
-pub fn attribute_meta_entity(attr_name: &str) -> Result<Entity> {
-    let (ns, name) = attr_name.split_once('/').ok_or_else(|| {
-        anyhow::anyhow!(
-            "Malformed attribute '{}': expected 'namespace/name' format",
-            attr_name
-        )
-    })?;
-    let schema = dialog_query::AttributeSchema::<Value>::new(
-        leak_str(ns),
-        leak_str(name),
-        leak_str(""),
-        dialog_query::Type::String,
-    );
-    let uri = schema.to_uri();
-    derive_entity(&uri)
+    derive_entity_from_hash(&hasher.finalize())
 }
 
 /// Convert 32 bytes of hash output into a proper Ed25519 `did:key` entity.
-///
-/// Treats the hash as an Ed25519 signing key seed, then formats the
-/// resulting verifying (public) key as a standards-compliant `did:key`
-/// with the Ed25519 multicodec prefix `[0xed, 0x01]`.
-///
-/// This is the canonical implementation — `derive_entity()` and
-/// `derive_entity_from_fields()` both delegate here, as does `fact.rs`.
 pub fn derive_entity_from_hash(hash: &blake3::Hash) -> Result<Entity> {
     let signing_key = ed25519_dalek::SigningKey::from_bytes(hash.as_bytes());
     let verifying_key = signing_key.verifying_key();
@@ -372,18 +376,12 @@ pub fn derive_entity_from_hash(hash: &blake3::Hash) -> Result<Entity> {
     Entity::from_str(&uri).context("Failed to derive did:key entity")
 }
 
-/// Low-level: hash input to produce a deterministic `did:key` entity.
-///
-/// Uses blake3 to hash the input, then delegates to [`derive_entity_from_hash`].
+/// Hash input to produce a deterministic `did:key` entity.
 pub fn derive_entity(input: &str) -> Result<Entity> {
     derive_entity_from_hash(&blake3::hash(input.as_bytes()))
 }
 
 /// Derive an entity ID deterministically from field content.
-///
-/// Sorts fields by attribute name, hashes the concatenated key/value pairs
-/// with blake3, then delegates to [`derive_entity_from_hash`] for proper Ed25519
-/// `did:key` formatting.
 pub fn derive_entity_from_fields(fields: &[(String, String)]) -> Result<Entity> {
     let mut sorted = fields.to_vec();
     sorted.sort_by(|a, b| a.0.cmp(&b.0));
@@ -400,14 +398,342 @@ pub fn derive_entity_from_fields(fields: &[(String, String)]) -> Result<Entity> 
 }
 
 // ---------------------------------------------------------------------------
+// Concept resolution (runtime lookup via dialog.meta/name)
+// ---------------------------------------------------------------------------
+
+/// Look up any entity by its `dialog.meta/name` value.
+pub async fn lookup_entity_by_name<S: ArtifactStore>(
+    store: &S,
+    name: &str,
+) -> Result<Option<Entity>> {
+    let name_attr = dialog_meta::Name::selector();
+    let entities = find_entities_by_attribute(store, name_attr.clone()).await?;
+
+    for entity in entities {
+        let stored_names = fetch_string_values(store, &entity, name_attr.clone()).await?;
+        if stored_names
+            .iter()
+            .any(|n| n.to_lowercase() == name.to_lowercase())
+        {
+            return Ok(Some(entity));
+        }
+    }
+    Ok(None)
+}
+
+/// A concept resolved from the database at runtime.
+#[derive(Debug, Clone)]
+pub struct ResolvedConcept {
+    /// The concept entity.
+    pub entity: Entity,
+    /// The concept's name.
+    pub name: String,
+    /// Required fields: field_name → (attribute_entity, attribute_selector).
+    pub with_fields: BTreeMap<String, (Entity, String)>,
+    /// Optional fields: same structure.
+    pub maybe_fields: BTreeMap<String, (Entity, String)>,
+}
+
+/// Resolve a concept by name: look up the entity, fetch its
+/// `dialog.concept.with/*` and `dialog.concept.maybe/*` claims,
+/// and for each attribute entity fetch its `dialog.attribute/id`.
+pub async fn resolve_concept<S: ArtifactStore>(
+    store: &S,
+    concept_name: &str,
+) -> Result<ResolvedConcept> {
+    let concept_entity = lookup_entity_by_name(store, concept_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Concept '{}' not found", concept_name))?;
+
+    let with_fields = fetch_concept_fields(store, &concept_entity, "dialog.concept.with/").await?;
+    let maybe_fields =
+        fetch_concept_fields(store, &concept_entity, "dialog.concept.maybe/").await?;
+
+    if with_fields.is_empty() {
+        anyhow::bail!("Concept '{}' has no required fields", concept_name);
+    }
+
+    Ok(ResolvedConcept {
+        entity: concept_entity,
+        name: concept_name.to_string(),
+        with_fields,
+        maybe_fields,
+    })
+}
+
+/// Fetch concept fields from `dialog.concept.with/*` or `dialog.concept.maybe/*` claims.
+///
+/// Returns a map of field_name → (attribute_entity, attribute_selector).
+async fn fetch_concept_fields<S: ArtifactStore>(
+    store: &S,
+    concept_entity: &Entity,
+    prefix: &str,
+) -> Result<BTreeMap<String, (Entity, String)>> {
+    let mut fields = BTreeMap::new();
+
+    let results: Vec<_> = store
+        .select(ArtifactSelector::new().of(concept_entity.clone()))
+        .try_collect()
+        .await?;
+
+    let attr_id_selector = dialog_attribute::Id::selector();
+
+    for artifact in &results {
+        let attr_str = artifact.the.to_string();
+        if let Some(field_name) = attr_str.strip_prefix(prefix) {
+            if field_name.is_empty() {
+                continue;
+            }
+            let attr_entity = match &artifact.is {
+                Value::Entity(e) => e.clone(),
+                _ => continue,
+            };
+
+            let selector = fetch_string(store, &attr_entity, attr_id_selector.clone())
+                .await?
+                .unwrap_or_default();
+
+            fields.insert(field_name.to_string(), (attr_entity, selector));
+        }
+    }
+
+    Ok(fields)
+}
+
+/// Get all attribute selectors for a resolved concept's required fields.
+pub fn concept_attribute_selectors(concept: &ResolvedConcept) -> Vec<String> {
+    concept
+        .with_fields
+        .values()
+        .map(|(_, selector)| selector.clone())
+        .collect()
+}
+
+/// Resolve a concept field name to its attribute selector.
+pub fn resolve_field_selector(concept: &ResolvedConcept, field_name: &str) -> Result<String> {
+    if let Some((_, selector)) = concept.with_fields.get(field_name) {
+        return Ok(selector.clone());
+    }
+    if let Some((_, selector)) = concept.maybe_fields.get(field_name) {
+        return Ok(selector.clone());
+    }
+    anyhow::bail!(
+        "Field '{}' not found in concept '{}'. Available fields: {}",
+        field_name,
+        concept.name,
+        concept
+            .with_fields
+            .keys()
+            .chain(concept.maybe_fields.keys())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Concept membership (structural matching)
+// ---------------------------------------------------------------------------
+
+/// Find all entities belonging to a concept by checking ALL required attribute selectors.
+pub async fn find_entities_by_concept<S: ArtifactStore>(
+    store: &S,
+    schema_attrs: &[String],
+) -> Result<Vec<Entity>> {
+    if schema_attrs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
+    let mut result_set: std::collections::HashSet<String> =
+        find_entities_by_attribute(store, first_attr)
+            .await?
+            .iter()
+            .map(|e| e.to_string())
+            .collect();
+
+    for attr in &schema_attrs[1..] {
+        let claim_attr = parse_claim_attribute(attr)?;
+        let attr_entities: std::collections::HashSet<String> =
+            find_entities_by_attribute(store, claim_attr)
+                .await?
+                .iter()
+                .map(|e| e.to_string())
+                .collect();
+        result_set = result_set.intersection(&attr_entities).cloned().collect();
+        if result_set.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
+
+    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
+    let all_entities = find_entities_by_attribute(store, first_attr).await?;
+    Ok(all_entities
+        .into_iter()
+        .filter(|e| result_set.contains(&e.to_string()))
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Init bootstrapping
+// ---------------------------------------------------------------------------
+
+/// Assert all pre-registered concepts into the space.
+///
+/// Called during `carry init` to bootstrap the meta-schema.
+/// Claims are deterministic (content-addressed), so re-running is idempotent.
+pub async fn bootstrap_builtins<S: dialog_query::Store>(
+    session: &mut dialog_query::Session<S>,
+) -> Result<()> {
+    use dialog_query::claim::{Claim, Relation};
+
+    let builtins = [&BUILTIN_ATTRIBUTE, &BUILTIN_CONCEPT, &BUILTIN_BOOKMARK];
+
+    // First pass: derive attribute entities for all fixed fields.
+    let mut attr_entities: BTreeMap<String, Entity> = BTreeMap::new();
+
+    for builtin in &builtins {
+        for field in builtin
+            .with_fields
+            .iter()
+            .chain(builtin.maybe_fields.iter())
+        {
+            if field.variable_keyed {
+                continue;
+            }
+            let entity =
+                derive_attribute_entity(field.relation, field.value_type, field.cardinality)?;
+            attr_entities.insert(field.relation.to_string(), entity);
+        }
+    }
+
+    let mut transaction = session.edit();
+
+    let name_attr = dialog_meta::Name::selector();
+    let desc_attr = dialog_meta::Description::selector();
+    let attr_id = dialog_attribute::Id::selector();
+    let attr_type = dialog_attribute::Kind::selector();
+    let attr_card = dialog_attribute::Cardinality::selector();
+
+    // Assert attribute entity claims
+    for builtin in &builtins {
+        for field in builtin
+            .with_fields
+            .iter()
+            .chain(builtin.maybe_fields.iter())
+        {
+            if field.variable_keyed {
+                continue;
+            }
+
+            let entity = attr_entities[field.relation].clone();
+
+            // dialog.attribute/id
+            Relation::new(
+                attr_id.clone(),
+                entity.clone(),
+                Value::String(field.relation.to_string()),
+            )
+            .assert(&mut transaction);
+
+            // dialog.attribute/type
+            Relation::new(
+                attr_type.clone(),
+                entity.clone(),
+                Value::String(field.value_type.to_string()),
+            )
+            .assert(&mut transaction);
+
+            // dialog.attribute/cardinality
+            Relation::new(
+                attr_card.clone(),
+                entity.clone(),
+                Value::String(field.cardinality.to_string()),
+            )
+            .assert(&mut transaction);
+
+            // dialog.meta/name = qualified name (e.g. "attribute/the")
+            Relation::new(
+                name_attr.clone(),
+                entity.clone(),
+                Value::String(format!("{}/{}", builtin.name, field.cli_name)),
+            )
+            .assert(&mut transaction);
+        }
+    }
+
+    // Assert concept entity claims
+    for builtin in &builtins {
+        let mut with_fields: BTreeMap<String, Entity> = BTreeMap::new();
+        for field in builtin.with_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            with_fields.insert(
+                field.cli_name.to_string(),
+                attr_entities[field.relation].clone(),
+            );
+        }
+
+        let concept_entity = derive_concept_entity(&with_fields)?;
+
+        // dialog.meta/name
+        Relation::new(
+            name_attr.clone(),
+            concept_entity.clone(),
+            Value::String(builtin.name.to_string()),
+        )
+        .assert(&mut transaction);
+
+        // dialog.meta/description
+        Relation::new(
+            desc_attr.clone(),
+            concept_entity.clone(),
+            Value::String(builtin.description.to_string()),
+        )
+        .assert(&mut transaction);
+
+        // dialog.concept.with/{field} = attribute_entity
+        for field in builtin.with_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            let rel = format!("dialog.concept.with/{}", field.cli_name);
+            let rel_attr = parse_claim_attribute(&rel)?;
+            Relation::new(
+                rel_attr,
+                concept_entity.clone(),
+                Value::Entity(attr_entities[field.relation].clone()),
+            )
+            .assert(&mut transaction);
+        }
+
+        // dialog.concept.maybe/{field} = attribute_entity
+        for field in builtin.maybe_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            let rel = format!("dialog.concept.maybe/{}", field.cli_name);
+            let rel_attr = parse_claim_attribute(&rel)?;
+            Relation::new(
+                rel_attr,
+                concept_entity.clone(),
+                Value::Entity(attr_entities[field.relation].clone()),
+            )
+            .assert(&mut transaction);
+        }
+    }
+
+    session.commit(transaction).await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Attribute name helpers
 // ---------------------------------------------------------------------------
 
-/// Given a namespace and user-supplied attribute key, produce the fully
-/// qualified attribute name `{namespace}/{key}`.
-///
-/// If the key already contains a `/`, it is returned as-is (the user
-/// provided a fully qualified attribute name).
+/// Qualify a field name within a namespace: `{namespace}/{key}`.
+/// If the key already contains `/`, it is returned as-is.
 pub fn qualify_attribute(namespace: &str, key: &str) -> Result<String> {
     if key.contains('/') {
         Ok(key.to_string())
@@ -416,22 +742,15 @@ pub fn qualify_attribute(namespace: &str, key: &str) -> Result<String> {
     }
 }
 
-/// Strip the namespace prefix from an attribute name, returning just the
-/// short key (e.g. `"my-space/title"` -> `"title"`).
-///
-/// If the attribute doesn't match the provided namespace, the full
-/// attribute name is returned as-is.
+/// Strip the namespace prefix from an attribute name.
 pub fn short_attribute(namespace: &str, attr: &str) -> String {
     let prefix = format!("{}/", namespace);
     if let Some(short) = attr.strip_prefix(&prefix) {
         short.to_string()
+    } else if let Some((_ns, name)) = attr.split_once('/') {
+        name.to_string()
     } else {
-        // Fall back to stripping any namespace prefix
-        if let Some((_ns, name)) = attr.split_once('/') {
-            name.to_string()
-        } else {
-            attr.to_string()
-        }
+        attr.to_string()
     }
 }
 
@@ -527,10 +846,6 @@ pub async fn fetch_values<S: ArtifactStore>(
 // ---------------------------------------------------------------------------
 
 /// Find all entities that have a given attribute (using the AEV index).
-///
-/// This replaces the old `concept/entity` back-reference pattern.
-/// Dialog-db identifies concept membership structurally: an entity belongs
-/// to a concept if it has facts for that concept's attributes.
 pub async fn find_entities_by_attribute<S: ArtifactStore>(
     store: &S,
     attr: ClaimAttribute,
@@ -540,8 +855,6 @@ pub async fn find_entities_by_attribute<S: ArtifactStore>(
         .try_collect()
         .await?;
 
-    // Deduplicate entities (multiple values for the same entity+attribute
-    // would otherwise produce duplicates).
     let mut seen = std::collections::HashSet::new();
     let mut entities = Vec::new();
     for artifact in results {
@@ -552,123 +865,12 @@ pub async fn find_entities_by_attribute<S: ArtifactStore>(
     Ok(entities)
 }
 
-/// Find all entities belonging to a concept by checking ALL schema attributes.
-///
-/// Queries the AEV index for each schema attribute and intersects the
-/// entity sets. An entity must have facts for every attribute to be
-/// included — matching dialog-db's structural inner-join semantics.
-pub async fn find_entities_by_concept<S: ArtifactStore>(
-    store: &S,
-    schema_attrs: &[String],
-) -> Result<Vec<Entity>> {
-    if schema_attrs.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Start with entities from the first attribute
-    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
-    let mut result_set: std::collections::HashSet<String> =
-        find_entities_by_attribute(store, first_attr)
-            .await?
-            .iter()
-            .map(|e| e.to_string())
-            .collect();
-
-    // Intersect with entities from each subsequent attribute
-    for attr in &schema_attrs[1..] {
-        let claim_attr = parse_claim_attribute(attr)?;
-        let attr_entities: std::collections::HashSet<String> =
-            find_entities_by_attribute(store, claim_attr)
-                .await?
-                .iter()
-                .map(|e| e.to_string())
-                .collect();
-        result_set = result_set.intersection(&attr_entities).cloned().collect();
-        if result_set.is_empty() {
-            return Ok(Vec::new());
-        }
-    }
-
-    // Convert back to Entity values (preserving original Entity objects)
-    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
-    let all_entities = find_entities_by_attribute(store, first_attr).await?;
-    Ok(all_entities
-        .into_iter()
-        .filter(|e| result_set.contains(&e.to_string()))
-        .collect())
-}
-
 /// Parse a string attribute name into a `ClaimAttribute`.
 pub fn parse_claim_attribute(attr_name: &str) -> Result<ClaimAttribute> {
     ClaimAttribute::from_str(attr_name).context(format!("Invalid attribute: {}", attr_name))
 }
 
-/// Infer the concept that an entity belongs to by examining its attributes.
-///
-/// Fetches all facts about the entity, then checks each registered concept
-/// to see if the entity has facts for ALL of that concept's attributes.
-/// Returns the best-matching concept (the one with the most attributes).
-///
-/// Returns `(concept_name, concept_entity, schema_attrs)` or an error if
-/// the entity has no attributes or the concept cannot be resolved.
-pub async fn infer_concept_from_entity<S: ArtifactStore>(
-    store: &S,
-    entity: &Entity,
-) -> Result<(ConceptName, Entity, Vec<String>)> {
-    // Fetch all facts about this entity
-    let results: Vec<_> = store
-        .select(ArtifactSelector::new().of(entity.clone()))
-        .try_collect()
-        .await?;
-
-    if results.is_empty() {
-        anyhow::bail!("Entity '{}' not found (no facts)", entity);
-    }
-
-    // Collect the entity's attribute names
-    let entity_attrs: std::collections::HashSet<String> =
-        results.iter().map(|a| a.the.to_string()).collect();
-
-    // Find all named concepts via structural discovery (AEV index)
-    let concept_entities = find_entities_by_attribute(store, concept_name_selector()).await?;
-
-    let mut best_match: Option<(ConceptName, Entity, Vec<String>, usize)> = None;
-
-    for concept_ent in &concept_entities {
-        let name = match fetch_string(store, concept_ent, concept_name_selector()).await? {
-            Some(n) => ConceptName::from_stored(n),
-            None => continue,
-        };
-        let schema_attrs =
-            fetch_string_values(store, concept_ent, concept_attribute_selector()).await?;
-
-        if schema_attrs.is_empty() {
-            continue;
-        }
-
-        // Check if the entity has ALL of this concept's attributes
-        let has_all = schema_attrs.iter().all(|a| entity_attrs.contains(a));
-        if has_all {
-            let score = schema_attrs.len();
-            if best_match.as_ref().is_none_or(|(_, _, _, s)| score > *s) {
-                best_match = Some((name, concept_ent.clone(), schema_attrs, score));
-            }
-        }
-    }
-
-    match best_match {
-        Some((name, ent, attrs, _)) => Ok((name, ent, attrs)),
-        None => anyhow::bail!(
-            "Could not resolve concept for entity '{}' (no named concept matches its attributes)",
-            entity
-        ),
-    }
-}
-
 /// Fetch all facts (as Artifacts) for an entity.
-///
-/// Used by retract operations to discover and remove all facts about an
-/// entity without needing to know its concept schema in advance.
 pub async fn fetch_all_entity_facts<S: ArtifactStore>(
     store: &S,
     entity: &Entity,
@@ -681,37 +883,11 @@ pub async fn fetch_all_entity_facts<S: ArtifactStore>(
 }
 
 // ---------------------------------------------------------------------------
-// Cardinality helpers
-// ---------------------------------------------------------------------------
-
-/// Fetch the cardinality for each attribute from stored metadata.
-///
-/// Returns a map from fully-qualified attribute name to `Cardinality`.
-/// Attributes without stored cardinality metadata default to `Cardinality::One`.
-pub async fn fetch_attribute_cardinalities<S: ArtifactStore>(
-    store: &S,
-    schema_attrs: &[String],
-) -> Result<std::collections::HashMap<String, Cardinality>> {
-    let cardinality_attr = parse_claim_attribute(ATTR_ATTRIBUTE_CARDINALITY)?;
-    let mut cardinalities = std::collections::HashMap::new();
-    for attr_name in schema_attrs {
-        let meta_entity = attribute_meta_entity(attr_name)?;
-        if let Some(val) = fetch_string(store, &meta_entity, cardinality_attr.clone()).await?
-            && val.to_lowercase() == "many"
-        {
-            cardinalities.insert(attr_name.clone(), Cardinality::Many);
-        }
-    }
-    Ok(cardinalities)
-}
-
-// ---------------------------------------------------------------------------
 // Value helpers
 // ---------------------------------------------------------------------------
 
 /// Parse a string input into a Value, trying integer -> float -> string.
 pub fn parse_value(input: &str) -> Value {
-    // Entity references (DID URIs)
     if input.starts_with("did:")
         && let Ok(entity) = dialog_query::Entity::from_str(input)
     {
@@ -727,7 +903,6 @@ pub fn parse_value(input: &str) -> Value {
     if let Ok(f) = input.parse::<f64>() {
         return Value::Float(f);
     }
-    // Handle booleans
     match input.to_lowercase().as_str() {
         "true" => return Value::Boolean(true),
         "false" => return Value::Boolean(false),
@@ -770,72 +945,7 @@ pub fn format_value(value: &Value) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Dynamic concept construction (for rule compilation)
-// ---------------------------------------------------------------------------
-
 /// Leak a runtime string to get a `&'static str`.
-///
-/// This is safe for CLI tools that run once and exit. The leaked memory
-/// lives for the process lifetime, which is exactly what `AttributeSchema`
-/// needs for its `&'static str` fields.
-///
-/// # Safety note
-///
-/// Intentionally leaks memory for CLI single-run usage. Each call leaks
-/// one small `String` allocation that lives until process exit.
 pub fn leak_str(s: &str) -> &'static str {
     Box::leak(s.to_string().into_boxed_str())
-}
-
-/// Build a `dialog_query::predicate::Concept` dynamically from a list of
-/// fully-qualified attribute names (e.g. `["task/title", "task/status"]`).
-///
-/// Each attribute is split on `/` to extract namespace and name, then
-/// wrapped in an `AttributeSchema<Value>`.
-///
-/// ## Type::String default
-///
-/// `Type::String` is used for all attributes because dialog-db's type
-/// checking at query time is a no-op (`AttributeSchema::check()` always
-/// returns Ok). Type only affects the concept's identity hash (used for
-/// rule resolution), but since both `build_dynamic_concept()` and
-/// `compile_rule()` use the same `Type::String` default, concept URIs
-/// are consistent and rules resolve correctly.
-///
-/// ## Cardinality
-///
-/// If a `cardinalities` map is provided, attributes with
-/// `Cardinality::Many` get correct cost estimates from the query planner.
-/// Attributes not in the map default to `Cardinality::One`.
-pub fn build_dynamic_concept(
-    attributes: &[String],
-    cardinalities: &std::collections::HashMap<String, Cardinality>,
-) -> Result<dialog_query::predicate::Concept> {
-    use dialog_query::{AttributeSchema, Type};
-
-    let attr_schemas: Vec<(&str, AttributeSchema<Value>)> = attributes
-        .iter()
-        .map(|attr| {
-            let (ns, name) = attr.split_once('/').ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Malformed attribute '{}': expected 'namespace/name' format",
-                    attr
-                )
-            })?;
-            let short_name = leak_str(name);
-            let mut schema = AttributeSchema::<Value>::new(
-                leak_str(ns),
-                short_name,
-                leak_str(""), // description
-                Type::String, // see doc comment above
-            );
-            if let Some(&cardinality) = cardinalities.get(attr) {
-                schema.cardinality = cardinality;
-            }
-            Ok((short_name, schema))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(dialog_query::predicate::Concept::new(attr_schemas.into()))
 }

--- a/rust/carry/src/schema.rs
+++ b/rust/carry/src/schema.rs
@@ -50,8 +50,7 @@ pub mod dialog_attribute {
     /// Value type of the attribute (e.g. Text, UnsignedInteger, Symbol).
     #[derive(dialog_query::Attribute, Clone, PartialEq)]
     #[namespace("dialog.attribute")]
-    #[dialog(rename = "type")]
-    pub struct Kind(pub String);
+    pub struct Type(pub String);
 
     /// Cardinality: `one` or `many`.
     #[derive(dialog_query::Attribute, Clone, PartialEq)]
@@ -74,10 +73,9 @@ pub mod dialog_attribute {
 pub struct AttributeDef {
     pub this: Entity,
     pub description: dialog_meta::Description,
-    #[dialog(rename = "the")]
-    pub selector: dialog_attribute::Id,
-    #[dialog(rename = "as")]
-    pub value_type: dialog_attribute::Kind,
+    pub the: dialog_attribute::Id,
+    // TODO: use `#[dialog(rename = "as")]` when available
+    pub as_type: dialog_attribute::Type,
     pub cardinality: dialog_attribute::Cardinality,
 }
 
@@ -244,15 +242,13 @@ pub fn resolve_builtin_field(
     }
     // Check variable-keyed fields (e.g. "with.name" → prefix "with")
     for f in schema.with_fields.iter().chain(schema.maybe_fields.iter()) {
-        if f.variable_keyed {
-            if let Some(key) = cli_field
+        if f.variable_keyed
+            && let Some(key) = cli_field
                 .strip_prefix(f.cli_name)
                 .and_then(|s| s.strip_prefix('.'))
-            {
-                if !key.is_empty() {
-                    return Some((format!("{}{}", f.relation, key), true));
-                }
-            }
+            && !key.is_empty()
+        {
+            return Some((format!("{}{}", f.relation, key), true));
         }
     }
     None
@@ -612,7 +608,7 @@ pub async fn bootstrap_builtins<S: dialog_query::Store>(
     let name_attr = dialog_meta::Name::selector();
     let desc_attr = dialog_meta::Description::selector();
     let attr_id = dialog_attribute::Id::selector();
-    let attr_type = dialog_attribute::Kind::selector();
+    let attr_type = dialog_attribute::Type::selector();
     let attr_card = dialog_attribute::Cardinality::selector();
 
     // Assert attribute entity claims

--- a/rust/carry/src/target.rs
+++ b/rust/carry/src/target.rs
@@ -115,19 +115,43 @@ impl Field {
 // Parsing
 // ---------------------------------------------------------------------------
 
+/// Parsed fields from CLI arguments.
+#[derive(Debug, Clone)]
+pub struct ParsedFields {
+    /// The field list (projections and filters).
+    pub fields: Vec<Field>,
+    /// The entity target (`this=<ENTITY>`), if provided.
+    pub this_entity: Option<String>,
+    /// The entity name (`@name`), if provided.
+    pub entity_name: Option<String>,
+}
+
 /// Parse a list of field arguments from the CLI.
 ///
 /// Each argument is either:
-/// - `name` — projection (include in output)
+/// - `@name` — entity name (asserts `dialog.meta/name = name`)
+/// - `this=<ENTITY>` — targets an existing entity
 /// - `name=value` — filter/assertion
-///
-/// The special field `this=<ENTITY>` is extracted separately and returned
-/// as the second element of the tuple.
-pub fn parse_fields(args: &[String]) -> Result<(Vec<Field>, Option<String>)> {
+/// - `name` — projection (include in output)
+pub fn parse_fields(args: &[String]) -> Result<ParsedFields> {
     let mut fields = Vec::new();
     let mut this_entity = None;
+    let mut entity_name = None;
 
     for arg in args {
+        // @name — entity naming
+        if let Some(name) = arg.strip_prefix('@') {
+            if entity_name.is_some() {
+                anyhow::bail!("Duplicate `@name` argument");
+            }
+            if name.is_empty() {
+                anyhow::bail!("`@` requires a name (e.g. @person)");
+            }
+            entity_name = Some(name.to_string());
+            continue;
+        }
+
+        // this=<ENTITY>
         if let Some(entity) = arg.strip_prefix("this=") {
             if this_entity.is_some() {
                 anyhow::bail!("Duplicate `this=` argument");
@@ -154,7 +178,11 @@ pub fn parse_fields(args: &[String]) -> Result<(Vec<Field>, Option<String>)> {
         fields.push(field);
     }
 
-    Ok((fields, this_entity))
+    Ok(ParsedFields {
+        fields,
+        this_entity,
+        entity_name,
+    })
 }
 
 /// Determine whether the first CLI argument is a file path, stdin marker,
@@ -227,34 +255,55 @@ mod tests {
     #[test]
     fn test_parse_fields_projection() {
         let args = vec!["name".to_string(), "age".to_string()];
-        let (fields, this_ent) = parse_fields(&args).unwrap();
-        assert!(this_ent.is_none());
-        assert_eq!(fields.len(), 2);
-        assert!(fields[0].is_projection());
-        assert!(fields[1].is_projection());
+        let parsed = parse_fields(&args).unwrap();
+        assert!(parsed.this_entity.is_none());
+        assert!(parsed.entity_name.is_none());
+        assert_eq!(parsed.fields.len(), 2);
+        assert!(parsed.fields[0].is_projection());
+        assert!(parsed.fields[1].is_projection());
     }
 
     #[test]
     fn test_parse_fields_filter() {
         let args = vec!["name=Alice".to_string(), "age".to_string()];
-        let (fields, _) = parse_fields(&args).unwrap();
-        assert_eq!(fields.len(), 2);
-        assert!(fields[0].is_filter());
-        assert_eq!(fields[0].value.as_deref(), Some("Alice"));
-        assert!(fields[1].is_projection());
+        let parsed = parse_fields(&args).unwrap();
+        assert_eq!(parsed.fields.len(), 2);
+        assert!(parsed.fields[0].is_filter());
+        assert_eq!(parsed.fields[0].value.as_deref(), Some("Alice"));
+        assert!(parsed.fields[1].is_projection());
     }
 
     #[test]
     fn test_parse_fields_this() {
         let args = vec!["this=did:key:z123".to_string(), "name=Alice".to_string()];
-        let (fields, this_ent) = parse_fields(&args).unwrap();
-        assert_eq!(this_ent, Some("did:key:z123".to_string()));
-        assert_eq!(fields.len(), 1);
+        let parsed = parse_fields(&args).unwrap();
+        assert_eq!(parsed.this_entity, Some("did:key:z123".to_string()));
+        assert_eq!(parsed.fields.len(), 1);
     }
 
     #[test]
     fn test_duplicate_this_fails() {
         let args = vec!["this=did:key:z1".to_string(), "this=did:key:z2".to_string()];
+        assert!(parse_fields(&args).is_err());
+    }
+
+    #[test]
+    fn test_parse_fields_entity_name() {
+        let args = vec!["@person".to_string(), "name=Alice".to_string()];
+        let parsed = parse_fields(&args).unwrap();
+        assert_eq!(parsed.entity_name, Some("person".to_string()));
+        assert_eq!(parsed.fields.len(), 1);
+    }
+
+    #[test]
+    fn test_duplicate_entity_name_fails() {
+        let args = vec!["@foo".to_string(), "@bar".to_string()];
+        assert!(parse_fields(&args).is_err());
+    }
+
+    #[test]
+    fn test_empty_entity_name_fails() {
+        let args = vec!["@".to_string()];
         assert!(parse_fields(&args).is_err());
     }
 

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for carry.
+//! Integration tests for the carry CLI (tonk-cli crate).
 //!
 //! These tests exercise the CLI through its library API, using isolated
 //! `.carry/` site directories for each test. Every test gets its own
@@ -89,7 +89,7 @@ async fn test_assert_and_query_domain() {
             value: Some("28".to_string()),
         },
     ];
-    carry::assert_cmd::execute(&ctx, target, None, fields, "yaml")
+    carry::assert_cmd::execute(&ctx, target, None, None, fields, "yaml")
         .await
         .unwrap();
 
@@ -130,6 +130,7 @@ async fn test_assert_multiple_entities() {
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields1,
         "yaml",
     )
@@ -149,6 +150,7 @@ async fn test_assert_multiple_entities() {
     carry::assert_cmd::execute(
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
         None,
         fields2,
         "yaml",
@@ -191,6 +193,7 @@ async fn test_query_with_filter() {
         carry::assert_cmd::execute(
             &ctx,
             FirstArg::Target(Target::Domain("io.test.person".to_string())),
+            None,
             None,
             fields,
             "yaml",
@@ -238,6 +241,7 @@ async fn test_assert_with_this_entity() {
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields,
         "yaml",
     )
@@ -260,6 +264,7 @@ async fn test_assert_with_this_entity() {
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         Some(entity.to_string()),
+        None,
         update_fields,
         "yaml",
     )
@@ -290,6 +295,7 @@ async fn test_retract_specific_field() {
     carry::assert_cmd::execute(
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
         None,
         fields,
         "yaml",
@@ -332,6 +338,7 @@ async fn test_retract_all_fields() {
     carry::assert_cmd::execute(
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
         None,
         fields,
         "yaml",
@@ -384,6 +391,7 @@ async fn test_assert_from_json_content() {
         &ctx,
         FirstArg::File(json_path.clone()),
         None,
+        None,
         vec![],
         "yaml",
     )
@@ -406,6 +414,7 @@ async fn test_assert_requires_fields() {
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         vec![],
         "yaml",
     )
@@ -422,6 +431,7 @@ async fn test_assert_requires_values() {
     let result = carry::assert_cmd::execute(
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
         None,
         vec![Field {
             name: "name".to_string(),
@@ -471,6 +481,7 @@ async fn test_assert_json_format() {
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields,
         "json",
     )
@@ -490,6 +501,7 @@ async fn test_query_json_format() {
     carry::assert_cmd::execute(
         &ctx,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
         None,
         fields,
         "yaml",
@@ -939,6 +951,7 @@ async fn test_space_data_isolation() {
         &ctx_a,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields,
         "yaml",
     )
@@ -1026,6 +1039,7 @@ async fn test_space_flag_cross_space_query() {
         &ctx_a,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields_a,
         "yaml",
     )
@@ -1090,6 +1104,7 @@ async fn test_space_flag_cross_space_query_by_label() {
     carry::assert_cmd::execute(
         &ctx_labeled,
         FirstArg::Target(Target::Domain("io.test.role".to_string())),
+        None,
         None,
         fields,
         "yaml",
@@ -1158,6 +1173,7 @@ async fn test_space_flag_cross_space_assert() {
         &ctx_target,
         FirstArg::Target(Target::Domain("io.test.pref".to_string())),
         None,
+        None,
         fields,
         "yaml",
     )
@@ -1224,6 +1240,7 @@ async fn test_space_flag_cross_space_retract() {
         &ctx_b,
         FirstArg::Target(Target::Domain("io.test.person".to_string())),
         None,
+        None,
         fields,
         "yaml",
     )
@@ -1283,4 +1300,847 @@ async fn test_space_flag_cross_space_retract() {
         1,
         "Name should still exist in space B after retracting age"
     );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Bootstrap & Init
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// After init, the pre-registered concepts (attribute, concept, bookmark)
+/// should be discoverable by name via `dialog.meta/name`.
+#[tokio::test]
+async fn test_init_bootstraps_builtins() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+    let session = ctx.open_session().await.unwrap();
+
+    for name in &["attribute", "concept", "bookmark"] {
+        let entity = carry::schema::lookup_entity_by_name(&session, name)
+            .await
+            .unwrap();
+        assert!(
+            entity.is_some(),
+            "Builtin concept '{}' should be discoverable by name after init",
+            name
+        );
+    }
+}
+
+/// The bootstrapped `attribute` concept should resolve with the expected
+/// required fields: `the`, `as`, `cardinality`.
+#[tokio::test]
+async fn test_bootstrap_attribute_concept_has_fields() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+    let session = ctx.open_session().await.unwrap();
+
+    let concept = carry::schema::resolve_concept(&session, "attribute")
+        .await
+        .unwrap();
+
+    let field_names: Vec<&String> = concept.with_fields.keys().collect();
+    assert!(
+        field_names.contains(&&"the".to_string()),
+        "attribute concept should have 'the' field, got: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&&"as".to_string()),
+        "attribute concept should have 'as' field, got: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&&"cardinality".to_string()),
+        "attribute concept should have 'cardinality' field, got: {:?}",
+        field_names
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Attribute assertion
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Asserting a builtin `attribute` concept should create an entity with
+/// the expected dialog.attribute/* claims.
+#[tokio::test]
+async fn test_assert_attribute_creates_entity() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let fields = vec![
+        Field {
+            name: "the".to_string(),
+            value: Some("io.test.person/name".to_string()),
+        },
+        Field {
+            name: "as".to_string(),
+            value: Some("Text".to_string()),
+        },
+        Field {
+            name: "cardinality".to_string(),
+            value: Some("one".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify the attribute entity exists with the right dialog.attribute/id
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let attr_id = ClaimAttribute::from_str("dialog.attribute/id").unwrap();
+    let entities = carry::schema::find_entities_by_attribute(&session, attr_id)
+        .await
+        .unwrap();
+
+    // Should find at least the one we just created (plus bootstrapped ones)
+    let mut found = false;
+    for entity in &entities {
+        let ids = carry::schema::fetch_string_values(
+            &session,
+            entity,
+            ClaimAttribute::from_str("dialog.attribute/id").unwrap(),
+        )
+        .await
+        .unwrap();
+        if ids.contains(&"io.test.person/name".to_string()) {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "Should find an attribute entity with dialog.attribute/id = io.test.person/name"
+    );
+}
+
+/// Asserting an attribute with `@name` should store `dialog.meta/name` on the entity.
+#[tokio::test]
+async fn test_assert_attribute_with_name() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let fields = vec![
+        Field {
+            name: "the".to_string(),
+            value: Some("io.test.person/name".to_string()),
+        },
+        Field {
+            name: "as".to_string(),
+            value: Some("Text".to_string()),
+        },
+        Field {
+            name: "cardinality".to_string(),
+            value: Some("one".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        Some("person-name".to_string()),
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify the attribute entity is discoverable by name
+    let session = ctx.open_session().await.unwrap();
+    let entity = carry::schema::lookup_entity_by_name(&session, "person-name")
+        .await
+        .unwrap();
+    assert!(
+        entity.is_some(),
+        "Attribute should be discoverable as 'person-name' via dialog.meta/name"
+    );
+}
+
+/// Asserting an attribute without `cardinality` should default to `one`.
+#[tokio::test]
+async fn test_assert_attribute_defaults_cardinality() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let fields = vec![
+        Field {
+            name: "the".to_string(),
+            value: Some("io.test.thing/color".to_string()),
+        },
+        Field {
+            name: "as".to_string(),
+            value: Some("Text".to_string()),
+        },
+    ];
+    // This should succeed without cardinality — defaults to "one"
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // The entity should have been derived with cardinality=one
+    let entity =
+        carry::schema::derive_attribute_entity("io.test.thing/color", "Text", "one").unwrap();
+
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let card_attr = ClaimAttribute::from_str("dialog.attribute/cardinality").unwrap();
+    let values = carry::schema::fetch_string_values(&session, &entity, card_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        values,
+        vec!["one".to_string()],
+        "Cardinality should default to 'one'"
+    );
+}
+
+/// Same attribute definition (same the/as/cardinality) should produce the
+/// same entity DID deterministically.
+#[tokio::test]
+async fn test_assert_attribute_deterministic_entity() {
+    let entity_a =
+        carry::schema::derive_attribute_entity("io.test.person/name", "Text", "one").unwrap();
+    let entity_b =
+        carry::schema::derive_attribute_entity("io.test.person/name", "Text", "one").unwrap();
+    assert_eq!(
+        entity_a, entity_b,
+        "Same attribute definition should produce same entity"
+    );
+
+    // Different type should produce different entity
+    let entity_c =
+        carry::schema::derive_attribute_entity("io.test.person/name", "UnsignedInteger", "one")
+            .unwrap();
+    assert_ne!(
+        entity_a, entity_c,
+        "Different value type should produce different entity"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Concept assertion
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Define two named attributes, then assert a concept referencing them by
+/// bookmark name. The concept entity should exist with the correct
+/// `dialog.concept.with/*` claims.
+#[tokio::test]
+async fn test_assert_concept_with_named_attrs() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Define attribute @test-name
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        Some("test-name".to_string()),
+        vec![
+            Field {
+                name: "the".to_string(),
+                value: Some("io.test.person/name".to_string()),
+            },
+            Field {
+                name: "as".to_string(),
+                value: Some("Text".to_string()),
+            },
+            Field {
+                name: "cardinality".to_string(),
+                value: Some("one".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Define attribute @test-age
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        Some("test-age".to_string()),
+        vec![
+            Field {
+                name: "the".to_string(),
+                value: Some("io.test.person/age".to_string()),
+            },
+            Field {
+                name: "as".to_string(),
+                value: Some("UnsignedInteger".to_string()),
+            },
+            Field {
+                name: "cardinality".to_string(),
+                value: Some("one".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Define concept @test-person with.name=test-name with.age=test-age
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("concept".to_string())),
+        None,
+        Some("test-person".to_string()),
+        vec![
+            Field {
+                name: "with.name".to_string(),
+                value: Some("test-name".to_string()),
+            },
+            Field {
+                name: "with.age".to_string(),
+                value: Some("test-age".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify concept is discoverable by name
+    let session = ctx.open_session().await.unwrap();
+    let concept_entity = carry::schema::lookup_entity_by_name(&session, "test-person")
+        .await
+        .unwrap();
+    assert!(
+        concept_entity.is_some(),
+        "Concept should be discoverable as 'test-person'"
+    );
+
+    // Verify concept resolves with correct fields
+    let resolved = carry::schema::resolve_concept(&session, "test-person")
+        .await
+        .unwrap();
+    assert_eq!(
+        resolved.with_fields.len(),
+        2,
+        "Concept should have 2 required fields"
+    );
+    assert!(
+        resolved.with_fields.contains_key("name"),
+        "Concept should have 'name' field"
+    );
+    assert!(
+        resolved.with_fields.contains_key("age"),
+        "Concept should have 'age' field"
+    );
+
+    // Verify the attribute selectors are correct
+    let (_, name_selector) = &resolved.with_fields["name"];
+    let (_, age_selector) = &resolved.with_fields["age"];
+    assert_eq!(name_selector, "io.test.person/name");
+    assert_eq!(age_selector, "io.test.person/age");
+}
+
+/// Asserting a concept with selector-style attribute values (containing '/')
+/// should auto-create the attribute if it doesn't exist.
+#[tokio::test]
+async fn test_assert_concept_with_selector_attrs() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Define concept with inline selectors — attributes auto-created
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("concept".to_string())),
+        None,
+        Some("test-widget".to_string()),
+        vec![Field {
+            name: "with.color".to_string(),
+            value: Some("io.test.widget/color".to_string()),
+        }],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify concept resolves
+    let session = ctx.open_session().await.unwrap();
+    let resolved = carry::schema::resolve_concept(&session, "test-widget")
+        .await
+        .unwrap();
+    assert_eq!(resolved.with_fields.len(), 1);
+    let (_, color_selector) = &resolved.with_fields["color"];
+    assert_eq!(color_selector, "io.test.widget/color");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Concept query
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Helper: set up a concept with two attributes and assert some data.
+/// Returns the ctx for further querying.
+async fn setup_concept_with_data() -> (TestEnv, carry::site::SiteContext) {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Define attributes
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        Some("cq-name".to_string()),
+        vec![
+            Field {
+                name: "the".to_string(),
+                value: Some("io.test.cq/name".to_string()),
+            },
+            Field {
+                name: "as".to_string(),
+                value: Some("Text".to_string()),
+            },
+            Field {
+                name: "cardinality".to_string(),
+                value: Some("one".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("attribute".to_string())),
+        None,
+        Some("cq-age".to_string()),
+        vec![
+            Field {
+                name: "the".to_string(),
+                value: Some("io.test.cq/age".to_string()),
+            },
+            Field {
+                name: "as".to_string(),
+                value: Some("UnsignedInteger".to_string()),
+            },
+            Field {
+                name: "cardinality".to_string(),
+                value: Some("one".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Define concept
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("concept".to_string())),
+        None,
+        Some("cq-person".to_string()),
+        vec![
+            Field {
+                name: "with.name".to_string(),
+                value: Some("cq-name".to_string()),
+            },
+            Field {
+                name: "with.age".to_string(),
+                value: Some("cq-age".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Assert data using the domain (so concept query can find it)
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.cq".to_string())),
+        None,
+        None,
+        vec![
+            Field {
+                name: "name".to_string(),
+                value: Some("Alice".to_string()),
+            },
+            Field {
+                name: "age".to_string(),
+                value: Some("28".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.cq".to_string())),
+        None,
+        None,
+        vec![
+            Field {
+                name: "name".to_string(),
+                value: Some("Bob".to_string()),
+            },
+            Field {
+                name: "age".to_string(),
+                value: Some("35".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    (env, ctx)
+}
+
+/// Concept query should resolve by name and return matching entities.
+#[tokio::test]
+async fn test_concept_query_resolves_by_name() {
+    let (_env, ctx) = setup_concept_with_data().await;
+
+    // Query using concept name — should succeed and find both entities
+    carry::query_cmd::execute(
+        &ctx,
+        Target::Concept("cq-person".to_string()),
+        vec![],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify at the data level that the concept resolved correctly
+    let session = ctx.open_session().await.unwrap();
+    let resolved = carry::schema::resolve_concept(&session, "cq-person")
+        .await
+        .unwrap();
+
+    // Find entities that match the concept's attributes
+    let selectors = carry::schema::concept_attribute_selectors(&resolved);
+    let entities = carry::schema::find_entities_by_concept(&session, &selectors)
+        .await
+        .unwrap();
+    assert_eq!(
+        entities.len(),
+        2,
+        "Should find 2 entities matching the concept"
+    );
+}
+
+/// Concept query with a filter should narrow results.
+#[tokio::test]
+async fn test_concept_query_with_filter() {
+    let (_env, ctx) = setup_concept_with_data().await;
+
+    // Query with filter name=Alice
+    carry::query_cmd::execute(
+        &ctx,
+        Target::Concept("cq-person".to_string()),
+        vec![Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        }],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // The query itself printed output; verify at data level that only Alice matches
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let name_attr = ClaimAttribute::from_str("io.test.cq/name").unwrap();
+    let all_entities = carry::schema::find_entities_by_attribute(&session, name_attr.clone())
+        .await
+        .unwrap();
+
+    let mut alice_count = 0;
+    for entity in &all_entities {
+        let names = carry::schema::fetch_string_values(&session, entity, name_attr.clone())
+            .await
+            .unwrap();
+        if names.contains(&"Alice".to_string()) {
+            alice_count += 1;
+        }
+    }
+    assert_eq!(alice_count, 1, "Should find exactly 1 Alice entity");
+}
+
+/// Querying a concept that doesn't exist should return an error.
+#[tokio::test]
+async fn test_concept_query_unknown_concept_fails() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let result = carry::query_cmd::execute(
+        &ctx,
+        Target::Concept("nonexistent-concept".to_string()),
+        vec![],
+        "yaml",
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Querying a nonexistent concept should fail"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("not found"),
+        "Error should mention concept not found, got: {}",
+        err
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: @name syntax
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Using @name with a domain assert should store dialog.meta/name on the entity.
+#[tokio::test]
+async fn test_domain_assert_with_name() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        Some("alice".to_string()),
+        vec![
+            Field {
+                name: "name".to_string(),
+                value: Some("Alice".to_string()),
+            },
+            Field {
+                name: "age".to_string(),
+                value: Some("28".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify the entity is discoverable by the @name
+    let session = ctx.open_session().await.unwrap();
+    let entity = carry::schema::lookup_entity_by_name(&session, "alice")
+        .await
+        .unwrap();
+    assert!(
+        entity.is_some(),
+        "Entity should be discoverable as 'alice' via dialog.meta/name"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Concept retract
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Retracting a field by concept field name should work: the concept's
+/// field name is resolved to its attribute selector for the retraction.
+#[tokio::test]
+async fn test_retract_concept_field() {
+    let (_env, ctx) = setup_concept_with_data().await;
+
+    // Find Alice's entity DID
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let name_attr = ClaimAttribute::from_str("io.test.cq/name").unwrap();
+    let all_entities = carry::schema::find_entities_by_attribute(&session, name_attr.clone())
+        .await
+        .unwrap();
+
+    let mut alice_entity = None;
+    for entity in &all_entities {
+        let names = carry::schema::fetch_string_values(&session, entity, name_attr.clone())
+            .await
+            .unwrap();
+        if names.contains(&"Alice".to_string()) {
+            alice_entity = Some(entity.clone());
+            break;
+        }
+    }
+    let alice_entity = alice_entity.expect("Alice should exist");
+    drop(session);
+
+    // Retract age using concept field name
+    carry::retract_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("cq-person".to_string())),
+        Some(alice_entity.to_string()),
+        vec![Field {
+            name: "age".to_string(),
+            value: None,
+        }],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Verify age is gone but name remains
+    let session = ctx.open_session().await.unwrap();
+    let age_attr = ClaimAttribute::from_str("io.test.cq/age").unwrap();
+    let age_values = carry::schema::fetch_string_values(&session, &alice_entity, age_attr)
+        .await
+        .unwrap();
+    assert!(
+        age_values.is_empty(),
+        "Age should have been retracted from Alice"
+    );
+
+    let name_values = carry::schema::fetch_string_values(&session, &alice_entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        name_values,
+        vec!["Alice".to_string()],
+        "Name should still exist after retracting age"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Meta-schema: Full round-trip
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Full round-trip: define attributes → define concept → assert data via
+/// domain → query via concept name → verify all field names and values.
+#[tokio::test]
+async fn test_attribute_concept_data_roundtrip() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // 1. Define attributes
+    for (name, selector, val_type) in [
+        ("rt-title", "io.test.book/title", "Text"),
+        ("rt-pages", "io.test.book/pages", "UnsignedInteger"),
+    ] {
+        carry::assert_cmd::execute(
+            &ctx,
+            FirstArg::Target(Target::Concept("attribute".to_string())),
+            None,
+            Some(name.to_string()),
+            vec![
+                Field {
+                    name: "the".to_string(),
+                    value: Some(selector.to_string()),
+                },
+                Field {
+                    name: "as".to_string(),
+                    value: Some(val_type.to_string()),
+                },
+                Field {
+                    name: "cardinality".to_string(),
+                    value: Some("one".to_string()),
+                },
+            ],
+            "yaml",
+        )
+        .await
+        .unwrap();
+    }
+
+    // 2. Define concept
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Concept("concept".to_string())),
+        None,
+        Some("rt-book".to_string()),
+        vec![
+            Field {
+                name: "with.title".to_string(),
+                value: Some("rt-title".to_string()),
+            },
+            Field {
+                name: "with.pages".to_string(),
+                value: Some("rt-pages".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // 3. Assert data via domain
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.book".to_string())),
+        None,
+        None,
+        vec![
+            Field {
+                name: "title".to_string(),
+                value: Some("Moby Dick".to_string()),
+            },
+            Field {
+                name: "pages".to_string(),
+                value: Some("635".to_string()),
+            },
+        ],
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // 4. Verify concept resolves correctly
+    let session = ctx.open_session().await.unwrap();
+    let concept = carry::schema::resolve_concept(&session, "rt-book")
+        .await
+        .unwrap();
+    assert_eq!(concept.with_fields.len(), 2);
+    assert_eq!(concept.with_fields["title"].1, "io.test.book/title");
+    assert_eq!(concept.with_fields["pages"].1, "io.test.book/pages");
+
+    // 5. Find entities matching the concept
+    let selectors = carry::schema::concept_attribute_selectors(&concept);
+    let entities = carry::schema::find_entities_by_concept(&session, &selectors)
+        .await
+        .unwrap();
+    assert_eq!(entities.len(), 1, "Should find exactly 1 book entity");
+
+    // 6. Verify the data values
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+
+    let title_attr = ClaimAttribute::from_str("io.test.book/title").unwrap();
+    let pages_attr = ClaimAttribute::from_str("io.test.book/pages").unwrap();
+
+    let title_val = carry::schema::fetch_value(&session, &entities[0], title_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        title_val.map(|v| carry::schema::format_value(&v)),
+        Some("Moby Dick".to_string())
+    );
+
+    let pages_val = carry::schema::fetch_value(&session, &entities[0], pages_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        pages_val.map(|v| carry::schema::format_value(&v)),
+        Some("635".to_string())
+    );
+
+    // 7. Verify concept query works (doesn't error)
+    carry::query_cmd::execute(&ctx, Target::Concept("rt-book".to_string()), vec![], "yaml")
+        .await
+        .unwrap();
 }

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -6,6 +6,8 @@
 
 mod common;
 
+use std::f64::consts::PI;
+
 use carry::target::{Field, FirstArg, Target};
 use common::TestEnv;
 
@@ -399,6 +401,820 @@ async fn test_assert_from_json_content() {
     .unwrap();
 
     std::fs::remove_file(&json_path).ok();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Piping: --format triples, asserted notation, stdin round-trips
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Helper: assert a file's YAML content and return the path
+fn write_yaml_file(content: &str) -> (String, tempfile::NamedTempFile) {
+    let tmp = tempfile::NamedTempFile::with_suffix(".yaml").unwrap();
+    std::fs::write(tmp.path(), content).unwrap();
+    (tmp.path().to_string_lossy().to_string(), tmp)
+}
+
+/// format_triples produces valid EAV YAML for a single entity.
+#[tokio::test]
+async fn test_format_triples_single_entity() {
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Alice".to_string())],
+    );
+    attrs.insert(
+        "io.test.person/age".to_string(),
+        vec![Value::UnsignedInt(28)],
+    );
+
+    let mut results = BTreeMap::new();
+    results.insert(
+        "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD".to_string(),
+        attrs,
+    );
+
+    let yaml = carry::query_cmd::format_triples(&results).unwrap();
+    assert!(!yaml.is_empty());
+
+    // Parse back to verify it's valid YAML with expected structure
+    let parsed: Vec<serde_yaml::Value> = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(parsed.len(), 2); // Two triples (name + age)
+
+    // Each triple should have the/of/is keys
+    for triple in &parsed {
+        assert!(triple["the"].as_str().is_some());
+        assert!(triple["of"].as_str().is_some());
+        assert!(!triple["is"].is_null());
+    }
+}
+
+/// format_triples expands multi-valued attributes into separate triples.
+#[tokio::test]
+async fn test_format_triples_multivalued() {
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/tag".to_string(),
+        vec![
+            Value::String("engineer".to_string()),
+            Value::String("leader".to_string()),
+        ],
+    );
+
+    let mut results = BTreeMap::new();
+    results.insert(
+        "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD".to_string(),
+        attrs,
+    );
+
+    let yaml = carry::query_cmd::format_triples(&results).unwrap();
+    let parsed: Vec<serde_yaml::Value> = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(
+        parsed.len(),
+        2,
+        "Multi-valued attr should produce two triples"
+    );
+
+    // Both should reference the same attribute
+    assert_eq!(parsed[0]["the"].as_str().unwrap(), "io.test.person/tag");
+    assert_eq!(parsed[1]["the"].as_str().unwrap(), "io.test.person/tag");
+}
+
+/// format_triples handles multiple entities.
+#[tokio::test]
+async fn test_format_triples_multiple_entities() {
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+
+    let mut results = BTreeMap::new();
+
+    let mut attrs1 = BTreeMap::new();
+    attrs1.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Alice".to_string())],
+    );
+    results.insert(
+        "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD".to_string(),
+        attrs1,
+    );
+
+    let mut attrs2 = BTreeMap::new();
+    attrs2.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Bob".to_string())],
+    );
+    results.insert(
+        "did:key:z6Mkf5rGMoatrSj1f4CyvuHqdjKN6pVpGGqruHMgfJBuRnQE".to_string(),
+        attrs2,
+    );
+
+    let yaml = carry::query_cmd::format_triples(&results).unwrap();
+    let parsed: Vec<serde_yaml::Value> = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(parsed.len(), 2, "Two entities should produce two triples");
+}
+
+/// format_triples returns empty string for empty results.
+#[tokio::test]
+async fn test_format_triples_empty() {
+    use std::collections::BTreeMap;
+
+    let results: BTreeMap<String, BTreeMap<String, Vec<dialog_query::Value>>> = BTreeMap::new();
+    let yaml = carry::query_cmd::format_triples(&results).unwrap();
+    assert!(yaml.is_empty());
+}
+
+/// format_triples preserves various value types.
+#[tokio::test]
+async fn test_format_triples_value_types() {
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+
+    let entity = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.data/text".to_string(),
+        vec![Value::String("hello".to_string())],
+    );
+    attrs.insert(
+        "io.test.data/uint".to_string(),
+        vec![Value::UnsignedInt(42)],
+    );
+    attrs.insert("io.test.data/sint".to_string(), vec![Value::SignedInt(-7)]);
+    attrs.insert("io.test.data/float".to_string(), vec![Value::Float(PI)]);
+    attrs.insert("io.test.data/bool".to_string(), vec![Value::Boolean(true)]);
+
+    let mut results = BTreeMap::new();
+    results.insert(entity.to_string(), attrs);
+
+    let yaml = carry::query_cmd::format_triples(&results).unwrap();
+    let parsed: Vec<serde_yaml::Value> = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(parsed.len(), 5);
+}
+
+/// Round-trip: assert data → derive entity → format as triples YAML → assert from file → verify.
+#[tokio::test]
+async fn test_roundtrip_triples_yaml() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // 1. Assert data using domain target
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("28".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // 2. Derive the entity DID (same deterministic derivation as the CLI uses)
+    let entity = carry::schema::derive_entity_from_fields(&[
+        ("io.test.person/name".to_string(), "Alice".to_string()),
+        ("io.test.person/age".to_string(), "28".to_string()),
+    ])
+    .unwrap();
+
+    // 3. Verify we can fetch the data
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    drop(session);
+
+    // 4. Build results map and format as triples YAML
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Alice".to_string())],
+    );
+    attrs.insert(
+        "io.test.person/age".to_string(),
+        vec![Value::UnsignedInt(28)],
+    );
+    let mut results = BTreeMap::new();
+    results.insert(entity.to_string(), attrs);
+
+    let triples_yaml = carry::query_cmd::format_triples(&results).unwrap();
+
+    // 5. Assert from the triples YAML file (idempotent in same space)
+    let (yaml_path, _tmp) = write_yaml_file(&triples_yaml);
+    carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // 6. Verify the data still exists (round-trip preserved it)
+    let session = ctx.open_session().await.unwrap();
+    let name_attr2 = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, name_attr2)
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(carry::schema::format_value(&values[0]), "Alice");
+
+    let age_attr = ClaimAttribute::from_str("io.test.person/age").unwrap();
+    let age_values = carry::schema::fetch_values(&session, &entity, age_attr)
+        .await
+        .unwrap();
+    assert_eq!(age_values.len(), 1);
+    assert_eq!(carry::schema::format_value(&age_values[0]), "28");
+}
+
+/// Round-trip: asserted notation YAML → assert from file → verify.
+#[tokio::test]
+async fn test_roundtrip_asserted_notation_yaml() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // 1. Assert data
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Bob".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("35".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // 2. Derive entity and build asserted notation YAML
+    let entity = carry::schema::derive_entity_from_fields(&[
+        ("io.test.person/name".to_string(), "Bob".to_string()),
+        ("io.test.person/age".to_string(), "35".to_string()),
+    ])
+    .unwrap();
+
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Bob".to_string())],
+    );
+    attrs.insert(
+        "io.test.person/age".to_string(),
+        vec![Value::UnsignedInt(35)],
+    );
+    let mut results = BTreeMap::new();
+    results.insert(entity.to_string(), attrs);
+
+    let asserted_yaml = carry::query_cmd::format_asserted_yaml(&results, "io.test.person");
+
+    // 3. Assert from the asserted notation YAML (idempotent in same space)
+    let (yaml_path, _tmp) = write_yaml_file(&asserted_yaml);
+    carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // 4. Verify data is still intact
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(carry::schema::format_value(&values[0]), "Bob");
+}
+
+/// Round-trip: asserted notation YAML with multi-valued fields.
+#[tokio::test]
+async fn test_roundtrip_asserted_notation_multivalued() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Construct asserted notation YAML with a list value
+    let entity_did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    let yaml = format!(
+        "{}:\n  io.test.person:\n    name: Alice\n    tag:\n      - engineer\n      - leader\n",
+        entity_did
+    );
+
+    let (yaml_path, _tmp) = write_yaml_file(&yaml);
+    carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let entity = dialog_query::Entity::from_str(entity_did).unwrap();
+    let tag_attr = ClaimAttribute::from_str("io.test.person/tag").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, tag_attr)
+        .await
+        .unwrap();
+    assert_eq!(
+        values.len(),
+        2,
+        "Multi-valued field should produce two claims"
+    );
+}
+
+/// Assert from EAV triple YAML file.
+#[tokio::test]
+async fn test_assert_from_eav_triple_yaml() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let entity_did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    let yaml = format!(
+        "- the: io.test.person/name\n  of: {}\n  is: Alice\n- the: io.test.person/age\n  of: {}\n  is: 28\n",
+        entity_did, entity_did
+    );
+
+    let (yaml_path, _tmp) = write_yaml_file(&yaml);
+    carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let entity = dialog_query::Entity::from_str(entity_did).unwrap();
+
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    assert_eq!(carry::schema::format_value(&values[0]), "Alice");
+
+    let age_attr = ClaimAttribute::from_str("io.test.person/age").unwrap();
+    let age_values = carry::schema::fetch_values(&session, &entity, age_attr)
+        .await
+        .unwrap();
+    assert_eq!(age_values.len(), 1);
+    assert_eq!(carry::schema::format_value(&age_values[0]), "28");
+}
+
+/// Retract from EAV triple YAML file.
+#[tokio::test]
+async fn test_retract_from_eav_triple_yaml() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // First assert some data
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("28".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    let entity = carry::schema::derive_entity_from_fields(&[
+        ("io.test.person/name".to_string(), "Alice".to_string()),
+        ("io.test.person/age".to_string(), "28".to_string()),
+    ])
+    .unwrap();
+
+    // Verify data exists
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let age_attr = ClaimAttribute::from_str("io.test.person/age").unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, age_attr.clone())
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 1);
+    drop(session);
+
+    // Now retract the age via EAV triple YAML file
+    let yaml = format!("- the: io.test.person/age\n  of: {}\n  is: 28\n", entity);
+    let (yaml_path, _tmp) = write_yaml_file(&yaml);
+    carry::retract_cmd::execute(&ctx, FirstArg::File(yaml_path), None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify age is retracted
+    let session = ctx.open_session().await.unwrap();
+    let values = carry::schema::fetch_values(&session, &entity, age_attr)
+        .await
+        .unwrap();
+    assert_eq!(values.len(), 0, "Age should be retracted");
+
+    // Name should still exist
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let name_values = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(name_values.len(), 1, "Name should still exist");
+}
+
+/// Retract from asserted notation YAML file.
+#[tokio::test]
+async fn test_retract_from_asserted_yaml() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Assert data
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Charlie".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("40".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    let entity = carry::schema::derive_entity_from_fields(&[
+        ("io.test.person/name".to_string(), "Charlie".to_string()),
+        ("io.test.person/age".to_string(), "40".to_string()),
+    ])
+    .unwrap();
+
+    // Build asserted notation YAML for retraction (matching query output)
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Charlie".to_string())],
+    );
+    attrs.insert(
+        "io.test.person/age".to_string(),
+        vec![Value::UnsignedInt(40)],
+    );
+    let mut results = BTreeMap::new();
+    results.insert(entity.to_string(), attrs);
+
+    let asserted_yaml = carry::query_cmd::format_asserted_yaml(&results, "io.test.person");
+    let (yaml_path, _tmp) = write_yaml_file(&asserted_yaml);
+
+    carry::retract_cmd::execute(&ctx, FirstArg::File(yaml_path), None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify both fields are retracted
+    let session = ctx.open_session().await.unwrap();
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let name_vals = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(name_vals.len(), 0, "Name should be retracted");
+
+    let age_attr = ClaimAttribute::from_str("io.test.person/age").unwrap();
+    let age_vals = carry::schema::fetch_values(&session, &entity, age_attr)
+        .await
+        .unwrap();
+    assert_eq!(age_vals.len(), 0, "Age should be retracted");
+}
+
+/// Retract from JSON content (EAV triples).
+#[tokio::test]
+async fn test_retract_from_json_content() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let entity_did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+
+    // Assert via JSON first
+    let json_content = format!(
+        r#"[{{"the": "io.test.person/name", "of": "{}", "is": "Alice"}}]"#,
+        entity_did
+    );
+    let tmp = tempfile::NamedTempFile::with_suffix(".json").unwrap();
+    std::fs::write(tmp.path(), &json_content).unwrap();
+    let json_path = tmp.path().to_string_lossy().to_string();
+
+    carry::assert_cmd::execute(&ctx, FirstArg::File(json_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify exists
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let entity = dialog_query::Entity::from_str(entity_did).unwrap();
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, name_attr.clone())
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 1);
+    drop(session);
+
+    // Retract via JSON
+    let retract_json = format!(
+        r#"[{{"the": "io.test.person/name", "of": "{}", "is": "Alice"}}]"#,
+        entity_did
+    );
+    let tmp2 = tempfile::NamedTempFile::with_suffix(".json").unwrap();
+    std::fs::write(tmp2.path(), &retract_json).unwrap();
+    let json_path2 = tmp2.path().to_string_lossy().to_string();
+
+    carry::retract_cmd::execute(&ctx, FirstArg::File(json_path2), None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify retracted
+    let session = ctx.open_session().await.unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 0, "Should be retracted");
+}
+
+/// Round-trip: assert → format triples → retract from triples → verify gone.
+#[tokio::test]
+async fn test_roundtrip_query_retract_triples() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Assert data
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Eve".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("25".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    let entity = carry::schema::derive_entity_from_fields(&[
+        ("io.test.person/name".to_string(), "Eve".to_string()),
+        ("io.test.person/age".to_string(), "25".to_string()),
+    ])
+    .unwrap();
+
+    // Build triples YAML (simulating carry query --format triples output)
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.person/name".to_string(),
+        vec![Value::String("Eve".to_string())],
+    );
+    attrs.insert(
+        "io.test.person/age".to_string(),
+        vec![Value::UnsignedInt(25)],
+    );
+    let mut results = BTreeMap::new();
+    results.insert(entity.to_string(), attrs);
+
+    let triples_yaml = carry::query_cmd::format_triples(&results).unwrap();
+
+    // Retract using the triples YAML
+    let (yaml_path, _tmp) = write_yaml_file(&triples_yaml);
+    carry::retract_cmd::execute(&ctx, FirstArg::File(yaml_path), None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify both fields are retracted
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let name_attr = ClaimAttribute::from_str("io.test.person/name").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, name_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 0, "Name should be retracted");
+}
+
+/// format_triples YAML can be parsed back by assert (end-to-end format contract).
+#[tokio::test]
+async fn test_triples_format_contract() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Build triples with various value types
+    use dialog_query::Value;
+    use std::collections::BTreeMap;
+
+    let entity_did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+        "io.test.data/text".to_string(),
+        vec![Value::String("hello world".to_string())],
+    );
+    attrs.insert(
+        "io.test.data/number".to_string(),
+        vec![Value::UnsignedInt(42)],
+    );
+    attrs.insert(
+        "io.test.data/negative".to_string(),
+        vec![Value::SignedInt(-7)],
+    );
+    attrs.insert("io.test.data/flag".to_string(), vec![Value::Boolean(true)]);
+
+    let mut results = BTreeMap::new();
+    results.insert(entity_did.to_string(), attrs);
+
+    let triples_yaml = carry::query_cmd::format_triples(&results).unwrap();
+
+    // Assert from the triples YAML
+    let (yaml_path, _tmp) = write_yaml_file(&triples_yaml);
+    carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+        .await
+        .unwrap();
+
+    // Verify each value was stored
+    use dialog_query::claim::Attribute as ClaimAttribute;
+    use std::str::FromStr;
+    let session = ctx.open_session().await.unwrap();
+    let entity = dialog_query::Entity::from_str(entity_did).unwrap();
+
+    let text_attr = ClaimAttribute::from_str("io.test.data/text").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, text_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 1);
+    assert_eq!(carry::schema::format_value(&vals[0]), "hello world");
+
+    let num_attr = ClaimAttribute::from_str("io.test.data/number").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, num_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 1);
+    assert_eq!(carry::schema::format_value(&vals[0]), "42");
+
+    let neg_attr = ClaimAttribute::from_str("io.test.data/negative").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, neg_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 1);
+    assert_eq!(carry::schema::format_value(&vals[0]), "-7");
+
+    let flag_attr = ClaimAttribute::from_str("io.test.data/flag").unwrap();
+    let vals = carry::schema::fetch_values(&session, &entity, flag_attr)
+        .await
+        .unwrap();
+    assert_eq!(vals.len(), 1);
+    assert_eq!(carry::schema::format_value(&vals[0]), "true");
+}
+
+/// Query with --format triples doesn't error.
+#[tokio::test]
+async fn test_query_triples_format_runs() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Assert some data
+    let fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: Some("Alice".to_string()),
+        },
+        Field {
+            name: "age".to_string(),
+            value: Some("28".to_string()),
+        },
+    ];
+    carry::assert_cmd::execute(
+        &ctx,
+        FirstArg::Target(Target::Domain("io.test.person".to_string())),
+        None,
+        None,
+        fields,
+        "yaml",
+    )
+    .await
+    .unwrap();
+
+    // Query with triples format
+    let query_fields = vec![
+        Field {
+            name: "name".to_string(),
+            value: None,
+        },
+        Field {
+            name: "age".to_string(),
+            value: None,
+        },
+    ];
+    carry::query_cmd::execute(
+        &ctx,
+        Target::Domain("io.test.person".to_string()),
+        query_fields,
+        "triples",
+    )
+    .await
+    .unwrap();
+}
+
+/// Malformed YAML input gives a clear error.
+#[tokio::test]
+async fn test_assert_malformed_yaml_error() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let bad_yaml = "this is not valid YAML for triples: [[[";
+    let (yaml_path, _tmp) = write_yaml_file(bad_yaml);
+    let result =
+        carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+            .await;
+    assert!(result.is_err());
+}
+
+/// Malformed YAML input to retract gives a clear error.
+#[tokio::test]
+async fn test_retract_malformed_yaml_error() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let bad_yaml = "this is not valid YAML for triples: [[[";
+    let (yaml_path, _tmp) = write_yaml_file(bad_yaml);
+    let result =
+        carry::retract_cmd::execute(&ctx, FirstArg::File(yaml_path), None, vec![], "yaml").await;
+    assert!(result.is_err());
+}
+
+/// EAV triple YAML with missing 'the' gives a clear error.
+#[tokio::test]
+async fn test_assert_eav_missing_the_error() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    let yaml = "- of: did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD\n  is: Alice\n";
+    let (yaml_path, _tmp) = write_yaml_file(yaml);
+    let result =
+        carry::assert_cmd::execute(&ctx, FirstArg::File(yaml_path), None, None, vec![], "yaml")
+            .await;
+    assert!(result.is_err());
+    // The error chain should mention the missing 'the' key
+    let err = result.unwrap_err();
+    let full_err = format!("{:#}", err);
+    assert!(
+        full_err.contains("the"),
+        "Error should mention missing 'the': {}",
+        full_err
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/rust/carry/tests/common.rs
+++ b/rust/carry/tests/common.rs
@@ -22,12 +22,20 @@ pub struct TestEnv {
 #[allow(dead_code)]
 impl TestEnv {
     /// Create a new test environment with a bootstrapped space.
+    ///
+    /// The space is initialized with pre-registered concepts (attribute,
+    /// concept, bookmark) so that meta-schema operations work immediately.
     pub async fn new() -> Result<Self> {
         let temp_dir = TempDir::new().context("Failed to create temp directory")?;
         let site_path = temp_dir.path().to_path_buf();
         let site = Site::init(&site_path)?;
         let space = site.create_space()?;
         site.set_active_space(&space.did)?;
+
+        // Bootstrap pre-registered concepts (attribute, concept, bookmark)
+        let mut session = space.open_session().await?;
+        carry::schema::bootstrap_builtins(&mut session).await?;
+
         let space_did = space.did.clone();
 
         Ok(Self {


### PR DESCRIPTION
Introduces various small improvements to `carry` that further align it with https://github.com/tonk-labs/rfc/blob/main/rfc/carry.md or otherwise improve QoL:
- `@name` bookmark sugar
- dialog self-referential definitions of concepts and attributes asserted on `carry init`
- implicit namespacing on query and the ability to query concepts formally
- triple format and piping
- cli tab complete

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `carry` CLI tool, adding support for new features, improving command handling, and refining the structure of the codebase. It focuses on better input handling, new dependencies, and updates to the functionality of existing commands.

### Detailed summary
- Added `clap_complete` dependency for enhanced CLI completion.
- Improved `new` function in `TestEnv` to bootstrap pre-registered concepts.
- Updated `Cargo.toml` to include new dependencies and features.
- Enhanced error handling and added support for new command formats.
- Introduced `ParsedFields` struct for better field parsing.
- Updated query and assert commands to handle new input formats and improve output.
- Added tests for new functionality and input handling.

> The following files were skipped due to too many changes: `rust/carry/src/assert_cmd.rs`, `rust/carry/src/schema.rs`, `rust/carry/tests/cli_integration.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->