### PR TITLE
chore: staging env, hub.tonk.xyz

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   pull_request:
   push:
-    branches: [stable]
+    branches: [stable, staging]
 
 jobs:
   deploy:
@@ -43,6 +43,14 @@ jobs:
             nix --accept-flake-config develop .#ci --command wrangler versions upload --preview-alias pr-${{ github.event.pull_request.number }}
             echo EOF
           } >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy staging
+        if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+        working-directory: rust/tonk-access-service
+        run: nix --accept-flake-config develop --command wrangler deploy --env staging
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - stable
+      - staging
 
 name: 'Test'
 

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -106,9 +106,8 @@ enum Command {
     /// redelegating from the embedded ephemeral key.
     Invite {
         /// Override the URL prefix the invite is built against.
-        /// Default: `tonk_invite::DEFAULT_BASE_URL`.
-        #[arg(long, value_name = "URL")]
-        base_url: Option<String>,
+        #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
+        base_url: String,
 
         /// Embed a registered remote's URL in the invite so
         /// the claimer auto-configures the same access service
@@ -150,10 +149,9 @@ enum ShareCommand {
         /// Local name of the concept to share.
         #[arg(value_name = "NAME")]
         name: String,
-        /// Override the URL prefix the launcher is built
-        /// against. Default: the standard `slide invite` base.
-        #[arg(long, value_name = "URL")]
-        ui_base: Option<String>,
+        /// Override the URL prefix the launcher is built against.
+        #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
+        ui_base: String,
         /// Suggested local name for the recipient's space —
         /// pre-fills the join form's "Local name" input. The
         /// recipient can rename before joining.
@@ -175,8 +173,8 @@ enum ShareCommand {
         #[arg(value_name = "NAME_OR_ENTITY")]
         target: String,
         /// Override the URL prefix the launcher is built against.
-        #[arg(long, value_name = "URL")]
-        ui_base: Option<String>,
+        #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
+        ui_base: String,
         /// Suggested local name for the recipient's space.
         #[arg(long, value_name = "NAME")]
         space_name: Option<String>,
@@ -537,7 +535,7 @@ async fn share_op(command: ShareCommand) -> ExitCode {
             remote,
         } => {
             let options = ShareOptions {
-                ui_base,
+                ui_base: Some(ui_base),
                 remote,
                 space_name,
             };
@@ -559,7 +557,7 @@ async fn share_op(command: ShareCommand) -> ExitCode {
             remote,
         } => {
             let options = ShareOptions {
-                ui_base,
+                ui_base: Some(ui_base),
                 remote,
                 space_name,
             };
@@ -610,7 +608,7 @@ fn print_set_upstream_outcome(outcome: &UpstreamOutcome) {
     );
 }
 
-async fn mint_invite(base_url: Option<String>, remote_name: Option<String>) -> ExitCode {
+async fn mint_invite(base_url: String, remote_name: Option<String>) -> ExitCode {
     let cwd = match std::env::current_dir() {
         Ok(p) => p,
         Err(e) => return print_error(format!("could not determine current directory: {e}")),
@@ -636,7 +634,7 @@ async fn mint_invite(base_url: Option<String>, remote_name: Option<String>) -> E
         None => None,
     };
 
-    match invite::mint(&site, base_url.as_deref(), remote_url.as_deref()).await {
+    match invite::mint(&site, Some(&base_url), remote_url.as_deref()).await {
         Ok(outcome) => {
             print_invite_outcome(&outcome);
             ExitCode::Success

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -37,9 +37,9 @@ use url::Url;
 
 /// Canonical base URL for tonk invite links. Callers serializing an
 /// [`Invite`] can pass this to [`Invite::to_url`] to mint a link rooted at
-/// tonk.xyz. Changing this value is a breaking change for any outstanding
+/// hub.tonk.xyz. Changing this value is a breaking change for any outstanding
 /// invite URLs that embed it.
-pub const DEFAULT_BASE_URL: &str = "https://tonk.xyz/join";
+pub const DEFAULT_BASE_URL: &str = "https://hub.tonk.xyz/join";
 
 /// Length in bytes of the Ed25519 seed embedded in the URL fragment for
 /// audience-open invites.
@@ -459,7 +459,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_missing_access_parameter() {
-        let err = Invite::parse_url("https://tonk.xyz/join")
+        let err = Invite::parse_url("https://hub.tonk.xyz/join")
             .await
             .unwrap_err();
         assert!(err.to_string().contains("`access`"), "{err}");
@@ -467,7 +467,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_invalid_base58_in_access() {
-        let err = Invite::parse_url("https://tonk.xyz/join?access=!!!not-b58!!!")
+        let err = Invite::parse_url("https://hub.tonk.xyz/join?access=!!!not-b58!!!")
             .await
             .unwrap_err();
         assert!(err.to_string().contains("valid base58"), "{err}");
@@ -501,7 +501,7 @@ mod tests {
         let audience_signer = signer(&AUDIENCE_SEED).await;
         let audience = audience_signer.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
-        let remote = Url::parse("https://access.tonk.xyz/ucan").unwrap();
+        let remote = Url::parse("https://hub.tonk.xyz/ucan/").unwrap();
 
         // Scoped, with remote
         let invite = Invite::new(chain.clone(), InviteAudience::Scoped, Some(remote.clone()))

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,10 @@ main = "./result/tonk-access-service/worker/shim.mjs"
 compatibility_date = "2026-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+routes = [
+  { pattern = "hub.tonk.xyz", custom_domain = true }
+]
+
 [build]
 command = "nix build .#tonk-cloudflare-artifacts"
 
@@ -11,12 +15,23 @@ directory = "./result/tonk-ui"
 not_found_handling = "single-page-application"
 binding = "ASSETS"
 
-# R2 bucket binding - for checking blob existence
 [[r2_buckets]]
 binding = "BUCKET"
 bucket_name = "tonk-spaces"
 
-# Environment variables
 [vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
 R2_BUCKET_NAME = "tonk-spaces"
+
+[env.staging]
+routes = [
+  { pattern = "staging.tonk.xyz", custom_domain = true }
+]
+
+[[env.staging.r2_buckets]]
+binding = "BUCKET"
+bucket_name = "tonk-spaces-staging"
+
+[env.staging.vars]
+R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
+R2_BUCKET_NAME = "tonk-spaces-staging"


### PR DESCRIPTION
## Summary

- Add `[env.staging]` to `wrangler.toml` with a `staging.tonk.xyz` custom-domain route and a separate `tonk-spaces-staging` R2 bucket; CI deploys on push to `staging` via `wrangler deploy --env staging`, alongside the existing `stable` → `hub.tonk.xyz` flow.
- Repoint `tonk_invite::DEFAULT_BASE_URL` from `tonk.xyz` to `hub.tonk.xyz` (worker), since the access service + UI now live there. Update the matching test fixtures.
- Switch `slide invite --base-url` and `slide share concept/view --ui-base` to clap `default_value_t` so `--help` substitutes the actual URL instead of rendering the Rust path.

## Notes

The `tonk.xyz` DNS zone moved from Route 53 to Cloudflare out-of-band so `custom_domain = true` can attach the worker. Apex Vercel record and all other records (Google MX, ATProto, DKIM, ELB targets, etc.) are preserved as DNS-only. Nameservers flipped at GoDaddy.

To deploy staging from CLI tooling, override at call time:

```fish
slide remote add staging https://staging.tonk.xyz/ucan/
slide invite --base-url https://staging.tonk.xyz/join --remote staging

The web UI is already environment-aware (mints invites from origin()), so it needs no per-env config.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing deployment configurations and URLs for staging and production environments in a GitHub Actions workflow, along with updates to the `rust/tonk-invite` and `rust/slide` modules to reflect the new base URL.

### Detailed summary
- Updated `.github/workflows/test.yml` to include `staging` branch.
- Modified `.github/workflows/publish.yml` to add deployment for `staging`.
- Updated `wrangler.toml` to define routes and R2 bucket for `staging`.
- Changed `DEFAULT_BASE_URL` in `rust/tonk-invite/src/lib.rs` to `hub.tonk.xyz`.
- Updated test cases in `rust/tonk-invite/src/lib.rs` to use the new base URL.
- Adjusted `rust/slide/src/bin/slide.rs` to set `base_url` and `ui_base` as required strings.
- Changed function signatures in `rust/slide/src/bin/slide.rs` to remove `Option` for `base_url`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->