### PR TITLE
feat: fix name resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-trait",
  "base58",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-trait",
  "base58",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-stream",
  "base58",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "async-trait",
  "base58",
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-24#5f3ff3444a445733fb8201fd27113d43622ac38b"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,20 +116,20 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-04-24" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-11" }
 
 [profile.dev]
 opt-level = 1

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -18,8 +18,8 @@ let
   # that the same dependencies can be used across all derivations that
   # need them. Crane expects the full git URL as the key.
   cargoGitDependencies = {
-    "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-04-20#86d660fbb078e68566844032ff0efa6f0d3ee22c" =
-      "sha256-XECPSoBENMkolx0viPyUGzzx6re+cp76llL/S6McqgA=";
+    "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-11#647c231f04be3b10abf152a004539ffa7cacd523" =
+      "sha256-7Y5wgXS+joBN5uhx91lKWxg0Nm7ipIUpO6EqcWnsETQ=";
   };
 
   # Filter source to only Rust-relevant files

--- a/rust/tonk-notation/guide.md
+++ b/rust/tonk-notation/guide.md
@@ -104,7 +104,7 @@ have many in one document; they all commit in one transaction.
 
 ```yaml
 attribute!: &person-age
-  description: "The person's age in years"
+  description: The person's age in years
   the:         xyz.tonk.person/age
   as:          unsigned-integer
   cardinality: one
@@ -118,13 +118,13 @@ as bare symbols, which resolve through the name table.
 
 ```yaml
 attribute!: &person-name
-  description: "The person's name"
+  description: The person's name
   the:         xyz.tonk.person/name
   as:          text
   cardinality: one
 
 attribute!: &person-age
-  description: "The person's age"
+  description: The person's age
   the:         xyz.tonk.person/age
   as:          unsigned-integer
   cardinality: one
@@ -142,12 +142,11 @@ document.
 
 ### 4. Add a person
 
-`person!:` is asserts the `person` concept. Use `&alice` to name
-the resulting entity `alice`:
+`person!:` is asserts the `person` concept. Use `&maintainer` to name the resulting entity `maintainer`:
 
 ```yaml
-person!: &alice
-  name: "Alice"
+person!: &maintainer
+  name: Alice
   age:  28
 ```
 
@@ -175,7 +174,7 @@ Constrain the match by giving fields literal values:
 
 ```yaml
 person:
-  name: "Alice"
+  name: Alice
 ```
 
 Bind the matched entity to a variable using `this:`, and captures it under a
@@ -184,13 +183,13 @@ variable so it could be used in other expressions.
 ```yaml
 person:
   this: ?p
-  name: "Alice"
+  name: Alice
   age:  ?age
 ```
 
 `?p` and `?age` come back in the result frame.
 
-### 6. Update Alice
+### 6. Update Maintainer
 
 Two distinct operations, syntactically different.
 
@@ -198,13 +197,13 @@ Two distinct operations, syntactically different.
 target). Reuse the anchor with a different body:
 
 ```yaml
-person!: &alice
-  name: "Alice"
-  age:  29
+person!: &maintainer
+  name: Bob
+  age:  40
 ```
 
 This produces a *new* entity (different body hash). The name
-`id:alice` is re-pointed to it.
+`id:maintainer` is re-pointed to it.
 
 **Update the same entity**. Use a query to bind the entity to
 a variable, then assert against the variable:
@@ -212,11 +211,11 @@ a variable, then assert against the variable:
 ```yaml
 person:
   this: ?alice
-  name: "Alice"
+  name: Alice
 
 person!:
   this: ?alice
-  age:  30
+  age:  29
 ```
 
 The query binds `?alice` to every entity currently named

--- a/rust/tonk-schema/src/builtin.rs
+++ b/rust/tonk-schema/src/builtin.rs
@@ -22,6 +22,7 @@ use dialog_artifacts::Entity;
 use dialog_query::ConceptDescriptor;
 
 use crate::analyzer::ResolvedConcept;
