### PR TITLE
feat(ci): `slide` staging/stable ci/cd

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,132 @@
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - stable
+      - staging
+
+name: 'CLI'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-cli:
+    name: 'Build CLI'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-name: slide-linux-x86_64
+          - os: macos-latest
+            artifact-name: slide-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wimpysworld/nothing-but-nix@main
+        if: runner.os == 'Linux'
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: 'Build slide'
+        run: nix build --accept-flake-config .#slide
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: result/bin/slide
+
+  publish-staging:
+    name: 'Publish Staging'
+    needs: ['build-cli']
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: slide-macos-arm64
+          path: artifacts/macos-arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: slide-linux-x86_64
+          path: artifacts/linux-x86_64
+      - name: Prepare release assets
+        run: |
+          mv artifacts/macos-arm64/slide slide-macos-arm64
+          mv artifacts/linux-x86_64/slide slide-linux-x86_64
+          chmod +x slide-macos-arm64 slide-linux-x86_64
+      - name: Delete existing staging release
+        run: gh release delete slide-staging --yes --cleanup-tag || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+      - name: Create staging release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: slide-staging
+          name: slide CLI (staging)
+          body: |
+            Rolling staging release of the slide CLI, built from the latest `staging` branch.
+
+            **Download for your platform:**
+            - macOS (Apple Silicon): `slide-macos-arm64`
+            - Linux (x86_64): `slide-linux-x86_64`
+
+            After downloading, make it executable: `chmod +x slide-*`
+          prerelease: true
+          make_latest: false
+          files: |
+            slide-macos-arm64
+            slide-linux-x86_64
+
+  publish-stable:
+    name: 'Publish Stable'
+    needs: ['build-cli']
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/stable' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: slide-macos-arm64
+          path: artifacts/macos-arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: slide-linux-x86_64
+          path: artifacts/linux-x86_64
+      - name: Prepare release assets
+        run: |
+          mv artifacts/macos-arm64/slide slide-macos-arm64
+          mv artifacts/linux-x86_64/slide slide-linux-x86_64
+          chmod +x slide-macos-arm64 slide-linux-x86_64
+      - name: Delete existing rolling release
+        run: gh release delete slide-latest --yes --cleanup-tag || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+      - name: Create rolling release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: slide-latest
+          name: slide CLI (latest)
+          body: |
+            Rolling release of the slide CLI, built from the latest `stable` branch.
+
+            **Download for your platform:**
+            - macOS (Apple Silicon): `slide-macos-arm64`
+            - Linux (x86_64): `slide-linux-x86_64`
+
+            After downloading, make it executable: `chmod +x slide-*`
+          prerelease: true
+          make_latest: false
+          files: |
+            slide-macos-arm64
+            slide-linux-x86_64

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,20 @@
           wasm-bindgen-cli
           ;
 
