### PR TITLE
fix(carry): conform to tonk-schema, save remotes in meta during join

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 resolver = "2"
 members = [
-    "rust/carry",
-    "rust/carry-telemetry-service",
-    "rust/tonk-access-service",
-    "rust/tonk-code",
-    "rust/tonk-assess",
-    "rust/tonk-common",
-    "rust/tonk-invite",
-    "rust/tonk-language-server",
-    "rust/tonk-notation",
-    "rust/tonk-schema",
-    "rust/tonk-sigil",
-    "rust/tonk-ui",
-    "rust/tonk-worker",
+  "rust/carry",
+  "rust/carry-telemetry-service",
+  "rust/tonk-access-service",
+  "rust/tonk-assess",
+  "rust/tonk-code",
+  "rust/tonk-common",
+  "rust/tonk-invite",
+  "rust/tonk-language-server",
+  "rust/tonk-notation",
+  "rust/tonk-schema",
+  "rust/tonk-sigil",
+  "rust/tonk-ui",
+  "rust/tonk-worker",
 ]
 
 [workspace.package]
@@ -26,8 +26,8 @@ license = "MIT"
 carry = { path = "./rust/carry" }
 carry-telemetry-service = { path = "./rust/carry-telemetry-service" }
 tonk-access-service = { path = "./rust/tonk-access-service" }
-tonk-code = { path = "./rust/tonk-code" }
 tonk-assess = { path = "./rust/tonk-assess" }