+use crate::meta::{AnonymousAttributeQuery, NameQuery};
 use crate::{BranchQuery, RemoteQuery, ReplicaQuery, TrackingBranchQuery};
 
 /// Look up a built-in concept by head-name. Returns `None` for
@@ -45,43 +46,17 @@ static REGISTRY: OnceLock<Vec<(&'static str, ResolvedConcept)>> = OnceLock::new(
 
 fn build_registry() -> Vec<(&'static str, ResolvedConcept)> {
     vec![
-        ("attribute", attribute_descriptor()),
+        ("attribute", builtin::<AnonymousAttributeQuery>("attribute")),
         ("concept", concept_descriptor()),
-        ("name", name_descriptor()),
-        ("branch", concept_from_query::<BranchQuery>()),
-        ("replica", concept_from_query::<ReplicaQuery>()),
-        ("remote", concept_from_query::<RemoteQuery>()),
+        ("name", builtin::<NameQuery>("name")),
+        ("branch", builtin::<BranchQuery>("branch")),
+        ("replica", builtin::<ReplicaQuery>("replica")),
+        ("remote", builtin::<RemoteQuery>("remote")),
         (
             "tracking-branch",
-            concept_from_query::<TrackingBranchQuery>(),
+            builtin::<TrackingBranchQuery>("tracking-branch"),
         ),
     ]
-}
-
-/// Built-in `attribute` view — anonymous attribute shape:
-/// `id`, `type`, `cardinality`, `description`. Every attribute
-/// (bookmark, variable, or inline in `concept!`'s `with:`) carries
-/// these four claims with non-empty defaults, so the descriptor's
-/// match-all-fields semantics surfaces every defined attribute.
-///
-/// `dialog.meta/name` is *not* part of this view: only bookmark-
-/// form attributes carry that claim, and dialog's
-/// [`ConceptDescriptor::maybe`] is parsed but not yet consulted
-/// by the engine — moving `name` to `maybe:` would make every
-/// query miss anonymous attrs. To recover the name when needed,
-/// join with `dialog.meta/name` separately.
-fn attribute_descriptor() -> ResolvedConcept {
-    let json = serde_json::json!({
-        "with": {
-            "id":          { "the": "dialog.attribute/id",          "as": "Text", "cardinality": "one" },
-            "type":        { "the": "dialog.attribute/type",        "as": "Text", "cardinality": "one" },
-            "cardinality": { "the": "dialog.attribute/cardinality", "as": "Text", "cardinality": "one" },
-            "description": { "the": "dialog.meta/description",      "as": "Text", "cardinality": "one" },
-        }
-    });
-    let descriptor: ConceptDescriptor =
-        serde_json::from_value(json).expect("attribute schema is well-formed");
-    descriptor_to_resolved(descriptor)
 }
 
 /// Built-in `concept` view — the concept-of-concept descriptor.
@@ -92,12 +67,11 @@ fn attribute_descriptor() -> ResolvedConcept {
 /// query time enumerates *every* concept (built-in + branch) with
 /// a synthesised `source` field.
 ///
-/// The entity is fixed at the well-known `db:concept` URI
-/// (rather than `descriptor.this()`'s content hash) so the row
-/// for the concept-of-concept built-in is identifiable without
-/// knowing the descriptor's hash. This is the same URI used as
-/// the value of every `dialog.meta/concept` marker claim — the
-/// symmetry is intentional.
+/// Kept as a hand-built [`ConceptDescriptor`] (rather than
+/// `derive(Concept)`) because the concept-of-concept's `with:` is
+/// a dictionary — an arbitrary map of names to attribute
+/// references — not a fixed record of named fields. Rust struct
+/// derives can't express that shape, so this one stays JSON.
 fn concept_descriptor() -> ResolvedConcept {
     ResolvedConcept {
         entity: "db:concept"
@@ -107,45 +81,25 @@ fn concept_descriptor() -> ResolvedConcept {
     }
 }
 
-/// Built-in `name` view — a name entity carries an `entity:`
-/// claim pointing at the entity it currently identifies.
+/// Build a built-in `ResolvedConcept` from a
+/// `#[derive(Concept)]` Rust type's `Query` newtype.
 ///
-/// The schema is a single-field concept whose backing attribute
-/// is `dialog.meta/name` (cardinality one). User-published names
-/// live at `id:<name>` URIs; built-in names live at `db:<name>`
-/// URIs and aren't writable.
-///
-/// The concept's own entity is fixed at `db:name` (rather than a
-/// content-derived hash) so the row for the name-of-name built-in
-/// is identifiable by URI and the `db:` scheme protection covers
-/// it.
-fn name_descriptor() -> ResolvedConcept {
-    let json = serde_json::json!({
-        "with": {
-            "entity": { "the": "dialog.meta/name", "as": "Entity", "cardinality": "one" },
-        }
-    });
-    let descriptor: ConceptDescriptor =
-        serde_json::from_value(json).expect("name schema is well-formed");
-    ResolvedConcept {
-        entity: "db:name".parse().expect("`db:name` is a valid entity URI"),
-        descriptor,
-    }
-}
-
-/// Build a `ResolvedConcept` from a `#[derive(Concept)]` Rust
-/// type's `Query` newtype. The `Query` type's `Default` impl is
-/// generated by the derive and the `From<Query>` conversion drops
-/// values, so this is a pure schema-only path.
-fn concept_from_query<Q>() -> ResolvedConcept
+/// The `Query` type's `Default` impl is generated by the derive
+/// and the `From<Query>` conversion drops values, so this is a
+/// pure schema-only path. The descriptor's `this()` would be a
+/// content-derived hash; built-ins instead live at the stable
+/// `db:<name>` URI so the `db:` scheme protection covers them
+/// and the row remains identifiable without knowing the hash.
+fn builtin<Q>(name: &str) -> ResolvedConcept
 where
     Q: Default,
     ConceptDescriptor: From<Q>,
 {
-    descriptor_to_resolved(ConceptDescriptor::from(Q::default()))
-}
-
-fn descriptor_to_resolved(descriptor: ConceptDescriptor) -> ResolvedConcept {
-    let entity: Entity = descriptor.this();
-    ResolvedConcept { entity, descriptor }
+    let entity: Entity = format!("db:{name}")
+        .parse()
+        .expect("`db:<builtin>` is a valid entity URI");
+    ResolvedConcept {
+        entity,
+        descriptor: ConceptDescriptor::from(Q::default()),
+    }
 }

--- a/rust/tonk-schema/src/concept.rs
+++ b/rust/tonk-schema/src/concept.rs
@@ -855,16 +855,20 @@ async fn lookup_entity_name<'a, Env>(
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
-    let claims: Vec<Claim> = the!("dialog.meta/name")
-        .of(Term::<Entity>::var("__concept_query_id"))
-        .is(Term::from(entity.clone()))
-        .perform(env)
-        .try_vec()
-        .await?;
-    Ok(claims
+    use crate::meta::Name;
+    use dialog_query::Output as _;
+
+    let rows: Vec<Name> = Query::<Name> {
+        this: Term::<Entity>::var("__concept_query_id"),
+        entity: Term::from(entity.clone()),
+    }
+    .perform(env)
+    .try_vec()
+    .await?;
+    Ok(rows
         .into_iter()
         .next()
-        .and_then(|claim| name_from_id_uri(&claim.of)))
+        .and_then(|row| name_from_id_uri(&row.this)))
 }
 
 /// Strip the `id:` scheme prefix from a name URI to recover the
@@ -891,28 +895,23 @@ pub async fn lookup_named_entity<Env: QueryEnv>(
     branch: &Branch,
     env: &Env,
 ) -> Result<Option<Entity>, ConceptLookupError> {
+    use crate::meta::Name;
+    use dialog_query::Output as _;
+
     let Ok(id_entity) = format!("id:{name}").parse::<Entity>() else {
         return Ok(None);
     };
-    let claims: Vec<Claim> = branch
+    let rows: Vec<Name> = branch
         .query()
-        .select(dialog_query::AttributeQuery::from(
-            Term::<dialog_query::attribute::The>::from(
-                "dialog.meta/name"
-                    .parse::<dialog_query::attribute::The>()
-                    .expect("dialog.meta/name is a valid attribute URI"),
-            )
-            .of(Term::from(id_entity))
-            .is(Term::<Entity>::var("__concept_query_target")),
-        ))
+        .select(Query::<Name> {
+            this: Term::from(id_entity),
+            entity: Term::<Entity>::var("__concept_query_target"),
+        })
         .perform(env)
         .try_vec()
         .await
         .map_err(|e| ConceptLookupError::query(format!("name lookup failed: {e:?}")))?;
-    Ok(claims
-        .into_iter()
-        .next()
-        .and_then(|claim| Entity::try_from(claim.is).ok()))
+    Ok(rows.into_iter().next().map(|row| row.entity.0))
 }
 
 /// Walk a [`ConceptDescriptor`] and call `op` (either
@@ -1307,8 +1306,8 @@ mod tests {
     }
 
     /// `lookup_named_entity("alice")` reads the
-    /// `(id:alice, dialog.meta/name, ?target)` claim and
-    /// returns the target entity. Round-trip a hand-written
+    /// `(id:alice, dialog.name/referent, ?target)` claim
+    /// and returns the target entity. Round-trip a hand-written
     /// claim through a branch and confirm the lookup recovers
     /// the target.
     #[dialog_common::test]
@@ -1323,7 +1322,7 @@ mod tests {
         let target: Entity = "did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv".parse()?;
         branch
             .transaction()
-            .assert(the!("dialog.meta/name").of(id_alice).is(target.clone()))
+            .assert(the!("dialog.name/referent").of(id_alice).is(target.clone()))
             .commit()
             .perform(&operator)
             .await?;
@@ -1512,6 +1511,81 @@ mod tests {
             "expected one Pointer after same-tx supersession, got {results:?}",
         );
         assert_eq!(results[0].target.0, page_v2);
+        Ok(())
+    }
+
+    /// End-to-end check on the real `Name` concept: assert two
+    /// successive `Name` claims for `id:page` (v1 then v2) via
+    /// the same code path the analyzer uses
+    /// (`emit_name_assertion`), then verify both lookup
+    /// directions return only v2.
+    ///
+    /// This is the regression test for the page-disambiguation
+    /// bug. Before the rewrite, `lookup_entity_name` used a raw
+    /// `the!("dialog.meta/name").of(?).is(value)` query that
+    /// surfaces the superseded v1 claim from the EAV log. Going
+    /// through the `Name` concept's derived `Query` runs the
+    /// same cardinality-one filter dialog applies to the forward
+    /// direction, so v1 disappears.
+    #[dialog_common::test]
+    async fn it_resolves_only_latest_name_target_via_name_concept() -> anyhow::Result<()> {
+        use crate::meta::{Name, name};
+        use dialog_query::Output as _;
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        // Use the `concept:` scheme for targets — this matches
+        // the real-world case where `concept!: &page` derives a
+        // content-hashed `concept:…` entity URI for each body.
+        // Same supersession path, different value scheme; this
+        // catches a bug where the cardinality-one filter was
+        // sensitive to the value's URI scheme.
+        let id_page: Entity = "id:page".parse()?;
+        let page_v1: Entity = "concept:Fx8sv1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?;
+        let page_v2: Entity = "concept:AfmLeBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".parse()?;
+
+        // tx1 — point id:page at v1.
+        branch
+            .transaction()
+            .assert(Name {
+                this: id_page.clone(),
+                entity: name::Referent(page_v1.clone()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        // tx2 — point id:page at v2. Cardinality-one supersedes v1.
+        branch
+            .transaction()
+            .assert(Name {
+                this: id_page.clone(),
+                entity: name::Referent(page_v2.clone()),
+            })
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let lookup = branch
+            .select(Query::<Name> {
+                this: id_page.clone().into(),
+                entity: Term::var("entity"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(lookup.iter().len(), 1);
+        assert_eq!(
+            lookup,
+            vec![Name {
+                this: id_page.clone(),
+                entity: name::Referent(page_v2.clone())
+            }]
+        );
         Ok(())
     }
 }

--- a/rust/tonk-schema/src/meta.rs
+++ b/rust/tonk-schema/src/meta.rs
@@ -15,21 +15,39 @@
 use dialog_artifacts::Entity;
 use dialog_query::{Attribute, Concept};
 
-/// The `dialog.meta/name` attribute — the published target a
-/// name URI points at.
+/// Newtype for the attribute backing the [`Name`] concept's
+/// `entity` field. Submodule so the struct name `Referent`
+/// kebab-cases into `referent` (yielding the relation
+/// `dialog.name/referent`) without colliding with [`Name`].
+pub mod name {
+    use super::{Attribute, Entity};
+
+    /// The `dialog.name/referent` attribute — the entity a name
+    /// currently points at. Cardinality `one` (the derive
+    /// default), so re-pointing a name supersedes the prior
+    /// claim instead of accumulating.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("dialog.name")]
+    pub struct Referent(pub Entity);
+}
+
+/// A user-published name — an `id:<n>` entity carrying a
+/// single `entity` claim that points at the target the name
+/// currently identifies.
 ///
-/// Cardinality `one`. Lives on the *name entity* (an `id:<n>`
-/// URI), not on the named target. The value is the entity the
-/// name currently identifies. Re-pointing a name to a different
-/// entity is a cardinality-one supersession on this attribute.
-///
-/// This is the inverted shape of the pre-Stage-2 model, where
-/// `dialog.meta/name` lived on the target with a string value
-/// — see `transact::emit_name_assertion` for how the analyzer
-/// emits the new direction from anchor-form heads.
-#[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[domain("dialog.meta")]
-pub struct Name(pub Entity);
+/// `this` is derived from the name string by prefixing `id:`.
+/// `entity` is the target. Asserting two `Name` claims for the
+/// same `this` with different `entity` values supersedes the
+/// prior claim because the backing attribute is cardinality
+/// one.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Name {
+    /// The name entity — `id:<n>` for user-published names,
+    /// `db:<n>` for built-ins.
+    pub this: Entity,
+    /// The target this name currently identifies.
+    pub entity: name::Referent,
+}
 
 /// Human-readable description for any entity.
 ///

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -403,29 +403,27 @@ fn emit_name_assertion<U: Update>(
     update: &mut U,
     assert: bool,
 ) {
-    let Some(name) = name else {
+    use crate::meta::{Name, name};
+    use dialog_artifacts::Statement as _;
+
+    let Some(name_str) = name else {
         return;
     };
     let Some(target) = entity_of_this(terms) else {
         return;
     };
-    let Ok(id_entity) = format!("id:{name}").parse::<Entity>() else {
+    let Ok(id_entity) = format!("id:{name_str}").parse::<Entity>() else {
         return;
     };
-    let attribute = meta_name_attr();
-    let value = Value::Entity(target);
+    let claim = Name {
+        this: id_entity,
+        entity: name::Referent(target),
+    };
     if assert {
-        // Cardinality-one: replace, not accumulate.
-        update.associate_unique(attribute, id_entity, value);
+        claim.assert(update);
     } else {
-        update.dissociate(attribute, id_entity, value);
+        claim.retract(update);
     }
-}
-
-fn meta_name_attr() -> dialog_artifacts::Attribute {
-    "dialog.meta/name"
-        .parse()
-        .expect("dialog.meta/name is a valid attribute URI")
 }
 
 // ---------------------------------------------------------------- //
@@ -724,18 +722,25 @@ mod tests {
 
         let id_alice: Entity = "id:alice".parse().unwrap();
         let target: Entity = target_uri.parse().unwrap();
-        let meta_name = meta_name_attr();
+        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
 
         let mut id_alice_name_claim_count = 0;
         let mut wrong_direction_count = 0;
         for inst in changes.into_instructions() {
-            if let Instruction::Assert(a) = &inst
-                && a.the == meta_name
-            {
-                if a.of == id_alice && a.is == Value::Entity(target.clone()) {
+            // Cardinality-one fields use `Instruction::Replace`
+            // (added in dialog tonk-2026-05-11). The anchor name
+            // is `dialog.name/referent` with cardinality one, so
+            // the desugared `name!` lands as a Replace, not an
+            // Assert.
+            let artifact = match &inst {
+                Instruction::Assert(a) | Instruction::Replace(a) => a,
+                Instruction::Retract(_) => continue,
+            };
+            if artifact.the == meta_name {
+                if artifact.of == id_alice && artifact.is == Value::Entity(target.clone()) {
                     id_alice_name_claim_count += 1;
                 }
-                if a.of == target {
+                if artifact.of == target {
                     wrong_direction_count += 1;
                 }
             }
@@ -761,7 +766,7 @@ mod tests {
 
         let id_alice: Entity = "id:alice".parse().unwrap();
         let target: Entity = target_uri.parse().unwrap();
-        let meta_name = meta_name_attr();
+        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
 
         let saw_dissociate = changes.into_instructions().into_iter().any(|inst| {
             matches!(
@@ -802,7 +807,7 @@ mod tests {
         let mut changes = Changes::new();
         plan.assert(&mut changes);
 
-        let meta_name = meta_name_attr();
+        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
         let saw_meta_name = changes
             .into_instructions()
             .into_iter()

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -8,6 +8,10 @@ edition.workspace = true
 [features]
 integration-tests = []
 web-integration-tests = []
+# Test helpers — wire-query builders and seeding fixtures.
+# Auto-enabled in this crate's own test builds via `cfg(test)`;
+# opt-in for downstream crates that want the same fixtures.
+helpers = []
 
 [dependencies]
 async-trait = { workspace = true }

--- a/rust/tonk-worker/src/helpers.rs
+++ b/rust/tonk-worker/src/helpers.rs
@@ -1,0 +1,26 @@
+//! Test helpers for `tonk-worker` consumers.
+//!
+//! Auto-enabled in this crate's test builds via `cfg(test)`; opt-in
+//! for downstream crates that want the same fixtures via the
+//! `helpers` cargo feature.
+
+use dialog_query::{ConceptQuery, Query as ConceptPattern};
+use tonk_schema::meta::Name;
+use tonk_schema::query::Query as WireQuery;
+
+/// Wire-form `/query` body that selects every published [`Name`]
+/// on a branch — `this` (the `id:<n>` name entity) plus `entity`
+/// (the target it currently points at).
+///
+/// Derived from the [`Name`] concept's own
+/// [`dialog_query::ConceptDescriptor`] rather than hand-rolled
+/// JSON, so the wire shape stays in lockstep with the Rust type
+/// definition. Tests that need a stable query with bound
+/// variables — projection tests, subscription tests — use this so
+/// they pick up Name-shape changes automatically.
+pub fn named_concept_wire_query() -> serde_json::Value {
+    let pattern = ConceptPattern::<Name>::default();
+    let query = ConceptQuery::from(pattern);
+    let wire = WireQuery::from(&query);
+    serde_json::to_value(&wire).expect("Name query serializes")
+}

--- a/rust/tonk-worker/src/lib.rs
+++ b/rust/tonk-worker/src/lib.rs
@@ -74,3 +74,6 @@ pub use r#async::*;
 
 mod reactor;
 pub use reactor::*;
+
+#[cfg(any(test, feature = "helpers"))]
+pub mod helpers;

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1822,30 +1822,7 @@ employee:
     // Reactor: /api/repository/{repo}/branch/{branch}/query      //
     // ---------------------------------------------------------- //
 
-    /// A wire `Query` over the `Named` view — `this` plus
-    /// `dialog.meta/name`. Matches every entity on the branch
-    /// that carries a `dialog.meta/name` claim. Tests below seed
-    /// at least one such entity via `/evaluate` before querying.
-    /// Binds both `this` and `name` so the projected
-    /// [`Conclusion::fields`] carries the entity URI and the
-    /// concept's display name.
-    fn named_concept_wire_query() -> serde_json::Value {
-        serde_json::json!({
-            "terms": {
-                "this": { "?": { "name": "this" } },
-                "name": { "?": { "name": "name" } },
-            },
-            "predicate": {
-                "with": {
-                    "name": {
-                        "the": "dialog.meta/name",
-                        "as": "Text",
-                        "cardinality": "one",
-                    },
-                },
-            },
-        })
-    }
+    use crate::helpers::named_concept_wire_query;
 
     /// Seed one named entity on `main` so the reactor tests have
     /// something to query.
@@ -2160,8 +2137,9 @@ attribute!: &{name}
 
     /// One-shot `/query` projects every term named in the
     /// query's `terms` map into [`Conclusion::fields`]. The
-    /// `Named` view binds `this` and `name`, so each row must
-    /// carry both — the entity URI and the display name string.
+    /// `Name` view binds `this` (the `id:<n>` name entity) and
+    /// `entity` (its current target), so each row must carry
+    /// both.
     #[dialog_common::test]
     async fn it_projects_query_terms_into_conclusion_fields() {
         let state = test_state().await;
@@ -2177,15 +2155,19 @@ attribute!: &{name}
         for row in arr {
             let fields = row.get("fields").and_then(|f| f.as_object());
             let fields = fields.unwrap_or_else(|| panic!("row missing fields object: {row}"));
-            assert!(
-                fields.contains_key("this"),
-                "fields must include `this`: {row}",
-            );
-            let name = fields
-                .get("name")
+            let this = fields
+                .get("this")
                 .and_then(|v| v.as_str())
-                .unwrap_or_else(|| panic!("fields[\"name\"] must be a string: {row}"));
-            assert!(!name.is_empty(), "name binding must be non-empty: {row}");
+                .unwrap_or_else(|| panic!("fields[\"this\"] must be a string: {row}"));
+            assert!(
+                this.starts_with("id:"),
+                "name entity `this` must be an `id:<n>` URI: {row}",
+            );
+            let entity = fields
+                .get("entity")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("fields[\"entity\"] must be a string: {row}"));
+            assert!(!entity.is_empty(), "entity target must be non-empty: {row}");
         }
     }
 

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -336,18 +336,7 @@ async fn run<'a>(
                     .map_err(|e| TonkWorkerError::Internal(format!("plan failed: {e}")))?;
                 match statement {
                     Statement::Assert(_) => {
-                        // Cardinality-one fields need prior
-                        // values dissociated so the new value
-                        // replaces rather than accumulates with
-                        // them. Dialog's storage layer is
-                        // additive — `associate_unique` only
-                        // de-dupes within the current batch, not
-                        // against committed state. So query the
-                        // branch first.
-                        let supersedes =
-                            resolve_supersession_targets(&plan, branch, operator).await?;
                         claim_count += count_emitted_claims(&plan);
-                        retract_claims.extend(supersedes);
                         tx = tx.assert(plan);
                     }
                     Statement::Retract(_) => {
@@ -510,82 +499,6 @@ impl dialog_artifacts::Statement for RawClaim {
     fn retract(self, update: &mut impl dialog_artifacts::Update) {
         update.dissociate(self.the, self.of, self.is);
     }
-}
-
-/// For an *assert* plan: find prior values of every
-/// cardinality-one field on the plan's `this` entity and emit
-/// them as `RawClaim`s ready for `tx.retract`. Dialog's storage
-/// is additive — without this, re-asserting `age = 30` on Alice
-/// leaves `age = 28` and `age = 30` both present, and the
-/// engine returns whichever it finds first.
-///
-/// Cardinality-many fields are skipped (the whole point is
-/// multiple values per entity).
-async fn resolve_supersession_targets(
-    plan: &ApplicationPlan,
-    branch: &Branch,
-    operator: &DefaultOperator,
-) -> Result<Vec<RawClaim>, TonkWorkerError> {
-    use dialog_query::Cardinality;
-
-    let Some(this_term) = plan.statement.terms.get("this") else {
-        return Ok(Vec::new());
-    };
-    let this_entity = match this_term {
-        Term::Constant(Value::Entity(e)) => e.clone(),
-        _ => return Ok(Vec::new()),
-    };
-
-    let mut out = Vec::new();
-    for (field_name, attribute) in plan.statement.predicate.with().iter() {
-        if attribute.cardinality() != Cardinality::One {
-            continue;
-        }
-        // Only supersede when the new assert *would* write a
-        // concrete value — leaving a blank is an "unset" /
-        // "skip" signal, not "retract whatever's there".
-        let new_value = match plan.statement.terms.get(field_name) {
-            Some(Term::Constant(value)) => value.clone(),
-            _ => continue,
-        };
-
-        let the_term: dialog_query::attribute::The = attribute.the().clone();
-        let query = dialog_query::AttributeQuery::new(
-            Term::from(the_term),
-            Term::from(this_entity.clone()),
-            Term::<dialog_query::Any>::var("v"),
-            Term::<dialog_query::attribute::Cause>::blank(),
-            None,
-        );
-        let claims: Vec<dialog_query::Claim> = branch
-            .query()
-            .select(query)
-            .perform(operator)
-            .try_vec()
-            .await
-            .map_err(|e| {
-                TonkWorkerError::Internal(format!(
-                    "supersession query failed for ({:?}, {of}): {e:?}",
-                    attribute.the(),
-                    of = this_entity
-                ))
-            })?;
-        for claim in claims {
-            // Skip retracting the value we're about to write —
-            // re-asserting the same value is a no-op, and
-            // emitting a retract+assert pair for the same
-            // (the, of, is) would be churn.
-            if claim.is == new_value {
-                continue;
-            }
-            out.push(RawClaim {
-                the: claim.the.into(),
-                of: this_entity.clone(),
-                is: claim.is,
-            });
-        }
-    }
-    Ok(out)
 }
 
 /// Resolve a retraction `ApplicationPlan` to concrete


### PR DESCRIPTION
### Description

Re-asserting `concept!: &page` with a different body left the prior entity surfacing under the same name. Investigating it rediscovered that dialog's `cardinality: one` was never actually enforced — the engine assumed callers would set `cause` on the new fact to point at the one being superseded, which nothing in tonk does. That gap is fixed upstream in [dialog#333](https://github.com/dialog-db/dialog-db/pull/333), which routes cardinality-one writes through a new `Change::Replace`/`Instruction::Replace` so the prior value is dropped at commit time and re-asserting the same value is a no-op.

While we were here, the JSON descriptors derived from `#[derive(Concept)]` were also leaking raw-identifier prefixes (`r#type` → `"r#type"` instead of `"type"`) and skipping the kebab-casing convention used everywhere else (`display_name` stayed snake-cased). [dialog#334](https://github.com/dialog-db/dialog-db/pull/334) normalizes both — `unraw()` strips the prefix, `convert_case::Case::Kebab` folds snake/camel/Pascal — at derive time, applied to both `Concept` and `Formula`.

This PR pulls in both upstream fixes via the `tonk-2026-05-11` dialog tag and lets us drop the local workarounds they were holding up: the worker's manual cardinality-one supersession pre-pass (a brittle query-then-retract that only handled the entity it was writing to and missed cross-name supersession entirely) is gone, and built-in concept descriptors switch from inline JSON to `derive(Concept)` everywhere except concept-of-concept (which has a dictionary `with:` field a Rust struct can't express). Name publication and resolution route through one `Name` concept (`this: id:<n>, entity: name::Referent`) so dialog's cardinality-one filter applies in both directions consistently.

### Backwards compatibility

Backing attribute URI moves from `dialog.meta/name` to `dialog.name/referent`. Branches written before this change won't resolve published names anymore.
