### PR TITLE
feat(carry): invite and join spaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "hex",
  "rand 0.8.5",
  "serde",
+ "serde_ipld_dagcbor",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,8 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -271,6 +273,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -471,6 +474,7 @@ name = "carry"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "base64",
  "blake3",
  "bs58",
@@ -482,12 +486,15 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures-util",
+ "hex",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
  "tonk-space",
+ "webbrowser",
 ]
 
 [[package]]
@@ -1850,6 +1857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,7 +2278,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2273,10 +2286,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2706,6 +2768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,6 +2856,31 @@ name = "numeric_cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
 
 [[package]]
 name = "oco_ref"
@@ -3541,7 +3634,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -3994,6 +4087,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -5147,6 +5250,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ version = "0.1.0"
 name = "tonk-space"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "dialog-artifacts",
  "dialog-capability",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,26 @@
 [workspace]
-
-members = [
-    "rust/tonk-access-service",
-    "rust/tonk-blobs",
-    "rust/carry",
-    "rust/tonk-core",
-    "rust/tonk-common",
-    "rust/tonk-assess",
-    "rust/tonk-space",
-    "rust/tonk-ui",
-    "rust/tonk-worker",
-]
 resolver = "2"
+members = [
+  "rust/carry",
+  "rust/tonk-access-service",
+  "rust/tonk-assess",
+  "rust/tonk-blobs",
+  "rust/tonk-common",
+  "rust/tonk-core",
+  "rust/tonk-space",
+  "rust/tonk-ui",
+  "rust/tonk-worker",
+]
 
 [workspace.package]
 version = "0.1.0"
 authors = ["Tonk Labs"]
-license = "MIT"
 edition = "2024"
+license = "MIT"
 
 [workspace.dependencies]
-tonk-access-service = { path = "./rust/tonk-access-service" }
 carry = { path = "./rust/carry" }
+tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-core = { path = "./rust/tonk-core" }
 tonk-space = { path = "./rust/tonk-space" }
@@ -36,11 +35,12 @@ base58 = "0.2"
 base64 = "0.22"
 blake3 = "1.5"
 bs58 = "0.5"
-ciborium = "0.2"
+bytes = "1"
 chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "wasmbind",
+  "clock",
+  "wasmbind",
 ] }
+ciborium = "0.2"
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 console_error_panic_hook = "0.1"
@@ -52,17 +52,20 @@ ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
+getrandom = { version = "0.4", features = ["wasm_js"] }
 getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom_0_3 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
-getrandom = { version = "0.4", features = ["wasm_js"] }
 hex = "0.4"
 hkdf = "0.12"
+http-body-util = "0.1"
+hyper = "1"
+hyper-util = "0.1"
 idb = "0.6"
 ipld-core = { version = "0.4", features = ["serde"] }
 keyring = "3.6"
 leptos = "0.8"
-leptos-use = "0.17"
 leptos_router = "0.8"
+leptos-use = "0.17"
 port_check = "0.3"
 rand = "0.9"
 rand_0_8 = { package = "rand", version = "0.8" }
@@ -70,47 +73,45 @@ rand_core = "0.9"
 reqwest = "0.13"
 serde = "1"
 serde_bytes = "0.11"
+serde_ipld_dagcbor = "0.6"
 serde_json = "1"
 serde_yaml = "0.9"
-serde_ipld_dagcbor = "0.6"
+serial_test = "3"
 sha2_0_10 = { package = "sha2", version = "0.10" }
 tempfile = "3"
 thirtyfour = "0.36"
 thiserror = "2"
 tokio = "1"
 tokio-stream = "0.1"
-walkdir = "2"
 tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 tower-service = "0.3"
-hyper = "1"
-hyper-util = "0.1"
-bytes = "1"
-http-body-util = "0.1"
-url = "2"
 ulid = "1"
+url = "2"
+walkdir = "2"
 wasm-streams = "0.4"
 web-time = "1"
 webbrowser = "1.0"
 worker = "0.7.4"
 worker-macros = "0.7.4"
-serial_test = "3"
 
+js-sys = "0.3"
 # Bindgen
 wasm-bindgen = "=0.2.108"
-wasm-bindgen-test = "0.3"
 wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
+wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
+dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14", features = [
+  "ucan"
+] }
 # Dialog DB
 dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
-dialog-s3-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14", features = ["ucan"] }
 dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
 dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-02-14" }
 
@@ -122,13 +123,12 @@ strip = "debuginfo"
 opt-level = 3
 
 [profile.release]
+strip = "debuginfo"
 lto = "thin"
 codegen-units = 1
-strip = "debuginfo"
 
 [profile.wasm-release]
+inherits = "release"
 opt-level = "s"
 debug = 0
-inherits = "release"
 strip = "debuginfo"
-

--- a/rust/carry/Cargo.toml
+++ b/rust/carry/Cargo.toml
@@ -45,6 +45,7 @@ base64 = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # Serialization
+serde_ipld_dagcbor = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 

--- a/rust/carry/Cargo.toml
+++ b/rust/carry/Cargo.toml
@@ -42,9 +42,15 @@ ed25519-dalek = { workspace = true }
 rand_0_8 = { workspace = true }
 
 base64 = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 # Serialization
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+
+# HTTP server (for passkey browser flow)
+axum = { workspace = true, features = ["http1", "json", "tokio"] }
+webbrowser = { workspace = true }
 
 # Utilities
 anyhow = { workspace = true }

--- a/rust/carry/src/assert_cmd.rs
+++ b/rust/carry/src/assert_cmd.rs
@@ -615,7 +615,13 @@ fn atty_stdout() -> bool {
 
 /// Assert claims from a YAML/JSON file.
 async fn assert_from_file(ctx: &SiteContext, path: &str, format: &str) -> Result<()> {
-    let content = std::fs::read_to_string(path)?;
+    let content = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "Failed to read '{}'. If this is a target (not a file), \
+             use a dotted domain (e.g. books.dune) instead of a slash",
+            path
+        )
+    })?;
     assert_from_content(ctx, &content, path, format).await
 }
 

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -34,6 +34,10 @@ mod inner {
             /// Label for the repository (stored as a name claim)
             #[arg(value_name = "LABEL")]
             name: Option<String>,
+
+            /// Additional admin DIDs to delegate authority to at init time
+            #[arg(long = "admin", value_name = "DID")]
+            admins: Vec<String>,
         },
 
         /// Query entities by domain or concept
