### PR TITLE
feat(docs): TON-1983: update-readme to reflect new structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,73 @@
 # Tonk
 
-```
+Tonk is a data substrate: a software environment as easy to change as it is to use. Where stacks are rigid and vertically integrated, substrates are malleable and horizontally connected. You modify software in the context of its use, not through a separate process. In a substrate, software truly becomes yours.
 
+Substrates are essential when LLMs make code generation abundant and personal software becomes practical. We won't get there by speeding up the same engineering-heavy processes of traditional software practice. We need a new surface; one interoperable and owned by the person running it. Tonk is that surface.
 
-                                    .-            ::.
-                                    -##.   ..     +@@@+
-                              -:    ###-  *##
-                              +##+  ###* *##%
-                              ########%*###*   +*%
-                        *###*:+##=*..:=####*++*#@
-                          ######*==-.----%#**##%..:                        :=
-                          .:=##-=:*#===*-##%@@*#@-                      ::.:=.
-                      =#%%%#%%***##+#-*-##@@@@@              -..      .---++
-                      =@%####@@@%%=*#@#*@@@@                -:      :--++
-                        -+****#*#%@@@@%@@@-                  :.:   =::     .....
-                      ++*#%*-+++*#@@@@@@@.                .:::-+:.#+   ..  .::::.
-                      -%     =+#@   . %@@@*                     =##@        .
-      ..                   *#%        .%@@+                       =###
-    ##@%#*%                             +@%+                           #=
-    :*#%%-:@                              @#=                            +-
-      +@@@##@                               %+-                             *
-                                        ::: :+=-     ...:-==.
-                                    ......:-++:  ::.::::=+
-                                    ++=-::+%@@#:--:...:-=+
-                            .--           @@%%#*+-:::-=+-
-                        .=++=--=+-     -==#%%####****#-
-                    .%@@@      +%+ ..-*%#
-              -=    =@@@@#       --:+%-     .    +@@%  :+#%*-:.
-          :+-==+=   =@@@       ==+%  *#     +@+%@@@@ #=    %#****@:
-          ###*=*  ..       .- .*=*. *        -@@#.-=#+      .**#*@+
-          :=-:=@.+=*   ::= :..===+= #-:.     .#-...++ .=....   =@+
-                %%%.   . -+    @*---%=*@@*:  ......-=  ==...-+  +%
-          -++    .+%=*::+.*-    ##*@+--#@@@+.....=:.==. *-*+%  +%+-
-```
+## Dialog DB: The Foundation
 
