### PR TITLE
feat(carry): TON-2013: passkey-derived `Account` key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,8 +324,10 @@ name = "carry"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "base64",
  "blake3",
  "bs58",
+ "bytes",
  "carry-telemetry-service",
  "clap",
  "clap_complete",
@@ -342,6 +344,11 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures-util",
+ "getrandom 0.3.4",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "open",
  "reqwest",
  "serde",
  "serde_json",
@@ -1761,6 +1768,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_executable"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2127,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tonk-assess = { path = "./rust/tonk-assess" }
 
 # Common
 anyhow = "1"
+base64 = "0.22"
 blake3 = "1.5"
 bs58 = "0.5"
 bytes = "1"
@@ -30,9 +31,11 @@ clap_complete = { version = "4", features = ["unstable-dynamic"] }
 dirs = "5"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 futures-util = "0.3"
+getrandom = "0.3"
 http-body-util = "0.1"
-hyper = "1"
+hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = "0.1"
+open = "5"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls"

--- a/rust/carry/Cargo.toml
+++ b/rust/carry/Cargo.toml
@@ -42,11 +42,18 @@ dialog-varsig = { workspace = true }
 futures-util = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
+base64 = { workspace = true }
 blake3 = { workspace = true }
 bs58 = { workspace = true }
+bytes = { workspace = true }
 # Crypto
 ed25519-dalek = { workspace = true }
+getrandom = { workspace = true }
 
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true, features = ["tokio"] }
+open = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # Serialization

--- a/rust/carry/src/bin/carry.rs
+++ b/rust/carry/src/bin/carry.rs
@@ -241,12 +241,20 @@ async fn main() -> anyhow::Result<()> {
         Commands::Pull { .. } => "pull",
     };
 