@@ -206,8 +210,8 @@ async fn main() -> anyhow::Result<()> {
     let space_flag = cli.space.as_deref();
 
     match cli.command {
-        Commands::Init { name } => {
-            carry::init::execute(name, repo_path).await?;
+        Commands::Init { name, admins } => {
+            carry::init::execute(name, admins, repo_path).await?;
         }
         Commands::Query {
             target,

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -91,6 +91,20 @@ mod inner {
         #[command(after_help = help::STATUS_AFTER_HELP)]
         Status,
 
+        /// Create an invite token for a collaborator
+        Invite {
+            /// DID of the user to invite (e.g., did:key:z6Mk...)
+            #[arg(value_name = "INVITED_DID")]
+            invited_did: String,
+        },
+
+        /// Join a space using an invite token
+        Join {
+            /// The invite token received from a collaborator
+            #[arg(value_name = "TOKEN")]
+            token: String,
+        },
+
         /// Manage spaces within a .carry/ repository
         #[command(alias = "s", hide = true)]
         #[command(long_about = help::SPACE_LONG_ABOUT)]
@@ -199,6 +213,13 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Status => {
             carry::status_cmd::execute(repo_path, format).await?;
+        }
+        Commands::Invite { invited_did } => {
+            let ctx = carry::site::SiteContext::resolve(repo_path, space_flag).await?;
+            carry::invite_cmd::execute(&ctx, &invited_did).await?;
+        }
+        Commands::Join { token } => {
+            carry::join_cmd::execute(&token, repo_path).await?;
         }
         Commands::Space { command } => {
             let site = carry::space_cmd::resolve_site(repo_path)?;

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -22,10 +22,6 @@ mod inner {
         /// Target a specific space by DID or label (overrides active space)
         #[arg(long, global = true, hide = true)]
         pub space: Option<String>,
-
-        /// Output format for query results
-        #[arg(long, global = true, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
-        pub format: String,
     }
 
     #[derive(Subcommand)]
@@ -53,6 +49,10 @@ mod inner {
             /// 'field=value' to filter results.
             #[arg(value_name = "FIELD[=VALUE]")]
             fields: Vec<String>,
+
+            /// Output format for query results
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
         },
 
         /// Assert claims on entities
@@ -68,6 +68,10 @@ mod inner {
             /// otherwise a new entity is created.
             #[arg(value_name = "FIELD=VALUE")]
             fields: Vec<String>,
+
+            /// Output format for query results
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
         },
 
         /// Retract claims from entities
@@ -83,13 +87,29 @@ mod inner {
             /// 'field' retracts any value; 'field=value' retracts exact match only.
             #[arg(value_name = "FIELD[=VALUE]")]
             fields: Vec<String>,
+
+            /// Output format for query results
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
         },
 
         /// Show current repository information
         #[command(alias = "st")]
         #[command(long_about = help::STATUS_LONG_ABOUT)]
         #[command(after_help = help::STATUS_AFTER_HELP)]
-        Status,
+        Status {
+            /// Output format for query results
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
+        },
+
+        /// Show or create your local identity
+        #[command(alias = "id")]
+        Identity {
+            /// Discard cached identity and re-derive from passkey
+            #[arg(long)]
+            reset: bool,
+        },
 
         /// Create an invite token for a collaborator
         Invite {
@@ -119,7 +139,11 @@ mod inner {
     pub enum SpaceCommands {
         /// List all spaces in the site
         #[command(alias = "l")]
-        List,
+        List {
+            /// Output format
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
+        },
 
         /// Create a new space
         #[command(alias = "c")]
@@ -127,6 +151,10 @@ mod inner {
             /// Label for the new space
             #[arg(value_name = "LABEL")]
             label: Option<String>,
+
+            /// Output format
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
         },
 
         /// Switch active space
@@ -139,7 +167,11 @@ mod inner {
 
         /// Show current active space
         #[command(alias = "a")]
-        Active,
+        Active {
+            /// Output format
+            #[arg(long, default_value = "yaml", value_parser = ["yaml", "json", "triples"])]
+            format: String,
+        },
 
         /// Delete a space (cannot delete the active space)
         #[command(alias = "d")]
@@ -172,21 +204,25 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let repo_path = cli.repo.as_deref().map(std::path::Path::new);
     let space_flag = cli.space.as_deref();
-    let format = &cli.format;
 
     match cli.command {
         Commands::Init { name } => {
             carry::init::execute(name, repo_path).await?;
         }
-        Commands::Query { target, fields } => {
+        Commands::Query {
+            target,
+            fields,
+            format,
+        } => {
             let parsed_target = carry::target::Target::parse(&target)?;
             let parsed = carry::target::parse_fields(&fields)?;
             let ctx = carry::site::SiteContext::resolve(repo_path, space_flag).await?;
-            carry::query_cmd::execute(&ctx, parsed_target, parsed.fields, format).await?;
+            carry::query_cmd::execute(&ctx, parsed_target, parsed.fields, &format).await?;
         }
         Commands::Assert {
             target_or_file,
             fields,
+            format,
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
             let parsed = carry::target::parse_fields(&fields)?;
@@ -197,22 +233,32 @@ async fn main() -> anyhow::Result<()> {
                 parsed.this_entity,
                 parsed.entity_name,
                 parsed.fields,
-                format,
+                &format,
             )
             .await?;
         }
         Commands::Retract {
             target_or_file,
             fields,
+            format,
         } => {
             let first_arg = carry::target::FirstArg::parse(&target_or_file)?;
             let parsed = carry::target::parse_fields(&fields)?;
             let ctx = carry::site::SiteContext::resolve(repo_path, space_flag).await?;
-            carry::retract_cmd::execute(&ctx, first_arg, parsed.this_entity, parsed.fields, format)
-                .await?;
+            carry::retract_cmd::execute(
+                &ctx,
+                first_arg,
+                parsed.this_entity,
+                parsed.fields,
+                &format,
+            )
+            .await?;
         }
-        Commands::Status => {
-            carry::status_cmd::execute(repo_path, format).await?;
+        Commands::Status { format } => {
+            carry::status_cmd::execute(repo_path, &format).await?;
+        }
+        Commands::Identity { reset } => {
+            carry::identity_cmd::execute(reset).await?;
         }
         Commands::Invite { invited_did } => {
             let ctx = carry::site::SiteContext::resolve(repo_path, space_flag).await?;
@@ -224,17 +270,17 @@ async fn main() -> anyhow::Result<()> {
         Commands::Space { command } => {
             let site = carry::space_cmd::resolve_site(repo_path)?;
             match command {
-                SpaceCommands::List => {
-                    carry::space_cmd::list(&site, format).await?;
+                SpaceCommands::List { format } => {
+                    carry::space_cmd::list(&site, &format).await?;
                 }
-                SpaceCommands::Create { label } => {
-                    carry::space_cmd::create(&site, label, format).await?;
+                SpaceCommands::Create { label, format } => {
+                    carry::space_cmd::create(&site, label, &format).await?;
                 }
                 SpaceCommands::Switch { target } => {
                     carry::space_cmd::switch(&site, &target).await?;
                 }
-                SpaceCommands::Active => {
-                    carry::space_cmd::active(&site, format).await?;
+                SpaceCommands::Active { format } => {
+                    carry::space_cmd::active(&site, &format).await?;
                 }
                 SpaceCommands::Delete { target, yes } => {
                     carry::space_cmd::delete(&site, &target, yes).await?;
@@ -275,6 +321,7 @@ mod tests {
             Commands::Query {
                 ref target,
                 ref fields,
+                ..
             } => {
                 assert_eq!(target, "com.app.person");
                 assert_eq!(fields, &["name", "age"]);
@@ -300,6 +347,7 @@ mod tests {
             Commands::Query {
                 ref target,
                 ref fields,
+                ..
             } => {
                 assert_eq!(target, "com.app.person");
                 assert_eq!(fields, &["name", "age"]);
@@ -335,10 +383,14 @@ mod tests {
             "json",
         ])
         .unwrap();
-        assert_eq!(cli.format, "json");
         match cli.command {
-            Commands::Query { ref fields, .. } => {
+            Commands::Query {
+                ref fields,
+                ref format,
+                ..
+            } => {
                 assert_eq!(fields, &["name"]);
+                assert_eq!(format, "json");
             }
             _ => panic!("Expected Query command"),
         }
@@ -361,14 +413,15 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(cli.space.as_deref(), Some("research"));
-        assert_eq!(cli.format, "json");
         match cli.command {
             Commands::Query {
                 ref target,
                 ref fields,
+                ref format,
             } => {
                 assert_eq!(target, "com.app.person");
                 assert_eq!(fields, &["name", "age"]);
+                assert_eq!(format, "json");
             }
             _ => panic!("Expected Query command"),
         }
@@ -393,6 +446,7 @@ mod tests {
             Commands::Assert {
                 ref target_or_file,
                 ref fields,
+                ..
             } => {
                 assert_eq!(target_or_file, "com.app.person");
                 assert_eq!(fields, &["name=Alice", "age=28"]);
@@ -412,10 +466,14 @@ mod tests {
             "json",
         ])
         .unwrap();
-        assert_eq!(cli.format, "json");
         match cli.command {
-            Commands::Assert { ref fields, .. } => {
+            Commands::Assert {
+                ref fields,
+                ref format,
+                ..
+            } => {
                 assert_eq!(fields, &["name=Alice"]);
+                assert_eq!(format, "json");
             }
             _ => panic!("Expected Assert command"),
         }
@@ -440,6 +498,7 @@ mod tests {
             Commands::Retract {
                 ref target_or_file,
                 ref fields,
+                ..
             } => {
                 assert_eq!(target_or_file, "com.app.person");
                 assert_eq!(fields, &["this=did:key:zAlice", "age"]);
@@ -460,10 +519,14 @@ mod tests {
             "json",
         ])
         .unwrap();
-        assert_eq!(cli.format, "json");
         match cli.command {
-            Commands::Retract { ref fields, .. } => {
+            Commands::Retract {
+                ref fields,
+                ref format,
+                ..
+            } => {
                 assert_eq!(fields, &["this=did:key:zAlice", "name"]);
+                assert_eq!(format, "json");
             }
             _ => panic!("Expected Retract command"),
         }
@@ -505,10 +568,14 @@ mod tests {
             "triples",
         ])
         .unwrap();
-        assert_eq!(cli.format, "triples");
         match cli.command {
-            Commands::Query { ref fields, .. } => {
+            Commands::Query {
+                ref fields,
+                ref format,
+                ..
+            } => {
                 assert_eq!(fields, &["name"]);
+                assert_eq!(format, "triples");
             }
             _ => panic!("Expected Query command"),
         }
@@ -528,11 +595,15 @@ mod tests {
             "research",
         ])
         .unwrap();
-        assert_eq!(cli.format, "triples");
         assert_eq!(cli.space.as_deref(), Some("research"));
         match cli.command {
-            Commands::Query { ref fields, .. } => {
+            Commands::Query {
+                ref fields,
+                ref format,
+                ..
+            } => {
                 assert_eq!(fields, &["name", "age"]);
+                assert_eq!(format, "triples");
             }
             _ => panic!("Expected Query command"),
         }
@@ -548,6 +619,90 @@ mod tests {
             "--format",
             "csv",
         ]);
+        assert!(result.is_err());
+    }
+
+    // -- Identity ---------------------------------------------------------------
+
+    #[test]
+    fn identity_parses() {
+        let cli = Cli::try_parse_from(["carry", "identity"]).unwrap();
+        match cli.command {
+            Commands::Identity { reset } => {
+                assert!(!reset);
+            }
+            _ => panic!("Expected Identity command"),
+        }
+    }
+
+    #[test]
+    fn identity_reset_flag() {
+        let cli = Cli::try_parse_from(["carry", "identity", "--reset"]).unwrap();
+        match cli.command {
+            Commands::Identity { reset } => {
+                assert!(reset);
+            }
+            _ => panic!("Expected Identity command"),
+        }
+    }
+
+    #[test]
+    fn identity_alias_id() {
+        let cli = Cli::try_parse_from(["carry", "id"]).unwrap();
+        assert!(matches!(cli.command, Commands::Identity { .. }));
+    }
+
+    // -- Invite -----------------------------------------------------------------
+
+    #[test]
+    fn invite_parses_did() {
+        let did = "did:key:z6MkvSLQtPtAraTvgQwjz3ps9JBuY8a41STNikZ9bJdShNr6";
+        let cli = Cli::try_parse_from(["carry", "invite", did]).unwrap();
+        match cli.command {
+            Commands::Invite { ref invited_did } => {
+                assert_eq!(invited_did, did);
+            }
+            _ => panic!("Expected Invite command"),
+        }
+    }
+
+    #[test]
+    fn invite_with_repo_flag() {
+        let cli = Cli::try_parse_from([
+            "carry",
+            "--repo",
+            "/tmp/myrepo",
+            "invite",
+            "did:key:z6MkTest",
+        ])
+        .unwrap();
+        assert_eq!(cli.repo.as_deref(), Some("/tmp/myrepo"));
+        assert!(matches!(cli.command, Commands::Invite { .. }));
+    }
+
+    #[test]
+    fn invite_missing_did_fails() {
+        let result = Cli::try_parse_from(["carry", "invite"]);
+        assert!(result.is_err());
+    }
+
+    // -- Join -------------------------------------------------------------------
+
+    #[test]
+    fn join_parses_token() {
+        let tok = "carry_inv1_somebase64data";
+        let cli = Cli::try_parse_from(["carry", "join", tok]).unwrap();
+        match cli.command {
+            Commands::Join { ref token } => {
+                assert_eq!(token, tok);
+            }
+            _ => panic!("Expected Join command"),
+        }
+    }
+
+    #[test]
+    fn join_missing_token_fails() {
+        let result = Cli::try_parse_from(["carry", "join"]);
         assert!(result.is_err());
     }
 }

--- a/rust/carry/src/help.rs
+++ b/rust/carry/src/help.rs
@@ -99,8 +99,12 @@ provided, it is asserted as the repository label.
 
 If a repository already exists, reports its status.
 
-The command generates an Ed25519 keypair for the repository, creating a unique
-DID (e.g., did:key:z...). The private key is stored in .carry/<did>/credentials.
+If no user identity exists (~/.carry/identity), the passkey authentication
+flow is triggered automatically before creating the repository.
+
+The command generates an ephemeral Ed25519 space key, delegates full authority
+to the user's identity (and any additional --admin DIDs), then discards the
+space key. The delegation proofs are stored in .carry/<did>/proofs.
 
 Pre-registered concepts (attribute, concept, bookmark) are bootstrapped during
 init so they can be queried and used immediately.";
@@ -112,6 +116,9 @@ EXAMPLES:
 
   # Initialize with a label
   carry init my-project
+
+  # Initialize with additional admins
+  carry init --admin did:key:z6Mk... --admin did:key:z6Mn...
 
   # Initialize in a specific directory
   carry init --repo /path/to/project

--- a/rust/carry/src/identity_cmd.rs
+++ b/rust/carry/src/identity_cmd.rs
@@ -152,8 +152,16 @@ pub async fn execute(reset: bool) -> Result<()> {
     }
 
     if reset {
-        std::fs::remove_file(carry_home()?.join(CREDENTIAL_FILE)).ok();
-        std::fs::remove_file(identity_path()?).ok();
+        match std::fs::remove_file(carry_home()?.join(CREDENTIAL_FILE)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).context("Failed to remove credential file"),
+        }
+        match std::fs::remove_file(identity_path()?) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).context("Failed to remove identity file"),
+        }
     }
 
     // Run the passkey browser flow
@@ -196,6 +204,7 @@ struct CallbackPayload {
 struct ServerState {
     credential_id: Option<String>,
     challenge: String,
+    expected_origin: String,
     tx: std::sync::Mutex<Option<oneshot::Sender<Result<CallbackPayload>>>>,
 }
 
@@ -216,9 +225,15 @@ async fn run_passkey_flow() -> Result<String> {
 
     let (tx, rx) = oneshot::channel();
 
+    // Bind to ephemeral port
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let expected_origin = format!("http://localhost:{}", addr.port());
+
     let state = Arc::new(ServerState {
         credential_id: credential_id.clone(),
         challenge: challenge.clone(),
+        expected_origin: expected_origin.clone(),
         tx: std::sync::Mutex::new(Some(tx)),
     });
 
@@ -242,10 +257,7 @@ async fn run_passkey_flow() -> Result<String> {
         .route("/callback", post(handle_callback))
         .with_state(state);
 
-    // Bind to ephemeral port
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let addr = listener.local_addr()?;
-    let url = format!("http://localhost:{}/auth", addr.port());
+    let url = format!("{}/auth", expected_origin);
 
     eprintln!("Opening browser for passkey authentication...");
 
@@ -275,8 +287,15 @@ async fn serve_page() -> Html<&'static str> {
 
 async fn handle_callback(
     State(state): State<Arc<ServerState>>,
+    headers: axum::http::HeaderMap,
     Json(payload): Json<CallbackPayload>,
 ) -> StatusCode {
+    // Reject requests from unexpected origins to prevent local cross-origin theft
+    if let Some(origin) = headers.get("origin")
+        && origin.as_bytes() != state.expected_origin.as_bytes()
+    {
+        return StatusCode::FORBIDDEN;
+    }
     if let Some(tx) = state.tx.lock().unwrap().take() {
         let _ = tx.send(Ok(payload));
         StatusCode::OK

--- a/rust/carry/src/identity_cmd.rs
+++ b/rust/carry/src/identity_cmd.rs
@@ -1,0 +1,276 @@
+//! `carry identity` — manage the local user identity.
+//!
+//! Identity is derived from a WebAuthn passkey via the PRF extension. The CLI
+//! starts a local HTTP server, opens a browser for the passkey ceremony, and
+//! receives the PRF output. The output is fed through HKDF-SHA256 to produce
+//! a deterministic Ed25519 keypair, cached at `~/.carry/identity`.
+
+use anyhow::{Context, Result};
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Html;
+use axum::routing::{get, post};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tonk_space::Operator;
+
+/// The HTML page for the WebAuthn ceremony.
+const IDENTITY_PAGE: &str = include_str!("identity_page.html");
+
+/// Filename for the cached identity key.
+const IDENTITY_FILE: &str = "identity";
+
+/// Filename for the stored WebAuthn credential ID.
+const CREDENTIAL_FILE: &str = "credential";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Get the carry home directory (`~/.carry/`), creating it if needed.
+fn carry_home() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let carry_dir = home.join(".carry");
+    if !carry_dir.exists() {
+        std::fs::create_dir_all(&carry_dir)
+            .with_context(|| format!("Failed to create {}", carry_dir.display()))?;
+    }
+    Ok(carry_dir)
+}
+
+/// Load a cached identity from `~/.carry/identity`, if it exists.
+pub fn load_identity() -> Result<Option<Operator>> {
+    let path = carry_home()?.join(IDENTITY_FILE);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes =
+        std::fs::read(&path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if bytes.len() != 32 {
+        anyhow::bail!(
+            "Invalid identity file at {} (expected 32 bytes, got {})",
+            path.display(),
+            bytes.len()
+        );
+    }
+    let mut secret = [0u8; 32];
+    secret.copy_from_slice(&bytes);
+    Ok(Some(Operator::from_secret(secret)))
+}
+
+/// Load identity or error with a helpful message.
+pub fn require_identity() -> Result<Operator> {
+    load_identity()?.context("No local identity found. Run `carry identity` to create one.")
+}
+
+/// Save an identity to `~/.carry/identity`.
+fn save_identity(operator: &Operator) -> Result<()> {
+    let path = carry_home()?.join(IDENTITY_FILE);
+    std::fs::write(&path, operator.to_secret())
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+/// Load a stored WebAuthn credential ID, if it exists.
+fn load_credential_id() -> Result<Option<String>> {
+    let path = carry_home()?.join(CREDENTIAL_FILE);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed))
+    }
+}
+
+/// Save a WebAuthn credential ID.
+fn save_credential_id(id: &str) -> Result<()> {
+    let path = carry_home()?.join(CREDENTIAL_FILE);
+    std::fs::write(&path, id).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CLI execute
+// ---------------------------------------------------------------------------
+
+/// Execute `carry identity [--reset]`.
+///
+/// If `reset` is false and a cached identity exists, just print the DID.
+/// Otherwise, run the passkey browser flow.
+pub async fn execute(reset: bool) -> Result<()> {
+    if !reset && let Some(operator) = load_identity()? {
+        println!("{}", operator.did());
+        return Ok(());
+    }
+
+    // Run the passkey browser flow
+    let prf_output = run_passkey_flow().await?;
+
+    // Derive identity from PRF output via HKDF
+    let operator = Operator::from_passphrase(&prf_output).await;
+
+    // Cache the derived identity
+    save_identity(&operator)?;
+
+    println!("{}", operator.did());
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Passkey browser flow
+// ---------------------------------------------------------------------------
+
+/// Info sent to the browser page to decide register vs authenticate.
+#[derive(Serialize)]
+struct SessionInfo {
+    credential_id: Option<String>,
+    rp_id: String,
+    user_id: String,
+    challenge: String,
+}
+
+/// Callback payload from the browser page.
+#[derive(Deserialize)]
+struct CallbackPayload {
+    credential_id: Option<String>,
+    prf_output: Option<String>,
+    phase: Option<String>,
+    error: Option<String>,
+}
+
+/// Shared state for the axum server.
+struct ServerState {
+    credential_id: Option<String>,
+    challenge: String,
+    tx: std::sync::Mutex<Option<oneshot::Sender<Result<CallbackPayload>>>>,
+}
+
+/// Start a local HTTP server, open the browser, wait for the PRF result.
+async fn run_passkey_flow() -> Result<String> {
+    let credential_id = load_credential_id()?;
+
+    // Generate a random challenge for registration
+    let mut challenge_bytes = [0u8; 32];
+    use rand_0_8::RngCore;
+    rand_0_8::rngs::OsRng.fill_bytes(&mut challenge_bytes);
+    let challenge = URL_SAFE_NO_PAD.encode(challenge_bytes);
+
+    // Random user ID for registration (only used once, not security-critical)
+    let mut user_id_bytes = [0u8; 16];
+    rand_0_8::rngs::OsRng.fill_bytes(&mut user_id_bytes);
+    let user_id = URL_SAFE_NO_PAD.encode(user_id_bytes);
+
+    let (tx, rx) = oneshot::channel();
+
+    let state = Arc::new(ServerState {
+        credential_id: credential_id.clone(),
+        challenge: challenge.clone(),
+        tx: std::sync::Mutex::new(Some(tx)),
+    });
+
+    let app = axum::Router::new()
+        .route("/", get(serve_page))
+        .route("/auth", get(serve_page))
+        .route(
+            "/info",
+            get({
+                let user_id = user_id.clone();
+                move |State(state): State<Arc<ServerState>>| async move {
+                    Json(SessionInfo {
+                        credential_id: state.credential_id.clone(),
+                        rp_id: "localhost".to_string(),
+                        user_id,
+                        challenge: state.challenge.clone(),
+                    })
+                }
+            }),
+        )
+        .route("/callback", post(handle_callback))
+        .with_state(state);
+
+    // Bind to ephemeral port
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let url = format!("http://localhost:{}/auth", addr.port());
+
+    eprintln!("Opening browser for passkey authentication...");
+
+    // Open browser
+    if webbrowser::open(&url).is_err() {
+        eprintln!("Could not open browser automatically.");
+        eprintln!("Please open this URL manually: {}", url);
+    }
+
+    // Serve until we get the callback
+    let server = axum::serve(listener, app).into_future();
+    tokio::select! {
+        result = rx => {
+            let payload: CallbackPayload = result.context("Server channel closed unexpectedly")??;
+            process_callback(payload).await
+        }
+        result = server => {
+            let _: Result<(), std::io::Error> = result;
+            anyhow::bail!("Server exited without receiving callback")
+        }
+    }
+}
+
+async fn serve_page() -> Html<&'static str> {
+    Html(IDENTITY_PAGE)
+}
+
+async fn handle_callback(
+    State(state): State<Arc<ServerState>>,
+    Json(payload): Json<CallbackPayload>,
+) -> StatusCode {
+    if let Some(tx) = state.tx.lock().unwrap().take() {
+        let _ = tx.send(Ok(payload));
+        StatusCode::OK
+    } else {
+        StatusCode::GONE
+    }
+}
+
+/// Process the callback payload: save credential ID, return PRF output as hex.
+async fn process_callback(payload: CallbackPayload) -> Result<String> {
+    // Check for errors from the browser
+    if let Some(error) = payload.error {
+        anyhow::bail!("Passkey authentication failed: {}", error);
+    }
+
+    let prf_b64u = payload.prf_output.context("No PRF output in callback")?;
+
+    let prf_bytes = URL_SAFE_NO_PAD
+        .decode(&prf_b64u)
+        .context("Invalid base64url in PRF output")?;
+
+    // Save credential ID for future authentications
+    if let Some(ref cred_id) = payload.credential_id {
+        save_credential_id(cred_id)?;
+    }
+
+    let phase = payload.phase.as_deref().unwrap_or("unknown");
+    eprintln!("Passkey {} successful.", phase);
+
+    // Return PRF output as hex string (used as passphrase input to HKDF)
+    Ok(hex::encode(&prf_bytes))
+}

--- a/rust/carry/src/identity_cmd.rs
+++ b/rust/carry/src/identity_cmd.rs
@@ -44,9 +44,20 @@ fn carry_home() -> Result<PathBuf> {
     Ok(carry_dir)
 }
 
-/// Load a cached identity from `~/.carry/identity`, if it exists.
+/// Resolve the identity file path.
+///
+/// Checks `CARRY_IDENTITY` env var first, then falls back to
+/// `~/.carry/identity`.
+pub fn identity_path() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CARRY_IDENTITY") {
+        return Ok(PathBuf::from(p));
+    }
+    Ok(carry_home()?.join(IDENTITY_FILE))
+}
+
+/// Load a cached identity from the identity file, if it exists.
 pub fn load_identity() -> Result<Option<Operator>> {
-    let path = carry_home()?.join(IDENTITY_FILE);
+    let path = identity_path()?;
     if !path.exists() {
         return Ok(None);
     }
@@ -69,9 +80,14 @@ pub fn require_identity() -> Result<Operator> {
     load_identity()?.context("No local identity found. Run `carry identity` to create one.")
 }
 
-/// Save an identity to `~/.carry/identity`.
+/// Save an identity to the identity file.
 fn save_identity(operator: &Operator) -> Result<()> {
-    let path = carry_home()?.join(IDENTITY_FILE);
+    let path = identity_path()?;
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
     std::fs::write(&path, operator.to_secret())
         .with_context(|| format!("Failed to write {}", path.display()))?;
 
@@ -111,6 +127,20 @@ fn save_credential_id(id: &str) -> Result<()> {
 // CLI execute
 // ---------------------------------------------------------------------------
 
+/// Ensure a local identity exists, running the passkey flow if needed.
+/// Returns the operator without printing to stdout.
+pub async fn ensure_identity() -> Result<Operator> {
+    if let Some(op) = load_identity()? {
+        return Ok(op);
+    }
+    eprintln!("No local identity found. Creating one now...");
+    let prf_output = run_passkey_flow().await?;
+    let operator = Operator::from_passphrase(&prf_output).await;
+    save_identity(&operator)?;
+    eprintln!("Identity created: {}", operator.did());
+    Ok(operator)
+}
+
 /// Execute `carry identity [--reset]`.
 ///
 /// If `reset` is false and a cached identity exists, just print the DID.
@@ -119,6 +149,11 @@ pub async fn execute(reset: bool) -> Result<()> {
     if !reset && let Some(operator) = load_identity()? {
         println!("{}", operator.did());
         return Ok(());
+    }
+
+    if reset {
+        std::fs::remove_file(carry_home()?.join(CREDENTIAL_FILE)).ok();
+        std::fs::remove_file(identity_path()?).ok();
     }
 
     // Run the passkey browser flow

--- a/rust/carry/src/identity_page.html
+++ b/rust/carry/src/identity_page.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>carry identity</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 480px; margin: 80px auto; padding: 0 20px;
+    text-align: center;
+  }
+  h1 { font-size: 1.4em; margin-bottom: 0.5em; }
+  p { color: #666; line-height: 1.5; }
+  @media (prefers-color-scheme: dark) { p { color: #aaa; } }
+  .status { margin-top: 2em; font-size: 0.95em; }
+  .error { color: #c00; }
+  .ok { color: #080; }
+  @media (prefers-color-scheme: dark) { .ok { color: #4c4; } .error { color: #f66; } }
+</style>
+</head>
+<body>
+<h1>carry identity</h1>
+<p>Authenticate with your passkey to derive your carry identity.</p>
+<div id="status" class="status">Initializing...</div>
+
+<script>
+(async function() {
+  const status = document.getElementById('status');
+  const CALLBACK = '/callback';
+  const SALT = new TextEncoder().encode('carry identity v1');
+
+  // Check PRF support
+  if (!window.PublicKeyCredential) {
+    status.className = 'status error';
+    status.textContent = 'WebAuthn is not supported in this browser.';
+    return;
+  }
+
+  try {
+    // Fetch session info from the server (tells us if we have a stored credential)
+    const infoResp = await fetch('/info');
+    const info = await infoResp.json();
+
+    let prfOutput;
+
+    if (info.credential_id) {
+      // Authentication flow — we have a stored credential
+      status.textContent = 'Waiting for passkey authentication...';
+      prfOutput = await authenticate(info.credential_id);
+    } else {
+      // Registration flow — create a new passkey
+      status.textContent = 'Creating passkey...';
+      prfOutput = await register(info.rp_id, info.user_id, info.challenge);
+    }
+
+    // Send the PRF output back to the CLI
+    const resp = await fetch(CALLBACK, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(prfOutput),
+    });
+
+    if (resp.ok) {
+      status.className = 'status ok';
+      status.textContent = 'Identity derived. You can close this tab.';
+    } else {
+      const err = await resp.text();
+      throw new Error(err);
+    }
+  } catch (e) {
+    status.className = 'status error';
+    status.textContent = 'Error: ' + e.message;
+    // Report error to server so it can exit cleanly
+    fetch(CALLBACK, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: e.message }),
+    }).catch(() => {});
+  }
+
+  async function register(rpId, userId, challengeB64) {
+    const challenge = b64uToBytes(challengeB64);
+    const userIdBytes = b64uToBytes(userId);
+
+    const credential = await navigator.credentials.create({
+      publicKey: {
+        rp: { name: 'carry', id: rpId },
+        user: {
+          id: userIdBytes,
+          name: 'carry-identity',
+          displayName: 'Carry Identity',
+        },
+        challenge: challenge,
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -7 },   // ES256
+          { type: 'public-key', alg: -257 },  // RS256
+        ],
+        authenticatorSelection: {
+          residentKey: 'required',
+          userVerification: 'required',
+        },
+        extensions: {
+          prf: { eval: { first: SALT } },
+        },
+      },
+    });
+
+    const prfResults = credential.getClientExtensionResults().prf;
+    if (!prfResults || !prfResults.results || !prfResults.results.first) {
+      throw new Error(
+        'PRF extension not supported by this authenticator. ' +
+        'Try a different passkey provider (e.g., iCloud Keychain, Chrome profile).'
+      );
+    }
+
+    return {
+      credential_id: bytesToB64u(new Uint8Array(credential.rawId)),
+      prf_output: bytesToB64u(new Uint8Array(prfResults.results.first)),
+      phase: 'register',
+    };
+  }
+
+  async function authenticate(credentialIdB64) {
+    const credentialId = b64uToBytes(credentialIdB64);
+
+    // Generate a random challenge client-side (server doesn't need to verify
+    // the assertion — we only need the PRF output)
+    const challenge = new Uint8Array(32);
+    crypto.getRandomValues(challenge);
+
+    const assertion = await navigator.credentials.get({
+      publicKey: {
+        challenge: challenge,
+        allowCredentials: [{
+          type: 'public-key',
+          id: credentialId,
+        }],
+        userVerification: 'required',
+        extensions: {
+          prf: { eval: { first: SALT } },
+        },
+      },
+    });
+
+    const prfResults = assertion.getClientExtensionResults().prf;
+    if (!prfResults || !prfResults.results || !prfResults.results.first) {
+      throw new Error('PRF extension did not return a result.');
+    }
+
+    return {
+      credential_id: credentialIdB64,
+      prf_output: bytesToB64u(new Uint8Array(prfResults.results.first)),
+      phase: 'authenticate',
+    };
+  }
+
+  function b64uToBytes(b64u) {
+    const b64 = b64u.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4));
+    const bin = atob(b64 + pad);
+    return Uint8Array.from(bin, c => c.charCodeAt(0));
+  }
+
+  function bytesToB64u(bytes) {
+    const bin = String.fromCharCode(...bytes);
+    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+})();
+</script>
+</body>
+</html>

--- a/rust/carry/src/init.rs
+++ b/rust/carry/src/init.rs
@@ -1,18 +1,28 @@
 //! `carry init` — create a new `.carry/` repository.
 //!
-//! Creates a `.carry/` directory and a first space. Optionally asserts a
-//! label claim on the space. Bootstraps pre-registered concepts (attribute,
-//! concept, bookmark) so they can be queried and used immediately.
+//! Creates a `.carry/` directory and a first space with delegation-based
+//! authority. The space key is ephemeral: it powerline-delegates to admin
+//! identities, then is discarded. All subsequent operations use the user's
+//! passkey-derived identity from `~/.carry/identity`.
+//!
+//! Bootstraps pre-registered concepts (attribute, concept, bookmark) so
+//! they can be queried and used immediately.
 
+use crate::identity_cmd;
 use crate::schema;
 use crate::site::Site;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use dialog_query::Attribute;
 use dialog_query::claim::{Claim, Relation};
 use std::path::Path;
+use tonk_space::Did;
 
-/// Execute `carry init [<name>] [--repo <REPO>]`.
-pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<()> {
+/// Execute `carry init [<name>] [--admin <DID>...] [--repo <REPO>]`.
+pub async fn execute(
+    name: Option<String>,
+    admin_dids: Vec<String>,
+    site_path: Option<&Path>,
+) -> Result<()> {
     let parent = if let Some(p) = site_path {
         p.to_path_buf()
     } else {
@@ -40,11 +50,29 @@ pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<(
         return Ok(());
     }
 
+    // Ensure we have a local identity (auto-trigger passkey flow if needed)
+    let identity = identity_cmd::ensure_identity().await?;
+
+    // Build list of admin DIDs (always includes the local identity)
+    let mut all_admins: Vec<Did> = vec![identity.did()];
+    for did_str in &admin_dids {
+        let did: Did = did_str
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Invalid admin DID '{}': {:?}", did_str, e))?;
+        // Deduplicate
+        if !all_admins.iter().any(|d| d.to_string() == did.to_string()) {
+            all_admins.push(did);
+        }
+    }
+
     // Create the .carry/ directory
     let site = Site::init(&parent)?;
 
-    // Create the first space
-    let space = site.create_space()?;
+    // Create the first space with delegation to admin(s)
+    let (space, _proofs) = site
+        .create_delegated_space(&all_admins)
+        .await
+        .context("Failed to create delegated space")?;
     site.set_active_space(&space.did)?;
 
     // Open a session for bootstrapping
@@ -70,6 +98,10 @@ pub async fn execute(name: Option<String>, site_path: Option<&Path>) -> Result<(
         println!("Initialized {} repository in {}", label, dir_display);
     } else {
         println!("Initialized repository in {}", dir_display);
+    }
+    eprintln!("Identity: {}", identity.did());
+    if all_admins.len() > 1 {
+        eprintln!("Admins: {} total", all_admins.len());
     }
 
     Ok(())

--- a/rust/carry/src/invite_cmd.rs
+++ b/rust/carry/src/invite_cmd.rs
@@ -1,0 +1,42 @@
+//! `carry invite <INVITED_DID>` — create an invite token for a collaborator.
+//!
+//! Mints a UCAN delegation from the active space to the invited DID, wraps it
+//! in a self-contained invite token, and prints it to stdout.
+
+use crate::site::SiteContext;
+use anyhow::{Context, Result};
+use tonk_space::{create_invite, encode_invite};
+
+/// Execute `carry invite <invited_did>`.
+pub async fn execute(ctx: &SiteContext, invited_did: &str) -> Result<()> {
+    // Parse the invited DID
+    let invited: tonk_space::Did = invited_did
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid DID '{}': {:?}", invited_did, e))?;
+
+    // Load the space operator (the space's signing key)
+    let space_operator = ctx.space.load_operator()?;
+    let space_did = space_operator.did();
+
+    // Read repo label for the hint field
+    let repo_hint = ctx.site.space_label(&ctx.space).await.ok().flatten();
+
+    // Create the invite (delegation + envelope)
+    let (envelope, delegation) = create_invite(&space_operator, &space_did, &invited, repo_hint)
+        .await
+        .context("Failed to create invite")?;
+
+    // Store the delegation in the space DB for audit
+    let mut session = ctx.space.open_session().await?;
+    let mut tx = session.edit();
+    dialog_query::claim::Claim::assert(delegation, &mut tx);
+    session.commit(tx).await?;
+
+    // Encode and print the token
+    let token = encode_invite(&envelope).context("Failed to encode invite token")?;
+
+    eprintln!("Invite token (share securely with your collaborator):");
+    println!("{}", token);
+
+    Ok(())
+}

--- a/rust/carry/src/invite_cmd.rs
+++ b/rust/carry/src/invite_cmd.rs
@@ -1,8 +1,10 @@
 //! `carry invite <INVITED_DID>` — create an invite token for a collaborator.
 //!
-//! Mints a UCAN delegation from the active space to the invited DID, wraps it
-//! in a self-contained invite token, and prints it to stdout.
+//! Mints a UCAN delegation from the inviter's identity to the invited DID,
+//! includes the upstream proof chain (space → admin → ... → inviter),
+//! wraps it in a self-contained invite token, and prints it to stdout.
 
+use crate::identity_cmd;
 use crate::site::SiteContext;
 use anyhow::{Context, Result};
 use tonk_space::{create_invite, encode_invite};
@@ -14,17 +16,25 @@ pub async fn execute(ctx: &SiteContext, invited_did: &str) -> Result<()> {
         .parse()
         .map_err(|e| anyhow::anyhow!("Invalid DID '{}': {:?}", invited_did, e))?;
 
-    // Load the space operator (the space's signing key)
-    let space_operator = ctx.space.load_operator()?;
-    let space_did = space_operator.did();
+    // Load the inviter's identity
+    let identity = identity_cmd::require_identity()?;
+
+    // Load the space's proof chain (our authority over this space)
+    let upstream_proofs = ctx.space.load_proofs()?;
+
+    let space_did: tonk_space::Did =
+        ctx.space.did.parse().map_err(|e| {
+            anyhow::anyhow!("Failed to parse space DID '{}': {:?}", ctx.space.did, e)
+        })?;
 
     // Read repo label for the hint field
     let repo_hint = ctx.site.space_label(&ctx.space).await.ok().flatten();
 
     // Create the invite (delegation + envelope)
-    let (envelope, delegation) = create_invite(&space_operator, &space_did, &invited, repo_hint)
-        .await
-        .context("Failed to create invite")?;
+    let (envelope, delegation) =
+        create_invite(&identity, &space_did, &invited, repo_hint, &upstream_proofs)
+            .await
+            .context("Failed to create invite")?;
 
     // Store the delegation in the space DB for audit
     let mut session = ctx.space.open_session().await?;

--- a/rust/carry/src/join_cmd.rs
+++ b/rust/carry/src/join_cmd.rs
@@ -1,0 +1,123 @@
+//! `carry join <TOKEN>` — redeem an invite token to join a space.
+//!
+//! Decodes the invite token, verifies the delegation grants, creates local
+//! space directories with the collaborator's credentials, and stores the
+//! delegations in the space DB.
+
+use crate::schema;
+use crate::site::Site;
+use anyhow::{Context, Result};
+use std::path::Path;
+use tonk_space::{Timestamp, decode_invite, verify_envelope};
+
+/// Execute `carry join <token> [--repo <REPO>]`.
+pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
+    // Decode and validate the token structure
+    let envelope = decode_invite(token).context("Failed to decode invite token")?;
+
+    // Verify all grants cryptographically
+    let now = Timestamp::now().to_unix();
+    let delegations =
+        verify_envelope(&envelope, now).context("Invite token verification failed")?;
+
+    // Resolve or create the .carry/ site
+    let site = match Site::resolve(site_flag) {
+        Ok(site) => site,
+        Err(_) => {
+            let parent = if let Some(p) = site_flag {
+                p.to_path_buf()
+            } else {
+                std::env::current_dir().context("Failed to determine current directory")?
+            };
+            Site::init(&parent)?
+        }
+    };
+
+    // Generate the collaborator's operator keypair
+    let collab_key = ed25519_dalek::SigningKey::generate(&mut rand_0_8::rngs::OsRng);
+    let collab_operator = tonk_space::Operator::from_secret(collab_key.to_bytes());
+
+    // Verify the local operator matches the invited DID
+    if collab_operator.did().to_string() != envelope.invited {
+        // The collaborator needs a stable identity that matches the invited DID.
+        // For now, we need the invited DID's credentials to already exist locally,
+        // or we generate fresh (which won't match). This is a placeholder until
+        // `carry identity` exists.
+        //
+        // For v1: check if there's already a space with credentials whose DID
+        // matches the invited DID. If not, error with guidance.
+        let spaces = site.list_spaces()?;
+        let mut found_operator = None;
+        for space in &spaces {
+            if let Ok(op) = space.load_operator() {
+                if op.did().to_string() == envelope.invited {
+                    found_operator = Some(op);
+                    break;
+                }
+            }
+        }
+
+        let collab_operator = found_operator.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No local identity matching invited DID {}.\n\
+                 Your local operator DID must match the invite. \
+                 A `carry identity` command will address this in a future release.",
+                envelope.invited
+            )
+        })?;
+
+        return join_spaces(&site, &collab_operator, &delegations, &envelope).await;
+    }
+
+    join_spaces(&site, &collab_operator, &delegations, &envelope).await
+}
+
+async fn join_spaces(
+    site: &Site,
+    _collab_operator: &tonk_space::Operator,
+    delegations: &[tonk_space::Delegation],
+    envelope: &tonk_space::InviteEnvelopeV1,
+) -> Result<()> {
+    let mut joined_count = 0;
+
+    for (grant, delegation) in envelope.grants.iter().zip(delegations.iter()) {
+        let space_did = &grant.space;
+
+        // Create local space directory if it doesn't exist
+        let space_ref = if let Some(existing) = site.space_by_did(space_did) {
+            existing
+        } else {
+            // Create a new space directory for this space DID.
+            // The collaborator uses their own keypair as credentials.
+            let collab_key = ed25519_dalek::SigningKey::generate(&mut rand_0_8::rngs::OsRng);
+            let space = site.create_space_from_key(&collab_key)?;
+
+            // Bootstrap builtins in the new space
+            let mut session = space.open_session().await?;
+            schema::bootstrap_builtins(&mut session).await?;
+
+            space
+        };
+
+        // Store the delegation in the space DB
+        let mut session = space_ref.open_session().await?;
+        let mut tx = session.edit();
+        dialog_query::claim::Claim::assert(delegation.clone(), &mut tx);
+        session.commit(tx).await?;
+
+        joined_count += 1;
+    }
+
+    // Set the first joined space as active if we only joined one
+    if joined_count == 1 {
+        let space_did = &envelope.grants[0].space;
+        site.set_active_space(space_did)?;
+    }
+
+    eprintln!(
+        "Joined {} space(s) as {}",
+        joined_count, envelope.invited
+    );
+
+    Ok(())
+}

--- a/rust/carry/src/join_cmd.rs
+++ b/rust/carry/src/join_cmd.rs
@@ -1,8 +1,8 @@
 //! `carry join <TOKEN>` — redeem an invite token to join a space.
 //!
-//! Decodes the invite token, verifies the delegation grants, creates local
-//! space directories with the collaborator's credentials, and stores the
-//! delegations in the space DB.
+//! Decodes the invite token, verifies the delegation chain, creates local
+//! space directories with the delegation proofs, and stores the delegations
+//! in the space DB.
 
 use crate::identity_cmd;
 use crate::schema;
@@ -17,7 +17,7 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
     let envelope = decode_invite(token).context("Failed to decode invite token")?;
 
     // Load the local identity (must exist and match the invited DID)
-    let operator = identity_cmd::require_identity()?;
+    let operator = identity_cmd::ensure_identity().await?;
     if operator.did().to_string() != envelope.invited {
         anyhow::bail!(
             "Local identity {} does not match invited DID {}.\n\
@@ -38,9 +38,6 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
         Ok(site) => site,
         Err(_) => {
             let parent = if let Some(p) = site_flag {
-                // Normalize: if --repo points at a .carry path, init at its
-                // parent (mirrors Site::open semantics), otherwise init at the
-                // given path.
                 if p.ends_with(".carry") {
                     p.parent()
                         .context("--repo .carry path has no parent")?
@@ -64,9 +61,13 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
         let space_ref = if let Some(existing) = site.space_by_did(space_did) {
             existing
         } else {
-            // Create a directory named after the *space* DID, storing the
-            // collaborator's own key as credentials.
-            let space = site.create_space_for_did(space_did, operator.signer())?;
+            // Collect the full proof chain: upstream proofs + this grant's delegation
+            let all_proofs = grant
+                .all_proof_bytes()
+                .context("Failed to decode proof bytes from grant")?;
+
+            // Create space directory with proofs
+            let space = site.create_space_with_proofs(space_did, &all_proofs)?;
 
             // Bootstrap builtins in the new space
             let mut session = space.open_session().await?;

--- a/rust/carry/src/join_cmd.rs
+++ b/rust/carry/src/join_cmd.rs
@@ -4,6 +4,7 @@
 //! space directories with the collaborator's credentials, and stores the
 //! delegations in the space DB.
 
+use crate::identity_cmd;
 use crate::schema;
 use crate::site::Site;
 use anyhow::{Context, Result};
@@ -14,6 +15,17 @@ use tonk_space::{Timestamp, decode_invite, verify_envelope};
 pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
     // Decode and validate the token structure
     let envelope = decode_invite(token).context("Failed to decode invite token")?;
+
+    // Load the local identity (must exist and match the invited DID)
+    let operator = identity_cmd::require_identity()?;
+    if operator.did().to_string() != envelope.invited {
+        anyhow::bail!(
+            "Local identity {} does not match invited DID {}.\n\
+             Run `carry identity` to check your identity.",
+            operator.did(),
+            envelope.invited
+        );
+    }
 
     // Verify all grants cryptographically
     let now = Timestamp::now().to_unix();
@@ -33,51 +45,6 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
         }
     };
 
-    // Generate the collaborator's operator keypair
-    let collab_key = ed25519_dalek::SigningKey::generate(&mut rand_0_8::rngs::OsRng);
-    let collab_operator = tonk_space::Operator::from_secret(collab_key.to_bytes());
-
-    // Verify the local operator matches the invited DID
-    if collab_operator.did().to_string() != envelope.invited {
-        // The collaborator needs a stable identity that matches the invited DID.
-        // For now, we need the invited DID's credentials to already exist locally,
-        // or we generate fresh (which won't match). This is a placeholder until
-        // `carry identity` exists.
-        //
-        // For v1: check if there's already a space with credentials whose DID
-        // matches the invited DID. If not, error with guidance.
-        let spaces = site.list_spaces()?;
-        let mut found_operator = None;
-        for space in &spaces {
-            if let Ok(op) = space.load_operator() {
-                if op.did().to_string() == envelope.invited {
-                    found_operator = Some(op);
-                    break;
-                }
-            }
-        }
-
-        let collab_operator = found_operator.ok_or_else(|| {
-            anyhow::anyhow!(
-                "No local identity matching invited DID {}.\n\
-                 Your local operator DID must match the invite. \
-                 A `carry identity` command will address this in a future release.",
-                envelope.invited
-            )
-        })?;
-
-        return join_spaces(&site, &collab_operator, &delegations, &envelope).await;
-    }
-
-    join_spaces(&site, &collab_operator, &delegations, &envelope).await
-}
-
-async fn join_spaces(
-    site: &Site,
-    _collab_operator: &tonk_space::Operator,
-    delegations: &[tonk_space::Delegation],
-    envelope: &tonk_space::InviteEnvelopeV1,
-) -> Result<()> {
     let mut joined_count = 0;
 
     for (grant, delegation) in envelope.grants.iter().zip(delegations.iter()) {
@@ -88,9 +55,8 @@ async fn join_spaces(
             existing
         } else {
             // Create a new space directory for this space DID.
-            // The collaborator uses their own keypair as credentials.
-            let collab_key = ed25519_dalek::SigningKey::generate(&mut rand_0_8::rngs::OsRng);
-            let space = site.create_space_from_key(&collab_key)?;
+            // The collaborator uses their own identity key as credentials.
+            let space = site.create_space_from_key(operator.signer())?;
 
             // Bootstrap builtins in the new space
             let mut session = space.open_session().await?;
@@ -114,10 +80,7 @@ async fn join_spaces(
         site.set_active_space(space_did)?;
     }
 
-    eprintln!(
-        "Joined {} space(s) as {}",
-        joined_count, envelope.invited
-    );
+    eprintln!("Joined {} space(s) as {}", joined_count, envelope.invited);
 
     Ok(())
 }

--- a/rust/carry/src/join_cmd.rs
+++ b/rust/carry/src/join_cmd.rs
@@ -29,15 +29,25 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
 
     // Verify all grants cryptographically
     let now = Timestamp::now().to_unix();
-    let delegations =
-        verify_envelope(&envelope, now).context("Invite token verification failed")?;
+    let delegations = verify_envelope(&envelope, now)
+        .await
+        .context("Invite token verification failed")?;
 
     // Resolve or create the .carry/ site
     let site = match Site::resolve(site_flag) {
         Ok(site) => site,
         Err(_) => {
             let parent = if let Some(p) = site_flag {
-                p.to_path_buf()
+                // Normalize: if --repo points at a .carry path, init at its
+                // parent (mirrors Site::open semantics), otherwise init at the
+                // given path.
+                if p.ends_with(".carry") {
+                    p.parent()
+                        .context("--repo .carry path has no parent")?
+                        .to_path_buf()
+                } else {
+                    p.to_path_buf()
+                }
             } else {
                 std::env::current_dir().context("Failed to determine current directory")?
             };
@@ -54,9 +64,9 @@ pub async fn execute(token: &str, site_flag: Option<&Path>) -> Result<()> {
         let space_ref = if let Some(existing) = site.space_by_did(space_did) {
             existing
         } else {
-            // Create a new space directory for this space DID.
-            // The collaborator uses their own identity key as credentials.
-            let space = site.create_space_from_key(operator.signer())?;
+            // Create a directory named after the *space* DID, storing the
+            // collaborator's own key as credentials.
+            let space = site.create_space_for_did(space_did, operator.signer())?;
 
             // Bootstrap builtins in the new space
             let mut session = space.open_session().await?;

--- a/rust/carry/src/lib.rs
+++ b/rust/carry/src/lib.rs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------
 pub mod assert_cmd;
 pub mod help;
+pub mod identity_cmd;
 pub mod init;
 pub mod invite_cmd;
 pub mod join_cmd;

--- a/rust/carry/src/lib.rs
+++ b/rust/carry/src/lib.rs
@@ -6,6 +6,8 @@
 pub mod assert_cmd;
 pub mod help;
 pub mod init;
+pub mod invite_cmd;
+pub mod join_cmd;
 pub mod query_cmd;
 pub mod retract_cmd;
 pub mod site;

--- a/rust/carry/src/site.rs
+++ b/rust/carry/src/site.rs
@@ -7,8 +7,12 @@
 //! A **space** is a subdirectory of `.carry/` named by its `did:key:z...` DID.
 //! Each space directory contains:
 //!
-//! - `credentials` — 32-byte Ed25519 secret key
-//! - `claims/`     — dialog-db prolly tree storage
+//! - `proofs`  — DAG-CBOR encoded delegation chain (list of UCAN delegations)
+//! - `claims/` — dialog-db prolly tree storage
+//!
+//! Space keys are ephemeral: at creation time, the space key powerline-delegates
+//! authority to admin identities, then is discarded. All operations use the
+//! user's identity from `~/.carry/identity`.
 //!
 //! The active space is tracked in `.carry/@active` (a plain-text file
 //! containing the space DID).
@@ -25,17 +29,15 @@ use anyhow::{Context, Result};
 use dialog_artifacts::repository::{BranchId, Credentials, Repository};
 use dialog_query::Session;
 use dialog_query::claim::Attribute as ClaimAttribute;
-use ed25519_dalek::SigningKey;
-use rand_0_8::rngs::OsRng;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use tonk_space::{FsBackend, Operator};
+use tonk_space::{Delegation, Did, Ed25519Signer, FsBackend, Operator, Subject};
 
 /// Marker file for the active space within a `.carry/` directory.
 const ACTIVE_MARKER: &str = "@active";
 
-/// Filename for the 32-byte Ed25519 secret key inside a space directory.
-const CREDENTIALS_FILE: &str = "credentials";
+/// Filename for the delegation proof chain inside a space directory.
+const PROOFS_FILE: &str = "proofs";
 
 /// Subdirectory inside each space for dialog-db storage.
 const CLAIMS_DIR: &str = "claims";
@@ -265,35 +267,43 @@ impl Site {
         Ok(())
     }
 
-    /// Create a new space: generate an Ed25519 keypair, create the directory
-    /// structure, and write the credentials file.
-    ///
-    /// Returns a `SpaceRef` for the newly created space.
-    pub fn create_space(&self) -> Result<SpaceRef> {
-        let signing_key = SigningKey::generate(&mut OsRng);
-        self.create_space_from_key(&signing_key)
+    /// Create a new space with the delegation model: generates an ephemeral
+    /// space key, delegates authority to the given admin identities, stores
+    /// the delegation proofs, and discards the space key.
+    pub async fn create_delegated_space(
+        &self,
+        admin_dids: &[Did],
+    ) -> Result<(SpaceRef, Vec<Vec<u8>>)> {
+        let space_operator = Operator::generate();
+        let space_did = space_operator.did();
+
+        let mut proof_bytes: Vec<Vec<u8>> = Vec::new();
+        for admin_did in admin_dids {
+            let signer = Ed25519Signer::from(&space_operator);
+            let ucan_delegation = Delegation::builder()
+                .issuer(signer)
+                .audience(admin_did)
+                .subject(Subject::Specific(space_did.clone()))
+                .command(Vec::new()) // root command "/"
+                .try_build()
+                .await
+                .context("Failed to build admin delegation")?;
+            proof_bytes.push(Delegation::from(ucan_delegation).to_bytes());
+        }
+        // space_operator is dropped here — ephemeral key discarded
+
+        let space = self.create_space_with_proofs(space_did.as_ref(), &proof_bytes)?;
+        Ok((space, proof_bytes))
     }
 
-    /// Create a space from an existing signing key.
+    /// Create a space directory for a given DID, storing delegation proofs.
     ///
-    /// The directory is named after the DID derived from the signing key.
-    pub fn create_space_from_key(&self, signing_key: &SigningKey) -> Result<SpaceRef> {
-        let operator = Operator::from_secret(signing_key.to_bytes());
-        let did = operator.did().to_string();
-        self.create_space_for_did(&did, signing_key)
-    }
-
-    /// Create a local space directory for a given space DID, storing the
-    /// provided signing key as credentials.
-    ///
-    /// Unlike `create_space_from_key`, the directory is named after `space_did`
-    /// (which may differ from the DID derived from `credentials_key`). This is
-    /// used when joining a space via an invite: the directory is keyed by the
-    /// *space* DID, but the credentials belong to the *collaborator*.
-    pub fn create_space_for_did(
+    /// `proofs` is a list of DAG-CBOR-encoded UCAN delegations forming the
+    /// chain of trust from the space root to the local operator.
+    pub fn create_space_with_proofs(
         &self,
         space_did: &str,
-        credentials_key: &SigningKey,
+        proofs: &[Vec<u8>],
     ) -> Result<SpaceRef> {
         let space_dir = self.root.join(space_did);
 
@@ -310,17 +320,19 @@ impl Site {
         std::fs::create_dir_all(&claims_dir)
             .with_context(|| format!("Failed to create {}", claims_dir.display()))?;
 
-        // Write credentials (raw 32-byte secret key)
-        let creds_path = space_dir.join(CREDENTIALS_FILE);
-        std::fs::write(&creds_path, credentials_key.to_bytes())
-            .with_context(|| format!("Failed to write {}", creds_path.display()))?;
+        // Write proofs file (DAG-CBOR encoded list of delegation bytes)
+        let proofs_path = space_dir.join(PROOFS_FILE);
+        let encoded =
+            serde_ipld_dagcbor::to_vec(proofs).context("Failed to encode proofs as DAG-CBOR")?;
+        std::fs::write(&proofs_path, &encoded)
+            .with_context(|| format!("Failed to write {}", proofs_path.display()))?;
 
-        // Restrict permissions on credentials file (Unix only)
+        // Restrict permissions on proofs file (Unix only)
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&creds_path, perms)?;
+            std::fs::set_permissions(&proofs_path, perms)?;
         }
 
         Ok(SpaceRef {
@@ -354,32 +366,51 @@ impl SpaceRef {
         self.dir.join(CLAIMS_DIR)
     }
 
-    /// Path to the `credentials` file.
-    fn credentials_path(&self) -> PathBuf {
-        self.dir.join(CREDENTIALS_FILE)
+    /// Path to the `proofs` file.
+    fn proofs_path(&self) -> PathBuf {
+        self.dir.join(PROOFS_FILE)
     }
 
-    /// Load the Ed25519 signing key from the `credentials` file.
-    pub fn load_signing_key(&self) -> Result<SigningKey> {
-        let path = self.credentials_path();
-        let bytes = std::fs::read(&path)
-            .with_context(|| format!("Failed to read credentials at {}", path.display()))?;
-        if bytes.len() != 32 {
-            anyhow::bail!(
-                "Invalid credentials file at {} (expected 32 bytes, got {})",
-                path.display(),
-                bytes.len()
-            );
+    /// Load delegation proofs from the `proofs` file.
+    ///
+    /// Returns a list of raw delegation byte vectors (each is DAG-CBOR
+    /// encoded UCAN delegation) forming the chain of trust from the space
+    /// root to the local operator.
+    pub fn load_proofs(&self) -> Result<Vec<Vec<u8>>> {
+        let path = self.proofs_path();
+        if !path.exists() {
+            return Ok(Vec::new());
         }
-        let mut key_bytes = [0u8; 32];
-        key_bytes.copy_from_slice(&bytes);
-        Ok(SigningKey::from_bytes(&key_bytes))
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("Failed to read proofs at {}", path.display()))?;
+        let proofs: Vec<Vec<u8>> = serde_ipld_dagcbor::from_slice(&bytes)
+            .with_context(|| format!("Failed to decode proofs at {}", path.display()))?;
+        Ok(proofs)
     }
 
-    /// Load an `Operator` from the credentials file.
+    /// Save delegation proofs to the `proofs` file.
+    pub fn save_proofs(&self, proofs: &[Vec<u8>]) -> Result<()> {
+        let path = self.proofs_path();
+        let encoded =
+            serde_ipld_dagcbor::to_vec(proofs).context("Failed to encode proofs as DAG-CBOR")?;
+        std::fs::write(&path, &encoded)
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+
+    /// Load the operator identity for this space.
+    ///
+    /// In the delegation model, the operator is the user's identity from
+    /// `~/.carry/identity`, not a space-specific key.
     pub fn load_operator(&self) -> Result<Operator> {
-        let key = self.load_signing_key()?;
-        Ok(Operator::from_secret(key.to_bytes()))
+        crate::identity_cmd::require_identity()
     }
 
     /// Open a dialog-db `Session` for this space.
@@ -455,6 +486,26 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Helper: create a delegated space for tests (generates ephemeral key,
+    /// delegates to a test admin operator).
+    async fn create_test_space(site: &Site) -> (SpaceRef, Operator) {
+        let admin = Operator::generate();
+        let (space, _proofs) = site.create_delegated_space(&[admin.did()]).await.unwrap();
+        (space, admin)
+    }
+
+    /// Helper: set up identity for tests that call load_operator().
+    /// Writes a test identity to ~/.carry/identity (or a temp override).
+    fn setup_test_identity() -> Operator {
+        let op = Operator::generate();
+        let home = dirs::home_dir().expect("home dir");
+        let carry_home = home.join(".carry");
+        std::fs::create_dir_all(&carry_home).unwrap();
+        let identity_path = carry_home.join("identity");
+        std::fs::write(&identity_path, op.to_secret()).unwrap();
+        op
+    }
+
     #[test]
     fn test_init_creates_carry_dir() {
         let tmp = TempDir::new().unwrap();
@@ -464,26 +515,26 @@ mod tests {
         assert_eq!(site.root(), tmp.path().join(".carry"));
     }
 
-    #[test]
-    fn test_create_space_and_list() {
+    #[tokio::test]
+    async fn test_create_space_and_list() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let (space, _admin) = create_test_space(&site).await;
         assert!(space.did.starts_with("did:key:"));
         assert!(space.dir().exists());
         assert!(space.claims_dir().exists());
-        assert!(space.credentials_path().exists());
+        assert!(space.proofs_path().exists());
 
         let spaces = site.list_spaces().unwrap();
         assert_eq!(spaces.len(), 1);
         assert_eq!(spaces[0].did, space.did);
     }
 
-    #[test]
-    fn test_active_space_roundtrip() {
+    #[tokio::test]
+    async fn test_active_space_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let (space, _admin) = create_test_space(&site).await;
 
         assert!(site.active_space_did().unwrap().is_none());
 
@@ -497,15 +548,40 @@ mod tests {
         assert!(site.active_space_did().unwrap().is_none());
     }
 
-    #[test]
-    fn test_credentials_roundtrip() {
+    #[tokio::test]
+    async fn test_proofs_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let (space, _admin) = create_test_space(&site).await;
 
-        let key = space.load_signing_key().unwrap();
-        let operator = Operator::from_secret(key.to_bytes());
-        assert_eq!(operator.did().to_string(), space.did);
+        let proofs = space.load_proofs().unwrap();
+        assert_eq!(proofs.len(), 1);
+
+        // Each proof should deserialize as a valid delegation
+        let delegation = serde_ipld_dagcbor::from_slice::<Delegation>(&proofs[0]).unwrap();
+        assert_eq!(delegation.audience().to_string(), _admin.did().to_string());
+    }
+
+    #[tokio::test]
+    async fn test_multi_admin_proofs() {
+        let tmp = TempDir::new().unwrap();
+        let site = Site::init(tmp.path()).unwrap();
+        let admin1 = Operator::generate();
+        let admin2 = Operator::generate();
+        let (space, _) = site
+            .create_delegated_space(&[admin1.did(), admin2.did()])
+            .await
+            .unwrap();
+
+        let proofs = space.load_proofs().unwrap();
+        assert_eq!(proofs.len(), 2);
+
+        let d1 = serde_ipld_dagcbor::from_slice::<Delegation>(&proofs[0]).unwrap();
+        let d2 = serde_ipld_dagcbor::from_slice::<Delegation>(&proofs[1]).unwrap();
+        assert_eq!(d1.audience().to_string(), admin1.did().to_string());
+        assert_eq!(d2.audience().to_string(), admin2.did().to_string());
+        // Both should have the same issuer (the ephemeral space key)
+        assert_eq!(d1.issuer().to_string(), d2.issuer().to_string());
     }
 
     #[test]
@@ -513,11 +589,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _site = Site::init(tmp.path()).unwrap();
 
-        // Create a nested directory
         let nested = tmp.path().join("foo").join("bar").join("baz");
         std::fs::create_dir_all(&nested).unwrap();
 
-        // Discovery from nested should find the .carry/ at root
         let found = Site::discover(&nested).unwrap();
         assert_eq!(found.root(), tmp.path().join(".carry"));
     }
@@ -533,23 +607,21 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let _site = Site::init(tmp.path()).unwrap();
 
-        // Open via parent directory
         let opened = Site::open(tmp.path()).unwrap();
         assert_eq!(opened.root(), tmp.path().join(".carry"));
 
-        // Open via .carry/ directly
         let opened2 = Site::open(&tmp.path().join(".carry")).unwrap();
         assert_eq!(opened2.root(), tmp.path().join(".carry"));
     }
 
-    #[test]
-    fn test_duplicate_space_fails() {
+    #[tokio::test]
+    async fn test_duplicate_space_fails() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
 
-        let key = SigningKey::generate(&mut OsRng);
-        site.create_space_from_key(&key).unwrap();
-        let result = site.create_space_from_key(&key);
+        let admin = Operator::generate();
+        let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
+        let result = site.create_space_with_proofs(&space.did, &[]);
         assert!(result.is_err());
     }
 
@@ -557,10 +629,15 @@ mod tests {
     async fn test_open_session() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let (_space, admin) = create_test_space(&site).await;
 
-        // Should successfully open a session (creates the prolly tree storage)
-        let _session = space.open_session().await.unwrap();
+        // Set up the admin as the local identity so load_operator() works
+        let home = dirs::home_dir().expect("home dir");
+        let carry_home = home.join(".carry");
+        std::fs::create_dir_all(&carry_home).unwrap();
+        std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+
+        let _session = _space.open_session().await.unwrap();
     }
 
     // -- Helper: assert a label claim on a space ----------------------------
@@ -583,7 +660,8 @@ mod tests {
     async fn test_resolve_space_by_did() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let admin = setup_test_identity();
+        let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
 
         let resolved = site.resolve_space(&space.did).await.unwrap();
         assert_eq!(resolved.did, space.did);
@@ -593,7 +671,8 @@ mod tests {
     async fn test_resolve_space_by_label() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let admin = setup_test_identity();
+        let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space, "my-space").await;
 
         let resolved = site.resolve_space("my-space").await.unwrap();
@@ -604,8 +683,9 @@ mod tests {
     async fn test_resolve_space_ambiguous_label() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space1 = site.create_space().unwrap();
-        let space2 = site.create_space().unwrap();
+        let admin = setup_test_identity();
+        let (space1, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
+        let (space2, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space1, "shared-label").await;
         assert_label(&space2, "shared-label").await;
 
@@ -623,7 +703,6 @@ mod tests {
     async fn test_resolve_space_nonexistent_did() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let _space = site.create_space().unwrap();
 
         let result = site.resolve_space("did:key:zBogus").await;
         assert!(result.is_err());
@@ -633,7 +712,6 @@ mod tests {
     async fn test_resolve_space_nonexistent_label() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let _space = site.create_space().unwrap();
 
         let result = site.resolve_space("no-such-label").await;
         assert!(result.is_err());
@@ -651,7 +729,8 @@ mod tests {
     async fn test_space_label_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let admin = setup_test_identity();
+        let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space, "test-label").await;
 
         let label = site.space_label(&space).await.unwrap();
@@ -662,7 +741,8 @@ mod tests {
     async fn test_space_label_none() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let admin = setup_test_identity();
+        let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
 
         let label = site.space_label(&space).await.unwrap();
         assert_eq!(label, None);
@@ -674,16 +754,14 @@ mod tests {
     async fn test_delete_space_removes_dir() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let space = site.create_space().unwrap();
+        let (space, _admin) = create_test_space(&site).await;
         let space_dir = space.dir().to_path_buf();
 
-        // Verify directory exists before delete
         assert!(space_dir.exists());
         assert_eq!(site.list_spaces().unwrap().len(), 1);
 
         site.delete_space(&space).unwrap();
 
-        // Verify directory is gone
         assert!(!space_dir.exists());
         assert_eq!(site.list_spaces().unwrap().len(), 0);
     }

--- a/rust/carry/src/site.rs
+++ b/rust/carry/src/site.rs
@@ -495,15 +495,15 @@ mod tests {
     }
 
     /// Helper: set up identity for tests that call load_operator().
-    /// Writes a test identity to ~/.carry/identity (or a temp override).
-    fn setup_test_identity() -> Operator {
+    /// Uses CARRY_IDENTITY env var to avoid writing to the real ~/.carry/.
+    /// Returns (operator, temp_dir) — caller must keep temp_dir alive.
+    fn setup_test_identity() -> (Operator, tempfile::TempDir) {
         let op = Operator::generate();
-        let home = dirs::home_dir().expect("home dir");
-        let carry_home = home.join(".carry");
-        std::fs::create_dir_all(&carry_home).unwrap();
-        let identity_path = carry_home.join("identity");
-        std::fs::write(&identity_path, op.to_secret()).unwrap();
-        op
+        let dir = tempfile::TempDir::new().expect("temp dir for identity");
+        let path = dir.path().join("identity");
+        std::fs::write(&path, op.to_secret()).unwrap();
+        unsafe { std::env::set_var("CARRY_IDENTITY", &path) };
+        (op, dir)
     }
 
     #[test]
@@ -629,15 +629,16 @@ mod tests {
     async fn test_open_session() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let (_space, admin) = create_test_space(&site).await;
+        let (space, admin) = create_test_space(&site).await;
 
-        // Set up the admin as the local identity so load_operator() works
-        let home = dirs::home_dir().expect("home dir");
-        let carry_home = home.join(".carry");
-        std::fs::create_dir_all(&carry_home).unwrap();
-        std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+        // Point CARRY_IDENTITY to a temp file so load_operator() works
+        let id_dir = tempfile::TempDir::new().unwrap();
+        let id_path = id_dir.path().join("identity");
+        std::fs::write(&id_path, admin.to_secret()).unwrap();
+        unsafe { std::env::set_var("CARRY_IDENTITY", &id_path) };
 
-        let _session = _space.open_session().await.unwrap();
+        let _session = space.open_session().await.unwrap();
+        drop(id_dir);
     }
 
     // -- Helper: assert a label claim on a space ----------------------------
@@ -660,30 +661,32 @@ mod tests {
     async fn test_resolve_space_by_did() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let admin = setup_test_identity();
+        let (admin, id_dir) = setup_test_identity();
         let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
 
         let resolved = site.resolve_space(&space.did).await.unwrap();
         assert_eq!(resolved.did, space.did);
+        drop(id_dir);
     }
 
     #[tokio::test]
     async fn test_resolve_space_by_label() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let admin = setup_test_identity();
+        let (admin, id_dir) = setup_test_identity();
         let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space, "my-space").await;
 
         let resolved = site.resolve_space("my-space").await.unwrap();
         assert_eq!(resolved.did, space.did);
+        drop(id_dir);
     }
 
     #[tokio::test]
     async fn test_resolve_space_ambiguous_label() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let admin = setup_test_identity();
+        let (admin, id_dir) = setup_test_identity();
         let (space1, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         let (space2, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space1, "shared-label").await;
@@ -697,6 +700,7 @@ mod tests {
             "Expected 'Ambiguous' in error, got: {}",
             err_msg
         );
+        drop(id_dir);
     }
 
     #[tokio::test]
@@ -729,23 +733,25 @@ mod tests {
     async fn test_space_label_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let admin = setup_test_identity();
+        let (admin, id_dir) = setup_test_identity();
         let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
         assert_label(&space, "test-label").await;
 
         let label = site.space_label(&space).await.unwrap();
         assert_eq!(label, Some("test-label".to_string()));
+        drop(id_dir);
     }
 
     #[tokio::test]
     async fn test_space_label_none() {
         let tmp = TempDir::new().unwrap();
         let site = Site::init(tmp.path()).unwrap();
-        let admin = setup_test_identity();
+        let (admin, id_dir) = setup_test_identity();
         let (space, _) = site.create_delegated_space(&[admin.did()]).await.unwrap();
 
         let label = site.space_label(&space).await.unwrap();
         assert_eq!(label, None);
+        drop(id_dir);
     }
 
     // -- delete_space tests -------------------------------------------------

--- a/rust/carry/src/site.rs
+++ b/rust/carry/src/site.rs
@@ -275,13 +275,34 @@ impl Site {
     }
 
     /// Create a space from an existing signing key.
+    ///
+    /// The directory is named after the DID derived from the signing key.
     pub fn create_space_from_key(&self, signing_key: &SigningKey) -> Result<SpaceRef> {
         let operator = Operator::from_secret(signing_key.to_bytes());
         let did = operator.did().to_string();
-        let space_dir = self.root.join(&did);
+        self.create_space_for_did(&did, signing_key)
+    }
+
+    /// Create a local space directory for a given space DID, storing the
+    /// provided signing key as credentials.
+    ///
+    /// Unlike `create_space_from_key`, the directory is named after `space_did`
+    /// (which may differ from the DID derived from `credentials_key`). This is
+    /// used when joining a space via an invite: the directory is keyed by the
+    /// *space* DID, but the credentials belong to the *collaborator*.
+    pub fn create_space_for_did(
+        &self,
+        space_did: &str,
+        credentials_key: &SigningKey,
+    ) -> Result<SpaceRef> {
+        let space_dir = self.root.join(space_did);
 
         if space_dir.exists() {
-            anyhow::bail!("Space {} already exists at {}", did, space_dir.display());
+            anyhow::bail!(
+                "Space {} already exists at {}",
+                space_did,
+                space_dir.display()
+            );
         }
 
         // Create directories
@@ -291,7 +312,7 @@ impl Site {
 
         // Write credentials (raw 32-byte secret key)
         let creds_path = space_dir.join(CREDENTIALS_FILE);
-        std::fs::write(&creds_path, signing_key.to_bytes())
+        std::fs::write(&creds_path, credentials_key.to_bytes())
             .with_context(|| format!("Failed to write {}", creds_path.display()))?;
 
         // Restrict permissions on credentials file (Unix only)
@@ -303,7 +324,7 @@ impl Site {
         }
 
         Ok(SpaceRef {
-            did,
+            did: space_did.to_string(),
             dir: space_dir,
         })
     }

--- a/rust/carry/src/space_cmd.rs
+++ b/rust/carry/src/space_cmd.rs
@@ -64,7 +64,8 @@ pub async fn list(site: &Site, format: &str) -> Result<()> {
 
 /// Execute `carry space create [LABEL]`.
 pub async fn create(site: &Site, label: Option<String>, format: &str) -> Result<()> {
-    let space = site.create_space()?;
+    let identity = crate::identity_cmd::require_identity()?;
+    let (space, _proofs) = site.create_delegated_space(&[identity.did()]).await?;
     site.set_active_space(&space.did)?;
 
     // If a label is provided, assert it as a claim

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -3045,3 +3045,173 @@ async fn test_attribute_concept_data_roundtrip() {
         .await
         .unwrap();
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invite & Join
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_invite_creates_valid_token() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+
+    // Create an invited operator (simulating Bob)
+    let bob = tonk_space::Operator::generate();
+
+    // Create invite
+    let (envelope, delegation) = tonk_space::create_invite(
+        &ctx.space.load_operator().unwrap(),
+        &ctx.space.load_operator().unwrap().did(),
+        &bob.did(),
+        Some("test-repo".to_string()),
+    )
+    .await
+    .unwrap();
+
+    // Encode and decode roundtrip
+    let token = tonk_space::encode_invite(&envelope).unwrap();
+    assert!(token.starts_with("carry_inv1_"));
+
+    let decoded = tonk_space::decode_invite(&token).unwrap();
+    assert_eq!(decoded.v, 1);
+    assert_eq!(decoded.kind, "carry.invite");
+    assert_eq!(decoded.invited, bob.did().to_string());
+    assert_eq!(decoded.grants.len(), 1);
+    assert_eq!(decoded.grants[0].space, env.space_did);
+    assert_eq!(decoded.repo_hint.as_deref(), Some("test-repo"));
+
+    // Verify the delegation fields
+    assert_eq!(delegation.audience().to_string(), bob.did().to_string());
+    assert_eq!(
+        delegation.issuer().to_string(),
+        ctx.space.load_operator().unwrap().did().to_string()
+    );
+}
+
+#[tokio::test]
+async fn test_invite_cmd_runs_without_error() {
+    let env = TestEnv::new().await.unwrap();
+    let ctx = env.ctx().await;
+    let bob = tonk_space::Operator::generate();
+
+    // The invite command should succeed
+    carry::invite_cmd::execute(&ctx, &bob.did().to_string())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_invite_verify_rejects_wrong_did() {
+    let env = TestEnv::new().await.unwrap();
+    let bob = tonk_space::Operator::generate();
+    let charlie = tonk_space::Operator::generate();
+
+    let space_op = env.space().load_operator().unwrap();
+    let (envelope, _) = tonk_space::create_invite(&space_op, &space_op.did(), &bob.did(), None)
+        .await
+        .unwrap();
+
+    let token = tonk_space::encode_invite(&envelope).unwrap();
+    let decoded = tonk_space::decode_invite(&token).unwrap();
+
+    // Verify with Charlie's DID should fail (invite is for Bob)
+    let now = tonk_space::Timestamp::now().to_unix();
+    let result = tonk_space::verify_grant(&decoded.grants[0], &charlie.did(), now);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_invite_multi_space_grants() {
+    // Create a site with two spaces
+    let tmp = tempfile::TempDir::new().unwrap();
+    let site = carry::site::Site::init(tmp.path()).unwrap();
+
+    let space1 = site.create_space().unwrap();
+    site.set_active_space(&space1.did).unwrap();
+    let mut session1 = space1.open_session().await.unwrap();
+    carry::schema::bootstrap_builtins(&mut session1)
+        .await
+        .unwrap();
+
+    let space2 = site.create_space().unwrap();
+    let mut session2 = space2.open_session().await.unwrap();
+    carry::schema::bootstrap_builtins(&mut session2)
+        .await
+        .unwrap();
+
+    let bob = tonk_space::Operator::generate();
+    let now = tonk_space::Timestamp::now().to_unix();
+    let exp = now + 3600;
+
+    let op1 = space1.load_operator().unwrap();
+    let op2 = space2.load_operator().unwrap();
+
+    let (grant1, _) = tonk_space::create_space_grant(&op1, &op1.did(), &bob.did(), exp, Some(now))
+        .await
+        .unwrap();
+
+    let (grant2, _) = tonk_space::create_space_grant(&op2, &op2.did(), &bob.did(), exp, Some(now))
+        .await
+        .unwrap();
+
+    let envelope = tonk_space::InviteEnvelopeV1 {
+        v: 1,
+        kind: "carry.invite".to_string(),
+        invited: bob.did().to_string(),
+        issued_at: now,
+        issuer_hint: None,
+        repo_hint: None,
+        grants: vec![grant1, grant2],
+    };
+
+    let token = tonk_space::encode_invite(&envelope).unwrap();
+    let decoded = tonk_space::decode_invite(&token).unwrap();
+    assert_eq!(decoded.grants.len(), 2);
+
+    // All grants should verify
+    let delegations = tonk_space::verify_envelope(&decoded, now).unwrap();
+    assert_eq!(delegations.len(), 2);
+}
+
+#[tokio::test]
+async fn test_identity_load_save_roundtrip() {
+    // This test uses a custom HOME to avoid touching the real ~/.carry/
+    let tmp = tempfile::TempDir::new().unwrap();
+    let identity_path = tmp.path().join("identity");
+
+    // Write a test identity
+    let operator = tonk_space::Operator::generate();
+    let secret = operator.to_secret();
+    std::fs::write(&identity_path, secret).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&identity_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    // Read it back
+    let bytes = std::fs::read(&identity_path).unwrap();
+    assert_eq!(bytes.len(), 32);
+    let mut secret_read = [0u8; 32];
+    secret_read.copy_from_slice(&bytes);
+    let operator_read = tonk_space::Operator::from_secret(secret_read);
+
+    assert_eq!(
+        operator.did().to_string(),
+        operator_read.did().to_string(),
+        "Identity should roundtrip through file"
+    );
+}
+
+#[tokio::test]
+async fn test_decode_invite_rejects_bad_tokens() {
+    // Missing prefix
+    assert!(tonk_space::decode_invite("not_a_token").is_err());
+
+    // Invalid base64
+    assert!(tonk_space::decode_invite("carry_inv1_!!!").is_err());
+
+    // Valid base64 but invalid CBOR
+    assert!(tonk_space::decode_invite("carry_inv1_aGVsbG8").is_err());
+}

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -27,8 +27,15 @@ async fn test_init_creates_site() {
 
 #[tokio::test]
 async fn test_init_with_name() {
+    // Set up a test identity so ensure_identity() doesn't trigger passkey flow
+    let admin = tonk_space::Operator::generate();
+    let home = dirs::home_dir().unwrap();
+    let carry_home = home.join(".carry");
+    std::fs::create_dir_all(&carry_home).unwrap();
+    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+
     let tmp = tempfile::TempDir::new().unwrap();
-    carry::init::execute(Some("my-project".to_string()), Some(tmp.path()))
+    carry::init::execute(Some("my-project".to_string()), vec![], Some(tmp.path()))
         .await
         .unwrap();
 
@@ -40,9 +47,19 @@ async fn test_init_with_name() {
 
 #[tokio::test]
 async fn test_init_idempotent() {
+    let admin = tonk_space::Operator::generate();
+    let home = dirs::home_dir().unwrap();
+    let carry_home = home.join(".carry");
+    std::fs::create_dir_all(&carry_home).unwrap();
+    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+
     let tmp = tempfile::TempDir::new().unwrap();
-    carry::init::execute(None, Some(tmp.path())).await.unwrap();
-    carry::init::execute(None, Some(tmp.path())).await.unwrap();
+    carry::init::execute(None, vec![], Some(tmp.path()))
+        .await
+        .unwrap();
+    carry::init::execute(None, vec![], Some(tmp.path()))
+        .await
+        .unwrap();
 
     let site = carry::site::Site::open(tmp.path()).unwrap();
     let spaces = site.list_spaces().unwrap();
@@ -1432,7 +1449,7 @@ async fn test_query_json_format() {
 async fn test_site_discovery() {
     let tmp = tempfile::TempDir::new().unwrap();
     let site = carry::site::Site::init(tmp.path()).unwrap();
-    let space = site.create_space().unwrap();
+    let (space, _proofs) = site.create_delegated_space(&[]).await.unwrap();
     site.set_active_space(&space.did).unwrap();
 
     // Create a nested directory
@@ -1663,7 +1680,7 @@ async fn test_space_active_json() {
 async fn test_space_active_none() {
     let tmp = tempfile::TempDir::new().unwrap();
     let site = carry::site::Site::init(tmp.path()).unwrap();
-    let _space = site.create_space().unwrap();
+    let (_space, _proofs) = site.create_delegated_space(&[]).await.unwrap();
     // Don't set active — @active marker is absent
 
     // Should run without error, printing a helpful message
@@ -1763,7 +1780,7 @@ async fn test_space_flag_resolve_by_did() {
     let site = env.site();
 
     // Create a second space
-    let space2 = site.create_space().unwrap();
+    let (space2, _proofs) = site.create_delegated_space(&[]).await.unwrap();
 
     let ctx = carry::site::SiteContext::resolve(Some(env.site_path.as_path()), Some(&space2.did))
         .await
@@ -1798,7 +1815,7 @@ async fn test_space_flag_overrides_active() {
     let site = env.site();
 
     // Create a second space
-    let space2 = site.create_space().unwrap();
+    let (space2, _proofs) = site.create_delegated_space(&[]).await.unwrap();
 
     // Active is still the original (TestEnv sets it)
     assert_eq!(site.active_space_did().unwrap().unwrap(), env.space_did);
@@ -3058,12 +3075,15 @@ async fn test_invite_creates_valid_token() {
     // Create an invited operator (simulating Bob)
     let bob = tonk_space::Operator::generate();
 
-    // Create invite
+    // Create invite — admin invites bob, with admin's proofs from space
+    let proofs = ctx.space.load_proofs().unwrap_or_default();
+    let space_did_parsed: tonk_space::Did = env.space_did.parse().unwrap();
     let (envelope, delegation) = tonk_space::create_invite(
-        &ctx.space.load_operator().unwrap(),
-        &ctx.space.load_operator().unwrap().did(),
+        &env.admin,
+        &space_did_parsed,
         &bob.did(),
         Some("test-repo".to_string()),
+        &proofs,
     )
     .await
     .unwrap();
@@ -3082,10 +3102,7 @@ async fn test_invite_creates_valid_token() {
 
     // Verify the delegation fields
     assert_eq!(delegation.audience().to_string(), bob.did().to_string());
-    assert_eq!(
-        delegation.issuer().to_string(),
-        ctx.space.load_operator().unwrap().did().to_string()
-    );
+    assert_eq!(delegation.issuer().to_string(), env.admin.did().to_string());
 }
 
 #[tokio::test]
@@ -3106,10 +3123,12 @@ async fn test_invite_verify_rejects_wrong_did() {
     let bob = tonk_space::Operator::generate();
     let charlie = tonk_space::Operator::generate();
 
-    let space_op = env.space().load_operator().unwrap();
-    let (envelope, _) = tonk_space::create_invite(&space_op, &space_op.did(), &bob.did(), None)
-        .await
-        .unwrap();
+    let proofs = env.space().load_proofs().unwrap_or_default();
+    let space_did_parsed: tonk_space::Did = env.space_did.parse().unwrap();
+    let (envelope, _) =
+        tonk_space::create_invite(&env.admin, &space_did_parsed, &bob.did(), None, &proofs)
+            .await
+            .unwrap();
 
     let token = tonk_space::encode_invite(&envelope).unwrap();
     let decoded = tonk_space::decode_invite(&token).unwrap();
@@ -3126,14 +3145,21 @@ async fn test_invite_multi_space_grants() {
     let tmp = tempfile::TempDir::new().unwrap();
     let site = carry::site::Site::init(tmp.path()).unwrap();
 
-    let space1 = site.create_space().unwrap();
+    // Set up a test admin identity
+    let admin = tonk_space::Operator::generate();
+    let home = dirs::home_dir().unwrap();
+    let carry_home = home.join(".carry");
+    std::fs::create_dir_all(&carry_home).unwrap();
+    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+
+    let (space1, proofs1) = site.create_delegated_space(&[admin.did()]).await.unwrap();
     site.set_active_space(&space1.did).unwrap();
     let mut session1 = space1.open_session().await.unwrap();
     carry::schema::bootstrap_builtins(&mut session1)
         .await
         .unwrap();
 
-    let space2 = site.create_space().unwrap();
+    let (space2, proofs2) = site.create_delegated_space(&[admin.did()]).await.unwrap();
     let mut session2 = space2.open_session().await.unwrap();
     carry::schema::bootstrap_builtins(&mut session2)
         .await
@@ -3143,16 +3169,18 @@ async fn test_invite_multi_space_grants() {
     let now = tonk_space::Timestamp::now().to_unix();
     let exp = now + 3600;
 
-    let op1 = space1.load_operator().unwrap();
-    let op2 = space2.load_operator().unwrap();
+    let space1_did: tonk_space::Did = space1.did.parse().unwrap();
+    let space2_did: tonk_space::Did = space2.did.parse().unwrap();
 
-    let (grant1, _) = tonk_space::create_space_grant(&op1, &op1.did(), &bob.did(), exp, Some(now))
-        .await
-        .unwrap();
+    let (grant1, _) =
+        tonk_space::create_space_grant(&admin, &space1_did, &bob.did(), exp, Some(now), &proofs1)
+            .await
+            .unwrap();
 
-    let (grant2, _) = tonk_space::create_space_grant(&op2, &op2.did(), &bob.did(), exp, Some(now))
-        .await
-        .unwrap();
+    let (grant2, _) =
+        tonk_space::create_space_grant(&admin, &space2_did, &bob.did(), exp, Some(now), &proofs2)
+            .await
+            .unwrap();
 
     let envelope = tonk_space::InviteEnvelopeV1 {
         v: 1,
@@ -3207,19 +3235,21 @@ async fn test_identity_load_save_roundtrip() {
 #[tokio::test]
 async fn test_invite_join_roundtrip() {
     // Full invite→join flow: Alice invites Bob, Bob joins the space.
-    // Exercises: create_invite → encode → decode → verify → create_space_for_did → store delegation
+    // Exercises: create_invite → encode → decode → verify → create_space_with_proofs → store delegation
     let alice_env = TestEnv::new().await.unwrap();
     let alice_space = alice_env.space();
-    let alice_op = alice_space.load_operator().unwrap();
+    let alice_proofs = alice_space.load_proofs().unwrap_or_default();
+    let space_did_parsed: tonk_space::Did = alice_env.space_did.parse().unwrap();
 
     let bob = tonk_space::Operator::generate();
 
     // Alice creates invite for Bob
     let (envelope, _) = tonk_space::create_invite(
-        &alice_op,
-        &alice_op.did(),
+        &alice_env.admin,
+        &space_did_parsed,
         &bob.did(),
         Some("shared-repo".to_string()),
+        &alice_proofs,
     )
     .await
     .unwrap();
@@ -3239,29 +3269,23 @@ async fn test_invite_join_roundtrip() {
     let bob_site = carry::site::Site::init(bob_tmp.path()).unwrap();
 
     let space_did = &decoded.grants[0].space;
+    // Collect the full proof chain from the grant
+    let grant_proofs = decoded.grants[0].all_proof_bytes().unwrap();
     let bob_space = bob_site
-        .create_space_for_did(space_did, bob.signer())
+        .create_space_with_proofs(space_did, &grant_proofs)
         .unwrap();
-
-    // Bootstrap builtins in the new space
-    let mut session = bob_space.open_session().await.unwrap();
-    carry::schema::bootstrap_builtins(&mut session)
-        .await
-        .unwrap();
-
-    // Store the delegation
-    let mut session = bob_space.open_session().await.unwrap();
-    let mut tx = session.edit();
-    dialog_query::claim::Claim::assert(delegations[0].clone(), &mut tx);
-    session.commit(tx).await.unwrap();
 
     // Verify Bob's space directory exists and is keyed by the *space* DID
-    assert_eq!(bob_space.did, alice_op.did().to_string());
+    assert_eq!(bob_space.did, alice_env.space_did);
     assert!(bob_space.dir().exists());
 
-    // Verify Bob's credentials are his own key, not Alice's
-    let bob_loaded = bob_space.load_operator().unwrap();
-    assert_eq!(bob_loaded.did().to_string(), bob.did().to_string());
+    // Verify the full proof chain is stored (upstream + grant delegation)
+    let bob_proofs = bob_space.load_proofs().unwrap();
+    assert_eq!(
+        bob_proofs.len(),
+        2,
+        "Bob should have 2 proofs: space→admin + admin→bob"
+    );
 }
 
 #[tokio::test]
@@ -3269,8 +3293,6 @@ async fn test_invite_verify_rejects_wrong_issuer() {
     // An attacker creates a grant signed by their own key, but sets the
     // grant's space field to point to a real space they don't control.
     let env = TestEnv::new().await.unwrap();
-    let real_space_op = env.space().load_operator().unwrap();
-
     let attacker = tonk_space::Operator::generate();
     let bob = tonk_space::Operator::generate();
 
@@ -3279,23 +3301,24 @@ async fn test_invite_verify_rejects_wrong_issuer() {
 
     // Attacker signs a delegation with their own key
     let (mut grant, _) =
-        tonk_space::create_space_grant(&attacker, &attacker.did(), &bob.did(), exp, Some(now))
+        tonk_space::create_space_grant(&attacker, &attacker.did(), &bob.did(), exp, Some(now), &[])
             .await
             .unwrap();
 
     // Overwrite the space field to claim it's for the real space
-    grant.space = real_space_op.did().to_string();
+    grant.space = env.space_did.clone();
 
-    // Verification should reject: issuer doesn't match grant.space
+    // Verification should reject: either subject mismatch (delegation's
+    // subject is attacker's DID, not the space) or issuer mismatch
     let result = tonk_space::verify_grant(&grant, &bob.did(), now).await;
     assert!(
         result.is_err(),
-        "Should reject grant where issuer doesn't match space DID"
+        "Should reject grant where attacker's delegation doesn't match space DID"
     );
     let err = result.unwrap_err().to_string();
     assert!(
-        err.contains("issuer DID mismatch"),
-        "Expected issuer mismatch error, got: {}",
+        err.contains("mismatch"),
+        "Expected a mismatch error, got: {}",
         err
     );
 }

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -3095,7 +3095,7 @@ async fn test_invite_cmd_runs_without_error() {
     let bob = tonk_space::Operator::generate();
 
     // The invite command should succeed
-    carry::invite_cmd::execute(&ctx, &bob.did().to_string())
+    carry::invite_cmd::execute(&ctx, bob.did().as_ref())
         .await
         .unwrap();
 }
@@ -3116,7 +3116,7 @@ async fn test_invite_verify_rejects_wrong_did() {
 
     // Verify with Charlie's DID should fail (invite is for Bob)
     let now = tonk_space::Timestamp::now().to_unix();
-    let result = tonk_space::verify_grant(&decoded.grants[0], &charlie.did(), now);
+    let result = tonk_space::verify_grant(&decoded.grants[0], &charlie.did(), now).await;
     assert!(result.is_err());
 }
 
@@ -3169,7 +3169,7 @@ async fn test_invite_multi_space_grants() {
     assert_eq!(decoded.grants.len(), 2);
 
     // All grants should verify
-    let delegations = tonk_space::verify_envelope(&decoded, now).unwrap();
+    let delegations = tonk_space::verify_envelope(&decoded, now).await.unwrap();
     assert_eq!(delegations.len(), 2);
 }
 
@@ -3202,6 +3202,133 @@ async fn test_identity_load_save_roundtrip() {
         operator_read.did().to_string(),
         "Identity should roundtrip through file"
     );
+}
+
+#[tokio::test]
+async fn test_invite_join_roundtrip() {
+    // Full invite→join flow: Alice invites Bob, Bob joins the space.
+    // Exercises: create_invite → encode → decode → verify → create_space_for_did → store delegation
+    let alice_env = TestEnv::new().await.unwrap();
+    let alice_space = alice_env.space();
+    let alice_op = alice_space.load_operator().unwrap();
+
+    let bob = tonk_space::Operator::generate();
+
+    // Alice creates invite for Bob
+    let (envelope, _) = tonk_space::create_invite(
+        &alice_op,
+        &alice_op.did(),
+        &bob.did(),
+        Some("shared-repo".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let token = tonk_space::encode_invite(&envelope).unwrap();
+
+    // Bob decodes and verifies
+    let decoded = tonk_space::decode_invite(&token).unwrap();
+    assert_eq!(decoded.invited, bob.did().to_string());
+
+    let now = tonk_space::Timestamp::now().to_unix();
+    let delegations = tonk_space::verify_envelope(&decoded, now).await.unwrap();
+    assert_eq!(delegations.len(), 1);
+
+    // Bob creates a local site and joins the space
+    let bob_tmp = tempfile::TempDir::new().unwrap();
+    let bob_site = carry::site::Site::init(bob_tmp.path()).unwrap();
+
+    let space_did = &decoded.grants[0].space;
+    let bob_space = bob_site
+        .create_space_for_did(space_did, bob.signer())
+        .unwrap();
+
+    // Bootstrap builtins in the new space
+    let mut session = bob_space.open_session().await.unwrap();
+    carry::schema::bootstrap_builtins(&mut session)
+        .await
+        .unwrap();
+
+    // Store the delegation
+    let mut session = bob_space.open_session().await.unwrap();
+    let mut tx = session.edit();
+    dialog_query::claim::Claim::assert(delegations[0].clone(), &mut tx);
+    session.commit(tx).await.unwrap();
+
+    // Verify Bob's space directory exists and is keyed by the *space* DID
+    assert_eq!(bob_space.did, alice_op.did().to_string());
+    assert!(bob_space.dir().exists());
+
+    // Verify Bob's credentials are his own key, not Alice's
+    let bob_loaded = bob_space.load_operator().unwrap();
+    assert_eq!(bob_loaded.did().to_string(), bob.did().to_string());
+}
+
+#[tokio::test]
+async fn test_invite_verify_rejects_wrong_issuer() {
+    // An attacker creates a grant signed by their own key, but sets the
+    // grant's space field to point to a real space they don't control.
+    let env = TestEnv::new().await.unwrap();
+    let real_space_op = env.space().load_operator().unwrap();
+
+    let attacker = tonk_space::Operator::generate();
+    let bob = tonk_space::Operator::generate();
+
+    let now = tonk_space::Timestamp::now().to_unix();
+    let exp = now + 3600;
+
+    // Attacker signs a delegation with their own key
+    let (mut grant, _) =
+        tonk_space::create_space_grant(&attacker, &attacker.did(), &bob.did(), exp, Some(now))
+            .await
+            .unwrap();
+
+    // Overwrite the space field to claim it's for the real space
+    grant.space = real_space_op.did().to_string();
+
+    // Verification should reject: issuer doesn't match grant.space
+    let result = tonk_space::verify_grant(&grant, &bob.did(), now).await;
+    assert!(
+        result.is_err(),
+        "Should reject grant where issuer doesn't match space DID"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("issuer DID mismatch"),
+        "Expected issuer mismatch error, got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_join_repo_normalization_carry_suffix() {
+    // When --repo points to a .carry path that doesn't exist yet,
+    // Site::init should create .carry at the parent, not .carry/.carry
+    let tmp = tempfile::TempDir::new().unwrap();
+    let carry_path = tmp.path().join(".carry");
+
+    // The .carry path doesn't exist yet — this mimics `join --repo /x/.carry`
+    assert!(!carry_path.exists());
+
+    // Normalize like join_cmd does: if path ends with .carry, init at parent
+    let init_target = if carry_path.ends_with(".carry") {
+        carry_path.parent().unwrap().to_path_buf()
+    } else {
+        carry_path.clone()
+    };
+
+    let site = carry::site::Site::init(&init_target).unwrap();
+
+    // Should create .carry/ at the right level, not nested
+    assert!(
+        carry_path.is_dir(),
+        ".carry should exist at expected location"
+    );
+    assert!(
+        !carry_path.join(".carry").exists(),
+        "Should NOT have nested .carry/.carry"
+    );
+    assert_eq!(site.root(), carry_path);
 }
 
 #[tokio::test]

--- a/rust/carry/tests/cli_integration.rs
+++ b/rust/carry/tests/cli_integration.rs
@@ -27,12 +27,8 @@ async fn test_init_creates_site() {
 
 #[tokio::test]
 async fn test_init_with_name() {
-    // Set up a test identity so ensure_identity() doesn't trigger passkey flow
     let admin = tonk_space::Operator::generate();
-    let home = dirs::home_dir().unwrap();
-    let carry_home = home.join(".carry");
-    std::fs::create_dir_all(&carry_home).unwrap();
-    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+    let id_dir = common::TestEnv::setup_test_identity(&admin);
 
     let tmp = tempfile::TempDir::new().unwrap();
     carry::init::execute(Some("my-project".to_string()), vec![], Some(tmp.path()))
@@ -43,15 +39,13 @@ async fn test_init_with_name() {
     let spaces = site.list_spaces().unwrap();
     assert_eq!(spaces.len(), 1);
     assert!(site.active_space_did().unwrap().is_some());
+    drop(id_dir);
 }
 
 #[tokio::test]
 async fn test_init_idempotent() {
     let admin = tonk_space::Operator::generate();
-    let home = dirs::home_dir().unwrap();
-    let carry_home = home.join(".carry");
-    std::fs::create_dir_all(&carry_home).unwrap();
-    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+    let id_dir = common::TestEnv::setup_test_identity(&admin);
 
     let tmp = tempfile::TempDir::new().unwrap();
     carry::init::execute(None, vec![], Some(tmp.path()))
@@ -64,6 +58,7 @@ async fn test_init_idempotent() {
     let site = carry::site::Site::open(tmp.path()).unwrap();
     let spaces = site.list_spaces().unwrap();
     assert_eq!(spaces.len(), 1, "Should not create a second space");
+    drop(id_dir);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -3145,12 +3140,8 @@ async fn test_invite_multi_space_grants() {
     let tmp = tempfile::TempDir::new().unwrap();
     let site = carry::site::Site::init(tmp.path()).unwrap();
 
-    // Set up a test admin identity
     let admin = tonk_space::Operator::generate();
-    let home = dirs::home_dir().unwrap();
-    let carry_home = home.join(".carry");
-    std::fs::create_dir_all(&carry_home).unwrap();
-    std::fs::write(carry_home.join("identity"), admin.to_secret()).unwrap();
+    let id_dir = common::TestEnv::setup_test_identity(&admin);
 
     let (space1, proofs1) = site.create_delegated_space(&[admin.did()]).await.unwrap();
     site.set_active_space(&space1.did).unwrap();
@@ -3199,6 +3190,7 @@ async fn test_invite_multi_space_grants() {
     // All grants should verify
     let delegations = tonk_space::verify_envelope(&decoded, now).await.unwrap();
     assert_eq!(delegations.len(), 2);
+    drop(id_dir);
 }
 
 #[tokio::test]

--- a/rust/carry/tests/common.rs
+++ b/rust/carry/tests/common.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use carry::site::{Site, SpaceRef};
 use std::path::PathBuf;
 use tempfile::TempDir;
+use tonk_space::Operator;
 
 /// An isolated test environment backed by a temporary directory.
 ///
@@ -17,19 +18,28 @@ pub struct TestEnv {
     _temp_dir: TempDir,
     pub site_path: PathBuf,
     pub space_did: String,
+    pub admin: Operator,
 }
 
 #[allow(dead_code)]
 impl TestEnv {
     /// Create a new test environment with a bootstrapped space.
     ///
-    /// The space is initialized with pre-registered concepts (attribute,
-    /// concept, bookmark) so that meta-schema operations work immediately.
+    /// Sets up a test identity in `~/.carry/identity` and creates a
+    /// delegated space.
     pub async fn new() -> Result<Self> {
         let temp_dir = TempDir::new().context("Failed to create temp directory")?;
         let site_path = temp_dir.path().to_path_buf();
         let site = Site::init(&site_path)?;
-        let space = site.create_space()?;
+
+        // Create a test admin identity
+        let admin = Operator::generate();
+        let home = dirs::home_dir().context("home dir")?;
+        let carry_home = home.join(".carry");
+        std::fs::create_dir_all(&carry_home)?;
+        std::fs::write(carry_home.join("identity"), admin.to_secret())?;
+
+        let (space, _proofs) = site.create_delegated_space(&[admin.did()]).await?;
         site.set_active_space(&space.did)?;
 
         // Bootstrap pre-registered concepts (attribute, concept, bookmark)
@@ -42,6 +52,7 @@ impl TestEnv {
             _temp_dir: temp_dir,
             site_path,
             space_did,
+            admin,
         })
     }
 

--- a/rust/carry/tests/common.rs
+++ b/rust/carry/tests/common.rs
@@ -16,6 +16,7 @@ use tonk_space::Operator;
 #[allow(dead_code)]
 pub struct TestEnv {
     _temp_dir: TempDir,
+    _identity_dir: TempDir,
     pub site_path: PathBuf,
     pub space_did: String,
     pub admin: Operator,
@@ -25,19 +26,20 @@ pub struct TestEnv {
 impl TestEnv {
     /// Create a new test environment with a bootstrapped space.
     ///
-    /// Sets up a test identity in `~/.carry/identity` and creates a
-    /// delegated space.
+    /// Sets up a test identity via `CARRY_IDENTITY` env var pointing to a
+    /// temp file, avoiding writes to the real `~/.carry/identity`.
     pub async fn new() -> Result<Self> {
         let temp_dir = TempDir::new().context("Failed to create temp directory")?;
         let site_path = temp_dir.path().to_path_buf();
         let site = Site::init(&site_path)?;
 
-        // Create a test admin identity
+        // Create a test admin identity in an isolated temp directory
+        let identity_dir = TempDir::new().context("Failed to create identity temp dir")?;
         let admin = Operator::generate();
-        let home = dirs::home_dir().context("home dir")?;
-        let carry_home = home.join(".carry");
-        std::fs::create_dir_all(&carry_home)?;
-        std::fs::write(carry_home.join("identity"), admin.to_secret())?;
+        let identity_path = identity_dir.path().join("identity");
+        std::fs::write(&identity_path, admin.to_secret())?;
+        // Point CARRY_IDENTITY to the temp file so load_identity() finds it
+        unsafe { std::env::set_var("CARRY_IDENTITY", &identity_path) };
 
         let (space, _proofs) = site.create_delegated_space(&[admin.did()]).await?;
         site.set_active_space(&space.did)?;
@@ -50,6 +52,7 @@ impl TestEnv {
 
         Ok(Self {
             _temp_dir: temp_dir,
+            _identity_dir: identity_dir,
             site_path,
             space_did,
             admin,
@@ -76,6 +79,18 @@ impl TestEnv {
         carry::site::SiteContext::resolve(Some(self.site_path.as_path()), None)
             .await
             .unwrap()
+    }
+
+    /// Set up a test identity via `CARRY_IDENTITY` env var.
+    ///
+    /// Returns the operator and a `TempDir` that must be kept alive for the
+    /// identity file to persist.
+    pub fn setup_test_identity(op: &Operator) -> TempDir {
+        let dir = TempDir::new().expect("Failed to create identity temp dir");
+        let path = dir.path().join("identity");
+        std::fs::write(&path, op.to_secret()).unwrap();
+        unsafe { std::env::set_var("CARRY_IDENTITY", &path) };
+        dir
     }
 
     /// Get path to a specific example YAML file.

--- a/rust/tonk-space/Cargo.toml
+++ b/rust/tonk-space/Cargo.toml
@@ -17,6 +17,9 @@ js-sys = { workspace = true }
 web-sys = { workspace = true, features = ["Crypto", "SubtleCrypto", "CryptoKey", "HkdfParams"] }
 tonk-common = { workspace = true }
 
+# Encoding
+base64 = { workspace = true }
+
 # Error handling
 thiserror = { workspace = true }
 

--- a/rust/tonk-space/src/delegation.rs
+++ b/rust/tonk-space/src/delegation.rs
@@ -157,6 +157,17 @@ impl Delegation {
         Entity::from_str(&cid_str).expect("ucan:{cid} is a valid Entity URI")
     }
 
+    /// Verify the cryptographic signature of this delegation.
+    ///
+    /// Resolves the issuer DID to an Ed25519 verifier, then checks that the
+    /// signature over the encoded payload is valid.
+    pub async fn verify_signature(&self) -> Result<(), DelegationError> {
+        let resolver = dialog_credentials::ed25519::Ed25519KeyResolver;
+        self.0.verify_signature(&resolver).await.map_err(|e| {
+            DelegationError::InvalidDelegation(format!("signature verification failed: {}", e))
+        })
+    }
+
     /// Serializes this delegation to DAG-CBOR bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
         serde_ipld_dagcbor::to_vec(&self.0).expect("UcanDelegation serialization cannot fail")

--- a/rust/tonk-space/src/invite.rs
+++ b/rust/tonk-space/src/invite.rs
@@ -9,8 +9,8 @@
 
 use crate::delegation::Delegation;
 use crate::operator::Operator;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan::subject::Subject;
 use dialog_ucan::time::Timestamp;
@@ -109,8 +109,7 @@ pub struct InviteGrantV1 {
 impl InviteGrantV1 {
     /// Decode the embedded delegation from base64url DAG-CBOR.
     pub fn delegation(&self) -> Result<Delegation, InviteError> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(&self.delegation_b64u)?;
+        let bytes = URL_SAFE_NO_PAD.decode(&self.delegation_b64u)?;
         let delegation: Delegation = serde_ipld_dagcbor::from_slice(&bytes)
             .map_err(|e| InviteError::CborDecode(e.to_string()))?;
         Ok(delegation)
@@ -123,8 +122,8 @@ impl InviteGrantV1 {
 
 /// Encode an invite envelope into a `carry_inv1_...` token string.
 pub fn encode_invite(envelope: &InviteEnvelopeV1) -> Result<String, InviteError> {
-    let cbor = serde_ipld_dagcbor::to_vec(envelope)
-        .map_err(|e| InviteError::Encoding(e.to_string()))?;
+    let cbor =
+        serde_ipld_dagcbor::to_vec(envelope).map_err(|e| InviteError::Encoding(e.to_string()))?;
     let b64 = URL_SAFE_NO_PAD.encode(&cbor);
     Ok(format!("{}{}", TOKEN_PREFIX, b64))
 }
@@ -432,15 +431,10 @@ mod tests {
         let now = Timestamp::now().to_unix();
         let exp = now + 10; // expires in 10 seconds
 
-        let (grant, _) = create_space_grant(
-            &space_op,
-            &space_op.did(),
-            &invited_op.did(),
-            exp,
-            None,
-        )
-        .await
-        .unwrap();
+        let (grant, _) =
+            create_space_grant(&space_op, &space_op.did(), &invited_op.did(), exp, None)
+                .await
+                .unwrap();
 
         // Verify at a time after expiration
         let future = exp + 100;

--- a/rust/tonk-space/src/invite.rs
+++ b/rust/tonk-space/src/invite.rs
@@ -56,6 +56,12 @@ pub enum InviteError {
     #[error("Grant verification failed: delegation not yet valid")]
     NotYetValid,
 
+    #[error("Grant verification failed: invalid signature: {0}")]
+    InvalidSignature(String),
+
+    #[error("Grant verification failed: issuer DID mismatch (expected {expected}, got {got})")]
+    IssuerMismatch { expected: String, got: String },
+
     #[error("Delegation build error: {0}")]
     DelegationBuild(String),
 
@@ -237,15 +243,31 @@ pub async fn create_invite(
 /// Verify a single grant against the expected invited DID and current time.
 ///
 /// Checks:
-/// - Delegation deserializes and has correct audience
+/// - Delegation deserializes and has a valid cryptographic signature
+/// - Issuer matches the grant's space DID (only the space key can delegate)
+/// - Audience matches the expected invited DID
 /// - Subject is Specific (not Any) and matches the grant's space field
 /// - Time bounds are valid
-pub fn verify_grant(
+pub async fn verify_grant(
     grant: &InviteGrantV1,
     invited: &Did,
     now_unix: u64,
 ) -> Result<Delegation, InviteError> {
     let delegation = grant.delegation()?;
+
+    // Verify cryptographic signature before trusting any fields
+    delegation
+        .verify_signature()
+        .await
+        .map_err(|e| InviteError::InvalidSignature(e.to_string()))?;
+
+    // Issuer must match the space DID — only the space key can delegate for itself
+    if delegation.issuer().to_string() != grant.space {
+        return Err(InviteError::IssuerMismatch {
+            expected: grant.space.clone(),
+            got: delegation.issuer().to_string(),
+        });
+    }
 
     // Audience must match invited DID
     if delegation.audience().to_string() != invited.to_string() {
@@ -283,7 +305,7 @@ pub fn verify_grant(
 }
 
 /// Verify all grants in an envelope.
-pub fn verify_envelope(
+pub async fn verify_envelope(
     envelope: &InviteEnvelopeV1,
     now_unix: u64,
 ) -> Result<Vec<Delegation>, InviteError> {
@@ -292,11 +314,11 @@ pub fn verify_envelope(
         .parse()
         .map_err(|e| InviteError::InvalidDid(format!("{:?}", e)))?;
 
-    envelope
-        .grants
-        .iter()
-        .map(|grant| verify_grant(grant, &invited, now_unix))
-        .collect()
+    let mut delegations = Vec::with_capacity(envelope.grants.len());
+    for grant in &envelope.grants {
+        delegations.push(verify_grant(grant, &invited, now_unix).await?);
+    }
+    Ok(delegations)
 }
 
 // ---------------------------------------------------------------------------
@@ -394,7 +416,7 @@ mod tests {
         .await
         .unwrap();
 
-        let result = verify_grant(&grant, &invited_op.did(), now);
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(result.is_ok());
     }
 
@@ -418,8 +440,44 @@ mod tests {
         .await
         .unwrap();
 
-        let result = verify_grant(&grant, &wrong_op.did(), now);
+        let result = verify_grant(&grant, &wrong_op.did(), now).await;
         assert!(matches!(result, Err(InviteError::AudienceMismatch { .. })));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_wrong_issuer() {
+        // An attacker signs a delegation with their own key but claims it's
+        // for a different space — the signature is valid but the issuer doesn't
+        // match the space DID in the grant.
+        let attacker_op = Operator::generate();
+        let real_space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        // Attacker creates a grant using their own key as issuer, but
+        // the grant's space field points to the real space DID.
+        let (mut grant, _) = create_space_grant(
+            &attacker_op,
+            &attacker_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        // Overwrite the space field to point to the real space
+        grant.space = real_space_op.did().to_string();
+
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
+        assert!(
+            matches!(result, Err(InviteError::IssuerMismatch { .. })),
+            "Expected IssuerMismatch, got: {:?}",
+            result
+        );
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -438,7 +496,7 @@ mod tests {
 
         // Verify at a time after expiration
         let future = exp + 100;
-        let result = verify_grant(&grant, &invited_op.did(), future);
+        let result = verify_grant(&grant, &invited_op.did(), future).await;
         assert!(matches!(result, Err(InviteError::Expired)));
     }
 
@@ -463,7 +521,7 @@ mod tests {
         .unwrap();
 
         // Verify at current time (before nbf)
-        let result = verify_grant(&grant, &invited_op.did(), now);
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(matches!(result, Err(InviteError::NotYetValid)));
     }
 
@@ -526,7 +584,7 @@ mod tests {
         assert_eq!(decoded.grants[1].space, space2_op.did().to_string());
 
         // Verify all grants
-        let delegations = verify_envelope(&decoded, now).unwrap();
+        let delegations = verify_envelope(&decoded, now).await.unwrap();
         assert_eq!(delegations.len(), 2);
     }
 
@@ -535,13 +593,17 @@ mod tests {
     async fn verify_grant_rejects_subject_mismatch() {
         let space_op = Operator::generate();
         let invited_op = Operator::generate();
+        let other = Operator::generate();
 
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
+        // Create a grant where the delegation's subject differs from the
+        // grant's space field, but the issuer still matches grant.space.
+        // We do this by passing a different space_did to create_space_grant.
         let (mut grant, _) = create_space_grant(
             &space_op,
-            &space_op.did(),
+            &other.did(), // subject will be other's DID
             &invited_op.did(),
             exp,
             Some(now),
@@ -549,11 +611,11 @@ mod tests {
         .await
         .unwrap();
 
-        // Tamper with the space field to mismatch the delegation's subject
-        let other = Operator::generate();
-        grant.space = other.did().to_string();
+        // Set grant.space to match the issuer (passes issuer check)
+        // but now it mismatches the delegation's subject (other.did())
+        grant.space = space_op.did().to_string();
 
-        let result = verify_grant(&grant, &invited_op.did(), now);
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(matches!(result, Err(InviteError::SubjectMismatch { .. })));
     }
 }

--- a/rust/tonk-space/src/invite.rs
+++ b/rust/tonk-space/src/invite.rs
@@ -1,0 +1,565 @@
+//! Invite token creation and validation for space collaboration.
+//!
+//! An invite token grants a specific DID access to one or more spaces.
+//! The token is DID-bound (not bearer) — only the intended recipient can
+//! use it. Each grant in the token contains a signed UCAN delegation from
+//! the space key to the invited DID.
+//!
+//! Token format: `carry_inv1_<base64url_no_pad(dag-cbor(InviteEnvelopeV1))>`
+
+use crate::delegation::Delegation;
+use crate::operator::Operator;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan::subject::Subject;
+use dialog_ucan::time::Timestamp;
+use dialog_varsig::Did;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Token prefix for v1 invite tokens.
+const TOKEN_PREFIX: &str = "carry_inv1_";
+
+/// Default invite lifetime: 7 days in seconds.
+const DEFAULT_LIFETIME_SECS: u64 = 7 * 24 * 60 * 60;
+
+#[derive(Debug, Error)]
+pub enum InviteError {
+    #[error("Invalid token: missing 'carry_inv1_' prefix")]
+    MissingPrefix,
+
+    #[error("Invalid token: base64 decode failed: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
+
+    #[error("Invalid token: DAG-CBOR decode failed: {0}")]
+    CborDecode(String),
+
+    #[error("Invalid token: unsupported version {0}")]
+    UnsupportedVersion(u8),
+
+    #[error("Invalid token: wrong kind '{0}', expected 'carry.invite'")]
+    WrongKind(String),
+
+    #[error("Grant verification failed: audience DID mismatch (expected {expected}, got {got})")]
+    AudienceMismatch { expected: String, got: String },
+
+    #[error("Grant verification failed: subject must be Specific, not Any")]
+    SubjectIsAny,
+
+    #[error("Grant verification failed: subject DID mismatch (expected {expected}, got {got})")]
+    SubjectMismatch { expected: String, got: String },
+
+    #[error("Grant verification failed: delegation expired")]
+    Expired,
+
+    #[error("Grant verification failed: delegation not yet valid")]
+    NotYetValid,
+
+    #[error("Delegation build error: {0}")]
+    DelegationBuild(String),
+
+    #[error("Encoding error: {0}")]
+    Encoding(String),
+
+    #[error("Invalid DID: {0}")]
+    InvalidDid(String),
+
+    #[error("No grants in invite token")]
+    EmptyGrants,
+}
+
+/// V1 invite envelope — the top-level structure serialized into the token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InviteEnvelopeV1 {
+    /// Version number (must be 1).
+    pub v: u8,
+    /// Token kind discriminator.
+    pub kind: String,
+    /// The DID this invite is addressed to.
+    pub invited: String,
+    /// Unix timestamp when the invite was created.
+    pub issued_at: u64,
+    /// Hint: DID of the user who created the invite.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer_hint: Option<String>,
+    /// Hint: repo label for display purposes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_hint: Option<String>,
+    /// One grant per space being shared.
+    pub grants: Vec<InviteGrantV1>,
+}
+
+/// A single space grant within an invite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InviteGrantV1 {
+    /// The space DID this grant applies to.
+    pub space: String,
+    /// Base64url-no-pad encoded DAG-CBOR of the signed UCAN delegation.
+    pub delegation_b64u: String,
+    /// The ability being granted (e.g., "/").
+    pub ability: String,
+    /// Earliest valid time (unix seconds), if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nbf: Option<u64>,
+    /// Expiration time (unix seconds).
+    pub exp: u64,
+}
+
+impl InviteGrantV1 {
+    /// Decode the embedded delegation from base64url DAG-CBOR.
+    pub fn delegation(&self) -> Result<Delegation, InviteError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(&self.delegation_b64u)?;
+        let delegation: Delegation = serde_ipld_dagcbor::from_slice(&bytes)
+            .map_err(|e| InviteError::CborDecode(e.to_string()))?;
+        Ok(delegation)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encode / Decode
+// ---------------------------------------------------------------------------
+
+/// Encode an invite envelope into a `carry_inv1_...` token string.
+pub fn encode_invite(envelope: &InviteEnvelopeV1) -> Result<String, InviteError> {
+    let cbor = serde_ipld_dagcbor::to_vec(envelope)
+        .map_err(|e| InviteError::Encoding(e.to_string()))?;
+    let b64 = URL_SAFE_NO_PAD.encode(&cbor);
+    Ok(format!("{}{}", TOKEN_PREFIX, b64))
+}
+
+/// Decode a `carry_inv1_...` token string into an invite envelope.
+pub fn decode_invite(token: &str) -> Result<InviteEnvelopeV1, InviteError> {
+    let payload = token
+        .strip_prefix(TOKEN_PREFIX)
+        .ok_or(InviteError::MissingPrefix)?;
+    let cbor = URL_SAFE_NO_PAD.decode(payload)?;
+    let envelope: InviteEnvelopeV1 = serde_ipld_dagcbor::from_slice(&cbor)
+        .map_err(|e| InviteError::CborDecode(e.to_string()))?;
+
+    if envelope.v != 1 {
+        return Err(InviteError::UnsupportedVersion(envelope.v));
+    }
+    if envelope.kind != "carry.invite" {
+        return Err(InviteError::WrongKind(envelope.kind));
+    }
+    if envelope.grants.is_empty() {
+        return Err(InviteError::EmptyGrants);
+    }
+
+    Ok(envelope)
+}
+
+// ---------------------------------------------------------------------------
+// Grant creation
+// ---------------------------------------------------------------------------
+
+/// Create a delegation grant for a single space.
+///
+/// Signs a UCAN delegation: `issuer=space_operator, audience=invited,
+/// subject=Specific(space_did), command=/`.
+pub async fn create_space_grant(
+    space_operator: &Operator,
+    space_did: &Did,
+    invited: &Did,
+    exp_unix: u64,
+    nbf_unix: Option<u64>,
+) -> Result<(InviteGrantV1, Delegation), InviteError> {
+    let signer = Ed25519Signer::from(space_operator);
+
+    let exp_ts = Timestamp::try_from(exp_unix as i128)
+        .map_err(|e| InviteError::DelegationBuild(format!("invalid expiration: {}", e)))?;
+
+    let mut builder = Delegation::builder()
+        .issuer(signer)
+        .audience(invited)
+        .subject(Subject::Specific(space_did.clone()))
+        .command(Vec::new()) // empty = root command "/"
+        .expiration(exp_ts);
+
+    if let Some(nbf) = nbf_unix {
+        let nbf_ts = Timestamp::try_from(nbf as i128)
+            .map_err(|e| InviteError::DelegationBuild(format!("invalid not_before: {}", e)))?;
+        builder = builder.not_before(nbf_ts);
+    }
+
+    let ucan_delegation = builder
+        .try_build()
+        .await
+        .map_err(|e| InviteError::DelegationBuild(e.to_string()))?;
+
+    let delegation = Delegation::from(ucan_delegation);
+    let delegation_bytes = delegation.to_bytes();
+    let delegation_b64u = URL_SAFE_NO_PAD.encode(&delegation_bytes);
+
+    let grant = InviteGrantV1 {
+        space: space_did.to_string(),
+        delegation_b64u,
+        ability: delegation.command().to_string(),
+        nbf: nbf_unix,
+        exp: exp_unix,
+    };
+
+    Ok((grant, delegation))
+}
+
+/// Convenience: create a full invite envelope for a single space with default
+/// lifetime (7 days).
+pub async fn create_invite(
+    space_operator: &Operator,
+    space_did: &Did,
+    invited: &Did,
+    repo_hint: Option<String>,
+) -> Result<(InviteEnvelopeV1, Delegation), InviteError> {
+    let now = Timestamp::now().to_unix();
+    let exp = now + DEFAULT_LIFETIME_SECS;
+
+    let (grant, delegation) =
+        create_space_grant(space_operator, space_did, invited, exp, Some(now)).await?;
+
+    let envelope = InviteEnvelopeV1 {
+        v: 1,
+        kind: "carry.invite".to_string(),
+        invited: invited.to_string(),
+        issued_at: now,
+        issuer_hint: Some(space_operator.did().to_string()),
+        repo_hint,
+        grants: vec![grant],
+    };
+
+    Ok((envelope, delegation))
+}
+
+// ---------------------------------------------------------------------------
+// Grant verification
+// ---------------------------------------------------------------------------
+
+/// Verify a single grant against the expected invited DID and current time.
+///
+/// Checks:
+/// - Delegation deserializes and has correct audience
+/// - Subject is Specific (not Any) and matches the grant's space field
+/// - Time bounds are valid
+pub fn verify_grant(
+    grant: &InviteGrantV1,
+    invited: &Did,
+    now_unix: u64,
+) -> Result<Delegation, InviteError> {
+    let delegation = grant.delegation()?;
+
+    // Audience must match invited DID
+    if delegation.audience().to_string() != invited.to_string() {
+        return Err(InviteError::AudienceMismatch {
+            expected: invited.to_string(),
+            got: delegation.audience().to_string(),
+        });
+    }
+
+    // Subject must be Specific, not Any
+    match delegation.subject() {
+        Subject::Specific(did) => {
+            if did.to_string() != grant.space {
+                return Err(InviteError::SubjectMismatch {
+                    expected: grant.space.clone(),
+                    got: did.to_string(),
+                });
+            }
+        }
+        Subject::Any => {
+            return Err(InviteError::SubjectIsAny);
+        }
+    }
+
+    // Time validation
+    let now_ts = Timestamp::try_from(now_unix as i128)
+        .map_err(|e| InviteError::DelegationBuild(format!("invalid timestamp: {}", e)))?;
+    delegation.validate(now_ts).map_err(|e| match e {
+        crate::DelegationError::Expired => InviteError::Expired,
+        crate::DelegationError::NotYetValid => InviteError::NotYetValid,
+        other => InviteError::DelegationBuild(other.to_string()),
+    })?;
+
+    Ok(delegation)
+}
+
+/// Verify all grants in an envelope.
+pub fn verify_envelope(
+    envelope: &InviteEnvelopeV1,
+    now_unix: u64,
+) -> Result<Vec<Delegation>, InviteError> {
+    let invited: Did = envelope
+        .invited
+        .parse()
+        .map_err(|e| InviteError::InvalidDid(format!("{:?}", e)))?;
+
+    envelope
+        .grants
+        .iter()
+        .map(|grant| verify_grant(grant, &invited, now_unix))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Operator;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn encode_decode_roundtrip() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let (envelope, _delegation) = create_invite(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            Some("my-repo".to_string()),
+        )
+        .await
+        .expect("create_invite should succeed");
+
+        let token = encode_invite(&envelope).expect("encode should succeed");
+        assert!(token.starts_with(TOKEN_PREFIX));
+
+        let decoded = decode_invite(&token).expect("decode should succeed");
+        assert_eq!(decoded.v, 1);
+        assert_eq!(decoded.kind, "carry.invite");
+        assert_eq!(decoded.invited, invited_op.did().to_string());
+        assert_eq!(decoded.grants.len(), 1);
+        assert_eq!(decoded.grants[0].space, space_op.did().to_string());
+        assert_eq!(decoded.repo_hint.as_deref(), Some("my-repo"));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn grant_has_correct_delegation_fields() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        let (grant, delegation) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .expect("create_space_grant should succeed");
+
+        assert_eq!(delegation.issuer().to_string(), space_op.did().to_string());
+        assert_eq!(
+            delegation.audience().to_string(),
+            invited_op.did().to_string()
+        );
+        match delegation.subject() {
+            Subject::Specific(did) => {
+                assert_eq!(did.to_string(), space_op.did().to_string());
+            }
+            Subject::Any => panic!("Expected specific subject"),
+        }
+        assert_eq!(grant.exp, exp);
+        assert_eq!(grant.nbf, Some(now));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_succeeds_for_valid_grant() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        let (grant, _) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        let result = verify_grant(&grant, &invited_op.did(), now);
+        assert!(result.is_ok());
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_wrong_audience() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+        let wrong_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        let (grant, _) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        let result = verify_grant(&grant, &wrong_op.did(), now);
+        assert!(matches!(result, Err(InviteError::AudienceMismatch { .. })));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_expired() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 10; // expires in 10 seconds
+
+        let (grant, _) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Verify at a time after expiration
+        let future = exp + 100;
+        let result = verify_grant(&grant, &invited_op.did(), future);
+        assert!(matches!(result, Err(InviteError::Expired)));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_not_yet_valid() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let nbf = now + 3600; // not valid for another hour
+        let exp = now + 7200;
+
+        let (grant, _) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(nbf),
+        )
+        .await
+        .unwrap();
+
+        // Verify at current time (before nbf)
+        let result = verify_grant(&grant, &invited_op.did(), now);
+        assert!(matches!(result, Err(InviteError::NotYetValid)));
+    }
+
+    #[test]
+    fn decode_rejects_missing_prefix() {
+        let result = decode_invite("not_a_valid_token");
+        assert!(matches!(result, Err(InviteError::MissingPrefix)));
+    }
+
+    #[test]
+    fn decode_rejects_invalid_base64() {
+        let result = decode_invite("carry_inv1_!!!not-base64!!!");
+        assert!(matches!(result, Err(InviteError::Base64Decode(_))));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn multi_grant_roundtrip() {
+        let space1_op = Operator::generate();
+        let space2_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        let (grant1, _) = create_space_grant(
+            &space1_op,
+            &space1_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        let (grant2, _) = create_space_grant(
+            &space2_op,
+            &space2_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        let envelope = InviteEnvelopeV1 {
+            v: 1,
+            kind: "carry.invite".to_string(),
+            invited: invited_op.did().to_string(),
+            issued_at: now,
+            issuer_hint: None,
+            repo_hint: None,
+            grants: vec![grant1, grant2],
+        };
+
+        let token = encode_invite(&envelope).unwrap();
+        let decoded = decode_invite(&token).unwrap();
+        assert_eq!(decoded.grants.len(), 2);
+        assert_eq!(decoded.grants[0].space, space1_op.did().to_string());
+        assert_eq!(decoded.grants[1].space, space2_op.did().to_string());
+
+        // Verify all grants
+        let delegations = verify_envelope(&decoded, now).unwrap();
+        assert_eq!(delegations.len(), 2);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_subject_mismatch() {
+        let space_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+
+        let (mut grant, _) = create_space_grant(
+            &space_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+        )
+        .await
+        .unwrap();
+
+        // Tamper with the space field to mismatch the delegation's subject
+        let other = Operator::generate();
+        grant.space = other.did().to_string();
+
+        let result = verify_grant(&grant, &invited_op.did(), now);
+        assert!(matches!(result, Err(InviteError::SubjectMismatch { .. })));
+    }
+}

--- a/rust/tonk-space/src/invite.rs
+++ b/rust/tonk-space/src/invite.rs
@@ -110,6 +110,11 @@ pub struct InviteGrantV1 {
     pub nbf: Option<u64>,
     /// Expiration time (unix seconds).
     pub exp: u64,
+    /// Upstream delegation proofs (base64url-encoded DAG-CBOR bytes).
+    /// Each entry is a serialized UCAN delegation forming the chain of trust
+    /// from the space root to the inviter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub proofs: Vec<String>,
 }
 
 impl InviteGrantV1 {
@@ -119,6 +124,31 @@ impl InviteGrantV1 {
         let delegation: Delegation = serde_ipld_dagcbor::from_slice(&bytes)
             .map_err(|e| InviteError::CborDecode(e.to_string()))?;
         Ok(delegation)
+    }
+
+    /// Decode upstream proof delegations from base64url DAG-CBOR.
+    pub fn decode_proofs(&self) -> Result<Vec<Delegation>, InviteError> {
+        self.proofs
+            .iter()
+            .map(|p| {
+                let bytes = URL_SAFE_NO_PAD.decode(p)?;
+                let d: Delegation = serde_ipld_dagcbor::from_slice(&bytes)
+                    .map_err(|e| InviteError::CborDecode(e.to_string()))?;
+                Ok(d)
+            })
+            .collect()
+    }
+
+    /// Get all proof bytes (raw DAG-CBOR) including the grant delegation itself.
+    /// This is the full chain the joiner should store.
+    pub fn all_proof_bytes(&self) -> Result<Vec<Vec<u8>>, InviteError> {
+        let mut all: Vec<Vec<u8>> = self
+            .proofs
+            .iter()
+            .map(|p| URL_SAFE_NO_PAD.decode(p).map_err(InviteError::from))
+            .collect::<Result<_, _>>()?;
+        all.push(URL_SAFE_NO_PAD.decode(&self.delegation_b64u)?);
+        Ok(all)
     }
 }
 
@@ -162,16 +192,21 @@ pub fn decode_invite(token: &str) -> Result<InviteEnvelopeV1, InviteError> {
 
 /// Create a delegation grant for a single space.
 ///
-/// Signs a UCAN delegation: `issuer=space_operator, audience=invited,
+/// Signs a UCAN delegation: `issuer=inviter, audience=invited,
 /// subject=Specific(space_did), command=/`.
+///
+/// `upstream_proofs` is the chain of delegations from the space root to the
+/// inviter (e.g., `[space_key → admin]`). These are included in the grant
+/// so the joiner can verify the full chain.
 pub async fn create_space_grant(
-    space_operator: &Operator,
+    inviter: &Operator,
     space_did: &Did,
     invited: &Did,
     exp_unix: u64,
     nbf_unix: Option<u64>,
+    upstream_proofs: &[Vec<u8>],
 ) -> Result<(InviteGrantV1, Delegation), InviteError> {
-    let signer = Ed25519Signer::from(space_operator);
+    let signer = Ed25519Signer::from(inviter);
 
     let exp_ts = Timestamp::try_from(exp_unix as i128)
         .map_err(|e| InviteError::DelegationBuild(format!("invalid expiration: {}", e)))?;
@@ -198,12 +233,19 @@ pub async fn create_space_grant(
     let delegation_bytes = delegation.to_bytes();
     let delegation_b64u = URL_SAFE_NO_PAD.encode(&delegation_bytes);
 
+    // Encode upstream proofs as base64url
+    let proofs: Vec<String> = upstream_proofs
+        .iter()
+        .map(|p| URL_SAFE_NO_PAD.encode(p))
+        .collect();
+
     let grant = InviteGrantV1 {
         space: space_did.to_string(),
         delegation_b64u,
         ability: delegation.command().to_string(),
         nbf: nbf_unix,
         exp: exp_unix,
+        proofs,
     };
 
     Ok((grant, delegation))
@@ -211,24 +253,29 @@ pub async fn create_space_grant(
 
 /// Convenience: create a full invite envelope for a single space with default
 /// lifetime (7 days).
+///
+/// `inviter` is the identity of the user creating the invite.
+/// `upstream_proofs` is the chain of delegations from the space root to the
+/// inviter (proving the inviter has authority over this space).
 pub async fn create_invite(
-    space_operator: &Operator,
+    inviter: &Operator,
     space_did: &Did,
     invited: &Did,
     repo_hint: Option<String>,
+    upstream_proofs: &[Vec<u8>],
 ) -> Result<(InviteEnvelopeV1, Delegation), InviteError> {
     let now = Timestamp::now().to_unix();
     let exp = now + DEFAULT_LIFETIME_SECS;
 
     let (grant, delegation) =
-        create_space_grant(space_operator, space_did, invited, exp, Some(now)).await?;
+        create_space_grant(inviter, space_did, invited, exp, Some(now), upstream_proofs).await?;
 
     let envelope = InviteEnvelopeV1 {
         v: 1,
         kind: "carry.invite".to_string(),
         invited: invited.to_string(),
         issued_at: now,
-        issuer_hint: Some(space_operator.did().to_string()),
+        issuer_hint: Some(inviter.did().to_string()),
         repo_hint,
         grants: vec![grant],
     };
@@ -240,49 +287,24 @@ pub async fn create_invite(
 // Grant verification
 // ---------------------------------------------------------------------------
 
-/// Verify a single grant against the expected invited DID and current time.
-///
-/// Checks:
-/// - Delegation deserializes and has a valid cryptographic signature
-/// - Issuer matches the grant's space DID (only the space key can delegate)
-/// - Audience matches the expected invited DID
-/// - Subject is Specific (not Any) and matches the grant's space field
-/// - Time bounds are valid
-pub async fn verify_grant(
-    grant: &InviteGrantV1,
-    invited: &Did,
+/// Verify a single delegation's signature, subject, and time bounds.
+async fn verify_single_delegation(
+    delegation: &Delegation,
+    space_did: &str,
     now_unix: u64,
-) -> Result<Delegation, InviteError> {
-    let delegation = grant.delegation()?;
-
-    // Verify cryptographic signature before trusting any fields
+) -> Result<(), InviteError> {
+    // Verify cryptographic signature
     delegation
         .verify_signature()
         .await
         .map_err(|e| InviteError::InvalidSignature(e.to_string()))?;
 
-    // Issuer must match the space DID — only the space key can delegate for itself
-    if delegation.issuer().to_string() != grant.space {
-        return Err(InviteError::IssuerMismatch {
-            expected: grant.space.clone(),
-            got: delegation.issuer().to_string(),
-        });
-    }
-
-    // Audience must match invited DID
-    if delegation.audience().to_string() != invited.to_string() {
-        return Err(InviteError::AudienceMismatch {
-            expected: invited.to_string(),
-            got: delegation.audience().to_string(),
-        });
-    }
-
-    // Subject must be Specific, not Any
+    // Subject must be Specific and match the space DID
     match delegation.subject() {
         Subject::Specific(did) => {
-            if did.to_string() != grant.space {
+            if did.to_string() != space_did {
                 return Err(InviteError::SubjectMismatch {
-                    expected: grant.space.clone(),
+                    expected: space_did.to_string(),
                     got: did.to_string(),
                 });
             }
@@ -300,6 +322,62 @@ pub async fn verify_grant(
         crate::DelegationError::NotYetValid => InviteError::NotYetValid,
         other => InviteError::DelegationBuild(other.to_string()),
     })?;
+
+    Ok(())
+}
+
+/// Verify a single grant against the expected invited DID and current time.
+///
+/// Walks the full delegation chain from the space root:
+/// 1. Each upstream proof is verified (signature, subject, time bounds)
+/// 2. Chain continuity: each delegation's audience == next delegation's issuer
+/// 3. First delegation's issuer must be the space DID (root of trust)
+/// 4. Final delegation's audience must be the invited DID
+pub async fn verify_grant(
+    grant: &InviteGrantV1,
+    invited: &Did,
+    now_unix: u64,
+) -> Result<Delegation, InviteError> {
+    let delegation = grant.delegation()?;
+    let upstream = grant.decode_proofs()?;
+
+    // Build the full chain: [upstream_0, upstream_1, ..., delegation]
+    let mut chain: Vec<&Delegation> = upstream.iter().collect();
+    chain.push(&delegation);
+
+    // Verify each delegation individually
+    for d in &chain {
+        verify_single_delegation(d, &grant.space, now_unix).await?;
+    }
+
+    // Chain root: first delegation's issuer must be the space DID
+    if chain[0].issuer().to_string() != grant.space {
+        return Err(InviteError::IssuerMismatch {
+            expected: grant.space.clone(),
+            got: chain[0].issuer().to_string(),
+        });
+    }
+
+    // Chain continuity: audience[i] == issuer[i+1]
+    for i in 0..chain.len() - 1 {
+        let audience = chain[i].audience().to_string();
+        let next_issuer = chain[i + 1].issuer().to_string();
+        if audience != next_issuer {
+            return Err(InviteError::IssuerMismatch {
+                expected: audience,
+                got: next_issuer,
+            });
+        }
+    }
+
+    // Final delegation's audience must match invited DID
+    let last = chain.last().unwrap();
+    if last.audience().to_string() != invited.to_string() {
+        return Err(InviteError::AudienceMismatch {
+            expected: invited.to_string(),
+            got: last.audience().to_string(),
+        });
+    }
 
     Ok(delegation)
 }
@@ -329,6 +407,7 @@ pub async fn verify_envelope(
 mod tests {
     use super::*;
     use crate::Operator;
+    use dialog_credentials::Ed25519Signer;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -336,17 +415,36 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
+    /// Helper: create a powerline delegation from space_op to admin_op,
+    /// returning the raw bytes (simulating what `carry init` does).
+    async fn make_admin_proof(space_op: &Operator, admin_op: &Operator) -> Vec<u8> {
+        let signer = Ed25519Signer::from(space_op);
+        let ucan = Delegation::builder()
+            .issuer(signer)
+            .audience(&admin_op.did())
+            .subject(Subject::Specific(space_op.did()))
+            .command(Vec::new())
+            .try_build()
+            .await
+            .unwrap();
+        Delegation::from(ucan).to_bytes()
+    }
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn encode_decode_roundtrip() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
 
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
+
         let (envelope, _delegation) = create_invite(
-            &space_op,
+            &admin_op,
             &space_op.did(),
             &invited_op.did(),
             Some("my-repo".to_string()),
+            &[admin_proof],
         )
         .await
         .expect("create_invite should succeed");
@@ -361,28 +459,32 @@ mod tests {
         assert_eq!(decoded.grants.len(), 1);
         assert_eq!(decoded.grants[0].space, space_op.did().to_string());
         assert_eq!(decoded.repo_hint.as_deref(), Some("my-repo"));
+        assert_eq!(decoded.grants[0].proofs.len(), 1);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn grant_has_correct_delegation_fields() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
 
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
         let (grant, delegation) = create_space_grant(
-            &space_op,
+            &admin_op,
             &space_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof],
         )
         .await
         .expect("create_space_grant should succeed");
 
-        assert_eq!(delegation.issuer().to_string(), space_op.did().to_string());
+        assert_eq!(delegation.issuer().to_string(), admin_op.did().to_string());
         assert_eq!(
             delegation.audience().to_string(),
             invited_op.did().to_string()
@@ -395,23 +497,27 @@ mod tests {
         }
         assert_eq!(grant.exp, exp);
         assert_eq!(grant.nbf, Some(now));
+        assert_eq!(grant.proofs.len(), 1);
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn verify_grant_succeeds_for_valid_grant() {
+    async fn verify_grant_succeeds_for_valid_chain() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
 
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
         let (grant, _) = create_space_grant(
-            &space_op,
+            &admin_op,
             &space_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof],
         )
         .await
         .unwrap();
@@ -424,18 +530,21 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn verify_grant_rejects_wrong_audience() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
         let wrong_op = Operator::generate();
 
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
         let (grant, _) = create_space_grant(
-            &space_op,
+            &admin_op,
             &space_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof],
         )
         .await
         .unwrap();
@@ -446,31 +555,28 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn verify_grant_rejects_wrong_issuer() {
-        // An attacker signs a delegation with their own key but claims it's
-        // for a different space — the signature is valid but the issuer doesn't
-        // match the space DID in the grant.
-        let attacker_op = Operator::generate();
-        let real_space_op = Operator::generate();
+    async fn verify_grant_rejects_broken_chain() {
+        // Admin signs a delegation but with no upstream proof connecting
+        // them to the space — the chain root won't match the space DID.
+        let space_op = Operator::generate();
+        let unlinked_admin = Operator::generate();
         let invited_op = Operator::generate();
 
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
-        // Attacker creates a grant using their own key as issuer, but
-        // the grant's space field points to the real space DID.
-        let (mut grant, _) = create_space_grant(
-            &attacker_op,
-            &attacker_op.did(),
+        // No upstream proofs — the chain is just [admin → invited],
+        // so chain[0].issuer != space_did.
+        let (grant, _) = create_space_grant(
+            &unlinked_admin,
+            &space_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[], // no proofs!
         )
         .await
         .unwrap();
-
-        // Overwrite the space field to point to the real space
-        grant.space = real_space_op.did().to_string();
 
         let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(
@@ -482,19 +588,65 @@ mod tests {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
-    async fn verify_grant_rejects_expired() {
-        let space_op = Operator::generate();
+    async fn verify_grant_rejects_wrong_issuer() {
+        // An attacker creates their own proof chain for a different space,
+        // then sets the grant.space to the real space DID.
+        let attacker_space_op = Operator::generate();
+        let real_space_op = Operator::generate();
+        let attacker_admin = Operator::generate();
         let invited_op = Operator::generate();
 
+        let attacker_proof = make_admin_proof(&attacker_space_op, &attacker_admin).await;
         let now = Timestamp::now().to_unix();
-        let exp = now + 10; // expires in 10 seconds
+        let exp = now + 3600;
 
-        let (grant, _) =
-            create_space_grant(&space_op, &space_op.did(), &invited_op.did(), exp, None)
-                .await
-                .unwrap();
+        let (mut grant, _) = create_space_grant(
+            &attacker_admin,
+            &attacker_space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+            &[attacker_proof],
+        )
+        .await
+        .unwrap();
 
-        // Verify at a time after expiration
+        // Overwrite the space field to point to the real space
+        grant.space = real_space_op.did().to_string();
+
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
+        assert!(
+            matches!(
+                result,
+                Err(InviteError::SubjectMismatch { .. } | InviteError::IssuerMismatch { .. })
+            ),
+            "Expected SubjectMismatch or IssuerMismatch, got: {:?}",
+            result
+        );
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_grant_rejects_expired() {
+        let space_op = Operator::generate();
+        let admin_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
+        let now = Timestamp::now().to_unix();
+        let exp = now + 10;
+
+        let (grant, _) = create_space_grant(
+            &admin_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            None,
+            &[admin_proof],
+        )
+        .await
+        .unwrap();
+
         let future = exp + 100;
         let result = verify_grant(&grant, &invited_op.did(), future).await;
         assert!(matches!(result, Err(InviteError::Expired)));
@@ -504,23 +656,25 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn verify_grant_rejects_not_yet_valid() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
 
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
-        let nbf = now + 3600; // not valid for another hour
+        let nbf = now + 3600;
         let exp = now + 7200;
 
         let (grant, _) = create_space_grant(
-            &space_op,
+            &admin_op,
             &space_op.did(),
             &invited_op.did(),
             exp,
             Some(nbf),
+            &[admin_proof],
         )
         .await
         .unwrap();
 
-        // Verify at current time (before nbf)
         let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(matches!(result, Err(InviteError::NotYetValid)));
     }
@@ -542,27 +696,32 @@ mod tests {
     async fn multi_grant_roundtrip() {
         let space1_op = Operator::generate();
         let space2_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
 
+        let admin_proof1 = make_admin_proof(&space1_op, &admin_op).await;
+        let admin_proof2 = make_admin_proof(&space2_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
         let (grant1, _) = create_space_grant(
-            &space1_op,
+            &admin_op,
             &space1_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof1],
         )
         .await
         .unwrap();
 
         let (grant2, _) = create_space_grant(
-            &space2_op,
+            &admin_op,
             &space2_op.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof2],
         )
         .await
         .unwrap();
@@ -583,7 +742,6 @@ mod tests {
         assert_eq!(decoded.grants[0].space, space1_op.did().to_string());
         assert_eq!(decoded.grants[1].space, space2_op.did().to_string());
 
-        // Verify all grants
         let delegations = verify_envelope(&decoded, now).await.unwrap();
         assert_eq!(delegations.len(), 2);
     }
@@ -592,30 +750,78 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     async fn verify_grant_rejects_subject_mismatch() {
         let space_op = Operator::generate();
+        let admin_op = Operator::generate();
         let invited_op = Operator::generate();
         let other = Operator::generate();
 
+        // Admin proof is for the real space
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
         let now = Timestamp::now().to_unix();
         let exp = now + 3600;
 
-        // Create a grant where the delegation's subject differs from the
-        // grant's space field, but the issuer still matches grant.space.
-        // We do this by passing a different space_did to create_space_grant.
+        // Create a grant where the delegation's subject is other.did()
         let (mut grant, _) = create_space_grant(
-            &space_op,
-            &other.did(), // subject will be other's DID
+            &admin_op,
+            &other.did(),
             &invited_op.did(),
             exp,
             Some(now),
+            &[admin_proof],
         )
         .await
         .unwrap();
 
-        // Set grant.space to match the issuer (passes issuer check)
-        // but now it mismatches the delegation's subject (other.did())
+        // Set grant.space to match space_op (mismatches delegation subject)
         grant.space = space_op.did().to_string();
 
         let result = verify_grant(&grant, &invited_op.did(), now).await;
         assert!(matches!(result, Err(InviteError::SubjectMismatch { .. })));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    async fn verify_three_level_chain() {
+        // space_key → admin → collaborator → invitee
+        let space_op = Operator::generate();
+        let admin_op = Operator::generate();
+        let collab_op = Operator::generate();
+        let invited_op = Operator::generate();
+
+        let admin_proof = make_admin_proof(&space_op, &admin_op).await;
+
+        // Admin delegates to collaborator
+        let now = Timestamp::now().to_unix();
+        let exp = now + 3600;
+        let signer = Ed25519Signer::from(&admin_op);
+        let ucan = Delegation::builder()
+            .issuer(signer)
+            .audience(&collab_op.did())
+            .subject(Subject::Specific(space_op.did()))
+            .command(Vec::new())
+            .expiration(Timestamp::try_from(exp as i128).unwrap())
+            .not_before(Timestamp::try_from(now as i128).unwrap())
+            .try_build()
+            .await
+            .unwrap();
+        let collab_proof = Delegation::from(ucan).to_bytes();
+
+        // Collaborator invites
+        let (grant, _) = create_space_grant(
+            &collab_op,
+            &space_op.did(),
+            &invited_op.did(),
+            exp,
+            Some(now),
+            &[admin_proof, collab_proof],
+        )
+        .await
+        .unwrap();
+
+        let result = verify_grant(&grant, &invited_op.did(), now).await;
+        assert!(
+            result.is_ok(),
+            "Three-level chain should verify: {:?}",
+            result
+        );
     }
 }

--- a/rust/tonk-space/src/lib.rs
+++ b/rust/tonk-space/src/lib.rs
@@ -8,8 +8,8 @@ pub mod space;
 
 pub use delegation::{Delegation, DelegationError};
 pub use invite::{
-    InviteEnvelopeV1, InviteError, InviteGrantV1, create_invite, create_space_grant,
-    decode_invite, encode_invite, verify_envelope, verify_grant,
+    InviteEnvelopeV1, InviteError, InviteGrantV1, create_invite, create_space_grant, decode_invite,
+    encode_invite, verify_envelope, verify_grant,
 };
 pub use operator::Operator;
 pub use secret::*;

--- a/rust/tonk-space/src/lib.rs
+++ b/rust/tonk-space/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod delegation;
+pub mod invite;
 pub mod operator;
 pub mod ownership;
 pub mod schema;
@@ -6,6 +7,10 @@ pub mod secret;
 pub mod space;
 
 pub use delegation::{Delegation, DelegationError};
+pub use invite::{
+    InviteEnvelopeV1, InviteError, InviteGrantV1, create_invite, create_space_grant,
+    decode_invite, encode_invite, verify_envelope, verify_grant,
+};
 pub use operator::Operator;
 pub use secret::*;
 


### PR DESCRIPTION
### Description

There was previously no way to collaborate on a space with others, and no sense of user identity. This change introduces the ability to:
- create portable invite tokens scoped to spaces and users,
- redeem invites locally,
- and establish a stable user identity that survives across joins.

`tonk-space` received the invite token format, grant creation, and verification primitives
`carry` got new CLI commands—`carry invite`, `carry join`, and `carry identity`—to issue and redeem invites

User identity is deterministically derived from WebAuthn passkey

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces significant enhancements to the `carry` project, focusing on identity management and delegation features, including invite and join functionalities for spaces.

### Detailed summary
- Added `identity_cmd` module for managing user identity via WebAuthn passkeys.
- Introduced `invite_cmd` and `join_cmd` modules for inviting users and joining spaces.
- Updated `init` command to support additional admin DIDs.
- Enhanced error handling and context for file reading.
- Implemented delegation proof management in space creation.
- Modified Cargo files to include new dependencies for HTTP handling and serialization.
- Updated tests to cover new invite and join functionalities.

> The following files were skipped due to too many changes: `rust/carry/src/site.rs`, `rust/tonk-space/src/invite.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->