### PR TITLE
feat(invite): shared invite URL and claim orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -176,9 +176,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -323,22 +323,22 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -381,10 +381,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecheck"
@@ -447,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -490,13 +499,13 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
- "core2",
  "multibase",
  "multihash",
+ "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -504,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -555,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.19"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "convert_case 0.6.0",
  "pathdiff",
@@ -602,11 +611,12 @@ checksum = "b0664d2867b4a32697dfe655557f5c3b187e9b605b38612a748e5ec99811d160"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -643,18 +653,18 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -697,19 +707,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -802,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -922,18 +932,18 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -960,7 +970,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "leb128",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
@@ -1005,7 +1015,7 @@ dependencies = [
  "dialog-macros",
  "futures-util",
  "getrandom 0.2.17",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_bytes",
@@ -1090,7 +1100,7 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
@@ -1117,7 +1127,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "nonempty",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -1167,7 +1177,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "md5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.12.28",
  "s3s",
  "serde",
@@ -1277,7 +1287,7 @@ dependencies = [
  "js-sys",
  "parking_lot",
  "pidlock",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rexie",
  "s3s",
  "serde",
@@ -1473,9 +1483,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "either_of"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216d23e0ec69759a17f05e1c553f3a6870e5ec73420fbb07807a6f34d5d1d5a4"
+checksum = "5060e0a4cbf26a87550792688ade88e6b8aec9208613631a7a363bda7bc2d4cd"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -1529,7 +1539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1555,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1729,21 +1739,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1853,6 +1863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,9 +1958,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -1965,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1980,7 +1996,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1988,15 +2003,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2054,12 +2068,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2067,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2080,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2094,15 +2109,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2114,15 +2129,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2183,12 +2198,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2201,9 +2216,9 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "ipld-core"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
+checksum = "090f624976d72f0b0bb71b86d58dc16c15e069193067cb3a3a09d655246cbbda"
 dependencies = [
  "cid",
  "serde",
@@ -2212,15 +2227,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2237,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -2250,7 +2265,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2259,9 +2274,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2296,6 +2333,21 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -2347,8 +2399,8 @@ dependencies = [
  "tachys",
  "thiserror 2.0.18",
  "throw_error",
- "typed-builder 0.23.2",
- "typed-builder-macro 0.23.2",
+ "typed-builder",
+ "typed-builder-macro",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_split_helpers",
@@ -2382,22 +2434,22 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071fc40aeb9fcab885965bad1887990477253ad51f926cd19068f45a44c59e89"
+checksum = "0c06f751315bccc0d193fab302ac01d25bcfcd97474d4676440e7e3250dc3fc3"
 dependencies = [
  "config",
  "regex",
  "serde",
  "thiserror 2.0.18",
- "typed-builder 0.21.2",
+ "typed-builder",
 ]
 
 [[package]]
 name = "leptos_dom"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f4330c88694c5575e0bfe4eecf81b045d14e76a4f8b00d5fd2a63f8779f895"
+checksum = "35742e9ed8f8aaf9e549b454c68a7ac0992536e06856365639b111f72ab07884"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -2410,14 +2462,14 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d61ec3e1ff8aaee8c5151688550c0363f85bc37845450764c31ff7584a33f38"
+checksum = "9d2a0f220c8a5ef3c51199dfb9cdd702bc0eb80d52fbe70c7890adfaaae8a4b1"
 dependencies = [
  "anyhow",
  "camino",
  "indexmap",
- "parking_lot",
+ "or_poisoned",
  "proc-macro2",
  "quote",
  "rstml",
@@ -2507,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libm"
@@ -2519,31 +2571,24 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
-name = "linear-map"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2658,9 +2703,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2681,11 +2726,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "serde",
  "unsigned-varint",
 ]
@@ -2715,6 +2760,15 @@ name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -2759,14 +2813,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -2796,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -2920,18 +2974,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2943,12 +2997,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -2968,9 +3016,9 @@ checksum = "4c2749dcd0984ec1be3c01001bb1d83623a58c3c0049a99b9afec61464fa98e7"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3116,15 +3164,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3152,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3188,6 +3236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3209,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3257,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f0df355582937223ea403e52490201d65295bd6981383c69bfae5a1f8730c2"
+checksum = "00c5a025366836190c7030e883cc2bcd9e384ff555336e3c7954741ca411b177"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -3281,12 +3335,12 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores"
-version = "0.3.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35372f05664a62a3dd389503371a15b8feb3396f99f6ec000de651fddb030942"
+checksum = "c30fd35b7d299c591293bb69fed47a703eb2703b1cff0493e78b16ed007e5382"
 dependencies = [
- "dashmap",
  "guardian",
+ "indexmap",
  "itertools",
  "or_poisoned",
  "paste",
@@ -3298,11 +3352,11 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.2.6"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa40919eb2975100283b2a70e68eafce1e8bcf81f0622ff168e4c2b3f8d46bb"
+checksum = "e5d8e790a5ae5ddf9b7fa380c728375b06858e0cca7d063a73b3408320c523e1"
 dependencies = [
- "convert_case 0.8.0",
+ "convert_case 0.11.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -3354,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -3527,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3542,22 +3596,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3608,7 +3662,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3619,9 +3673,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3704,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3733,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -3746,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3756,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
@@ -3900,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3954,12 +4008,12 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950b8cfc9ff5f39ca879c5a7c5e640de2695a199e18e424c3289d0964cabe642"
+checksum = "1295b54815397d30d986b63f93cfd515fa86d5e528e0bb589ce9d530502f9e0f"
 dependencies = [
  "const_format",
- "convert_case 0.8.0",
+ "convert_case 0.11.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3984,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.2",
 ]
 
@@ -3995,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4006,7 +4060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.2",
 ]
 
@@ -4061,9 +4115,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -4130,9 +4184,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4194,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b2db11e455f7e84e2cc3e76f8a3f3843f7956096265d5ecff781eabe235077"
+checksum = "2989c94c59db8497727875aa561d4d0daa3cc79b5774d5ced48263f7091beff1"
 dependencies = [
  "any_spawner",
  "async-trait",
@@ -4209,11 +4263,9 @@ dependencies = [
  "indexmap",
  "itertools",
  "js-sys",
- "linear-map",
  "next_tuple",
  "oco_ref",
  "or_poisoned",
- "parking_lot",
  "paste",
  "reactive_graph",
  "reactive_stores",
@@ -4236,7 +4288,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4360,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -4371,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4386,9 +4438,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4401,9 +4453,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4457,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
  "serde_spanned",
@@ -4470,18 +4522,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -4508,7 +4560,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.2.17",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -4535,6 +4587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonk-invite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "dialog-credentials",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "tokio",
+ "url",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "tonk-ui"
 version = "0.1.0"
 dependencies = [
@@ -4544,13 +4610,13 @@ dependencies = [
  "dialog-common",
  "futures-util",
  "getrandom 0.3.4",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "leptos",
  "leptos-use",
  "leptos_router",
  "port_check",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -4590,7 +4656,7 @@ dependencies = [
  "dialog-varsig",
  "futures-util",
  "getrandom 0.3.4",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde",
  "serde_json",
@@ -4702,31 +4768,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-builder"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
-dependencies = [
- "typed-builder-macro 0.21.2",
-]
-
-[[package]]
-name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
 dependencies = [
- "typed-builder-macro 0.23.2",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "typed-builder-macro",
 ]
 
 [[package]]
@@ -4766,15 +4812,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -4827,11 +4873,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5026,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_helpers"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a114b3073258dd5de3d812cdd048cca6842342755e828a14dbf15f843f2d1b84"
+checksum = "d0cb6d1008be3c4c5abc31a407bfb8c8449ae14efc8561c1db821f79b9614b0a"
 dependencies = [
  "async-once-cell",
  "wasm_split_macros",
@@ -5036,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56481f8ed1a9f9ae97ea7b08a5e2b12e8adf9a7818a6ba952b918e09c7be8bf0"
+checksum = "d0a659ffe5c7f4538aa6357c07e3d73221cc61eba03bd9a081e14bc91ed09b8c"
 dependencies = [
  "base16",
  "quote",
@@ -5080,18 +5126,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5102,7 +5148,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5465,9 +5511,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -5620,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
@@ -5638,9 +5684,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5649,9 +5695,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5661,18 +5707,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5681,18 +5727,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5708,9 +5754,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5719,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -5731,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5742,6 +5788,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,7 +4592,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bs58",
+ "dialog-capability",
  "dialog-credentials",
+ "dialog-ucan",
  "dialog-ucan-core",
  "dialog-varsig",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "anyhow",
  "bs58",
  "dialog-capability",
+ "dialog-common",
  "dialog-credentials",
  "dialog-ucan",
  "dialog-ucan-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "rust/tonk-access-service",
     "rust/tonk-common",
+    "rust/tonk-invite",
     "rust/tonk-ui",
     "rust/tonk-worker",
 ]
@@ -17,6 +18,7 @@ edition = "2024"
 [workspace.dependencies]
 tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-common = { path = "./rust/tonk-common" }
+tonk-invite = { path = "./rust/tonk-invite" }
 tonk-ui = { path = "./rust/tonk-ui" }
 tonk-worker = { path = "./rust/tonk-worker" }
 

--- a/rust/tonk-invite/Cargo.toml
+++ b/rust/tonk-invite/Cargo.toml
@@ -9,7 +9,9 @@ description = "Tonk invite URL format and claim orchestration, shared by CLI and
 [dependencies]
 anyhow = { workspace = true }
 bs58 = { workspace = true }
+dialog-capability = { workspace = true }
 dialog-credentials = { workspace = true }
+dialog-ucan = { workspace = true }
 dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }
 url = { workspace = true }

--- a/rust/tonk-invite/Cargo.toml
+++ b/rust/tonk-invite/Cargo.toml
@@ -16,8 +16,14 @@ dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }
 url = { workspace = true }
 
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
-
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(dialog_test_native_integration)',
+    'cfg(dialog_test_wasm_integration)',
+    'cfg(feature, values("web-integration-tests"))',
+] }

--- a/rust/tonk-invite/Cargo.toml
+++ b/rust/tonk-invite/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tonk-invite"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Tonk invite URL format and claim orchestration, shared by CLI and web clients."
+
+[dependencies]
+anyhow = { workspace = true }
+bs58 = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-varsig = { workspace = true }
+url = { workspace = true }
+
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -286,7 +286,7 @@ impl Invite {
                 let chain_audience = self.chain.audience();
                 anyhow::ensure!(
                     *chain_audience == *audience,
-                    "this scoped invite was issued to {}, but the redeemer is {}; \
+                    "this invite is for {} and cannot be redeemed by {}; \
                      ask the inviter to issue a new invite for your DID, \
                      or switch to the identity the invite was issued to",
                     chain_audience,
@@ -312,7 +312,16 @@ impl From<Invite> for UcanProof {
 }
 
 /// Outcome of [`Invite::claim`]: a delegation chain ready to be persisted
-/// by the caller, plus metadata carried over from the invite.
+/// by the caller, paired with the invite's sync remote.
+///
+/// We return this wrapper rather than a bare [`DelegationChain`] so that
+/// the `Subject::Specific` invariant validated at [`Invite`] construction
+/// carries through to [`ClaimedInvite::subject`] without re-checking, and
+/// so `remote_url` threads through to callers that want to persist sync
+/// config alongside the chain.
+///
+/// `#[non_exhaustive]` reserves room to grow additional carry-over fields
+/// (e.g. capability metadata) without a breaking change.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ClaimedInvite {
@@ -341,7 +350,7 @@ mod tests {
     use dialog_varsig::principal::Principal;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test_configure!(run_in_browser);
@@ -374,33 +383,26 @@ mod tests {
         Ed25519Signer::import(seed).await.unwrap()
     }
 
-    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    fn parse_rejects_non_url_input() {
+    #[dialog_common::test]
+    fn it_rejects_non_url_input() {
         let err = Invite::parse_url("not a url").unwrap_err();
         assert!(err.to_string().contains("not a valid URL"), "{err}");
     }
 
-    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    fn parse_rejects_missing_access_parameter() {
+    #[dialog_common::test]
+    fn it_rejects_missing_access_parameter() {
         let err = Invite::parse_url("https://tonk.xyz/join").unwrap_err();
         assert!(err.to_string().contains("`access`"), "{err}");
     }
 
-    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    fn parse_rejects_invalid_base58_in_access() {
+    #[dialog_common::test]
+    fn it_rejects_invalid_base58_in_access() {
         let err = Invite::parse_url("https://tonk.xyz/join?access=!!!not-b58!!!").unwrap_err();
         assert!(err.to_string().contains("valid base58"), "{err}");
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn parse_rejects_wrong_length_fragment() {
+    #[dialog_common::test]
+    async fn it_rejects_wrong_length_fragment() {
         let subject = signer(&SUBJECT_SEED).await.did();
         let audience = signer(&AUDIENCE_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
@@ -419,12 +421,8 @@ mod tests {
         );
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn build_and_parse_round_trip() {
+    #[dialog_common::test]
+    async fn it_round_trips_through_url() {
         let subject = signer(&SUBJECT_SEED).await.did();
         let audience = signer(&AUDIENCE_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
@@ -458,12 +456,8 @@ mod tests {
         assert!(decoded.remote_url.is_none());
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn claim_scoped_rejects_wrong_audience() {
+    #[dialog_common::test]
+    async fn it_rejects_scoped_claim_by_wrong_audience() {
         let subject = signer(&SUBJECT_SEED).await.did();
         let issued_to = signer(&AUDIENCE_SEED).await.did();
         let wrong_redeemer = signer(&EPHEMERAL_SEED).await.did();
@@ -471,15 +465,11 @@ mod tests {
         let invite = Invite::new(chain, InviteAudience::Scoped, None).unwrap();
 
         let err = invite.claim(&wrong_redeemer).await.unwrap_err();
-        assert!(err.to_string().contains("scoped invite"), "{err}");
+        assert!(err.to_string().contains("cannot be redeemed"), "{err}");
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn claim_scoped_accepts_matching_audience() {
+    #[dialog_common::test]
+    async fn it_accepts_scoped_claim_by_matching_audience() {
         let subject = signer(&SUBJECT_SEED).await.did();
         let audience = signer(&AUDIENCE_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
@@ -490,12 +480,8 @@ mod tests {
         assert_eq!(*claimed.chain.audience(), audience);
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn claim_open_invite_extends_chain_to_redeemer() {
+    #[dialog_common::test]
+    async fn it_extends_chain_to_redeemer_when_claiming_open_invite() {
         // Setup: a chain `issuer -> ephemeral_key`, scoped to a specific repo.
         // The invite carries the ephemeral seed; anyone can claim it.
         let subject = signer(&SUBJECT_SEED).await.did();
@@ -531,12 +517,8 @@ mod tests {
         );
     }
 
-    #[cfg_attr(
-        not(all(target_arch = "wasm32", target_os = "unknown")),
-        tokio::test(flavor = "current_thread")
-    )]
-    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
-    async fn claim_from_url_round_trip() {
+    #[dialog_common::test]
+    async fn it_claims_invite_parsed_from_url() {
         // End-to-end: an open invite minted by one client, serialized to a
         // URL, and claimed by another via parse_url + claim.
         let subject = signer(&SUBJECT_SEED).await.did();

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -1,0 +1,476 @@
+#![warn(missing_docs)]
+
+//! Tonk invite URL format and claim orchestration.
+//!
+//! This crate builds on `dialog-{credentials, ucan-core, varsig}` only and
+//! compiles for both native and WASM targets. Both the `carry` CLI and the
+//! `tonk-ui` web client depend on it so that invite URLs issued by one are
+//! redeemable by the other.
+//!
+//! ## URL format
+//!
+//! ```text
+//! <base>?access=<base58-ucan-chain>[&remote=<access-service-url>][#<base58-seed>]
+//! ```
+//!
+//! - `access`: base58-encoded [`DelegationChain`] bytes. The chain's subject
+//!   must be [`Subject::Specific`]; chains with [`Subject::Any`] are rejected
+//!   because an invite must always scope to a specific repository.
+//! - `remote` (optional): UCAN access service endpoint for sync.
+//! - `#fragment` (optional): base58 of a 32-byte Ed25519 seed. Presence marks
+//!   the invite as **audience-open** — any redeemer can claim it by
+//!   redelegating from the embedded ephemeral key. Absence marks it as
+//!   **audience-scoped** — only the chain's recorded audience DID can claim.
+//!
+//! The open/scoped distinction is the *audience* axis. The *subject* axis is
+//! always scoped to a specific repo — orthogonal and non-negotiable.
+//!
+//! [`Subject::Specific`]: dialog_ucan_core::subject::Subject::Specific
+//! [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
+
+use anyhow::{Context, Result};
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+use dialog_varsig::Did;
+use url::Url;
+
+/// Default base URL for invite links. Used when no override is
+/// provided. Changing this value is a breaking change for any outstanding
+/// invite URLs that embed it.
+pub const DEFAULT_BASE_URL: &str = "https://tonk.xyz/join";
+
+/// Length in bytes of the Ed25519 seed embedded in the URL fragment for
+/// audience-open invites.
+const SEED_LEN: usize = 32;
+
+/// Ed25519 seed for the ephemeral key in an audience-open invite.
+pub type EphemeralSeed = [u8; SEED_LEN];
+
+/// Audience dimension of an invite.
+///
+/// This is orthogonal to the subject dimension (which is always a specific
+/// repo). See the [crate-level documentation][crate] for the full model.
+#[derive(Debug)]
+pub enum InviteAudience {
+    /// Any redeemer can claim, by redelegating from the ephemeral key whose
+    /// seed is embedded in the URL fragment.
+    Open {
+        /// Ed25519 seed for the ephemeral key; matches the chain's audience DID.
+        seed: EphemeralSeed,
+    },
+    /// Only the chain's recorded audience DID can claim; no redelegation.
+    Scoped,
+}
+
+/// Decoded components of an invite URL.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct DecodedInvite {
+    /// Delegation chain granting access to `subject`.
+    pub chain: DelegationChain,
+    /// Repo subject DID.
+    pub subject: Did,
+    /// Whether the invite is open to any redeemer or scoped to one DID.
+    pub audience: InviteAudience,
+    /// Access service URL for sync, if included via `&remote=`.
+    pub remote_url: Option<Url>,
+}
+
+/// Outcome of [`claim`]: a delegation chain ready to be persisted by the
+/// caller, plus metadata about the invite.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ClaimedInvite {
+    /// Final delegation chain terminating at the redeemer's DID.
+    pub chain: DelegationChain,
+    /// Repo subject DID (always `Subject::Specific`).
+    pub subject: Did,
+    /// Access service URL for sync, if the invite included one.
+    pub remote_url: Option<Url>,
+}
+
+/// Parse an invite URL into its components.
+///
+/// Validates that the URL is syntactically a URL, that `access` is present
+/// and decodes to a [`DelegationChain`] with a specific subject, and — if a
+/// fragment is present — that it decodes to exactly [`SEED_LEN`] bytes.
+///
+/// # Errors
+///
+/// Returns an error if the string is not a valid URL, if the `access` query
+/// parameter is missing or not valid base58, if the decoded chain fails to
+/// parse or has no specific subject ([`Subject::Any`] is rejected), if the
+/// `remote` parameter is present but not a valid URL, or if the fragment is
+/// present but does not decode to exactly 32 bytes of base58.
+///
+/// [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
+pub fn parse_invite_url(url: &str) -> Result<DecodedInvite> {
+    let parsed = Url::parse(url).context("invite URL is not a valid URL")?;
+
+    let mut access: Option<String> = None;
+    let mut remote_url: Option<Url> = None;
+    for (key, value) in parsed.query_pairs() {
+        match key.as_ref() {
+            "access" => access = Some(value.into_owned()),
+            "remote" => {
+                let r =
+                    Url::parse(&value).context("invite `remote` parameter is not a valid URL")?;
+                remote_url = Some(r);
+            }
+            _ => {}
+        }
+    }
+    let access = access.context("invite URL is missing the `access` query parameter")?;
+
+    let chain_bytes = bs58::decode(&access)
+        .into_vec()
+        .context("invite `access` parameter is not valid base58")?;
+    let chain = DelegationChain::try_from(chain_bytes.as_slice()).with_context(|| {
+        format!(
+            "invite `access` parameter did not decode to a valid delegation chain ({} bytes)",
+            chain_bytes.len()
+        )
+    })?;
+    let subject = chain.subject().cloned().context(
+        "invite delegation chain must target a specific repo subject; \
+         chains with Subject::Any are not valid invites",
+    )?;
+
+    let audience = match parsed.fragment() {
+        Some(frag) => {
+            let bytes = bs58::decode(frag).into_vec().context(
+                "invite URL fragment is not valid base58 \
+                 (expected a 32-byte Ed25519 seed)",
+            )?;
+            let seed: EphemeralSeed = bytes.as_slice().try_into().map_err(|_| {
+                anyhow::anyhow!(
+                    "invite URL fragment must decode to exactly {} bytes, got {}",
+                    SEED_LEN,
+                    bytes.len()
+                )
+            })?;
+            InviteAudience::Open { seed }
+        }
+        None => InviteAudience::Scoped,
+    };
+
+    Ok(DecodedInvite {
+        chain,
+        subject,
+        audience,
+        remote_url,
+    })
+}
+
+/// Build an invite URL from a delegation chain and optional components.
+///
+/// `base_url` must parse as a URL and must not already carry a query string
+/// or fragment — those slots are reserved for invite data.
+///
+/// # Errors
+///
+/// Returns an error if the base URL is malformed, if it already has a query
+/// or fragment, or if the delegation chain fails to serialize.
+pub fn build_invite_url(
+    base_url: &str,
+    chain: &DelegationChain,
+    remote_url: Option<&Url>,
+    secret_seed: Option<&EphemeralSeed>,
+) -> Result<String> {
+    let chain_bytes = chain
+        .to_bytes()
+        .context("failed to serialize delegation chain")?;
+    let access = bs58::encode(&chain_bytes).into_string();
+
+    let mut url = Url::parse(base_url).context("invite base URL is not a valid URL")?;
+    anyhow::ensure!(
+        url.query().is_none(),
+        "invite base URL must not already contain a query string"
+    );
+    anyhow::ensure!(
+        url.fragment().is_none(),
+        "invite base URL must not already contain a fragment"
+    );
+
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("access", &access);
+        if let Some(remote) = remote_url {
+            pairs.append_pair("remote", remote.as_str());
+        }
+    }
+
+    if let Some(seed) = secret_seed {
+        url.set_fragment(Some(&bs58::encode(seed.as_ref()).into_string()));
+    }
+
+    Ok(url.into())
+}
+
+/// Redelegate from an ephemeral key to a target DID.
+///
+/// Takes an existing delegation chain (whose audience is the ephemeral key's
+/// DID and whose subject is a specific repo) and extends it with a new
+/// delegation from the ephemeral key to `audience`, preserving the subject.
+///
+/// # Errors
+///
+/// Returns an error if the chain has no specific subject (tonk invites must
+/// always scope to a specific repo — [`Subject::Any`] is never minted), if
+/// the ephemeral key cannot be imported from the seed, if the redelegation
+/// cannot be built, or if the new delegation cannot be appended to the chain
+/// (e.g. because the chain's tail audience does not match the ephemeral key's
+/// DID).
+///
+/// [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
+pub async fn redelegate(
+    chain: DelegationChain,
+    ephemeral_seed: &EphemeralSeed,
+    audience: &Did,
+) -> Result<DelegationChain> {
+    let subject = chain.subject().cloned().context(
+        "refusing to redelegate a chain with no specific subject; \
+         invites must always target a specific repo (Subject::Any is rejected)",
+    )?;
+
+    let ephemeral = Ed25519Signer::import(ephemeral_seed)
+        .await
+        .context("failed to import ephemeral key from seed")?;
+
+    let delegation = DelegationBuilder::new()
+        .issuer(ephemeral)
+        .audience(audience)
+        .subject(UcanSubject::Specific(subject))
+        .command(vec![])
+        .try_build()
+        .await
+        .context("failed to build redelegation")?;
+
+    chain
+        .push(delegation)
+        .context("failed to extend delegation chain with redelegation")
+}
+
+/// Redeem an invite URL on behalf of `audience`, returning a delegation
+/// chain ready to persist.
+///
+/// - **Audience-open** (URL fragment present): redelegates from the ephemeral
+///   key embedded in the fragment to `audience`, producing an extended chain.
+/// - **Audience-scoped** (no fragment): verifies the chain's existing
+///   audience matches `audience` and returns it as-is.
+///
+/// Persistence of the returned chain, and configuration of any `remote_url`
+/// for sync, are the caller's responsibility — see `carry`'s `claim` command
+/// for a native reference implementation and `tonk-ui`'s invite flow for a
+/// WASM one.
+///
+/// # Errors
+///
+/// Returns an error from [`parse_invite_url`] if the URL is malformed, from
+/// [`redelegate`] if an open invite fails to extend, or a bespoke error if a
+/// scoped invite's recorded audience does not match `audience`.
+pub async fn claim(url: &str, audience: &Did) -> Result<ClaimedInvite> {
+    let decoded = parse_invite_url(url)?;
+
+    let chain = match decoded.audience {
+        InviteAudience::Open { seed } => redelegate(decoded.chain, &seed, audience).await?,
+        InviteAudience::Scoped => {
+            let chain_audience = decoded.chain.audience();
+            anyhow::ensure!(
+                *chain_audience == *audience,
+                "this scoped invite was issued to {}, but the redeemer is {}; \
+                 ask the inviter to issue a new invite for your DID, \
+                 or switch to the identity the invite was issued to",
+                chain_audience,
+                audience
+            );
+            decoded.chain
+        }
+    };
+
+    Ok(ClaimedInvite {
+        chain,
+        subject: decoded.subject,
+        remote_url: decoded.remote_url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::ed25519::Ed25519Signer;
+    use dialog_varsig::principal::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    const ISSUER_SEED: [u8; 32] = [1u8; 32];
+    const SUBJECT_SEED: [u8; 32] = [2u8; 32];
+    const AUDIENCE_SEED: [u8; 32] = [3u8; 32];
+    const EPHEMERAL_SEED: [u8; 32] = [4u8; 32];
+
+    /// Build a single-hop delegation chain: `issuer -> audience`, scoped to
+    /// `subject`. Test callers pick the three seeds.
+    async fn make_chain(
+        issuer_seed: &[u8; 32],
+        audience_did: &Did,
+        subject_did: &Did,
+    ) -> DelegationChain {
+        let issuer = Ed25519Signer::import(issuer_seed).await.unwrap();
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer)
+            .audience(audience_did)
+            .subject(UcanSubject::Specific(subject_did.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        DelegationChain::new(delegation)
+    }
+
+    async fn signer(seed: &[u8; 32]) -> Ed25519Signer {
+        Ed25519Signer::import(seed).await.unwrap()
+    }
+
+    #[test]
+    fn parse_rejects_non_url_input() {
+        let err = parse_invite_url("not a url").unwrap_err();
+        assert!(err.to_string().contains("not a valid URL"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_missing_access_parameter() {
+        let err = parse_invite_url("https://tonk.xyz/join").unwrap_err();
+        assert!(err.to_string().contains("`access`"), "{err}");
+    }
+
+    #[test]
+    fn parse_rejects_invalid_base58_in_access() {
+        let err = parse_invite_url("https://tonk.xyz/join?access=!!!not-b58!!!").unwrap_err();
+        assert!(err.to_string().contains("valid base58"), "{err}");
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn parse_rejects_wrong_length_fragment() {
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let audience = signer(&AUDIENCE_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
+        // Valid, round-trippable URL — but we overwrite the fragment with a
+        // 3-byte payload (base58 of [9,9,9]) to probe the length check.
+        let mut url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+        url.push('#');
+        url.push_str(&bs58::encode([9u8, 9, 9]).into_string());
+
+        let err = parse_invite_url(&url).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exactly 32 bytes") || msg.contains("got 3"),
+            "{msg}"
+        );
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn build_and_parse_round_trip() {
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let audience = signer(&AUDIENCE_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
+        let remote = Url::parse("https://access.tonk.xyz/ucan").unwrap();
+
+        // Scoped, with remote
+        let url = build_invite_url(DEFAULT_BASE_URL, &chain, Some(&remote), None).unwrap();
+        let decoded = parse_invite_url(&url).unwrap();
+        assert_eq!(decoded.subject, subject);
+        assert!(matches!(decoded.audience, InviteAudience::Scoped));
+        assert_eq!(decoded.remote_url.as_ref(), Some(&remote));
+
+        // Open, no remote
+        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, Some(&EPHEMERAL_SEED)).unwrap();
+        let decoded = parse_invite_url(&url).unwrap();
+        assert_eq!(decoded.subject, subject);
+        match decoded.audience {
+            InviteAudience::Open { seed } => assert_eq!(seed, EPHEMERAL_SEED),
+            InviteAudience::Scoped => panic!("expected open audience"),
+        }
+        assert!(decoded.remote_url.is_none());
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn claim_scoped_rejects_wrong_audience() {
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let issued_to = signer(&AUDIENCE_SEED).await.did();
+        let wrong_redeemer = signer(&EPHEMERAL_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &issued_to, &subject).await;
+        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+
+        let err = claim(&url, &wrong_redeemer).await.unwrap_err();
+        assert!(err.to_string().contains("scoped invite"), "{err}");
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn claim_scoped_accepts_matching_audience() {
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let audience = signer(&AUDIENCE_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
+        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+
+        let claimed = claim(&url, &audience).await.unwrap();
+        assert_eq!(claimed.subject, subject);
+        assert_eq!(*claimed.chain.audience(), audience);
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn claim_open_invite_extends_chain_to_redeemer() {
+        // Setup: a chain `issuer -> ephemeral_key`, scoped to a specific repo.
+        // The invite URL carries the ephemeral seed in its fragment.
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let ephemeral_did = signer(&EPHEMERAL_SEED).await.did();
+        let redeemer = signer(&AUDIENCE_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &ephemeral_did, &subject).await;
+        let pre_len = chain.proof_cids().len();
+        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, Some(&EPHEMERAL_SEED)).unwrap();
+
+        let claimed = claim(&url, &redeemer).await.unwrap();
+
+        assert_eq!(claimed.subject, subject, "subject must not change");
+        assert_eq!(
+            claimed.chain.subject(),
+            Some(&subject),
+            "chain subject must remain scoped to the original repo"
+        );
+        assert_eq!(
+            *claimed.chain.audience(),
+            redeemer,
+            "chain audience must terminate at the redeemer"
+        );
+        assert_eq!(
+            claimed.chain.proof_cids().len(),
+            pre_len + 1,
+            "chain should grow by exactly one redelegation"
+        );
+        assert!(
+            claimed.remote_url.is_none(),
+            "remote_url must be absent — none was provided"
+        );
+    }
+}

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -29,14 +29,16 @@
 //! [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
 
 use anyhow::{Context, Result};
+use dialog_capability::access::{Authorization, Proof};
 use dialog_credentials::Ed25519Signer;
-use dialog_ucan_core::subject::Subject as UcanSubject;
-use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+use dialog_ucan::{Scope, UcanProof};
+use dialog_ucan_core::DelegationChain;
 use dialog_varsig::Did;
 use url::Url;
 
-/// Default base URL for invite links. Used when no override is
-/// provided. Changing this value is a breaking change for any outstanding
+/// Canonical base URL for tonk invite links. Callers serializing an
+/// [`Invite`] can pass this to [`Invite::to_url`] to mint a link rooted at
+/// tonk.xyz. Changing this value is a breaking change for any outstanding
 /// invite URLs that embed it.
 pub const DEFAULT_BASE_URL: &str = "https://tonk.xyz/join";
 
@@ -51,7 +53,7 @@ pub type EphemeralSeed = [u8; SEED_LEN];
 ///
 /// This is orthogonal to the subject dimension (which is always a specific
 /// repo). See the [crate-level documentation][crate] for the full model.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InviteAudience {
     /// Any redeemer can claim, by redelegating from the ephemeral key whose
     /// seed is embedded in the URL fragment.
@@ -63,247 +65,286 @@ pub enum InviteAudience {
     Scoped,
 }
 
-/// Decoded components of an invite URL.
-#[derive(Debug)]
+/// A shareable tonk invite: a delegation chain plus its audience mode and
+/// an optional sync remote. Serializable to several wire formats — today a
+/// URL via [`Invite::to_url`]; QR codes and invite files slot in as
+/// additional methods without touching the core type.
+///
+/// Construct via [`Invite::new`] (programmatic) or [`Invite::parse_url`]
+/// (from a URL). Both reject chains whose subject is not specific, so
+/// [`Invite::subject`] always resolves.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct DecodedInvite {
-    /// Delegation chain granting access to `subject`.
+pub struct Invite {
+    /// Delegation chain granting access to the repo named by [`Invite::subject`].
     pub chain: DelegationChain,
-    /// Repo subject DID.
-    pub subject: Did,
     /// Whether the invite is open to any redeemer or scoped to one DID.
     pub audience: InviteAudience,
-    /// Access service URL for sync, if included via `&remote=`.
+    /// Access service URL for sync, if the inviter attached one.
     pub remote_url: Option<Url>,
 }
 
-/// Outcome of [`claim`]: a delegation chain ready to be persisted by the
-/// caller, plus metadata about the invite.
+impl Invite {
+    /// Assemble an invite from its parts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the chain's subject is not
+    /// [`Subject::Specific`][dialog_ucan_core::subject::Subject::Specific]
+    /// — tonk invites must always target a specific repo.
+    pub fn new(
+        chain: DelegationChain,
+        audience: InviteAudience,
+        remote_url: Option<Url>,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            chain.subject().is_some(),
+            "invite delegation chain must target a specific repo subject; \
+             chains with Subject::Any are not valid invites"
+        );
+        Ok(Self {
+            chain,
+            audience,
+            remote_url,
+        })
+    }
+
+    /// Repo subject DID. Guaranteed specific by construction.
+    pub fn subject(&self) -> &Did {
+        self.chain
+            .subject()
+            .expect("Invite invariant: chain.subject() is Some (validated at construction)")
+    }
+
+    /// Parse an invite URL into an [`Invite`].
+    ///
+    /// Validates that the URL is syntactically a URL, that `access` is
+    /// present and decodes to a [`DelegationChain`] with a specific
+    /// subject, and — if a fragment is present — that it decodes to
+    /// exactly [`SEED_LEN`] bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a valid URL, if the `access`
+    /// query parameter is missing or not valid base58, if the decoded
+    /// chain fails to parse or has no specific subject
+    /// ([`Subject::Any`][dialog_ucan_core::subject::Subject::Any] is
+    /// rejected), if the `remote` parameter is present but not a valid
+    /// URL, or if the fragment is present but does not decode to exactly
+    /// 32 bytes of base58.
+    pub fn parse_url(url: &str) -> Result<Self> {
+        let parsed = Url::parse(url).context("invite URL is not a valid URL")?;
+
+        let mut access: Option<String> = None;
+        let mut remote_url: Option<Url> = None;
+        for (key, value) in parsed.query_pairs() {
+            match key.as_ref() {
+                "access" => access = Some(value.into_owned()),
+                "remote" => {
+                    let r = Url::parse(&value)
+                        .context("invite `remote` parameter is not a valid URL")?;
+                    remote_url = Some(r);
+                }
+                _ => {}
+            }
+        }
+        let access = access.context("invite URL is missing the `access` query parameter")?;
+
+        let chain_bytes = bs58::decode(&access)
+            .into_vec()
+            .context("invite `access` parameter is not valid base58")?;
+        let chain = DelegationChain::try_from(chain_bytes.as_slice()).with_context(|| {
+            format!(
+                "invite `access` parameter did not decode to a valid delegation chain ({} bytes)",
+                chain_bytes.len()
+            )
+        })?;
+
+        let audience = match parsed.fragment() {
+            Some(frag) => {
+                let bytes = bs58::decode(frag).into_vec().context(
+                    "invite URL fragment is not valid base58 \
+                     (expected a 32-byte Ed25519 seed)",
+                )?;
+                let seed: EphemeralSeed = bytes.as_slice().try_into().map_err(|_| {
+                    anyhow::anyhow!(
+                        "invite URL fragment must decode to exactly {} bytes, got {}",
+                        SEED_LEN,
+                        bytes.len()
+                    )
+                })?;
+                InviteAudience::Open { seed }
+            }
+            None => InviteAudience::Scoped,
+        };
+
+        Self::new(chain, audience, remote_url)
+    }
+
+    /// Serialize the invite as a URL rooted at `base_url`.
+    ///
+    /// `base_url` must parse as a URL and must not already carry a query
+    /// string or fragment — those slots are reserved for invite data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the base URL is malformed, if it already has a
+    /// query or fragment, or if the delegation chain fails to serialize.
+    pub fn to_url(&self, base_url: &str) -> Result<String> {
+        let chain_bytes = self
+            .chain
+            .to_bytes()
+            .context("failed to serialize delegation chain")?;
+        let access = bs58::encode(&chain_bytes).into_string();
+
+        let mut url = Url::parse(base_url).context("invite base URL is not a valid URL")?;
+        anyhow::ensure!(
+            url.query().is_none(),
+            "invite base URL must not already contain a query string"
+        );
+        anyhow::ensure!(
+            url.fragment().is_none(),
+            "invite base URL must not already contain a fragment"
+        );
+
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("access", &access);
+            if let Some(remote) = &self.remote_url {
+                pairs.append_pair("remote", remote.as_str());
+            }
+        }
+
+        if let InviteAudience::Open { seed } = &self.audience {
+            url.set_fragment(Some(&bs58::encode(seed.as_ref()).into_string()));
+        }
+
+        Ok(url.into())
+    }
+
+    /// The ephemeral signer empowered by an audience-open invite.
+    ///
+    /// For [`InviteAudience::Open`] returns `Some(signer)` imported from
+    /// the seed carried by the invite; the signer's DID matches the
+    /// chain's tail audience, so claiming an open invite is just
+    /// redelegation from this signer to the redeemer. For
+    /// [`InviteAudience::Scoped`] returns `None` — the redeemer must
+    /// already hold the audience key themselves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the embedded seed fails to import as an
+    /// Ed25519 signer (e.g. cryptographically invalid bytes).
+    pub async fn signer(&self) -> Result<Option<Ed25519Signer>> {
+        match &self.audience {
+            InviteAudience::Open { seed } => Ed25519Signer::import(seed)
+                .await
+                .map(Some)
+                .context("failed to import ephemeral signer from invite seed"),
+            InviteAudience::Scoped => Ok(None),
+        }
+    }
+
+    /// Redeem this invite on behalf of `audience`, returning a delegation
+    /// chain ready to persist.
+    ///
+    /// - **Audience-open** (fragment was present on the source URL):
+    ///   redelegates from the embedded ephemeral key to `audience`,
+    ///   extending the chain by one hop. Flows through
+    ///   [`UcanProof::claim`] and [`UcanAuthorization::delegate`] rather
+    ///   than reimplementing the redelegation inline.
+    /// - **Audience-scoped** (no fragment): verifies the chain's existing
+    ///   audience matches `audience` and returns it as-is.
+    ///
+    /// Persistence of the returned chain, and configuration of any
+    /// `remote_url` for sync, are the caller's responsibility.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an open invite fails to extend, or if a scoped
+    /// invite's recorded audience does not match `audience`.
+    ///
+    /// [`UcanProof::claim`]: dialog_ucan::UcanProof
+    /// [`UcanAuthorization::delegate`]: dialog_ucan::UcanAuthorization
+    pub async fn claim(self, audience: &Did) -> Result<ClaimedInvite> {
+        let signer = self.signer().await?;
+        let remote_url = self.remote_url.clone();
+
+        let chain = match signer {
+            Some(ephemeral) => {
+                let proof = UcanProof::from(self);
+                let auth = proof
+                    .claim(ephemeral)
+                    .map_err(|e| anyhow::anyhow!("failed to build authorization: {e}"))?;
+                let delegation = auth
+                    .delegate(audience.clone())
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to redelegate invite: {e}"))?;
+                delegation.into_chain()
+            }
+            None => {
+                let chain_audience = self.chain.audience();
+                anyhow::ensure!(
+                    *chain_audience == *audience,
+                    "this scoped invite was issued to {}, but the redeemer is {}; \
+                     ask the inviter to issue a new invite for your DID, \
+                     or switch to the identity the invite was issued to",
+                    chain_audience,
+                    audience
+                );
+                self.chain
+            }
+        };
+
+        Ok(ClaimedInvite { chain, remote_url })
+    }
+}
+
+impl From<Invite> for UcanProof {
+    /// Project the invite's delegation chain into a [`UcanProof`], with
+    /// scope derived from the chain's subject and command. Combined with
+    /// [`Invite::signer`] this gives an invite-to-authorization pipeline
+    /// that reuses the dialog-ucan claim/delegate machinery.
+    fn from(invite: Invite) -> Self {
+        let scope = Scope::from_chain(&invite.chain);
+        UcanProof::from_chain(&invite.chain, scope)
+    }
+}
+
+/// Outcome of [`Invite::claim`]: a delegation chain ready to be persisted
+/// by the caller, plus metadata carried over from the invite.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ClaimedInvite {
     /// Final delegation chain terminating at the redeemer's DID.
     pub chain: DelegationChain,
-    /// Repo subject DID (always `Subject::Specific`).
-    pub subject: Did,
     /// Access service URL for sync, if the invite included one.
     pub remote_url: Option<Url>,
 }
 
-/// Parse an invite URL into its components.
-///
-/// Validates that the URL is syntactically a URL, that `access` is present
-/// and decodes to a [`DelegationChain`] with a specific subject, and — if a
-/// fragment is present — that it decodes to exactly [`SEED_LEN`] bytes.
-///
-/// # Errors
-///
-/// Returns an error if the string is not a valid URL, if the `access` query
-/// parameter is missing or not valid base58, if the decoded chain fails to
-/// parse or has no specific subject ([`Subject::Any`] is rejected), if the
-/// `remote` parameter is present but not a valid URL, or if the fragment is
-/// present but does not decode to exactly 32 bytes of base58.
-///
-/// [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
-pub fn parse_invite_url(url: &str) -> Result<DecodedInvite> {
-    let parsed = Url::parse(url).context("invite URL is not a valid URL")?;
-
-    let mut access: Option<String> = None;
-    let mut remote_url: Option<Url> = None;
-    for (key, value) in parsed.query_pairs() {
-        match key.as_ref() {
-            "access" => access = Some(value.into_owned()),
-            "remote" => {
-                let r =
-                    Url::parse(&value).context("invite `remote` parameter is not a valid URL")?;
-                remote_url = Some(r);
-            }
-            _ => {}
-        }
+impl ClaimedInvite {
+    /// Repo subject DID. Carried over from the source [`Invite`], whose
+    /// construction guarantees [`Subject::Specific`][dialog_ucan_core::subject::Subject::Specific].
+    pub fn subject(&self) -> &Did {
+        self.chain
+            .subject()
+            .expect("ClaimedInvite invariant: chain.subject() is Some (inherited from Invite)")
     }
-    let access = access.context("invite URL is missing the `access` query parameter")?;
-
-    let chain_bytes = bs58::decode(&access)
-        .into_vec()
-        .context("invite `access` parameter is not valid base58")?;
-    let chain = DelegationChain::try_from(chain_bytes.as_slice()).with_context(|| {
-        format!(
-            "invite `access` parameter did not decode to a valid delegation chain ({} bytes)",
-            chain_bytes.len()
-        )
-    })?;
-    let subject = chain.subject().cloned().context(
-        "invite delegation chain must target a specific repo subject; \
-         chains with Subject::Any are not valid invites",
-    )?;
-
-    let audience = match parsed.fragment() {
-        Some(frag) => {
-            let bytes = bs58::decode(frag).into_vec().context(
-                "invite URL fragment is not valid base58 \
-                 (expected a 32-byte Ed25519 seed)",
-            )?;
-            let seed: EphemeralSeed = bytes.as_slice().try_into().map_err(|_| {
-                anyhow::anyhow!(
-                    "invite URL fragment must decode to exactly {} bytes, got {}",
-                    SEED_LEN,
-                    bytes.len()
-                )
-            })?;
-            InviteAudience::Open { seed }
-        }
-        None => InviteAudience::Scoped,
-    };
-
-    Ok(DecodedInvite {
-        chain,
-        subject,
-        audience,
-        remote_url,
-    })
-}
-
-/// Build an invite URL from a delegation chain and optional components.
-///
-/// `base_url` must parse as a URL and must not already carry a query string
-/// or fragment — those slots are reserved for invite data.
-///
-/// # Errors
-///
-/// Returns an error if the base URL is malformed, if it already has a query
-/// or fragment, or if the delegation chain fails to serialize.
-pub fn build_invite_url(
-    base_url: &str,
-    chain: &DelegationChain,
-    remote_url: Option<&Url>,
-    secret_seed: Option<&EphemeralSeed>,
-) -> Result<String> {
-    let chain_bytes = chain
-        .to_bytes()
-        .context("failed to serialize delegation chain")?;
-    let access = bs58::encode(&chain_bytes).into_string();
-
-    let mut url = Url::parse(base_url).context("invite base URL is not a valid URL")?;
-    anyhow::ensure!(
-        url.query().is_none(),
-        "invite base URL must not already contain a query string"
-    );
-    anyhow::ensure!(
-        url.fragment().is_none(),
-        "invite base URL must not already contain a fragment"
-    );
-
-    {
-        let mut pairs = url.query_pairs_mut();
-        pairs.append_pair("access", &access);
-        if let Some(remote) = remote_url {
-            pairs.append_pair("remote", remote.as_str());
-        }
-    }
-
-    if let Some(seed) = secret_seed {
-        url.set_fragment(Some(&bs58::encode(seed.as_ref()).into_string()));
-    }
-
-    Ok(url.into())
-}
-
-/// Redelegate from an ephemeral key to a target DID.
-///
-/// Takes an existing delegation chain (whose audience is the ephemeral key's
-/// DID and whose subject is a specific repo) and extends it with a new
-/// delegation from the ephemeral key to `audience`, preserving the subject.
-///
-/// # Errors
-///
-/// Returns an error if the chain has no specific subject (tonk invites must
-/// always scope to a specific repo — [`Subject::Any`] is never minted), if
-/// the ephemeral key cannot be imported from the seed, if the redelegation
-/// cannot be built, or if the new delegation cannot be appended to the chain
-/// (e.g. because the chain's tail audience does not match the ephemeral key's
-/// DID).
-///
-/// [`Subject::Any`]: dialog_ucan_core::subject::Subject::Any
-pub async fn redelegate(
-    chain: DelegationChain,
-    ephemeral_seed: &EphemeralSeed,
-    audience: &Did,
-) -> Result<DelegationChain> {
-    let subject = chain.subject().cloned().context(
-        "refusing to redelegate a chain with no specific subject; \
-         invites must always target a specific repo (Subject::Any is rejected)",
-    )?;
-
-    let ephemeral = Ed25519Signer::import(ephemeral_seed)
-        .await
-        .context("failed to import ephemeral key from seed")?;
-
-    let delegation = DelegationBuilder::new()
-        .issuer(ephemeral)
-        .audience(audience)
-        .subject(UcanSubject::Specific(subject))
-        .command(vec![])
-        .try_build()
-        .await
-        .context("failed to build redelegation")?;
-
-    chain
-        .push(delegation)
-        .context("failed to extend delegation chain with redelegation")
-}
-
-/// Redeem an invite URL on behalf of `audience`, returning a delegation
-/// chain ready to persist.
-///
-/// - **Audience-open** (URL fragment present): redelegates from the ephemeral
-///   key embedded in the fragment to `audience`, producing an extended chain.
-/// - **Audience-scoped** (no fragment): verifies the chain's existing
-///   audience matches `audience` and returns it as-is.
-///
-/// Persistence of the returned chain, and configuration of any `remote_url`
-/// for sync, are the caller's responsibility — see `carry`'s `claim` command
-/// for a native reference implementation and `tonk-ui`'s invite flow for a
-/// WASM one.
-///
-/// # Errors
-///
-/// Returns an error from [`parse_invite_url`] if the URL is malformed, from
-/// [`redelegate`] if an open invite fails to extend, or a bespoke error if a
-/// scoped invite's recorded audience does not match `audience`.
-pub async fn claim(url: &str, audience: &Did) -> Result<ClaimedInvite> {
-    let decoded = parse_invite_url(url)?;
-
-    let chain = match decoded.audience {
-        InviteAudience::Open { seed } => redelegate(decoded.chain, &seed, audience).await?,
-        InviteAudience::Scoped => {
-            let chain_audience = decoded.chain.audience();
-            anyhow::ensure!(
-                *chain_audience == *audience,
-                "this scoped invite was issued to {}, but the redeemer is {}; \
-                 ask the inviter to issue a new invite for your DID, \
-                 or switch to the identity the invite was issued to",
-                chain_audience,
-                audience
-            );
-            decoded.chain
-        }
-    };
-
-    Ok(ClaimedInvite {
-        chain,
-        subject: decoded.subject,
-        remote_url: decoded.remote_url,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use dialog_credentials::ed25519::Ed25519Signer;
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
     use dialog_varsig::principal::Principal;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    use wasm_bindgen_test::wasm_bindgen_test;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
 
     const ISSUER_SEED: [u8; 32] = [1u8; 32];
     const SUBJECT_SEED: [u8; 32] = [2u8; 32];
@@ -333,21 +374,24 @@ mod tests {
         Ed25519Signer::import(seed).await.unwrap()
     }
 
-    #[test]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn parse_rejects_non_url_input() {
-        let err = parse_invite_url("not a url").unwrap_err();
+        let err = Invite::parse_url("not a url").unwrap_err();
         assert!(err.to_string().contains("not a valid URL"), "{err}");
     }
 
-    #[test]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn parse_rejects_missing_access_parameter() {
-        let err = parse_invite_url("https://tonk.xyz/join").unwrap_err();
+        let err = Invite::parse_url("https://tonk.xyz/join").unwrap_err();
         assert!(err.to_string().contains("`access`"), "{err}");
     }
 
-    #[test]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn parse_rejects_invalid_base58_in_access() {
-        let err = parse_invite_url("https://tonk.xyz/join?access=!!!not-b58!!!").unwrap_err();
+        let err = Invite::parse_url("https://tonk.xyz/join?access=!!!not-b58!!!").unwrap_err();
         assert!(err.to_string().contains("valid base58"), "{err}");
     }
 
@@ -362,11 +406,12 @@ mod tests {
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
         // Valid, round-trippable URL — but we overwrite the fragment with a
         // 3-byte payload (base58 of [9,9,9]) to probe the length check.
-        let mut url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+        let invite = Invite::new(chain, InviteAudience::Scoped, None).unwrap();
+        let mut url = invite.to_url(DEFAULT_BASE_URL).unwrap();
         url.push('#');
         url.push_str(&bs58::encode([9u8, 9, 9]).into_string());
 
-        let err = parse_invite_url(&url).unwrap_err();
+        let err = Invite::parse_url(&url).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("exactly 32 bytes") || msg.contains("got 3"),
@@ -386,16 +431,26 @@ mod tests {
         let remote = Url::parse("https://access.tonk.xyz/ucan").unwrap();
 
         // Scoped, with remote
-        let url = build_invite_url(DEFAULT_BASE_URL, &chain, Some(&remote), None).unwrap();
-        let decoded = parse_invite_url(&url).unwrap();
-        assert_eq!(decoded.subject, subject);
+        let invite =
+            Invite::new(chain.clone(), InviteAudience::Scoped, Some(remote.clone())).unwrap();
+        let url = invite.to_url(DEFAULT_BASE_URL).unwrap();
+        let decoded = Invite::parse_url(&url).unwrap();
+        assert_eq!(*decoded.subject(), subject);
         assert!(matches!(decoded.audience, InviteAudience::Scoped));
         assert_eq!(decoded.remote_url.as_ref(), Some(&remote));
 
         // Open, no remote
-        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, Some(&EPHEMERAL_SEED)).unwrap();
-        let decoded = parse_invite_url(&url).unwrap();
-        assert_eq!(decoded.subject, subject);
+        let invite = Invite::new(
+            chain,
+            InviteAudience::Open {
+                seed: EPHEMERAL_SEED,
+            },
+            None,
+        )
+        .unwrap();
+        let url = invite.to_url(DEFAULT_BASE_URL).unwrap();
+        let decoded = Invite::parse_url(&url).unwrap();
+        assert_eq!(*decoded.subject(), subject);
         match decoded.audience {
             InviteAudience::Open { seed } => assert_eq!(seed, EPHEMERAL_SEED),
             InviteAudience::Scoped => panic!("expected open audience"),
@@ -413,9 +468,9 @@ mod tests {
         let issued_to = signer(&AUDIENCE_SEED).await.did();
         let wrong_redeemer = signer(&EPHEMERAL_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &issued_to, &subject).await;
-        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+        let invite = Invite::new(chain, InviteAudience::Scoped, None).unwrap();
 
-        let err = claim(&url, &wrong_redeemer).await.unwrap_err();
+        let err = invite.claim(&wrong_redeemer).await.unwrap_err();
         assert!(err.to_string().contains("scoped invite"), "{err}");
     }
 
@@ -428,10 +483,10 @@ mod tests {
         let subject = signer(&SUBJECT_SEED).await.did();
         let audience = signer(&AUDIENCE_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
-        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, None).unwrap();
+        let invite = Invite::new(chain, InviteAudience::Scoped, None).unwrap();
 
-        let claimed = claim(&url, &audience).await.unwrap();
-        assert_eq!(claimed.subject, subject);
+        let claimed = invite.claim(&audience).await.unwrap();
+        assert_eq!(*claimed.subject(), subject);
         assert_eq!(*claimed.chain.audience(), audience);
     }
 
@@ -442,22 +497,24 @@ mod tests {
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     async fn claim_open_invite_extends_chain_to_redeemer() {
         // Setup: a chain `issuer -> ephemeral_key`, scoped to a specific repo.
-        // The invite URL carries the ephemeral seed in its fragment.
+        // The invite carries the ephemeral seed; anyone can claim it.
         let subject = signer(&SUBJECT_SEED).await.did();
         let ephemeral_did = signer(&EPHEMERAL_SEED).await.did();
         let redeemer = signer(&AUDIENCE_SEED).await.did();
         let chain = make_chain(&ISSUER_SEED, &ephemeral_did, &subject).await;
         let pre_len = chain.proof_cids().len();
-        let url = build_invite_url(DEFAULT_BASE_URL, &chain, None, Some(&EPHEMERAL_SEED)).unwrap();
+        let invite = Invite::new(
+            chain,
+            InviteAudience::Open {
+                seed: EPHEMERAL_SEED,
+            },
+            None,
+        )
+        .unwrap();
 
-        let claimed = claim(&url, &redeemer).await.unwrap();
+        let claimed = invite.claim(&redeemer).await.unwrap();
 
-        assert_eq!(claimed.subject, subject, "subject must not change");
-        assert_eq!(
-            claimed.chain.subject(),
-            Some(&subject),
-            "chain subject must remain scoped to the original repo"
-        );
+        assert_eq!(*claimed.subject(), subject, "subject must not change");
         assert_eq!(
             *claimed.chain.audience(),
             redeemer,
@@ -472,5 +529,36 @@ mod tests {
             claimed.remote_url.is_none(),
             "remote_url must be absent — none was provided"
         );
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tokio::test(flavor = "current_thread")
+    )]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    async fn claim_from_url_round_trip() {
+        // End-to-end: an open invite minted by one client, serialized to a
+        // URL, and claimed by another via parse_url + claim.
+        let subject = signer(&SUBJECT_SEED).await.did();
+        let ephemeral_did = signer(&EPHEMERAL_SEED).await.did();
+        let redeemer = signer(&AUDIENCE_SEED).await.did();
+        let chain = make_chain(&ISSUER_SEED, &ephemeral_did, &subject).await;
+        let invite = Invite::new(
+            chain,
+            InviteAudience::Open {
+                seed: EPHEMERAL_SEED,
+            },
+            None,
+        )
+        .unwrap();
+        let url = invite.to_url(DEFAULT_BASE_URL).unwrap();
+
+        let claimed = Invite::parse_url(&url)
+            .unwrap()
+            .claim(&redeemer)
+            .await
+            .unwrap();
+        assert_eq!(*claimed.subject(), subject);
+        assert_eq!(*claimed.chain.audience(), redeemer);
     }
 }


### PR DESCRIPTION
- new `tonk-invite` crate provides invite URL format and claim orchestration for native and browser
- both `carry` and `tonk-ui` will depend on it so invite URLs issued by one are redeemable by the other, making them wire-compatible
- requires that invites target a specific repo, but `InviteAudience::{Open, Scoped}` allows for open-ended invites if no user DID provided, and scoped invites if one is

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `tonk-invite` crate, which facilitates the creation and management of invite URLs for a service. It adds relevant dependencies and implements core functionality for generating and parsing invite URLs, including audience management.

### Detailed summary
- Added `tonk-invite` to `Cargo.toml` and workspace dependencies.
- Created `rust/tonk-invite/Cargo.toml` with metadata and dependencies.
- Implemented `Invite` struct in `rust/tonk-invite/src/lib.rs` for managing invites.
- Added methods for creating, parsing, and claiming invites.
- Defined `InviteAudience` enum for audience management (open/scoped).
- Introduced error handling for invite URL parsing and validation.
- Implemented tests for invite functionality, including URL round-tripping and audience checks.

> The following files were skipped due to too many changes: `Cargo.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->