### PR TITLE
feat(carry): add telemetry

### DIFF
--- a/.github/workflows/deploy-telemetry.yml
+++ b/.github/workflows/deploy-telemetry.yml
@@ -1,0 +1,48 @@
+name: Deploy Telemetry
+
+on:
+  pull_request:
+  push:
+    branches: [stable]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    name: Deploy Telemetry Service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wimpysworld/nothing-but-nix@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        id: deploy-preview
+        run: |
+          echo 'Telemetry service wrangler output:' > "$RUNNER_TEMP/telemetry-pr-comment.md"
+          echo '' >> "$RUNNER_TEMP/telemetry-pr-comment.md"
+          nix --accept-flake-config develop .#ci --command wrangler versions upload -c wrangler-telemetry.toml --preview-alias pr-${{ github.event.pull_request.number }} 2>&1 | tail -30 >> "$RUNNER_TEMP/telemetry-pr-comment.md"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+        run: nix --accept-flake-config develop .#ci --command wrangler deploy -c wrangler-telemetry.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - uses: mshick/add-pr-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          message-path: ${{ runner.temp }}/telemetry-pr-comment.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "bs58",
+ "carry-telemetry-service",
  "clap",
  "clap_complete",
  "dialog-artifacts",
@@ -339,11 +340,29 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures-util",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "carry-telemetry-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "worker",
+ "worker-macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "rust/carry",
+  "rust/carry-telemetry-service",
   "rust/tonk-access-service",
   "rust/tonk-assess",
 ]
@@ -14,6 +15,7 @@ license = "MIT"
 
 [workspace.dependencies]
 carry = { path = "./rust/carry" }
+carry-telemetry-service = { path = "./rust/carry-telemetry-service" }
 tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-assess = { path = "./rust/tonk-assess" }
 
