### PR TITLE
chore(carry): bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+## 0.2.1
+
+Adds `git`-style remote management commands and optional anonymous
+usage telemetry.
+
+### New commands
+
+- **`carry remote list`** (alias `ls`) -- list configured remotes.
+
+- **`carry remote show <NAME>`** -- show a single remote's URL,
+  subject DID, and upstream status.
+
+- **`carry remote set-upstream <NAME>`** -- wire an existing remote
+  up as the push/pull target after the fact.
+
+- **`carry remote remove <NAME>`** (alias `rm`) -- unregister a remote
+  and clear its upstream link if it was the upstream.
+
+### New flags
+
+- **`carry remote add --set-upstream`** (`-u`) -- also wire the new
+  remote up as the push/pull target in one step, mirroring
+  `git remote add -u`. Without the flag the remote is registered but
+  no upstream is set; use `carry remote set-upstream` later.
+
+### New
+
+- Anonymous usage telemetry. Each invocation reports the command name,
+  carry version, and a blinded blake3 hash of the profile DID to a
+  Cloudflare Worker (`carry-telemetry-service`). No IP addresses or
+  raw DIDs are collected. Opt out with `DO_NOT_TRACK=1`. A notice is
+  printed at `carry init` time and in `carry --help`.
+
+### Changed
+
+- Repository metadata (remotes, branches, tracking links) now lives on
+  a dedicated `meta` branch as `tonk-schema` concepts rather than
+  being scraped from dialog's on-disk layout. `remote list` / `remote
+  show` query that branch; `push` / `pull` continue to drive the
+  underlying dialog state directly, and the two are kept in sync
+  inside each `remote` command.
+
+## 0.2.0
+
+Repository sync between devices and collaborators via UCAN-S3.
+
+### New commands
+
+- **`carry remote add <NAME> <URL>`** -- register a sync destination.
+  Accepts `https://` URLs for UCAN-S3 access services (recommended) or
+  `s3://` with explicit `--endpoint`/`--region`/`--bucket` flags for
+  direct S3. Optional `--subject <DID>` overrides the default (this
+  repo's own DID) for cross-repo pulls.
+
+- **`carry push`** -- fast-forward the configured remote with local
+  changes. Exits with an error if the remote has diverged (run
+  `carry pull` first).
+
+- **`carry pull`** -- fetch and three-way merge changes from the
+  configured remote.
+
+- **`carry invite <DID>`** -- delegate repository access to a
+  collaborator's DID. Outputs an invite URL (default base
+  `https://tonk.xyz/join`, override with `--url`) carrying the UCAN
+  delegation chain and the access service URL in its fragment. The
+  recipient redeems it with `carry join`.
+
+- **`carry join <INVITE-URL>`** -- redeem an invite URL. Saves the
+  delegation chain, registers the sync remote, and pulls the latest
+  data in one step.
+
+### Changed
+
+- `carry invite` now takes a DID argument (the collaborator to invite)
+  instead of generating an ephemeral bearer token. Simpler, fewer
+  moving parts, and the delegation chain works immediately without
+  re-delegation on the recipient's side.
+
+- Bumped `dialog-db` dependency to `ab6f1a08` (`feat/repository-redesign`)
+  which brings:
+  - `From<RemoteBranch> for UpstreamState` (no more `NodeReference` in
+    carry's public surface)
+  - `remote(name).create(SiteAddress)` with default subject
+  - `From<S3Address>` / `From<UcanAddress>` for `SiteAddress`
+  - `profile.access().claim().delegate()` replaces `Ucan::delegate()`
+  - `Repository<SignerCredential>` type parameter
+
+### Security
+
+- Direct S3 credentials (`--access-key`/`--secret-key`) are persisted in
+  plaintext inside `.carry/`. A warning is printed at `remote add` time.
+  Prefer a UCAN-S3 access service (`https://` URL) so credentials stay
+  on the server.
+
+## 0.1.0
+
+Initial release. Local-first semantic database CLI with `init`, `assert`,
+`query`, `retract`, `status`, and `identity` commands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "carry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "carry-telemetry-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-assess"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "custom-elements",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,23 @@
 [workspace]
 resolver = "2"
 members = [
-    "rust/carry",
-    "rust/carry-telemetry-service",
-    "rust/tonk-access-service",
-    "rust/tonk-code",
-    "rust/tonk-assess",
-    "rust/tonk-common",
-    "rust/tonk-invite",
-    "rust/tonk-language-server",
-    "rust/tonk-notation",
-    "rust/tonk-schema",
-    "rust/tonk-sigil",
-    "rust/tonk-ui",
-    "rust/tonk-worker",
+  "rust/carry",
+  "rust/carry-telemetry-service",
+  "rust/tonk-access-service",
+  "rust/tonk-assess",
+  "rust/tonk-code",
+  "rust/tonk-common",
+  "rust/tonk-invite",
+  "rust/tonk-language-server",
+  "rust/tonk-notation",
+  "rust/tonk-schema",
+  "rust/tonk-sigil",
+  "rust/tonk-ui",
+  "rust/tonk-worker",
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"
@@ -26,8 +26,8 @@ license = "MIT"
 carry = { path = "./rust/carry" }
 carry-telemetry-service = { path = "./rust/carry-telemetry-service" }
 tonk-access-service = { path = "./rust/tonk-access-service" }
-tonk-code = { path = "./rust/tonk-code" }
 tonk-assess = { path = "./rust/tonk-assess" }
+tonk-code = { path = "./rust/tonk-code" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-invite = { path = "./rust/tonk-invite" }
 tonk-language-server = { path = "./rust/tonk-language-server" }
@@ -54,8 +54,8 @@ ciborium = "0.2"
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 console_error_panic_hook = "0.1"
-custom-elements = "0.2"
 crypto-common = "=0.2.0-rc.5"
+custom-elements = "0.2"
 dialoguer = "0.11"
 digest = "=0.11.0-rc.4"
 dirs = "5"
@@ -78,7 +78,6 @@ leptos = "0.8"
 leptos_router = "0.8"
 leptos-use = "0.17"
 lsp-types = "0.97"
-saphyr = "0.0.6"
 open = "5"
 port_check = "0.3"
 rand = "0.9"
@@ -88,6 +87,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
+saphyr = "0.0.6"
 serde = "1"
 serde_bytes = "0.11"
 serde_ipld_dagcbor = "0.6"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of several packages from `0.2.0` to `0.2.1` in the `Cargo.toml` and `Cargo.lock` files. Additionally, it introduces new features and commands in the `CHANGELOG.md`, including remote management commands and optional anonymous usage telemetry.

### Detailed summary
- Updated package versions from `0.2.0` to `0.2.1` in `Cargo.toml` and `Cargo.lock`.
- Added new commands for remote management in `CHANGELOG.md`:
  - **`carry remote list`** (alias `ls`)
  - **`carry remote show <NAME>`**
  - **`carry remote set-upstream <NAME>`**
  - **`carry remote remove <NAME>`** (alias `rm`)
- Introduced `carry remote add --set-upstream` flag.
- Implemented anonymous usage telemetry reporting.
- Changed repository metadata handling to a dedicated `meta` branch.
- Updated `CHANGELOG.md` with details for versions `0.2.1` and `0.2.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->