### PR TITLE
chore: stash schema work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonk-schema"
+version = "0.1.0"
+dependencies = [
+ "base58",
+ "dialog-artifacts",
+ "dialog-common",
+ "dialog-query",
+ "dialog-repository",
+ "dialog-varsig",
+ "serde",
+ "serde_ipld_dagcbor",
+]
+
+[[package]]
 name = "tonk-ui"
 version = "0.1.0"
 dependencies = [
@@ -4619,6 +4633,7 @@ dependencies = [
  "tokio",
  "tonk-access-service",
  "tonk-common",
+ "tonk-schema",
  "tower",
  "tower-service",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "rust/tonk-access-service",
     "rust/tonk-common",
+    "rust/tonk-schema",
     "rust/tonk-ui",
     "rust/tonk-worker",
 ]
@@ -17,6 +18,7 @@ edition = "2024"
 [workspace.dependencies]
 tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-common = { path = "./rust/tonk-common" }
+tonk-schema = { path = "./rust/tonk-schema" }
 tonk-ui = { path = "./rust/tonk-ui" }
 tonk-worker = { path = "./rust/tonk-worker" }
 

--- a/rust/tonk-schema/Cargo.toml
+++ b/rust/tonk-schema/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tonk-schema"
+description = "Typed schema for facts stored on a repository's meta branch"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[dependencies]
+base58 = { workspace = true }
+dialog-artifacts = { workspace = true }
+dialog-common = { workspace = true }
+dialog-query = { workspace = true }
+dialog-repository = { workspace = true }
+dialog-varsig = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_ipld_dagcbor = { workspace = true }

--- a/rust/tonk-schema/src/branch.rs
+++ b/rust/tonk-schema/src/branch.rs
@@ -89,13 +89,16 @@ impl Branch {
     /// The `origin` argument can be anything that views as an
     /// [`Entity`] — a [`Replica`] (for a local branch) or a
     /// [`Remote`] (for a remote-side branch) both work via their
-    /// `AsRef<Entity>` impls. Derives `this` from `(origin, name)`
+    /// `AsRef<Entity>` impls. `name` takes anything convertible
+    /// into [`Name`] — e.g. a `&str` — so callers don't have to
+    /// wrap string literals. Derives `this` from `(origin, name)`
     /// and stores `origin` as an attribute so every field is
     /// consistent with the entity hash.
     ///
     /// [`Remote`]: crate::Remote
-    pub fn new(origin: impl AsRef<Entity>, name: Name) -> Self {
+    pub fn new(origin: impl AsRef<Entity>, name: impl Into<Name>) -> Self {
         let origin = origin.as_ref();
+        let name = name.into();
         Self {
             this: Entity::of(&This::Branch {
                 origin,

--- a/rust/tonk-schema/src/branch.rs
+++ b/rust/tonk-schema/src/branch.rs
@@ -1,0 +1,191 @@
+//! [`Branch`] — a branch within a replica of a repository.
+
+// The `#[derive(Concept)]` and `#[derive(Attribute)]` macros generate
+// helper types and associated functions without doc comments. Suppress
+// the crate-level `missing_docs` lint for this module so the macros
+// compile under `-D warnings`.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+use serde::Serialize;
+
+use crate::prelude::*;
+use crate::{Name, Origin};
+
+/// Hash input for [`Branch::this`].
+///
+/// `Branch` identity is `(replica, name)`: the branch named `"main"`
+/// on one replica is distinct from the branch named `"main"` on a
+/// different replica (whether that's a different profile's view of
+/// the same repository, or an entirely different repository).
+///
+/// The single-variant enum shape tags the CBOR encoding with the
+/// concept name, so a branch and a remote with the same
+/// `(origin, name)` pair hash to different entities.
+///
+/// Not stored — constructed transiently inside [`Branch::new`] so
+/// the hash can be computed.
+#[derive(Serialize)]
+enum This<'a> {
+    Branch { origin: &'a Entity, name: &'a str },
+}
+
+/// A branch within a replica.
+///
+/// The `this` entity is content-derived from the replica's entity
+/// and the branch name, so:
+///
+/// - the same replica + the same branch name always yields the same
+///   `Branch` entity (devices sharing a profile converge on the same
+///   `Replica.this`, and therefore the same `Branch.this`), and
+/// - different replicas — or different names within one replica —
+///   yield different entities.
+///
+/// # Redundant by design
+///
+/// [`Subject`] and [`Origin`] duplicate information that went into
+/// the hash. The hash is one-way, so without these attributes there
+/// would be no way to answer "which branches are on this replica"
+/// or "which branches belong to this repository" without knowing
+/// the inputs upfront.
+///
+/// # Constructing
+///
+/// [`Branch::new`] takes a reference to the replica and a name,
+/// reads the replica's `this` and `subject` attributes, and derives
+/// every field consistently:
+///
+/// ```no_run
+/// use dialog_varsig::did;
+/// use tonk_schema::{Branch, Replica, Name};
+/// let replica = Replica::new(
+///     did!("test:profile"),
+///     did!("test:repo"),
+///     Name("home".into()),
+/// );
+/// let main = Branch::new(&replica, Name("main".into()));
+/// ```
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(missing_docs)]
+pub struct Branch {
+    /// The branch's entity. Derived from `(replica, name)`.
+    pub this: Entity,
+    /// The branch's name on this replica.
+    pub name: Name,
+    /// The replica this branch lives on.
+    pub origin: Origin,
+}
+
+impl AsRef<Entity> for Branch {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+impl Branch {
+    /// Build a branch concept from an owning entity and a name.
+    ///
+    /// The `origin` argument can be anything that views as an
+    /// [`Entity`] — a [`Replica`] (for a local branch) or a
+    /// [`Remote`] (for a remote-side branch) both work via their
+    /// `AsRef<Entity>` impls. Derives `this` from `(origin, name)`
+    /// and stores `origin` as an attribute so every field is
+    /// consistent with the entity hash.
+    ///
+    /// [`Remote`]: crate::Remote
+    pub fn new(origin: impl AsRef<Entity>, name: Name) -> Self {
+        let origin = origin.as_ref();
+        Self {
+            this: Entity::of(&This::Branch {
+                origin,
+                name: &name.0,
+            }),
+            origin: Origin::from(origin.clone()),
+            name,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Name, Replica};
+    use dialog_varsig::did;
+
+    fn branch_name(tag: &str) -> Name {
+        Name(tag.into())
+    }
+
+    #[test]
+    fn same_replica_same_name_same_entity() {
+        let r = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let a = Branch::new(&r, branch_name("main"));
+        let b = Branch::new(&r, branch_name("main"));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[test]
+    fn different_name_different_entity() {
+        let r = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let a = Branch::new(&r, branch_name("main"));
+        let b = Branch::new(&r, branch_name("meta"));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[test]
+    fn different_replica_different_entity() {
+        let r1 = Replica::new(did!("test:p1"), did!("test:r"), Name("home".into()));
+        let r2 = Replica::new(did!("test:p2"), did!("test:r"), Name("home".into()));
+        let a = Branch::new(&r1, branch_name("main"));
+        let b = Branch::new(&r2, branch_name("main"));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[test]
+    fn different_repo_different_entity() {
+        let r1 = Replica::new(did!("test:p"), did!("test:r1"), Name("home".into()));
+        let r2 = Replica::new(did!("test:p"), did!("test:r2"), Name("home".into()));
+        let a = Branch::new(&r1, branch_name("main"));
+        let b = Branch::new(&r2, branch_name("main"));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[test]
+    fn attributes_reflect_replica() {
+        let r = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let b = Branch::new(&r, branch_name("main"));
+        assert_eq!(b.origin.0, r.this);
+    }
+
+    #[test]
+    fn replica_name_does_not_affect_branch_entity() {
+        // The replica's display name is not part of Replica.this, so
+        // renaming the replica doesn't change the branch entity.
+        let home = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let pics = Replica::new(did!("test:p"), did!("test:r"), Name("pictures".into()));
+        let a = Branch::new(&home, branch_name("main"));
+        let b = Branch::new(&pics, branch_name("main"));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[test]
+    fn branch_on_replica_and_remote_differ() {
+        // A `Branch` is polymorphic over its origin — the same name
+        // on a replica vs. on a remote still produces distinct
+        // entities because the origin entities themselves differ.
+        use crate::{Address, Remote};
+        let replica = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let remote = Remote::new(
+            &replica,
+            did!("test:repo"),
+            Address(b"addr".to_vec()),
+            Name("origin".into()),
+        );
+        let local = Branch::new(&replica, branch_name("main"));
+        let tracking = Branch::new(&remote, branch_name("main"));
+        assert_ne!(local.this, tracking.this);
+        assert_eq!(local.origin.0, replica.this);
+        assert_eq!(tracking.origin.0, remote.this);
+    }
+}

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -101,4 +101,17 @@ impl Address {
             .expect("SiteAddress is serde-serializable and dag-cbor-compatible");
         Self(bytes)
     }
+
+    /// Decode the stored dag-cbor bytes back into a
+    /// [`SiteAddress`].
+    ///
+    /// Inverse of [`Address::encode`]. Produces an error when the
+    /// stored bytes aren't a valid dag-cbor encoding of a
+    /// `SiteAddress` — which today can only happen if the data
+    /// was written by a different version of the format.
+    pub fn decode(
+        &self,
+    ) -> Result<SiteAddress, serde_ipld_dagcbor::DecodeError<std::convert::Infallible>> {
+        serde_ipld_dagcbor::from_slice(&self.0)
+    }
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -86,6 +86,16 @@ pub struct Address(pub Vec<u8>);
 
 impl Address {
     /// Encode a [`SiteAddress`] as dag-cbor bytes.
+    ///
+    /// Note: we can't expose this as `From<SiteAddress>` or
+    /// `From<&SiteAddress>`. `#[derive(Attribute)]` emits a
+    /// blanket `impl<T: Into<Vec<u8>>> From<T> for Address`
+    /// and Rust's coherence rules reject any further `From`
+    /// impl whose argument type could ever implement
+    /// `Into<Vec<u8>>`. `Address::encode` stays the canonical
+    /// entry point; convenience methods like
+    /// [`Replica::remote`][crate::Replica::remote] take a
+    /// `SiteAddress` directly and call `encode` internally.
     pub fn encode(address: &SiteAddress) -> Self {
         let bytes = serde_ipld_dagcbor::to_vec(address)
             .expect("SiteAddress is serde-serializable and dag-cbor-compatible");

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -1,0 +1,94 @@
+//! Attributes shared across concepts in the `xyz.tonk` domain.
+
+// The `#[derive(Attribute)]` macro generates helper types and
+// associated functions without doc comments. Suppress the
+// crate-level `missing_docs` lint for this module so the macros
+// compile under `-D warnings`.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Attribute;
+use dialog_repository::SiteAddress;
+
+/// A human-readable name.
+///
+/// `xyz.tonk/name` is a single attribute in the schema, reused across
+/// every concept that has a display name (replicas, branches, and so
+/// on). Keeping it as one attribute means a single query shape —
+/// `?entity :name ?n` — can retrieve the name of anything that has
+/// one, regardless of which concept it belongs to.
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk")]
+pub struct Name(pub String);
+
+/// The repository a concept is about, as an entity reference.
+///
+/// `xyz.tonk/subject` points at a repository's subject DID interpreted
+/// as an [`Entity`]. Shared across concepts that belong to a specific
+/// repository (replicas, branches, remotes), so "all things about
+/// repository X" is a single query.
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk")]
+pub struct Subject(pub Entity);
+
+/// The profile that owns a replica, as an entity reference.
+///
+/// The value is the profile's DID interpreted as an [`Entity`]. Like
+/// [`Subject`], it duplicates information that went into the `this`
+/// hash, but keeping it queryable lets code find "all replicas that
+/// belong to this profile" without scanning every replica and
+/// recomputing hashes.
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk")]
+pub struct Profile(pub Entity);
+
+/// The entity a concept lives on, as an entity reference.
+///
+/// `xyz.tonk/origin` points at the parent entity for concepts that
+/// belong to something — a branch belongs to its replica (local
+/// branch) or its remote (remote branch), a remote belongs to its
+/// replica, and so on. A single attribute handles all cases; the
+/// target type is whatever entity the concept is scoped under.
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk")]
+pub struct Origin(pub Entity);
+
+/// The upstream branch a local branch is tracking, as an entity
+/// reference.
+///
+/// `xyz.tonk.branch/upstream` is the direction-explicit counterpart
+/// to [`Origin`]. Asserting `local -upstream-> remote_branch`
+/// records that the local branch tracks the remote branch. A local
+/// branch either has this attribute (it's tracking something) or
+/// doesn't (it isn't) — the presence/absence stands in for what
+/// would otherwise be an optional field.
+///
+/// Scoped to the `xyz.tonk.branch` sub-domain because unlike the
+/// other attributes in this module it's meaningful only on
+/// [`Branch`] entities, not cross-cutting.
+///
+/// [`Branch`]: crate::Branch
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk.branch")]
+pub struct Upstream(pub Entity);
+
+/// A network address, as raw bytes.
+///
+/// `xyz.tonk.remote/address` stores a serialized [`SiteAddress`] — the
+/// opaque bytes a remote uses to locate a peer. Keeping it as bytes
+/// (rather than a parsed URL or enum) means dialog's `Attribute`
+/// value type (which only supports scalar `Value`s) can carry it
+/// directly; consumers deserialize back into `SiteAddress` when they
+/// need to connect.
+#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[domain("xyz.tonk.remote")]
+pub struct Address(pub Vec<u8>);
+
+impl Address {
+    /// Encode a [`SiteAddress`] as dag-cbor bytes.
+    pub fn encode(address: &SiteAddress) -> Self {
+        let bytes = serde_ipld_dagcbor::to_vec(address)
+            .expect("SiteAddress is serde-serializable and dag-cbor-compatible");
+        Self(bytes)
+    }
+}

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -1,0 +1,52 @@
+#![warn(missing_docs)]
+//! Typed schema for facts stored on a repository's meta branch.
+//!
+//! Each Tonk repository has a `meta` branch alongside its content branches.
+//! The meta branch is a normal dialog-db branch — it participates in sync
+//! like any other branch — but its artifacts describe the repository's
+//! own configuration: the replicas that hold it, the branches it has,
+//! the remotes it tracks, and so on.
+//!
+//! This crate defines the [`dialog_query::Concept`]s and
+//! [`dialog_query::Attribute`]s that make up that schema. It is shared
+//! between the service worker (which reads and writes meta facts) and
+//! any future client that needs to query the same shape.
+//!
+//! # Entity identity
+//!
+//! Entities in this schema are identified as `did:key:z6Mk<base58>` URIs
+//! — the same format dialog-db uses elsewhere. The base58-encoded bytes
+//! come from one of two sources:
+//!
+//! - **Intrinsic** — the bytes are real cryptographic key material.
+//!   Profile DIDs and repository subject DIDs fall here. The entity is
+//!   whoever holds the keypair.
+//!
+//! - **Content-derived** — the bytes are the blake3 hash of a CBOR
+//!   encoding of the entity's defining inputs. Two parties independently
+//!   describing "the same thing" converge on the same entity, which
+//!   makes the resulting artifacts merge cleanly when the meta branch
+//!   syncs across devices.
+//!
+//! The URI scheme is the same in both cases; the difference lives in how
+//! the bytes are produced, not in how they are formatted. For
+//! content-derived entities, import [`prelude::EntityExt`] and call
+//! [`Entity::of`][dialog_artifacts::Entity] with any serializable
+//! value.
+
+pub mod prelude;
+
+pub mod domain;
+pub use domain::*;
+
+pub mod replica;
+pub use replica::*;
+
+pub mod branch;
+pub use branch::*;
+
+pub mod remote;
+pub use remote::*;
+
+pub mod tracking_branch;
+pub use tracking_branch::*;

--- a/rust/tonk-schema/src/prelude.rs
+++ b/rust/tonk-schema/src/prelude.rs
@@ -1,0 +1,107 @@
+//! Extension traits intended for glob import.
+//!
+//! ```no_run
+//! # use dialog_artifacts::Entity;
+//! use tonk_schema::prelude::*;
+//!
+//! # #[derive(serde::Serialize)] struct Origin;
+//! # let origin = Origin;
+//! let entity = Entity::of(&origin);
+//! ```
+
+use base58::ToBase58;
+use dialog_artifacts::Entity;
+use dialog_common::Blake3Hash;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+/// Derive an [`Entity`] from a serializable value.
+///
+/// `Entity` comes from `dialog_artifacts` and has no awareness of the
+/// content-derivation scheme this crate uses. `EntityExt` adds that
+/// shortcut: [`Entity::of`] hashes the dag-cbor encoding of a value
+/// and wraps the result as a `did:key:z6Mk<base58>` URI.
+///
+/// # Canonical encoding
+///
+/// The hash is taken over `serde_ipld_dagcbor` bytes, so the resulting
+/// entity depends only on the value's semantic content. Field
+/// ordering, integer width, and map key sorting are fixed by the
+/// dag-cbor specification, so independent implementations that
+/// serialize the same logical value converge on the same entity.
+///
+/// # DID-key shape
+///
+/// The `did:key:z6Mk` prefix reuses the multibase/multicodec shape
+/// dialog-db already uses for randomly generated entity URIs. The
+/// `6Mk` prefix nominally indicates ed25519 key material, but nothing
+/// in dialog-db enforces that the bytes actually *are* an ed25519
+/// public key, so the same shape works for arbitrary 32-byte hashes.
+/// If a future version of dialog-db begins validating the multicodec
+/// prefix, this is the one place that would need to change.
+pub trait EntityExt {
+    /// Derive an `Entity` from the dag-cbor encoding of `value`.
+    fn of<T: Serialize>(value: &T) -> Entity;
+}
+
+impl EntityExt for Entity {
+    fn of<T: Serialize>(value: &T) -> Entity {
+        let bytes = serde_ipld_dagcbor::to_vec(value)
+            .expect("dag-cbor encoding should not fail for schema types");
+        let hash = Blake3Hash::hash(&bytes);
+        let encoded = hash.as_bytes().as_ref().to_base58();
+        format!("did:key:z6Mk{encoded}")
+            .parse()
+            .expect("did:key URI formed from a 32-byte hash is always valid")
+    }
+}
+
+/// View a [`Did`] as the entity it identifies.
+///
+/// DIDs and entities share the `did:method:identifier` URI shape, so
+/// a DID string always parses as a valid [`Entity`]. Dialog treats
+/// the two types as distinct concerns — one is "a cryptographic
+/// identifier," the other is "the subject of artifacts" — but when
+/// a schema concept's identity *is* a DID (a profile, a repository),
+/// the DID is also the concept's `this` entity. [`Did::this`] bridges
+/// the two.
+pub trait DidExt {
+    /// Produce the `Entity` this DID identifies.
+    fn this(&self) -> Entity;
+}
+
+impl DidExt for Did {
+    fn this(&self) -> Entity {
+        self.as_str()
+            .parse()
+            .expect("DID string is always a valid Entity URI")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_varsig::did;
+
+    #[test]
+    fn same_value_same_entity() {
+        assert_eq!(Entity::of(&"hello"), Entity::of(&"hello"));
+    }
+
+    #[test]
+    fn different_values_different_entity() {
+        assert_ne!(Entity::of(&"alice"), Entity::of(&"bob"));
+    }
+
+    #[test]
+    fn entity_of_has_did_key_prefix() {
+        let e = Entity::of(&"anything");
+        assert!(e.to_string().starts_with("did:key:z6Mk"));
+    }
+
+    #[test]
+    fn did_this_preserves_uri() {
+        let d = did!("key:z6MkTestEntity");
+        assert_eq!(d.this().to_string(), d.as_str());
+    }
+}

--- a/rust/tonk-schema/src/remote.rs
+++ b/rust/tonk-schema/src/remote.rs
@@ -1,0 +1,203 @@
+//! [`Remote`] — a named upstream for a replica.
+
+// The `#[derive(Concept)]` macro generates helper types and
+// associated functions without doc comments. Suppress the
+// crate-level `missing_docs` lint for this module so the macros
+// compile under `-D warnings`.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+use crate::prelude::*;
+use crate::{Address, Branch, Name, Origin, Replica, Subject};
+
+/// Hash input for [`Remote::this`].
+///
+/// `Remote` identity is `(replica, name)`: the remote named `"origin"`
+/// on one replica is distinct from `"origin"` on a different replica.
+/// The remote's target repository and address are stored as
+/// attributes — they're queryable but not part of the hash, so
+/// changing them reasserts attributes on the same entity rather than
+/// minting a new one.
+///
+/// The single-variant enum shape tags the CBOR encoding with the
+/// concept name, so a remote and a branch with the same
+/// `(origin, name)` pair hash to different entities.
+///
+/// Not stored — constructed transiently inside [`Remote::new`] so
+/// the hash can be computed.
+#[derive(Serialize)]
+enum This<'a> {
+    Remote { origin: &'a Entity, name: &'a str },
+}
+
+/// A named upstream for a replica.
+///
+/// A `Remote` records "replica R calls server S 'origin', and the
+/// repository there is subject X." The name is local to the replica,
+/// the subject+address identify the target. Two replicas can each
+/// have their own `"origin"` pointing at different targets.
+///
+/// # Redundant by design
+///
+/// [`Origin`], [`Subject`], and [`Address`] duplicate information
+/// that either went into the hash (`origin`, via `name`) or describes
+/// the target (`subject`, `address`). Keeping them as attributes
+/// makes "which remotes live on replica X," "which remotes point at
+/// repository Y," and "which remotes are at address Z" queryable
+/// without re-hashing.
+///
+/// # Constructing
+///
+/// [`Remote::new`] takes the owning replica, the target repository
+/// DID, the target address bytes, and the local name:
+///
+/// ```no_run
+/// use dialog_varsig::did;
+/// use tonk_schema::{Address, Name, Remote, Replica};
+/// let replica = Replica::new(
+///     did!("test:profile"),
+///     did!("test:repo"),
+///     Name("home".into()),
+/// );
+/// let remote = Remote::new(
+///     &replica,
+///     did!("test:repo"),
+///     Address(vec![]),
+///     Name("origin".into()),
+/// );
+/// ```
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(missing_docs)]
+pub struct Remote {
+    /// The remote's entity. Derived from `(replica, name)`.
+    pub this: Entity,
+    /// The remote's local name on this replica.
+    pub name: Name,
+    /// The replica that owns this remote.
+    pub origin: Origin,
+    /// The repository on the remote side.
+    pub subject: Subject,
+    /// The address of the remote site.
+    pub address: Address,
+}
+
+impl Remote {
+    /// Build a remote concept from a replica, target repository DID,
+    /// address, and local name.
+    ///
+    /// Derives `this` from `(replica.this, name)` and fills in the
+    /// `origin`, `subject`, and `address` attributes so every field
+    /// is consistent with the entity hash.
+    pub fn new(replica: &Replica, subject: Did, address: Address, name: Name) -> Self {
+        Self {
+            this: Entity::of(&This::Remote {
+                origin: replica.this(),
+                name: &name.0,
+            }),
+            origin: Origin::from(replica.this().clone()),
+            subject: Subject::from(subject.this()),
+            address,
+            name,
+        }
+    }
+
+    /// Create a [`Branch`] concept on this remote.
+    pub fn branch(&self, name: &str) -> Branch {
+        Branch::new(self, Name::from(name))
+    }
+}
+
+impl AsRef<Entity> for Remote {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_varsig::did;
+
+    fn replica() -> Replica {
+        Replica::new(did!("test:p"), did!("test:r"), Name("home".into()))
+    }
+
+    fn addr(bytes: &[u8]) -> Address {
+        Address(bytes.to_vec())
+    }
+
+    #[test]
+    fn same_replica_same_name_same_entity() {
+        let r = replica();
+        let a = Remote::new(&r, did!("test:repo"), addr(b"host1"), Name("origin".into()));
+        let b = Remote::new(&r, did!("test:repo"), addr(b"host1"), Name("origin".into()));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[test]
+    fn different_name_different_entity() {
+        let r = replica();
+        let a = Remote::new(&r, did!("test:repo"), addr(b"host1"), Name("origin".into()));
+        let b = Remote::new(&r, did!("test:repo"), addr(b"host1"), Name("backup".into()));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[test]
+    fn address_does_not_affect_entity() {
+        // Address is an attribute, not part of the hash — pointing
+        // "origin" at a different host rewrites the attribute on
+        // the same entity.
+        let r = replica();
+        let a = Remote::new(&r, did!("test:repo"), addr(b"host1"), Name("origin".into()));
+        let b = Remote::new(&r, did!("test:repo"), addr(b"host2"), Name("origin".into()));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[test]
+    fn subject_does_not_affect_entity() {
+        let r = replica();
+        let a = Remote::new(&r, did!("test:repo-a"), addr(b"h"), Name("origin".into()));
+        let b = Remote::new(&r, did!("test:repo-b"), addr(b"h"), Name("origin".into()));
+        assert_eq!(a.this, b.this);
+    }
+
+    #[test]
+    fn different_replica_different_entity() {
+        let r1 = Replica::new(did!("test:p1"), did!("test:r"), Name("home".into()));
+        let r2 = Replica::new(did!("test:p2"), did!("test:r"), Name("home".into()));
+        let a = Remote::new(&r1, did!("test:repo"), addr(b"h"), Name("origin".into()));
+        let b = Remote::new(&r2, did!("test:repo"), addr(b"h"), Name("origin".into()));
+        assert_ne!(a.this, b.this);
+    }
+
+    #[test]
+    fn branch_and_remote_with_same_inputs_differ() {
+        // Branch and Remote both hash (replica, name), but the
+        // concept tag in the enum variant makes their entities
+        // distinct.
+        use crate::Branch;
+        let r = replica();
+        let branch = Branch::new(&r, Name("shared".into()));
+        let remote = Remote::new(&r, did!("test:repo"), addr(b"h"), Name("shared".into()));
+        assert_ne!(branch.this, remote.this);
+    }
+
+    #[test]
+    fn attributes_reflect_inputs() {
+        let r = replica();
+        let remote = Remote::new(
+            &r,
+            did!("test:repo-x"),
+            addr(b"addr"),
+            Name("origin".into()),
+        );
+        assert_eq!(remote.origin.0, r.this);
+        assert_eq!(remote.subject.0.to_string(), "did:test:repo-x");
+        assert_eq!(remote.address.0, b"addr");
+        assert_eq!(remote.name.0, "origin");
+    }
+}

--- a/rust/tonk-schema/src/remote.rs
+++ b/rust/tonk-schema/src/remote.rs
@@ -91,8 +91,16 @@ impl Remote {
     ///
     /// Derives `this` from `(replica.this, name)` and fills in the
     /// `origin`, `subject`, and `address` attributes so every field
-    /// is consistent with the entity hash.
-    pub fn new(replica: &Replica, subject: Did, address: Address, name: Name) -> Self {
+    /// is consistent with the entity hash. `name` takes anything
+    /// convertible into [`Name`] — e.g. a `&str` — so callers
+    /// don't have to wrap string literals.
+    pub fn new(
+        replica: &Replica,
+        subject: Did,
+        address: Address,
+        name: impl Into<Name>,
+    ) -> Self {
+        let name = name.into();
         Self {
             this: Entity::of(&This::Remote {
                 origin: replica.this(),
@@ -106,8 +114,11 @@ impl Remote {
     }
 
     /// Create a [`Branch`] concept on this remote.
-    pub fn branch(&self, name: &str) -> Branch {
-        Branch::new(self, Name::from(name))
+    ///
+    /// `name` accepts anything convertible into [`Name`],
+    /// matching the [`Branch::new`] signature.
+    pub fn branch(&self, name: impl Into<Name>) -> Branch {
+        Branch::new(self, name)
     }
 }
 

--- a/rust/tonk-schema/src/remote.rs
+++ b/rust/tonk-schema/src/remote.rs
@@ -194,7 +194,24 @@ mod tests {
         let r = replica();
         let branch = Branch::new(&r, Name("shared".into()));
         let remote = Remote::new(&r, did!("test:repo"), addr(b"h"), Name("shared".into()));
-        assert_ne!(branch.this, remote.this);
+        assert_ne!(branch.this, remote.this, "branch and remote collided on entity");
+    }
+
+    #[test]
+    fn remote_and_replica_branch_with_same_name_differ() {
+        // Regression: a remote named "origin" on a replica and
+        // a branch named "origin" on the same replica must
+        // produce distinct entities. If they didn't, querying
+        // `Branch` would also return the remote (every entity
+        // has the same `origin` + `name` attribute shape).
+        use crate::Branch;
+        let r = replica();
+        let remote_origin = Remote::new(&r, did!("test:repo"), addr(b"h"), Name("origin".into()));
+        let branch_origin = Branch::new(&r, Name("origin".into()));
+        assert_ne!(
+            remote_origin.this, branch_origin.this,
+            "a replica's remote 'origin' and branch 'origin' collided on entity"
+        );
     }
 
     #[test]

--- a/rust/tonk-schema/src/replica.rs
+++ b/rust/tonk-schema/src/replica.rs
@@ -1,0 +1,163 @@
+//! [`Replica`] — this device's view of a repository.
+
+// The `#[derive(Concept)]` and `#[derive(Attribute)]` macros generate
+// helper types and associated functions without doc comments. Suppress
+// the crate-level `missing_docs` lint for this module so the macros
+// compile under `-D warnings`.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+use dialog_repository::SiteAddress;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+use crate::{Address, Branch, Name, Profile, Remote, Subject};
+
+use crate::prelude::*;
+
+/// A replica — this device's view of a specific repository.
+///
+/// The `this` entity is content-derived from the `(profile, subject)`
+/// pair (see [`Origin`]), so:
+///
+/// - two devices holding the same profile converge on the same
+///   replica entity for a given repository, and
+/// - different profiles produce different replica entities even when
+///   pointing at the same repository.
+///
+/// The concept lives on the repository's meta branch. It is
+/// typically the first thing asserted when a repository is opened
+/// locally: writing the replica record announces "this profile has
+/// a local view of this repository" and anchors subsequent
+/// per-replica facts (branches, upstream configuration, etc.).
+///
+/// # Redundant by design
+///
+/// The [`Subject`] and [`Profile`] attributes carry the same two DIDs
+/// that went into hashing the entity. The redundancy is intentional:
+/// the hash is a one-way function, so without these attributes it
+/// would be impossible to answer queries like "find the replica this
+/// profile has for subject X" — you would need to know both inputs
+/// upfront and re-hash to locate the entity. The stored attributes
+/// make the relationships discoverable through normal queries.
+///
+/// # Constructing
+///
+/// [`Replica::new`] takes the profile and subject DIDs plus a name
+/// and derives every field consistently:
+///
+/// ```no_run
+/// use dialog_varsig::Did;
+/// use tonk_schema::{Replica, Name};
+/// # fn example(profile: Did, subject: Did) -> Replica {
+/// Replica::new(profile, subject, Name("home".into()))
+/// # }
+/// ```
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Replica {
+    /// The replica's entity. Derived from `(profile, subject)` via
+    /// [`Origin::this`].
+    pub this: Entity,
+    /// Human-readable name for the repository on this replica.
+    pub name: Name,
+    /// Reference to the repository this replica is a view of.
+    pub subject: Subject,
+    /// Reference to the profile that owns this replica.
+    pub profile: Profile,
+}
+
+/// Hash input for [`Replica::this`].
+///
+/// The single-variant enum shape tags the CBOR encoding with the
+/// concept name: two inputs with the same data but different
+/// concepts (e.g. a replica and a branch that happened to share
+/// field shapes) produce distinct hashes.
+#[derive(Debug, Clone, Serialize)]
+enum This<'a> {
+    Replica { subject: &'a Did, profile: &'a Did },
+}
+
+impl Replica {
+    /// Build a replica concept from a profile DID, a subject DID,
+    /// and a name.
+    ///
+    /// Derives `this` from `(profile, subject)` and fills in the
+    /// `subject` and `profile` attributes from the same DIDs so
+    /// every field is consistent with the entity hash.
+    pub fn new(profile: Did, subject: Did, name: Name) -> Self {
+        Self {
+            this: Entity::of(&This::Replica {
+                subject: &subject,
+                profile: &profile,
+            }),
+            subject: Subject(subject.this()),
+            profile: Profile(profile.this()),
+            name,
+        }
+    }
+
+    /// The replica's entity.
+    pub fn this(&self) -> &Entity {
+        &self.this
+    }
+
+    /// Create a [`Branch`] concept on this replica.
+    pub fn branch(&self, name: &str) -> Branch {
+        Branch::new(self, Name::from(name))
+    }
+
+    /// Create a [`Remote`] concept on this replica.
+    pub fn remote(&self, name: &str, subject: Did, address: &SiteAddress) -> Remote {
+        Remote::new(self, subject, Address::encode(address), Name::from(name))
+    }
+}
+
+impl AsRef<Entity> for Replica {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_varsig::did;
+
+    fn named(tag: &str) -> Name {
+        Name(tag.into())
+    }
+
+    #[test]
+    fn same_origin_same_entity() {
+        let a = Replica::new(did!("test:p"), did!("test:r"), named("home"));
+        let b = Replica::new(did!("test:p"), did!("test:r"), named("home"));
+        assert_eq!(a.this.to_string(), b.this.to_string());
+    }
+
+    #[test]
+    fn different_profile_different_entity() {
+        let a = Replica::new(did!("test:p1"), did!("test:r"), named("home"));
+        let b = Replica::new(did!("test:p2"), did!("test:r"), named("home"));
+        assert_ne!(a.this.to_string(), b.this.to_string());
+    }
+
+    #[test]
+    fn name_does_not_affect_entity() {
+        // The entity is derived from (profile, subject) alone, so
+        // renaming a replica does not produce a new entity — it
+        // produces a new name attribute on the existing one.
+        let a = Replica::new(did!("test:p"), did!("test:r"), named("home"));
+        let b = Replica::new(did!("test:p"), did!("test:r"), named("pictures"));
+        assert_eq!(a.this.to_string(), b.this.to_string());
+    }
+
+    #[test]
+    fn subject_and_profile_reflect_inputs() {
+        let profile = did!("test:profile-x");
+        let subject = did!("test:repo-y");
+        let replica = Replica::new(profile.clone(), subject.clone(), named("n"));
+        assert_eq!(replica.profile.0.to_string(), profile.as_str());
+        assert_eq!(replica.subject.0.to_string(), subject.as_str());
+    }
+}

--- a/rust/tonk-schema/src/replica.rs
+++ b/rust/tonk-schema/src/replica.rs
@@ -84,8 +84,10 @@ impl Replica {
     ///
     /// Derives `this` from `(profile, subject)` and fills in the
     /// `subject` and `profile` attributes from the same DIDs so
-    /// every field is consistent with the entity hash.
-    pub fn new(profile: Did, subject: Did, name: Name) -> Self {
+    /// every field is consistent with the entity hash. `name`
+    /// takes anything convertible into [`Name`] — e.g. a `&str`
+    /// — so callers don't have to wrap string literals.
+    pub fn new(profile: Did, subject: Did, name: impl Into<Name>) -> Self {
         Self {
             this: Entity::of(&This::Replica {
                 subject: &subject,
@@ -93,7 +95,7 @@ impl Replica {
             }),
             subject: Subject(subject.this()),
             profile: Profile(profile.this()),
-            name,
+            name: name.into(),
         }
     }
 
@@ -103,13 +105,27 @@ impl Replica {
     }
 
     /// Create a [`Branch`] concept on this replica.
-    pub fn branch(&self, name: &str) -> Branch {
-        Branch::new(self, Name::from(name))
+    ///
+    /// `name` is anything convertible into [`Name`], matching
+    /// the [`Branch::new`] signature.
+    pub fn branch(&self, name: impl Into<Name>) -> Branch {
+        Branch::new(self, name)
     }
 
     /// Create a [`Remote`] concept on this replica.
-    pub fn remote(&self, name: &str, subject: Did, address: &SiteAddress) -> Remote {
-        Remote::new(self, subject, Address::encode(address), Name::from(name))
+    ///
+    /// `name` accepts anything convertible into [`Name`]; the
+    /// [`SiteAddress`] is encoded into an [`Address`] internally
+    /// (we can't surface that as a `From` impl without clashing
+    /// with the blanket one the `Attribute` derive emits — see
+    /// [`Address::encode`]).
+    pub fn remote(
+        &self,
+        name: impl Into<Name>,
+        subject: Did,
+        address: &SiteAddress,
+    ) -> Remote {
+        Remote::new(self, subject, Address::encode(address), name)
     }
 }
 

--- a/rust/tonk-schema/src/tracking_branch.rs
+++ b/rust/tonk-schema/src/tracking_branch.rs
@@ -1,0 +1,138 @@
+//! [`TrackingBranch`] — a local branch that tracks a remote branch.
+
+// The `#[derive(Concept)]` macro generates helper types and
+// associated functions without doc comments. Suppress the
+// crate-level `missing_docs` lint for this module so the macros
+// compile under `-D warnings`.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+
+use crate::{Branch, Upstream};
+
+/// A local branch's tracking relationship with a remote branch.
+///
+/// A `TrackingBranch` is an *attribute on the local branch entity*
+/// that names the remote branch it tracks. `this` is reused from
+/// the local branch itself (no hash); `upstream` points at the
+/// remote branch. Asserting a `TrackingBranch` fact says: "the
+/// branch whose entity is `this` is tracking the branch whose
+/// entity is `upstream`."
+///
+/// # Why a separate concept
+///
+/// Semantically this is just an optional `Upstream` attribute on
+/// [`Branch`] — a branch either tracks something or it doesn't.
+/// Dialog concepts require every field to be present, so
+/// "optional" can't be expressed as `Option<Upstream>` on `Branch`
+/// itself. Modeling it as a separate concept lets the optionality
+/// fall out of presence/absence of the fact: if a `TrackingBranch`
+/// fact is asserted for a given branch entity, that branch tracks
+/// something; if not, it doesn't. Queries pick it up via an
+/// optional-match / left-join pattern rather than a null check.
+///
+/// # Why `Upstream` instead of reusing `Origin`
+///
+/// [`Branch`] already has an `origin: Origin` attribute pointing at
+/// its replica or remote. Using `Origin` again here for the
+/// tracked-branch relation would conflate "I belong to X" with "I
+/// track X" across the schema, making queries ambiguous. A
+/// dedicated [`Upstream`] attribute keeps the two relations
+/// distinct.
+///
+/// # Constructing
+///
+/// [`TrackingBranch::new`] takes the local branch and the upstream
+/// (remote) branch it tracks:
+///
+/// ```no_run
+/// # use tonk_schema::{Branch, TrackingBranch};
+/// # fn example(local: Branch, upstream: Branch) -> TrackingBranch {
+/// TrackingBranch::new(&local, &upstream)
+/// # }
+/// ```
+///
+/// Or via the [`Branch::set_upstream`] shortcut:
+///
+/// ```no_run
+/// # use tonk_schema::{Branch, TrackingBranch};
+/// # fn example(local: Branch, upstream: Branch) -> TrackingBranch {
+/// local.set_upstream(&upstream)
+/// # }
+/// ```
+///
+/// [`Branch::set_upstream`]: crate::Branch::set_upstream
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(missing_docs)]
+pub struct TrackingBranch {
+    /// The local branch's entity.
+    pub this: Entity,
+    /// The upstream (remote) branch this one is tracking.
+    pub upstream: Upstream,
+}
+
+impl TrackingBranch {
+    /// Build a tracking-branch link.
+    ///
+    /// `this` is set to `local`'s entity (no hash — this concept
+    /// attaches a relationship attribute to an existing branch) and
+    /// `upstream` points at the `upstream` branch being tracked.
+    pub fn new(local: &Branch, upstream: &Branch) -> Self {
+        Self {
+            this: local.this.clone(),
+            upstream: Upstream::from(upstream.this.clone()),
+        }
+    }
+}
+
+impl Branch {
+    /// Record that this branch tracks `upstream`.
+    ///
+    /// Shortcut for [`TrackingBranch::new(self, upstream)`][TrackingBranch::new].
+    pub fn set_upstream(&self, upstream: &Branch) -> TrackingBranch {
+        TrackingBranch::new(self, upstream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Address, Name, Remote, Replica};
+    use dialog_varsig::did;
+
+    fn setup() -> (Branch, Branch) {
+        let replica = Replica::new(did!("test:p"), did!("test:r"), Name("home".into()));
+        let remote = Remote::new(
+            &replica,
+            did!("test:repo"),
+            Address(b"addr".to_vec()),
+            Name("origin".into()),
+        );
+        let local = replica.branch("main");
+        let tracked = remote.branch("main");
+        (local, tracked)
+    }
+
+    #[test]
+    fn this_is_local_branch_entity() {
+        let (local, upstream) = setup();
+        let link = TrackingBranch::new(&local, &upstream);
+        assert_eq!(link.this, local.this);
+    }
+
+    #[test]
+    fn upstream_is_remote_branch_entity() {
+        let (local, upstream) = setup();
+        let link = TrackingBranch::new(&local, &upstream);
+        assert_eq!(link.upstream.0, upstream.this);
+    }
+
+    #[test]
+    fn set_upstream_matches_new() {
+        let (local, upstream) = setup();
+        let via_method = local.set_upstream(&upstream);
+        let via_new = TrackingBranch::new(&local, &upstream);
+        assert_eq!(via_method, via_new);
+    }
+}

--- a/rust/tonk-schema/src/tracking_branch.rs
+++ b/rust/tonk-schema/src/tracking_branch.rs
@@ -9,16 +9,18 @@
 use dialog_artifacts::Entity;
 use dialog_query::Concept;
 
-use crate::{Branch, Upstream};
+use crate::{Branch, Origin, Upstream};
 
 /// A local branch's tracking relationship with a remote branch.
 ///
 /// A `TrackingBranch` is an *attribute on the local branch entity*
 /// that names the remote branch it tracks. `this` is reused from
 /// the local branch itself (no hash); `upstream` points at the
-/// remote branch. Asserting a `TrackingBranch` fact says: "the
-/// branch whose entity is `this` is tracking the branch whose
-/// entity is `upstream`."
+/// remote branch, and `origin` points at the local replica that
+/// owns the tracking relationship. Asserting a `TrackingBranch`
+/// fact says: "the branch whose entity is `this` is tracking the
+/// branch whose entity is `upstream`, as recorded by the replica
+/// whose entity is `origin`."
 ///
 /// # Why a separate concept
 ///
@@ -34,12 +36,14 @@ use crate::{Branch, Upstream};
 ///
 /// # Why `Upstream` instead of reusing `Origin`
 ///
-/// [`Branch`] already has an `origin: Origin` attribute pointing at
-/// its replica or remote. Using `Origin` again here for the
-/// tracked-branch relation would conflate "I belong to X" with "I
-/// track X" across the schema, making queries ambiguous. A
-/// dedicated [`Upstream`] attribute keeps the two relations
-/// distinct.
+/// `Upstream` is the direction-explicit "I track this" relation.
+/// `Origin` is the ownership "I belong to this" relation. The
+/// local branch already has its own `Origin` pointing at the
+/// replica; this concept carries both — `upstream` for the
+/// relation it represents, and `origin` (reused from the local
+/// branch's own origin) so queries can filter tracking links by
+/// the replica they belong to without joining through the local
+/// branch concept.
 ///
 /// # Constructing
 ///
@@ -70,18 +74,26 @@ pub struct TrackingBranch {
     pub this: Entity,
     /// The upstream (remote) branch this one is tracking.
     pub upstream: Upstream,
+    /// The replica that owns this tracking relationship —
+    /// mirrors `local.origin`, which is always the replica for a
+    /// local branch. Stored so tracking-branch queries can scope
+    /// to a single replica in one shot.
+    pub origin: Origin,
 }
 
 impl TrackingBranch {
     /// Build a tracking-branch link.
     ///
     /// `this` is set to `local`'s entity (no hash — this concept
-    /// attaches a relationship attribute to an existing branch) and
-    /// `upstream` points at the `upstream` branch being tracked.
+    /// attaches a relationship attribute to an existing branch),
+    /// `upstream` points at the `upstream` branch being tracked,
+    /// and `origin` is reused from `local.origin` (which, for a
+    /// local branch, is the replica).
     pub fn new(local: &Branch, upstream: &Branch) -> Self {
         Self {
             this: local.this.clone(),
             upstream: Upstream::from(upstream.this.clone()),
+            origin: local.origin.clone(),
         }
     }
 }
@@ -134,5 +146,12 @@ mod tests {
         let via_method = local.set_upstream(&upstream);
         let via_new = TrackingBranch::new(&local, &upstream);
         assert_eq!(via_method, via_new);
+    }
+
+    #[test]
+    fn origin_mirrors_local_branch_origin() {
+        let (local, upstream) = setup();
+        let link = TrackingBranch::new(&local, &upstream);
+        assert_eq!(link.origin, local.origin);
     }
 }

--- a/rust/tonk-ui/assets/styles/components.css
+++ b/rust/tonk-ui/assets/styles/components.css
@@ -1,3 +1,4 @@
 @import "./components/auth.css";
 @import "./components/toolbar.css";
 @import "./components/launcher.css";
+@import "./components/space.css";

--- a/rust/tonk-ui/assets/styles/components/launcher.css
+++ b/rust/tonk-ui/assets/styles/components/launcher.css
@@ -1,8 +1,30 @@
 .launcher {
     display: grid;
+    /* Two columns, one row. The toolbar has a fixed width; the
+       space takes the rest. Using `1fr` (not `auto`) caps the
+       space's width to the remaining track so overflow scrolls
+       *inside* the space rather than pushing the viewport. */
+    grid-template-columns: 80px 1fr;
+    grid-template-rows: 100%;
+    grid-template-areas: "toolbar space";
     width: 100vw;
     height: 100vh;
-    grid-template-columns: 80px auto;
-    grid-template-rows: 100%;
-    grid-template-areas: "toolbar" "space";
+    /* Belt and suspenders: don't let either grid cell escape
+       the viewport when its content overflows. */
+    overflow: hidden;
+}
+
+.launcher > .toolbar {
+    grid-area: toolbar;
+    overflow: hidden;
+}
+
+.launcher > .space {
+    grid-area: space;
+    /* The space is the scroll container for its own content so
+       the toolbar stays fixed while long repository details
+       scroll in place. */
+    overflow: auto;
+    min-width: 0;
+    min-height: 0;
 }

--- a/rust/tonk-ui/assets/styles/components/space.css
+++ b/rust/tonk-ui/assets/styles/components/space.css
@@ -1,0 +1,172 @@
+/* Repository detail view inside `.space`. The outer `.space`
+   owns scrolling (see launcher.css); this file just styles the
+   contents. */
+
+.repository {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 2rem 2.5rem;
+    max-width: 72rem;
+    margin: 0 auto;
+    font-family: var(--tonk-font-family, inherit);
+}
+
+.repository > header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    padding-bottom: 1.25rem;
+}
+
+.repository > header > .eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.5);
+}
+
+.repository > header > h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 600;
+    line-height: 1.1;
+}
+
+.repository > section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.repository > section > h2 {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.repository .empty {
+    color: rgba(0, 0, 0, 0.45);
+    font-style: italic;
+    padding: 0.75rem 0;
+}
+
+/* Generic key-value grid used for identity info and for each
+   branch / remote card. */
+.repository .fields {
+    display: grid;
+    grid-template-columns: minmax(7rem, max-content) 1fr;
+    gap: 0.5rem 1.25rem;
+    align-items: baseline;
+}
+
+.repository .fields > dt {
+    font-size: 0.8125rem;
+    color: rgba(0, 0, 0, 0.55);
+    font-weight: 500;
+}
+
+.repository .fields > dd {
+    margin: 0;
+    min-width: 0;
+    word-break: break-all;
+}
+
+/* Monospace identifiers (DIDs, entity refs, tree refs). */
+.repository code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono",
+        Menlo, Consolas, monospace;
+    font-size: 0.8125rem;
+    background: rgba(0, 0, 0, 0.04);
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.25rem;
+    word-break: break-all;
+}
+
+.repository .cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
+    gap: 1rem;
+}
+
+.repository .card {
+    background: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.repository .card-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.repository .card-header > .card-name {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.repository .card-header > .card-kind {
+    font-size: 0.6875rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.45);
+}
+
+/* A row that holds an identifier plus a status badge. Keeps
+   the badge glued to the end of the line without blowing up
+   wrapping when the identifier is long. */
+.repository .subject-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.repository .badge {
+    font-size: 0.6875rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    line-height: 1.4;
+    white-space: nowrap;
+    flex: none;
+}
+
+/* `same` — the remote points back at our own repository
+   subject. Green-ish to read as "aligned". */
+.repository .badge-same {
+    background: rgba(45, 160, 100, 0.14);
+    color: #207a4c;
+}
+
+/* `other` — the remote points at a different subject. A
+   neutral amber so it reads as "heads up" without implying an
+   error. */
+.repository .badge-other {
+    background: rgba(200, 130, 40, 0.14);
+    color: #7a4e12;
+}
+
+/* Loading / error / not-found states */
+.space > .loading,
+.space > .error,
+.space > .not-found {
+    display: block;
+    padding: 2rem 2.5rem;
+    color: rgba(0, 0, 0, 0.55);
+}
+
+.space > .error {
+    color: #9e2a2a;
+}

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -5,7 +5,7 @@ use leptos_router::{
     params::Params,
 };
 
-use crate::api;
+use crate::{api, components::Status};
 
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkSpaceParams {
@@ -36,9 +36,23 @@ pub fn TonkSpace() -> impl IntoView {
             .filter(|s| !s.is_empty())
     });
 
+    // Wait for the shell to finish init (service worker active
+    // AND default repository PUT completed) before firing any
+    // request. Deep-link loads like `/space/home` mount this
+    // component on the very first render, when the service
+    // worker is still installing — firing now would race the
+    // SW handover, which the browser handles by cancelling the
+    // in-flight fetch ("Fetch failed loading"). Reading the
+    // `Status` signal here makes the resource re-fire the
+    // moment init flips to `Ready`.
+    let status = use_context::<Signal<Status, LocalStorage>>();
     let repository = LocalResource::new(move || {
         let name = space_name.get();
+        let ready = status.map(|s| s.get() == Status::Ready).unwrap_or(true);
         async move {
+            if !ready {
+                return Ok(None);
+            }
             match name {
                 None => {
                     BrowserUrl::redirect(&format!("/space/{}", api::DEFAULT_REPO));

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -4,6 +4,7 @@ use leptos_router::{
     location::{BrowserUrl, LocationProvider},
     params::Params,
 };
+use tonk_worker::{BranchConfiguration, RemoteConfiguration, RepositoryInfo};
 
 use crate::{api, components::Status};
 
@@ -74,11 +75,7 @@ pub fn TonkSpace() -> impl IntoView {
                     </section>
                 }>
                     { move || repository.get().map(|result| result.map(|repo| match repo {
-                        Some(status) => Either::Left(view! {
-                            <pre class="repository">
-                                { serde_json::to_string_pretty(&status).unwrap_or_default() }
-                            </pre>
-                        }),
+                        Some(info) => Either::Left(repository_view(info)),
                         None => Either::Right(view! {
                             <section class="not-found">
                                 { move || format!(
@@ -91,5 +88,158 @@ pub fn TonkSpace() -> impl IntoView {
                 </ErrorBoundary>
             </Suspense>
         </section>
+    }
+}
+
+/// Render a [`RepositoryInfo`] as a structured detail view.
+///
+/// Layout: a header with the repo name and DID, an identity
+/// block showing profile/operator, and two card grids for
+/// branches and remotes. A `None` upstream or empty map is
+/// rendered as an "empty" placeholder so the reader doesn't
+/// have to guess whether the absence is data or a UI bug.
+fn repository_view(info: RepositoryInfo) -> impl IntoView {
+    // Sort branches / remotes by name so the view is stable
+    // across renders — `HashMap` iteration order is otherwise
+    // nondeterministic.
+    let mut branches: Vec<(String, BranchConfiguration)> = info.branch.into_iter().collect();
+    branches.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let mut remotes: Vec<(String, RemoteConfiguration)> = info.remote.into_iter().collect();
+    remotes.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let subject = info.subject.to_string();
+    let operator = info.operator.to_string();
+    let profile = info.profile.to_string();
+
+    let branch_cards = branches
+        .into_iter()
+        .map(|(name, config)| {
+            let upstream = config.upstream.map(|up| format!("{}/{}", up.remote, up.branch));
+            let revision = config.revision.map(|rev| {
+                // Split the revision into two human-readable
+                // parts: a compact version string and the tree
+                // hash. `TreeReference`'s `Display` renders as
+                // `#<base58>` — short and already identifies the
+                // prolly-tree root without needing to see its
+                // debug form.
+                let version = format!("{}.{}", rev.period, rev.moment);
+                let tree = rev.tree.to_string();
+                (version, tree)
+            });
+            view! {
+                <article class="card">
+                    <div class="card-header">
+                        <span class="card-name">{ name.clone() }</span>
+                        <span class="card-kind">"branch"</span>
+                    </div>
+                    <dl class="fields">
+                        <dt>"upstream"</dt>
+                        <dd>{
+                            match upstream {
+                                Some(u) => Either::Left(view! { <code>{ u }</code> }),
+                                None => Either::Right(view! { <span class="empty">"none"</span> }),
+                            }
+                        }</dd>
+                        <dt>"version"</dt>
+                        <dd>{
+                            match revision.as_ref().map(|(v, _)| v.clone()) {
+                                Some(v) => Either::Left(view! { <code>{ v }</code> }),
+                                None => Either::Right(view! { <span class="empty">"no commits"</span> }),
+                            }
+                        }</dd>
+                        <dt>"tree"</dt>
+                        <dd>{
+                            match revision.as_ref().map(|(_, t)| t.clone()) {
+                                Some(t) => Either::Left(view! { <code>{ t }</code> }),
+                                None => Either::Right(view! { <span class="empty">"—"</span> }),
+                            }
+                        }</dd>
+                    </dl>
+                </article>
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Local repository subject, used to decide whether a
+    // remote's subject DID matches our own. Always shown on
+    // every remote card — `None` on the wire means "same as
+    // local," but the UI still displays the concrete DID plus
+    // a badge that indicates whether it matches.
+    let local_subject = info.subject.to_string();
+
+    let remote_cards = remotes
+        .into_iter()
+        .map(|(name, config)| {
+            let address = serde_json::to_string_pretty(&config.address).unwrap_or_default();
+            let remote_subject = match &config.subject {
+                Some(did) => did.to_string(),
+                None => local_subject.clone(),
+            };
+            let is_same = config.subject.is_none();
+            let badge_class = if is_same { "badge badge-same" } else { "badge badge-other" };
+            let badge_text = if is_same { "same" } else { "other" };
+            view! {
+                <article class="card">
+                    <div class="card-header">
+                        <span class="card-name">{ name.clone() }</span>
+                        <span class="card-kind">"remote"</span>
+                    </div>
+                    <dl class="fields">
+                        <dt>"subject"</dt>
+                        <dd class="subject-row">
+                            <code>{ remote_subject }</code>
+                            <span class=badge_class>{ badge_text }</span>
+                        </dd>
+                        <dt>"address"</dt>
+                        <dd><code>{ address }</code></dd>
+                    </dl>
+                </article>
+            }
+        })
+        .collect::<Vec<_>>();
+
+    view! {
+        <article class="repository">
+            <header>
+                <span class="eyebrow">"repository"</span>
+                <h1>{ info.name.clone() }</h1>
+                <dl class="fields">
+                    <dt>"subject"</dt>
+                    <dd><code>{ subject }</code></dd>
+                </dl>
+            </header>
+
+            <section>
+                <h2>"Identity"</h2>
+                <dl class="fields">
+                    <dt>"profile"</dt>
+                    <dd><code>{ profile }</code></dd>
+                    <dt>"operator"</dt>
+                    <dd><code>{ operator }</code></dd>
+                </dl>
+            </section>
+
+            <section>
+                <h2>{ format!("Branches ({})", branch_cards.len()) }</h2>
+                {
+                    if branch_cards.is_empty() {
+                        Either::Left(view! { <div class="empty">"no branches recorded"</div> })
+                    } else {
+                        Either::Right(view! { <div class="cards">{ branch_cards }</div> })
+                    }
+                }
+            </section>
+
+            <section>
+                <h2>{ format!("Remotes ({})", remote_cards.len()) }</h2>
+                {
+                    if remote_cards.is_empty() {
+                        Either::Left(view! { <div class="empty">"no remotes recorded"</div> })
+                    } else {
+                        Either::Right(view! { <div class="cards">{ remote_cards }</div> })
+                    }
+                }
+            </section>
+        </article>
     }
 }

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tonk-common = { workspace = true }
+tonk-schema = { workspace = true }
 tower-service = { workspace = true }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/rust/tonk-worker/src/error.rs
+++ b/rust/tonk-worker/src/error.rs
@@ -30,6 +30,39 @@ pub enum TonkWorkerError {
     PreconditionFailed(String),
 }
 
+/// Failure mode when assembling a repository from a
+/// [`RepositoryConfiguration`][crate::router::RepositoryConfiguration].
+///
+/// Separate from [`TonkWorkerError`] so the core "create this
+/// repository" helper doesn't have to know about HTTP. The
+/// `From` impl below maps each variant to the HTTP status the
+/// handler wants: invalid configuration → 400, internal → 500.
+#[derive(Error, Debug)]
+pub enum RepositoryError {
+    /// The request body refers to something that doesn't exist
+    /// — currently only "branch upstream references a remote
+    /// that wasn't in the `remote` map." User-supplied and thus
+    /// a 4xx upstream.
+    #[error("Invalid configuration: {0}")]
+    InvalidConfiguration(String),
+
+    /// Any other failure during construction: a dialog-db
+    /// operation failed (create / open / commit), the meta
+    /// branch couldn't be written, delegation couldn't be
+    /// saved, etc.
+    #[error("Internal repository error: {0}")]
+    Internal(String),
+}
+
+impl From<RepositoryError> for TonkWorkerError {
+    fn from(error: RepositoryError) -> Self {
+        match error {
+            RepositoryError::InvalidConfiguration(m) => TonkWorkerError::Router(m),
+            RepositoryError::Internal(m) => TonkWorkerError::Internal(m),
+        }
+    }
+}
+
 impl TonkWorkerError {
     fn kind(&self) -> &'static str {
         match self {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -14,15 +14,16 @@ use ::axum::{
 };
 use axum_wasm_macros::wasm_compat;
 use dialog_credentials::SignerCredential;
+use dialog_query::{Output as _, Query, Term};
 use dialog_repository::{
-    RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
+    RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress,
 };
 use dialog_varsig::Did;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_schema::{Remote, Replica};
+use tonk_schema::{Branch as MetaBranch, Remote, Replica, TrackingBranch};
 
 use super::AppState;
 use crate::{RepositoryError, TonkWorkerError, worker::TonkState};
@@ -424,10 +425,16 @@ pub async fn create_repository(
             );
 
             // Mirror the upstream wiring on the meta side.
-            transaction = transaction.assert(
+            // Both halves of the link need to land on the meta
+            // branch: the remote-side `Branch` concept
+            // (otherwise the upstream pointer has no target to
+            // resolve to on read) and the `TrackingBranch` that
+            // connects them.
+            let tracked = concept.branch(upstream.branch.as_str());
+            transaction = transaction.assert(tracked.clone()).assert(
                 replica
                     .branch(branch_name.as_str())
-                    .set_upstream(&concept.branch(upstream.branch.as_str())),
+                    .set_upstream(&tracked),
             );
         }
     }
@@ -477,67 +484,239 @@ pub async fn get_repository(
     Ok(Json(info))
 }
 
-/// Construct [`RepositoryInfo`] for an open repository.
+/// Construct [`RepositoryInfo`] for an open repository by
+/// reading the schema concepts off its `meta` branch.
 ///
-/// Probes `main` for its upstream and revision. If `main.upstream`
-/// points at a remote, loads that remote and includes its address
-/// in the `remote` map. Other branches / other remotes are *not*
-/// surfaced today — those need the meta-branch schema to enumerate.
+/// The meta branch is the source of truth for which branches and
+/// remotes belong to the repository. Opening the repository's
+/// meta branch, running three queries, and joining the results
+/// gives the full picture without having to probe individual
+/// dialog-repository objects.
+///
+/// What each query finds:
+///
+/// - **Branches (all)** — every `Branch` concept on the meta
+///   branch, local *and* remote-side. Grouped by `origin`:
+///   origin == replica means local; origin == remote means
+///   remote-side (used later to resolve upstream references to
+///   a `(remote_name, branch_name)` pair).
+/// - **Remotes (on replica)** — `Remote` concepts scoped to
+///   this replica.
+/// - **Tracking branches (on replica)** — `TrackingBranch`
+///   concepts that link local branches to their upstream remote
+///   branches.
+///
+/// Revisions still come from the dialog layer: for each local
+/// branch, we open it and read `.revision()`. That's a handful
+/// of sequential I/O calls but they're quick and the data
+/// doesn't live in meta.
+///
+/// Repositories that predate the meta-branch writes show up as
+/// empty here (no branches or remotes). That's fine — the
+/// `subject` / `operator` / `profile` fields still surface, and
+/// the UI can tell the repo is unpopulated.
 async fn build_repository_info<R>(
     tonk: &crate::worker::TonkState,
     name: &str,
-    repository: &dialog_repository::Repository<R>,
+    repository: &Repository<R>,
 ) -> RepositoryInfo
 where
     R: dialog_varsig::Principal + Clone,
 {
-    let mut branches = HashMap::new();
-    let mut remotes = HashMap::new();
-
-    if let Ok(main) = repository
-        .branch("main")
+    let meta = match repository
+        .branch(META_BRANCH)
         .open()
         .perform(&tonk.operator)
         .await
     {
-        // Only remote upstreams can be represented as
-        // `UpstreamConfiguration` today (it always names a remote).
-        // Local upstreams are reported as "no upstream" here; they
-        // need a richer response shape if/when we start using them.
-        let upstream = match main.upstream() {
-            Some(Upstream::Remote { remote, branch, .. }) => {
-                Some(UpstreamConfiguration::new(remote, branch))
+        Ok(meta) => meta,
+        Err(e) => {
+            log!("No meta branch for repository '{}': {}", name, e);
+            return RepositoryInfo {
+                name: name.to_string(),
+                subject: repository.did(),
+                operator: tonk.operator.did(),
+                profile: tonk.profile.did(),
+                branch: HashMap::new(),
+                remote: HashMap::new(),
+            };
+        }
+    };
+
+    // Derive the replica entity the way `create_repository`
+    // did — `(profile, subject)` hashed into an entity. We
+    // don't query for `Replica` itself; nothing we return
+    // depends on its name or attributes, and filtering
+    // branches/remotes by `origin == replica.this()` is all we
+    // need.
+    let replica = Replica::new(
+        tonk.profile.did(),
+        repository.did(),
+        name,
+    );
+    let replica_entity = replica.this().clone();
+
+    // Pull every branch on the meta branch, local and remote.
+    // Keyed by entity so the upstream-resolution step can look
+    // up any branch by its hash.
+    let all_branches: Vec<MetaBranch> = match meta
+        .query()
+        .select(Query::<MetaBranch> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+            origin: Term::var("origin"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            log!("Branch query on meta failed for '{}': {:?}", name, e);
+            Vec::new()
+        }
+    };
+    let branches_by_entity: HashMap<_, _> = all_branches
+        .iter()
+        .map(|b| (b.this.clone(), b.clone()))
+        .collect();
+
+    // Pull remotes on this replica. Keyed by entity for the
+    // same reason as branches — a tracking branch's upstream
+    // points at a remote-side `Branch`, whose `origin` is a
+    // `Remote.this`, and we want to go from that entity back to
+    // the remote's name.
+    let remote_concepts: Vec<Remote> = match meta
+        .query()
+        .select(Query::<Remote> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+            origin: Term::from(replica_entity.clone()),
+            subject: Term::var("subject"),
+            address: Term::var("address"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            log!("Remote query on meta failed for '{}': {:?}", name, e);
+            Vec::new()
+        }
+    };
+    let remotes_by_entity: HashMap<_, _> = remote_concepts
+        .iter()
+        .map(|r| (r.this.clone(), r.clone()))
+        .collect();
+
+    // Pull every tracking link on this replica. Keyed by the
+    // local branch's entity so the branch-assembly step below
+    // can find "does this branch track something?" in O(1).
+    let tracking: Vec<TrackingBranch> = match meta
+        .query()
+        .select(Query::<TrackingBranch> {
+            this: Term::var("this"),
+            upstream: Term::var("upstream"),
+            origin: Term::from(replica_entity.clone()),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            log!("Tracking-branch query on meta failed for '{}': {:?}", name, e);
+            Vec::new()
+        }
+    };
+    let tracking_by_local: HashMap<_, _> = tracking
+        .into_iter()
+        .map(|t| (t.this.clone(), t.upstream))
+        .collect();
+
+    // Assemble the branch map. Iterate local branches only
+    // (those whose origin is the replica), skipping any entity
+    // that is also a `Remote` — `Query<Branch>` matches on the
+    // `origin` + `name` attribute pair, which `Remote` shares
+    // (`Remote` has the same pair plus `subject` + `address`),
+    // so remote entities turn up as spurious branch hits. For
+    // each real local branch, resolve its upstream (if any) by
+    // looking up the tracked `Branch` entity, then the remote
+    // that branch belongs to.
+    let mut branches = HashMap::new();
+    for branch in &all_branches {
+        if branch.origin.0 != replica_entity {
+            continue;
+        }
+        if remotes_by_entity.contains_key(&branch.this) {
+            continue;
+        }
+        let upstream = tracking_by_local.get(&branch.this).and_then(|upstream| {
+            let tracked_branch = branches_by_entity.get(&upstream.0)?;
+            let remote = remotes_by_entity.get(&tracked_branch.origin.0)?;
+            Some(UpstreamConfiguration::new(
+                remote.name.0.clone(),
+                tracked_branch.name.0.clone(),
+            ))
+        });
+
+        let revision = match repository
+            .branch(branch.name.0.as_str())
+            .open()
+            .perform(&tonk.operator)
+            .await
+        {
+            Ok(opened) => opened.revision(),
+            Err(e) => {
+                log!(
+                    "Failed to open branch '{}' of '{}' for revision: {}",
+                    branch.name.0,
+                    name,
+                    e
+                );
+                None
             }
-            _ => None,
         };
 
-        // If main's upstream is remote, populate the remote map.
-        if let Some(Upstream::Remote { remote, .. }) = main.upstream()
-            && let Ok(remote_repo) = repository
-                .remote(remote.as_str())
-                .load()
-                .perform(&tonk.operator)
-                .await
-        {
-            let remote_addr = remote_repo.address();
-            let repo_did_str = repository.did().to_string();
-            let remote_subject = remote_addr.subject().clone();
-            let subject = (remote_subject.as_str() != repo_did_str).then_some(remote_subject);
-            remotes.insert(
-                remote.to_string(),
-                RemoteConfiguration {
-                    address: remote_addr.site().clone(),
-                    subject,
-                },
-            );
-        }
-
         branches.insert(
-            "main".to_string(),
-            BranchConfiguration {
-                upstream,
-                revision: main.revision(),
-            },
+            branch.name.0.clone(),
+            BranchConfiguration { upstream, revision },
+        );
+    }
+
+    // Assemble the remote map. Every remote concept scoped to
+    // this replica becomes a `RemoteConfiguration`. The address
+    // field comes back decoded from its dag-cbor bytes. The
+    // `subject` field stays `None` when no subject override was
+    // recorded — see `RemoteConfiguration.subject`'s "`None`
+    // means same as local repo" convention.
+    let mut remotes = HashMap::new();
+    for remote in &remote_concepts {
+        let address = match remote.address.decode() {
+            Ok(address) => address,
+            Err(e) => {
+                log!(
+                    "Failed to decode address for remote '{}' of '{}': {:?}",
+                    remote.name.0,
+                    name,
+                    e
+                );
+                continue;
+            }
+        };
+        // Emit `subject` only when it differs from the local
+        // repo's own DID; matches the write-side convention
+        // (see `RemoteConfiguration.subject`). If the stored
+        // value isn't a parseable `Did` for some reason we
+        // drop the field rather than fail the whole response.
+        let subject = match remote.subject.0.to_string().parse::<Did>() {
+            Ok(did) if did != repository.did() => Some(did),
+            _ => None,
+        };
+        remotes.insert(
+            remote.name.0.clone(),
+            RemoteConfiguration { address, subject },
         );
     }
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -13,15 +13,24 @@ use ::axum::{
     http::{HeaderMap, StatusCode},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_repository::{RepositoryExt as _, Revision, SiteAddress, Upstream};
+use dialog_credentials::SignerCredential;
+use dialog_repository::{
+    RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
+};
 use dialog_varsig::Did;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
+use tonk_schema::{Remote, Replica};
 
 use super::AppState;
-use crate::TonkWorkerError;
+use crate::{RepositoryError, TonkWorkerError, worker::TonkState};
+
+/// Name of the meta branch every repository has alongside its
+/// content branches. The meta branch stores schema concepts
+/// describing the repository itself (see [`tonk_schema`]).
+const META_BRANCH: &str = "meta";
 
 /// Configuration for a single remote.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -209,26 +218,74 @@ pub async fn put_repository(
         });
     }
 
-    // 2. Create the repository. Any failure here is genuinely
-    // internal — we already confirmed it doesn't exist.
+    // 2. Create the repository and everything that comes with
+    // it — delegation, remotes, branches, upstreams, meta facts.
+    // The helper doesn't know about HTTP; its errors are mapped
+    // to the right status via `RepositoryError::into`.
+    let repository = create_repository(&tonk, &name, &configuration).await?;
+
+    // 3. Respond with the current state of the repository.
+    let info = build_repository_info(&tonk, &name, &repository).await;
+    Ok((StatusCode::CREATED, Json(info)))
+}
+
+/// Build out a repository from a [`RepositoryConfiguration`].
+///
+/// Runs the full create-side pipeline in a single pass:
+///
+/// 1. `profile.repository(name).create()` — allocate a new
+///    signer-owned repository in dialog-db.
+/// 2. Delegate repository access to the profile and save the
+///    delegation, so future operations authenticated by the
+///    profile can reach the repo.
+/// 3. Open the `meta` branch and start a transaction, seeded
+///    with the [`Replica`] concept and a [`TonkBranch`] for the
+///    meta branch itself.
+/// 4. For each configured remote: create it at the dialog layer
+///    *and* assert the corresponding [`TonkRemote`] concept on
+///    the transaction. Concepts are kept keyed by remote name
+///    so the upstream-linking step can find them.
+/// 5. For each configured branch: open it at the dialog layer
+///    and assert a [`TonkBranch`]. If the config names an
+///    upstream, wire it at the dialog layer and assert the
+///    corresponding [`TrackingBranch`].
+/// 6. Commit the meta transaction — one commit containing
+///    every concept, so the metadata lands atomically.
+///
+/// Interleaving dialog mutations with meta assertions keeps
+/// both sides in lockstep and means we never have to
+/// "reconstruct what we just built" as a second pass.
+///
+/// Returns the opened [`Repository<SignerCredential>`] so the
+/// caller can still introspect it (e.g. to build a response
+/// body) without a separate load. The caller is responsible
+/// for existence-checking before calling — this function
+/// assumes the name is free.
+pub async fn create_repository(
+    tonk: &TonkState,
+    name: &str,
+    configuration: &RepositoryConfiguration,
+) -> Result<Repository<SignerCredential>, RepositoryError> {
+    // 1. Create the repository. Any failure here is genuinely
+    // internal — we assume the caller has already confirmed the
+    // name is free.
     let repository = tonk
         .profile
-        .repository(&name)
+        .repository(name)
         .create()
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
-            TonkWorkerError::Internal(format!("Failed to create repository '{}': {}", name, e))
+            RepositoryError::Internal(format!("Failed to create repository '{}': {}", name, e))
         })?;
     log!("Repository created. DID: {}", repository.did());
 
-    // 3. Delegate repo access to the profile. A freshly created
-    // repository always has a signer credential, so `.access()` is
-    // available directly. This used to live in
-    // `TonkServiceWorker::new`; it belongs with creation, and if
-    // either half of it fails we fail the whole request — a repo
-    // without a working delegation chain is half-initialised and
-    // the caller needs to know.
+    // 2. Delegate repo access to the profile. A freshly created
+    // repository always has a signer credential, so `.access()`
+    // is available directly. Splitting this delegation from
+    // creation would leave the repo half-initialised if the save
+    // fails; commit it immediately so the caller sees a clean
+    // success or a clean failure.
     let delegation = repository
         .access()
         .claim(&repository)
@@ -236,7 +293,7 @@ pub async fn put_repository(
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
-            TonkWorkerError::Internal(format!("Failed to delegate repo access to profile: {}", e))
+            RepositoryError::Internal(format!("Failed to delegate repo access to profile: {}", e))
         })?;
 
     tonk.profile
@@ -244,51 +301,98 @@ pub async fn put_repository(
         .save(delegation)
         .perform(&tonk.operator)
         .await
-        .map_err(|e| TonkWorkerError::Internal(format!("Failed to save repo delegation: {}", e)))?;
+        .map_err(|e| RepositoryError::Internal(format!("Failed to save repo delegation: {}", e)))?;
 
-    // 4. Create any remotes listed in the body.
-    for (name, remote) in &configuration.remote {
+    // 3. Open the meta branch and start the single transaction
+    // that will carry every concept describing the repository.
+    // Seed it with the replica record and the meta branch's own
+    // `Branch` fact — the meta branch is a real branch of this
+    // replica, so it belongs in the enumeration like any other.
+
+    let meta = repository
+        .branch(META_BRANCH)
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("Failed to open meta branch: {}", e)))?;
+
+    // Local replica of this repository
+    let replica = Replica::new(tonk.profile.did(), repository.did(), name);
+
+    let mut transaction = meta
+        .transaction()
+        .assert(replica.clone())
+        .assert(replica.branch(META_BRANCH));
+
+    // 4. Create remotes at the dialog layer and assert their
+    // concepts on the same transaction. Stash each created
+    // `RemoteRepository` alongside its `Remote` concept so the
+    // branch loop below can resolve upstream references without
+    // a second `.load()` round-trip against dialog — we just
+    // created these remotes, so the data we'd load is still in
+    // hand.
+    let mut remotes: HashMap<String, (RemoteRepository, Remote)> =
+        HashMap::with_capacity(configuration.remote.len());
+
+    for (remote_name, remote_config) in &configuration.remote {
+        // Subject defaults to the local repo's DID — that's the
+        // existing `RemoteConfiguration` convention (remote
+        // repository subject == local subject unless explicitly
+        // overridden).
+        let subject = remote_config
+            .subject
+            .clone()
+            .unwrap_or_else(|| repository.did());
+
         let mut create = repository
-            .remote(name.as_str())
-            .create(remote.address.clone());
+            .remote(remote_name.as_str())
+            .create(remote_config.address.clone());
 
-        // If subject is specified, it means remote repository subject is
-        // different from the local one so we need to set it explicitly.
-        if let Some(subject) = remote.subject.clone() {
-            create = create.subject(subject);
+        if remote_config.subject.is_some() {
+            create = create.subject(subject.clone());
         }
-
-        create.perform(&tonk.operator).await.map_err(|e| {
-            TonkWorkerError::Internal(format!("Failed to create remote '{}': {}", name, e))
+        let remote = create.perform(&tonk.operator).await.map_err(|e| {
+            RepositoryError::Internal(format!("Failed to create remote '{}': {}", remote_name, e))
         })?;
-        log!("Remote '{}' created", name);
+
+        log!("Remote '{}' created", remote_name);
+
+        let concept = replica.remote(remote_name.as_str(), subject, &remote_config.address);
+        transaction = transaction.assert(concept.clone());
+        remotes.insert(remote_name.clone(), (remote, concept));
     }
 
-    // 5. Open each branch listed in the body (opens-or-creates) and
-    // optionally wire its upstream. Missing from the body = don't
-    // create; present with `{}` = create without upstream.
-    for (name, settings) in &configuration.branch {
+    // 5. Open each branch at the dialog layer and assert its
+    // `TonkBranch` concept. If the branch names an upstream,
+    // wire it through dialog and assert a `TrackingBranch` link
+    // on the same transaction. An upstream that references an
+    // unknown remote is a user-facing configuration error —
+    // surface it as `InvalidConfiguration` (400), not Internal.
+    for (branch_name, settings) in &configuration.branch {
         let branch = repository
-            .branch(name.as_str())
+            .branch(branch_name.as_str())
             .open()
             .perform(&tonk.operator)
             .await
             .map_err(|e| {
-                TonkWorkerError::Internal(format!("Failed to open branch '{}': {}", name, e))
+                RepositoryError::Internal(format!("Failed to open branch '{}': {}", branch_name, e))
             })?;
 
+        transaction = transaction.assert(replica.branch(branch_name.as_str()));
+
         if let Some(upstream) = &settings.upstream {
-            let remote = repository
-                .remote(upstream.remote.as_str())
-                .load()
-                .perform(&tonk.operator)
-                .await
-                .map_err(|e| {
-                    TonkWorkerError::Router(format!(
-                        "Upstream references unknown remote '{}': {}",
-                        upstream.remote, e
-                    ))
-                })?;
+            // Look up the remote we just created in step 4
+            // instead of doing another `.load()` round-trip
+            // against dialog. If the upstream names a remote
+            // that wasn't in the configuration, that's a
+            // user-facing configuration error (400), not an
+            // internal failure.
+            let (remote, concept) = remotes.get(&upstream.remote).ok_or_else(|| {
+                RepositoryError::InvalidConfiguration(format!(
+                    "Upstream for branch '{}' references unknown remote '{}'",
+                    branch_name, upstream.remote
+                ))
+            })?;
 
             let target = remote
                 .branch(upstream.branch.as_str())
@@ -296,7 +400,7 @@ pub async fn put_repository(
                 .perform(&tonk.operator)
                 .await
                 .map_err(|e| {
-                    TonkWorkerError::Internal(format!(
+                    RepositoryError::Internal(format!(
                         "Failed to open remote branch '{}/{}': {}",
                         upstream.remote, upstream.branch, e
                     ))
@@ -307,23 +411,43 @@ pub async fn put_repository(
                 .perform(&tonk.operator)
                 .await
                 .map_err(|e| {
-                    TonkWorkerError::Internal(format!(
+                    RepositoryError::Internal(format!(
                         "Failed to set upstream for branch '{}': {}",
-                        name, e
+                        branch_name, e
                     ))
                 })?;
             log!(
                 "Upstream for branch '{}' set to {}/{}",
-                name,
+                branch_name,
                 upstream.remote,
                 upstream.branch
+            );
+
+            // Mirror the upstream wiring on the meta side.
+            transaction = transaction.assert(
+                replica
+                    .branch(branch_name.as_str())
+                    .set_upstream(&concept.branch(upstream.branch.as_str())),
             );
         }
     }
 
-    // 6. Respond with the current state of the repository.
-    let info = build_repository_info(&tonk, &name, &repository).await;
-    Ok((StatusCode::CREATED, Json(info)))
+    // 6. Commit the meta transaction. Everything above has
+    // already happened at the dialog layer; committing here
+    // makes the schema view of it land atomically.
+    transaction
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            RepositoryError::Internal(format!(
+                "Failed to commit meta for repository '{}': {}",
+                name, e
+            ))
+        })?;
+    log!("Wrote meta facts for repository '{}'", name);
+
+    Ok(repository)
 }
 
 /// Load a repository by name and return its [`RepositoryInfo`].
@@ -419,11 +543,7 @@ where
 
     RepositoryInfo {
         name: name.to_string(),
-        subject: repository
-            .did()
-            .to_string()
-            .parse()
-            .expect("repository DID is always a valid Did"),
+        subject: repository.did(),
         operator: tonk.operator.did(),
         profile: tonk.profile.did(),
         branch: branches,


### PR DESCRIPTION
### Description

Defines data model for storing information about repo inside a repo itself

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `tonk-schema` crate and integrates it into the existing `tonk` project, enhancing repository management with structured concepts for branches, remotes, and replicas.

### Detailed summary
- Added `tonk-schema` crate to the workspace.
- Modified CSS files for UI components.
- Introduced `RepositoryError` enum for error handling.
- Created `Replica`, `Branch`, `Remote`, and `TrackingBranch` concepts.
- Updated repository creation logic to handle new schema concepts.
- Enhanced repository info retrieval to include schema-based data.

> The following files were skipped due to too many changes: `rust/tonk-worker/src/router/repository.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->