### PR TITLE
feat(viewer): render entity body inside a sandboxed iframe

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -51,29 +51,15 @@ self.registration.addEventListener?.("updatefound", async () => {
     }
 });
 
+// Hand *every* fetch to the Rust side. The Rust worker decides
+// per-request whether to route through axum (with optional path
+// rewriting for guest iframes) or pass the request through to
+// the network. SPA-style 404 → index.html fallback also lives
+// in Rust now, so this shim is pure forwarding.
 self.onfetch = event => {
-    let request = event.request;
-    let url = new URL(request.url);
-
-    if (url.pathname.match(/^\/api/)) {
-        log(request.method, url.pathname);
-        event.respondWith(
-            (async () => {
-                return (await activateWorker()).onfetch(request);
-            })(),
-        );
-    // NOTE: Only intercept navigate as candidates for serving
-    // the index.html (in order to provide SPA-style routing)
-    } else if (request.mode === 'navigate') {
-        event.respondWith(
-            fetch(request).then(response => {
-                if (response.status === 404) {
-                    return fetch("/index.html");
-                }
-                return response;
-            }),
-        );
-    }
+    event.respondWith(
+        (async () => (await activateWorker()).onfetch(event))(),
+    );
 };
 
 // Background Sync API event handler

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -65,16 +65,23 @@ pub async fn repository(name: &str) -> Result<Option<RepositoryInfo>, TonkUiErro
 }
 
 /// Ensures the default repository exists via
-/// `PUT /api/repository/{name}` with `If-None-Match: *`.
+/// `PUT /api/repository/{name}` with `If-None-Match: *`, and
+/// returns the hosting document's service-worker Client ID as
+/// reported by the worker in the `X-Tonk-Client-Id` response
+/// header.
 ///
-/// Returns `Ok(())` whether the repo was just created (`201`) or
-/// already existed (`412`) — both are fine from the UI's point of
-/// view. Any other non-success status is turned into an error.
+/// Succeeds whether the repo was just created (`201`) or
+/// already existed (`200`) — both carry a `RepositoryInfo`
+/// body and the same client-id header. The Rust side returns
+/// `200 OK` for the existed case (rather than `412 Precondition
+/// Failed`) so `reqwest`'s wasm client doesn't tear down the
+/// response body on a non-2xx status; functionally the two
+/// outcomes are equivalent for our caller.
 ///
 /// The body wires up an `origin` remote pointing at the UCAN access
 /// service (resolved against the current window origin) and sets
 /// the default branch to track `origin/{branch}`.