@@ -31,6 +33,10 @@ futures-util = "0.3"
 http-body-util = "0.1"
 hyper = "1"
 hyper-util = "0.1"
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls"
+] }
 serde = "1"
 serde_ipld_dagcbor = "0.6"
 serde_json = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -140,12 +140,12 @@
         packages = {
           tests-native-debug = buildTestArchive {
             name = "native-debug";
-            args = "--workspace --exclude tonk-access-service";
+            args = "--workspace --exclude tonk-access-service --exclude carry-telemetry-service";
           };
 
           tests-native-release = buildTestArchive {
             name = "native-release";
-            args = "--workspace --exclude tonk-access-service --release";
+            args = "--workspace --exclude tonk-access-service --exclude carry-telemetry-service --release";
           };
 
           tests-cli-integration = buildTestArchive {
@@ -193,6 +193,20 @@
               cd rust/tonk-access-service
               worker-build --release
               echo "fin"
+            '';
+
+            installPhase = ''
+              mkdir -p $out
+              cp -r ./build/* $out/
+            '';
+          };
+
+          carry-telemetry-service = buildWasmCrate {
+            pname = "carry-telemetry-service";
+
+            buildPhase = ''
+              cd rust/carry-telemetry-service
+              worker-build --release
             '';
 
             installPhase = ''

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -101,7 +101,8 @@ let
   # Exclude native-only crates that can't compile for wasm32-unknown-unknown.
   # carry requires tokio["full"] which pulls in mio, a crate that needs
   # OS-level async I/O primitives (epoll/kqueue) unavailable in WASM.
-  wasmCargoExcludeArgs = "--workspace --exclude carry --exclude tonk-assess";
+  # If you add a new native-only crate, add it to the --exclude list here.
+  wasmCargoExcludeArgs = "--workspace --exclude carry --exclude tonk-assess --exclude carry-telemetry-service";
 
   wasmAttributes = commonAttributes // {
     CARGO_BUILD_TARGET = "wasm32-unknown-unknown";

--- a/rust/carry-telemetry-service/Cargo.toml
+++ b/rust/carry-telemetry-service/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "carry-telemetry-service"
+description = "Minimal privacy-preserving telemetry for carry"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+helpers = [
+    "dep:anyhow",
+    "dep:bytes",
+    "dep:http-body-util",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:tokio",
+]
+
+[dependencies]
+worker = { workspace = true }
+worker-macros = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+# Test helpers (optional, for integration testing)
+anyhow = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+http-body-util = { workspace = true, optional = true }
+hyper = { workspace = true, optional = true, features = ["http1", "server"] }
+hyper-util = { workspace = true, optional = true, features = ["tokio"] }
+tokio = { workspace = true, optional = true, features = ["net", "sync", "rt", "macros"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/rust/carry-telemetry-service/src/helpers.rs
+++ b/rust/carry-telemetry-service/src/helpers.rs
@@ -1,0 +1,179 @@
+//! Test helpers for the carry telemetry service.
+//!
+//! Provides a local HTTP server that mirrors the Cloudflare Worker behavior
+//! but runs natively, storing received pings in memory for test assertions.
+
+use crate::Ping;
+use hyper::body::Incoming;
+use hyper::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    ACCESS_CONTROL_MAX_AGE,
+};
+use hyper::server::conn::http1;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+/// A recorded telemetry ping for test assertions.
+#[derive(Debug, Clone)]
+pub struct RecordedPing {
+    pub id: String,
+    pub command: String,
+    pub version: String,
+}
+
+/// A running telemetry test server that records pings in memory.
+pub struct TelemetryTestServer {
+    pub endpoint: String,
+    pings: Arc<Mutex<Vec<RecordedPing>>>,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    server_handle: tokio::task::JoinHandle<()>,
+}
+
+impl TelemetryTestServer {
+    /// Start a local telemetry test server on a random port.
+    pub async fn start() -> anyhow::Result<Self> {
+        let pings: Arc<Mutex<Vec<RecordedPing>>> = Arc::new(Mutex::new(Vec::new()));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}", addr);
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let pings_clone = pings.clone();
+        let server_handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = listener.accept() => {
+                        if let Ok((stream, _)) = result {
+                            let pings = pings_clone.clone();
+                            tokio::spawn(async move {
+                                let service = hyper::service::service_fn(move |req| {
+                                    let pings = pings.clone();
+                                    async move { handle_request(req, pings).await }
+                                });
+                                let _ = http1::Builder::new()
+                                    .serve_connection(TokioIo::new(stream), service)
+                                    .await;
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            endpoint,
+            pings,
+            shutdown_tx,
+            server_handle,
+        })
+    }
+
+    /// Get all recorded pings.
+    pub async fn recorded_pings(&self) -> Vec<RecordedPing> {
+        self.pings.lock().await.clone()
+    }
+
+    /// Clear all recorded pings.
+    pub async fn clear(&self) {
+        self.pings.lock().await.clear();
+    }
+
+    /// Shut down the server.
+    pub async fn stop(self) {
+        let _ = self.shutdown_tx.send(());
+        let _ = self.server_handle.await;
+    }
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    pings: Arc<Mutex<Vec<RecordedPing>>>,
+) -> Result<Response<http_body_util::Full<bytes::Bytes>>, std::convert::Infallible> {
+    use bytes::Bytes;
+    use http_body_util::Full;
+
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+
+    // GET /health
+    if method == Method::GET && path == "/health" {
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::from("OK")))
+            .unwrap());
+    }
+
+    // OPTIONS /ping (CORS preflight)
+    if method == Method::OPTIONS && path == "/ping" {
+        return Ok(cors_response(
+            Response::builder()
+                .status(StatusCode::NO_CONTENT)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                .header(ACCESS_CONTROL_ALLOW_METHODS, "POST, OPTIONS")
+                .header(ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+                .header(ACCESS_CONTROL_MAX_AGE, "86400")
+                .body(Full::new(Bytes::new()))
+                .unwrap(),
+        ));
+    }
+
+    // POST /ping
+    if method == Method::POST && path == "/ping" {
+        use http_body_util::BodyExt;
+        let body_bytes = match req.into_body().collect().await {
+            Ok(collected) => collected.to_bytes(),
+            Err(_) => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Full::new(Bytes::from("Bad request")))
+                    .unwrap());
+            }
+        };
+
+        let ping: Ping = match serde_json::from_slice(&body_bytes) {
+            Ok(p) => p,
+            Err(_) => {
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Full::new(Bytes::from("Bad request")))
+                    .unwrap());
+            }
+        };
+
+        if crate::validate_ping(&ping).is_err() {
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Full::new(Bytes::from("Bad request")))
+                .unwrap());
+        }
+
+        pings.lock().await.push(RecordedPing {
+            id: ping.id,
+            command: ping.command,
+            version: ping.version,
+        });
+
+        return Ok(cors_response(
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(Full::new(Bytes::from("OK")))
+                .unwrap(),
+        ));
+    }
+
+    // 404 for everything else
+    Ok(Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Full::new(Bytes::from("Not found")))
+        .unwrap())
+}
+
+fn cors_response<T>(mut response: Response<T>) -> Response<T> {
+    let headers = response.headers_mut();
+    headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
+    response
+}

--- a/rust/carry-telemetry-service/src/lib.rs
+++ b/rust/carry-telemetry-service/src/lib.rs
@@ -1,0 +1,97 @@
+//! Carry Telemetry Service
+//!
+//! A minimal Cloudflare Worker that receives anonymous usage pings from
+//! the `carry` CLI and writes them to Workers Analytics Engine.
+//!
+//! No IP addresses are read, logged, or stored.
+//!
+//! ## Endpoints
+//!
+//! - `POST /ping` -- record a usage event
+//! - `GET  /health` -- health check
+//!
+//! ## Data point schema (Analytics Engine)
+//!
+//! - index: blinded user ID (first 16 hex chars of blake3 hash of DID)
+//! - blob1: command name (init, query, assert, ...)
+//! - blob2: carry version
+
+use serde::Deserialize;
+use worker::*;
+
+/// A telemetry ping from the carry CLI.
+#[derive(Deserialize, Debug, Clone)]
+pub struct Ping {
+    /// Blinded user ID -- blake3(salt || DID), truncated to hex
+    pub id: String,
+    /// Subcommand that was run
+    pub command: String,
+    /// Carry CLI version
+    pub version: String,
+}
+
+/// Validate a ping payload. Returns an error message on failure.
+pub fn validate_ping(ping: &Ping) -> Result<()> {
+    if ping.id.is_empty() || ping.id.len() > 32 || !ping.id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Error::RustError("invalid id".to_string()));
+    }
+    if ping.command.is_empty() || ping.command.len() > 64 {
+        return Err(Error::RustError("invalid command".to_string()));
+    }
+    if ping.version.is_empty() || ping.version.len() > 32 {
+        return Err(Error::RustError("invalid version".to_string()));
+    }
+    Ok(())
+}
+
+/// Test helpers for integration testing (native HTTP server).
+#[cfg(feature = "helpers")]
+pub mod helpers;
+
+#[event(fetch)]
+async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    let router = Router::new();
+
+    router
+        .get_async("/health", handle_health)
+        .options_async("/ping", handle_preflight)
+        .post_async("/ping", handle_ping)
+        .run(req, env)
+        .await
+}
+
+async fn handle_health(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Response::ok("OK")
+}
+
+async fn handle_preflight(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    let headers = Headers::new();
+    headers.set("Access-Control-Allow-Origin", "*")?;
+    headers.set("Access-Control-Allow-Methods", "POST, OPTIONS")?;
+    headers.set("Access-Control-Allow-Headers", "Content-Type")?;
+    headers.set("Access-Control-Max-Age", "86400")?;
+    Ok(Response::empty()?.with_status(204).with_headers(headers))
+}
+
+async fn handle_ping(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let ping: Ping = match req.json().await {
+        Ok(p) => p,
+        Err(_) => return Response::error("Bad request", 400),
+    };
+
+    if validate_ping(&ping).is_err() {
+        return Response::error("Bad request", 400);
+    }
+
+    // Write to Analytics Engine -- no IP is ever read from the request
+    let dataset = ctx.env.analytics_engine("TELEMETRY")?;
+    AnalyticsEngineDataPointBuilder::new()
+        .indexes([ping.id.as_str()])
+        .add_blob(ping.command)
+        .add_blob(ping.version)
+        .write_to(&dataset)?;
+
+    let headers = Headers::new();
+    headers.set("Access-Control-Allow-Origin", "*")?;
+    Response::ok("OK").map(|r| r.with_headers(headers))
+}

--- a/rust/carry-telemetry-service/tests/telemetry_integration.rs
+++ b/rust/carry-telemetry-service/tests/telemetry_integration.rs
@@ -1,0 +1,465 @@
+//! Integration tests for the carry telemetry service.
+//!
+//! These tests run a local HTTP server that mirrors the Cloudflare Worker
+//! behavior, exercising the full request/response cycle.
+
+use carry_telemetry_service::helpers::TelemetryTestServer;
+use serde_json::json;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Health check
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn health_returns_ok() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let resp = reqwest::get(format!("{}/health", server.endpoint))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), "OK");
+    server.stop().await;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /ping -- valid payloads
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn ping_valid_payload_returns_ok() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 1);
+    assert_eq!(pings[0].id, "abcdef0123456789");
+    assert_eq!(pings[0].command, "query");
+    assert_eq!(pings[0].version, "0.1.0");
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_records_multiple_events() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+
+    let commands = ["init", "query", "assert", "retract", "status"];
+    for cmd in &commands {
+        client
+            .post(format!("{}/ping", server.endpoint))
+            .json(&json!({
+                "id": "aabbccdd11223344",
+                "command": cmd,
+                "version": "0.1.0"
+            }))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), commands.len());
+    for (i, cmd) in commands.iter().enumerate() {
+        assert_eq!(pings[i].command, *cmd);
+    }
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_distinct_user_ids() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+
+    let ids = ["aaaa000000000000", "bbbb111111111111", "cccc222222222222"];
+    for id in &ids {
+        client
+            .post(format!("{}/ping", server.endpoint))
+            .json(&json!({
+                "id": id,
+                "command": "init",
+                "version": "0.1.0"
+            }))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 3);
+    let unique_ids: std::collections::HashSet<&str> = pings.iter().map(|p| p.id.as_str()).collect();
+    assert_eq!(unique_ids.len(), 3);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_minimum_length_fields() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "a",
+            "command": "q",
+            "version": "0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 1);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_maximum_length_id() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    // 32 hex chars (maximum)
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789abcdef0123456789",
+            "command": "init",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    server.stop().await;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// POST /ping -- invalid payloads
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn ping_empty_id_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "",
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    assert_eq!(server.recorded_pings().await.len(), 0);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_non_hex_id_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "not-hex-at-all!!",
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    assert_eq!(server.recorded_pings().await.len(), 0);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_id_too_long_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    // 33 hex chars (one over max)
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789abcdef01234567890",
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_empty_command_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_empty_version_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "query",
+            "version": ""
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_command_too_long_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let long_command = "x".repeat(65);
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": long_command,
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_version_too_long_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let long_version = "9".repeat(33);
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "query",
+            "version": long_version,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_missing_fields_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+
+    // Missing id
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Missing command
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Missing version
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "query"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    assert_eq!(server.recorded_pings().await.len(), 0);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_invalid_json_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .header("content-type", "application/json")
+        .body("not json at all")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_empty_body_rejected() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .header("content-type", "application/json")
+        .body("")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    server.stop().await;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// CORS preflight
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn options_ping_returns_cors_headers() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/ping", server.endpoint),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "*"
+    );
+    assert!(
+        resp.headers()
+            .get("access-control-allow-methods")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("POST")
+    );
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn post_ping_response_has_cors_header() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "query",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "*"
+    );
+    server.stop().await;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Wrong methods / routes
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn get_ping_returns_404() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let resp = reqwest::get(format!("{}/ping", server.endpoint))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn unknown_route_returns_404() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let resp = reqwest::get(format!("{}/nonexistent", server.endpoint))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+    server.stop().await;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Server lifecycle
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn clear_resets_recorded_pings() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{}/ping", server.endpoint))
+        .json(&json!({
+            "id": "abcdef0123456789",
+            "command": "init",
+            "version": "0.1.0"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(server.recorded_pings().await.len(), 1);
+    server.clear().await;
+    assert_eq!(server.recorded_pings().await.len(), 0);
+    server.stop().await;
+}

--- a/rust/carry/Cargo.toml
+++ b/rust/carry/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/bin/carry.rs"
 
 [dev-dependencies]
 anyhow = { workspace = true }
+carry-telemetry-service = { workspace = true, features = ["helpers"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
@@ -42,6 +43,7 @@ bs58 = { workspace = true }
 # Crypto
 ed25519-dalek = { workspace = true }
 
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # Serialization
 serde_json = { workspace = true }

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -140,6 +140,25 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let repo_path = cli.repo.as_deref().map(std::path::Path::new);
 
+    let command_name = match &cli.command {
+        Commands::Init { .. } => "init",
+        Commands::Query { .. } => "query",
+        Commands::Assert { .. } => "assert",
+        Commands::Retract { .. } => "retract",
+        Commands::Status { .. } => "status",
+        Commands::Identity { .. } => "identity",
+        Commands::Invite { .. } => "invite",
+        Commands::Join { .. } => "join",
+    };
+
+    // Best-effort telemetry: resolve identity for the blinded ID, but
+    // fall back silently if the profile doesn't exist yet.
+    let telemetry_handle = if let Ok(id) = carry::identity_cmd::ensure_identity(None).await {
+        carry::telemetry::ping(id.profile.did().as_ref(), command_name)
+    } else {
+        None
+    };
+
     match cli.command {
         Commands::Init { name, admins } => {
             carry::init::execute(name, admins, repo_path, None, None).await?;
@@ -202,6 +221,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Join { token } => {
             carry::join_cmd::execute(&token, repo_path, None).await?;
         }
+    }
+
+    // Wait for the telemetry ping to finish (up to its 500ms timeout)
+    // so tokio doesn't cancel the spawned task on shutdown.
+    if let Some(handle) = telemetry_handle {
+        let _ = handle.await;
     }
 
     Ok(())

--- a/rust/carry/src/help.rs
+++ b/rust/carry/src/help.rs
@@ -41,6 +41,10 @@ META-SCHEMA:
   Domains starting with 'dialog.' are reserved for Dialog DB internals.
   Pre-registered concepts: attribute, concept, bookmark.";
 
+pub const TELEMETRY_NOTICE: &str = "\
+Anonymous usage telemetry is enabled to help improve carry. No IP addresses \
+or personal data are collected. Set DO_NOT_TRACK=1 to disable.";
+
 pub const MAIN_AFTER_HELP: &str = "\
 QUICK START:
   # Initialize a new repository
@@ -84,6 +88,11 @@ COMMON WORKFLOWS:
 
   # Pipe default YAML output (asserted notation also accepted)
   carry query com.app.person name age | carry assert -
+
+TELEMETRY:
+  Anonymous usage statistics are collected to help improve carry.
+  No IP addresses or personal data are collected.
+  Opt out: export DO_NOT_TRACK=1
 
 For detailed help on any command: carry help <command>";
 

--- a/rust/carry/src/init.rs
+++ b/rust/carry/src/init.rs
@@ -65,6 +65,8 @@ pub async fn execute(
         println!("Initialized repository in {}", dir_display);
     }
     eprintln!("Identity: {}", site.did());
+    eprintln!();
+    eprintln!("{}", crate::help::TELEMETRY_NOTICE);
 
     Ok(())
 }

--- a/rust/carry/src/lib.rs
+++ b/rust/carry/src/lib.rs
@@ -14,6 +14,7 @@ pub mod retract_cmd;
 pub mod site;
 pub mod status_cmd;
 pub mod target;
+pub mod telemetry;
 
 // ---------------------------------------------------------------------------
 // Retained internal library modules

--- a/rust/carry/src/telemetry.rs
+++ b/rust/carry/src/telemetry.rs
@@ -1,0 +1,104 @@
+//! Minimal, privacy-preserving usage telemetry.
+//!
+//! Sends an anonymous ping on each CLI invocation so we can count unique
+//! users and see which commands are used. The user's DID is hashed
+//! client-side (blake3 with a fixed salt) so neither the DID nor IP
+//! address reaches us in identifiable form.
+//!
+//! Opt out by setting the environment variable `DO_NOT_TRACK=1`.
+
+const DEFAULT_TELEMETRY_URL: &str = "https://carry-telemetry-service.tonk.workers.dev/ping";
+const SALT: &str = "carry-telemetry-v1";
+
+/// Resolve the telemetry endpoint. Reads `CARRY_TELEMETRY_URL` for testing,
+/// falls back to the production URL.
+fn telemetry_url() -> String {
+    std::env::var("CARRY_TELEMETRY_URL").unwrap_or_else(|_| DEFAULT_TELEMETRY_URL.to_string())
+}
+
+/// Derive a blinded, non-reversible user identifier from a DID.
+pub fn blinded_id(did: &str) -> String {
+    let hash = blake3::hash(format!("{SALT}:{did}").as_bytes());
+    hash.to_hex()[..16].to_string()
+}
+
+/// Fire-and-forget a telemetry ping. Returns a handle that should be
+/// awaited before the process exits (otherwise tokio may cancel it).
+/// Respects `DO_NOT_TRACK=1`.
+pub fn ping(did: &str, command: &str) -> Option<tokio::task::JoinHandle<()>> {
+    if std::env::var("DO_NOT_TRACK").unwrap_or_default() == "1" {
+        return None;
+    }
+    Some(ping_to(&telemetry_url(), did, command))
+}
+
+/// Fire-and-forget a telemetry ping to a specific URL.
+/// Exposed for testing; production code should use `ping()`.
+pub fn ping_to(url: &str, did: &str, command: &str) -> tokio::task::JoinHandle<()> {
+    let url = url.to_string();
+    let id = blinded_id(did);
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let command = command.to_string();
+
+    tokio::spawn(async move {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            send_ping(&url, &id, &command, &version),
+        )
+        .await;
+    })
+}
+
+async fn send_ping(
+    url: &str,
+    id: &str,
+    command: &str,
+    version: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::new();
+    client
+        .post(url)
+        .json(&serde_json::json!({
+            "id": id,
+            "command": command,
+            "version": version,
+        }))
+        .send()
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blinded_id_is_deterministic() {
+        let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+        let id1 = blinded_id(did);
+        let id2 = blinded_id(did);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn blinded_id_is_16_hex_chars() {
+        let id = blinded_id("did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD");
+        assert_eq!(id.len(), 16);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn blinded_id_differs_for_different_dids() {
+        let id1 = blinded_id("did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD");
+        let id2 = blinded_id("did:key:z6Mkf5rGMoatrSj1f4CyvuHqdjKN6pVpGGqruHMgfJBuRnQE");
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn blinded_id_does_not_contain_did() {
+        let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+        let id = blinded_id(did);
+        assert!(!did.contains(&id));
+        assert!(!id.contains("did:key"));
+    }
+}

--- a/rust/carry/tests/telemetry_integration.rs
+++ b/rust/carry/tests/telemetry_integration.rs
@@ -1,0 +1,205 @@
+//! Integration tests for the carry telemetry client.
+//!
+//! Uses the carry-telemetry-service test server to verify the full
+//! client-server round trip without any external dependencies.
+
+use carry_telemetry_service::helpers::TelemetryTestServer;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Blinded ID
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn blinded_id_is_deterministic() {
+    let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    assert_eq!(
+        carry::telemetry::blinded_id(did),
+        carry::telemetry::blinded_id(did)
+    );
+}
+
+#[test]
+fn blinded_id_is_hex_and_16_chars() {
+    let id =
+        carry::telemetry::blinded_id("did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD");
+    assert_eq!(id.len(), 16);
+    assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn different_dids_produce_different_ids() {
+    let id1 =
+        carry::telemetry::blinded_id("did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD");
+    let id2 =
+        carry::telemetry::blinded_id("did:key:z6Mkf5rGMoatrSj1f4CyvuHqdjKN6pVpGGqruHMgfJBuRnQE");
+    assert_ne!(id1, id2);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Client ping -> test server round trip
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn ping_reaches_server() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+
+    let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    let handle = carry::telemetry::ping_to(&ping_url, did, "query");
+    let _ = handle.await;
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 1);
+    assert_eq!(pings[0].id, carry::telemetry::blinded_id(did));
+    assert_eq!(pings[0].command, "query");
+    assert_eq!(pings[0].version, env!("CARGO_PKG_VERSION"));
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_sends_correct_blinded_id() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+
+    let did1 = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    let did2 = "did:key:z6Mkf5rGMoatrSj1f4CyvuHqdjKN6pVpGGqruHMgfJBuRnQE";
+
+    let h1 = carry::telemetry::ping_to(&ping_url, did1, "init");
+    let h2 = carry::telemetry::ping_to(&ping_url, did2, "query");
+    let _ = tokio::join!(h1, h2);
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 2);
+
+    let expected_id1 = carry::telemetry::blinded_id(did1);
+    let expected_id2 = carry::telemetry::blinded_id(did2);
+    assert_ne!(expected_id1, expected_id2);
+
+    // Pings may arrive in any order
+    let ids: std::collections::HashSet<String> = pings.iter().map(|p| p.id.clone()).collect();
+    assert!(ids.contains(&expected_id1));
+    assert!(ids.contains(&expected_id2));
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_does_not_contain_raw_did() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+
+    let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+    let handle = carry::telemetry::ping_to(&ping_url, did, "status");
+    let _ = handle.await;
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 1);
+
+    // The raw DID must not appear anywhere in the recorded data
+    assert!(!pings[0].id.contains("did:key"));
+    assert!(!pings[0].id.contains("z6Mk"));
+    assert!(!pings[0].command.contains("did:key"));
+    assert!(!pings[0].version.contains("did:key"));
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_sends_all_command_types() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+    let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+
+    let commands = [
+        "init", "query", "assert", "retract", "status", "identity", "invite", "join",
+    ];
+    let mut handles = Vec::new();
+    for cmd in &commands {
+        handles.push(carry::telemetry::ping_to(&ping_url, did, cmd));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), commands.len());
+
+    let recorded_commands: std::collections::HashSet<String> =
+        pings.iter().map(|p| p.command.clone()).collect();
+    for cmd in &commands {
+        assert!(
+            recorded_commands.contains(*cmd),
+            "Command '{}' should be recorded",
+            cmd
+        );
+    }
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn ping_silently_fails_on_unreachable_server() {
+    // Point at a server that doesn't exist -- should not panic or error
+    let handle = carry::telemetry::ping_to(
+        "http://127.0.0.1:1/ping",
+        "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD",
+        "query",
+    );
+
+    // Just verify it doesn't panic; the spawned task will fail silently
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn ping_includes_version() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+
+    let handle = carry::telemetry::ping_to(
+        &ping_url,
+        "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD",
+        "init",
+    );
+    let _ = handle.await;
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 1);
+    assert!(!pings[0].version.is_empty(), "Version should not be empty");
+    // Version should look like a semver string
+    assert!(
+        pings[0].version.contains('.'),
+        "Version '{}' should be semver-like",
+        pings[0].version
+    );
+
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn repeated_pings_same_did_produce_same_id() {
+    let server = TelemetryTestServer::start().await.unwrap();
+    let ping_url = format!("{}/ping", server.endpoint);
+    let did = "did:key:z6MkihEpYC9Q7Qx46UTkepj9WmvEFzn8Hymeb6BKH95ehSWD";
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        handles.push(carry::telemetry::ping_to(&ping_url, did, "query"));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let pings = server.recorded_pings().await;
+    assert_eq!(pings.len(), 5);
+
+    let expected_id = carry::telemetry::blinded_id(did);
+    for ping in &pings {
+        assert_eq!(
+            ping.id, expected_id,
+            "All pings from same DID should have same blinded ID"
+        );
+    }
+
+    server.stop().await;
+}

--- a/wrangler-telemetry.toml
+++ b/wrangler-telemetry.toml
@@ -1,0 +1,13 @@
+name = "carry-telemetry-service"
+account_id = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
+main = "./result-telemetry/worker/shim.mjs"
+compatibility_date = "2026-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+[build]
+command = "nix build --accept-flake-config .#carry-telemetry-service && chmod -R u+w result-telemetry 2>/dev/null; rm -rf result-telemetry && cp -rL result result-telemetry && rm -f result && chmod -R u+w result-telemetry"
+
+# Analytics Engine dataset binding
+[[analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "carry_telemetry"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a telemetry service for the `carry` CLI, enabling anonymous usage tracking to improve the application. It adds a new module for telemetry, modifies existing files to integrate telemetry functionality, and includes tests for the new features.

### Detailed summary
- Added `carry-telemetry-service` module for handling telemetry pings.
- Implemented telemetry features in `rust/carry/src/telemetry.rs`.
- Integrated telemetry into the CLI commands in `rust/carry/src/bin/carry.rs`.
- Updated `Cargo.toml` to include the new telemetry service and dependencies.
- Added telemetry notice in `rust/carry/src/help.rs`.
- Created tests for telemetry functionality in `rust/carry/tests/telemetry_integration.rs`.
- Implemented CORS handling and health check in the telemetry service.
- Added integration tests for the telemetry service in `rust/carry-telemetry-service/tests/telemetry_integration.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->