### PR TITLE
Feat/standard schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4706,14 +4706,27 @@ dependencies = [
 name = "tonk-schema"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base58",
+ "blake3",
+ "bs58",
  "dialog-artifacts",
+ "dialog-capability",
  "dialog-common",
+ "dialog-credentials",
+ "dialog-effects",
+ "dialog-operator",
  "dialog-query",
+ "dialog-remote-ucan-s3",
  "dialog-repository",
+ "dialog-storage",
  "dialog-varsig",
+ "ed25519-dalek",
+ "futures-util",
  "serde",
  "serde_ipld_dagcbor",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/tonk-schema/Cargo.toml
+++ b/rust/tonk-schema/Cargo.toml
@@ -7,11 +7,27 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 base58 = { workspace = true }
+blake3 = { workspace = true }
+bs58 = { workspace = true }
 dialog-artifacts = { workspace = true }
+dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
+dialog-effects = { workspace = true }
 dialog-query = { workspace = true }
 dialog-repository = { workspace = true }
 dialog-varsig = { workspace = true }
+ed25519-dalek = { workspace = true }
+futures-util = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_ipld_dagcbor = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+dialog-credentials = { workspace = true }
+dialog-operator = { workspace = true }
+dialog-remote-ucan-s3 = { workspace = true }
+dialog-repository = { workspace = true, features = ["helpers"] }
+dialog-storage = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -50,3 +50,8 @@ pub use remote::*;
 
 pub mod tracking_branch;
 pub use tracking_branch::*;
+
+pub mod store;
+pub use store::*;
+
+pub mod runtime;

--- a/rust/tonk-schema/src/runtime.rs
+++ b/rust/tonk-schema/src/runtime.rs
@@ -1,0 +1,1024 @@
+// `missing_docs` is allowed here for the lift from `carry/src/schema.rs`
+// — the original module wasn't fully documented and adding doc strings
+// is a separate task. Re-enable once the lift settles.
+#![allow(missing_docs)]
+
+//! Generic concepts & claims runtime — typed dialog-meta attributes,
+//! the built-in `attribute`/`concept`/`bookmark` schemas, deterministic
+//! entity derivation, and the storage helpers that the carry CLI and
+//! the future tonk-notation analyzer both build on.
+//!
+//! Lifted from `carry/src/schema.rs` so both clients (and any future
+//! ones — language server, web UI, etc.) can share one
+//! implementation. `Operator<NativeSpace>` was generalised to
+//! [`MetaEnv`] so the same code works on the wasm worker's
+//! `Operator<WebSpace>`, on the carry CLI's `Operator<NativeSpace>`,
+//! or on a `VolatileSpace` test rig.
+//!
+//! ## Meta-schema domains (RFC)
+//!
+//! | Domain                  | Purpose                                          |
+//! |-------------------------|--------------------------------------------------|
+//! | `dialog.attribute`      | Attribute identity fields (id, type, cardinality) |
+//! | `dialog.concept.with`   | Required concept membership by field name         |
+//! | `dialog.concept.maybe`  | Optional concept membership by field name          |
+//! | `dialog.meta`           | Universal metadata: names and descriptions        |
+
+use anyhow::{Context, Result};
+
+use dialog_artifacts::ArtifactSelector;
+/// Re-export the attribute type used in Artifacts (EAV triples).
+pub use dialog_artifacts::Attribute as ClaimAttribute;
+pub use dialog_query::AttributeStatement;
+use dialog_query::{Entity, The, Value};
+use dialog_repository::Branch;
+use futures_util::TryStreamExt;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+use crate::store::MetaEnv;
+
+// ---------------------------------------------------------------------------
+// Typed primitive attributes (RFC Appendix: Primitive domains)
+// ---------------------------------------------------------------------------
+
+/// Universal metadata attributes: names and descriptions for any entity.
+pub mod dialog_meta {
+    /// Human-readable name for any entity.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.meta")]
+    pub struct Name(pub String);
+
+    /// Human-readable description for any entity.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.meta")]
+    pub struct Description(pub String);
+}
+
+/// Attribute identity fields.
+pub mod dialog_attribute {
+    /// Nominal identifier (selector) of the attribute, e.g. `io.gozala.person/name`.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    pub struct Id(pub String);
+
+    /// Value type of the attribute (e.g. Text, UnsignedInteger, Symbol).
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    pub struct Type(pub String);
+
+    /// Cardinality: `one` or `many`.
+    #[derive(dialog_query::Attribute, Clone, PartialEq)]
+    #[namespace("dialog.attribute")]
+    pub struct Cardinality(pub String);
+}
+
+// ---------------------------------------------------------------------------
+// Typed builtin concept structs
+// ---------------------------------------------------------------------------
+
+/// The `attribute` concept: models a typed relation.
+///
+/// CLI field mapping:
+///   `the`         -> `dialog.attribute/id`
+///   `as`          -> `dialog.attribute/type`
+///   `cardinality` -> `dialog.attribute/cardinality`
+///   `description` -> `dialog.meta/description`
+#[derive(dialog_query::Concept, Debug, Clone)]
+pub struct AttributeDef {
+    pub this: Entity,
+    pub description: dialog_meta::Description,
+    pub the: dialog_attribute::Id,
+    // TODO: use `#[dialog(rename = "as")]` when available
+    pub as_type: dialog_attribute::Type,
+    pub cardinality: dialog_attribute::Cardinality,
+}
+
+/// The `bookmark` concept: maps a name to any entity.
+///
+/// CLI field mapping:
+///   `name` -> `dialog.meta/name`
+#[derive(dialog_query::Concept, Debug, Clone)]
+pub struct BookmarkDef {
+    pub this: Entity,
+    pub name: dialog_meta::Name,
+}
+
+// Note: The `concept` concept cannot be fully expressed with #[derive(Concept)]
+// because its `with` and `maybe` fields are variable-keyed (with.{?name}).
+// The fixed `description` field is captured here; variable-keyed fields are
+// handled dynamically.
+
+/// The `concept` concept (partial): captures the fixed `description` field.
+///
+/// Variable-keyed fields (`with.{name}`, `maybe.{name}`) are handled
+/// dynamically in assertion/query code.
+#[derive(dialog_query::Concept, Debug, Clone)]
+pub struct ConceptDef {
+    pub this: Entity,
+    pub description: dialog_meta::Description,
+}
+
+// ---------------------------------------------------------------------------
+// Builtin concept field mapping (CLI field name -> attribute selector)
+// ---------------------------------------------------------------------------
+
+/// A field within a pre-registered concept's schema.
+#[derive(Debug, Clone)]
+pub struct BuiltinField {
+    /// The field name as exposed to the CLI (e.g. "the", "as", "name").
+    pub cli_name: &'static str,
+    /// The fully-qualified relation identifier this field maps to.
+    pub relation: &'static str,
+    /// The expected value type (for documentation/validation).
+    pub value_type: &'static str,
+    /// Default cardinality.
+    pub cardinality: &'static str,
+    /// Whether this is a variable-keyed field (e.g. `with` on the concept concept).
+    pub variable_keyed: bool,
+}
+
+/// Schema for a pre-registered concept.
+#[derive(Debug, Clone)]
+pub struct BuiltinConceptSchema {
+    /// The concept name (also its bookmark).
+    pub name: &'static str,
+    /// Human-readable description.
+    pub description: &'static str,
+    /// Required fields (`with`).
+    pub with_fields: &'static [BuiltinField],
+    /// Optional fields (`maybe`).
+    pub maybe_fields: &'static [BuiltinField],
+}
+
+/// The `attribute` concept schema.
+pub static BUILTIN_ATTRIBUTE: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "attribute",
+    description: "Built-in concept for modeling attributes",
+    with_fields: &[
+        BuiltinField {
+            cli_name: "description",
+            relation: "dialog.meta/description",
+            value_type: "Text",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "the",
+            relation: "dialog.attribute/id",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "as",
+            relation: "dialog.attribute/type",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "cardinality",
+            relation: "dialog.attribute/cardinality",
+            value_type: "Symbol",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+    ],
+    maybe_fields: &[],
+};
+
+/// The `concept` concept schema.
+pub static BUILTIN_CONCEPT: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "concept",
+    description: "Built-in concept for composing attributes into a shape",
+    with_fields: &[
+        BuiltinField {
+            cli_name: "description",
+            relation: "dialog.meta/description",
+            value_type: "Text",
+            cardinality: "one",
+            variable_keyed: false,
+        },
+        BuiltinField {
+            cli_name: "with",
+            relation: "dialog.concept.with/",
+            value_type: "attribute",
+            cardinality: "one",
+            variable_keyed: true,
+        },
+    ],
+    maybe_fields: &[BuiltinField {
+        cli_name: "maybe",
+        relation: "dialog.concept.maybe/",
+        value_type: "attribute",
+        cardinality: "one",
+        variable_keyed: true,
+    }],
+};
+
+/// The `bookmark` concept schema.
+pub static BUILTIN_BOOKMARK: BuiltinConceptSchema = BuiltinConceptSchema {
+    name: "bookmark",
+    description: "Naming mechanism mapping a local name to any entity",
+    with_fields: &[BuiltinField {
+        cli_name: "name",
+        relation: "dialog.meta/name",
+        value_type: "Text",
+        cardinality: "one",
+        variable_keyed: false,
+    }],
+    maybe_fields: &[],
+};
+
+/// Look up a pre-registered (builtin) concept schema by name.
+pub fn lookup_builtin(name: &str) -> Option<&'static BuiltinConceptSchema> {
+    match name.to_lowercase().as_str() {
+        "attribute" => Some(&BUILTIN_ATTRIBUTE),
+        "concept" => Some(&BUILTIN_CONCEPT),
+        "bookmark" => Some(&BUILTIN_BOOKMARK),
+        _ => None,
+    }
+}
+
+/// Find the relation for a CLI field name within a builtin concept schema.
+///
+/// For variable-keyed fields, `cli_field` should be the dotted form (e.g. "with.name").
+/// Returns `(relation, is_variable_keyed)`.
+pub fn resolve_builtin_field(
+    schema: &BuiltinConceptSchema,
+    cli_field: &str,
+) -> Option<(String, bool)> {
+    // Check fixed fields first
+    for f in schema.with_fields.iter().chain(schema.maybe_fields.iter()) {
+        if !f.variable_keyed && f.cli_name == cli_field {
+            return Some((f.relation.to_string(), false));
+        }
+    }
+    // Check variable-keyed fields (e.g. "with.name" -> prefix "with")
+    for f in schema.with_fields.iter().chain(schema.maybe_fields.iter()) {
+        if f.variable_keyed
+            && let Some(key) = cli_field
+                .strip_prefix(f.cli_name)
+                .and_then(|s| s.strip_prefix('.'))
+            && !key.is_empty()
+        {
+            return Some((format!("{}{}", f.relation, key), true));
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Name validation
+// ---------------------------------------------------------------------------
+
+/// Validate that a name contains only safe characters: letters, digits,
+/// hyphens, and underscores.
+pub fn validate_safe_name(name: &str, kind: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("{} name cannot be empty", kind);
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "Invalid {} name '{}'. Names may only contain letters, digits, hyphens, and underscores.",
+            kind,
+            name
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// ConceptName newtype
+// ---------------------------------------------------------------------------
+
+/// A validated concept name (alphanumeric, hyphens, underscores only).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConceptName(String);
+
+impl ConceptName {
+    pub fn new(s: impl Into<String>) -> Result<Self> {
+        let s = s.into();
+        validate_safe_name(&s, "Concept")?;
+        Ok(Self(s.to_lowercase()))
+    }
+
+    pub fn from_stored(s: String) -> Self {
+        Self(s)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ConceptName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::ops::Deref for ConceptName {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ConceptName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entity derivation
+// ---------------------------------------------------------------------------
+
+/// Derive an attribute entity from its identity fields.
+///
+/// Per the RFC: `entity = hash(the, type, cardinality)`.
+/// Description and name do NOT participate in identity.
+pub fn derive_attribute_entity(
+    selector: &str,
+    value_type: &str,
+    cardinality: &str,
+) -> Result<Entity> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"attribute\0");
+    hasher.update(selector.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(value_type.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(cardinality.as_bytes());
+    derive_entity_from_hash(&hasher.finalize())
+}
+
+/// Derive a concept entity from its field->attribute mappings.
+///
+/// Per the RFC: identity = hash(sorted (field_name, attribute_entity) pairs).
+/// Both field names and attribute entities participate. `maybe` fields do NOT.
+pub fn derive_concept_entity(with_fields: &BTreeMap<String, Entity>) -> Result<Entity> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"concept\0");
+    for (field_name, attr_entity) in with_fields {
+        hasher.update(field_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(attr_entity.to_string().as_bytes());
+        hasher.update(b"\0");
+    }
+    derive_entity_from_hash(&hasher.finalize())
+}
+
+/// Convert 32 bytes of hash output into a proper Ed25519 `did:key` entity.
+pub fn derive_entity_from_hash(hash: &blake3::Hash) -> Result<Entity> {
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(hash.as_bytes());
+    let verifying_key = signing_key.verifying_key();
+    const ED25519_MULTICODEC: [u8; 2] = [0xed, 0x01];
+    let mut multicodec_key = [0u8; 34];
+    multicodec_key[..2].copy_from_slice(&ED25519_MULTICODEC);
+    multicodec_key[2..].copy_from_slice(verifying_key.as_bytes());
+    let encoded = bs58::encode(&multicodec_key).into_string();
+    let uri = format!("did:key:z{}", encoded);
+    Entity::from_str(&uri).context("Failed to derive did:key entity")
+}
+
+/// Hash input to produce a deterministic `did:key` entity.
+pub fn derive_entity(input: &str) -> Result<Entity> {
+    derive_entity_from_hash(&blake3::hash(input.as_bytes()))
+}
+
+/// Derive an entity ID deterministically from field content.
+pub fn derive_entity_from_fields(fields: &[(String, String)]) -> Result<Entity> {
+    let mut sorted = fields.to_vec();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = blake3::Hasher::new();
+    for (attr, value) in &sorted {
+        hasher.update(attr.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\0");
+    }
+
+    derive_entity_from_hash(&hasher.finalize())
+}
+
+// ---------------------------------------------------------------------------
+// Branch query helpers
+// ---------------------------------------------------------------------------
+
+/// Build an `AttributeStatement` from runtime-resolved parts.
+///
+/// This is the workhorse for dynamic attribute construction in carry.
+/// The `The` is parsed from a string, and the value is a `Value` enum.
+/// Returns a type that implements `Statement`, suitable for
+/// `branch.transaction().assert(stmt)`.
+pub fn make_statement(the: &str, of: Entity, is: Value) -> Result<AttributeStatement> {
+    let attr =
+        The::from_str(the).map_err(|e| anyhow::anyhow!("Invalid attribute '{}': {}", the, e))?;
+    Ok(AttributeStatement {
+        the: attr,
+        of,
+        is,
+        cause: None,
+        cardinality: None,
+    })
+}
+
+/// Select artifacts from a branch matching the given selector.
+async fn select_artifacts(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    selector: ArtifactSelector<dialog_artifacts::selector::Constrained>,
+) -> Result<Vec<dialog_artifacts::Artifact>> {
+    let results: Vec<_> = branch
+        .claims()
+        .select(selector)
+        .perform(operator)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?
+        .try_collect()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Concept resolution (runtime lookup via dialog.meta/name)
+// ---------------------------------------------------------------------------
+
+/// Look up any entity by its `dialog.meta/name` value.
+pub async fn lookup_entity_by_name(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    name: &str,
+) -> Result<Option<Entity>> {
+    let name_attr: ClaimAttribute = dialog_meta::Name::the().into();
+    let entities = find_entities_by_attribute(branch, operator, name_attr.clone()).await?;
+
+    for entity in entities {
+        let stored_names =
+            fetch_string_values(branch, operator, &entity, name_attr.clone()).await?;
+        if stored_names
+            .iter()
+            .any(|n| n.to_lowercase() == name.to_lowercase())
+        {
+            return Ok(Some(entity));
+        }
+    }
+    Ok(None)
+}
+
+/// A concept resolved from the database at runtime.
+#[derive(Debug, Clone)]
+pub struct ResolvedConcept {
+    /// The concept entity.
+    pub entity: Entity,
+    /// The concept's name.
+    pub name: String,
+    /// Required fields: field_name -> (attribute_entity, attribute_selector).
+    pub with_fields: BTreeMap<String, (Entity, String)>,
+    /// Optional fields: same structure.
+    pub maybe_fields: BTreeMap<String, (Entity, String)>,
+}
+
+/// Resolve a concept by name: look up the entity, fetch its
+/// `dialog.concept.with/*` and `dialog.concept.maybe/*` claims,
+/// and for each attribute entity fetch its `dialog.attribute/id`.
+pub async fn resolve_concept(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    concept_name: &str,
+) -> Result<ResolvedConcept> {
+    let concept_entity = lookup_entity_by_name(branch, operator, concept_name)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Concept '{}' not found", concept_name))?;
+
+    let with_fields =
+        fetch_concept_fields(branch, operator, &concept_entity, "dialog.concept.with/").await?;
+    let maybe_fields =
+        fetch_concept_fields(branch, operator, &concept_entity, "dialog.concept.maybe/").await?;
+
+    if with_fields.is_empty() {
+        anyhow::bail!("Concept '{}' has no required fields", concept_name);
+    }
+
+    Ok(ResolvedConcept {
+        entity: concept_entity,
+        name: concept_name.to_string(),
+        with_fields,
+        maybe_fields,
+    })
+}
+
+/// Fetch concept fields from `dialog.concept.with/*` or `dialog.concept.maybe/*` claims.
+///
+/// Returns a map of field_name -> (attribute_entity, attribute_selector).
+async fn fetch_concept_fields(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    concept_entity: &Entity,
+    prefix: &str,
+) -> Result<BTreeMap<String, (Entity, String)>> {
+    let mut fields = BTreeMap::new();
+
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new().of(concept_entity.clone()),
+    )
+    .await?;
+
+    let attr_id_selector: ClaimAttribute = dialog_attribute::Id::the().into();
+
+    for artifact in &results {
+        let attr_str = artifact.the.to_string();
+        if let Some(field_name) = attr_str.strip_prefix(prefix) {
+            if field_name.is_empty() {
+                continue;
+            }
+            let attr_entity = match &artifact.is {
+                Value::Entity(e) => e.clone(),
+                _ => continue,
+            };
+
+            let selector = fetch_string(branch, operator, &attr_entity, attr_id_selector.clone())
+                .await?
+                .unwrap_or_default();
+
+            fields.insert(field_name.to_string(), (attr_entity, selector));
+        }
+    }
+
+    Ok(fields)
+}
+
+/// Get all attribute selectors for a resolved concept's required fields.
+pub fn concept_attribute_selectors(concept: &ResolvedConcept) -> Vec<String> {
+    concept
+        .with_fields
+        .values()
+        .map(|(_, selector)| selector.clone())
+        .collect()
+}
+
+/// Resolve a concept field name to its attribute selector.
+pub fn resolve_field_selector(concept: &ResolvedConcept, field_name: &str) -> Result<String> {
+    if let Some((_, selector)) = concept.with_fields.get(field_name) {
+        return Ok(selector.clone());
+    }
+    if let Some((_, selector)) = concept.maybe_fields.get(field_name) {
+        return Ok(selector.clone());
+    }
+    anyhow::bail!(
+        "Field '{}' not found in concept '{}'. Available fields: {}",
+        field_name,
+        concept.name,
+        concept
+            .with_fields
+            .keys()
+            .chain(concept.maybe_fields.keys())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Concept membership (structural matching)
+// ---------------------------------------------------------------------------
+
+/// Find all entities belonging to a concept by checking ALL required attribute selectors.
+pub async fn find_entities_by_concept(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    schema_attrs: &[String],
+) -> Result<Vec<Entity>> {
+    if schema_attrs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
+    let mut result_set: std::collections::HashSet<String> =
+        find_entities_by_attribute(branch, operator, first_attr)
+            .await?
+            .iter()
+            .map(|e| e.to_string())
+            .collect();
+
+    for attr in &schema_attrs[1..] {
+        let claim_attr = parse_claim_attribute(attr)?;
+        let attr_entities: std::collections::HashSet<String> =
+            find_entities_by_attribute(branch, operator, claim_attr)
+                .await?
+                .iter()
+                .map(|e| e.to_string())
+                .collect();
+        result_set = result_set.intersection(&attr_entities).cloned().collect();
+        if result_set.is_empty() {
+            return Ok(Vec::new());
+        }
+    }
+
+    let first_attr = parse_claim_attribute(&schema_attrs[0])?;
+    let all_entities = find_entities_by_attribute(branch, operator, first_attr).await?;
+    Ok(all_entities
+        .into_iter()
+        .filter(|e| result_set.contains(&e.to_string()))
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Init bootstrapping
+// ---------------------------------------------------------------------------
+
+/// Assert all pre-registered concepts into the space.
+///
+/// Called during `carry init` to bootstrap the meta-schema.
+/// Claims are deterministic (content-addressed), so re-running is idempotent.
+pub async fn bootstrap_builtins(branch: &Branch, operator: &impl MetaEnv) -> Result<()> {
+    let builtins = [&BUILTIN_ATTRIBUTE, &BUILTIN_CONCEPT, &BUILTIN_BOOKMARK];
+
+    // First pass: derive attribute entities for all fixed fields.
+    let mut attr_entities: BTreeMap<String, Entity> = BTreeMap::new();
+
+    for builtin in &builtins {
+        for field in builtin
+            .with_fields
+            .iter()
+            .chain(builtin.maybe_fields.iter())
+        {
+            if field.variable_keyed {
+                continue;
+            }
+            let entity =
+                derive_attribute_entity(field.relation, field.value_type, field.cardinality)?;
+            attr_entities.insert(field.relation.to_string(), entity);
+        }
+    }
+
+    // Build a single transaction for all bootstrap claims.
+    let mut tx = branch.transaction();
+
+    // Assert attribute entity claims
+    for builtin in &builtins {
+        for field in builtin
+            .with_fields
+            .iter()
+            .chain(builtin.maybe_fields.iter())
+        {
+            if field.variable_keyed {
+                continue;
+            }
+
+            let entity = attr_entities[field.relation].clone();
+
+            // dialog.attribute/id
+            tx = tx.assert(dialog_attribute::Id::of(entity.clone()).is(field.relation.to_string()));
+
+            // dialog.attribute/type
+            tx = tx.assert(
+                dialog_attribute::Type::of(entity.clone()).is(field.value_type.to_string()),
+            );
+
+            // dialog.attribute/cardinality
+            tx = tx.assert(
+                dialog_attribute::Cardinality::of(entity.clone()).is(field.cardinality.to_string()),
+            );
+
+            // dialog.meta/name = qualified name (e.g. "attribute/the")
+            tx = tx.assert(
+                dialog_meta::Name::of(entity.clone())
+                    .is(format!("{}/{}", builtin.name, field.cli_name)),
+            );
+        }
+    }
+
+    // Assert concept entity claims
+    for builtin in &builtins {
+        let mut with_fields: BTreeMap<String, Entity> = BTreeMap::new();
+        for field in builtin.with_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            with_fields.insert(
+                field.cli_name.to_string(),
+                attr_entities[field.relation].clone(),
+            );
+        }
+
+        let concept_entity = derive_concept_entity(&with_fields)?;
+
+        // dialog.meta/name
+        tx = tx.assert(dialog_meta::Name::of(concept_entity.clone()).is(builtin.name.to_string()));
+
+        // dialog.meta/description
+        tx = tx.assert(
+            dialog_meta::Description::of(concept_entity.clone())
+                .is(builtin.description.to_string()),
+        );
+
+        // dialog.concept.with/{field} = attribute_entity
+        for field in builtin.with_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            let rel = format!("dialog.concept.with/{}", field.cli_name);
+            tx = tx.assert(make_statement(
+                &rel,
+                concept_entity.clone(),
+                Value::Entity(attr_entities[field.relation].clone()),
+            )?);
+        }
+
+        // dialog.concept.maybe/{field} = attribute_entity
+        for field in builtin.maybe_fields {
+            if field.variable_keyed {
+                continue;
+            }
+            let rel = format!("dialog.concept.maybe/{}", field.cli_name);
+            tx = tx.assert(make_statement(
+                &rel,
+                concept_entity.clone(),
+                Value::Entity(attr_entities[field.relation].clone()),
+            )?);
+        }
+    }
+
+    tx.commit()
+        .perform(operator)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to bootstrap builtins: {}", e))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Attribute name helpers
+// ---------------------------------------------------------------------------
+
+/// Qualify a field name within a namespace: `{namespace}/{key}`.
+/// If the key already contains `/`, it is returned as-is.
+pub fn qualify_attribute(namespace: &str, key: &str) -> Result<String> {
+    if key.contains('/') {
+        Ok(key.to_string())
+    } else {
+        Ok(format!("{}/{}", namespace, key))
+    }
+}
+
+/// Strip the namespace prefix from an attribute name.
+pub fn short_attribute(namespace: &str, attr: &str) -> String {
+    let prefix = format!("{}/", namespace);
+    if let Some(short) = attr.strip_prefix(&prefix) {
+        short.to_string()
+    } else if let Some((_ns, name)) = attr.split_once('/') {
+        name.to_string()
+    } else {
+        attr.to_string()
+    }
+}
+
+/// Extract the namespace from a fully-qualified attribute name.
+pub fn attribute_namespace(attr: &str) -> &str {
+    attr.split_once('/').map(|(ns, _)| ns).unwrap_or("")
+}
+
+// ---------------------------------------------------------------------------
+// Common query helpers
+// ---------------------------------------------------------------------------
+
+/// Fetch all string values for a multi-valued attribute on an entity.
+pub async fn fetch_string_values(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+    attr: ClaimAttribute,
+) -> Result<Vec<String>> {
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new().of(entity.clone()).the(attr),
+    )
+    .await?;
+
+    Ok(results
+        .into_iter()
+        .filter_map(|a| match a.is {
+            Value::String(s) => Some(s),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Fetch a single string value for an attribute on an entity.
+pub async fn fetch_string(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+    attr: ClaimAttribute,
+) -> Result<Option<String>> {
+    let values = fetch_string_values(branch, operator, entity, attr).await?;
+    Ok(values.into_iter().next())
+}
+
+/// Fetch all entity values for a multi-valued attribute.
+pub async fn fetch_entity_values(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+    attr: ClaimAttribute,
+) -> Result<Vec<Entity>> {
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new().of(entity.clone()).the(attr),
+    )
+    .await?;
+
+    Ok(results
+        .into_iter()
+        .filter_map(|a| match a.is {
+            Value::Entity(e) => Some(e),
+            _ => None,
+        })
+        .collect())
+}
+
+/// Fetch a single Value for an attribute on an entity.
+pub async fn fetch_value(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+    attr: ClaimAttribute,
+) -> Result<Option<Value>> {
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new().of(entity.clone()).the(attr),
+    )
+    .await?;
+
+    Ok(results.into_iter().next().map(|a| a.is))
+}
+
+/// Fetch all Values for a multi-valued attribute on an entity.
+pub async fn fetch_values(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+    attr: ClaimAttribute,
+) -> Result<Vec<Value>> {
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new().of(entity.clone()).the(attr),
+    )
+    .await?;
+
+    Ok(results.into_iter().map(|a| a.is).collect())
+}
+
+/// Look up the cardinality of an attribute by its selector string.
+///
+/// Searches for an attribute entity whose `dialog.attribute/id` equals the
+/// given selector, then reads its `dialog.attribute/cardinality` value.
+/// Returns `"one"` (the documented default) if the attribute entity is not
+/// found or has no cardinality claim.
+pub async fn fetch_attribute_cardinality(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    selector: &str,
+) -> Result<String> {
+    let id_attr: ClaimAttribute = dialog_attribute::Id::the().into();
+    let card_attr: ClaimAttribute = dialog_attribute::Cardinality::the().into();
+
+    // Find the attribute entity by its selector value: the=dialog.attribute/id, is=<selector>
+    let results = select_artifacts(
+        branch,
+        operator,
+        ArtifactSelector::new()
+            .the(id_attr)
+            .is(Value::String(selector.to_string())),
+    )
+    .await?;
+
+    if let Some(artifact) = results.into_iter().next() {
+        let attr_entity = artifact.of;
+        if let Some(card) = fetch_string(branch, operator, &attr_entity, card_attr).await? {
+            return Ok(card);
+        }
+    }
+
+    // Default cardinality is "one"
+    Ok("one".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Entity discovery helpers
+// ---------------------------------------------------------------------------
+
+/// Find all entities that have a given attribute (using the AEV index).
+pub async fn find_entities_by_attribute(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    attr: ClaimAttribute,
+) -> Result<Vec<Entity>> {
+    let results = select_artifacts(branch, operator, ArtifactSelector::new().the(attr)).await?;
+
+    let mut seen = std::collections::HashSet::new();
+    let mut entities = Vec::new();
+    for artifact in results {
+        if seen.insert(artifact.of.to_string()) {
+            entities.push(artifact.of);
+        }
+    }
+    Ok(entities)
+}
+
+/// Parse a string attribute name into a `ClaimAttribute`.
+pub fn parse_claim_attribute(attr_name: &str) -> Result<ClaimAttribute> {
+    ClaimAttribute::from_str(attr_name).context(format!("Invalid attribute: {}", attr_name))
+}
+
+/// Fetch all claims (as Artifacts) for an entity.
+pub async fn fetch_all_entity_claims(
+    branch: &Branch,
+    operator: &impl MetaEnv,
+    entity: &Entity,
+) -> Result<Vec<dialog_artifacts::Artifact>> {
+    select_artifacts(branch, operator, ArtifactSelector::new().of(entity.clone())).await
+}
+
+// ---------------------------------------------------------------------------
+// Value helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a string input into a Value, trying integer -> float -> string.
+pub fn parse_value(input: &str) -> Value {
+    if input.starts_with("did:")
+        && let Ok(entity) = Entity::from_str(input)
+    {
+        return Value::Entity(entity);
+    }
+    if let Ok(n) = input.parse::<i128>() {
+        if n >= 0 {
+            return Value::UnsignedInt(n as u128);
+        } else {
+            return Value::SignedInt(n);
+        }
+    }
+    if let Ok(f) = input.parse::<f64>() {
+        return Value::Float(f);
+    }
+    match input.to_lowercase().as_str() {
+        "true" => return Value::Boolean(true),
+        "false" => return Value::Boolean(false),
+        _ => {}
+    }
+    Value::String(input.to_string())
+}
+
+/// Convert a Value to a serde_json::Value.
+pub fn value_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::UnsignedInt(n) => serde_json::json!(*n),
+        Value::SignedInt(n) => serde_json::json!(*n),
+        Value::Float(f) => serde_json::json!(*f),
+        Value::Boolean(b) => serde_json::Value::Bool(*b),
+        Value::Entity(e) => serde_json::Value::String(e.to_string()),
+        Value::Symbol(s) => serde_json::json!({"symbol": s.to_string()}),
+        Value::Bytes(b) => {
+            serde_json::json!({"bytes": format!("{:02x?}", b)})
+        }
+        Value::Record(r) => {
+            serde_json::json!({"record": format!("{:02x?}", r)})
+        }
+    }
+}
+
+/// Format a Value for human-readable display.
+pub fn format_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::UnsignedInt(n) => n.to_string(),
+        Value::SignedInt(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::Entity(e) => e.to_string(),
+        Value::Symbol(s) => format!(":{}", s),
+        Value::Bytes(b) => format!("<{} bytes>", b.len()),
+        Value::Record(r) => format!("<{} bytes record>", r.len()),
+    }
+}
+
+/// Leak a runtime string to get a `&'static str`.
+pub fn leak_str(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
+}

--- a/rust/tonk-schema/src/store.rs
+++ b/rust/tonk-schema/src/store.rs
@@ -1,0 +1,780 @@
+//! Typed read/write surface over a meta branch.
+//!
+//! `MetaStore` is the shared facade that carry (CLI) and tonk-worker
+//! (browser service worker) both use to transact and query the
+//! `tonk-schema` concepts on a meta branch. It wraps `(operator,
+//! branch)` and exposes typed methods for the operations both crates
+//! used to hand-roll inline.
+//!
+//! # Caller composes the transaction
+//!
+//! Write-side methods on `MetaStore` are *concept-returning*, not
+//! commit-driving. They build the typed concept (or look up the
+//! concepts that need retracting) and hand them back; the caller
+//! composes them into a `branch.transaction()` and commits when
+//! ready. This matches dialog's own builder pattern and lets the
+//! caller batch a `MetaStore` operation and a future
+//! [`tonk-notation`]-emitted statement into one atomic transaction.
+//!
+//! Reads are direct — they take the round trip and return typed
+//! values.
+//!
+//! # Per-repo meta vs profile meta
+//!
+//! The same `MetaStore` works for both flavours of meta branch:
+//!
+//! - **Per-repository meta**: facts about a repository's replicas,
+//!   branches, remotes, and tracking links. Methods take a
+//!   `Replica::new(profile_did, repo_did, name)`.
+//! - **Profile meta**: facts about every repository the profile has
+//!   a replica of. Methods take the profile's self-replica
+//!   `Replica::new(profile_did, profile_did, name)`. The
+//!   `find_replica_for_subject` and `list_replicas_for_profile`
+//!   queries are the load-bearing ops here.
+
+#![allow(clippy::needless_lifetimes)]
+
+use anyhow::{Context, Result};
+use dialog_artifacts::Entity;
+use dialog_capability::{Fork, Provider};
+use dialog_common::ConditionalSync;
+use dialog_effects::archive::{Get, Put};
+use dialog_effects::authority::Identify;
+use dialog_effects::memory::{Publish, Resolve};
+use dialog_query::{Output as _, Query, Term};
+use dialog_repository::{Branch as DialogBranch, RemoteSite, SiteAddress};
+use dialog_varsig::Did;
+
+use crate::prelude::DidExt;
+use crate::{Branch, Name, Remote, Replica, TrackingBranch};
+
+/// Operator-shaped environment for meta-branch reads and writes.
+///
+/// Mirrors the `Provider<...>` chain that dialog itself requires
+/// for `branch.query()...perform(env)` and
+/// `branch.transaction()...commit().perform(env)`. Any operator
+/// (native, wasm, or test/volatile) that satisfies these provider
+/// bounds implements `MetaEnv` automatically — call sites just
+/// pass `&operator`.
+pub trait MetaEnv:
+    Provider<Get>
+    + Provider<Put>
+    + Provider<Resolve>
+    + Provider<Publish>
+    + Provider<Identify>
+    + Provider<Fork<RemoteSite, Get>>
+    + Provider<Fork<RemoteSite, Resolve>>
+    + ConditionalSync
+    + 'static
+{
+}
+
+impl<T> MetaEnv for T where
+    T: Provider<Get>
+        + Provider<Put>
+        + Provider<Resolve>
+        + Provider<Publish>
+        + Provider<Identify>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static
+{
+}
+
+/// Concepts that must be retracted alongside a `Remote` to avoid
+/// dangling references on the meta branch. Returned by
+/// [`MetaStore::dependents_of_remote`].
+#[derive(Debug, Clone)]
+pub struct RemoteDependents {
+    /// The remote-side `Branch` concept owned by the remote
+    /// (e.g. `<remote>/main`). The schema has no convention for
+    /// "the" tracked branch beyond this — callers retract every
+    /// branch that names the remote as origin.
+    pub branches: Vec<Branch>,
+    /// Tracking links pointing at any branch on the remote.
+    pub tracking_links: Vec<TrackingBranch>,
+}
+
+/// Typed read/write facade over a meta branch.
+///
+/// Hold one of these at the call site — all operations are
+/// methods. Both crates can construct it the same way:
+///
+/// ```ignore
+/// let store = MetaStore::new(&meta_branch, &operator);
+/// let remotes = store.list_remotes(&replica).await?;
+/// ```
+pub struct MetaStore<'a, E> {
+    /// The meta branch this store reads from and writes to.
+    pub branch: &'a DialogBranch,
+    /// The operator/environment used to perform I/O.
+    pub env: &'a E,
+}
+
+impl<'a, E> MetaStore<'a, E> {
+    /// Build a new store over `(branch, env)`.
+    pub fn new(branch: &'a DialogBranch, env: &'a E) -> Self {
+        Self { branch, env }
+    }
+
+    // ---------------- pure builders ----------------
+    //
+    // Zero-I/O wrappers around the existing concept constructors.
+    // Their job is discoverability — call sites that already hold
+    // a `MetaStore` shouldn't also need to glob-import every
+    // concept module to compose an assertion.
+
+    /// Construct a [`Replica`] concept (no I/O).
+    pub fn replica(&self, profile: Did, subject: Did, name: impl Into<Name>) -> Replica {
+        Replica::new(profile, subject, name)
+    }
+
+    /// Construct a [`Remote`] concept owned by `replica` (no I/O).
+    pub fn remote(
+        &self,
+        replica: &Replica,
+        name: impl Into<Name>,
+        subject: Did,
+        address: &SiteAddress,
+    ) -> Remote {
+        replica.remote(name, subject, address)
+    }
+
+    /// Construct a [`Branch`] concept on `owner` (no I/O).
+    ///
+    /// `owner` is anything that views as an entity — a `Replica`
+    /// for a local branch, a `Remote` for the remote-side
+    /// counterpart.
+    pub fn branch_of(&self, owner: impl AsRef<Entity>, name: impl Into<Name>) -> Branch {
+        Branch::new(owner, name)
+    }
+
+    /// Construct a [`TrackingBranch`] linking `local` → `upstream`
+    /// (no I/O).
+    pub fn tracking(&self, local: &Branch, upstream: &Branch) -> TrackingBranch {
+        TrackingBranch::new(local, upstream)
+    }
+
+    /// Replica-anchor bundle for a fresh meta branch.
+    ///
+    /// Returns `(Replica, Branch)` — the replica concept plus a
+    /// `Branch` concept naming the meta branch itself (using the
+    /// dialog branch's own name, so the returned `Branch.name`
+    /// always matches `self.branch.name()`).
+    ///
+    /// Caller asserts both in one transaction:
+    ///
+    /// ```ignore
+    /// let (replica, meta_branch) = store.claim_replica(profile, subject, "home");
+    /// store.branch.transaction()
+    ///     .assert(replica)
+    ///     .assert(meta_branch)
+    ///     .commit().perform(env).await?;
+    /// ```
+    pub fn claim_replica(
+        &self,
+        profile: Did,
+        subject: Did,
+        name: impl Into<Name>,
+    ) -> (Replica, Branch) {
+        let replica = Replica::new(profile, subject, name);
+        let meta = replica.branch(self.branch.name());
+        (replica, meta)
+    }
+}
+
+impl<'a, E: MetaEnv> MetaStore<'a, E> {
+    // ---------------- reads ----------------
+
+    /// Every [`Remote`] on `replica`, sorted by name for stable
+    /// output.
+    pub async fn list_remotes(&self, replica: &Replica) -> Result<Vec<Remote>> {
+        let mut rows: Vec<Remote> = self
+            .branch
+            .query()
+            .select(Query::<Remote> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                origin: Term::from(replica.this().clone()),
+                subject: Term::var("subject"),
+                address: Term::var("address"),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::list_remotes: query failed")?;
+        rows.sort_by(|a, b| a.name.0.cmp(&b.name.0));
+        Ok(rows)
+    }
+
+    /// Find a single [`Remote`] on `replica` by its local name.
+    pub async fn find_remote(&self, replica: &Replica, name: &str) -> Result<Option<Remote>> {
+        Ok(self
+            .list_remotes(replica)
+            .await?
+            .into_iter()
+            .find(|r| r.name.0 == name))
+    }
+
+    /// Every [`Branch`] whose `origin` is `replica`.
+    ///
+    /// # Polymorphism gotcha
+    ///
+    /// `Query::<Branch>` matches any entity with a `(name, origin)`
+    /// attribute pair. [`Remote`] has the same pair (plus `subject`
+    /// and `address`), so a `Remote` on `replica` shows up here
+    /// alongside true local `Branch` entities. Callers that need to
+    /// distinguish them should also call [`MetaStore::list_remotes`]
+    /// and filter by entity. The schema-level query engine has no
+    /// concept-tag discriminator today.
+    pub async fn list_branches(&self, replica: &Replica) -> Result<Vec<Branch>> {
+        let mut rows: Vec<Branch> = self
+            .branch
+            .query()
+            .select(Query::<Branch> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                origin: Term::from(replica.this().clone()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::list_branches: query failed")?;
+        rows.sort_by(|a, b| a.name.0.cmp(&b.name.0));
+        Ok(rows)
+    }
+
+    /// Every [`Branch`] on the meta branch — local *and*
+    /// remote-side, across all replicas. Used to build the
+    /// `entity → Branch` lookup table for resolving upstream
+    /// targets (a `TrackingBranch.upstream` points at a remote-side
+    /// branch entity, and you need to find the corresponding
+    /// `Branch` to recover its name and which remote owns it).
+    ///
+    /// Same polymorphism caveat as [`MetaStore::list_branches`] —
+    /// `Remote` entities surface here too. Callers typically build
+    /// a `HashMap<Entity, Branch>` and skip any entity that's also
+    /// in the remotes set.
+    pub async fn list_all_branches(&self) -> Result<Vec<Branch>> {
+        self.branch
+            .query()
+            .select(Query::<Branch> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                origin: Term::var("origin"),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::list_all_branches: query failed")
+    }
+
+    /// Every [`TrackingBranch`] owned by `replica`. The
+    /// per-replica counterpart to [`MetaStore::find_upstream`]
+    /// (single branch) and [`MetaStore::stale_tracking_for`]
+    /// (single branch) — used when assembling a full repository
+    /// view in one pass.
+    pub async fn list_tracking_for_replica(
+        &self,
+        replica: &Replica,
+    ) -> Result<Vec<TrackingBranch>> {
+        self.branch
+            .query()
+            .select(Query::<TrackingBranch> {
+                this: Term::var("this"),
+                upstream: Term::var("upstream"),
+                origin: Term::from(replica.this().clone()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::list_tracking_for_replica: query failed")
+    }
+
+    /// The tracking link recorded for `local`, or `None` if the
+    /// branch has no upstream.
+    pub async fn find_upstream(&self, local: &Branch) -> Result<Option<TrackingBranch>> {
+        let rows: Vec<TrackingBranch> = self
+            .branch
+            .query()
+            .select(Query::<TrackingBranch> {
+                this: Term::from(local.this.clone()),
+                upstream: Term::var("upstream"),
+                origin: Term::from(local.origin.0.clone()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::find_upstream: query failed")?;
+        Ok(rows.into_iter().next())
+    }
+
+    /// Resolve `local`'s upstream branch all the way to the
+    /// `Remote` entity that owns it.
+    ///
+    /// Two-hop walk: tracking → upstream branch → branch.origin
+    /// (a remote's entity for a remote-side branch). Returns `None`
+    /// if `local` has no upstream or if the upstream branch is not
+    /// recorded on this meta branch.
+    pub async fn resolve_upstream_remote(&self, local: &Branch) -> Result<Option<Entity>> {
+        let Some(tracking) = self.find_upstream(local).await? else {
+            return Ok(None);
+        };
+        let upstream_branches: Vec<Branch> = self
+            .branch
+            .query()
+            .select(Query::<Branch> {
+                this: Term::from(tracking.upstream.0.clone()),
+                name: Term::var("name"),
+                origin: Term::var("origin"),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::resolve_upstream_remote: upstream-branch query failed")?;
+        Ok(upstream_branches.into_iter().next().map(|b| b.origin.0))
+    }
+
+    /// Every [`Replica`] owned by `profile`. Used by profile-meta
+    /// callers to enumerate the spaces a profile knows about.
+    pub async fn list_replicas_for_profile(&self, profile: &Did) -> Result<Vec<Replica>> {
+        let mut rows: Vec<Replica> = self
+            .branch
+            .query()
+            .select(Query::<Replica> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                subject: Term::var("subject"),
+                profile: Term::from(profile.this()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::list_replicas_for_profile: query failed")?;
+        rows.sort_by(|a, b| a.name.0.cmp(&b.name.0));
+        Ok(rows)
+    }
+
+    /// The replica `profile` already has for `subject`, or `None`.
+    /// Load-bearing for `join` flows: "do I already have this
+    /// space?".
+    pub async fn find_replica_for_subject(
+        &self,
+        profile: &Did,
+        subject: &Did,
+    ) -> Result<Option<Replica>> {
+        let rows: Vec<Replica> = self
+            .branch
+            .query()
+            .select(Query::<Replica> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                subject: Term::from(subject.this()),
+                profile: Term::from(profile.this()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::find_replica_for_subject: query failed")?;
+        Ok(rows.into_iter().next())
+    }
+
+    // ---------------- stale-cleanup helpers ----------------
+    //
+    // These return concepts to retract. Caller composes the
+    // retract chain into a transaction; nothing is committed here.
+
+    /// Tracking links currently recorded on `local`, suitable for
+    /// retraction before re-asserting a fresh upstream. Returns
+    /// `Vec` rather than `Option` because `set-upstream` semantics
+    /// permit (defensively) retracting any number of stale links
+    /// in one transaction.
+    pub async fn stale_tracking_for(&self, local: &Branch) -> Result<Vec<TrackingBranch>> {
+        self.branch
+            .query()
+            .select(Query::<TrackingBranch> {
+                this: Term::from(local.this.clone()),
+                upstream: Term::var("upstream"),
+                origin: Term::from(local.origin.0.clone()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::stale_tracking_for: query failed")
+    }
+
+    /// Concepts that must be retracted alongside a `Remote` to keep
+    /// the meta branch internally consistent: the remote-side
+    /// `Branch` concepts owned by it, plus any local
+    /// `TrackingBranch` whose upstream lives on the remote.
+    pub async fn dependents_of_remote(&self, remote: &Remote) -> Result<RemoteDependents> {
+        let branches: Vec<Branch> = self
+            .branch
+            .query()
+            .select(Query::<Branch> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                origin: Term::from(remote.this.clone()),
+            })
+            .perform(self.env)
+            .try_vec()
+            .await
+            .context("MetaStore::dependents_of_remote: branch query failed")?;
+
+        let mut tracking_links = Vec::new();
+        for branch in &branches {
+            let mut links: Vec<TrackingBranch> = self
+                .branch
+                .query()
+                .select(Query::<TrackingBranch> {
+                    this: Term::var("this"),
+                    upstream: Term::from(branch.this.clone()),
+                    origin: Term::var("origin"),
+                })
+                .perform(self.env)
+                .try_vec()
+                .await
+                .context("MetaStore::dependents_of_remote: tracking query failed")?;
+            tracking_links.append(&mut links);
+        }
+
+        Ok(RemoteDependents {
+            branches,
+            tracking_links,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end tests against an in-memory dialog repo.
+    //!
+    //! Every test goes through the full claim → assert → query
+    //! cycle so the dialog wiring is exercised end-to-end. The
+    //! pure builders (`replica`, `remote`, etc.) don't get their
+    //! own tests here — they're covered by the corresponding
+    //! `tests` modules in `replica.rs`, `remote.rs`, etc.
+
+    use super::*;
+    use dialog_credentials::Credential;
+    use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+    use dialog_repository::{Repository, SiteAddress};
+    use dialog_varsig::did;
+
+    /// Open a fresh in-memory repo and its meta branch, returning
+    /// the operator + repository handle (kept alive for the test)
+    /// and the opened meta branch.
+    async fn fixture() -> (
+        dialog_operator::Operator<dialog_storage::provider::storage::VolatileSpace>,
+        Repository<Credential>,
+        DialogBranch,
+    ) {
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let meta = repo
+            .branch("meta")
+            .open()
+            .perform(&operator)
+            .await
+            .expect("open meta branch");
+        (operator, repo, meta)
+    }
+
+    /// Convenience: a `SiteAddress` for tests. Any non-trivial
+    /// bytes — the fact-roundtripping is what matters here, not
+    /// the address contents.
+    fn fake_address(tag: &str) -> SiteAddress {
+        // We use a UCAN address with a placeholder URL. If
+        // SiteAddress::Ucan is removed in a future dialog version,
+        // swap to whatever the test-friendly variant is.
+        use dialog_remote_ucan_s3::UcanAddress;
+        UcanAddress::new(format!("https://example.invalid/{tag}/")).into()
+    }
+
+    #[tokio::test]
+    async fn claim_replica_yields_consistent_meta_branch() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let (replica, meta_branch_concept) =
+            store.claim_replica(profile.clone(), subject.clone(), "home");
+
+        assert_eq!(meta_branch_concept.origin.0, *replica.this());
+        assert_eq!(meta_branch_concept.name.0, meta.name());
+    }
+
+    #[tokio::test]
+    async fn replica_round_trip() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let (replica, meta_branch_concept) =
+            store.claim_replica(profile.clone(), subject.clone(), "home");
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(meta_branch_concept)
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit replica anchor");
+
+        // The replica should be discoverable by (profile, subject).
+        let found = store
+            .find_replica_for_subject(&profile, &subject)
+            .await
+            .expect("find_replica_for_subject");
+        assert_eq!(found.as_ref().map(|r| r.this()), Some(replica.this()));
+
+        // It should also surface in list_replicas_for_profile.
+        let all = store
+            .list_replicas_for_profile(&profile)
+            .await
+            .expect("list_replicas_for_profile");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].this(), replica.this());
+    }
+
+    #[tokio::test]
+    async fn add_remote_round_trip_and_sorted_listing() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let replica = store.replica(profile, subject.clone(), "home");
+
+        // Add two remotes whose insertion order != sort order, so
+        // we exercise the sort-by-name guarantee.
+        let backup_addr = fake_address("backup");
+        let origin_addr = fake_address("origin");
+        let backup = store.remote(&replica, "backup", subject.clone(), &backup_addr);
+        let origin = store.remote(&replica, "origin", subject, &origin_addr);
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(backup)
+            .assert(origin)
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit remotes");
+
+        let listed = store.list_remotes(&replica).await.expect("list_remotes");
+        let names: Vec<&str> = listed.iter().map(|r| r.name.0.as_str()).collect();
+        assert_eq!(names, vec!["backup", "origin"]);
+
+        let found = store
+            .find_remote(&replica, "origin")
+            .await
+            .expect("find_remote present");
+        assert_eq!(found.map(|r| r.name.0), Some("origin".into()));
+
+        let missing = store
+            .find_remote(&replica, "nope")
+            .await
+            .expect("find_remote absent");
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn upstream_resolution() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let replica = store.replica(profile, subject.clone(), "home");
+        let addr = fake_address("origin");
+        let remote = store.remote(&replica, "origin", subject, &addr);
+        let local = store.branch_of(&replica, "main");
+        let tracked = store.branch_of(&remote, "main");
+        let tracking = store.tracking(&local, &tracked);
+
+        // No upstream yet → both queries return None.
+        let pre = store
+            .find_upstream(&local)
+            .await
+            .expect("find_upstream pre");
+        assert!(pre.is_none());
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(remote.clone())
+            .assert(local.clone())
+            .assert(tracked.clone())
+            .assert(tracking.clone())
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit upstream");
+
+        let post = store
+            .find_upstream(&local)
+            .await
+            .expect("find_upstream post")
+            .expect("tracking link present");
+        assert_eq!(post.upstream.0, tracked.this);
+
+        let resolved = store
+            .resolve_upstream_remote(&local)
+            .await
+            .expect("resolve_upstream_remote")
+            .expect("upstream remote present");
+        assert_eq!(resolved, remote.this);
+    }
+
+    #[tokio::test]
+    async fn dependents_of_remote_lists_branches_and_tracking() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let replica = store.replica(profile, subject.clone(), "home");
+        let addr = fake_address("origin");
+        let remote = store.remote(&replica, "origin", subject, &addr);
+        let local = store.branch_of(&replica, "main");
+        let tracked = store.branch_of(&remote, "main");
+        let tracking = store.tracking(&local, &tracked);
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(remote.clone())
+            .assert(local)
+            .assert(tracked.clone())
+            .assert(tracking.clone())
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit");
+
+        let deps = store
+            .dependents_of_remote(&remote)
+            .await
+            .expect("dependents_of_remote");
+
+        assert_eq!(deps.branches.len(), 1);
+        assert_eq!(deps.branches[0].this, tracked.this);
+        assert_eq!(deps.tracking_links.len(), 1);
+        assert_eq!(deps.tracking_links[0].this, tracking.this);
+    }
+
+    #[tokio::test]
+    async fn list_all_branches_spans_local_and_remote_side() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let replica = store.replica(profile, subject.clone(), "home");
+        let addr = fake_address("origin");
+        let remote = store.remote(&replica, "origin", subject, &addr);
+        let local = store.branch_of(&replica, "main");
+        let tracked = store.branch_of(&remote, "main");
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(remote)
+            .assert(local.clone())
+            .assert(tracked.clone())
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit");
+
+        let all = store.list_all_branches().await.expect("list_all_branches");
+        // Both the local and the remote-side branch must surface.
+        // The query also picks up the `Remote` entity (same
+        // `(name, origin)` shape), which the caller is expected to
+        // filter — so we assert the *required* entries are present
+        // rather than the exact length.
+        let entities: Vec<_> = all.iter().map(|b| b.this.clone()).collect();
+        assert!(entities.contains(&local.this));
+        assert!(entities.contains(&tracked.this));
+    }
+
+    #[tokio::test]
+    async fn list_tracking_for_replica_returns_all_replica_links() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let profile = did!("test:profile");
+        let subject = did!("test:repo");
+        let replica = store.replica(profile, subject.clone(), "home");
+        let addr = fake_address("origin");
+        let remote = store.remote(&replica, "origin", subject.clone(), &addr);
+        let main = store.branch_of(&replica, "main");
+        let main_tracked = store.branch_of(&remote, "main");
+        let main_track = store.tracking(&main, &main_tracked);
+
+        // Second branch with its own upstream, so we assert that
+        // *every* tracking link surfaces — not just the first one.
+        let dev = store.branch_of(&replica, "dev");
+        let dev_tracked = store.branch_of(&remote, "dev");
+        let dev_track = store.tracking(&dev, &dev_tracked);
+
+        meta.transaction()
+            .assert(replica.clone())
+            .assert(remote)
+            .assert(main)
+            .assert(main_tracked)
+            .assert(main_track.clone())
+            .assert(dev)
+            .assert(dev_tracked)
+            .assert(dev_track.clone())
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit");
+
+        let links = store
+            .list_tracking_for_replica(&replica)
+            .await
+            .expect("list_tracking_for_replica");
+        assert_eq!(links.len(), 2);
+        let upstreams: Vec<_> = links.iter().map(|l| l.upstream.0.clone()).collect();
+        assert!(upstreams.contains(&main_track.upstream.0));
+        assert!(upstreams.contains(&dev_track.upstream.0));
+    }
+
+    #[tokio::test]
+    async fn replicas_isolated_per_profile() {
+        let (operator, _repo, meta) = fixture().await;
+        let store = MetaStore::new(&meta, &operator);
+
+        let alice = did!("test:alice");
+        let bob = did!("test:bob");
+        let subject = did!("test:repo");
+
+        let alice_replica = store.replica(alice.clone(), subject.clone(), "alice-home");
+        let bob_replica = store.replica(bob.clone(), subject.clone(), "bob-home");
+
+        meta.transaction()
+            .assert(alice_replica.clone())
+            .assert(bob_replica.clone())
+            .commit()
+            .perform(&operator)
+            .await
+            .expect("commit replicas");
+
+        let alice_seen = store
+            .list_replicas_for_profile(&alice)
+            .await
+            .expect("list alice");
+        assert_eq!(alice_seen.len(), 1);
+        assert_eq!(alice_seen[0].this(), alice_replica.this());
+
+        let bob_seen = store
+            .list_replicas_for_profile(&bob)
+            .await
+            .expect("list bob");
+        assert_eq!(bob_seen.len(), 1);
+        assert_eq!(bob_seen[0].this(), bob_replica.this());
+    }
+}

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -30,7 +30,6 @@ use axum_wasm_macros::wasm_compat;
 use dialog_capability::Subject;
 use dialog_credentials::{Credential, Ed25519Verifier};
 use dialog_effects::space::{Space, SpaceExt as _};
-use dialog_query::{Output as _, Query, Term};
 use dialog_remote_ucan_s3::UcanAddress;
 use dialog_repository::{Repository, RepositoryExt as _, SiteAddress};
 use dialog_ucan::UcanDelegation;
@@ -40,7 +39,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_invite::Invite;
-use tonk_schema::{Replica, prelude::DidExt as _};
+use tonk_schema::MetaStore;
 
 use super::AppState;
 use super::repository::{
@@ -261,20 +260,13 @@ async fn find_replica_name_for_subject(
             TonkWorkerError::Internal(format!("failed to open profile meta branch: {e}"))
         })?;
 
-    let rows: Vec<Replica> = profile_meta
-        .query()
-        .select(Query::<Replica> {
-            this: Term::var("this"),
-            name: Term::var("name"),
-            subject: Term::from(tonk_schema::Subject(subject.this())),
-            profile: Term::from(tonk_schema::Profile(tonk.profile.did().this())),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
+    let store = MetaStore::new(&profile_meta, &tonk.operator);
+    let replica = store
+        .find_replica_for_subject(&tonk.profile.did(), subject)
         .await
         .map_err(|e| {
             TonkWorkerError::Internal(format!("replica query on profile meta failed: {e:?}"))
         })?;
 
-    Ok(rows.into_iter().next().map(|replica| replica.name.0))
+    Ok(replica.map(|r| r.name.0))
 }

--- a/rust/tonk-worker/src/router/profile.rs
+++ b/rust/tonk-worker/src/router/profile.rs
@@ -5,14 +5,13 @@ use std::collections::HashMap;
 
 use ::axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
-use dialog_query::{Output as _, Query, Term};
 use dialog_repository::Repository;
 use dialog_varsig::Did;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_schema::{Profile as ProfileEntity, Replica, prelude::DidExt as _};
+use tonk_schema::{MetaStore, prelude::DidExt as _};
 
 use super::{AppState, RepositoryInfo, repository::build_repository_info};
 use crate::TonkWorkerError;
@@ -82,16 +81,9 @@ pub async fn get_profile(
             TonkWorkerError::Internal(format!("Failed to open profile meta branch: {}", e))
         })?;
 
-    let rows: Vec<Replica> = meta
-        .query()
-        .select(Query::<Replica> {
-            this: Term::var("this"),
-            name: Term::var("name"),
-            subject: Term::var("subject"),
-            profile: Term::from(ProfileEntity(profile_did.this())),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
+    let store = MetaStore::new(&meta, &tonk.operator);
+    let rows = store
+        .list_replicas_for_profile(&profile_did)
         .await
         .map_err(|e| {
             TonkWorkerError::Internal(format!("Replica query on profile meta failed: {:?}", e))

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -14,14 +14,13 @@ use ::axum::{
 };
 use axum_wasm_macros::wasm_compat;
 use dialog_credentials::SignerCredential;
-use dialog_query::{Output as _, Query, Term};
 use dialog_repository::{RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress};
 use dialog_varsig::{Did, Principal};
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_schema::{Branch as MetaBranch, Remote, Replica, TrackingBranch};
+use tonk_schema::{MetaStore, Remote as RemoteConcept};
 
 use super::AppState;
 use crate::{Notification, RepositoryError, TonkWorkerError, broadcast, worker::TonkState};
@@ -346,13 +345,17 @@ where
         .await
         .map_err(|e| RepositoryError::Internal(format!("Failed to open meta branch: {}", e)))?;
 
-    // Local replica of this repository
-    let replica = Replica::new(tonk.profile.did(), repository.did(), name);
+    // Local replica of this repository, plus the meta branch's
+    // own `Branch` concept — the meta branch is a real branch of
+    // this replica and belongs in the enumeration like any other.
+    let store = MetaStore::new(&meta, &tonk.operator);
+    let (replica, meta_branch_concept) =
+        store.claim_replica(tonk.profile.did(), repository.did(), name);
 
     let mut transaction = meta
         .transaction()
         .assert(replica.clone())
-        .assert(replica.branch(META_BRANCH));
+        .assert(meta_branch_concept);
 
     // 4. Create remotes at the dialog layer and assert their
     // concepts on the same transaction. Stash each created
@@ -361,7 +364,7 @@ where
     // a second `.load()` round-trip against dialog — we just
     // created these remotes, so the data we'd load is still in
     // hand.
-    let mut remotes: HashMap<String, (RemoteRepository, Remote)> =
+    let mut remotes: HashMap<String, (RemoteRepository, RemoteConcept)> =
         HashMap::with_capacity(configuration.remote.len());
 
     for (remote_name, remote_config) in &configuration.remote {
@@ -387,7 +390,12 @@ where
 
         log!("Remote '{}' created", remote_name);
 
-        let concept = replica.remote(remote_name.as_str(), subject, &remote_config.address);
+        let concept = store.remote(
+            &replica,
+            remote_name.as_str(),
+            subject,
+            &remote_config.address,
+        );
         transaction = transaction.assert(concept.clone());
         remotes.insert(remote_name.clone(), (remote, concept));
     }
@@ -408,7 +416,8 @@ where
                 RepositoryError::Internal(format!("Failed to open branch '{}': {}", branch_name, e))
             })?;
 
-        transaction = transaction.assert(replica.branch(branch_name.as_str()));
+        let local_concept = store.branch_of(&replica, branch_name.as_str());
+        transaction = transaction.assert(local_concept.clone());
 
         if let Some(upstream) = &settings.upstream {
             // Look up the remote we just created in step 4
@@ -459,10 +468,9 @@ where
             // (otherwise the upstream pointer has no target to
             // resolve to on read) and the `TrackingBranch` that
             // connects them.
-            let tracked = concept.branch(upstream.branch.as_str());
-            transaction = transaction
-                .assert(tracked.clone())
-                .assert(replica.branch(branch_name.as_str()).set_upstream(&tracked));
+            let tracked = store.branch_of(concept, upstream.branch.as_str());
+            let tracking = store.tracking(&local_concept, &tracked);
+            transaction = transaction.assert(tracked).assert(tracking);
         }
     }
 
@@ -527,7 +535,8 @@ async fn record_replica_in_profile(
             RepositoryError::Internal(format!("Failed to open profile meta branch: {}", e))
         })?;
 
-    let replica = Replica::new(tonk.profile.did(), subject.clone(), name);
+    let store = MetaStore::new(&profile_meta, &tonk.operator);
+    let replica = store.replica(tonk.profile.did(), subject.clone(), name);
 
     let revision = profile_meta
         .transaction()
@@ -583,13 +592,15 @@ pub async fn bootstrap_profile_meta(
             RepositoryError::Internal(format!("Failed to open profile meta branch: {}", e))
         })?;
 
+    let store = MetaStore::new(&profile_meta, &tonk.operator);
     let profile_did = tonk.profile.did();
-    let replica = Replica::new(profile_did.clone(), profile_did, profile_name);
+    let (replica, meta_branch_concept) =
+        store.claim_replica(profile_did.clone(), profile_did, profile_name);
 
     profile_meta
         .transaction()
-        .assert(replica.clone())
-        .assert(replica.branch(META_BRANCH))
+        .assert(replica)
+        .assert(meta_branch_concept)
         .commit()
         .perform(&tonk.operator)
         .await
@@ -693,23 +704,17 @@ where
     // depends on its name or attributes, and filtering
     // branches/remotes by `origin == replica.this()` is all we
     // need.
-    let replica = Replica::new(tonk.profile.did(), repository.did(), name);
+    let store = MetaStore::new(&meta, &tonk.operator);
+    let replica = store.replica(tonk.profile.did(), repository.did(), name);
     let replica_entity = replica.this().clone();
 
     // Pull every branch on the meta branch, local and remote.
     // Keyed by entity so the upstream-resolution step can look
-    // up any branch by its hash.
-    let all_branches: Vec<MetaBranch> = match meta
-        .query()
-        .select(Query::<MetaBranch> {
-            this: Term::var("this"),
-            name: Term::var("name"),
-            origin: Term::var("origin"),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
-        .await
-    {
+    // up any branch by its hash. `list_all_branches` returns
+    // remote entities too (they share the `(name, origin)`
+    // attribute pair) — that's filtered out below by
+    // cross-checking against `remotes_by_entity`.
+    let all_branches = match store.list_all_branches().await {
         Ok(rows) => rows,
         Err(e) => {
             log!("Branch query on meta failed for '{}': {:?}", name, e);
@@ -726,19 +731,7 @@ where
     // points at a remote-side `Branch`, whose `origin` is a
     // `Remote.this`, and we want to go from that entity back to
     // the remote's name.
-    let remote_concepts: Vec<Remote> = match meta
-        .query()
-        .select(Query::<Remote> {
-            this: Term::var("this"),
-            name: Term::var("name"),
-            origin: Term::from(replica_entity.clone()),
-            subject: Term::var("subject"),
-            address: Term::var("address"),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
-        .await
-    {
+    let remote_concepts = match store.list_remotes(&replica).await {
         Ok(rows) => rows,
         Err(e) => {
             log!("Remote query on meta failed for '{}': {:?}", name, e);
@@ -753,31 +746,20 @@ where
     // Pull every tracking link on this replica. Keyed by the
     // local branch's entity so the branch-assembly step below
     // can find "does this branch track something?" in O(1).
-    let tracking: Vec<TrackingBranch> = match meta
-        .query()
-        .select(Query::<TrackingBranch> {
-            this: Term::var("this"),
-            upstream: Term::var("upstream"),
-            origin: Term::from(replica_entity.clone()),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
-        .await
-    {
-        Ok(rows) => rows,
+    let tracking_by_local: HashMap<_, _> = match store.list_tracking_for_replica(&replica).await {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|t| (t.this.clone(), t.upstream))
+            .collect(),
         Err(e) => {
             log!(
                 "Tracking-branch query on meta failed for '{}': {:?}",
                 name,
                 e
             );
-            Vec::new()
+            HashMap::new()
         }
     };
-    let tracking_by_local: HashMap<_, _> = tracking
-        .into_iter()
-        .map(|t| (t.this.clone(), t.upstream))
-        .collect();
 
     // Assemble the branch map. Iterate local branches only
     // (those whose origin is the replica), skipping any entity


### PR DESCRIPTION
## Summary

- standardize meta-branch I/O
- add `MetaStore` to `tonk-schema` as the shared typed surface for transacting and querying tonk concepts on a dialog branch
  - migrate `tonk-worker` to use it
- lift carry's generic concepts/claims runtime into `tonk_schema::runtime`.

Carry-side consumer migration PR opened separately against `feat/carry`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new module `store` in the `tonk-schema` and enhances the functionality of the `MetaStore`. It adds various dependencies and refactors existing code to utilize the `MetaStore` for querying and managing replicas, branches, and tracking links.

### Detailed summary
- Added `store` module and exported it.
- Introduced `MetaStore` for handling meta branch operations.
- Refactored queries to use `MetaStore` methods for fetching replicas and branches.
- Updated error handling for queries using `MetaStore`.
- Added new dependencies in `Cargo.lock` and `Cargo.toml`.

> The following files were skipped due to too many changes: `rust/tonk-schema/src/runtime.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->