-Tonk is a containerized format, host environment and protocol for multiplayer software you keep and
-share like files.
+At the core of Tonk is [Dialog DB](https://github.com/dialog-db/dialog-db), an embeddable, local-first database that stores everything as facts: semantic triples of (entity, attribute, value). Facts are never deleted, only superseded or retracted. This append-only, content-addressed design means prolly-tree indexes depend only on data, not insertion order. Replicas sync deterministically without conflicts.
 
-Every file contains both its application and its data, is designed to work across any connection, on
-any machine, last forever, and remain under user control.
+You interact with Dialog through two primitives:
 
-## What is Tonk?
+- **Concepts** group related facts into structures. Define a `Person` with a name, location, and photo. Then create a `ClubMember` concept that reuses name and photo but leaves out location — multiple views over the same data.
+- **Rules** derive new concepts from existing facts. "A `FamilyMember` is any `Person` whose last name matches another and who shares the same home location."
 
-Tonk represents a credibly neutral platform for building and sharing local software. It embodies
-principles of malleable software (as easy to change as it is to use) and user ownership (people
-retain control of their tools and data).
+Add new rules, new concepts, or extend existing ones. Declaratively express what data you expect and it works without a single migrations.
 
-### Key Features
+We encourage you to check out the repository to learn more.
 
-- **Human-Centered**: Authority is centered on you, the human using the computer
-- **Offline-First**: Applications work whether or not you have an internet connection
-- **Multiplayer**: Automatic, real-time, conflict-free sync with privacy controls
+# What's in This Repo
 
-## Quick Start
+This is a Rust workspace (with some JS/WASM packages) where we are implementing our early experimentations on the Tonk substrate. This repo is heavily in flux, and not meant to be friendly for public access or contributions. If you would like to try some of our experiments, see the [Released Experiments](#released-experiments) section below!
 
-> ⚠️ Tonk is under heavy development. See the [quickstart guide](docs/src/quickstart.md) for setup
-> instructions.
+### Rust Crates
 
-Install Nix and then run the following in your terminal:
+| Crate                   | Purpose                                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------- |
+| **tonk-cli**            | CLI tool (`tonk` binary) — the primary interface for managing spaces, concepts, instances, and sync |
+| **tonk-space**          | Core space primitives: operators, delegation, ownership, storage                                    |
+| **tonk-common**         | Cross-platform utilities (logging, etc.)                                                            |
+| **tonk-blobs**          | Content-addressed blob storage (filesystem + IndexedDB)                                             |
+| **tonk-access-service** | Cloudflare Worker that authorizes S3/R2 access via UCAN                                             |
+| **tonk-ui**             | Leptos-based web frontend                                                                           |
+| **tonk-worker**         | Browser service worker (WASM) for offline web support                                               |
+| **tonk-core**           | Core library (in progress)                                                                          |
 
-```bash
-nix develop
-```
+### JavaScript Packages (`packages/`)
 
-## Resources
+| Package   | Purpose                                               |
+| --------- | ----------------------------------------------------- |
+| **core**  | WASM-compiled core library for browsers (sync engine) |
+| **relay** | Communication relay                                   |
 
-- [Documentation](https://tonk-labs.github.io/tonk)
+# Released Experiments
+
+## Carry
+
+[Carry](https://github.com/tonk-labs/carry) is a local-first semantic database for humans and machines in the form of a CLI tool. It allows you to assert, query, and manage structured data in a local Dialog DB repository.
+
+This is useful for a few things, but one that's been working well for us is as a persistent memory layer for local LLM-driven workflows. You can read more about the use cases in [the documentation](https://tonk-labs.github.io/carry/philosophy.html).
+
+Carry is synced from this monorepo and published separately.
+
+# Adjacent Projects
+
+Tonk is pluralist by design and built to work alongside other protocols building on open technology. We think that is the best way to accomplish our mission. Here are some projects that are adjacent to us and think you should check out.
+
+- [Ink and Switch](https://www.inkandswitch.com/)
+- [Automerge](https://automerge.org/)
+- [Common Tools](https://common.tools/)
+- [Iroh](https://www.iroh.computer/)
+
+If you are a friend or adjacent project and would like to be listed here, please reach out!
+
+# Resources
+
 - [Website](https://tonk.xyz)
-- [GitHub](https://github.com/tonk-labs/tonk)
-- [Community](https://discord.gg/cHqkYpRE)
-
-## Thanks
-
-Special thanks to our external friends and supporters:
-
-- **[Automerge](https://automerge.org/)** - A library of data structures for building collaborative
-  applications.
-  - [Alex Good](https://patternist.xyz/) for supporting our queries and collaborating with us on the
-    WASM implementation.
-- **[Ink & Switch](https://www.inkandswitch.com/)** - An independent research lab exploring the
-  future of tools for thought.
-  - [Peter Van Hardenburg](https://www.pvh.ca/) for sharing his
-    [trail-runner](https://github.com/pvh/trail-runner) project with us, which the host web package
-    is heavily based on.
-  - [Chee](https://chee.party/) for sharing papers and imagining with us what's possible.
-- **[Common Tools](https://common.tools/)** A new fabric for computing.
-  - [Alex Komoroske](https://www.komoroske.com/) for being a nexus of ideas. He publishes an
-    incredible weekly update.
-- **[Grjte](https://grjte.sh/)** - For charting the frontier with us every step of the way.
-- **[Boris Mann](https://bmannconsulting.com/)** - For being a super connector and arguing with us
-  about files.
-
-<br/>
-There are many more who have expressed their support and contributed something meaningful and we
-can't possibly list everyone, but know that we are so grateful to work with together with you.
-❤️
+- [Roadmap](https://tonk.xyz/roadmap)
+- [Discord](https://discord.com/invite/hBPQ9xPWF7)
 
 ## License
-
-Simplicity and freedom
 
 MIT © Tonk Labs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # Tonk
 
+```
+                                    .-            ::.
+                                    -##.   ..     +@@@+
+                              -:    ###-  *##
+                              +##+  ###* *##%
+                              ########%*###*   +*%
+                        *###*:+##=*..:=####*++*#@
+                          ######*==-.----%#**##%..:                        :=
+                          .:=##-=:*#===*-##%@@*#@-                      ::.:=.
+                      =#%%%#%%***##+#-*-##@@@@@              -..      .---++
+                      =@%####@@@%%=*#@#*@@@@                -:      :--++
+                        -+****#*#%@@@@%@@@-                  :.:   =::     .....
+                      ++*#%*-+++*#@@@@@@@.                .:::-+:.#+   ..  .::::.
+                      -%     =+#@   . %@@@*                     =##@        .
+      ..                   *#%        .%@@+                       =###
+    ##@%#*%                             +@%+                           #=
+    :*#%%-:@                              @#=                            +-
+      +@@@##@                               %+-                             *
+                                        ::: :+=-     ...:-==.
+                                    ......:-++:  ::.::::=+
+                                    ++=-::+%@@#:--:...:-=+
+                            .--           @@%%#*+-:::-=+-
+                        .=++=--=+-     -==#%%####****#-
+                    .%@@@      +%+ ..-*%#
+              -=    =@@@@#       --:+%-     .    +@@%  :+#%*-:.
+          :+-==+=   =@@@       ==+%  *#     +@+%@@@@ #=    %#****@:
+          ###*=*  ..       .- .*=*. *        -@@#.-=#+      .**#*@+
+          :=-:=@.+=*   ::= :..===+= #-:.     .#-...++ .=....   =@+
+                %%%.   . -+    @*---%=*@@*:  ......-=  ==...-+  +%
+          -++    .+%=*::+.*-    ##*@+--#@@@+.....=:.==. *-*+%  +%+-
+```
+
 Tonk is a data substrate: a software environment as easy to change as it is to use. Where stacks are rigid and vertically integrated, substrates are malleable and horizontally connected. You modify software in the context of its use, not through a separate process. In a substrate, software truly becomes yours.
 
 Substrates are essential when LLMs make code generation abundant and personal software becomes practical. We won't get there by speeding up the same engineering-heavy processes of traditional software practice. We need a new surface; one interoperable and owned by the person running it. Tonk is that surface.
@@ -19,7 +51,9 @@ We encourage you to check out the repository to learn more.
 
 # What's in This Repo
 
-This is a Rust workspace (with some JS/WASM packages) where we are implementing our early experimentations on the Tonk substrate. This repo is heavily in flux, and not meant to be friendly for public access or contributions. If you would like to try some of our experiments, see the [Released Experiments](#released-experiments) section below!
+This is a Rust workspace (with some JS/WASM packages) where we are implementing our early experimentations on the Tonk substrate.
+
+> ⚠️ This repo is heavily in flux, and not meant to be friendly for public access or contributions. If you would like to try some of our experiments, see the [Released Experiments](#released-experiments) section below!
 
 ### Rust Crates
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Substrates are essential when LLMs make code generation abundant and personal so
 
 At the core of Tonk is [Dialog DB](https://github.com/dialog-db/dialog-db), an embeddable, local-first database. Dialog stores everything as claims — semantic triples of (entity, attribute, value). Claims are never deleted, only superseded or retracted. This append-only, content-addressed design makes it straightforward to sync data across devices and collaborators without conflicts.
 
-You interact with Dialog through two primitives:
+The primary interface is claims themselves — assert data, query it, retract it. On top of that, you can optionally define:
 
-- **Concepts** group related claims into structures. Define a `Person` with a name, location, and photo. Then create a `ClubMember` concept that reuses name and photo but leaves out location — multiple views over the same data.
-- **Rules** derive new concepts from existing claims. "A `FamilyMember` is any `Person` whose last name matches another and who shares the same home location."
+- **Concepts** to group related claims into queryable structures. Define a `Person` with a name, location, and photo. Then create a `ClubMember` concept that reuses name and photo but leaves out location — multiple views over the same data.
+- **Rules** to derive new concepts from existing claims. "A `FamilyMember` is any `Person` whose last name matches another and who shares the same home location."
 
-Add new rules, new concepts, or extend existing ones. Declaratively express what data you expect and it works. No migrations required.
+Add new rules, concepts, or extend existing ones as your needs evolve. No migrations required.
 
 Check out the [Dialog DB repository](https://github.com/dialog-db/dialog-db) to learn more about how it works under the hood.
 

--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ Substrates are essential when LLMs make code generation abundant and personal so
 
 ## Dialog DB: The Foundation
 
-At the core of Tonk is [Dialog DB](https://github.com/dialog-db/dialog-db), an embeddable, local-first database that stores everything as facts: semantic triples of (entity, attribute, value). Facts are never deleted, only superseded or retracted. This append-only, content-addressed design means prolly-tree indexes depend only on data, not insertion order. Replicas sync deterministically without conflicts.
+At the core of Tonk is [Dialog DB](https://github.com/dialog-db/dialog-db), an embeddable, local-first database. Dialog stores everything as claims — semantic triples of (entity, attribute, value). Claims are never deleted, only superseded or retracted. This append-only, content-addressed design makes it straightforward to sync data across devices and collaborators without conflicts.
 
 You interact with Dialog through two primitives:
 
-- **Concepts** group related facts into structures. Define a `Person` with a name, location, and photo. Then create a `ClubMember` concept that reuses name and photo but leaves out location — multiple views over the same data.
-- **Rules** derive new concepts from existing facts. "A `FamilyMember` is any `Person` whose last name matches another and who shares the same home location."
+- **Concepts** group related claims into structures. Define a `Person` with a name, location, and photo. Then create a `ClubMember` concept that reuses name and photo but leaves out location — multiple views over the same data.
+- **Rules** derive new concepts from existing claims. "A `FamilyMember` is any `Person` whose last name matches another and who shares the same home location."
 
-Add new rules, new concepts, or extend existing ones. Declaratively express what data you expect and it works without a single migrations.
+Add new rules, new concepts, or extend existing ones. Declaratively express what data you expect and it works. No migrations required.
 
-We encourage you to check out the repository to learn more.
+Check out the [Dialog DB repository](https://github.com/dialog-db/dialog-db) to learn more about how it works under the hood.
 
 # What's in This Repo
 
-This is a Rust workspace (with some JS/WASM packages) where we are implementing our early experimentations on the Tonk substrate.
+This is a Rust workspace where we are implementing our early experimentations on the Tonk substrate.
 
 > ⚠️ This repo is heavily in flux, and not meant to be friendly for public access or contributions. If you would like to try some of our experiments, see the [Released Experiments](#released-experiments) section below!
 
@@ -67,13 +67,6 @@ This is a Rust workspace (with some JS/WASM packages) where we are implementing 
 | **tonk-ui**             | Leptos-based web frontend                                                                           |
 | **tonk-worker**         | Browser service worker (WASM) for offline web support                                               |
 | **tonk-core**           | Core library (in progress)                                                                          |
-
-### JavaScript Packages (`packages/`)
-
-| Package   | Purpose                                               |
-| --------- | ----------------------------------------------------- |
-| **core**  | WASM-compiled core library for browsers (sync engine) |
-| **relay** | Communication relay                                   |
 
 # Released Experiments
 


### PR DESCRIPTION
### Description

Updates the Tonk readme to reflect the new structure

### Related issues

- closes TON-1983

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `README.md` to provide a clearer and more comprehensive explanation of `Tonk`, emphasizing its role as a data substrate and introducing `Dialog DB` as its foundation, along with details on features, Rust crates, and adjacent projects.

### Detailed summary
- Revised description of `Tonk` as a data substrate.
- Introduced `Dialog DB` and its functionality.
- Added details on the primary interface and features like `Concepts` and `Rules`.
- Listed Rust crates with their purposes.
- Introduced a new section for `Carry`, a CLI tool.
- Added a section for `Adjacent Projects` and resources.
- Updated the `Thanks` section with relevant links and acknowledgments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->