### PR TITLE
feat(worker, concept, ui): replace js tonk-concept with rust

### DIFF
--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -117,7 +117,9 @@ impl CustomElement for TonkConcept {
             if let Some(abort) = s.abort.take() {
                 abort.abort();
             }
-            s.renderer = None;
+            if let Some(mut renderer) = s.renderer.take() {
+                renderer.clear();
+            }
         }
         start_subscription(&host_element, state);
     }
@@ -158,23 +160,23 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     }
     let parsed: ParsedSource = parse_source(&source_attr);
 
-    // TODO: when neither `space` nor `branch` is set, use a relative
-    // `/query` URL so the service worker's virtual-root rewrite
-    // resolves it to the host's actual branch. The current `home`/
-    // `main` fallback is wrong inside an iframe (the iframe is rooted
-    // under whatever branch the host route bound it to, which is
-    // rarely `home`). See `rust/tonk-worker/assets/tonk-concept.js`
-    // for the JS port that already does this — both impls should
-    // agree on the override semantics: relative URL when no attrs;
-    // absolute `/api/repository/{space}/branch/{branch}/query` when
-    // either is set.
-    let space = host
-        .get_attribute("space")
-        .unwrap_or_else(|| "home".to_owned());
-    let branch = host
-        .get_attribute("branch")
-        .unwrap_or_else(|| "main".to_owned());
-    let url = format!("/api/repository/{space}/branch/{branch}/query");
+    // Either-or override: if the author sets `space` or `branch`,
+    // build an absolute `/api/repository/{space}/branch/{branch}/query`
+    // URL — missing half defaults to `home`/`main`. With neither
+    // attribute set, a relative `/query` URL lets the service
+    // worker's guest-iframe rewrite resolve the request under
+    // whatever branch the iframe is actually rooted at, which is
+    // rarely `home`/`main`.
+    let space_attr = host.get_attribute("space");
+    let branch_attr = host.get_attribute("branch");
+    let url = match (&space_attr, &branch_attr) {
+        (None, None) => "/query".to_owned(),
+        _ => format!(
+            "/api/repository/{}/branch/{}/query",
+            space_attr.as_deref().unwrap_or("home"),
+            branch_attr.as_deref().unwrap_or("main"),
+        ),
+    };
 
     // Phase 1 — one-shot resolve via plain JSON request.
     let phase1_body = serde_json::to_string(&phase1_query(&parsed))

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -40,6 +40,19 @@ impl Renderer {
         }
     }
 