-    // Best-effort telemetry: resolve identity for the blinded ID, but
-    // fall back silently if the profile doesn't exist yet.
-    let telemetry_handle = if let Ok(id) = carry::identity_cmd::ensure_identity(None).await {
-        carry::telemetry::ping(id.profile.did().as_ref(), command_name)
-    } else {
-        None
+    // Best-effort telemetry: load existing identity for the blinded ID,
+    // but fall back silently if no profile exists yet.
+    let telemetry_handle = {
+        use dialog_repository::profile::Profile;
+        use dialog_repository::storage::Storage;
+        let storage = Storage::new();
+        if let Ok(profile) = Profile::load(Storage::profile("carry"))
+            .perform(&storage)
+            .await
+        {
+            carry::telemetry::ping(profile.did().as_ref(), command_name)
+        } else {
+            None
+        }
     };
 
     match cli.command {

--- a/rust/carry/src/identity_cmd.rs
+++ b/rust/carry/src/identity_cmd.rs
@@ -1,23 +1,31 @@
 //! `carry identity` -- manage the local user identity.
 //!
-//! Identity is backed by a dialog-artifacts `Profile` which auto-generates
-//! and persists an Ed25519 keypair. The profile lives under the platform
-//! data directory via `Storage::profile("carry")`.
+//! Identity is derived from a passkey via WebAuthn PRF. On first use, the
+//! user authenticates with a passkey and the PRF output is used to
+//! deterministically derive an account key and a profile key. The profile
+//! credential is persisted so subsequent runs don't require the browser.
+//!
+//! The account key signs a UCAN delegation to the profile, enabling
+//! cross-device recovery: the same passkey on a new device produces the
+//! same account key, which can delegate to that device's profile.
 
+use crate::passkey;
 use anyhow::{Context, Result};
 use dialog_capability::storage::Location;
-use dialog_capability::{Capability, Subject};
+use dialog_capability::{Capability, Policy, Subject};
+use dialog_credentials::SignerCredential;
+use dialog_credentials::credential::Credential;
 use dialog_repository::profile::Profile;
-use dialog_repository::storage::Storage;
+use dialog_repository::storage::{LocationExt, Storage};
 use dialog_repository::{Operator, Remote};
 use dialog_storage::provider::Address;
+use dialog_ucan::DelegationChain;
+use dialog_ucan::delegation::builder::DelegationBuilder;
+use dialog_ucan::subject::Subject as UcanSubject;
+use dialog_varsig::{Did, Principal};
 
 /// A capability pointing to a profile's storage location.
 pub type ProfileLocation = Capability<Location<Address>>;
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 /// The trio that every command needs: profile identity, an operator
 /// environment, and the backing storage.
@@ -25,21 +33,31 @@ pub struct Identity {
     pub profile: Profile,
     pub operator: Operator,
     pub storage: Storage,
+    pub account_did: Option<Did>,
 }
 
-/// Ensure a local identity exists (creates on first use).
-/// Returns the Profile, Operator, and Storage.
+/// Ensure a local identity exists. On first use, runs the passkey WebAuthn
+/// flow to derive keys. Subsequent calls load the persisted profile.
 ///
 /// `location` controls where the profile is stored:
-/// - `None` -> platform data directory (`Storage::profile("carry")`)
-/// - `Some(loc)` -> custom location (e.g. `Storage::temp(...)` for tests)
+/// - `None` -> platform data directory, uses passkey-derived keys
+/// - `Some(loc)` -> custom location (e.g. for tests), uses auto-generated keys
 pub async fn ensure_identity(location: Option<ProfileLocation>) -> Result<Identity> {
     let storage = Storage::new();
+    let use_passkey = location.is_none();
     let profile_location = location.unwrap_or_else(|| Storage::profile("carry"));
-    let profile = Profile::open(profile_location)
-        .perform(&storage)
-        .await
-        .context("Failed to open carry profile")?;
+
+    let (profile, account_did) = if use_passkey {
+        ensure_passkey_identity(&storage, &profile_location).await?
+    } else {
+        // Test/custom path: auto-generate a random profile (no passkey).
+        let profile = Profile::open(profile_location.clone())
+            .perform(&storage)
+            .await
+            .context("Failed to open carry profile")?;
+        (profile, None)
+    };
+
     let operator = profile
         .derive(b"carry-cli")
         .allow(Subject::any())
@@ -47,51 +65,140 @@ pub async fn ensure_identity(location: Option<ProfileLocation>) -> Result<Identi
         .build(storage.clone())
         .await
         .context("Failed to build operator from profile")?;
+
     Ok(Identity {
         profile,
         operator,
         storage,
+        account_did,
     })
 }
 
-// ---------------------------------------------------------------------------
-// CLI execute
-// ---------------------------------------------------------------------------
+/// Passkey-based identity: load existing or derive from passkey ceremony.
+async fn ensure_passkey_identity(
+    storage: &Storage,
+    profile_location: &ProfileLocation,
+) -> Result<(Profile, Option<Did>)> {
+    // Try to load an existing profile.
+    if let Ok(profile) = Profile::load(profile_location.clone())
+        .perform(storage)
+        .await
+    {
+        let account_did = profile_data_dir()
+            .and_then(|dir| passkey::load_account_did(&dir))
+            .and_then(|s| s.parse::<Did>().ok());
+        return Ok((profile, account_did));
+    }
+
+    // No profile -- run passkey ceremony.
+    let profile_dir = profile_data_dir().context("Cannot determine profile data directory")?;
+
+    let credential_id = passkey::load_credential_id(&profile_dir);
+    let result = passkey::authenticate(credential_id.as_deref()).await?;
+
+    let derived = passkey::derive_identity(&result.prf_output).await?;
+    let account_did = derived.account_signer.did();
+
+    // Save the derived profile credential where Profile::load expects it.
+    save_derived_profile(storage, profile_location, &derived.profile_signer).await?;
+    let profile = Profile::load(profile_location.clone())
+        .perform(storage)
+        .await
+        .context("Failed to load newly created profile")?;
+
+    // Persist passkey metadata.
+    passkey::save_credential_id(&profile_dir, &result.credential_id)?;
+    passkey::save_account_did(&profile_dir, account_did.as_ref())?;
+
+    // Build a temporary operator to store the account->profile delegation.
+    let tmp_operator = profile
+        .derive(b"carry-cli")
+        .allow(Subject::any())
+        .network(Remote)
+        .build(storage.clone())
+        .await
+        .context("Failed to build operator for delegation setup")?;
+
+    create_account_delegation(&derived.account_signer, &profile, &tmp_operator).await?;
+
+    eprintln!("Identity created from passkey.");
+    eprintln!("  account:  {}", account_did);
+    eprintln!("  profile:  {}", profile.did());
+
+    Ok((profile, Some(account_did)))
+}
+
+/// Save a derived profile credential to the location dialog-db's Profile expects.
+async fn save_derived_profile(
+    storage: &Storage,
+    location: &ProfileLocation,
+    credential: &SignerCredential,
+) -> Result<()> {
+    let cred_location = location
+        .resolve("credential/profile")
+        .context("Failed to resolve credential path")?;
+
+    cred_location
+        .save(Credential::Signer(credential.clone()))
+        .perform(storage)
+        .await
+        .context("Failed to save derived profile credential")?;
+
+    let address = Location::of(location).address().clone();
+    dialog_capability::storage::Storage::mount(credential.did(), address)
+        .perform(storage)
+        .await
+        .context("Failed to mount profile DID")?;
+
+    Ok(())
+}
+
+/// Create a powerline UCAN delegation from account to profile.
+async fn create_account_delegation(
+    account_credential: &SignerCredential,
+    profile: &Profile,
+    operator: &Operator,
+) -> Result<()> {
+    let delegation = DelegationBuilder::new()
+        .issuer(account_credential.clone())
+        .audience(profile)
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await
+        .context("Failed to build account->profile delegation")?;
+
+    let chain = DelegationChain::new(delegation);
+    profile
+        .save(chain)
+        .perform(operator)
+        .await
+        .context("Failed to save account->profile delegation")?;
+
+    Ok(())
+}
 
 /// Execute `carry identity [--reset]`.
-///
-/// If `reset` is false and a profile exists, just print the DID.
-/// If `reset` is true, delete the stored profile and create a new one.
 pub async fn execute(reset: bool) -> Result<()> {
-    if reset {
-        // Delete the profile storage directory
-        let storage = Storage::new();
-        let profile_result = Profile::load(Storage::profile("carry"))
-            .perform(&storage)
-            .await;
-        if profile_result.is_ok() {
-            // Remove the profile data directory
-            if let Some(profile_dir) = profile_data_dir() {
-                match std::fs::remove_dir_all(&profile_dir) {
-                    Ok(()) => eprintln!("Profile reset."),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(e).context("Failed to remove profile data"),
-                }
-            }
+    if reset && let Some(profile_dir) = profile_data_dir() {
+        match std::fs::remove_dir_all(&profile_dir) {
+            Ok(()) => eprintln!("Profile reset."),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).context("Failed to remove profile data"),
         }
     }
 
     let id = ensure_identity(None).await?;
-    println!("{}", id.profile.did());
+
+    if let Some(account_did) = &id.account_did {
+        println!("account:  {}", account_did);
+    }
+    println!("profile:  {}", id.profile.did());
 
     Ok(())
 }
 
 /// Platform data directory for the carry profile.
-///
-/// `Storage::profile("carry")` resolves to `<data_dir>/dialog/carry`
-/// (the `dialog` prefix comes from the `profile://` scheme in
-/// `dialog-storage`).
 fn profile_data_dir() -> Option<std::path::PathBuf> {
     dirs::data_dir().map(|d| d.join("dialog").join("carry"))
 }

--- a/rust/carry/src/lib.rs
+++ b/rust/carry/src/lib.rs
@@ -9,6 +9,7 @@ pub mod identity_cmd;
 pub mod init;
 pub mod invite_cmd;
 pub mod join_cmd;
+pub mod passkey;
 pub mod pull_cmd;
 pub mod push_cmd;
 pub mod query_cmd;

--- a/rust/carry/src/passkey.rs
+++ b/rust/carry/src/passkey.rs
@@ -1,0 +1,292 @@
+//! Passkey-based identity derivation via WebAuthn PRF.
+//!
+//! Spins up a localhost HTTP server, opens the user's browser to perform a
+//! WebAuthn ceremony with the PRF extension, and derives deterministic
+//! Ed25519 keys from the PRF output.
+
+use anyhow::{Context, Result, bail};
+use dialog_credentials::{Ed25519Signer, SignerCredential};
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+const IDENTITY_PAGE: &str = include_str!("identity_page.html");
+
+/// Result of a successful passkey ceremony.
+pub struct PasskeyResult {
+    /// The raw 32-byte PRF output.
+    pub prf_output: [u8; 32],
+    /// The WebAuthn credential ID (base64url-encoded) for future authentication.
+    pub credential_id: String,
+}
+
+/// Keys derived from a passkey PRF output.
+pub struct DerivedIdentity {
+    pub account_signer: SignerCredential,
+    pub profile_signer: SignerCredential,
+}
+
+/// Derive account and profile signers from a PRF output.
+///
+/// Uses blake3 key derivation with distinct context strings so the same
+/// PRF output yields two independent Ed25519 keys.
+pub async fn derive_identity(prf_output: &[u8; 32]) -> Result<DerivedIdentity> {
+    let account_seed = blake3::derive_key("carry account v1", prf_output);
+    let profile_seed = blake3::derive_key("carry profile v1", prf_output);
+
+    let account_signer = Ed25519Signer::import(&account_seed)
+        .await
+        .context("Failed to derive account key from PRF output")?;
+    let profile_signer = Ed25519Signer::import(&profile_seed)
+        .await
+        .context("Failed to derive profile key from PRF output")?;
+
+    Ok(DerivedIdentity {
+        account_signer: SignerCredential::from(account_signer),
+        profile_signer: SignerCredential::from(profile_signer),
+    })
+}
+
+/// Run the passkey WebAuthn ceremony via a local browser.
+///
+/// If `credential_id` is `Some`, uses the authentication flow (returning user).
+/// Otherwise uses the registration flow (new passkey).
+pub async fn authenticate(credential_id: Option<&str>) -> Result<PasskeyResult> {
+    let (tx, rx) = oneshot::channel::<Result<CallbackPayload>>();
+    let tx = Arc::new(tokio::sync::Mutex::new(Some(tx)));
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("Failed to bind local server")?;
+    let addr = listener.local_addr()?;
+
+    let session = Arc::new(Session {
+        credential_id: credential_id.map(String::from),
+    });
+
+    let server_handle = tokio::spawn({
+        let tx = tx.clone();
+        let session = session.clone();
+        async move {
+            // Accept connections until the callback is received.
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(_) => break,
+                };
+                let tx = tx.clone();
+                let session = session.clone();
+                tokio::spawn(async move {
+                    let service = service_fn(move |req| {
+                        let tx = tx.clone();
+                        let session = session.clone();
+                        async move { handle_request(req, &session, tx).await }
+                    });
+                    let _ = http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        }
+    });
+
+    let url = format!("http://localhost:{}", addr.port());
+    eprintln!("Opening browser for passkey authentication...");
+    eprintln!("If the browser doesn't open, visit: {}", url);
+
+    if open::that(&url).is_err() {
+        eprintln!("Could not open browser automatically.");
+    }
+
+    let payload = tokio::time::timeout(std::time::Duration::from_secs(300), rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("Passkey ceremony timed out after 5 minutes"))?
+        .context("Passkey server shut down unexpectedly")?
+        .context("Passkey authentication failed")?;
+
+    server_handle.abort();
+
+    let prf_bytes =
+        base64url_decode(&payload.prf_output).context("Invalid base64url in PRF output")?;
+
+    if prf_bytes.len() != 32 {
+        bail!("PRF output is {} bytes, expected 32", prf_bytes.len());
+    }
+
+    let mut prf_output = [0u8; 32];
+    prf_output.copy_from_slice(&prf_bytes);
+
+    Ok(PasskeyResult {
+        prf_output,
+        credential_id: payload.credential_id,
+    })
+}
+
+/// Load a stored passkey credential ID from the profile directory.
+pub fn load_credential_id(profile_dir: &Path) -> Option<String> {
+    let path = profile_dir.join("passkey");
+    std::fs::read_to_string(&path).ok()
+}
+
+/// Save a passkey credential ID to the profile directory.
+pub fn save_credential_id(profile_dir: &Path, credential_id: &str) -> Result<()> {
+    std::fs::create_dir_all(profile_dir)
+        .with_context(|| format!("Failed to create {}", profile_dir.display()))?;
+    std::fs::write(profile_dir.join("passkey"), credential_id)
+        .context("Failed to save passkey credential ID")
+}
+
+/// Save the account DID string to the profile directory.
+pub fn save_account_did(profile_dir: &Path, account_did: &str) -> Result<()> {
+    std::fs::create_dir_all(profile_dir)
+        .with_context(|| format!("Failed to create {}", profile_dir.display()))?;
+    std::fs::write(profile_dir.join("account-did"), account_did)
+        .context("Failed to save account DID")
+}
+
+/// Load a stored account DID from the profile directory.
+pub fn load_account_did(profile_dir: &Path) -> Option<String> {
+    let path = profile_dir.join("account-did");
+    std::fs::read_to_string(&path).ok()
+}
+
+struct Session {
+    credential_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CallbackPayload {
+    credential_id: String,
+    prf_output: String,
+    #[allow(dead_code)]
+    phase: String,
+}
+
+#[derive(Deserialize)]
+struct CallbackError {
+    error: String,
+}
+
+#[derive(Serialize)]
+struct InfoResponseAuth {
+    credential_id: String,
+}
+
+#[derive(Serialize)]
+struct InfoResponseRegister {
+    rp_id: String,
+    user_id: String,
+    challenge: String,
+}
+
+type BoxBody = Full<bytes::Bytes>;
+type HyperResponse = Response<BoxBody>;
+
+fn json_response(status: StatusCode, body: &impl Serialize) -> Result<HyperResponse, hyper::Error> {
+    let json = serde_json::to_string(body).unwrap();
+    Ok(Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json")
+        .body(Full::new(bytes::Bytes::from(json)))
+        .unwrap())
+}
+
+fn text_response(status: StatusCode, text: &str) -> Result<HyperResponse, hyper::Error> {
+    Ok(Response::builder()
+        .status(status)
+        .header("Content-Type", "text/plain")
+        .body(Full::new(bytes::Bytes::from(text.to_string())))
+        .unwrap())
+}
+
+fn html_response(html: &str) -> Result<HyperResponse, hyper::Error> {
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "text/html; charset=utf-8")
+        .body(Full::new(bytes::Bytes::from(html.to_string())))
+        .unwrap())
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    session: &Session,
+    tx: Arc<tokio::sync::Mutex<Option<oneshot::Sender<Result<CallbackPayload>>>>>,
+) -> Result<HyperResponse, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/") => html_response(IDENTITY_PAGE),
+
+        (&Method::GET, "/info") => {
+            if let Some(ref cred_id) = session.credential_id {
+                json_response(
+                    StatusCode::OK,
+                    &InfoResponseAuth {
+                        credential_id: cred_id.clone(),
+                    },
+                )
+            } else {
+                let mut user_id = [0u8; 32];
+                getrandom::fill(&mut user_id).unwrap();
+                let mut challenge = [0u8; 32];
+                getrandom::fill(&mut challenge).unwrap();
+
+                json_response(
+                    StatusCode::OK,
+                    &InfoResponseRegister {
+                        rp_id: "localhost".to_string(),
+                        user_id: base64url_encode(&user_id),
+                        challenge: base64url_encode(&challenge),
+                    },
+                )
+            }
+        }
+
+        (&Method::POST, "/callback") => {
+            use http_body_util::BodyExt;
+            let body = req.into_body().collect().await.unwrap().to_bytes();
+            let body_str = String::from_utf8_lossy(&body);
+
+            // Check if this is an error response
+            if let Ok(err) = serde_json::from_str::<CallbackError>(&body_str) {
+                if let Some(tx) = tx.lock().await.take() {
+                    let _ = tx.send(Err(anyhow::anyhow!("Passkey error: {}", err.error)));
+                }
+                return text_response(StatusCode::OK, "error received");
+            }
+
+            match serde_json::from_str::<CallbackPayload>(&body_str) {
+                Ok(payload) => {
+                    if let Some(tx) = tx.lock().await.take() {
+                        let _ = tx.send(Ok(payload));
+                    }
+                    text_response(StatusCode::OK, "ok")
+                }
+                Err(e) => text_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid callback payload: {}", e),
+                ),
+            }
+        }
+
+        _ => text_response(StatusCode::NOT_FOUND, "not found"),
+    }
+}
+
+fn base64url_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn base64url_decode(s: &str) -> Result<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s)
+        .context("base64url decode failed")
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `passkey` module for deriving identities using WebAuthn passkeys, enhances identity management, and updates dependencies in the `Cargo.toml` files.

### Detailed summary
- Added `passkey` module for passkey-based identity derivation.
- Updated `ensure_identity` to support passkey authentication.
- Enhanced telemetry handling in `carry.rs` using profiles.
- Updated dependencies in `Cargo.toml` and `Cargo.lock`.
- Added functions for saving and loading passkey credentials and account DIDs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->