### PR TITLE
feat(shell): render repo space inside a same-origin sandboxed iframe

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -24,29 +24,15 @@ self.onactivate = event => {
     log("Activated");
 };
 
+// Hand *every* fetch to the Rust side. The Rust worker decides
+// whether to route through its own handlers or pass the request
+// through to the network (which it does itself via `self.fetch`).
+// SPA-style 404 → index.html fallback and /api/* routing all
+// live in Rust now, so this shim is pure forwarding.
 self.onfetch = event => {
-    let request = event.request;
-    let url = new URL(request.url);
-
-    if (url.pathname.match(/^\/api/)) {
-        log(request.method, url.pathname);
-        event.respondWith(
-            (async () => {
-                return (await activateWorker()).onfetch(request);
-            })(),
-        );
-    // NOTE: Only intercept navigate as candidates for serving
-    // the index.html (in order to provide SPA-style routing)
-    } else if (request.mode === 'navigate') {
-        event.respondWith(
-            fetch(request).then(response => {
-                if (response.status === 404) {
-                    return fetch("/index.html");
-                }
-                return response;
-            }),
-        );
-    }
+    event.respondWith(
+        (async () => (await activateWorker()).onfetch(event))(),
+    );
 };
 
 // Background Sync API event handler

--- a/rust/tonk-ui/assets/styles/components.css
+++ b/rust/tonk-ui/assets/styles/components.css
@@ -1,3 +1,4 @@
 @import "./components/auth.css";
 @import "./components/toolbar.css";
 @import "./components/launcher.css";
+@import "./components/space.css";

--- a/rust/tonk-ui/assets/styles/components/launcher.css
+++ b/rust/tonk-ui/assets/styles/components/launcher.css
@@ -2,7 +2,7 @@
     display: grid;
     width: 100vw;
     height: 100vh;
-    grid-template-columns: 80px auto;
+    grid-template-columns: 80px 1fr;
     grid-template-rows: 100%;
-    grid-template-areas: "toolbar" "space";
+    grid-template-areas: "toolbar space";
 }

--- a/rust/tonk-ui/assets/styles/components/space.css
+++ b/rust/tonk-ui/assets/styles/components/space.css
@@ -1,0 +1,18 @@
+.space {
+    /* Sits in the `space` grid area of `.launcher` — see
+       components/launcher.css. Fill it and make the guest
+       iframe stretch edge-to-edge with no browser default
+       inset. */
+    grid-area: space;
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    overflow: hidden;
+}
+
+.space > .guest {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    border: 0;
+}

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -64,16 +64,20 @@ pub async fn repository(name: &str) -> Result<Option<RepositoryInfo>, TonkUiErro
 }
 
 /// Ensures the default repository exists via
-/// `PUT /api/repository/{name}` with `If-None-Match: *`.
+/// `PUT /api/repository/{name}` with `If-None-Match: *`, and
+/// returns the current document's service-worker Client ID as
+/// reported by the worker in the `X-Tonk-Client-Id` response
+/// header.
 ///
-/// Returns `Ok(())` whether the repo was just created (`201`) or
-/// already existed (`412`) — both are fine from the UI's point of
-/// view. Any other non-success status is turned into an error.
+/// Succeeds whether the repo was just created (`201`) or already
+/// existed (`412`) — both are fine from the UI's point of view.
+/// Any other non-success status, or a missing client-id header,
+/// is turned into an error.
 ///
 /// The body wires up an `origin` remote pointing at the UCAN access
 /// service (resolved against the current window origin) and sets
 /// the default branch to track `origin/{branch}`.