+        # Rewrite Nix store libiconv to the macOS system equivalent
+        # so the binary works on machines without Nix installed
+        darwinBinaryFixup = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+          for bin in $out/bin/*; do
+            if [ -f "$bin" ]; then
+              NIX_ICONV=$(otool -L "$bin" | grep '/nix/store.*libiconv' | awk '{print $1}' || true)
+              if [ -n "$NIX_ICONV" ]; then
+                install_name_tool -change "$NIX_ICONV" /usr/lib/libiconv.2.dylib "$bin"
+              fi
+              /usr/bin/codesign --force --sign - "$bin"
+            fi
+          done
+        '';
+
         # Include the Rust toolchain in build inputs for dev shells
         devShellBuildInputs = commonBuildInputs ++ [
           pkgs.cachix
@@ -221,6 +235,12 @@
             cp ${self.packages.${system}.tests-web-debug}/*.tar.zst $out/
             cp ${self.packages.${system}.tests-web-release}/*.tar.zst $out/
           '';
+
+          slide = buildCrate {
+            pname = "slide";
+            cargoExtraArgs = "--package slide";
+            fixupPhase = darwinBinaryFixup;
+          };
 
           tonk-ui = buildTrunkCrate {
             pname = "tonk-ui";

--- a/rust/slide/src/identity.rs
+++ b/rust/slide/src/identity.rs
@@ -3,8 +3,7 @@
 //! The profile is the user's persistent identity. It lives in
 //! the platform-specific data directory (`~/Library/Application
 //! Support/dialog/` on macOS, `~/.local/share/dialog/` on
-//! Linux), under the subdirectory named [`PROFILE_NAME`] —
-//! shared with carry, so a user with both CLIs sees the same DID.
+//! Linux), under the subdirectory named [`PROFILE_NAME`].
 
 use std::path::PathBuf;
 

--- a/rust/slide/src/invite.rs
+++ b/rust/slide/src/invite.rs
@@ -1,6 +1,6 @@
 //! `slide invite` / `slide join` — UCAN-delegation-chain mint
-//! and claim, on the same wire format `tonk-ui` and `carry`
-//! already speak via the [`tonk_invite`] crate.
+//! and claim, on the same wire format `tonk-ui` already speaks
+//! via the [`tonk_invite`] crate.
 //!
 //! `mint` builds an audience-open delegation from the local
 //! repo's subject DID to a freshly generated ephemeral signer,

--- a/rust/slide/src/site.rs
+++ b/rust/slide/src/site.rs
@@ -20,21 +20,17 @@ use dialog_repository::{Branch, Repository, RepositoryExt as _};
 use dialog_storage::provider::storage::{NativeSpace, Storage};
 
 /// Name of the dialog repository slide uses inside `.tonk/`.
-/// Mirrors carry's choice so a `.carry/` directory can be
-/// migrated to `.tonk/` byte-for-byte once the migration command
-/// lands.
 pub const REPO_NAME: &str = "main";
 
 /// The single branch slide reads and writes against.
 pub const BRANCH_NAME: &str = "main";
 
-/// Profile name used for the local identity. Shared with carry
-/// so a user who has both CLIs sees the same DID.
+/// Profile name used for the local identity.
 pub const PROFILE_NAME: &str = "tonk";
 
 /// Operator derivation context — distinguishes the slide-derived
 /// operator key from operator keys derived by other tools sharing
-/// the same profile (e.g. carry, the worker).
+/// the same profile (e.g. the worker).
 const OPERATOR_CONTEXT: &[u8] = b"slide";
 
 /// Name of the `.tonk/` sub-directory holding repository data.


### PR DESCRIPTION
## Summary

Adds CI/CD for the `slide` CLI, mirroring the staging/stable split we already have for the workers/UI and following the carry CLI's release pattern.

- **`flake.nix`**: new `slide` package built via `buildCrate` with `--package slide`. Factors out a reusable `darwinBinaryFixup` snippet that rewrites Nix-store `libiconv` to `/usr/lib/libiconv.2.dylib` and ad-hoc codesigns, so the macOS binary runs on machines without Nix.
- **`.github/workflows/cli.yml`**: new workflow.
  - `build-cli` — matrix-builds `slide` on `ubuntu-latest` (linux-x86_64) and `macos-latest` (macos-arm64) for every PR / push, uploading artifacts via cachix.
  - `publish-staging` — on push to `staging`, recreates the rolling `slide-staging` GitHub release with both binaries.
  - `publish-stable` — on push to `stable` (or `workflow_dispatch`), same for `slide-latest`.

Release tags are scoped (`slide-latest`, `slide-staging`) so future CLIs in this monorepo don't collide on a generic `latest`. No dedicated test job — `test.yml` already covers slide via `test:native:debug`/`release`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining documentation, adjusting Rust constants, and enhancing the CI/CD workflow for the `slide` CLI tool, including build processes for macOS and Linux.

### Detailed summary
- Removed references to shared identity with `carry` in documentation comments.
- Updated comments in `rust/slide/src/site.rs`.
- Added a `darwinBinaryFixup` script for macOS binary compatibility.
- Enhanced GitHub Actions workflow for building and publishing `slide` CLI artifacts for macOS and Linux.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->