-pub async fn init() -> Result<(), TonkUiError> {
+pub async fn init() -> Result<String, TonkUiError> {
     log!("Ensuring repository '{}' exists...", DEFAULT_REPO);
 
     let service_url = format!("{}{}", origin(), ACCESS_SERVICE_PATH);
@@ -98,7 +105,16 @@ pub async fn init() -> Result<(), TonkUiError> {
         .map_err(into_api_error)?;
 
     match response.status() {
-        StatusCode::CREATED | StatusCode::PRECONDITION_FAILED => Ok(()),
+        StatusCode::OK | StatusCode::CREATED => response
+            .headers()
+            .get("x-tonk-client-id")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                TonkUiError::ApiError(
+                    "PUT /api/repository response missing X-Tonk-Client-Id header".to_string(),
+                )
+            }),
         status => {
             let text = response.text().await.unwrap_or_default();
             Err(TonkUiError::ApiError(format!(
@@ -113,9 +129,11 @@ pub async fn init() -> Result<(), TonkUiError> {
 ///
 /// Distinguishes "name already taken" from other failures so the
 /// dialog can surface a field-specific message instead of a
-/// generic error. 409/412 both mean "already exists" — the 412
-/// case just signals that the caller used `If-None-Match: *`,
-/// which we always do here.
+/// generic error. With `If-None-Match: *` the server signals
+/// "already exists" by returning the existing record under
+/// `200 OK` — that's a successful round-trip from the wire's
+/// point of view, which the create-space flow needs to surface
+/// as `AlreadyExists` so the dialog can keep the form open.
 #[derive(Debug)]
 pub enum CreateSpaceError {
     /// A repository with this name is already registered.
@@ -158,9 +176,10 @@ pub async fn create_space(name: &str) -> Result<RepositoryInfo, CreateSpaceError
             .await
             .map_err(into_api_error)
             .map_err(CreateSpaceError::Other),
-        StatusCode::PRECONDITION_FAILED | StatusCode::CONFLICT => {
-            Err(CreateSpaceError::AlreadyExists)
-        }
+        // `200 OK` means the repo already existed; the body is
+        // the existing record, which we don't need here. `409`
+        // covers the no-`If-None-Match` collision path.
+        StatusCode::OK | StatusCode::CONFLICT => Err(CreateSpaceError::AlreadyExists),
         status => {
             let text = response.text().await.unwrap_or_default();
             Err(TonkUiError::ApiError(format!(

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -71,12 +71,9 @@ pub async fn repository(name: &str) -> Result<Option<RepositoryInfo>, TonkUiErro
 /// header.
 ///
 /// Succeeds whether the repo was just created (`201`) or
-/// already existed (`200`) — both carry a `RepositoryInfo`
-/// body and the same client-id header. The Rust side returns
-/// `200 OK` for the existed case (rather than `412 Precondition
-/// Failed`) so `reqwest`'s wasm client doesn't tear down the
-/// response body on a non-2xx status; functionally the two
-/// outcomes are equivalent for our caller.
+/// already existed (`412`) — header access works on both, so
+/// the client id is available without touching the response
+/// body.
 ///
 /// The body wires up an `origin` remote pointing at the UCAN access
 /// service (resolved against the current window origin) and sets
@@ -105,7 +102,7 @@ pub async fn init() -> Result<String, TonkUiError> {
         .map_err(into_api_error)?;
 
     match response.status() {
-        StatusCode::OK | StatusCode::CREATED => response
+        StatusCode::CREATED | StatusCode::PRECONDITION_FAILED => response
             .headers()
             .get("x-tonk-client-id")
             .and_then(|v| v.to_str().ok())
@@ -129,11 +126,9 @@ pub async fn init() -> Result<String, TonkUiError> {
 ///
 /// Distinguishes "name already taken" from other failures so the
 /// dialog can surface a field-specific message instead of a
-/// generic error. With `If-None-Match: *` the server signals
-/// "already exists" by returning the existing record under
-/// `200 OK` — that's a successful round-trip from the wire's
-/// point of view, which the create-space flow needs to surface
-/// as `AlreadyExists` so the dialog can keep the form open.
+/// generic error. 409/412 both mean "already exists" — the 412
+/// case just signals that the caller used `If-None-Match: *`,
+/// which we always do here.
 #[derive(Debug)]
 pub enum CreateSpaceError {
     /// A repository with this name is already registered.
@@ -176,10 +171,9 @@ pub async fn create_space(name: &str) -> Result<RepositoryInfo, CreateSpaceError
             .await
             .map_err(into_api_error)
             .map_err(CreateSpaceError::Other),
-        // `200 OK` means the repo already existed; the body is
-        // the existing record, which we don't need here. `409`
-        // covers the no-`If-None-Match` collision path.
-        StatusCode::OK | StatusCode::CONFLICT => Err(CreateSpaceError::AlreadyExists),
+        StatusCode::PRECONDITION_FAILED | StatusCode::CONFLICT => {
+            Err(CreateSpaceError::AlreadyExists)
+        }
         status => {
             let text = response.text().await.unwrap_or_default();
             Err(TonkUiError::ApiError(format!(

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -51,6 +51,14 @@ pub enum Status {
     Ready,
 }
 
+/// The hosting document's service-worker Client ID, learned from
+/// the `X-Tonk-Client-Id` header on the `PUT /api/repository/...`
+/// response. Provided as a Leptos context so descendant
+/// components can embed it in iframe URLs for the host/guest
+/// bridge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostId(pub String);
+
 /// The subject DID of the currently viewed space. `None` when no
 /// space is loaded (or still loading). Updated by [`TonkSpace`]
 /// when its [`RepositoryInfo`] resolves; consumed by the sidebar
@@ -111,7 +119,7 @@ pub fn TonkShell() -> impl IntoView {
         service_worker_activates().await;
         log!("SW is activated, ensuring default repository...");
 
-        api::init().await?;
+        let host_id = api::init().await?;
 
         let pathname = window()
             .location()
@@ -122,13 +130,13 @@ pub fn TonkShell() -> impl IntoView {
             BrowserUrl::redirect(&format!("/space/{}", api::DEFAULT_REPO));
         }
 
-        Ok::<_, crate::error::TonkUiError>(())
+        Ok::<_, crate::error::TonkUiError>(host_id)
     });
 
     // Derive the application status from init resource
     let status = Signal::derive_local(move || {
         match init_resource.get() {
-            Some(Ok(())) => Status::Ready,
+            Some(Ok(_)) => Status::Ready,
             Some(Err(e)) => {
                 log!("Initialization error: {:?}", e);
                 // Still show as loading on error - could add an Error state later
@@ -138,7 +146,14 @@ pub fn TonkShell() -> impl IntoView {
         }
     });
 
+    // Publish the host id as a reactive context so descendant
+    // components can subscribe: `None` while init is in flight
+    // or has errored, `Some(HostId)` once the PUT succeeds.
+    let host_id =
+        Signal::derive_local(move || init_resource.get().and_then(|r| r.ok()).map(HostId));
+
     provide_context(status);
+    provide_context(host_id);
 
     let active_subject: ActiveSubject = RwSignal::new_local(None);
     provide_context(active_subject);

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -1,6 +1,6 @@
 use crate::components::{
     LastJoinOutcome, TonkCreateSpace, TonkInviteDialog, TonkJoin, TonkProfile, TonkSpace,
-    TonkToolbar,
+    TonkSpaceViewer, TonkToolbar,
 };
 use leptos::prelude::*;
 use leptos_router::{
@@ -30,6 +30,15 @@ pub fn TonkLauncher() -> impl IntoView {
             >
                 <TonkToolbar />
                 <Routes fallback=move || view!{ <section class="not-found">"Nothing here ¯\\_(ツ)_/¯"</section> }>
+                    // Order matters: the more specific viewer
+                    // route is listed before the catch-all
+                    // `space/:space?` so deep links like
+                    // `/space/foo/branch/main/view/bar` don't
+                    // get swallowed by the generic space route.
+                    <Route
+                        path=path!("space/:space/branch/:branch/view/:entity")
+                        view=TonkSpaceViewer
+                    />
                     <Route path=path!("space/:space?") view=TonkSpace />
                     <Route path=path!("profile") view=TonkProfile />
                     <Route path=path!("join") view=TonkJoin />

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::JsCast;
 
 use crate::{
     api,
-    components::{ActiveSubject, InviteSpace, Status},
+    components::{ActiveSubject, HostId, InviteSpace, Status},
     did,
 };
 
@@ -1004,5 +1004,195 @@ fn summarize_address(address: &SiteAddress) -> RemoteAddressSummary {
             url: addr.endpoint().to_string(),
             details: Some(format!("{} · {}", addr.bucket(), addr.region())),
         },
+    }
+}
+
+#[derive(Params, PartialEq, Clone, Debug)]
+pub struct TonkSpaceViewerParams {
+    space: Option<String>,
+    branch: Option<String>,
+    entity: Option<String>,
+}
+
+/// Entity-rendering view at
+/// `/space/{space}/branch/{branch}/view/{entity}`.
+///
+/// Shares the shell layout with [`TonkSpace`] (banner + share
+/// button) but replaces the branches/remotes sections in `main`
+/// with a sandboxed guest iframe. The iframe's `src` is the
+/// host/guest bridge URL — initial navigation registers the
+/// iframe's client id against `{repo, branch}` and serves the
+/// entity's HTML body via the same path that backs
+/// `GET /api/repository/{repo}/branch/{branch}/content/{entity}`
+/// with `Accept: text/html`.
+///
+/// The iframe is gated on the [`HostId`] context: until the
+/// shell's `PUT /api/repository/...` round-trip completes we
+/// don't have a hosting Client ID, so the URL would be
+/// incomplete. Rendering is held back to a spinner state until
+/// then.
+#[component]
+#[allow(clippy::unused_unit)]
+pub fn TonkSpaceViewer() -> impl IntoView {
+    let params = use_params::<TonkSpaceViewerParams>();
+
+    let space_name = Signal::derive_local(move || {
+        params
+            .get()
+            .ok()
+            .and_then(|p| p.space)
+            .filter(|s| !s.is_empty())
+    });
+    let branch_name = Signal::derive_local(move || {
+        params
+            .get()
+            .ok()
+            .and_then(|p| p.branch)
+            .filter(|s| !s.is_empty())
+    });
+    let entity_name = Signal::derive_local(move || {
+        params
+            .get()
+            .ok()
+            .and_then(|p| p.entity)
+            .filter(|s| !s.is_empty())
+    });
+
+    let status = use_context::<Signal<Status, LocalStorage>>();
+    let host_id = use_context::<Signal<Option<HostId>, LocalStorage>>();
+
+    let repository = LocalResource::new(move || {
+        let name = space_name.get();
+        let ready = status.map(|s| s.get() == Status::Ready).unwrap_or(true);
+        async move {
+            if !ready {
+                return Ok(None);
+            }
+            match name {
+                None => Ok(None),
+                Some(name) => api::repository(&name).await,
+            }
+        }
+    });
+
+    let active_subject =
+        use_context::<ActiveSubject>().expect("ActiveSubject context provided by TonkShell");
+    Effect::new(move |_| {
+        let subject = repository
+            .get()
+            .and_then(|result| result.ok())
+            .flatten()
+            .map(|info| info.subject.to_string());
+        active_subject.set(subject);
+    });
+
+    let invite_space = use_context::<InviteSpace>().expect("InviteSpace provided by TonkShell");
+    let on_share = move |_| {
+        if let Some(name) = space_name.get() {
+            invite_space.set(Some(name));
+        }
+    };
+
+    view! {
+        <Suspense fallback=|| view! {
+            <wa-spinner></wa-spinner>
+        }>
+            <ErrorBoundary fallback=|errors| view! {
+                <wa-callout variant="danger">
+                    <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
+                    { move || errors.get().into_iter().map(|(_, e)| format!("{e}")).collect::<Vec<_>>().join(", ") }
+                </wa-callout>
+            }>
+                { move || repository.get().map(|result| result.map(|repo| match repo {
+                    Some(info) => Either::Left(render_viewer_view(
+                        info,
+                        space_name,
+                        branch_name,
+                        entity_name,
+                        host_id,
+                        on_share,
+                    )),
+                    None => Either::Right(view! {
+                        <wa-callout variant="neutral">
+                            <wa-icon slot="icon" name="circle-info"></wa-icon>
+                            { move || format!(
+                                "Repository '{}' not found",
+                                space_name.get().unwrap_or_default(),
+                            ) }
+                        </wa-callout>
+                    }),
+                })) }
+            </ErrorBoundary>
+        </Suspense>
+    }
+}
+
+/// Renders the viewer's banner header and an iframe-only
+/// `<main>`. Mirrors [`render_space_view`]'s banner so the
+/// viewer reads as the same page chrome — just with the
+/// branches/remotes sections replaced by the entity render.
+fn render_viewer_view<F>(
+    info: RepositoryInfo,
+    space_name: Signal<Option<String>, LocalStorage>,
+    branch_name: Signal<Option<String>, LocalStorage>,
+    entity_name: Signal<Option<String>, LocalStorage>,
+    host_id: Option<Signal<Option<HostId>, LocalStorage>>,
+    on_share: F,
+) -> impl IntoView
+where
+    F: Fn(leptos::ev::MouseEvent) + 'static + Clone,
+{
+    let local_subject = info.subject.to_string();
+    let space_title = info.name.clone();
+    let title_attr = local_subject.clone();
+
+    // Iframe `src` is `Some(...)` once we know all four pieces:
+    // the hosting document's Client ID (from [`HostId`]) plus
+    // the route's space, branch, and entity segments. Until
+    // then the iframe is a placeholder — same loading affordance
+    // [`TonkSpace`] uses while waiting on the shell.
+    let iframe_src = Signal::derive_local(move || {
+        let host = host_id.and_then(|s| s.get()).map(|h| h.0)?;
+        let space = space_name.get()?;
+        let branch = branch_name.get()?;
+        let entity = entity_name.get()?;
+        Some(format!(
+            "/api/repository/{}/branch/{}/host/{}/{}",
+            space, branch, host, entity,
+        ))
+    });
+
+    view! {
+        <header slot="main-header" class="space-banner">
+            <h1 class="space-banner-title" title=title_attr>
+                { space_title }
+            </h1>
+            <wa-button
+                variant="neutral"
+                appearance="accent"
+                size="small"
+                on:click=on_share
+            >
+                <wa-icon
+                    name="share-nodes"
+                    variant="solid"
+                    label="Invite someone to this space"
+                ></wa-icon>
+            </wa-button>
+        </header>
+        <main class="wa-stack space-view space-viewer">
+            { move || match iframe_src.get() {
+                Some(src) => Either::Left(view! {
+                    <iframe
+                        class="space-viewer-frame"
+                        sandbox="allow-scripts allow-same-origin"
+                        src=src
+                    />
+                }),
+                None => Either::Right(view! {
+                    <wa-spinner></wa-spinner>
+                }),
+            } }
+        </main>
     }
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -235,6 +235,23 @@ h6 {
     opacity: 0.7;
 }
 
+/* Viewer page: drop the inner padding so the iframe fills the
+   available main area edge-to-edge; the banner above keeps the
+   page chrome consistent with the regular space view. */
+.space-viewer {
+    padding: 0;
+    gap: 0;
+    flex: 1;
+    min-height: 0;
+}
+.space-viewer-frame {
+    border: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 60vh;
+    background: transparent;
+}
+
 /* Branches as collapsible rows. Each row's `<wa-details>`
    summary is a single horizontal line: icon + name + version +
    sync icon-buttons + status chip, all packed tight via gap.
@@ -735,8 +752,16 @@ tonk-code {
        fill is too saturated against the form-control background;
        a low-alpha tint of the foreground reads as a subtle band
        on both light and dark themes. */
-    --tonk-code-active-line: color-mix(in srgb, var(--wa-color-text-normal) 2%, transparent);
-    --tonk-code-gutter-bg: color-mix(in srgb, var(--wa-color-text-normal) 4%, transparent);
+    --tonk-code-active-line: color-mix(
+        in srgb,
+        var(--wa-color-text-normal) 2%,
+        transparent
+    );
+    --tonk-code-gutter-bg: color-mix(
+        in srgb,
+        var(--wa-color-text-normal) 4%,
+        transparent
+    );
     --tonk-code-cursor: var(--wa-color-brand-fill-loud);
     /* Selection / bracket match — color-mixed alpha tints rather
        than raw `--wa-color-brand-fill-quiet`, because wa-details
@@ -745,8 +770,16 @@ tonk-code {
        (a brand color, not a surface) is unaffected, so we mix
        against it for predictable visibility regardless of
        ancestor wa-component scoping. */
-    --tonk-code-selection: color-mix(in srgb, var(--wa-color-brand-fill-loud) 25%, transparent);
-    --tonk-code-bracket-match-bg: color-mix(in srgb, var(--wa-color-brand-fill-loud) 18%, transparent);
+    --tonk-code-selection: color-mix(
+        in srgb,
+        var(--wa-color-brand-fill-loud) 25%,
+        transparent
+    );
+    --tonk-code-bracket-match-bg: color-mix(
+        in srgb,
+        var(--wa-color-brand-fill-loud) 18%,
+        transparent
+    );
     --tonk-code-bracket-match-border: var(--wa-color-brand-border-loud);
     /* Suppress the element's default focus halo. wa-input doesn't
        paint one either, and rendering it inside a wa-details body
@@ -762,9 +795,17 @@ tonk-code {
        see-through. A color-mix against the page foreground gives
        a solid, raised-looking surface that survives any wa
        ancestor scoping. */
-    --tonk-code-tooltip-bg: color-mix(in srgb, var(--wa-color-text-normal) 12%, var(--wa-form-control-background-color));
+    --tonk-code-tooltip-bg: color-mix(
+        in srgb,
+        var(--wa-color-text-normal) 12%,
+        var(--wa-form-control-background-color)
+    );
     --tonk-code-tooltip-fg: var(--wa-color-text-normal);
-    --tonk-code-tooltip-border: color-mix(in srgb, var(--wa-color-text-normal) 18%, transparent);
+    --tonk-code-tooltip-border: color-mix(
+        in srgb,
+        var(--wa-color-text-normal) 18%,
+        transparent
+    );
 
     /* Syntax — muted Bauhaus palette.
        Kandinsky's triad (red→square, yellow→triangle, blue→circle)
@@ -778,23 +819,23 @@ tonk-code {
        further down map roles onto the palette so reassigning a
        role (e.g. point variables at red instead of blue) is a
        one-line change. */
-    --tonk-bauhaus-yellow: #c89a2b;    /* muted ochre */
-    --tonk-bauhaus-red:    #b94a3d;    /* muted brick */
-    --tonk-bauhaus-blue:   #3d6da8;    /* muted slate-blue */
-    --tonk-bauhaus-grey:   #7a7268;    /* warm neutral */
-    --tonk-bauhaus-alarm:  #a8302a;    /* hotter than the brick red */
+    --tonk-bauhaus-yellow: #c89a2b; /* muted ochre */
+    --tonk-bauhaus-red: #b94a3d; /* muted brick */
+    --tonk-bauhaus-blue: #3d6da8; /* muted slate-blue */
+    --tonk-bauhaus-grey: #7a7268; /* warm neutral */
+    --tonk-bauhaus-alarm: #a8302a; /* hotter than the brick red */
 
     /* Code-role assignments. The Bauhaus school's own logic for
        the primaries:
          - yellow / triangle → keys (loud, structural, eye-catching)
          - red    / square   → strings (grounded, literal substance)
          - blue   / circle   → numbers (abstract, receding) */
-    --tonk-code-key:         var(--tonk-bauhaus-yellow);
-    --tonk-code-string:      var(--tonk-bauhaus-red);
-    --tonk-code-number:      var(--tonk-bauhaus-blue);
-    --tonk-code-comment:     var(--tonk-bauhaus-grey);
+    --tonk-code-key: var(--tonk-bauhaus-yellow);
+    --tonk-code-string: var(--tonk-bauhaus-red);
+    --tonk-code-number: var(--tonk-bauhaus-blue);
+    --tonk-code-comment: var(--tonk-bauhaus-grey);
     --tonk-code-punctuation: var(--wa-color-text-normal);
-    --tonk-code-error:       var(--tonk-bauhaus-alarm);
+    --tonk-code-error: var(--tonk-bauhaus-alarm);
 
     /* Dialect decorations (dialog-yaml). Choices follow the
        Kandinsky logic: variables (abstract holes) → blue;
@@ -803,11 +844,11 @@ tonk-code {
        will change state") → alarm red. Entity URIs and the `.`
        sigil ride a quiet text color to read as "reference" without
        competing with the role color of the surrounding token. */
-    --tonk-code-variable:   var(--tonk-bauhaus-blue);
-    --tonk-code-entity:     var(--wa-color-text-quiet);
-    --tonk-code-name:       var(--tonk-bauhaus-yellow);
+    --tonk-code-variable: var(--tonk-bauhaus-blue);
+    --tonk-code-entity: var(--wa-color-text-quiet);
+    --tonk-code-name: var(--tonk-bauhaus-yellow);
     --tonk-code-name-sigil: var(--wa-color-text-quiet);
-    --tonk-code-effect:     var(--tonk-bauhaus-alarm);
+    --tonk-code-effect: var(--tonk-bauhaus-alarm);
 
     /* Typography */
     --tonk-code-font: var(--wa-font-family-code);
@@ -906,7 +947,10 @@ tonk-code:focus-within {
        reads as "previous" without making the text hard to
        read. */
     color: var(--wa-color-text-quiet);
-    background: var(--wa-color-surface-lowered, var(--wa-color-neutral-fill-quiet));
+    background: var(
+        --wa-color-surface-lowered,
+        var(--wa-color-neutral-fill-quiet)
+    );
 }
 .evaluate-revision {
     /* Sits above the match list as a one-line tag. */

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -58,6 +58,7 @@ web-sys = { workspace = true, features = [
     "Headers",
     "Request",
     "RequestInit",
+    "RequestMode",
     "Response",
     "ResponseInit",
     "ServiceWorkerGlobalScope",

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -44,6 +44,9 @@ pub use evaluate::{CommitSummary, EvaluatePath, EvaluateResponse, QueryMatchBloc
 mod query;
 pub use query::QueryPath;
 
+mod host;
+pub use host::{ClientId, GuestBinding, GuestBindings};
+
 /// Shared application state containing profile and operator.
 pub type AppState = Arc<RwLock<TonkState>>;
 
@@ -60,6 +63,17 @@ async fn root(State(_state): State<AppState>) -> &'static str {
 /// worker version begins installing.
 pub fn api_router(state: TonkState) -> (Router, Arc<LspHub>) {
     api_router_from_state(Arc::new(RwLock::new(state)))
+}
+
+/// Variant of [`api_router`] that also surfaces the wrapped
+/// [`AppState`] handle. The worker uses this so it can consult
+/// shared state (notably the guest-binding map) outside the
+/// request path, before deciding whether to dispatch into the
+/// router or pass a fetch through to the network.
+pub fn api_router_with_state(state: TonkState) -> (Router, AppState, Arc<LspHub>) {
+    let state = Arc::new(RwLock::new(state));
+    let (router, hub) = api_router_from_state(state.clone());
+    (router, state, hub)
 }
 
 /// Same as [`api_router`] but takes an already-wrapped
@@ -127,6 +141,17 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route(
             "/api/repository/{repo}/branch/{branch}/query",
             post(query::query),
+        )
+        // Host/guest iframe bridge. The shell embeds an iframe
+        // pointed at this URL; the handler records the iframe's
+        // client id against `{repo, branch}` so its later
+        // subresource fetches can be re-rooted, and serves the
+        // entity's body by selecting `(the=<mime>, of=<entity>)`
+        // on the branch. The MIME comes from the entity's
+        // trailing `.<ext>` (defaulting to `text/html`).
+        .route(
+            "/api/repository/{repo}/branch/{branch}/host/{host}/{entity}",
+            get(host::guest),
         )
         // Inspect operations
         .route(
@@ -213,6 +238,7 @@ pub mod tests {
             operator,
             profile_name: "test-tonk".to_string(),
             reactor,
+            guests: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -1,0 +1,261 @@
+//! Host/guest iframe bridge.
+//!
+//! A hosting document (the Tonk shell) discovers its own
+//! service-worker Client ID from the `X-Tonk-Client-Id` header
+//! the SW echoes on every response. It then embeds a sandboxed
+//! iframe pointed at
+//! `/api/repository/{repo}/branch/{branch}/host/{host}/{entity}`.
+//! When the browser issues the initial navigation fetch for that
+//! URL the service worker:
+//!
+//! - records `resulting_client_id → {repo, branch}` in the
+//!   [`GuestBindings`] map hanging off `TonkState`, so any
+//!   subsequent subresource fetch from the same iframe can be
+//!   identified by client id alone without re-parsing the URL;
+//! - serves the entity's body by selecting the claim
+//!   `(the = <mime>, of = <entity>)` against the branch and
+//!   returning its `is` value with the chosen MIME as the
+//!   response's `Content-Type`.
+//!
+//! Subsequent subresource fetches from inside the iframe are
+//! intercepted by the worker's `route_for`, which sees the
+//! registered guest client and rewrites the path to live under
+//! `/api/repository/{repo}/branch/{branch}/...`. That gives the
+//! iframe-rendered content a virtual root scoped to the branch
+//! it was loaded from, so `<script src="/foo.js">` resolves to
+//! `/api/repository/{repo}/branch/{branch}/foo.js`.
+
+use std::{collections::HashMap, sync::Arc};
+
+use ::axum::{
+    body::Body,
+    extract::{Path, Request, State},
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use axum_wasm_macros::wasm_compat;
+use dialog_artifacts::{ArtifactSelector, Attribute, Entity, Value};
+use dialog_repository::RepositoryExt as _;
+use futures_util::StreamExt;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use super::AppState;
+use crate::TonkWorkerError;
+
+/// A service worker Client ID, extracted from a `FetchEvent` by
+/// the worker's `on_fetch` and attached to each request as an
+/// extension.
+///
+/// This is the stable identifier for the document/worker that
+/// initiated the request — it outlives any single fetch and is
+/// stable for the lifetime of the document.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientId(pub String);
+
+/// Binding that records which repository and branch an iframe
+/// client is associated with.
+///
+/// Populated on the iframe's initial navigation fetch; looked up
+/// on every subsequent subresource fetch from the same client.
+#[derive(Clone, Debug)]
+pub struct GuestBinding {
+    /// The repository name the iframe is scoped to.
+    pub repo: String,
+    /// The branch name the iframe is scoped to.
+    pub branch: String,
+}
+
+/// Shared map of guest `ClientId → GuestBinding`.
+///
+/// Lives on [`TonkState::guests`] behind its own interior
+/// `RwLock`, so guest registration / lookup doesn't serialize
+/// against profile or operator access on the outer state lock.
+pub type GuestBindings = Arc<RwLock<HashMap<ClientId, GuestBinding>>>;
+
+/// Path parameters for the bridge route.
+#[derive(Debug, Deserialize)]
+pub struct GuestPath {
+    /// The hosting document's Client ID. Cosmetic — the
+    /// authoritative binding is keyed off the *current*
+    /// fetch's client id, not this URL segment.
+    #[allow(dead_code)]
+    pub host: String,
+    /// The repository name the iframe is scoped to.
+    pub repo: String,
+    /// The branch name the iframe is scoped to.
+    pub branch: String,
+    /// The entity URI whose body should fill the iframe.
+    /// May carry a trailing `.<ext>` to pick a non-HTML MIME
+    /// type — useful for entities served as images, scripts,
+    /// stylesheets, etc.
+    pub entity: String,
+}
+
+/// Split a trailing `.<ext>` off the entity segment so callers
+/// can request a specific MIME type via the URL alone (handy
+/// for `<img src=".../{entity}.png">`-style references).
+///
+/// The split is conservative: only a final dot followed by an
+/// alphanumeric token counts. Anything else (DIDs, URI-shaped
+/// entities, names that legitimately contain dots) is returned
+/// as-is with no extension.
+fn split_extension(entity: &str) -> (&str, Option<&str>) {
+    let Some(dot) = entity.rfind('.') else {
+        return (entity, None);
+    };
+    let ext = &entity[dot + 1..];
+    if !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
+        (&entity[..dot], Some(ext))
+    } else {
+        (entity, None)
+    }
+}
+
+/// Map a URL extension to the MIME type used as the claim's
+/// `the` attribute. Anything we don't have an explicit mapping
+/// for falls back to `application/<ext>` — a producer can assert
+/// under any attribute name and the bridge will route to it
+/// without a code change.
+fn mime_for_extension(ext: &str) -> String {
+    match ext.to_ascii_lowercase().as_str() {
+        "html" | "htm" => "text/html".to_string(),
+        "css" => "text/css".to_string(),
+        "js" | "mjs" => "application/javascript".to_string(),
+        "json" => "application/json".to_string(),
+        "txt" => "text/plain".to_string(),
+        "md" => "text/markdown".to_string(),
+        "svg" => "image/svg+xml".to_string(),
+        "png" => "image/png".to_string(),
+        "jpg" | "jpeg" => "image/jpeg".to_string(),
+        "gif" => "image/gif".to_string(),
+        "webp" => "image/webp".to_string(),
+        "wasm" => "application/wasm".to_string(),
+        other => format!("application/{}", other),
+    }
+}
+
+/// Render a [`Value`] into an HTTP response body.
+///
+/// Strings/symbols/entities go out as-is. Bytes/records are
+/// served raw. Numerics and booleans are stringified — they
+/// don't have an unambiguous binary form, and the caller asked
+/// for a specific MIME type, so a text rendering is the least
+/// surprising option.
+fn body_for(value: Value) -> Body {
+    match value {
+        Value::String(s) => Body::from(s),
+        Value::Symbol(s) => Body::from(s.to_string()),
+        Value::Entity(e) => Body::from(e.to_string()),
+        Value::Bytes(b) => Body::from(b),
+        Value::Record(r) => Body::from(r),
+        Value::Boolean(b) => Body::from(b.to_string()),
+        Value::SignedInt(i) => Body::from(i.to_string()),
+        Value::UnsignedInt(u) => Body::from(u.to_string()),
+        Value::Float(f) => Body::from(f.to_string()),
+    }
+}
+
+/// Handler for `GET /api/repository/{repo}/branch/{branch}/host/{host}/{entity}`.
+///
+/// Registers a guest binding for the requesting client and
+/// returns the entity's body. The MIME type comes from the
+/// entity's trailing extension (`{entity}.html`, `.css`, ...);
+/// a bare entity defaults to `text/html`. The selected MIME is
+/// used both as the claim's `the` attribute and as the
+/// response's `Content-Type`.
+#[wasm_compat]
+pub async fn guest(
+    State(state): State<AppState>,
+    Path(params): Path<GuestPath>,
+    request: Request,
+) -> Result<Response, TonkWorkerError> {
+    let client_id = request.extensions().get::<ClientId>().cloned();
+
+    let (entity_str, extension) = split_extension(&params.entity);
+    let attribute_str = match extension {
+        Some(ext) => mime_for_extension(ext),
+        None => "text/html".to_string(),
+    };
+    log!(
+        "guest navigation: repo={} branch={} entity={} the={} client={:?}",
+        params.repo,
+        params.branch,
+        entity_str,
+        attribute_str,
+        client_id,
+    );
+
+    if let Some(client) = client_id {
+        let guests = state.read().await.guests.clone();
+        guests.write().await.insert(
+            client,
+            GuestBinding {
+                repo: params.repo.clone(),
+                branch: params.branch.clone(),
+            },
+        );
+    }
+
+    let attribute: Attribute = attribute_str.parse().map_err(|e| {
+        TonkWorkerError::Router(format!("Invalid attribute '{}': {}", attribute_str, e))
+    })?;
+    let entity: Entity = entity_str
+        .parse()
+        .map_err(|e| TonkWorkerError::Router(format!("Invalid entity '{}': {}", entity_str, e)))?;
+
+    let tonk = state.read().await;
+
+    let repo = tonk
+        .profile
+        .repository(&params.repo)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::NotFound(format!("Repository '{}' not found: {}", params.repo, e))
+        })?;
+
+    let branch = repo
+        .branch(params.branch.as_str())
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("Failed to open branch '{}': {}", params.branch, e))
+        })?;
+
+    let selector = ArtifactSelector::new().the(attribute).of(entity);
+    let stream = branch
+        .claims()
+        .select(selector)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Query execution error: {}", e)))?;
+
+    tokio::pin!(stream);
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(artifact) => {
+                let body = body_for(artifact.is);
+                let mut response = (StatusCode::OK, body).into_response();
+                if let Ok(value) = HeaderValue::from_str(&attribute_str) {
+                    response.headers_mut().insert(header::CONTENT_TYPE, value);
+                }
+                return Ok(response);
+            }
+            Err(e) => {
+                log!("guest: error reading artifact: {:?}", e);
+            }
+        }
+    }
+
+    Err(TonkWorkerError::NotFound(format!(
+        "No claim found for entity={} attribute={}",
+        entity_str, attribute_str,
+    )))
+}

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -159,21 +159,13 @@ pub struct RepositoryInfo {
 /// Create a repository with optional remote and branch configuration.
 ///
 /// Semantics:
-/// - Fresh create returns `201 Created` with a [`RepositoryInfo`] body.
-/// - If the repository already exists, the response depends on
-///   the `If-None-Match` header:
-///   - With `If-None-Match: *` — same body, but `200 OK`. The
-///     status differs from the create case so callers can
-///     distinguish, while the body shape stays identical so
-///     `reqwest`'s wasm client doesn't trip over a missing body
-///     on the alternative `412 Precondition Failed` path (the
-///     Fetch API tears down opaque bodies on non-2xx responses
-///     in some Chromium builds, which `reqwest` then surfaces
-///     as a decode error).
-///   - Without `If-None-Match` — `409 Conflict`.
+/// - Always creates — if the repository exists, fails with `412
+///   Precondition Failed` when `If-None-Match: *` was sent, or
+///   `409 Conflict` otherwise.
 /// - On success, delegates repository access to the current profile,
 ///   sets up any remotes from the body, creates each listed branch,
 ///   and wires up upstream tracking when specified.
+/// - Returns `201 Created` with a [`RepositoryInfo`] body.
 #[wasm_compat]
 pub async fn put_repository(
     State(state): State<AppState>,
@@ -201,24 +193,28 @@ pub async fn put_repository(
 
     let tonk = state.write().await;
 
-    // 1. Check if the repo already exists. With `If-None-Match:
-    // *` we treat that as a no-op success and return the current
-    // repository info under `200 OK` — see the function-level
-    // doc comment for why we don't use `412` here. Without the
-    // header it's a genuine collision: `409 Conflict`.
-    if let Ok(existing) = tonk
+    // 1. Check if the repo already exists before attempting to
+    // create. `.load()` returns Ok when the space is present; in
+    // that case the PUT is rejected with 412 (if the caller sent
+    // `If-None-Match: *`) or 409 (otherwise). Relying on
+    // `.create()`'s own error signalling isn't enough because
+    // it's possible for the space to exist while being
+    // inconsistent enough that `.create()` would either succeed
+    // (overwriting) or fail in a way we can't classify cleanly.
+    if tonk
         .profile
         .repository(&name)
         .load()
         .perform(&tonk.operator)
         .await
+        .is_ok()
     {
-        if if_none_match_star {
-            let info = build_repository_info(&tonk, &name, &existing).await;
-            return Ok((StatusCode::OK, Json(info)));
-        }
         let message = format!("Repository '{}' already exists", name);
-        return Err(TonkWorkerError::Conflict(message));
+        return Err(if if_none_match_star {
+            TonkWorkerError::PreconditionFailed(message)
+        } else {
+            TonkWorkerError::Conflict(message)
+        });
     }
 
     // 2. Create the repository and everything that comes with

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -159,13 +159,21 @@ pub struct RepositoryInfo {
 /// Create a repository with optional remote and branch configuration.
 ///
 /// Semantics:
-/// - Always creates — if the repository exists, fails with `412
-///   Precondition Failed` when `If-None-Match: *` was sent, or
-///   `409 Conflict` otherwise.
+/// - Fresh create returns `201 Created` with a [`RepositoryInfo`] body.
+/// - If the repository already exists, the response depends on
+///   the `If-None-Match` header:
+///   - With `If-None-Match: *` — same body, but `200 OK`. The
+///     status differs from the create case so callers can
+///     distinguish, while the body shape stays identical so
+///     `reqwest`'s wasm client doesn't trip over a missing body
+///     on the alternative `412 Precondition Failed` path (the
+///     Fetch API tears down opaque bodies on non-2xx responses
+///     in some Chromium builds, which `reqwest` then surfaces
+///     as a decode error).
+///   - Without `If-None-Match` — `409 Conflict`.
 /// - On success, delegates repository access to the current profile,
 ///   sets up any remotes from the body, creates each listed branch,
 ///   and wires up upstream tracking when specified.
-/// - Returns `201 Created` with a [`RepositoryInfo`] body.
 #[wasm_compat]
 pub async fn put_repository(
     State(state): State<AppState>,
@@ -193,28 +201,24 @@ pub async fn put_repository(
 
     let tonk = state.write().await;
 
-    // 1. Check if the repo already exists before attempting to
-    // create. `.load()` returns Ok when the space is present; in
-    // that case the PUT is rejected with 412 (if the caller sent
-    // `If-None-Match: *`) or 409 (otherwise). Relying on
-    // `.create()`'s own error signalling isn't enough because
-    // it's possible for the space to exist while being
-    // inconsistent enough that `.create()` would either succeed
-    // (overwriting) or fail in a way we can't classify cleanly.
-    if tonk
+    // 1. Check if the repo already exists. With `If-None-Match:
+    // *` we treat that as a no-op success and return the current
+    // repository info under `200 OK` — see the function-level
+    // doc comment for why we don't use `412` here. Without the
+    // header it's a genuine collision: `409 Conflict`.
+    if let Ok(existing) = tonk
         .profile
         .repository(&name)
         .load()
         .perform(&tonk.operator)
         .await
-        .is_ok()
     {
+        if if_none_match_star {
+            let info = build_repository_info(&tonk, &name, &existing).await;
+            return Ok((StatusCode::OK, Json(info)));
+        }
         let message = format!("Repository '{}' already exists", name);
-        return Err(if if_none_match_star {
-            TonkWorkerError::PreconditionFailed(message)
-        } else {
-            TonkWorkerError::Conflict(message)
-        });
+        return Err(TonkWorkerError::Conflict(message));
     }
 
     // 2. Create the repository and everything that comes with

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -5,11 +5,16 @@
 use std::sync::Arc;
 
 use crate::{
-    LspHub, api_router,
+    LspHub,
     axum::{RequestConversion, ResponseConversion},
     bootstrap_profile_meta,
+    router::{AppState, ClientId, GuestBindings, api_router_with_state},
 };
-use axum::{Router, body::Body};
+use axum::{
+    Router,
+    body::Body,
+    http::{HeaderValue, header::HeaderName},
+};
 use dialog_capability::Subject;
 use dialog_operator::{Operator, Profile};
 use dialog_storage::provider::storage::Storage;
@@ -18,8 +23,189 @@ use tokio::sync::Mutex;
 use tonk_common::log;
 use tower_service::Service;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::future_to_promise;
-use web_sys::{Request, Response};
+use wasm_bindgen_futures::{JsFuture, future_to_promise};
+use web_sys::{FetchEvent, Request, Response};
+
+// Global `self.fetch(...)` in the service-worker scope. Fetches
+// issued from an SW bypass the SW's own `onfetch` listener (per
+// spec), so this is how we pass through requests the Rust side
+// chose not to handle.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = fetch)]
+    fn sw_fetch(request: &Request) -> Promise;
+
+    #[wasm_bindgen(js_name = fetch)]
+    fn sw_fetch_str(url: &str) -> Promise;
+}
+
+/// Extract the `resultingClientId` property from a `FetchEvent`.
+///
+/// `web-sys` exposes `FetchEvent.client_id()` but not
+/// `resultingClientId`. For navigation requests `client_id` is
+/// empty and `resultingClientId` carries the ID the new document
+/// will have, so we need both. Read the property via reflection
+/// rather than extending `FetchEvent` with a manual extern —
+/// `wasm-bindgen` doesn't allow extending foreign types from
+/// outside their defining crate.
+fn event_resulting_client_id(event: &FetchEvent) -> String {
+    js_sys::Reflect::get(event, &JsValue::from_str("resultingClientId"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+}
+
+/// Outcome of the routing decision made in
+/// [`TonkServiceWorker::on_fetch`].
+enum Route {
+    /// Dispatch through the axum router. `rewritten_path` is
+    /// `Some` only when the request originated from a registered
+    /// guest iframe and its path needs to be re-rooted under the
+    /// iframe's branch.
+    Handle { rewritten_path: Option<String> },
+    /// Pass the request through to the network.
+    Passthrough,
+}
+
+/// Decides how the Rust side should route this request.
+///
+/// - Paths under `/api/` are handled by the axum router as-is.
+/// - Requests whose initiating client is a registered guest
+///   iframe are *also* handled by the router, but with their
+///   path rewritten to live under
+///   `/api/repository/{repo}/branch/{branch}`. That gives the
+///   iframe a virtual root scoped to its branch: a fetch for
+///   `/foo.js` lands at `/api/repository/{repo}/branch/{branch}/foo.js`.
+/// - Everything else falls through to the network.
+async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
+    if path.starts_with("/api/") {
+        return Route::Handle {
+            rewritten_path: None,
+        };
+    }
+    if client_id.is_empty() {
+        return Route::Passthrough;
+    }
+
+    let binding = {
+        let guests = state.read().await.guests.clone();
+        let guard = guests.read().await;
+        guard.get(&ClientId(client_id.to_string())).cloned()
+    };
+
+    let Some(binding) = binding else {
+        return Route::Passthrough;
+    };
+
+    let suffix = if path == "/" || path.is_empty() {
+        String::new()
+    } else {
+        path.to_string()
+    };
+    let rewritten = format!(
+        "/api/repository/{}/branch/{}{}",
+        binding.repo, binding.branch, suffix,
+    );
+    Route::Handle {
+        rewritten_path: Some(rewritten),
+    }
+}
+
+/// Route the request through the axum router, apply response
+/// headers (CORS, client-id echo), and convert back to a browser
+/// `Response`.
+///
+/// If `rewritten_path` is `Some`, the request's URI is rewritten
+/// to that path before axum gets it — that's how guest-iframe
+/// requests get redirected into branch-scoped routes without
+/// axum's own routing layer ever seeing the un-scoped URL.
+async fn handle_via_router(
+    router: Arc<Mutex<Router>>,
+    browser_request: Request,
+    client_id: String,
+    rewritten_path: Option<String>,
+) -> Result<JsValue, JsValue> {
+    let mut request: axum::http::Request<Body> = RequestConversion::from(browser_request)
+        .try_into()
+        .map_err(JsValue::from)?;
+
+    if let Some(new_path) = rewritten_path {
+        let uri_string = match request.uri().query() {
+            Some(q) => format!("{}?{}", new_path, q),
+            None => new_path.clone(),
+        };
+        if let Ok(uri) = uri_string.parse::<axum::http::Uri>() {
+            log!("handle_via_router: rewriting path to {}", uri);
+            *request.uri_mut() = uri;
+        }
+    }
+
+    if !client_id.is_empty() {
+        request.extensions_mut().insert(ClientId(client_id.clone()));
+    }
+
+    let mut response = router
+        .lock()
+        .await
+        .call(request)
+        .await
+        .expect_throw("Failed to handle API request");
+
+    let headers = response.headers_mut();
+
+    if !client_id.is_empty()
+        && let Ok(value) = HeaderValue::from_str(&client_id)
+    {
+        headers.insert(HeaderName::from_static("x-tonk-client-id"), value);
+    }
+
+    // CORS: sandboxed iframes have an opaque origin and send
+    // `Origin: null`, so cross-origin rules apply even though
+    // the iframe and the SW share an origin. Send permissive
+    // headers on every response — same-origin callers ignore
+    // them and opaque-origin callers need them to read the body.
+    headers.insert(
+        HeaderName::from_static("access-control-allow-origin"),
+        HeaderValue::from_static("*"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-allow-methods"),
+        HeaderValue::from_static("GET, POST, PUT, DELETE, OPTIONS"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-allow-headers"),
+        HeaderValue::from_static("content-type, if-none-match, accept"),
+    );
+    headers.insert(
+        HeaderName::from_static("access-control-expose-headers"),
+        HeaderValue::from_static("x-tonk-client-id"),
+    );
+
+    ResponseConversion::from(response)
+        .try_into()
+        .map(|value: Response| JsValue::from(value))
+        .map_err(JsValue::from)
+}
+
+/// Pass the request through to the network by calling
+/// `self.fetch(request)` from inside the service worker. Such
+/// fetches bypass the SW's own `onfetch` handler (per spec), so
+/// this really does hit the network.
+///
+/// For navigation requests that 404, retry against `/index.html`
+/// so the client-side SPA router can match unknown paths.
+async fn passthrough(request: Request, is_navigation: bool) -> Result<JsValue, JsValue> {
+    let response: Response = JsFuture::from(sw_fetch(&request)).await?.dyn_into()?;
+
+    if is_navigation && response.status() == 404 {
+        let fallback: Response = JsFuture::from(sw_fetch_str("/index.html"))
+            .await?
+            .dyn_into()?;
+        return Ok(JsValue::from(fallback));
+    }
+
+    Ok(JsValue::from(response))
+}
 
 /// Default storage type — IndexedDB on WASM, filesystem on native.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -52,6 +238,11 @@ pub struct TonkState {
     /// mutate a branch flow through `reactor.repository(r).branch(b)`
     /// so subscription broadcasts happen automatically.
     pub reactor: crate::TonkReactor,
+    /// Guest-iframe bindings keyed by service-worker Client ID.
+    /// Behind its own interior lock so guest registration /
+    /// lookup doesn't contend with profile/operator access on
+    /// the outer state lock.
+    pub guests: GuestBindings,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -70,6 +261,13 @@ unsafe impl Sync for TonkState {}
 #[wasm_bindgen]
 pub struct TonkServiceWorker {
     router: Arc<Mutex<Router>>,
+    /// Shared application state. The router owns it too, but we
+    /// keep a handle here so [`Self::on_fetch`] can consult the
+    /// guest-binding map *before* dispatching — that's how we
+    /// decide whether a request should be routed through axum
+    /// (with optional path rewriting) or passed through to the
+    /// network.
+    state: AppState,
     /// Handle to the language-server hub. Used by [`Self::onupdatefound`]
     /// to release in-flight SSE responses when a newer worker
     /// version begins installing — without this the active worker
@@ -123,19 +321,20 @@ impl TonkServiceWorker {
             operator,
             profile_name: PROFILE_NAME.to_string(),
             reactor,
+            guests: Default::default(),
         };
         bootstrap_profile_meta(&state, PROFILE_NAME)
             .await
             .map_err(|e| JsError::new(&format!("Failed to bootstrap profile meta: {}", e)))?;
 
-        // 5. Wrap state in the router. `api_router` returns the LSP
-        // hub alongside it so the worker can address it directly
-        // (independent of the request-handling path) when the SW
-        // lifecycle requires releasing in-flight streams.
-        let (router, lsp) = api_router(state);
+        // 5. Wrap state in the router. `api_router_with_state`
+        // returns the LSP hub *and* a cloneable `AppState` handle:
+        // the worker keeps the latter so `on_fetch` can read the
+        // guest-binding map without going through the router.
+        let (router, state, lsp) = api_router_with_state(state);
         let router = Arc::new(Mutex::new(router));
 
-        Ok(Self { router, lsp })
+        Ok(Self { router, state, lsp })
     }
 
     /// Hook the SW's `updatefound` event from JavaScript.
@@ -162,35 +361,64 @@ impl TonkServiceWorker {
 
     /// Handles incoming fetch events from the browser.
     ///
-    /// Converts the browser's `Request` to an Axum request, processes it through
-    /// the router, and converts the response back to a browser `Response`.
+    /// Called from the JS shim's `self.onfetch` listener for *every*
+    /// request the service worker sees. The Rust side decides
+    /// whether to handle the request itself (via the axum router)
+    /// or pass it through to the network. The shim never
+    /// inspects the URL — all routing policy lives here.
     ///
-    /// # Parameters
+    /// Decision rule (see [`route_for`]):
+    /// - If the request's path starts with `/api/`, route through
+    ///   the axum router unchanged.
+    /// - If the initiating client is a registered guest iframe,
+    ///   rewrite the path to live under
+    ///   `/api/repository/{repo}/branch/{branch}` and route
+    ///   through the axum router. The iframe sees its branch as
+    ///   its virtual root.
+    /// - Otherwise, pass through to the network via `sw_fetch`.
     ///
-    /// - `request`: The incoming browser fetch request
-    ///
-    /// # Returns
-    ///
-    /// A JavaScript `Promise` that resolves to the response
+    /// Navigation requests that pass through and 404 are retried
+    /// against `/index.html` so the client-side SPA router can
+    /// match unknown paths.
     #[wasm_bindgen(js_name = "onfetch")]
-    pub fn on_fetch(&self, request: Request) -> Promise {
-        log!("Handling fetch!");
+    pub fn on_fetch(&self, event: FetchEvent) -> Promise {
+        let request = event.request();
+        let client_id = event.client_id().unwrap_or_default();
+        let resulting_client_id = event_resulting_client_id(&event);
+
+        // Prefer `clientId` (subresource fetches) over
+        // `resultingClientId` (navigations). Exactly one is
+        // populated for any fetch a service worker sees.
+        let effective_client_id = if !client_id.is_empty() {
+            client_id
+        } else {
+            resulting_client_id
+        };
+
+        let url = request.url();
+        let is_navigation = request.mode() == web_sys::RequestMode::Navigate;
+
+        let path = url::Url::parse(&url)
+            .map(|u| u.path().to_string())
+            .unwrap_or_default();
 
         let router = self.router.clone();
-        let request: axum::http::Request<Body> =
-            RequestConversion::from(request).try_into().unwrap_throw();
+        let state = self.state.clone();
 
         future_to_promise(async move {
-            let response = router
-                .lock()
-                .await
-                .call(request)
-                .await
-                .expect_throw("Failed to handle API request");
-            ResponseConversion::from(response)
-                .try_into()
-                .map(|value: Response| JsValue::from(value))
-                .map_err(JsValue::from)
+            log!(
+                "onfetch path={} mode={:?} client={:?}",
+                path,
+                request.mode(),
+                effective_client_id,
+            );
+
+            match route_for(&path, &effective_client_id, &state).await {
+                Route::Handle { rewritten_path } => {
+                    handle_via_router(router, request, effective_client_id, rewritten_path).await
+                }
+                Route::Passthrough => passthrough(request, is_navigation).await,
+            }
         })
     }
 


### PR DESCRIPTION
Adds a `/space/{name}/branch/{branch}/view/{entity}` SPA route that mirrors the regular space banner but replaces `<main>` with a sandboxed iframe whose `src` is
`/api/repository/{repo}/branch/{branch}/host/{host}/{entity}`.

The host route registers a `clientId → {repo, branch}` binding for the iframe and serves the entity's body by selecting `(the=<mime>, of=<entity>)` on the branch. The MIME comes from the entity's trailing `.<ext>` (defaulting to `text/html`), so `{entity}.css` / `.png` / `.js` work without a custom Accept.

`on_fetch` now takes a `FetchEvent`, decides per-request whether to dispatch through axum (with optional path rewriting) or pass through to the network. Subresource fetches from a registered guest iframe are re-rooted under
`/api/repository/{repo}/branch/{branch}/...` so iframe-rendered HTML can use absolute paths without leaking the namespace.

`put_repository` returns 200 with the existing record on `If-None-Match: *` collisions, sidestepping a reqwest-wasm body decode bug on 412.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `TonkSpaceViewer` component for rendering a viewer interface in the application. It enhances the service worker to handle guest iframe requests more effectively and includes updates to the API for better client ID management.

### Detailed summary
- Added `RequestMode` to `Cargo.toml`.
- Introduced `TonkSpaceViewer` component for viewing entities.
- Updated routing logic to prioritize specific viewer routes.
- Enhanced service worker to manage guest iframe requests and client IDs.
- Modified API response handling to include `X-Tonk-Client-Id` header.
- Improved error handling in the `init` function of the API.
- Added `HostId` context for managing hosting document IDs.
- Updated styles for the viewer page layout.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->