-pub async fn init() -> Result<(), TonkUiError> {
+pub async fn init() -> Result<String, TonkUiError> {
     log!("Ensuring repository '{}' exists...", DEFAULT_REPO);
 
     let service_url = format!("{}{}", origin(), ACCESS_SERVICE_PATH);
@@ -96,8 +100,29 @@ pub async fn init() -> Result<(), TonkUiError> {
         .await
         .map_err(into_api_error)?;
 
+    // The server returns a `RepositoryInfo` body on both `201
+    // Created` (fresh repo) and `412 Precondition Failed` (repo
+    // already existed). We don't use the body here — it's the
+    // `X-Tonk-Client-Id` header we're after — but leaving a
+    // JSON body on both status codes keeps `reqwest`'s wasm
+    // client happy: it otherwise surfaces a spurious "error
+    // decoding response body" when it finds an empty body on
+    // the `412` response path.
     match response.status() {
-        StatusCode::CREATED | StatusCode::PRECONDITION_FAILED => Ok(()),
+        StatusCode::OK | StatusCode::CREATED | StatusCode::PRECONDITION_FAILED => {
+            let host_id = response
+                .headers()
+                .get("x-tonk-client-id")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    TonkUiError::ApiError(
+                        "PUT /api/repository response missing X-Tonk-Client-Id header"
+                            .to_string(),
+                    )
+                })?;
+            Ok(host_id)
+        }
         status => {
             let text = response.text().await.unwrap_or_default();
             Err(TonkUiError::ApiError(format!(

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -38,6 +38,14 @@ pub enum Status {
     Ready,
 }
 
+/// The hosting document's service-worker Client ID, learned from
+/// the `X-Tonk-Client-Id` header on the `PUT /api/repository/...`
+/// response. Provided as a Leptos context so descendant
+/// components (notably [`TonkSpace`]) can embed it in iframe
+/// URLs for the host/guest bridge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostId(pub String);
+
 /// The root UI component for the Tonk application.
 ///
 /// This component serves as the main entry point for the Tonk user interface,
@@ -54,14 +62,17 @@ pub fn TonkShell() -> impl IntoView {
     // The worker no longer auto-creates anything at startup — we
     // `PUT` here with `If-None-Match: *`, which covers both
     // "didn't exist, created" (201) and "already existed" (412) as
-    // success. Redirect only fires when the current path is `/`
+    // success. The `PUT` response carries the hosting document's
+    // Client ID in `X-Tonk-Client-Id`, which we stash in context
+    // for descendant components to use when addressing guest
+    // iframes. Redirect only fires when the current path is `/`
     // so deep links like `/space/home/branch/main` are respected.
     let init_resource = LocalResource::new(|| async {
         log!("Waiting for SW to activate...");
         service_worker_activates().await;
         log!("SW is activated, ensuring default repository...");
 
-        api::init().await?;
+        let host_id = api::init().await?;
 
         let pathname = window()
             .location()
@@ -72,13 +83,13 @@ pub fn TonkShell() -> impl IntoView {
             BrowserUrl::redirect(&format!("/space/{}", api::DEFAULT_REPO));
         }
 
-        Ok::<_, crate::error::TonkUiError>(())
+        Ok::<_, crate::error::TonkUiError>(host_id)
     });
 
-    // Derive the application status from init resource
+    // Derive the application status from init resource.
     let status = Signal::derive_local(move || {
         match init_resource.get() {
-            Some(Ok(())) => Status::Ready,
+            Some(Ok(_)) => Status::Ready,
             Some(Err(e)) => {
                 log!("Initialization error: {:?}", e);
                 // Still show as loading on error - could add an Error state later
@@ -88,7 +99,18 @@ pub fn TonkShell() -> impl IntoView {
         }
     });
 
+    // Publish the host id as a reactive context so descendant
+    // components can subscribe to it: `None` while init is in
+    // flight or errored, `Some(host_id)` once the PUT succeeds.
+    let host_id = Signal::derive_local(move || {
+        init_resource
+            .get()
+            .and_then(|r| r.ok())
+            .map(HostId)
+    });
+
     provide_context(status);
+    provide_context(host_id);
 
     view! {
         <TonkLauncher></TonkLauncher>

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -5,7 +5,7 @@ use leptos_router::{
     params::Params,
 };
 
-use crate::api;
+use crate::{api, components::HostId};
 
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkSpaceParams {
@@ -20,6 +20,13 @@ pub struct TonkSpaceParams {
 /// for genuine failures (network errors, 5xx). A 404 is *not* an
 /// error — it's surfaced as `Ok(None)` from the API so it can flow
 /// through the normal value path and render a dedicated view.
+///
+/// Once the repository record is fetched, the space is presented
+/// inside a sandboxed guest iframe pointed at
+/// `/api/host/{host_id}/guest/{space}/`. The SW serves a
+/// pretty-printed JSON view of the repository as the iframe's
+/// content; the guest iframe reaches back into the SW to pull
+/// that info itself.
 ///
 /// If the `:space` segment is missing, redirects to
 /// `/space/{DEFAULT_REPO}`.
@@ -36,9 +43,15 @@ pub fn TonkSpace() -> impl IntoView {
             .filter(|s| !s.is_empty())
     });
 
+    let host_id = use_context::<Signal<Option<HostId>, LocalStorage>>();
+
     let repository = LocalResource::new(move || {
         let name = space_name.get();
+        let ready = host_id.and_then(|s| s.get()).is_some();
         async move {
+            if !ready {
+                return Ok(None);
+            }
             match name {
                 None => {
                     BrowserUrl::redirect(&format!("/space/{}", api::DEFAULT_REPO));
@@ -60,11 +73,27 @@ pub fn TonkSpace() -> impl IntoView {
                     </section>
                 }>
                     { move || repository.get().map(|result| result.map(|repo| match repo {
-                        Some(status) => Either::Left(view! {
-                            <pre class="repository">
-                                { serde_json::to_string_pretty(&status).unwrap_or_default() }
-                            </pre>
-                        }),
+                        Some(_info) => {
+                            let space = space_name.get().unwrap_or_default();
+                            let host = host_id.and_then(|s| s.get()).map(|h| h.0);
+                            Either::Left(match host {
+                                Some(host) => Either::Left(view! {
+                                    <iframe
+                                        class="guest"
+                                        sandbox="allow-scripts allow-same-origin"
+                                        src=format!(
+                                            "/api/host/{}/guest/{}/",
+                                            host, space,
+                                        )
+                                    />
+                                }),
+                                None => Either::Right(view! {
+                                    <span class="loading">
+                                        "Waiting for service worker…"
+                                    </span>
+                                }),
+                            })
+                        }
                         None => Either::Right(view! {
                             <section class="not-found">
                                 { move || format!(

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -25,6 +25,9 @@ pub use sync::SyncResponse;
 mod identify;
 pub use identify::IdentifyResponse;
 
+mod host;
+pub use host::{ClientId, GuestBinding, GuestBindings};
+
 /// Shared application state containing profile and operator.
 pub type AppState = Arc<RwLock<TonkState>>;
 
@@ -35,9 +38,18 @@ async fn root(State(_state): State<AppState>) -> &'static str {
 
 /// Creates the API router with all configured routes.
 ///
-/// Sets up the routing tree with the TonkState as shared state.
-pub fn api_router(state: TonkState) -> Router {
+/// Sets up the routing tree with the TonkState as shared state,
+/// and returns the router alongside a cloneable handle to the
+/// state itself. The worker keeps that handle so it can inspect
+/// shared state (e.g. the guest-binding map) before deciding
+/// whether to dispatch into the router at all.
+pub fn api_router(state: TonkState) -> (Router, AppState) {
     let state: AppState = Arc::new(RwLock::new(state));
+    let router = build_router(state.clone());
+    (router, state)
+}
+
+fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/api", get(root))
         .route("/api/identify", get(identify::identify))
@@ -93,6 +105,19 @@ pub fn api_router(state: TonkState) -> Router {
             "/api/inspect/repository/{repo}/remote/{remote}/archive/index/{hash}",
             get(inspect::archive::inspect_remote_archive_block),
         )
+        // Host/guest iframe bridge. The wildcard matches both the
+        // iframe's initial navigation (where `rest` is empty) and
+        // any subresource fetched under the same prefix. The
+        // handler looks at `rest` to decide which behaviour to
+        // apply.
+        .route(
+            "/api/host/{host_id}/guest/{repo}/{*rest}",
+            get(host::guest),
+        )
+        .route(
+            "/api/host/{host_id}/guest/{repo}/",
+            get(host::guest_empty_rest),
+        )
         .with_state(state)
 }
 
@@ -142,7 +167,11 @@ pub mod tests {
             .await
             .expect("Failed to build test operator");
 
-        TonkState { profile, operator }
+        TonkState {
+            profile,
+            operator,
+            guests: Default::default(),
+        }
     }
 
     /// Creates a test repository via `PUT /api/repository/{name}`.

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -1,0 +1,217 @@
+//! Host/guest iframe bridge.
+//!
+//! A hosting document (e.g. the Tonk shell) discovers its own
+//! Client ID from the `X-Tonk-Client-Id` header that the service
+//! worker echoes on every response. It then embeds a sandboxed
+//! iframe pointed at `/api/host/{host_id}/guest/{repo}/`. When the
+//! browser issues the initial navigation fetch for that URL the
+//! service worker:
+//!
+//! - records `resulting_client_id → {host_id, repo}` in the
+//!   [`GuestBindings`] map hanging off `TonkState`, so that all
+//!   subsequent subresource fetches from the same iframe can be
+//!   identified by client id alone without parsing the URL each
+//!   time;
+//! - serves a hardcoded HTML placeholder that exercises the full
+//!   round-trip (fetch back into the SW, read the clientId
+//!   binding, dispatch to an existing API handler).
+//!
+//! This is step 1 of the design. Path-rewriting into repository-
+//! scoped routes will come in a later step.
+//!
+//! The host_id is validated against the live set of controlled
+//! clients (via `self.clients.get(host_id)`) at some point — for
+//! now we accept any non-empty string so the first iteration is
+//! easy to poke at; tightening that up is a follow-up.
+
+use std::{collections::HashMap, sync::Arc};
+
+use ::axum::{
+    Json,
+    extract::{Path, Request, State},
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use axum_wasm_macros::wasm_compat;
+use tokio::sync::RwLock;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use super::{AppState, identify::IdentifyResponse};
+
+/// Snapshot what the guest-register / guest-lookup path needs
+/// out of [`AppState`], released before any awaits on the guest
+/// map itself, so that guest traffic never contends with
+/// profile/operator access on the outer [`TonkState`] lock.
+async fn snapshot(state: &AppState) -> (GuestBindings, String) {
+    let tonk = state.read().await;
+    (tonk.guests.clone(), tonk.profile.did().to_string())
+}
+
+/// A service worker Client ID, extracted from a `FetchEvent` by
+/// the JS shim and attached to each request as an extension.
+///
+/// This is the stable identifier for the document/worker that
+/// initiated the request — it outlives any single fetch and is
+/// stable for the lifetime of the document.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientId(pub String);
+
+/// Binding that records which repository (and which hosting
+/// document) an iframe client is associated with.
+///
+/// Populated on the iframe's initial navigation fetch; looked up
+/// on every subsequent subresource fetch from the same client.
+#[derive(Clone, Debug)]
+pub struct GuestBinding {
+    /// The Client ID of the hosting document — the one that
+    /// rendered the iframe.
+    pub host: ClientId,
+    /// The repository name the iframe is scoped to.
+    pub repo: String,
+}
+
+/// Shared map of guest `ClientId → GuestBinding`.
+///
+/// Lives on [`TonkState::guests`] behind its own interior
+/// `RwLock`, so guest registration / lookup doesn't serialize
+/// against profile or operator access on the outer state lock.
+pub type GuestBindings = Arc<RwLock<HashMap<ClientId, GuestBinding>>>;
+
+/// Placeholder HTML served for a guest iframe.
+///
+/// This is what the parent's bootstrap script pulls in via
+/// `fetch` + `document.write`. The `<base href="...">` is what
+/// makes relative URLs resolve under the guest's namespace: the
+/// iframe's own document URL is `about:srcdoc`, so without a
+/// base the browser would resolve `api/identify` against that
+/// (and fail). With the base set, `fetch("api/identify")` lands
+/// at `/api/host/{host}/guest/{repo}/api/identify`, which the
+/// guest router dispatches to the real identify handler.
+fn placeholder_html(_host: &str, repo: &str) -> String {
+    // The iframe's script fetches `"/"` without knowing its
+    // own repo name — the service worker's `guest_rewrite`
+    // middleware sees the request's clientId, looks up the
+    // guest binding, and rewrites `/` to
+    // `/api/repository/{repo}`. The iframe stays namespace-
+    // agnostic; the SW handles the scoping.
+    format!(
+        r#"<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tonk Guest — {repo}</title>
+<body>
+  <pre class="repository" id="repo">loading…</pre>
+  <script>
+    fetch("/")
+      .then(r => r.json())
+      .then(info => {{
+        document.getElementById("repo").textContent =
+          JSON.stringify(info, null, 2);
+      }})
+      .catch(e => {{
+        document.getElementById("repo").textContent =
+          "error: " + e;
+      }});
+  </script>
+</body>
+"#
+    )
+}
+
+/// Handler for `GET /api/host/{host_id}/guest/{repo}/{*rest}`.
+///
+/// On the iframe's initial navigation (empty `rest`) records a
+/// guest binding against the requesting client's ID and returns
+/// the placeholder HTML.
+///
+/// On subresource fetches (non-empty `rest`) looks up the
+/// caller's binding and, for step 1, dispatches exactly one
+/// known path (`api/identify`) to its real handler. Full path
+/// rewriting into the repository-scoped routes is a later step.
+#[wasm_compat]
+pub async fn guest(
+    State(state): State<AppState>,
+    Path((host_id, repo, rest)): Path<(String, String, String)>,
+    request: Request,
+) -> Response {
+    let client_id = request.extensions().get::<ClientId>().cloned();
+
+    log!(
+        "GUEST host={} repo={} rest={:?} client={:?}",
+        host_id,
+        repo,
+        rest,
+        client_id,
+    );
+
+    // Navigation request: empty rest means the iframe is loading
+    // its own document. Register the client and serve HTML.
+    if rest.is_empty() {
+        if let Some(client) = client_id {
+            let guests = state.read().await.guests.clone();
+            guests.write().await.insert(
+                client.clone(),
+                GuestBinding {
+                    host: ClientId(host_id.clone()),
+                    repo: repo.clone(),
+                },
+            );
+            log!(
+                "Registered guest client {:?} -> host={} repo={}",
+                client,
+                host_id,
+                repo
+            );
+        }
+
+        let body = placeholder_html(&host_id, &repo);
+        let mut response = (StatusCode::OK, body).into_response();
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        );
+        return response;
+    }
+
+    // Subresource request: client must already be bound.
+    let Some(client) = client_id else {
+        return (StatusCode::FORBIDDEN, "missing client id").into_response();
+    };
+
+    let (guests, did) = snapshot(&state).await;
+    let binding = guests.read().await.get(&client).cloned();
+    let Some(binding) = binding else {
+        return (StatusCode::FORBIDDEN, "client is not a registered guest").into_response();
+    };
+
+    // The authoritative binding is on clientId; the host_id/repo
+    // in the URL is cosmetic. If they disagree, something has
+    // drifted and it's not safe to serve.
+    if binding.repo != repo || binding.host.0 != host_id {
+        return (StatusCode::FORBIDDEN, "client binding does not match URL").into_response();
+    }
+
+    if rest == "api/identify" {
+        return Json(IdentifyResponse { did }).into_response();
+    }
+
+    (StatusCode::NOT_FOUND, format!("no guest route for {rest}")).into_response()
+}
+
+/// Thin shim for the empty-path variant of the guest route.
+///
+/// axum's `{*rest}` wildcard requires at least one segment, so a
+/// request for the bare trailing-slash URL doesn't match the
+/// wildcard route — it needs its own entry. This handler just
+/// constructs a fake empty `rest` and defers to [`guest`], so
+/// all the logic stays in one place.
+#[wasm_compat]
+pub async fn guest_empty_rest(
+    state: State<AppState>,
+    Path((host_id, repo)): Path<(String, String)>,
+    request: Request,
+) -> Response {
+    let path = ::axum::extract::Path((host_id, repo, String::new()));
+    guest(state, path, request).await
+}

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -186,27 +186,40 @@ pub async fn put_repository(
     let tonk = state.write().await;
 
     // 1. Check if the repo already exists before attempting to
-    // create. `.load()` returns Ok when the space is present; in
-    // that case the PUT is rejected with 412 (if the caller sent
-    // `If-None-Match: *`) or 409 (otherwise). Relying on
-    // `.create()`'s own error signalling isn't enough because
-    // it's possible for the space to exist while being
-    // inconsistent enough that `.create()` would either succeed
-    // (overwriting) or fail in a way we can't classify cleanly.
-    if tonk
+    // create. `.load()` returning Ok means the space is present,
+    // which drives one of three outcomes:
+    //   - `If-None-Match: *`: respond `412 Precondition Failed`
+    //     but still include the existing repository's info so
+    //     callers can hydrate from a single request.
+    //   - no precondition header: respond `409 Conflict`.
+    // Relying on `.create()`'s own error signalling isn't enough:
+    // an inconsistent space might either let `.create()` succeed
+    // (overwriting) or fail in a way we can't classify cleanly,
+    // so we probe with `.load()` first.
+    if let Ok(existing) = tonk
         .profile
         .repository(&name)
         .load()
         .perform(&tonk.operator)
         .await
-        .is_ok()
     {
-        let message = format!("Repository '{}' already exists", name);
-        return Err(if if_none_match_star {
-            TonkWorkerError::PreconditionFailed(message)
-        } else {
-            TonkWorkerError::Conflict(message)
-        });
+        if if_none_match_star {
+            // Repo exists: treat `If-None-Match: *` as "give me
+            // the current info" and respond with 200 + the same
+            // `RepositoryInfo` body as a fresh create. 412 would
+            // be the strictly HTTP-correct code, but reqwest's
+            // wasm client aborts 412 responses (ERR_ABORTED)
+            // even when the response body is valid, so callers
+            // can't read the body reliably. Since the payload
+            // fully describes the current state either way, 200
+            // is observationally equivalent for our UI.
+            let info = build_repository_info(&tonk, &name, &existing).await;
+            return Ok((StatusCode::OK, Json(info)));
+        }
+        return Err(TonkWorkerError::Conflict(format!(
+            "Repository '{}' already exists",
+            name
+        )));
     }
 
     // 2. Create the repository. Any failure here is genuinely

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -7,8 +7,13 @@ use std::sync::Arc;
 use crate::{
     api_router,
     axum::{RequestConversion, ResponseConversion},
+    router::{AppState, ClientId},
 };
-use axum::{Router, body::Body};
+use axum::{
+    Router,
+    body::Body,
+    http::{HeaderValue, header::HeaderName},
+};
 use dialog_capability::Subject;
 use dialog_operator::{Operator, Profile};
 use dialog_storage::provider::storage::Storage;
@@ -17,8 +22,202 @@ use tokio::sync::Mutex;
 use tonk_common::log;
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::future_to_promise;
-use web_sys::{Request, Response};
+use wasm_bindgen_futures::{JsFuture, future_to_promise};
+use web_sys::{FetchEvent, Request, Response};
+
+// Global `self.fetch(...)` in the service-worker scope. Fetches
+// issued from an SW bypass the SW's own `onfetch` listener (per
+// spec), so this is how we pass through requests the Rust side
+// chose not to handle.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = fetch)]
+    fn sw_fetch(request: &Request) -> Promise;
+
+    #[wasm_bindgen(js_name = fetch)]
+    fn sw_fetch_str(url: &str) -> Promise;
+}
+
+/// Extract the `resultingClientId` property from a `FetchEvent`.
+///
+/// web-sys 0.3.85 exposes `FetchEvent.client_id()` but not
+/// `resultingClientId`. For navigation requests `client_id` is
+/// empty and `resultingClientId` holds the ID the new document
+/// will have, so we need both. Read the property via reflection
+/// rather than extending `FetchEvent` with a manual extern —
+/// wasm-bindgen doesn't allow `impl`-style extension of foreign
+/// types from outside their defining crate.
+fn event_resulting_client_id(event: &FetchEvent) -> String {
+    js_sys::Reflect::get(event, &JsValue::from_str("resultingClientId"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+}
+
+/// Outcome of the routing decision made in `on_fetch`.
+enum Route {
+    /// Dispatch through the axum router. `rewritten_path` is
+    /// `Some` only when the request originated from a registered
+    /// guest iframe and its path needs to be re-rooted under the
+    /// iframe's repository (e.g. `/` → `/api/repository/home`).
+    Handle { rewritten_path: Option<String> },
+    /// Pass the request through to the network.
+    Passthrough,
+}
+
+/// Decides how the Rust side should route this request.
+///
+/// - Paths under `/api/` are always handled by the axum router as-is.
+/// - Requests whose initiating client is a registered guest
+///   iframe are *also* handled by the router, but with their
+///   path rewritten to live under `/api/repository/{repo}`. That
+///   's what gives the iframe a virtual root scoped to its
+///   repository: the iframe fetches `/` and the router sees
+///   `/api/repository/{repo}`, etc.
+/// - Everything else falls through to the network.
+async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
+    if path.starts_with("/api/") {
+        return Route::Handle {
+            rewritten_path: None,
+        };
+    }
+    if client_id.is_empty() {
+        return Route::Passthrough;
+    }
+
+    let binding = {
+        let guests = state.read().await.guests.clone();
+        let guard = guests.read().await;
+        guard.get(&ClientId(client_id.to_string())).cloned()
+    };
+
+    let Some(binding) = binding else {
+        return Route::Passthrough;
+    };
+
+    let rewritten = if path == "/" || path.is_empty() {
+        format!("/api/repository/{}", binding.repo)
+    } else {
+        format!("/api/repository/{}{}", binding.repo, path)
+    };
+    Route::Handle {
+        rewritten_path: Some(rewritten),
+    }
+}
+
+/// Route the request through the axum router, apply response
+/// headers (CORS, client-id echo), and convert back to a browser
+/// `Response`.
+///
+/// If `rewritten_path` is `Some`, the request's URI is rewritten
+/// to that path before axum gets it — that's how guest-iframe
+/// requests get redirected into their repository's namespace
+/// without axum's own routing layer ever seeing the un-scoped
+/// URL.
+async fn handle_via_router(
+    router: Arc<Mutex<Router>>,
+    browser_request: Request,
+    client_id: String,
+    rewritten_path: Option<String>,
+) -> Result<JsValue, JsValue> {
+    let mut request: axum::http::Request<Body> = RequestConversion::from(browser_request)
+        .try_into()
+        .map_err(JsValue::from)?;
+
+    if let Some(new_path) = rewritten_path {
+        // Preserve the query string; axum routes by path but
+        // handlers parse query params, so losing them would drop
+        // things like `?the=…&of=…` on claim/select requests.
+        let uri_string = match request.uri().query() {
+            Some(q) => format!("{}?{}", new_path, q),
+            None => new_path.clone(),
+        };
+        if let Ok(uri) = uri_string.parse::<axum::http::Uri>() {
+            log!("handle_via_router: rewriting path to {}", uri);
+            *request.uri_mut() = uri;
+        }
+    }
+
+    if !client_id.is_empty() {
+        request
+            .extensions_mut()
+            .insert(ClientId(client_id.clone()));
+    }
+
+    log!("handle_via_router: acquiring router lock");
+    let mut response = router
+        .lock()
+        .await
+        .call(request)
+        .await
+        .expect_throw("Failed to handle API request");
+    log!(
+        "handle_via_router: router returned status={}",
+        response.status()
+    );
+
+    let headers = response.headers_mut();
+
+    if !client_id.is_empty()
+        && let Ok(value) = HeaderValue::from_str(&client_id)
+    {
+        headers.insert(HeaderName::from_static("x-tonk-client-id"), value);
+    }
+
+    // CORS: sandboxed iframes have an opaque origin and send
+    // `Origin: null`, so cross-origin rules kick in even though
+    // the iframe and the service worker sit on the same URL
+    // origin. Send permissive headers on every response — same-
+    // origin callers ignore them and opaque-origin callers need
+    // them to read the body. Credentials stay off: the only
+    // valid value for `Access-Control-Allow-Credentials` is
+    // `true` (the header is omitted otherwise), so we simply
+    // don't emit it.
+    headers.insert(
+        HeaderName::from_static("access-control-allow-origin"),
+        HeaderValue::from_static("*"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-allow-methods"),
+        HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-allow-headers"),
+        HeaderValue::from_static("content-type, if-none-match"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-expose-headers"),
+        HeaderValue::from_static("x-tonk-client-id"),
+    );
+
+    log!("handle_via_router: converting response");
+    let result = ResponseConversion::from(response)
+        .try_into()
+        .map(|value: Response| JsValue::from(value))
+        .map_err(JsValue::from);
+    log!("handle_via_router: returning result");
+    result
+}
+
+/// Pass the request through to the network by calling
+/// `self.fetch(request)` from inside the service worker. Such
+/// fetches bypass the SW's own `onfetch` handler (per spec), so
+/// this really does hit the network.
+///
+/// For navigation requests that 404, retry against `/index.html`
+/// so the client-side SPA router can match unknown paths.
+async fn passthrough(request: Request, is_navigation: bool) -> Result<JsValue, JsValue> {
+    let response: Response = JsFuture::from(sw_fetch(&request)).await?.dyn_into()?;
+
+    if is_navigation && response.status() == 404 {
+        let fallback: Response = JsFuture::from(sw_fetch_str("/index.html"))
+            .await?
+            .dyn_into()?;
+        return Ok(JsValue::from(fallback));
+    }
+
+    Ok(JsValue::from(response))
+}
 
 /// Default storage type — IndexedDB on WASM, filesystem on native.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -31,12 +230,18 @@ pub type DefaultSpace = dialog_storage::provider::storage::NativeSpace;
 /// Concrete operator type for the default storage backend.
 pub type DefaultOperator = Operator<DefaultSpace>;
 
-/// Application state containing the profile and operator.
+/// Application state containing the profile, operator, and SW-
+/// plumbing bookkeeping (currently just the guest-iframe client
+/// bindings).
 pub struct TonkState {
     /// The user's persistent profile.
     pub profile: Profile,
     /// The operator derived from the profile.
     pub operator: DefaultOperator,
+    /// Guest-iframe bindings keyed by service-worker Client ID.
+    /// Behind its own interior lock so guest registration /
+    /// lookup doesn't contend with profile/operator access.
+    pub guests: crate::router::GuestBindings,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -55,6 +260,12 @@ unsafe impl Sync for TonkState {}
 #[wasm_bindgen]
 pub struct TonkServiceWorker {
     router: Arc<Mutex<Router>>,
+    /// Shared application state. Also owned by the router's
+    /// internal state, but we keep a handle here so `on_fetch`
+    /// can consult the guest-binding map *before* dispatching —
+    /// that's how we decide whether to route through axum or
+    /// pass the request through to the network.
+    state: AppState,
 }
 
 #[wasm_bindgen]
@@ -96,43 +307,87 @@ impl TonkServiceWorker {
             .map_err(|e| JsError::new(&format!("Failed to build operator: {}", e)))?;
 
         // 4. Build state and router
-        let state = TonkState { profile, operator };
-        let router = Arc::new(Mutex::new(api_router(state)));
+        let tonk_state = TonkState {
+            profile,
+            operator,
+            guests: Default::default(),
+        };
+        let (router, state) = api_router(tonk_state);
+        let router = Arc::new(Mutex::new(router));
 
-        Ok(Self { router })
+        Ok(Self { router, state })
     }
 
     /// Handles incoming fetch events from the browser.
     ///
-    /// Converts the browser's `Request` to an Axum request, processes it through
-    /// the router, and converts the response back to a browser `Response`.
+    /// Called from the JS shim's `self.onfetch` listener for
+    /// *every* request the service worker sees. Rust decides
+    /// whether to handle the request itself (via the axum router)
+    /// or pass it through to the network. The shim never
+    /// inspects the URL — all routing policy lives here.
     ///
-    /// # Parameters
+    /// Decision rule (see [`route_for`]):
+    /// - If the request's path starts with `/api/`, route through
+    ///   the axum router unchanged.
+    /// - If the initiating client is a registered guest iframe,
+    ///   rewrite the path to live under `/api/repository/{repo}`
+    ///   and route through the axum router. This is what makes
+    ///   the iframe see its repo as its virtual root: it fetches
+    ///   `/` and we dispatch `/api/repository/{repo}`, it fetches
+    ///   `/branch/main/...` and we dispatch
+    ///   `/api/repository/{repo}/branch/main/...`.
+    /// - Otherwise, pass through to the network via `sw_fetch`.
     ///
-    /// - `request`: The incoming browser fetch request
-    ///
-    /// # Returns
-    ///
-    /// A JavaScript `Promise` that resolves to the response
+    /// Navigation requests that pass through and 404 are retried
+    /// against `/index.html` so the client-side SPA router gets
+    /// a chance at unknown routes.
     #[wasm_bindgen(js_name = "onfetch")]
-    pub fn on_fetch(&self, request: Request) -> Promise {
-        log!("Handling fetch!");
+    pub fn on_fetch(&self, event: FetchEvent) -> Promise {
+        let request = event.request();
+        let client_id = event.client_id().unwrap_or_default();
+        let resulting_client_id = event_resulting_client_id(&event);
+
+        // Prefer `clientId` (present on subresource requests) over
+        // `resultingClientId` (present on navigations). Exactly one
+        // is populated for any fetch a service worker sees.
+        let effective_client_id = if !client_id.is_empty() {
+            client_id
+        } else {
+            resulting_client_id
+        };
+
+        let url = request.url();
+        let is_navigation = request.mode() == web_sys::RequestMode::Navigate;
+
+        // Parse the URL path locally so we can route-decide
+        // without touching Rust's http types yet.
+        let path = url::Url::parse(&url)
+            .map(|u| u.path().to_string())
+            .unwrap_or_default();
 
         let router = self.router.clone();
-        let request: axum::http::Request<Body> =
-            RequestConversion::from(request).try_into().unwrap_throw();
+        let state = self.state.clone();
 
         future_to_promise(async move {
-            let response = router
-                .lock()
-                .await
-                .call(request)
-                .await
-                .expect_throw("Failed to handle API request");
-            ResponseConversion::from(response)
-                .try_into()
-                .map(|value: Response| JsValue::from(value))
-                .map_err(JsValue::from)
+            log!(
+                "onfetch path={} mode={:?} client={:?}",
+                path,
+                request.mode(),
+                effective_client_id,
+            );
+
+            match route_for(&path, &effective_client_id, &state).await {
+                Route::Handle { rewritten_path } => {
+                    handle_via_router(
+                        router,
+                        request,
+                        effective_client_id,
+                        rewritten_path,
+                    )
+                    .await
+                }
+                Route::Passthrough => passthrough(request, is_navigation).await,
+            }
         })
     }
 


### PR DESCRIPTION
Adds a host/guest iframe bridge so each repository renders inside its own sandboxed `<iframe>` backed by the service worker instead of being printed directly into the shell's DOM. The JS shim now forwards every fetch to Rust, which decides per-request whether to route through the axum router or pass through to the network via `self.fetch`. Guest iframes get their URIs rewritten into `/api/repository/{repo}/...` before axum routes them, so iframe content can fetch relative to a virtual root without ever learning which repo it's in.

Summary of the moving parts:

- `TonkServiceWorker::on_fetch` now takes a `FetchEvent`, pulls `clientId` and `resultingClientId` (the latter via reflection — web-sys 0.3.85 has no binding for it), and decides via `route_for` whether to dispatch the request or pass it through. Pass-through is a direct `sw_fetch` with the SPA `/index.html` fallback for navigations — that behaviour lived in the JS shim before and now lives here alongside everything else.
- `router::host` serves the iframe's placeholder HTML at `/api/host/{host}/guest/{repo}/` and records a `clientId -> {host, repo}` binding on first load. Bindings hang off `TonkState.guests` so fetches from a known guest iframe can be rewritten without any extra handshake.
- `put_repository` now returns the existing `RepositoryInfo` on a same-shape `200 OK` when `If-None-Match: *` hits an existing repo, instead of `412 Precondition Failed`. reqwest's wasm client was aborting the 412 response body even though it carried valid JSON, which made first-load flakey; 200 is observationally equivalent for our caller and sidesteps the reqwest bug.
- `TonkShell::init` reads `X-Tonk-Client-Id` off the PUT response, publishes it through a `HostId` context signal, and `TonkSpace` uses it to build the iframe's `src`. The repository GET is gated on that signal so we don't race the service worker's activation with an unauthenticated fetch that would otherwise fall through to the dev server.

Isolation caveat worth naming: `allow-same-origin` is required for the sandboxed iframe to be SW-controlled at all, and it also gives the iframe full access to the parent's IndexedDB / DOM. The sandbox flags still prevent accidental top navigation, popups, forms, modals, and downloads, which is enough for content we author ourselves. Stronger isolation would require a second origin and a Lunet-style postMessage bridge, which is out of scope here.

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- closes [Linear ID, e.g. TON-123]

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` application by implementing a host/guest iframe bridge, improving routing for guest clients, and refining the service worker's fetch handling to support SPA-style navigation and repository management.

### Detailed summary
- Added `space.css` for styling the new `.space` grid area.
- Updated `launcher.css` to modify grid layout.
- Implemented guest iframe handling in `host.rs`, including guest registration.
- Enhanced `api_router` to return shared application state.
- Improved service worker's fetch logic for SPA routing and client ID management.
- Updated `init` function to return Client ID for the UI context.
- Added error handling for repository creation and existing checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->