+tonk-code = { path = "./rust/tonk-code" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-invite = { path = "./rust/tonk-invite" }
 tonk-language-server = { path = "./rust/tonk-language-server" }
@@ -54,8 +54,8 @@ ciborium = "0.2"
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 console_error_panic_hook = "0.1"
-custom-elements = "0.2"
 crypto-common = "=0.2.0-rc.5"
+custom-elements = "0.2"
 dialoguer = "0.11"
 digest = "=0.11.0-rc.4"
 dirs = "5"
@@ -72,14 +72,15 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["http1", "server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 idb = "0.6"
+indexmap = { version = "2", features = ["serde"] }
 ipld-core = { version = "0.4", features = ["serde"] }
 keyring = "3.6"
 leptos = "0.8"
 leptos_router = "0.8"
 leptos-use = "0.17"
 lsp-types = "0.97"
-saphyr = "0.0.6"
 open = "5"
+parking_lot = "0.12"
 port_check = "0.3"
 rand = "0.9"
 rand_0_8 = { package = "rand", version = "0.8" }
@@ -88,10 +89,13 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
+saphyr = "0.0.6"
+saphyr-parser = "0.0.6"
 serde = "1"
 serde_bytes = "0.11"
 serde_ipld_dagcbor = "0.6"
 serde_json = "1"
+serde-wasm-bindgen = "0.6"
 serde_yaml = "0.9"
 serial_test = "3"
 sha2_0_10 = { package = "sha2", version = "0.10" }

--- a/rust/carry/src/join_cmd.rs
+++ b/rust/carry/src/join_cmd.rs
@@ -12,7 +12,7 @@
 //!
 //! When no URL is provided, self-provisions an upstream for the space.
 
-use crate::remote_cmd::HIDDEN_BRANCH;
+use crate::remote_cmd;
 use crate::site::Site;
 use anyhow::{Context, Result};
 use dialog_remote_ucan_s3::UcanAddress;
@@ -89,25 +89,30 @@ pub async fn execute(
     if let Some(ref remote_url) = remote_url {
         eprintln!("Configuring sync remote...");
 
-        let remote = site
-            .repo
+        let site_address = SiteAddress::Ucan(UcanAddress::new(remote_url.as_str()));
+
+        site.repo
             .remote("origin")
-            .create(SiteAddress::Ucan(UcanAddress::new(remote_url.as_str())))
-            .subject(subject)
+            .create(site_address.clone())
+            .subject(subject.clone())
             .perform(&site.operator)
             .await
             .context("Failed to register remote")?;
 
-        let remote_branch = remote
-            .branch(HIDDEN_BRANCH)
-            .open()
+        // Mirror the registration on the meta branch so `remote list`
+        // / `remote show` find this remote.
+        site.meta
+            .transaction()
+            .assert(site.replica.remote("origin", subject, &site_address))
+            .commit()
             .perform(&site.operator)
             .await
-            .context("Failed to open remote branch")?;
+            .context("failed to record remote 'origin' on meta branch")?;
 
-        site.branch
-            .set_upstream(remote_branch)
-            .perform(&site.operator)
+        // Wire up upstream on both the dialog side (so push/pull
+        // resolve) and the meta side (so `remote show` can report
+        // the upstream of `main`).
+        remote_cmd::set_upstream(&site, "origin")
             .await
             .context("Failed to set upstream")?;
 

--- a/rust/carry/src/remote_cmd.rs
+++ b/rust/carry/src/remote_cmd.rs
@@ -266,7 +266,7 @@ pub async fn execute_set_upstream(site: &Site, name: &str) -> Result<()> {
 ///   and a `TrackingBranch` linking them so `remote show` (and any
 ///   other meta-branch reader) can answer "what's the upstream of
 ///   `main`?" without consulting dialog's storage.
-async fn set_upstream(site: &Site, name: &str) -> Result<()> {
+pub(crate) async fn set_upstream(site: &Site, name: &str) -> Result<()> {
     let remote = site
         .repo
         .remote(name)

--- a/rust/carry/src/site.rs
+++ b/rust/carry/src/site.rs
@@ -17,7 +17,7 @@ use dialog_operator::{Operator, Profile};
 use dialog_repository::{Branch, Repository, RepositoryExt as _};
 use dialog_storage::provider::storage::NativeSpace;
 use std::path::{Path, PathBuf};
-use tonk_schema::{Name, Replica};
+use tonk_schema::Replica;
 
 /// Repository name within the operator's base directory.
 ///
@@ -194,7 +194,7 @@ impl Site {
         let repo_dir = Self::repo_directory(&root, None);
         let id = identity_cmd::ensure_identity(profile_location.clone(), Some(repo_dir)).await?;
         let (repo, branch, meta) = Self::open_repo_and_branches(&id.operator, &id.profile).await?;
-        let replica = Replica::new(id.profile.did(), repo.did(), Name(REPO_NAME.into()));
+        let replica = Replica::new(id.profile.did(), repo.did(), REPO_NAME);
         Ok(Self {
             root,
             profile: id.profile,
@@ -220,7 +220,7 @@ impl Site {
         let repo_dir = Self::repo_directory(&carry_dir, repo_location);
         let id = identity_cmd::ensure_identity(profile_location.clone(), Some(repo_dir)).await?;
         let (repo, branch, meta) = Self::open_repo_and_branches(&id.operator, &id.profile).await?;
-        let replica = Replica::new(id.profile.did(), repo.did(), Name(REPO_NAME.into()));
+        let replica = Replica::new(id.profile.did(), repo.did(), REPO_NAME);
 
         Ok(Self {
             root: carry_dir,
@@ -251,7 +251,7 @@ impl Site {
         let repo_dir = Self::repo_directory(&carry_dir, repo_location);
         let id = identity_cmd::ensure_identity(profile_location.clone(), Some(repo_dir)).await?;
         let (repo, branch, meta) = Self::open_repo_and_branches(&id.operator, &id.profile).await?;
-        let replica = Replica::new(id.profile.did(), repo.did(), Name(REPO_NAME.into()));
+        let replica = Replica::new(id.profile.did(), repo.did(), REPO_NAME);
         Ok(Self {
             root: carry_dir,
             profile: id.profile,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on modifying the visibility of the `set_upstream` function and making updates to the `execute` function in `join_cmd.rs` to enhance remote configuration. It also includes changes to the `Replica` initialization in `site.rs` and updates to `Cargo.toml`.

### Detailed summary
- Changed `set_upstream` from private to `pub(crate)` in `remote_cmd.rs`.
- Updated `execute` function in `join_cmd.rs` to streamline remote creation and upstream setup.
- Replaced `Name(REPO_NAME.into())` with `REPO_NAME` in `Replica` initialization across multiple locations in `site.rs`.
- Updated dependencies in `Cargo.toml`, including adding `indexmap` and `serde-wasm-bindgen`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->