+    /// Remove every currently-rendered row from the DOM. Used when
+    /// an attribute change tears the subscription down and the
+    /// caller wants a clean slate before the next frame arrives.
+    pub fn clear(&mut self) {
+        for (_, row) in std::mem::take(&mut self.rows) {
+            for n in row.nodes {
+                if let Some(parent) = n.parent_node() {
+                    let _ = parent.remove_child(&n);
+                }
+            }
+        }
+    }
+
     /// Apply one wire frame. Adds, updates, and removes rows so
     /// the live DOM reflects exactly the conclusions in `frame`.
     pub fn apply(&mut self, frame: &[Conclusion]) {
@@ -338,6 +351,22 @@ mod tests {
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
         let article = host.query_selector("article").unwrap().expect("article");
         assert_eq!(article.text_content().as_deref(), Some("Alice"));
+    }
+
+    #[dialog_common::test]
+    fn it_clears_every_row_from_the_dom() {
+        let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
+        renderer.apply(&[
+            conclusion("did:key:zAlice", &[("name", "Alice")]),
+            conclusion("did:key:zBob", &[("name", "Bob")]),
+        ]);
+        assert_eq!(host.query_selector_all("article").unwrap().length(), 2);
+        renderer.clear();
+        assert_eq!(
+            host.query_selector_all("article").unwrap().length(),
+            0,
+            "clear() must remove every row's nodes from the DOM",
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -120,6 +120,16 @@
          static assets, you will want to modify this condiguration here. -->
   <link data-trunk rel="rust" data-bin="ui" data-type="main" data-wasm-opt="z" />
   <link data-trunk rel="rust" data-bin="worker" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
+  <!-- Standalone `<tonk-concept>` element module. The parent shell
+       registers the element directly from its own bundle; this
+       artefact exists so the tonk-worker HTML wrapper can also
+       register it inside the iframe's separate `customElements`
+       registry (see `rust/tonk-worker/src/router/host.rs`). Built
+       from the bin shim at `rust/tonk-concept/src/bin/tonk-concept.rs`.
+       Trunk's `worker` type drops the file at a stable unhashed
+       URL (`/tonk-concept.js`) without auto-injecting any script
+       into this page. -->
+  <link data-trunk rel="rust" data-bin="tonk-concept" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
 
   <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
   <link data-trunk rel="copy-dir" href="./assets/images" />

--- a/rust/tonk-ui/src/bin/tonk-concept.rs
+++ b/rust/tonk-ui/src/bin/tonk-concept.rs
@@ -1,0 +1,25 @@
+//! Standalone web-target entry point.
+//!
+//! Trunk builds this binary into `dist/tonk-concept.js` (+
+//! `tonk-concept_bg.wasm`) so the tonk-worker HTML wrapper can load
+//! the element from a stable URL instead of inlining a vanilla-JS
+//! port. The parent shell already registers `<tonk-concept>` from
+//! its own bundle (see `rust/tonk-ui/src/bin/ui.rs`); this entry
+//! exists purely so the iframe's `Document` — which has a separate
+//! `customElements` registry — can also register.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen::prelude::*;
+
+/// Module-load hook: `init()` runs this after wasm instantiation,
+/// registering `<tonk-concept>` in the host document.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[wasm_bindgen(main)]
+fn main() {
+    tonk_concept::register();
+}
+
+/// Native stub so `cargo check` / `cargo build` on a non-wasm host
+/// still succeeds.
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -159,29 +159,34 @@ fn body_for(value: Value) -> Body {
     }
 }
 
-/// Vanilla-JS `<tonk-concept>` runtime, inlined into every served
-/// `text/html` body via [`wrap_html_body`]. The script registers
-/// the element in the iframe's own `customElements` registry —
-/// the parent shell's registration doesn't reach across documents.
-const CONCEPT_RUNTIME: &str = include_str!("../../assets/tonk-concept.js");
-
 /// Wrap an agent-authored body fragment in a fixed shell that
 /// hydrates `<tonk-concept>` elements. The agent writes only the
 /// `<body>` content; we provide the doctype, the script, and the
 /// `<body>` boundary.
+///
+/// The script imports the standalone `<tonk-concept>` web-target
+/// build from `/tonk-concept.js`. `init()` instantiates the wasm
+/// module and the bin shim's `main` registers the element in the
+/// iframe's own `customElements` registry — the parent shell's
+/// registration doesn't reach across documents. The path is
+/// exempted from the iframe-branch rewrite in the worker's fetch
+/// router so the request reaches the dist-root asset rather than
+/// a guest entity lookup.
 fn wrap_html_body(body: &str) -> String {
     format!(
         "<!doctype html>\n\
          <html>\n\
          <head>\n\
          <meta charset=\"utf-8\">\n\
-         <script>{runtime}</script>\n\
+         <script type=\"module\">\n\
+         import init from '/tonk-concept.js';\n\
+         await init();\n\
+         </script>\n\
          </head>\n\
          <body>\n\
          {body}\n\
          </body>\n\
          </html>\n",
-        runtime = CONCEPT_RUNTIME,
         body = body,
     )
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -70,6 +70,10 @@ enum Route {
 /// Decides how the Rust side should route this request.
 ///
 /// - Paths under `/api/` are handled by the axum router as-is.
+/// - A small allow-list of shared dist-root assets (the
+///   `<tonk-concept>` web-target build and the wasm-bindgen
+///   `/snippets/*` shims it pulls in) is passed straight through,
+///   even from guest iframes — see [`is_shared_asset`] for why.
 /// - Requests whose initiating client is a registered guest
 ///   iframe are *also* handled by the router, but with their
 ///   path rewritten to live under
@@ -82,6 +86,9 @@ async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
         return Route::Handle {
             rewritten_path: None,
         };
+    }
+    if is_shared_asset(path) {
+        return Route::Passthrough;
     }
     if client_id.is_empty() {
         return Route::Passthrough;
@@ -109,6 +116,18 @@ async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
     Route::Handle {
         rewritten_path: Some(rewritten),
     }
+}
+
+/// Paths that must reach the network even when the requesting
+/// client is a registered guest iframe. The iframe shell loads
+/// `<tonk-concept>` from the dist root via `<script type="module"
+/// src="/tonk-concept.js">`; without this exemption the
+/// guest-binding rewrite would re-root that fetch under the
+/// iframe's branch and 404. `/snippets/*` covers the wasm-bindgen
+/// JS shims that the element's glue imports (e.g. for the
+/// `custom-elements` crate).
+fn is_shared_asset(path: &str) -> bool {
+    matches!(path, "/tonk-concept.js" | "/tonk-concept_bg.wasm") || path.starts_with("/snippets/")
 }
 
 /// Route the request through the axum router, apply response


### PR DESCRIPTION
Drop the vanilla-JS `<tonk-concept>` runtime that was inlined into every iframe body and load the Rust-built element instead.

- New `tonk-concept` bin shim in tonk-ui — Trunk builds it as a `worker` rel with `bindgen-target=web`, emitting an unhashed `/tonk-concept.js` (+ `_bg.wasm`) at the dist root without auto-injecting into the parent shell.
- The iframe wrapper now `<script type="module">`-imports that URL and awaits `init()`; the bin's `main` calls `tonk_concept::register()` so the element registers in the iframe's own customElements registry.
- Service-worker router gets a small shared-asset allow-list (`/tonk-concept.js`, `/tonk-concept_bg.wasm`, `/snippets/*`) so the guest-branch rewrite doesn't 404 those fetches.
- Iframe-context URL fix: when neither `space` nor `branch` is set, use a relative `/query` so the worker's virtual-root rewrite resolves it under the iframe's actual branch. Absolute `/api/repository/{space}/branch/{branch}/query` only when either attribute is explicitly set, defaulting the missing half to `home`/`main`. Matches the semantics the dropped JS port had.
- Tear down rendered rows on attribute change: `Renderer::clear()` removes every row's DOM nodes before the next subscription starts, so stale rows from the previous source don't linger.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a standalone `tonk-concept` element module, enabling better integration with the `tonk-worker` by allowing it to register the element in a separate iframe. It adds functionality to clear rendered rows and modifies asset handling for shared resources.

### Detailed summary
- Added a comment in `rust/tonk-ui/index.html` explaining the purpose of the `tonk-concept` module.
- Introduced a new entry point in `rust/tonk-ui/src/bin/tonk-concept.rs` to register the `tonk-concept` element.
- Implemented a `clear` method in `rust/tonk-concept/src/render.rs` to remove all rendered rows from the DOM.
- Added a test in `rust/tonk-concept/src/render.rs` to verify that `clear` removes all rows.
- Modified the `wrap_html_body` function in `rust/tonk-worker/src/router/host.rs` to load the `tonk-concept` script as a module.
- Enhanced asset routing in `rust/tonk-worker/src/worker.rs` to allow certain shared assets to bypass restrictions.
- Updated logic in `rust/tonk-concept/src/element.rs` to handle URL construction based on presence of `space` and `branch` attributes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->