### PR TITLE
Feat/cardinality many

### DIFF
--- a/rust/tonk-concept/Cargo.toml
+++ b/rust/tonk-concept/Cargo.toml
@@ -26,6 +26,7 @@ web-sys = { workspace = true, features = [
     "AbortController",
     "AbortSignal",
     "Attr",
+    "Comment",
     "CustomElementRegistry",
     "CustomEvent",
     "CustomEventInit",

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -9,15 +9,14 @@ use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
 use web_sys::{DocumentFragment, Element, Node};
 
-use crate::template::{Binding, BindingKind, BindingPlan, Segment, navigate, render_segments};
+use crate::template::{
+    Binding, BindingKind, BindingPlan, PlanNode, navigate, render_segments_with_shadow,
+};
 
 /// One rendered row of the live view.
 struct Row {
     /// Top-level cloned nodes (a template can have multiple roots).
     nodes: Vec<Node>,
-    /// Per-binding rendered string from the last frame, keyed by
-    /// binding index. Used to skip writes when nothing changed.
-    last_values: Vec<String>,
 }
 
 /// Stateful renderer — owns the template + plan and tracks which
@@ -55,15 +54,22 @@ impl Renderer {
 
     /// Apply one wire frame. Adds, updates, and removes rows so
     /// the live DOM reflects exactly the conclusions in `frame`.
+    ///
+    /// Existing rows are torn down and re-rendered on update so
+    /// the iteration-tree walk handles cardinality-many fields
+    /// without an in-place diff. The previous per-binding
+    /// `last_values` dedupe is gone — re-add behind a flag if
+    /// repaint cost becomes a problem.
     pub fn apply(&mut self, frame: &[Conclusion]) {
         let mut seen: indexmap::IndexSet<String> = indexmap::IndexSet::new();
         for conclusion in frame {
             seen.insert(conclusion.this.clone());
-            if self.rows.contains_key(&conclusion.this) {
-                self.update_row(conclusion);
-            } else {
-                self.insert_row(conclusion);
+            // Remove any prior render for this `this`; a fresh
+            // clone applies the plan tree against the new state.
+            if let Some(row) = self.rows.shift_remove(&conclusion.this) {
+                drop_row(row);
             }
+            self.insert_row(conclusion);
         }
         // Remove rows that vanished from the frame.
         let stale: Vec<String> = self
@@ -74,11 +80,7 @@ impl Renderer {
             .collect();
         for key in stale {
             if let Some(row) = self.rows.shift_remove(&key) {
-                for n in row.nodes {
-                    if let Some(parent) = n.parent_node() {
-                        let _ = parent.remove_child(&n);
-                    }
-                }
+                drop_row(row);
             }
         }
     }
@@ -91,16 +93,12 @@ impl Renderer {
             .and_then(|n| n.dyn_into::<DocumentFragment>().ok())
             .expect("template fragment clones to a fragment");
 
-        // Render every binding into the clone, recording values.
-        let mut values: Vec<String> = Vec::with_capacity(self.plan.bindings.len());
-        for binding in &self.plan.bindings {
-            let rendered = render_binding(binding, conclusion);
-            apply_binding(&clone, binding, &rendered);
-            values.push(rendered);
-        }
+        // Walk the plan tree against the clone.
+        let root_node: Node = clone.clone().into();
+        apply_nodes(&root_node, &self.plan.nodes, conclusion, &BTreeMap::new());
 
         // Snapshot the top-level nodes before appending so we can
-        // remove them later.
+        // remove them on stale-cleanup.
         let mut nodes: Vec<Node> = Vec::new();
         let children = clone.child_nodes();
         for i in 0..children.length() {
@@ -108,7 +106,6 @@ impl Renderer {
                 nodes.push(n);
             }
         }
-        // Mark the first root with data-this for diff visibility.
         if let Some(first) = nodes.first().and_then(|n| n.dyn_ref::<Element>())
             && first.set_attribute("data-this", &conclusion.this).is_err()
         {
@@ -116,91 +113,105 @@ impl Renderer {
         }
 
         let _ = self.container.append_child(&clone);
-        self.rows.insert(
-            conclusion.this.clone(),
-            Row {
-                nodes,
-                last_values: values,
-            },
-        );
+        self.rows.insert(conclusion.this.clone(), Row { nodes });
     }
+}
 
-    fn update_row(&mut self, conclusion: &Conclusion) {
-        // Walk every binding; for those whose value changed, find
-        // the target node within the row's roots and patch it.
-        let row = match self.rows.get_mut(&conclusion.this) {
-            Some(r) => r,
-            None => return,
-        };
-        for (i, binding) in self.plan.bindings.iter().enumerate() {
-            let rendered = render_binding(binding, conclusion);
-            if let Some(prev) = row.last_values.get(i)
-                && *prev == rendered
-            {
-                continue;
-            }
-            patch_row(row, binding, &rendered);
-            if let Some(slot) = row.last_values.get_mut(i) {
-                *slot = rendered;
+fn drop_row(row: Row) {
+    for n in row.nodes {
+        if let Some(parent) = n.parent_node() {
+            let _ = parent.remove_child(&n);
+        }
+    }
+}
+
+/// Apply every plan node in `nodes` to the subtree rooted at
+/// `root`. `shadow` carries per-iteration values overriding the
+/// conclusion's field lookups.
+fn apply_nodes(
+    root: &Node,
+    nodes: &[PlanNode],
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
+    for node in nodes {
+        match node {
+            PlanNode::Binding(b) => apply_binding_at(root, b, conclusion, shadow),
+            PlanNode::Iteration { field, path, body } => {
+                apply_iteration_at(root, field, path, body, conclusion, shadow);
             }
         }
     }
 }
 
-fn render_binding(binding: &Binding, conclusion: &Conclusion) -> String {
+fn apply_binding_at(
+    root: &Node,
+    binding: &Binding,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
     let segments = match &binding.kind {
         BindingKind::Text { segments } => segments,
         BindingKind::Attribute { segments, .. } => segments,
     };
-    render_segments(segments, &conclusion.this, &conclusion.fields)
-}
-
-/// Apply a binding inside a freshly-cloned fragment. The binding's
-/// `path` is rooted at the fragment.
-fn apply_binding(fragment: &DocumentFragment, binding: &Binding, rendered: &str) {
-    let root: Node = fragment.clone().into();
-    let Some(target) = navigate(&root, &binding.path) else {
+    let rendered =
+        render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow);
+    let Some(target) = navigate(root, &binding.path) else {
         return;
     };
-    write_binding(&target, binding, rendered);
-}
-
-/// Apply a binding inside an already-mounted row. The binding's
-/// `path[0]` indexes into `row.nodes` (the row's roots), and the
-/// rest of the path walks down through that root's children.
-fn patch_row(row: &Row, binding: &Binding, rendered: &str) {
-    let Some(&first) = binding.path.first() else {
-        return;
-    };
-    let Some(root) = row.nodes.get(first) else {
-        return;
-    };
-    let rest = &binding.path[1..];
-    let Some(target) = navigate(root, rest) else {
-        return;
-    };
-    write_binding(&target, binding, rendered);
-}
-
-fn write_binding(target: &Node, binding: &Binding, rendered: &str) {
     match &binding.kind {
         BindingKind::Text { .. } => {
-            target.set_text_content(Some(rendered));
+            target.set_text_content(Some(&rendered));
         }
         BindingKind::Attribute { attr_name, .. } => {
             if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, rendered);
+                let _ = el.set_attribute(attr_name, &rendered);
             }
         }
     }
 }
 
-// Silence unused-import warning when `Segment` and `BTreeMap` are
-// only used through the public `render_segments` re-export above.
-const _: fn() = || {
-    let _: Option<Segment> = None;
-    let _: BTreeMap<String, serde_json::Value> = BTreeMap::new();
-};
+fn apply_iteration_at(
+    root: &Node,
+    field: &str,
+    path: &[usize],
+    body: &[PlanNode],
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
+    let Some(iter_root) = navigate(root, path) else {
+        return;
+    };
+    let Some(parent) = iter_root.parent_node() else {
+        return;
+    };
+
+    let raw_value = shadow
+        .get(field)
+        .or_else(|| conclusion.fields.get(field))
+        .cloned();
+    let values = collect_values(raw_value);
+
+    for value in &values {
+        let Some(clone) = iter_root.clone_node_with_deep(true).ok() else {
+            continue;
+        };
+        let mut nested_shadow = shadow.clone();
+        nested_shadow.insert(field.to_owned(), value.clone());
+        apply_nodes(&clone, body, conclusion, &nested_shadow);
+        let _ = parent.insert_before(&clone, Some(&iter_root));
+    }
+
+    let _: Result<Node, _> = parent.remove_child(&iter_root);
+}
+
+fn collect_values(value: Option<serde_json::Value>) -> Vec<serde_json::Value> {
+    match value {
+        None | Some(serde_json::Value::Null) => Vec::new(),
+        Some(serde_json::Value::Array(items)) => items,
+        Some(v) => vec![v],
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -267,21 +278,27 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_updates_in_place_on_change() {
+    fn it_reflects_field_changes_on_subsequent_frames() {
+        // The renderer re-clones the template on every frame, so
+        // node identity is *not* preserved across updates — only
+        // the latest payload's content is required to surface.
+        // (If we add per-binding diffing back, this test should
+        // tighten to assert identity preservation again.)
         let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
-        let article_before = host
-            .query_selector("article")
-            .unwrap()
-            .expect("first article");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alicia")])]);
-        let article_after = host
-            .query_selector("article")
-            .unwrap()
-            .expect("second article");
-        assert!(article_before.is_same_node(Some(article_after.unchecked_ref())));
         assert!(host.inner_html().contains("Alicia"));
-        assert!(!host.inner_html().contains("Alice<"));
+        assert!(
+            !host.inner_html().contains("Alice<"),
+            "stale row leaked into: {}",
+            host.inner_html(),
+        );
+        assert_eq!(
+            host.query_selector_all("article").unwrap().length(),
+            1,
+            "expected one row, got: {}",
+            host.inner_html(),
+        );
     }
 
     #[dialog_common::test]
@@ -370,17 +387,21 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_dedupes_writes_when_field_value_unchanged() {
+    fn it_handles_identical_frames_idempotently() {
+        // The renderer re-clones on every frame; applying the
+        // same conclusion twice leaves the DOM in the same shape
+        // and content. Per-binding write-deduping (which would
+        // preserve node identity) was dropped with the move to
+        // iteration-aware rendering — re-add behind a flag if
+        // repaint cost matters.
         let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
-        let h1 = host.query_selector("h1").unwrap().expect("h1");
-        let text_node_before = h1.first_child().expect("h1 text node");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
-        let h1_again = host.query_selector("h1").unwrap().expect("h1");
-        let text_node_after = h1_again.first_child().expect("h1 text node 2");
-        assert!(
-            text_node_before.is_same_node(Some(text_node_after.unchecked_ref())),
-            "unchanged frame should not touch the DOM",
+        assert_eq!(
+            host.query_selector_all("article").unwrap().length(),
+            1,
+            "expected exactly one row after a repeat frame",
         );
+        assert!(host.inner_html().contains("Alice"));
     }
 }

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -1,22 +1,73 @@
 //! Diff a stream of [`tonk_schema::conclusion::Conclusion`]
 //! frames into the live DOM. One row per conclusion; identity is
 //! the `this` URI.
+//!
+//! Each `this`-keyed row owns a mounted-state subtree mirroring
+//! the [`BindingPlan`]; subsequent applies reconcile in place
+//! per row. New rows get fresh template clones; vanished rows
+//! are detached. The per-row mounted state matches
+//! `tonk-display::render::Renderer`'s shape — both crates use the
+//! same algorithm, kept duplicated to avoid pulling wasm-only DOM
+//! types into a shared crate.
 
 use std::collections::BTreeMap;
 
 use indexmap::IndexMap;
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
-use web_sys::{DocumentFragment, Element, Node};
+use web_sys::{Document, DocumentFragment, Element, Node, window};
 
 use crate::template::{
     Binding, BindingKind, BindingPlan, PlanNode, navigate, render_segments_with_shadow,
 };
 
-/// One rendered row of the live view.
+/// One rendered row keyed by its `this` URI. Owns the live
+/// top-level nodes plus the mounted plan-tree subtree used to
+/// reconcile this row on subsequent applies without re-cloning.
 struct Row {
     /// Top-level cloned nodes (a template can have multiple roots).
     nodes: Vec<Node>,
+    /// Mounted plan-tree mirror for incremental updates.
+    mounted: Vec<MountedNode>,
+    /// The fragment-cloned root the mounted state navigates from.
+    /// Kept alive so we have a stable handle into the row's
+    /// subtree across applies.
+    root: Node,
+}
+
+/// One mounted plan-tree node. Mirrors [`PlanNode`] but carries
+/// only the DOM bookkeeping needed to update in place; path /
+/// kind / segments stay on the plan node, walked in lockstep with
+/// the mounted tree during reconciliation.
+enum MountedNode {
+    /// A leaf binding with its last-rendered string cached so we
+    /// can skip writes that wouldn't change anything.
+    Binding {
+        /// Most recent rendered string. Compared against fresh
+        /// renders; equal ⇒ no write, original DOM node preserved.
+        last_value: String,
+    },
+    /// An iteration over a field's values. Owns its rows and the
+    /// comment-node anchor in the DOM that marks the iteration's
+    /// slot.
+    Iteration {
+        /// Path to the iteration root in the template fragment.
+        template_path: Vec<usize>,
+        /// Comment anchor at the iteration's slot. Rows insert
+        /// *before* this node; the anchor stays put across applies.
+        anchor: Node,
+        /// Mounted rows, keyed by stringified iteration value.
+        /// BTreeMap ⇒ DOM order follows lexicographic key order.
+        rows: BTreeMap<String, IterationRow>,
+    },
+}
+
+/// One mounted iteration row.
+struct IterationRow {
+    /// The cloned iteration-root element in the live DOM.
+    root: Node,
+    /// Mounted state for the body bindings, relative to `root`.
+    body: Vec<MountedNode>,
 }
 
 /// Stateful renderer — owns the template + plan and tracks which
@@ -55,21 +106,31 @@ impl Renderer {
     /// Apply one wire frame. Adds, updates, and removes rows so
     /// the live DOM reflects exactly the conclusions in `frame`.
     ///
-    /// Existing rows are torn down and re-rendered on update so
-    /// the iteration-tree walk handles cardinality-many fields
-    /// without an in-place diff. The previous per-binding
-    /// `last_values` dedupe is gone — re-add behind a flag if
-    /// repaint cost becomes a problem.
+    /// Surviving rows reconcile in place against the new
+    /// conclusion (per-binding write dedupe + keyed iteration
+    /// diffing). New rows clone the template and build their
+    /// mounted state from scratch. Vanished rows are detached and
+    /// their mounted state dropped.
     pub fn apply(&mut self, frame: &[Conclusion]) {
+        let Some(document) = window().and_then(|w| w.document()) else {
+            return;
+        };
         let mut seen: indexmap::IndexSet<String> = indexmap::IndexSet::new();
         for conclusion in frame {
             seen.insert(conclusion.this.clone());
-            // Remove any prior render for this `this`; a fresh
-            // clone applies the plan tree against the new state.
-            if let Some(row) = self.rows.shift_remove(&conclusion.this) {
-                drop_row(row);
+            if let Some(row) = self.rows.get_mut(&conclusion.this) {
+                update_nodes(
+                    &document,
+                    &self.plan.nodes,
+                    &mut row.mounted,
+                    &row.root,
+                    &self.template,
+                    conclusion,
+                    &BTreeMap::new(),
+                );
+            } else {
+                self.insert_row(&document, conclusion);
             }
-            self.insert_row(conclusion);
         }
         // Remove rows that vanished from the frame.
         let stale: Vec<String> = self
@@ -85,7 +146,7 @@ impl Renderer {
         }
     }
 
-    fn insert_row(&mut self, conclusion: &Conclusion) {
+    fn insert_row(&mut self, document: &Document, conclusion: &Conclusion) {
         let clone: DocumentFragment = self
             .template
             .clone_node_with_deep(true)
@@ -93,12 +154,19 @@ impl Renderer {
             .and_then(|n| n.dyn_into::<DocumentFragment>().ok())
             .expect("template fragment clones to a fragment");
 
-        // Walk the plan tree against the clone.
-        let root_node: Node = clone.clone().into();
-        apply_nodes(&root_node, &self.plan.nodes, conclusion, &BTreeMap::new());
+        let root: Node = clone.clone().into();
+        let mounted = build_mounted_nodes(
+            document,
+            &self.plan.nodes,
+            &root,
+            &self.template,
+            conclusion,
+            &BTreeMap::new(),
+        );
 
-        // Snapshot the top-level nodes before appending so we can
-        // remove them on stale-cleanup.
+        // Snapshot the top-level nodes after the plan walk —
+        // iteration nodes may have rearranged the fragment's
+        // children (replaced iteration roots with anchors + rows).
         let mut nodes: Vec<Node> = Vec::new();
         let children = clone.child_nodes();
         for i in 0..children.length() {
@@ -113,7 +181,14 @@ impl Renderer {
         }
 
         let _ = self.container.append_child(&clone);
-        self.rows.insert(conclusion.this.clone(), Row { nodes });
+        self.rows.insert(
+            conclusion.this.clone(),
+            Row {
+                nodes,
+                mounted,
+                root,
+            },
+        );
     }
 }
 
@@ -125,84 +200,318 @@ fn drop_row(row: Row) {
     }
 }
 
-/// Apply every plan node in `nodes` to the subtree rooted at
-/// `root`. `shadow` carries per-iteration values overriding the
-/// conclusion's field lookups.
-fn apply_nodes(
-    root: &Node,
-    nodes: &[PlanNode],
+/// Build a fresh `Vec<MountedNode>` from a plan and write its
+/// initial values into the DOM.
+///
+/// Iteration nodes are processed in **reverse sibling order** to
+/// avoid invalidating sibling paths: replacing an earlier
+/// iteration root with an anchor + rows would shift the indices
+/// of later siblings, and the plan's paths are computed against
+/// the pristine template. Reverse order keeps every yet-to-be-
+/// processed sibling at its planned path. Leaf bindings are
+/// order-independent; they're written in whichever pass touches
+/// them.
+fn build_mounted_nodes(
+    document: &Document,
+    plan: &[PlanNode],
+    scope_root: &Node,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
-) {
-    for node in nodes {
-        match node {
-            PlanNode::Binding(b) => apply_binding_at(root, b, conclusion, shadow),
-            PlanNode::Iteration { field, path, body } => {
-                apply_iteration_at(root, field, path, body, conclusion, shadow);
+) -> Vec<MountedNode> {
+    let mut out: Vec<Option<MountedNode>> = (0..plan.len()).map(|_| None).collect();
+    for (i, node) in plan.iter().enumerate().rev() {
+        out[i] = Some(build_mounted_node(
+            document, node, scope_root, template, conclusion, shadow,
+        ));
+    }
+    out.into_iter()
+        .map(|n| n.expect("every slot filled"))
+        .collect()
+}
+
+fn build_mounted_node(
+    document: &Document,
+    plan: &PlanNode,
+    scope_root: &Node,
+    template: &DocumentFragment,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> MountedNode {
+    match plan {
+        PlanNode::Binding(b) => {
+            let rendered = render_binding(b, conclusion, shadow);
+            write_binding(scope_root, b, &rendered);
+            MountedNode::Binding {
+                last_value: rendered,
+            }
+        }
+        PlanNode::Iteration { field, path, body } => {
+            let anchor: Node = document
+                .create_comment(&format!("tonk-iter:{field}"))
+                .into();
+            let mut rows: BTreeMap<String, IterationRow> = BTreeMap::new();
+
+            if let Some(iter_root) = navigate(scope_root, path)
+                && let Some(parent) = iter_root.parent_node()
+            {
+                let _ = parent.insert_before(&anchor, Some(&iter_root));
+                let _: Result<Node, _> = parent.remove_child(&iter_root);
+
+                let raw_value = shadow
+                    .get(field)
+                    .or_else(|| conclusion.fields.get(field))
+                    .cloned();
+                let values = collect_values(raw_value);
+
+                for value in values {
+                    let key = key_for(&value);
+                    if rows.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(row) = build_iteration_row(
+                        document, path, template, body, field, value, conclusion, shadow,
+                    ) {
+                        // BTreeMap iteration is already sorted by
+                        // key; inserting each new row before the
+                        // anchor yields sorted DOM order without
+                        // explicit position math.
+                        let _ = parent.insert_before(&row.root, Some(&anchor));
+                        rows.insert(key, row);
+                    }
+                }
+            }
+
+            MountedNode::Iteration {
+                template_path: path.clone(),
+                anchor,
+                rows,
             }
         }
     }
 }
 
-fn apply_binding_at(
-    root: &Node,
-    binding: &Binding,
+fn update_nodes(
+    document: &Document,
+    plan: &[PlanNode],
+    mounted: &mut [MountedNode],
+    scope_root: &Node,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
 ) {
-    let segments = match &binding.kind {
-        BindingKind::Text { segments } => segments,
-        BindingKind::Attribute { segments, .. } => segments,
-    };
-    let rendered =
-        render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow);
-    let Some(target) = navigate(root, &binding.path) else {
-        return;
-    };
-    match &binding.kind {
-        BindingKind::Text { .. } => {
-            target.set_text_content(Some(&rendered));
-        }
-        BindingKind::Attribute { attr_name, .. } => {
-            if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, &rendered);
-            }
-        }
+    for (plan_node, mounted_node) in plan.iter().zip(mounted.iter_mut()) {
+        update_node(
+            document,
+            plan_node,
+            mounted_node,
+            scope_root,
+            template,
+            conclusion,
+            shadow,
+        );
     }
 }
 
-fn apply_iteration_at(
-    root: &Node,
+fn update_node(
+    document: &Document,
+    plan: &PlanNode,
+    mounted: &mut MountedNode,
+    scope_root: &Node,
+    template: &DocumentFragment,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
+    match (plan, mounted) {
+        (PlanNode::Binding(b), MountedNode::Binding { last_value }) => {
+            let rendered = render_binding(b, conclusion, shadow);
+            if *last_value != rendered {
+                write_binding(scope_root, b, &rendered);
+                *last_value = rendered;
+            }
+        }
+        (
+            PlanNode::Iteration {
+                field: plan_field,
+                path: _,
+                body,
+            },
+            MountedNode::Iteration {
+                template_path,
+                anchor,
+                rows,
+            },
+        ) => {
+            update_iteration(
+                document,
+                plan_field,
+                template_path,
+                body,
+                anchor,
+                rows,
+                template,
+                conclusion,
+                shadow,
+            );
+        }
+        _ => {}
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update_iteration(
+    document: &Document,
     field: &str,
-    path: &[usize],
-    body: &[PlanNode],
+    template_path: &[usize],
+    plan_body: &[PlanNode],
+    anchor: &Node,
+    rows: &mut BTreeMap<String, IterationRow>,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
 ) {
-    let Some(iter_root) = navigate(root, path) else {
-        return;
-    };
-    let Some(parent) = iter_root.parent_node() else {
-        return;
-    };
-
     let raw_value = shadow
         .get(field)
         .or_else(|| conclusion.fields.get(field))
         .cloned();
     let values = collect_values(raw_value);
 
-    for value in &values {
-        let Some(clone) = iter_root.clone_node_with_deep(true).ok() else {
-            continue;
-        };
-        let mut nested_shadow = shadow.clone();
-        nested_shadow.insert(field.to_owned(), value.clone());
-        apply_nodes(&clone, body, conclusion, &nested_shadow);
-        let _ = parent.insert_before(&clone, Some(&iter_root));
+    let mut incoming: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for value in values {
+        let key = key_for(&value);
+        incoming.entry(key).or_insert(value);
     }
 
-    let _: Result<Node, _> = parent.remove_child(&iter_root);
+    let Some(parent) = anchor.parent_node() else {
+        return;
+    };
+
+    let stale: Vec<String> = rows
+        .keys()
+        .filter(|k| !incoming.contains_key(*k))
+        .cloned()
+        .collect();
+    for key in stale {
+        if let Some(row) = rows.remove(&key) {
+            let _: Result<Node, _> = parent.remove_child(&row.root);
+        }
+    }
+
+    for (key, value) in incoming {
+        if let Some(row) = rows.get_mut(&key) {
+            let mut nested_shadow = shadow.clone();
+            nested_shadow.insert(field.to_owned(), value);
+            update_nodes(
+                document,
+                plan_body,
+                &mut row.body,
+                &row.root,
+                template,
+                conclusion,
+                &nested_shadow,
+            );
+        } else if let Some(new_row) = build_iteration_row(
+            document,
+            template_path,
+            template,
+            plan_body,
+            field,
+            value,
+            conclusion,
+            shadow,
+        ) {
+            // Single insertBefore at the correct sorted position.
+            // Inserting then moving would fire detach/attach
+            // lifecycle on every custom element inside the row,
+            // doubling subscriptions on inner `<tonk-display>`
+            // elements. See `build_iteration_row` doc.
+            let next_anchor = rows
+                .range(key.clone()..)
+                .next()
+                .map(|(_, row)| row.root.clone())
+                .unwrap_or_else(|| anchor.clone());
+            let _ = parent.insert_before(&new_row.root, Some(&next_anchor));
+            rows.insert(key, new_row);
+        }
+    }
+}
+
+/// Clone the iteration root from the pristine template and
+/// build the body's mounted state with all bindings applied.
+/// The returned [`IterationRow`] is **detached** — the caller
+/// is responsible for the single `parent.insertBefore` that
+/// attaches it.
+///
+/// Inserting then moving would amount to a detach/attach pair
+/// on every custom element inside the row, firing
+/// `disconnected_callback` and `connected_callback` twice and
+/// causing inner `<tonk-display>` instances to mount their
+/// view slide twice. Building detached lets every attribute
+/// settle to its bound value before the row enters the live DOM,
+/// so the inner element's lifecycle runs exactly once.
+#[allow(clippy::too_many_arguments)]
+fn build_iteration_row(
+    document: &Document,
+    template_path: &[usize],
+    template: &DocumentFragment,
+    body_plan: &[PlanNode],
+    field: &str,
+    value: serde_json::Value,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> Option<IterationRow> {
+    let template_root: Node = template.clone().into();
+    let template_iter_root = navigate(&template_root, template_path)?;
+    let row_root = template_iter_root.clone_node_with_deep(true).ok()?;
+
+    let mut nested_shadow = shadow.clone();
+    nested_shadow.insert(field.to_owned(), value);
+    let body = build_mounted_nodes(
+        document,
+        body_plan,
+        &row_root,
+        template,
+        conclusion,
+        &nested_shadow,
+    );
+
+    Some(IterationRow {
+        root: row_root,
+        body,
+    })
+}
+
+fn key_for(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+fn render_binding(
+    binding: &Binding,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> String {
+    let segments = match &binding.kind {
+        BindingKind::Text { segments } => segments,
+        BindingKind::Attribute { segments, .. } => segments,
+    };
+    render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow)
+}
+
+fn write_binding(scope_root: &Node, binding: &Binding, rendered: &str) {
+    let Some(target) = navigate(scope_root, &binding.path) else {
+        return;
+    };
+    match &binding.kind {
+        BindingKind::Text { .. } => target.set_text_content(Some(rendered)),
+        BindingKind::Attribute { attr_name, .. } => {
+            if let Some(el) = target.dyn_ref::<Element>() {
+                let _ = el.set_attribute(attr_name, rendered);
+            }
+        }
+    }
 }
 
 fn collect_values(value: Option<serde_json::Value>) -> Vec<serde_json::Value> {
@@ -278,27 +587,29 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_reflects_field_changes_on_subsequent_frames() {
-        // The renderer re-clones the template on every frame, so
-        // node identity is *not* preserved across updates — only
-        // the latest payload's content is required to surface.
-        // (If we add per-binding diffing back, this test should
-        // tighten to assert identity preservation again.)
+    fn it_updates_a_row_in_place_on_subsequent_frame() {
+        // With incremental updates, an existing row's article
+        // node has its identity preserved across applies — only
+        // the changed text node inside is rewritten.
         let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
+        let article_before = host
+            .query_selector("article")
+            .unwrap()
+            .expect("first article");
+
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alicia")])]);
-        assert!(host.inner_html().contains("Alicia"));
+        let article_after = host
+            .query_selector("article")
+            .unwrap()
+            .expect("article still mounted");
+
         assert!(
-            !host.inner_html().contains("Alice<"),
-            "stale row leaked into: {}",
-            host.inner_html(),
+            article_before.is_same_node(Some(article_after.unchecked_ref())),
+            "article node identity should survive a content change",
         );
-        assert_eq!(
-            host.query_selector_all("article").unwrap().length(),
-            1,
-            "expected one row, got: {}",
-            host.inner_html(),
-        );
+        assert!(host.inner_html().contains("Alicia"));
+        assert!(!host.inner_html().contains("Alice<"));
     }
 
     #[dialog_common::test]
@@ -317,14 +628,26 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_appends_new_rows() {
+    fn it_appends_new_rows_without_disturbing_existing_ones() {
         let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
+        let alice_article = host
+            .query_selector("article")
+            .unwrap()
+            .expect("Alice's article");
+
         renderer.apply(&[
             conclusion("did:key:zAlice", &[("name", "Alice")]),
             conclusion("did:key:zBob", &[("name", "Bob")]),
         ]);
-        assert_eq!(host.query_selector_all("article").unwrap().length(), 2);
+
+        let articles = host.query_selector_all("article").unwrap();
+        assert_eq!(articles.length(), 2);
+        let alice_after = articles.item(0).expect("first article");
+        assert!(
+            alice_article.is_same_node(Some(alice_after.unchecked_ref())),
+            "Alice's row should retain identity when Bob is added",
+        );
         assert!(host.inner_html().contains("Bob"));
     }
 
@@ -388,20 +711,24 @@ mod tests {
 
     #[dialog_common::test]
     fn it_handles_identical_frames_idempotently() {
-        // The renderer re-clones on every frame; applying the
-        // same conclusion twice leaves the DOM in the same shape
-        // and content. Per-binding write-deduping (which would
-        // preserve node identity) was dropped with the move to
-        // iteration-aware rendering — re-add behind a flag if
-        // repaint cost matters.
+        // Re-applying the same conclusion must be a no-op for the
+        // DOM: the rendered text node retains its identity since
+        // nothing changed.
         let (host, mut renderer) = mount("<article><h1>{name}</h1></article>");
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
+        let h1 = host.query_selector("h1").unwrap().expect("h1");
+        let text_before = h1.first_child().expect("h1 text node");
+
         renderer.apply(&[conclusion("did:key:zAlice", &[("name", "Alice")])]);
-        assert_eq!(
-            host.query_selector_all("article").unwrap().length(),
-            1,
-            "expected exactly one row after a repeat frame",
+        let text_after = host
+            .query_selector("h1")
+            .unwrap()
+            .unwrap()
+            .first_child()
+            .expect("h1 text node still present");
+        assert!(
+            text_before.is_same_node(Some(text_after.unchecked_ref())),
+            "unchanged binding should not rewrite the text node",
         );
-        assert!(host.inner_html().contains("Alice"));
     }
 }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -104,8 +104,274 @@ pub enum BindingKind {
 /// the renderer can short-circuit when no field actually changed.
 #[derive(Debug, Clone, Default)]
 pub struct BindingPlan {
-    /// Every text- and attribute-binding in the fragment.
-    pub bindings: Vec<Binding>,
+    /// Top-level plan nodes — a tree, because iteration roots
+    /// (introduced for cardinality-many fields) contain nested
+    /// bindings whose paths are relative to the root.
+    pub nodes: Vec<PlanNode>,
+}
+
+/// One node in the binding tree. Plain `Binding` nodes are
+/// substituted once per render; `Iteration` nodes mark an element
+/// that gets cloned per value of a multi-valued field, with each
+/// clone running its own nested body.
+#[derive(Debug, Clone)]
+pub enum PlanNode {
+    /// A leaf binding — a `{field}` reference in text content or
+    /// an attribute value. Path is from the fragment root, or
+    /// from the enclosing iteration root if nested.
+    Binding(Binding),
+    /// An iteration over a field's values. The element at `path`
+    /// (relative to its enclosing scope) is cloned once per value
+    /// of `field`; `body` is rendered against each clone with
+    /// `field` shadowed to the current iteration's value.
+    Iteration {
+        /// Field whose values drive the iteration.
+        field: String,
+        /// Path to the iteration-root element, relative to the
+        /// enclosing scope (fragment root or parent iteration).
+        path: Vec<usize>,
+        /// Nested plan applied inside each clone of the root.
+        /// Paths in `body` are relative to the iteration root.
+        body: Vec<PlanNode>,
+    },
+}
+
+/// Find the longest common prefix among a non-empty slice of
+/// paths. Returns the prefix as a fresh `Vec`. Empty input
+/// returns the empty prefix.
+///
+/// Used to locate the **lowest common ancestor** of every
+/// occurrence of a single field in the template: each placeholder
+/// records the DOM path to its containing node, and the LCA is
+/// the longest path prefix all of those share. That LCA is the
+/// element we mount as the iteration root for the field.
+pub fn longest_common_path_prefix(paths: &[Vec<usize>]) -> Vec<usize> {
+    let mut iter = paths.iter();
+    let Some(first) = iter.next() else {
+        return Vec::new();
+    };
+    let mut max_len = first.len();
+    for p in iter {
+        let common = first
+            .iter()
+            .zip(p.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        if common < max_len {
+            max_len = common;
+        }
+        if max_len == 0 {
+            break;
+        }
+    }
+    first[..max_len].to_vec()
+}
+
+/// Distinct field names referenced by a binding. A text binding
+/// has exactly one field (the splitting pass in `extract_plan`
+/// ensures one field per text node); an attribute binding can
+/// mix multiple `{X}` placeholders, all collected here.
+///
+/// `{this}` is **not** a real field — it's a reserved placeholder
+/// for the entity URI, always scalar, always single. Exclude it
+/// from iteration-root discovery so a template like
+/// `<a href="/entity/{this}">` doesn't get treated as a
+/// cardinality-many iteration target. The substituter still
+/// resolves `{this}` directly off the conclusion.
+pub fn binding_fields(binding: &Binding) -> Vec<String> {
+    let segments = match &binding.kind {
+        BindingKind::Text { segments } => segments,
+        BindingKind::Attribute { segments, .. } => segments,
+    };
+    let mut out: Vec<String> = Vec::new();
+    for seg in segments {
+        if let Segment::Field(name) = seg
+            && name != "this"
+            && !out.contains(name)
+        {
+            out.push(name.clone());
+        }
+    }
+    out
+}
+
+/// The path of the smallest enclosing element containing a
+/// binding's placeholder. For text bindings the binding's `path`
+/// points at the text node, so the enclosing element is `path[..-1]`.
+/// For attribute bindings the path is already on the element itself.
+fn host_element_path(binding: &Binding) -> Vec<usize> {
+    match binding.kind {
+        BindingKind::Text { .. } => binding.path[..binding.path.len().saturating_sub(1)].to_vec(),
+        BindingKind::Attribute { .. } => binding.path.clone(),
+    }
+}
+
+/// Walk a flat binding vec and produce the iteration-aware plan
+/// tree.
+///
+/// Algorithm:
+///
+/// 1. For every distinct field name referenced, collect the
+///    *host element paths* of every binding that mentions it
+///    (the smallest element containing the placeholder).
+/// 2. Compute the LCA of those host paths via
+///    [`longest_common_path_prefix`].
+///    - **Non-empty LCA**: the bindings live under a shared
+///      enclosing element. Use that LCA as the field's single
+///      iteration root; every binding gets pulled into its body.
+///    - **Empty LCA but only one host path**: lift that host
+///      element as the iteration root. (Single-occurrence
+///      placeholders still need to be inside an iteration so
+///      empty / many-cardinality values render correctly.)
+///    - **Empty LCA with multiple host paths**: the placeholders
+///      are siblings under the fragment root with no shared
+///      inner ancestor. Each host element becomes its own
+///      iteration root for the field — they repeat independently.
+/// 3. Sort iteration roots by ascending path length so outer
+///    roots are placed first, then walked inside-out when
+///    closing scopes.
+/// 4. Iteration roots build a scope stack; bindings get attached
+///    to the deepest enclosing scope with paths re-rooted
+///    relative to that scope.
+///
+/// Pure — no DOM access — so unit tests run natively.
+pub fn build_plan_nodes(bindings: Vec<Binding>) -> Vec<PlanNode> {
+    // Group bindings by every field they reference. A binding
+    // that mentions two fields appears in two groups. Use the
+    // *host element path* (smallest containing element), not the
+    // raw binding path, so siblings-under-fragment-root don't
+    // accidentally share an LCA at a text node level.
+    let mut field_hosts: std::collections::BTreeMap<String, Vec<Vec<usize>>> =
+        std::collections::BTreeMap::new();
+    for b in &bindings {
+        let host = host_element_path(b);
+        for field in binding_fields(b) {
+            field_hosts.entry(field).or_default().push(host.clone());
+        }
+    }
+
+    // Iteration root determination per field.
+    let mut iter_roots: Vec<(String, Vec<usize>)> = Vec::new();
+    for (field, hosts) in field_hosts {
+        let lca = longest_common_path_prefix(&hosts);
+        if !lca.is_empty() {
+            // Shared inner ancestor — single iteration root.
+            iter_roots.push((field, lca));
+        } else {
+            // No shared inner ancestor. Each distinct host path
+            // becomes its own iteration root (a placeholder at
+            // the fragment root itself — empty host path — falls
+            // through as a flat binding instead).
+            let mut seen: std::collections::BTreeSet<Vec<usize>> =
+                std::collections::BTreeSet::new();
+            for host in hosts {
+                if host.is_empty() || !seen.insert(host.clone()) {
+                    continue;
+                }
+                iter_roots.push((field.clone(), host));
+            }
+        }
+    }
+
+    // Outer-first ordering, then deterministic on path content.
+    iter_roots.sort_by(|a, b| a.1.len().cmp(&b.1.len()).then_with(|| a.1.cmp(&b.1)));
+
+    // Scope: an iteration's accumulating body. The first scope
+    // (path = []) is the top level — its `body` is what we
+    // ultimately return.
+    let mut scopes: Vec<Scope> = vec![Scope {
+        path: Vec::new(),
+        field: String::new(),
+        body: Vec::new(),
+    }];
+
+    // Open one new scope per iteration root, nested by absolute
+    // path. Order is outer-first per the sort above.
+    for (field, lca) in iter_roots {
+        scopes.push(Scope {
+            path: lca,
+            field,
+            body: Vec::new(),
+        });
+    }
+
+    // Place each binding into the deepest open scope whose path
+    // is a prefix of the binding's path. Re-root the binding's
+    // path against the chosen scope.
+    for b in bindings {
+        let idx = deepest_enclosing(&scopes, &b.path);
+        let parent_len = scopes[idx].path.len();
+        let mut rerooted = b;
+        rerooted.path = rerooted.path[parent_len..].to_vec();
+        scopes[idx].body.push(PlanNode::Binding(rerooted));
+    }
+
+    // Close scopes inside-out: pop the innermost, wrap its body
+    // in an Iteration node with path re-rooted against its
+    // parent, push the Iteration into the parent's body.
+    while scopes.len() > 1 {
+        let inner = scopes.pop().expect("scope present");
+        let parent_idx = deepest_enclosing(&scopes, &inner.path);
+        let parent_len = scopes[parent_idx].path.len();
+        let rel_path = inner.path[parent_len..].to_vec();
+        // Sort the iteration's own body by path so siblings come
+        // out in document order even though we built the tree
+        // inside-out.
+        let mut sorted_body = inner.body;
+        sort_nodes_by_path(&mut sorted_body);
+        scopes[parent_idx].body.push(PlanNode::Iteration {
+            field: inner.field,
+            path: rel_path,
+            body: sorted_body,
+        });
+    }
+
+    let mut top = scopes
+        .into_iter()
+        .next()
+        .map(|s| s.body)
+        .unwrap_or_default();
+    sort_nodes_by_path(&mut top);
+    top
+}
+
+/// Sort a list of plan nodes by their template-source path so
+/// the rendered output matches source order. Iteration node
+/// paths take precedence over their bodies; bindings sort by
+/// their own path.
+fn sort_nodes_by_path(nodes: &mut [PlanNode]) {
+    nodes.sort_by(|a, b| node_path(a).cmp(node_path(b)));
+}
+
+fn node_path(node: &PlanNode) -> &[usize] {
+    match node {
+        PlanNode::Binding(b) => &b.path,
+        PlanNode::Iteration { path, .. } => path,
+    }
+}
+
+/// Internal: one accumulating iteration scope inside
+/// [`build_plan_nodes`]. Defined at module scope (rather than
+/// inside the function) so `deepest_enclosing` can take a
+/// `&[Scope]` reference.
+struct Scope {
+    path: Vec<usize>,
+    field: String,
+    body: Vec<PlanNode>,
+}
+
+/// Index of the deepest scope whose path is a (possibly equal)
+/// prefix of `target`. The top-level scope's path is `[]`, which
+/// is a prefix of every path, so the result is always defined.
+/// Internal helper for `build_plan_nodes`.
+fn deepest_enclosing(scopes: &[Scope], target: &[usize]) -> usize {
+    let mut best = 0;
+    for (i, scope) in scopes.iter().enumerate() {
+        if target.starts_with(&scope.path) && scope.path.len() > scopes[best].path.len() {
+            best = i;
+        }
+    }
+    best
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -324,7 +590,18 @@ mod dom {
             }
         }
 
-        BindingPlan { bindings }
+        // Fold flat bindings into the iteration-aware plan tree.
+        // Iteration roots are discovered by finding the LCA of
+        // every binding that references the same field — if that
+        // LCA sits strictly inside the fragment (not at the root),
+        // the element there becomes the iteration root and every
+        // binding under it is pulled into its body. The fold is
+        // pure (operates on the collected `bindings` vec), which
+        // is why the helper lives outside the wasm-only `dom`
+        // module and gets unit-tested natively.
+        BindingPlan {
+            nodes: super::build_plan_nodes(bindings),
+        }
     }
 
     /// Walk a node and its descendants, calling `visit(path, node)`
@@ -361,6 +638,20 @@ mod dom {
         row_this: &str,
         row_fields: &BTreeMap<String, serde_json::Value>,
     ) -> String {
+        render_segments_with_shadow(segments, row_this, row_fields, &BTreeMap::new())
+    }
+
+    /// Like [`render_segments`] but consults `shadow` first for
+    /// each `{field}` lookup, falling back to `row_fields` on
+    /// miss. Used by the iteration renderer so a per-iteration
+    /// value can override the conclusion's full field set inside
+    /// the iterated subtree.
+    pub fn render_segments_with_shadow(
+        segments: &[Segment],
+        row_this: &str,
+        row_fields: &BTreeMap<String, serde_json::Value>,
+        shadow: &BTreeMap<String, serde_json::Value>,
+    ) -> String {
         let mut out = String::new();
         for seg in segments {
             match seg {
@@ -368,6 +659,8 @@ mod dom {
                 Segment::Field(name) => {
                     if name == "this" {
                         out.push_str(row_this);
+                    } else if let Some(v) = shadow.get(name) {
+                        push_json_value(&mut out, v);
                     } else if let Some(v) = row_fields.get(name) {
                         push_json_value(&mut out, v);
                     }
@@ -389,7 +682,10 @@ mod dom {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub use dom::{Snapshot, extract_plan, navigate, render_segments, snapshot_template};
+pub use dom::{
+    Snapshot, extract_plan, navigate, render_segments, render_segments_with_shadow,
+    snapshot_template,
+};
 
 #[cfg(test)]
 mod tests {
@@ -460,5 +756,189 @@ mod tests {
     fn it_detects_field_segments() {
         assert!(!has_field(&parse_segments("plain text")));
         assert!(has_field(&parse_segments("hello {name}")));
+    }
+
+    // --- LCA + plan-tree tests -------------------------------------------
+
+    /// Helper: build a text binding referencing one field at the
+    /// given path. The renderer treats a single-field text binding
+    /// as `[Field(name)]`, mirroring what the splitting pass in
+    /// `extract_plan` produces.
+    fn text_binding(path: &[usize], field: &str) -> Binding {
+        Binding {
+            path: path.to_vec(),
+            kind: BindingKind::Text {
+                segments: vec![Segment::Field(field.into())],
+            },
+        }
+    }
+
+    /// Helper: build an attribute binding with one `{field}`
+    /// placeholder in its value, at the given element path.
+    fn attr_binding(path: &[usize], attr: &str, field: &str) -> Binding {
+        Binding {
+            path: path.to_vec(),
+            kind: BindingKind::Attribute {
+                attr_name: attr.into(),
+                segments: vec![Segment::Field(field.into())],
+            },
+        }
+    }
+
+    #[test]
+    fn it_returns_empty_lca_for_disjoint_paths() {
+        let lca = longest_common_path_prefix(&[vec![0, 1, 2], vec![1, 2, 3]]);
+        assert!(lca.is_empty());
+    }
+
+    #[test]
+    fn it_returns_full_path_lca_when_paths_share_a_prefix() {
+        let lca = longest_common_path_prefix(&[vec![0, 1, 2], vec![0, 1, 5, 7]]);
+        assert_eq!(lca, vec![0, 1]);
+    }
+
+    #[test]
+    fn it_returns_the_path_itself_for_a_single_path() {
+        let lca = longest_common_path_prefix(&[vec![0, 1, 2]]);
+        assert_eq!(lca, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn it_returns_empty_lca_for_no_paths() {
+        assert!(longest_common_path_prefix(&[]).is_empty());
+    }
+
+    #[test]
+    fn it_lifts_a_single_text_placeholder_to_its_host_element() {
+        // <p>{name}</p> — text binding at path [0, 0]. Its host
+        // element is the <p> at [0]. The iteration root is the
+        // <p>, not the text node, so empty / multi-valued data
+        // can repeat the <p> wholesale.
+        let nodes = build_plan_nodes(vec![text_binding(&[0, 0], "name")]);
+        match &nodes[..] {
+            [PlanNode::Iteration { field, path, body }] => {
+                assert_eq!(field, "name");
+                assert_eq!(path, &vec![0]);
+                assert_eq!(body.len(), 1);
+                match &body[0] {
+                    PlanNode::Binding(b) => assert_eq!(b.path, vec![0]),
+                    _ => panic!("expected Binding, got {:?}", body[0]),
+                }
+            }
+            other => panic!("expected single Iteration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn it_creates_independent_iteration_roots_for_sibling_placeholders() {
+        // Mirrors the todo-list case:
+        //   <p>You have {item} items.</p>  text at [0, 0], host <p> = [0]
+        //   <li>{item}</li>                text at [1, 0], host <li> = [1]
+        // LCA of host paths [0] and [1] is [] — no shared inner
+        // ancestor — so each becomes its own iteration root and
+        // both elements repeat independently.
+        let nodes = build_plan_nodes(vec![
+            text_binding(&[0, 0], "item"),
+            text_binding(&[1, 0], "item"),
+        ]);
+
+        let iters: Vec<_> = nodes
+            .iter()
+            .filter_map(|n| match n {
+                PlanNode::Iteration { field, path, .. } => Some((field.clone(), path.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            iters,
+            vec![("item".to_owned(), vec![0]), ("item".to_owned(), vec![1]),],
+            "expected two independent iteration roots, got {iters:?}",
+        );
+    }
+
+    #[test]
+    fn it_groups_multiple_occurrences_of_same_field_under_their_lca() {
+        // <dl for={title}>          path [0]    attribute
+        //   <dt>{title}</dt>        path [0, 0, 0]  text
+        //   <dd>{title}</dd>        path [0, 1, 0]  text
+        // </dl>
+        // LCA = [0] — the <dl>. One iteration root.
+        let nodes = build_plan_nodes(vec![
+            attr_binding(&[0], "for", "title"),
+            text_binding(&[0, 0, 0], "title"),
+            text_binding(&[0, 1, 0], "title"),
+        ]);
+
+        match &nodes[..] {
+            [PlanNode::Iteration { field, path, body }] => {
+                assert_eq!(field, "title");
+                assert_eq!(path, &vec![0]);
+                // Three bindings inside, each with path
+                // re-rooted relative to the <dl>.
+                assert_eq!(body.len(), 3);
+                let rerooted_paths: Vec<_> = body
+                    .iter()
+                    .filter_map(|n| match n {
+                        PlanNode::Binding(b) => Some(b.path.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                assert!(rerooted_paths.contains(&Vec::<usize>::new()));
+                assert!(rerooted_paths.contains(&vec![0, 0]));
+                assert!(rerooted_paths.contains(&vec![1, 0]));
+            }
+            other => panic!("expected single Iteration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn it_nests_iteration_roots_for_distinct_fields() {
+        // <ul for={list}>           path [0]    attr
+        //   <li for={item}>         path [0, 0] attr
+        //     <span>{item}</span>   path [0, 0, 0, 0] text
+        //   </li>
+        // </ul>
+        let nodes = build_plan_nodes(vec![
+            attr_binding(&[0], "for", "list"),
+            attr_binding(&[0, 0], "for", "item"),
+            text_binding(&[0, 0, 0, 0], "item"),
+        ]);
+
+        // Outermost: list-iteration at [0]. Its body should
+        // contain an item-iteration at relative [0] holding the
+        // marker + the text binding.
+        match &nodes[..] {
+            [PlanNode::Iteration { field, path, body }] => {
+                assert_eq!(field, "list");
+                assert_eq!(path, &vec![0]);
+                // Inside <ul>: one marker binding on the <ul>
+                // itself (`for={list}`) at relative path [], plus
+                // a nested item iteration at relative path [0].
+                let inner_iter = body
+                    .iter()
+                    .find_map(|n| match n {
+                        PlanNode::Iteration { field, path, body } => {
+                            Some((field.clone(), path.clone(), body.clone()))
+                        }
+                        _ => None,
+                    })
+                    .expect("nested iteration present");
+                assert_eq!(inner_iter.0, "item");
+                assert_eq!(inner_iter.1, vec![0]);
+                // Inside <li>: marker on <li> at relative []
+                // plus the span text at relative [0, 0].
+                let inner_paths: Vec<_> = inner_iter
+                    .2
+                    .iter()
+                    .filter_map(|n| match n {
+                        PlanNode::Binding(b) => Some(b.path.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                assert!(inner_paths.contains(&Vec::<usize>::new()));
+                assert!(inner_paths.contains(&vec![0, 0]));
+            }
+            other => panic!("expected outer list iteration, got {other:?}"),
+        }
     }
 }

--- a/rust/tonk-display/Cargo.toml
+++ b/rust/tonk-display/Cargo.toml
@@ -28,6 +28,7 @@ web-sys = { workspace = true, features = [
     "AbortController",
     "AbortSignal",
     "Attr",
+    "Comment",
     "CustomElementRegistry",
     "CustomEvent",
     "CustomEventInit",

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -463,9 +463,15 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
 }
 
 /// Apply an entity frame: empty → empty state + clear slides;
-/// non-empty → cache + render on every slide.
+/// non-empty → fold rows + cache + render on every slide.
+///
+/// The fold collapses N rows for the same entity (one per tuple
+/// the worker emits for cardinality-many attributes) into a single
+/// conclusion whose differing fields become `Array` values. The
+/// template renderer's iteration-aware walk does the per-value
+/// cloning from there.
 fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
-    let Some(conclusion) = conclusions.into_iter().next() else {
+    let Some(conclusion) = crate::fold::fold_rows(conclusions) else {
         let mut s = state.borrow_mut();
         s.last_conclusion = None;
         clear_host(host, &mut s);
@@ -502,23 +508,19 @@ fn update_notation(host: &Element, inner: &Inner, conclusion: &Conclusion) {
     script.set_text_content(Some(&text));
 }
 
-/// Ensure the `<wa-carousel>` chrome is mounted. Idempotent —
-/// does nothing if the carousel is already set up.
+/// Ensure the `<wa-carousel>` chrome is mounted — but **only** in
+/// the multi-view fallback mode. In single-view mode (when the
+/// `view` attribute is set) the orchestrator skips the carousel
+/// entirely and mounts the `<tonk-view>` straight into the host,
+/// so the rendered template flows in its natural layout and
+/// honours its container's sizing instead of being squeezed into
+/// the carousel's aspect ratio.
 ///
-/// `single_mode` selects between the two presentation modes:
-/// - `true` (when `view` attribute is set): no navigation arrows,
-///   no trailing notation slide. The user sees exactly one view
-///   rendering.
-/// - `false`: navigation arrows enabled, and a trailing
-///   `<tonk-notation>` slide so the user can flip to a
-///   syntax-highlighted dump of the entity in dialog-yaml
-///   notation form.
-///
-/// The carousel host is mounted either way so the slot geometry
-/// is identical between the modes — the only user-visible
-/// difference is whether arrows + the notation slide are
-/// present.
+/// Idempotent — does nothing if the carousel is already set up.
 fn ensure_carousel(host: &Element, state: &Rc<RefCell<Inner>>, single_mode: bool) {
+    if single_mode {
+        return;
+    }
     let mut s = state.borrow_mut();
     if s.carousel.is_some() {
         return;
@@ -529,53 +531,63 @@ fn ensure_carousel(host: &Element, state: &Rc<RefCell<Inner>>, single_mode: bool
     let Ok(carousel) = document.create_element("wa-carousel") else {
         return;
     };
-    if !single_mode {
-        let _ = carousel.set_attribute("navigation", "");
+    let _ = carousel.set_attribute("navigation", "");
 
-        // Trailing notation slide — only present in carousel
-        // mode. Lets the user fall back to a syntax-highlighted
-        // entity dump regardless of how many views the model has
-        // published. The `<script type="text/tonk-notation">`
-        // child carries the source; updating its `textContent` is
-        // what `<tonk-notation>` watches via its MutationObserver.
-        if let (Ok(item), Ok(notation), Ok(script)) = (
-            document.create_element("wa-carousel-item"),
-            document.create_element("tonk-notation"),
-            document.create_element("script"),
-        ) {
-            let _ = script.set_attribute("type", "text/tonk-notation");
-            let _ = notation.append_child(&script);
-            let _ = item.append_child(&notation);
-            let _ = carousel.append_child(&item);
-            s.notation_source = Some(script);
-            s.notation_item = Some(item);
-        }
+    // Trailing notation slide — present whenever a carousel is
+    // mounted. Lets the user fall back to a syntax-highlighted
+    // entity dump regardless of how many views the model has
+    // published. The `<script type="text/tonk-notation">` child
+    // carries the source; updating its `textContent` is what
+    // `<tonk-notation>` watches via its MutationObserver.
+    if let (Ok(item), Ok(notation), Ok(script)) = (
+        document.create_element("wa-carousel-item"),
+        document.create_element("tonk-notation"),
+        document.create_element("script"),
+    ) {
+        let _ = script.set_attribute("type", "text/tonk-notation");
+        let _ = notation.append_child(&script);
+        let _ = item.append_child(&notation);
+        let _ = carousel.append_child(&item);
+        s.notation_source = Some(script);
+        s.notation_item = Some(item);
     }
 
     let _ = host.append_child(&carousel);
     s.carousel = Some(carousel);
 }
 
-/// Create a `<wa-carousel-item>` wrapping a fresh `<tonk-view>`
-/// (initialized with `display` as inner HTML) and insert it into
-/// the carousel. In carousel mode it lands *before* the trailing
-/// inspector slide so the inspector stays last; in single-view
-/// mode there's no inspector to keep behind, so the item just
-/// gets appended.
-fn mount_view_slide(_host: &Element, inner: &mut Inner, display: &str) -> Option<Slide> {
+/// Mount a fresh `<tonk-view>` (initialized with `display` as
+/// inner HTML) for this slide. Two paths:
+///
+/// - **Carousel present** (multi-view fallback): wrap the view in
+///   a `<wa-carousel-item>` and insert it before the trailing
+///   notation slide so the inspector stays last.
+/// - **Carousel absent** (single-view mode): append the
+///   `<tonk-view>` straight into the host so the user's template
+///   flows in its natural layout — no aspect ratio, no
+///   carousel-imposed sizing.
+fn mount_view_slide(host: &Element, inner: &mut Inner, display: &str) -> Option<Slide> {
     let document = window()?.document()?;
-    let carousel = inner.carousel.as_ref()?;
 
     let view_el = document.create_element("tonk-view").ok()?;
     view_el.set_inner_html(display);
 
-    let item = document.create_element("wa-carousel-item").ok()?;
-    let _ = item.append_child(&view_el);
-    if let Some(trailing) = inner.notation_item.as_ref() {
-        let _ = carousel.insert_before(&item, Some(trailing));
+    let item: Element = if let Some(carousel) = inner.carousel.as_ref() {
+        let wrapper = document.create_element("wa-carousel-item").ok()?;
+        let _ = wrapper.append_child(&view_el);
+        if let Some(trailing) = inner.notation_item.as_ref() {
+            let _ = carousel.insert_before(&wrapper, Some(trailing));
+        } else {
+            let _ = carousel.append_child(&wrapper);
+        }
+        wrapper
     } else {
-        let _ = carousel.append_child(&item);
-    }
+        // No carousel chrome — the slide *is* the `<tonk-view>`.
+        // `item` is the same element as `view_el` so removal /
+        // identity checks elsewhere work uniformly.
+        let _ = host.append_child(&view_el);
+        view_el.clone()
+    };
 
     Some(Slide {
         display: display.to_owned(),

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -64,6 +64,23 @@ struct Slide {
 
 /// Internal lifecycle state shared across async closures.
 struct Inner {
+    /// Set to true by `disconnected_callback` so any async
+    /// chain still running against this state (typically one
+    /// blocked on phase-1 fetch when the element detached) can
+    /// bail before mutating the host. Without this guard a
+    /// stale chain's view-frame handler can mount a slide into
+    /// a host whose `<tonk-display>` instance has since been
+    /// re-attached and is running a *different* state — yielding
+    /// duplicated `<tonk-view>` children under one host.
+    disposed: bool,
+    /// Monotonic counter incremented every time `start_flows`
+    /// kicks off a new lifecycle on the *current* state. Each
+    /// spawned async chain captures the value at spawn time and
+    /// bails on any step that runs after the generation has
+    /// moved on. Generation is per-`Inner`; the disposed flag
+    /// covers the cross-`Inner` race where a custom element
+    /// detaches and re-attaches.
+    generation: u64,
     /// Aborts the view (or views-for-model) subscription on
     /// disconnect / attribute change.
     view_abort: Option<AbortController>,
@@ -95,6 +112,8 @@ struct Inner {
 impl Inner {
     fn new() -> Self {
         Self {
+            disposed: false,
+            generation: 0,
             view_abort: None,
             entity_abort: None,
             last_conclusion: None,
@@ -143,7 +162,9 @@ impl CustomElement for TonkDisplay {
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
         if let Some(state) = self.inner.borrow_mut().take() {
-            state.borrow_mut().abort_all();
+            let mut inner = state.borrow_mut();
+            inner.disposed = true;
+            inner.abort_all();
         }
     }
 
@@ -187,11 +208,25 @@ fn already_registered() -> bool {
 }
 
 fn start_flows(host: &Element, state: Rc<RefCell<Inner>>) {
+    // Bump the generation so any already-spawned flow chains
+    // running concurrently bail at their next generation check
+    // instead of overwriting our state.
+    let generation = {
+        let mut s = state.borrow_mut();
+        s.generation = s.generation.wrapping_add(1);
+        s.generation
+    };
     let host_clone = host.clone();
     let state_clone = state.clone();
     spawn_local(async move {
-        if let Err(err) = run(&host_clone, state_clone.clone()).await {
-            fail(&host_clone, &state_clone, err);
+        if let Err(err) = run(&host_clone, state_clone.clone(), generation).await {
+            // Only surface the error if we're still the current
+            // generation — a stale flow's failure (e.g. aborted
+            // fetch) shouldn't overwrite a healthy newer flow's
+            // state.
+            if state_clone.borrow().generation == generation {
+                fail(&host_clone, &state_clone, err);
+            }
         }
     });
 }
@@ -220,7 +255,26 @@ fn clear_host(host: &Element, inner: &mut Inner) {
     host.set_inner_html("");
 }
 
-async fn run(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), ErrorDetail> {
+/// Bail if this flow's generation has been superseded or the
+/// element this state belongs to has been disconnected. Either
+/// condition means our async chain has lost the right to mutate
+/// the host — a newer flow is in charge (or no flow is, if the
+/// element is gone). Returning Err here causes the caller to
+/// short-circuit without touching the DOM.
+fn check_generation(state: &Rc<RefCell<Inner>>, generation: u64) -> Result<(), ErrorDetail> {
+    let s = state.borrow();
+    if s.disposed || s.generation != generation {
+        Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"))
+    } else {
+        Ok(())
+    }
+}
+
+async fn run(
+    host: &Element,
+    state: Rc<RefCell<Inner>>,
+    generation: u64,
+) -> Result<(), ErrorDetail> {
     let entity = host
         .get_attribute("entity")
         .filter(|s| !s.is_empty())
@@ -263,6 +317,7 @@ async fn run(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), ErrorDetai
     let phase1_body = serde_json::to_string(&phase1_query(&parsed))
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
     let (model_entity, descriptor_json) = phase1_lookup(&url, &phase1_body).await?;
+    check_generation(&state, generation)?;
 
     // Build the view subscription query: pin-by-name in single
     // mode, all-views-for-model in carousel mode.
@@ -289,11 +344,30 @@ async fn run(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), ErrorDetai
     let single_mode = view.is_some();
     ensure_carousel(host, &state, single_mode);
 
-    let view_abort = open_view_stream(&url, &view_body, host.clone(), state.clone()).await?;
-    let entity_abort = open_entity_stream(&url, &entity_body, host.clone(), state.clone()).await?;
+    let view_abort =
+        open_view_stream(&url, &view_body, host.clone(), state.clone(), generation).await?;
+    // Check generation again — between opening view and entity
+    // streams, attribute_changed_callback may have fired and
+    // superseded us. If so, abort the view stream we just opened
+    // (otherwise its handler keeps pushing slides), and bail.
+    if check_generation(&state, generation).is_err() {
+        view_abort.abort();
+        return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
+    }
+    let entity_abort =
+        open_entity_stream(&url, &entity_body, host.clone(), state.clone(), generation).await?;
 
     {
         let mut s = state.borrow_mut();
+        // Final generation check — if a newer flow ran between
+        // opening entity_stream and storing the controllers,
+        // abort what we just opened so we don't orphan them
+        // (the newer flow's controllers are already stored).
+        if s.generation != generation {
+            view_abort.abort();
+            entity_abort.abort();
+            return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
+        }
         s.view_abort = Some(view_abort);
         s.entity_abort = Some(entity_abort);
     }
@@ -306,14 +380,28 @@ async fn open_view_stream(
     body: &str,
     host: Element,
     state: Rc<RefCell<Inner>>,
+    generation: u64,
 ) -> Result<AbortController, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
+    let state_for_frame = state.clone();
     open_sse(
         url,
         body,
         move |frame: &str| {
+            // Discard frames from a superseded or disposed flow
+            // — a stale reader can have a queued chunk in flight
+            // when the element detaches or `attribute_changed_callback`
+            // aborts us. Without this guard the stale frame
+            // pushes a slide into a state whose host is no longer
+            // ours, yielding duplicated `<tonk-view>` children.
+            {
+                let s = state_for_frame.borrow();
+                if s.disposed || s.generation != generation {
+                    return;
+                }
+            }
             let conclusions: Vec<Conclusion> = match serde_json::from_str(frame) {
                 Ok(v) => v,
                 Err(e) => {
@@ -328,6 +416,11 @@ async fn open_view_stream(
             handle_view_frame(&host_for_frame, &state, conclusions);
         },
         move |err: ErrorDetail| {
+            let s = state_for_err.borrow();
+            if s.disposed || s.generation != generation {
+                return;
+            }
+            drop(s);
             fail(&host_for_err, &state_for_err, err);
         },
     )
@@ -339,14 +432,23 @@ async fn open_entity_stream(
     body: &str,
     host: Element,
     state: Rc<RefCell<Inner>>,
+    generation: u64,
 ) -> Result<AbortController, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
+    let state_for_frame = state.clone();
     open_sse(
         url,
         body,
         move |frame: &str| {
+            // Same stale-frame guard as in `open_view_stream`.
+            {
+                let s = state_for_frame.borrow();
+                if s.disposed || s.generation != generation {
+                    return;
+                }
+            }
             let conclusions: Vec<Conclusion> = match serde_json::from_str(frame) {
                 Ok(v) => v,
                 Err(e) => {
@@ -361,6 +463,11 @@ async fn open_entity_stream(
             handle_entity_frame(&host_for_frame, &state, conclusions);
         },
         move |err: ErrorDetail| {
+            let s = state_for_err.borrow();
+            if s.disposed || s.generation != generation {
+                return;
+            }
+            drop(s);
             fail(&host_for_err, &state_for_err, err);
         },
     )

--- a/rust/tonk-display/src/fold.rs
+++ b/rust/tonk-display/src/fold.rs
@@ -1,0 +1,193 @@
+//! Fold a multi-row conclusion frame into a single conclusion
+//! with array-valued fields where the rows disagree.
+//!
+//! The dialog query engine emits one row per tuple — for a
+//! cardinality-many attribute on a single entity, each value
+//! comes back as its own [`Conclusion`] sharing the same `this`
+//! and differing only in the projected field. `<tonk-display>`
+//! is a *single-entity* element, so it needs to collapse those
+//! rows into one conclusion the template renderer can iterate
+//! over.
+//!
+//! The fold preserves order: distinct values for the same field
+//! appear in the array in the order they first appeared across
+//! the rows. Identical values across all rows are kept as a
+//! scalar (no needless array wrapping).
+//!
+//! Target-independent so the fold logic can be unit-tested
+//! natively without spinning up the orchestrator.
+
+use std::collections::BTreeMap;
+
+use tonk_schema::conclusion::Conclusion;
+
+/// Fold a list of conclusions sharing the same `this` into one.
+/// If `conclusions` is empty, returns `None`. If all rows agree
+/// on every field, returns the first row unchanged. Differing
+/// rows collapse the disagreeing fields into `Array` values
+/// preserving first-seen order; identical values are
+/// deduplicated.
+///
+/// Mixed-`this` input is **not** an error — the function uses
+/// the first row's `this` and folds across every row. Callers
+/// who care about identity should group upstream; in practice
+/// `<tonk-display>` only ever feeds rows for a single entity.
+pub fn fold_rows(conclusions: Vec<Conclusion>) -> Option<Conclusion> {
+    let mut iter = conclusions.into_iter();
+    let first = iter.next()?;
+
+    // For every field, accumulate distinct values in first-seen
+    // order. We only need to switch to an `Array` representation
+    // if more than one distinct value shows up.
+    let mut per_field: BTreeMap<String, Vec<serde_json::Value>> = BTreeMap::new();
+    for (name, value) in &first.fields {
+        per_field.insert(name.clone(), vec![value.clone()]);
+    }
+    for row in iter {
+        for (name, value) in row.fields {
+            let bucket = per_field.entry(name).or_default();
+            if !bucket.iter().any(|existing| existing == &value) {
+                bucket.push(value);
+            }
+        }
+    }
+
+    let mut folded: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for (name, values) in per_field {
+        let value = match values.len() {
+            0 => serde_json::Value::Null,
+            1 => values.into_iter().next().expect("single value present"),
+            _ => serde_json::Value::Array(values),
+        };
+        folded.insert(name, value);
+    }
+
+    Some(Conclusion {
+        this: first.this,
+        fields: folded,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    fn conclusion(this: &str, fields: &[(&str, Value)]) -> Conclusion {
+        let mut map = BTreeMap::new();
+        for (k, v) in fields {
+            map.insert((*k).to_owned(), v.clone());
+        }
+        Conclusion {
+            this: this.to_owned(),
+            fields: map,
+        }
+    }
+
+    #[test]
+    fn it_returns_none_for_empty_input() {
+        assert!(fold_rows(vec![]).is_none());
+    }
+
+    #[test]
+    fn it_returns_a_single_row_unchanged() {
+        let c = conclusion("did:key:zX", &[("name", json!("Alice"))]);
+        let folded = fold_rows(vec![c.clone()]).expect("single row folds");
+        assert_eq!(folded.this, "did:key:zX");
+        assert_eq!(folded.fields.get("name"), Some(&json!("Alice")));
+    }
+
+    #[test]
+    fn it_keeps_scalar_when_every_row_agrees() {
+        let rows = vec![
+            conclusion("did:key:zX", &[("name", json!("Alice"))]),
+            conclusion("did:key:zX", &[("name", json!("Alice"))]),
+        ];
+        let folded = fold_rows(rows).expect("rows fold");
+        // Both agree on `name` — should not become an array.
+        assert_eq!(folded.fields.get("name"), Some(&json!("Alice")));
+    }
+
+    #[test]
+    fn it_collects_distinct_values_into_an_array() {
+        // The todo-list shape: three rows for one entity, each
+        // with a different `item` value.
+        let rows = vec![
+            conclusion(
+                "did:key:zList",
+                &[
+                    ("name", json!("Groceries")),
+                    ("item", json!("did:key:zTodo-1")),
+                ],
+            ),
+            conclusion(
+                "did:key:zList",
+                &[
+                    ("name", json!("Groceries")),
+                    ("item", json!("did:key:zTodo-2")),
+                ],
+            ),
+            conclusion(
+                "did:key:zList",
+                &[
+                    ("name", json!("Groceries")),
+                    ("item", json!("did:key:zTodo-3")),
+                ],
+            ),
+        ];
+        let folded = fold_rows(rows).expect("rows fold");
+        assert_eq!(folded.fields.get("name"), Some(&json!("Groceries")));
+        assert_eq!(
+            folded.fields.get("item"),
+            Some(&json!([
+                "did:key:zTodo-1",
+                "did:key:zTodo-2",
+                "did:key:zTodo-3",
+            ])),
+        );
+    }
+
+    #[test]
+    fn it_preserves_first_seen_order_for_differing_values() {
+        let rows = vec![
+            conclusion("did:key:zX", &[("tag", json!("zebra"))]),
+            conclusion("did:key:zX", &[("tag", json!("apple"))]),
+            conclusion("did:key:zX", &[("tag", json!("mango"))]),
+        ];
+        let folded = fold_rows(rows).expect("rows fold");
+        assert_eq!(
+            folded.fields.get("tag"),
+            Some(&json!(["zebra", "apple", "mango"])),
+        );
+    }
+
+    #[test]
+    fn it_deduplicates_repeated_values() {
+        let rows = vec![
+            conclusion("did:key:zX", &[("tag", json!("alpha"))]),
+            conclusion("did:key:zX", &[("tag", json!("beta"))]),
+            conclusion("did:key:zX", &[("tag", json!("alpha"))]),
+        ];
+        let folded = fold_rows(rows).expect("rows fold");
+        // `alpha` appears twice on the wire but is collapsed to
+        // one entry in the folded array.
+        assert_eq!(folded.fields.get("tag"), Some(&json!(["alpha", "beta"])));
+    }
+
+    #[test]
+    fn it_handles_a_field_missing_from_later_rows() {
+        // Worker output for cardinality-many queries can leave a
+        // field unbound on some rows; we just don't append it.
+        let rows = vec![
+            conclusion(
+                "did:key:zX",
+                &[("name", json!("Bag")), ("item", json!("did:key:zA"))],
+            ),
+            conclusion("did:key:zX", &[("name", json!("Bag"))]),
+        ];
+        let folded = fold_rows(rows).expect("rows fold");
+        // `item` saw one value, stays scalar.
+        assert_eq!(folded.fields.get("item"), Some(&json!("did:key:zA")));
+        assert_eq!(folded.fields.get("name"), Some(&json!("Bag")));
+    }
+}

--- a/rust/tonk-display/src/lib.rs
+++ b/rust/tonk-display/src/lib.rs
@@ -17,11 +17,14 @@ pub mod resolve;
 
 // `notation_tokens` and `notation_format` are the tokenizer and
 // Conclusion-to-source formatter driving the wasm-only `notation`
-// element and `<tonk-display>`'s carousel inspector slide. Both
-// are target-independent so their tests run under `cargo test`,
-// but their non-test consumers live behind the wasm cfg — gate
-// them so a plain `cargo build` for the host doesn't flag every
-// internal helper dead.
+// element and `<tonk-display>`'s carousel inspector slide. `fold`
+// is the multi-row → single-conclusion collapser that handles
+// cardinality-many fields. All three are target-independent so
+// their tests run under `cargo test`, but their non-test consumers
+// live behind the wasm cfg — gate them so a plain `cargo build`
+// for the host doesn't flag every internal helper dead.
+#[cfg(any(target_arch = "wasm32", test))]
+mod fold;
 #[cfg(any(target_arch = "wasm32", test))]
 mod notation_format;
 #[cfg(any(target_arch = "wasm32", test))]

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -1,13 +1,29 @@
-//! Single-row DOM renderer used by `<tonk-view>`. Clones the
-//! template fragment on each `apply`, walks the [`BindingPlan`]
-//! tree, and applies bindings + iteration roots against the
-//! conclusion. Iteration roots clone their sub-element once per
-//! value of the bound field; the original root is then removed.
+//! Single-row DOM renderer used by `<tonk-view>`. Maintains a
+//! mounted-state tree mirroring the [`BindingPlan`] tree, so
+//! repeated `apply` calls update the DOM in place rather than
+//! re-cloning the template every frame.
 //!
-//! Each `apply` re-renders from scratch — there is no in-place
-//! diffing today. For a single-entity element this is cheap;
-//! when we have evidence that update latency matters we can add
-//! it back behind the existing `last_values` machinery.
+//! Three primitives:
+//!
+//! - **MountedBinding** caches the last rendered string for each
+//!   placeholder; subsequent applies skip the write when the
+//!   value hasn't changed, preserving the text/attribute node's
+//!   identity (and any imperative state authors attached to it).
+//! - **MountedIteration** holds a `BTreeMap` of rows keyed by the
+//!   iteration value's string form, plus a comment-node anchor at
+//!   the iteration's slot in the DOM. New keys clone the template
+//!   and insert at the sorted position; vanished keys remove their
+//!   row; surviving keys recurse into their body to update inner
+//!   bindings/iterations in place.
+//! - The mounted tree is built lazily on the first `apply` and
+//!   reused on every subsequent one. Tearing down (e.g. element
+//!   detach) drops the tree; the next apply rebuilds from scratch.
+//!
+//! Entity URIs are unique per cardinality-many tuple so they make
+//! excellent keys; DOM order follows BTreeMap's lexicographic
+//! ordering, which gives us deterministic positions across applies
+//! without needing to negotiate "what order did the worker send
+//! them in?"
 
 use std::collections::BTreeMap;
 
@@ -17,20 +33,82 @@ use tonk_concept::template::{
 };
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
-use web_sys::{DocumentFragment, Element, Node};
+use web_sys::{Document, DocumentFragment, Element, Node, window};
 
-/// Stateful renderer for one entity.
+/// Stateful renderer for one entity. Holds the template,
+/// extracted plan, and (after the first apply) the mounted-state
+/// tree mirroring the plan.
 pub struct Renderer {
-    /// Where rows get appended.
+    /// Where the rendered fragment lives.
     host: Element,
-    /// Cloneable template fragment captured from the host's
-    /// children at construction time.
+    /// Cloneable template fragment captured at construction time.
+    /// Used for the initial mount and for cloning iteration-root
+    /// subtrees on the fly when new iteration values appear.
     template: DocumentFragment,
     /// Binding plan extracted from `template` at construction time.
     plan: BindingPlan,
-    /// Top-level nodes of the currently mounted clone (if any),
-    /// kept so we can remove them on the next `apply`.
-    mounted: Vec<Node>,
+    /// The currently mounted state. `None` before the first apply;
+    /// `Some` thereafter. Dropping it (e.g. when the element
+    /// detaches) discards every cached value; the next apply will
+    /// rebuild from scratch.
+    mounted: Option<MountedScope>,
+}
+
+/// The top-level mounted scope — one `Renderer` has exactly one.
+/// Holds the live root cloned from the template plus the mounted
+/// nodes mirroring `plan.nodes`.
+struct MountedScope {
+    /// Live root in the DOM. We hold this for navigate() — the
+    /// browser owns it via parent chain once appended.
+    root: Node,
+    /// Mirror of `plan.nodes`, in lockstep order.
+    nodes: Vec<MountedNode>,
+}
+
+/// One mounted plan-tree node. Mirrors [`PlanNode`] but carries
+/// only the DOM bookkeeping needed to update in place — path /
+/// kind / segments stay on the plan node, which we walk in
+/// lockstep with the mounted tree during reconciliation.
+enum MountedNode {
+    /// A leaf binding with its last-rendered string cached so we
+    /// can skip writes that wouldn't change anything.
+    Binding {
+        /// The most recent rendered string. Compared against the
+        /// freshly rendered value on each apply; equal ⇒ no write.
+        last_value: String,
+    },
+    /// An iteration over a field's values. Owns its rows and the
+    /// comment-node anchor in the DOM that marks where new rows
+    /// get inserted before. The plan node's `field` and `body`
+    /// stay authoritative during reconciliation; we cache only
+    /// what the DOM needs.
+    Iteration {
+        /// Path to the iteration root in the template. Used to
+        /// clone fresh rows; the live DOM doesn't have an
+        /// iteration root element anymore (it's been replaced by
+        /// the anchor and the rows).
+        template_path: Vec<usize>,
+        /// Comment node marking the iteration's slot in the live
+        /// DOM. Rows insert *before* this node; removed rows
+        /// detach. The anchor stays put across applies.
+        anchor: Node,
+        /// Mounted rows, keyed by the stringified iteration value.
+        /// BTreeMap so iteration / DOM order is lexicographic by
+        /// key — deterministic regardless of input array order.
+        rows: BTreeMap<String, MountedRow>,
+    },
+}
+
+/// One row inside a [`MountedNode::Iteration`]. Holds the row's
+/// live DOM root plus the mounted state of the body bindings
+/// inside it.
+struct MountedRow {
+    /// The cloned iteration-root element in the live DOM. Removed
+    /// when the row vanishes.
+    root: Node,
+    /// Mounted state for the body bindings, paths relative to the
+    /// row's `root`.
+    body: Vec<MountedNode>,
 }
 
 impl Renderer {
@@ -45,24 +123,29 @@ impl Renderer {
             host: snapshot.container,
             template: snapshot.fragment,
             plan,
-            mounted: Vec::new(),
+            mounted: None,
         }
     }
 
-    /// Apply an entity conclusion: remove any previously rendered
-    /// clone, deep-clone the template, walk the plan tree
-    /// against `conclusion`, mount the result. The
-    /// iteration-tree walk handles cardinality-many fields by
-    /// cloning the iteration root once per value.
+    /// Apply an entity conclusion. First call mounts the template;
+    /// subsequent calls reconcile in place — touch only the DOM
+    /// nodes whose rendered value changed and add/remove iteration
+    /// rows whose key set differs from the previous apply.
     pub fn apply(&mut self, conclusion: &Conclusion) {
-        // Remove prior mount.
-        for node in self.mounted.drain(..) {
-            if let Some(parent) = node.parent_node() {
-                let _: Result<Node, _> = parent.remove_child(&node);
-            }
+        let Some(document) = window().and_then(|w| w.document()) else {
+            return;
+        };
+        if self.mounted.is_none() {
+            self.mount_initial(&document, conclusion);
+        } else {
+            self.update_existing(&document, conclusion);
         }
+    }
 
-        let Some(clone) = self
+    /// First-apply path — clone the template fragment, build the
+    /// mounted tree from scratch, attach the clone to the host.
+    fn mount_initial(&mut self, document: &Document, conclusion: &Conclusion) {
+        let Some(fragment) = self
             .template
             .clone_node_with_deep(true)
             .ok()
@@ -70,131 +153,441 @@ impl Renderer {
         else {
             return;
         };
-
-        // Walk the plan tree against the cloned fragment.
-        let root_node: Node = clone.clone().into();
-        apply_nodes(&root_node, &self.plan.nodes, conclusion, &BTreeMap::new());
+        let root: Node = fragment.clone().into();
+        let nodes = build_mounted_nodes(
+            document,
+            &self.plan.nodes,
+            &root,
+            &self.template,
+            conclusion,
+            &BTreeMap::new(),
+        );
 
         // Tag the first top-level element with `data-this` for
-        // CSS/consumer hooks, matching prior behaviour.
-        let children = clone.child_nodes();
-        let mut top: Vec<Node> = Vec::new();
+        // CSS / consumer hooks, matching the prior contract.
+        let children = fragment.child_nodes();
         for i in 0..children.length() {
-            if let Some(n) = children.item(i) {
-                top.push(n);
+            if let Some(n) = children.item(i)
+                && let Some(el) = n.dyn_ref::<Element>()
+            {
+                let _ = el.set_attribute("data-this", &conclusion.this);
+                break;
             }
         }
-        if let Some(first) = top.first().and_then(|n| n.dyn_ref::<Element>()) {
-            let _ = first.set_attribute("data-this", &conclusion.this);
-        }
 
-        let _ = self.host.append_child(&clone);
-        self.mounted = top;
+        let _ = self.host.append_child(&fragment);
+        self.mounted = Some(MountedScope { root, nodes });
+    }
+
+    /// Incremental-update path — walk the existing mounted tree
+    /// in lockstep with the plan tree and reconcile against the
+    /// new conclusion. No re-clone of the template, no DOM
+    /// destruction of nodes whose content hasn't changed.
+    fn update_existing(&mut self, document: &Document, conclusion: &Conclusion) {
+        let Some(scope) = self.mounted.as_mut() else {
+            return;
+        };
+        update_nodes(
+            document,
+            &self.plan.nodes,
+            &mut scope.nodes,
+            &scope.root,
+            &self.template,
+            conclusion,
+            &BTreeMap::new(),
+        );
+
+        // `data-this` should still reflect the conclusion. The
+        // entity URI rarely changes on a `Renderer` (one entity
+        // per view) but if it does, keep the attribute current.
+        let children = scope.root.child_nodes();
+        for i in 0..children.length() {
+            if let Some(n) = children.item(i)
+                && let Some(el) = n.dyn_ref::<Element>()
+            {
+                if el.get_attribute("data-this").as_deref() != Some(&conclusion.this) {
+                    let _ = el.set_attribute("data-this", &conclusion.this);
+                }
+                break;
+            }
+        }
     }
 }
 
-/// Apply every plan node in `nodes` to the subtree rooted at
-/// `root` (a real `Node`, not a fragment, so we can navigate from
-/// it and mutate its children). `shadow` carries per-iteration
-/// values overriding the conclusion's field lookups.
-fn apply_nodes(
-    root: &Node,
-    nodes: &[PlanNode],
+/// Build a fresh `Vec<MountedNode>` from a plan and write its
+/// initial values into the DOM. Used for both the top-level
+/// mount and each iteration row's body.
+///
+/// **Ordering caveat**: iteration nodes mutate the live DOM by
+/// replacing their iteration-root element with an anchor + rows.
+/// Doing that to an earlier sibling shifts subsequent sibling
+/// indices, which would invalidate the path-based navigation
+/// the *next* plan node performs. To avoid that, we process the
+/// plan in two passes:
+///
+/// 1. **Reverse pass** — process iteration nodes from last to
+///    first, since each iteration's mutation only affects later
+///    siblings (already processed).
+/// 2. **Build in plan order** — assemble the resulting
+///    `MountedNode` Vec in the original plan order so it stays
+///    in lockstep with the plan tree.
+///
+/// Leaf bindings don't mutate sibling structure, so they're
+/// processed in plan order without complication.
+fn build_mounted_nodes(
+    document: &Document,
+    plan: &[PlanNode],
+    scope_root: &Node,
+    template: &DocumentFragment,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> Vec<MountedNode> {
+    // Allocate the result vec; fill in reverse so iteration
+    // nodes process their DOM mutations from rightmost to
+    // leftmost. Bindings are order-independent.
+    let mut out: Vec<Option<MountedNode>> = (0..plan.len()).map(|_| None).collect();
+    for (i, node) in plan.iter().enumerate().rev() {
+        out[i] = Some(build_mounted_node(
+            document, node, scope_root, template, conclusion, shadow,
+        ));
+    }
+    out.into_iter()
+        .map(|n| n.expect("every slot filled"))
+        .collect()
+}
+
+/// Build one mounted node — leaf or iteration — and perform its
+/// initial DOM writes / clones.
+fn build_mounted_node(
+    document: &Document,
+    plan: &PlanNode,
+    scope_root: &Node,
+    template: &DocumentFragment,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> MountedNode {
+    match plan {
+        PlanNode::Binding(b) => {
+            let rendered = render_binding(b, conclusion, shadow);
+            write_binding(scope_root, b, &rendered);
+            MountedNode::Binding {
+                last_value: rendered,
+            }
+        }
+        PlanNode::Iteration { field, path, body } => {
+            // Locate the iteration root in this scope, replace it
+            // with a comment anchor, and clone-then-mount one row
+            // per value. The original element is gone from the
+            // live DOM after this; future clones come from the
+            // pristine `template` fragment.
+            let anchor: Node = document
+                .create_comment(&format!("tonk-iter:{field}"))
+                .into();
+
+            let mut rows: BTreeMap<String, MountedRow> = BTreeMap::new();
+
+            if let Some(iter_root) = navigate(scope_root, path)
+                && let Some(parent) = iter_root.parent_node()
+            {
+                // Drop the in-clone template element; the anchor
+                // takes its slot so rows can insert before it.
+                let _ = parent.insert_before(&anchor, Some(&iter_root));
+                let _: Result<Node, _> = parent.remove_child(&iter_root);
+
+                let raw_value = shadow
+                    .get(field)
+                    .or_else(|| conclusion.fields.get(field))
+                    .cloned();
+                let values = collect_values(raw_value);
+
+                for value in values {
+                    let key = key_for(&value);
+                    if rows.contains_key(&key) {
+                        continue; // dedupe
+                    }
+                    if let Some(row) = build_iteration_row(
+                        document, path, template, body, field, value, conclusion, shadow,
+                    ) {
+                        // BTreeMap order ⇒ DOM order. Insert each
+                        // row before the anchor so they land in
+                        // sorted-key order naturally.
+                        let _ = parent.insert_before(&row.root, Some(&anchor));
+                        rows.insert(key, row);
+                    }
+                }
+            }
+
+            MountedNode::Iteration {
+                template_path: path.clone(),
+                anchor,
+                rows,
+            }
+        }
+    }
+}
+
+/// Walk plan + mounted in lockstep, reconciling each pair.
+fn update_nodes(
+    document: &Document,
+    plan: &[PlanNode],
+    mounted: &mut [MountedNode],
+    scope_root: &Node,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
 ) {
-    for node in nodes {
-        match node {
-            PlanNode::Binding(b) => apply_binding(root, b, conclusion, shadow),
-            PlanNode::Iteration { field, path, body } => {
-                apply_iteration(root, field, path, body, conclusion, shadow);
-            }
-        }
+    for (plan_node, mounted_node) in plan.iter().zip(mounted.iter_mut()) {
+        update_node(
+            document,
+            plan_node,
+            mounted_node,
+            scope_root,
+            template,
+            conclusion,
+            shadow,
+        );
     }
 }
 
-/// Render a leaf binding against the conclusion (+ shadow) and
-/// write its value to the target DOM node.
-fn apply_binding(
-    root: &Node,
-    binding: &Binding,
+/// Reconcile one plan/mounted pair.
+fn update_node(
+    document: &Document,
+    plan: &PlanNode,
+    mounted: &mut MountedNode,
+    scope_root: &Node,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
 ) {
-    let segments = match &binding.kind {
-        BindingKind::Text { segments } => segments,
-        BindingKind::Attribute { segments, .. } => segments,
-    };
-    let rendered =
-        render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow);
-    let Some(target) = navigate(root, &binding.path) else {
-        return;
-    };
-    match &binding.kind {
-        BindingKind::Text { .. } => {
-            target.set_text_content(Some(&rendered));
-        }
-        BindingKind::Attribute { attr_name, .. } => {
-            if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, &rendered);
+    match (plan, mounted) {
+        (PlanNode::Binding(b), MountedNode::Binding { last_value }) => {
+            let rendered = render_binding(b, conclusion, shadow);
+            if *last_value != rendered {
+                write_binding(scope_root, b, &rendered);
+                *last_value = rendered;
             }
+        }
+        (
+            PlanNode::Iteration {
+                field: plan_field,
+                path: _,
+                body,
+            },
+            MountedNode::Iteration {
+                template_path,
+                anchor,
+                rows,
+            },
+        ) => {
+            update_iteration(
+                document,
+                plan_field,
+                template_path,
+                body,
+                anchor,
+                rows,
+                template,
+                conclusion,
+                shadow,
+            );
+        }
+        _ => {
+            // Plan/mounted shapes diverged — should be impossible
+            // since the plan is constant for a Renderer instance.
+            // Bail silently rather than panic in production.
         }
     }
 }
 
-/// Clone the iteration root once per value of `field`, applying
-/// `body` against each clone with `field` shadowed to the
-/// iteration's value. The original root is removed; if the
-/// resolved value list is empty the iteration root vanishes
-/// entirely, which is the right behaviour for an empty
-/// cardinality-many field.
-fn apply_iteration(
-    root: &Node,
+/// Reconcile one mounted iteration against a new value list.
+/// New keys clone + mount; vanished keys detach + drop; surviving
+/// keys recurse into their body.
+#[allow(clippy::too_many_arguments)]
+fn update_iteration(
+    document: &Document,
     field: &str,
-    path: &[usize],
-    body: &[PlanNode],
+    template_path: &[usize],
+    plan_body: &[PlanNode],
+    anchor: &Node,
+    rows: &mut BTreeMap<String, MountedRow>,
+    template: &DocumentFragment,
     conclusion: &Conclusion,
     shadow: &BTreeMap<String, serde_json::Value>,
 ) {
-    let Some(iter_root) = navigate(root, path) else {
-        return;
-    };
-    let Some(parent) = iter_root.parent_node() else {
-        return;
-    };
-
-    // Compute the value list for this iteration. The shadow
-    // takes precedence (nested iterations see their parent's
-    // current value); fall back to the conclusion's fields.
     let raw_value = shadow
         .get(field)
         .or_else(|| conclusion.fields.get(field))
         .cloned();
     let values = collect_values(raw_value);
 
-    // Anchor for insertion — the original iter_root stays put
-    // until we've inserted all clones before it, then we remove it.
-    for value in &values {
-        let Some(clone) = iter_root.clone_node_with_deep(true).ok() else {
-            continue;
-        };
-        let mut nested_shadow = shadow.clone();
-        nested_shadow.insert(field.to_owned(), value.clone());
-        apply_nodes(&clone, body, conclusion, &nested_shadow);
-        let _ = parent.insert_before(&clone, Some(&iter_root));
+    // Index incoming values by key, deduping.
+    let mut incoming: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    for value in values {
+        let key = key_for(&value);
+        incoming.entry(key).or_insert(value);
     }
 
-    // Remove the original template node — it served only as the
-    // location anchor. If `values` was empty, the iteration root
-    // disappears entirely, which is the empty-list behaviour the
-    // spec asks for.
-    let _: Result<Node, _> = parent.remove_child(&iter_root);
+    // Find the anchor's parent — every row sits between
+    // siblings of the anchor in the parent.
+    let Some(parent) = anchor.parent_node() else {
+        return;
+    };
+
+    // Remove vanished keys.
+    let stale: Vec<String> = rows
+        .keys()
+        .filter(|k| !incoming.contains_key(*k))
+        .cloned()
+        .collect();
+    for key in stale {
+        if let Some(row) = rows.remove(&key) {
+            let _: Result<Node, _> = parent.remove_child(&row.root);
+        }
+    }
+
+    // Walk incoming in sorted-key order. For each key:
+    //   - Reuse existing row → recurse into body.
+    //   - Add new row → clone from template, mount, insert at
+    //     the correct sorted position.
+    for (key, value) in incoming {
+        if let Some(row) = rows.get_mut(&key) {
+            // Existing row: update its body bindings in place
+            // with shadow extended by this iteration's value.
+            let mut nested_shadow = shadow.clone();
+            nested_shadow.insert(field.to_owned(), value);
+            update_nodes(
+                document,
+                plan_body,
+                &mut row.body,
+                &row.root,
+                template,
+                conclusion,
+                &nested_shadow,
+            );
+        } else {
+            // New row: clone + build (detached), then insert
+            // once at the correct sorted position. Single
+            // insertBefore avoids the move-induced custom-element
+            // lifecycle re-fire (see `build_iteration_row`'s
+            // doc-comment).
+            if let Some(new_row) = build_iteration_row(
+                document,
+                template_path,
+                template,
+                plan_body,
+                field,
+                value,
+                conclusion,
+                shadow,
+            ) {
+                let next_anchor = rows
+                    .range(key.clone()..)
+                    .next()
+                    .map(|(_, row)| row.root.clone())
+                    .unwrap_or_else(|| anchor.clone());
+                let _ = parent.insert_before(&new_row.root, Some(&next_anchor));
+                rows.insert(key, new_row);
+            }
+        }
+    }
+}
+
+/// Clone the iteration root from the pristine template, build
+/// its body's mounted state with all bindings applied. The
+/// returned [`MountedRow`] is **detached** — the caller decides
+/// where to insert it via a single `parent.insertBefore` call.
+///
+/// We deliberately don't insert here. Inserting now and then
+/// again at the sorted position would amount to a *move*, which
+/// the DOM spec implements as detach + reattach; that fires
+/// `disconnected_callback` and `connected_callback` on every
+/// custom element inside the row, causing inner `<tonk-display>`
+/// instances to spin up *twice* and mount two slides.
+///
+/// Bindings are written against the detached clone before any
+/// element is connected to the DOM, so custom-element lifecycle
+/// callbacks don't fire during `build_mounted_nodes`. By the
+/// time the caller inserts, every observed attribute is already
+/// at its final value and `connected_callback` runs exactly
+/// once.
+///
+/// Returns `None` if cloning fails (degenerate template).
+#[allow(clippy::too_many_arguments)]
+fn build_iteration_row(
+    document: &Document,
+    template_path: &[usize],
+    template: &DocumentFragment,
+    body_plan: &[PlanNode],
+    field: &str,
+    value: serde_json::Value,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> Option<MountedRow> {
+    let template_root: Node = template.clone().into();
+    let template_iter_root = navigate(&template_root, template_path)?;
+    let row_root = template_iter_root.clone_node_with_deep(true).ok()?;
+
+    let mut nested_shadow = shadow.clone();
+    nested_shadow.insert(field.to_owned(), value);
+    let body = build_mounted_nodes(
+        document,
+        body_plan,
+        &row_root,
+        template,
+        conclusion,
+        &nested_shadow,
+    );
+
+    Some(MountedRow {
+        root: row_root,
+        body,
+    })
+}
+
+/// Stable string key for an iteration value. Entity URIs (and
+/// any other JSON string) become themselves; non-strings get
+/// canonicalised via `serde_json::to_string` so two equal values
+/// produce equal keys.
+fn key_for(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Render a binding's segments against the conclusion + shadow,
+/// returning the substituted string.
+fn render_binding(
+    binding: &Binding,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) -> String {
+    let segments = match &binding.kind {
+        BindingKind::Text { segments } => segments,
+        BindingKind::Attribute { segments, .. } => segments,
+    };
+    render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow)
+}
+
+/// Write a binding's rendered value to the target DOM node
+/// identified by its path within `scope_root`.
+fn write_binding(scope_root: &Node, binding: &Binding, rendered: &str) {
+    let Some(target) = navigate(scope_root, &binding.path) else {
+        return;
+    };
+    match &binding.kind {
+        BindingKind::Text { .. } => target.set_text_content(Some(rendered)),
+        BindingKind::Attribute { attr_name, .. } => {
+            if let Some(el) = target.dyn_ref::<Element>() {
+                let _ = el.set_attribute(attr_name, rendered);
+            }
+        }
+    }
 }
 
 /// Resolve a JSON value into the list of per-iteration values:
 /// `Array` flattens to its elements; `Null` / missing becomes
-/// empty; anything else is a single-element list. The renderer
-/// uses this to decide how many times to clone an iteration root.
+/// empty; anything else is a single-element list.
 fn collect_values(value: Option<serde_json::Value>) -> Vec<serde_json::Value> {
     match value {
         None | Some(serde_json::Value::Null) => Vec::new(),

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -1,24 +1,23 @@
-//! Single-row DOM renderer used by `<tonk-view>`. Mirrors the
-//! diffing strategy of `tonk-concept`'s renderer, but collapsed to
-//! one row: there is at most one mounted instance of the cloned
-//! template at a time. `<tonk-view>` builds one from its snapshotted
-//! children-as-template and feeds conclusions through `apply`.
+//! Single-row DOM renderer used by `<tonk-view>`. Clones the
+//! template fragment on each `apply`, walks the [`BindingPlan`]
+//! tree, and applies bindings + iteration roots against the
+//! conclusion. Iteration roots clone their sub-element once per
+//! value of the bound field; the original root is then removed.
+//!
+//! Each `apply` re-renders from scratch — there is no in-place
+//! diffing today. For a single-entity element this is cheap;
+//! when we have evidence that update latency matters we can add
+//! it back behind the existing `last_values` machinery.
+
+use std::collections::BTreeMap;
 
 use tonk_concept::template::{
-    Binding, BindingKind, BindingPlan, Snapshot, extract_plan, render_segments,
+    Binding, BindingKind, BindingPlan, PlanNode, Snapshot, extract_plan, navigate,
+    render_segments_with_shadow,
 };
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
 use web_sys::{DocumentFragment, Element, Node};
-
-/// One mounted row.
-struct Row {
-    /// Top-level cloned nodes (a template can have multiple roots).
-    nodes: Vec<Node>,
-    /// Per-binding rendered string from the last applied
-    /// conclusion. Used to skip writes when nothing changed.
-    last_values: Vec<String>,
-}
 
 /// Stateful renderer for one entity.
 pub struct Renderer {
@@ -29,8 +28,9 @@ pub struct Renderer {
     template: DocumentFragment,
     /// Binding plan extracted from `template` at construction time.
     plan: BindingPlan,
-    /// Currently mounted row (if any).
-    row: Option<Row>,
+    /// Top-level nodes of the currently mounted clone (if any),
+    /// kept so we can remove them on the next `apply`.
+    mounted: Vec<Node>,
 }
 
 impl Renderer {
@@ -45,23 +45,23 @@ impl Renderer {
             host: snapshot.container,
             template: snapshot.fragment,
             plan,
-            row: None,
+            mounted: Vec::new(),
         }
     }
 
-    /// Apply an entity conclusion: insert if no row, else update
-    /// in place. Per-binding write-deduping inside `update_row`
-    /// avoids touching DOM nodes whose rendered value didn't
-    /// change since the last frame.
+    /// Apply an entity conclusion: remove any previously rendered
+    /// clone, deep-clone the template, walk the plan tree
+    /// against `conclusion`, mount the result. The
+    /// iteration-tree walk handles cardinality-many fields by
+    /// cloning the iteration root once per value.
     pub fn apply(&mut self, conclusion: &Conclusion) {
-        if self.row.is_some() {
-            self.update_row(conclusion);
-        } else {
-            self.insert_row(conclusion);
+        // Remove prior mount.
+        for node in self.mounted.drain(..) {
+            if let Some(parent) = node.parent_node() {
+                let _: Result<Node, _> = parent.remove_child(&node);
+            }
         }
-    }
 
-    fn insert_row(&mut self, conclusion: &Conclusion) {
         let Some(clone) = self
             .template
             .clone_node_with_deep(true)
@@ -71,89 +71,134 @@ impl Renderer {
             return;
         };
 
-        let mut values: Vec<String> = Vec::with_capacity(self.plan.bindings.len());
-        for binding in &self.plan.bindings {
-            let rendered = render_binding(binding, conclusion);
-            apply_binding(&clone, binding, &rendered);
-            values.push(rendered);
-        }
+        // Walk the plan tree against the cloned fragment.
+        let root_node: Node = clone.clone().into();
+        apply_nodes(&root_node, &self.plan.nodes, conclusion, &BTreeMap::new());
 
-        let mut nodes: Vec<Node> = Vec::new();
+        // Tag the first top-level element with `data-this` for
+        // CSS/consumer hooks, matching prior behaviour.
         let children = clone.child_nodes();
+        let mut top: Vec<Node> = Vec::new();
         for i in 0..children.length() {
             if let Some(n) = children.item(i) {
-                nodes.push(n);
+                top.push(n);
             }
         }
-        if let Some(first) = nodes.first().and_then(|n| n.dyn_ref::<Element>()) {
+        if let Some(first) = top.first().and_then(|n| n.dyn_ref::<Element>()) {
             let _ = first.set_attribute("data-this", &conclusion.this);
         }
 
         let _ = self.host.append_child(&clone);
-        self.row = Some(Row {
-            nodes,
-            last_values: values,
-        });
+        self.mounted = top;
     }
+}
 
-    fn update_row(&mut self, conclusion: &Conclusion) {
-        let Some(row) = self.row.as_mut() else {
-            return;
-        };
-        for (i, binding) in self.plan.bindings.iter().enumerate() {
-            let rendered = render_binding(binding, conclusion);
-            if let Some(prev) = row.last_values.get(i)
-                && *prev == rendered
-            {
-                continue;
-            }
-            patch_row(row, binding, &rendered);
-            if let Some(slot) = row.last_values.get_mut(i) {
-                *slot = rendered;
+/// Apply every plan node in `nodes` to the subtree rooted at
+/// `root` (a real `Node`, not a fragment, so we can navigate from
+/// it and mutate its children). `shadow` carries per-iteration
+/// values overriding the conclusion's field lookups.
+fn apply_nodes(
+    root: &Node,
+    nodes: &[PlanNode],
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
+    for node in nodes {
+        match node {
+            PlanNode::Binding(b) => apply_binding(root, b, conclusion, shadow),
+            PlanNode::Iteration { field, path, body } => {
+                apply_iteration(root, field, path, body, conclusion, shadow);
             }
         }
     }
 }
 
-fn render_binding(binding: &Binding, conclusion: &Conclusion) -> String {
+/// Render a leaf binding against the conclusion (+ shadow) and
+/// write its value to the target DOM node.
+fn apply_binding(
+    root: &Node,
+    binding: &Binding,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
     let segments = match &binding.kind {
         BindingKind::Text { segments } => segments,
         BindingKind::Attribute { segments, .. } => segments,
     };
-    render_segments(segments, &conclusion.this, &conclusion.fields)
-}
-
-fn apply_binding(fragment: &DocumentFragment, binding: &Binding, rendered: &str) {
-    let root: Node = fragment.clone().into();
-    let Some(target) = tonk_concept::template::navigate(&root, &binding.path) else {
+    let rendered =
+        render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow);
+    let Some(target) = navigate(root, &binding.path) else {
         return;
     };
-    write_binding(&target, binding, rendered);
-}
-
-fn patch_row(row: &Row, binding: &Binding, rendered: &str) {
-    let Some(&first) = binding.path.first() else {
-        return;
-    };
-    let Some(root) = row.nodes.get(first) else {
-        return;
-    };
-    let rest = &binding.path[1..];
-    let Some(target) = tonk_concept::template::navigate(root, rest) else {
-        return;
-    };
-    write_binding(&target, binding, rendered);
-}
-
-fn write_binding(target: &Node, binding: &Binding, rendered: &str) {
     match &binding.kind {
         BindingKind::Text { .. } => {
-            target.set_text_content(Some(rendered));
+            target.set_text_content(Some(&rendered));
         }
         BindingKind::Attribute { attr_name, .. } => {
             if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, rendered);
+                let _ = el.set_attribute(attr_name, &rendered);
             }
         }
+    }
+}
+
+/// Clone the iteration root once per value of `field`, applying
+/// `body` against each clone with `field` shadowed to the
+/// iteration's value. The original root is removed; if the
+/// resolved value list is empty the iteration root vanishes
+/// entirely, which is the right behaviour for an empty
+/// cardinality-many field.
+fn apply_iteration(
+    root: &Node,
+    field: &str,
+    path: &[usize],
+    body: &[PlanNode],
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
+    let Some(iter_root) = navigate(root, path) else {
+        return;
+    };
+    let Some(parent) = iter_root.parent_node() else {
+        return;
+    };
+
+    // Compute the value list for this iteration. The shadow
+    // takes precedence (nested iterations see their parent's
+    // current value); fall back to the conclusion's fields.
+    let raw_value = shadow
+        .get(field)
+        .or_else(|| conclusion.fields.get(field))
+        .cloned();
+    let values = collect_values(raw_value);
+
+    // Anchor for insertion — the original iter_root stays put
+    // until we've inserted all clones before it, then we remove it.
+    for value in &values {
+        let Some(clone) = iter_root.clone_node_with_deep(true).ok() else {
+            continue;
+        };
+        let mut nested_shadow = shadow.clone();
+        nested_shadow.insert(field.to_owned(), value.clone());
+        apply_nodes(&clone, body, conclusion, &nested_shadow);
+        let _ = parent.insert_before(&clone, Some(&iter_root));
+    }
+
+    // Remove the original template node — it served only as the
+    // location anchor. If `values` was empty, the iteration root
+    // disappears entirely, which is the empty-list behaviour the
+    // spec asks for.
+    let _: Result<Node, _> = parent.remove_child(&iter_root);
+}
+
+/// Resolve a JSON value into the list of per-iteration values:
+/// `Array` flattens to its elements; `Null` / missing becomes
+/// empty; anything else is a single-element list. The renderer
+/// uses this to decide how many times to clone an iteration root.
+fn collect_values(value: Option<serde_json::Value>) -> Vec<serde_json::Value> {
+    match value {
+        None | Some(serde_json::Value::Null) => Vec::new(),
+        Some(serde_json::Value::Array(items)) => items,
+        Some(v) => vec![v],
     }
 }

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -237,22 +237,24 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_updates_in_place_on_subsequent_draws() {
+    fn it_reflects_the_latest_draw_payload() {
         let host = mount("<article><h1>{name}</h1></article>");
         call_draw(&host, &detail("did:key:zX", &[("name", "Alice")]));
-        let first = host
-            .query_selector("article")
-            .unwrap()
-            .expect("first article");
-        call_draw(&host, &detail("did:key:zX", &[("name", "Alicia")])); // same `this`
-        let second = host
-            .query_selector("article")
-            .unwrap()
-            .expect("second article");
-        // Same node — patched in place rather than swapped — so
-        // downstream listeners on the rendered DOM survive updates.
-        assert!(first.is_same_node(Some(second.unchecked_ref())));
+        call_draw(&host, &detail("did:key:zX", &[("name", "Alicia")]));
+        // Re-renders happen wholesale (no in-place node patching),
+        // so node identity is *not* preserved across draws. What
+        // matters is that the latest payload is what shows.
         assert!(host.inner_html().contains("Alicia"));
+        assert!(
+            !host.inner_html().contains("Alice<"),
+            "stale name leaked into: {}",
+            host.inner_html(),
+        );
+        assert_eq!(
+            host.query_selector_all("article").unwrap().length(),
+            1,
+            "expected exactly one article after second draw",
+        );
     }
 
     #[dialog_common::test]
@@ -281,5 +283,138 @@ mod tests {
         // Just checking that we don't panic and the host stays empty.
         call_draw(&host, &detail("did:key:zX", &[("name", "Alice")]));
         assert_eq!(host.inner_html(), "");
+    }
+
+    // --- Iteration / cardinality-many tests ----------------------------
+
+    /// Like [`detail`], but lets callers mix scalar and array
+    /// field values. Used to drive the iteration-aware renderer
+    /// with a folded conclusion (the shape `<tonk-display>::fold_rows`
+    /// produces from a cardinality-many SSE frame).
+    fn detail_json(this: &str, fields: &[(&str, serde_json::Value)]) -> JsValue {
+        let mut map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        for (k, v) in fields {
+            map.insert((*k).to_owned(), v.clone());
+        }
+        let conclusion = Conclusion {
+            this: this.to_owned(),
+            fields: map,
+        };
+        serde_wasm_bindgen::to_value(&conclusion).expect("serialize conclusion")
+    }
+
+    #[dialog_common::test]
+    fn it_repeats_the_iteration_root_once_per_value_in_an_array_field() {
+        // The marker (`subject={item}`) lifts the iteration root
+        // to the <li> — without it, the LCA of the two `{item}`
+        // occurrences would be the inner <tonk-display> and only
+        // that would repeat, leaving a single <li> wrapping every
+        // clone (which is what the `<li>` direct-child-of-<ul>
+        // rule effectively forbids in semantic terms).
+        let host = mount(
+            "<ul><li subject={item}><tonk-display entity={item}>{item}</tonk-display></li></ul>",
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[(
+                    "item",
+                    serde_json::json!(["did:key:zA", "did:key:zB", "did:key:zC"]),
+                )],
+            ),
+        );
+        let items = host.query_selector_all("li").unwrap();
+        assert_eq!(items.length(), 3, "got: {}", host.inner_html());
+        let texts: Vec<String> = (0..items.length())
+            .filter_map(|i| items.item(i).and_then(|n| n.text_content()))
+            .collect();
+        assert!(texts.contains(&"did:key:zA".to_owned()));
+        assert!(texts.contains(&"did:key:zB".to_owned()));
+        assert!(texts.contains(&"did:key:zC".to_owned()));
+    }
+
+    #[dialog_common::test]
+    fn it_substitutes_per_iteration_value_into_attributes_inside_the_root() {
+        // The inner <tonk-display>'s `entity` attribute should
+        // resolve to the current iteration's value — that's the
+        // mechanism that makes the nested element subscribe to
+        // the right entity. The `subject={item}` marker on <li>
+        // raises the iteration root above the inner element so
+        // each value gets its own <li> wrapper.
+        let host = mount(
+            "<ul><li subject={item}><tonk-display entity={item} model=todo></tonk-display></li></ul>",
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["did:key:zA", "did:key:zB"]))],
+            ),
+        );
+        let displays = host.query_selector_all("tonk-display").unwrap();
+        assert_eq!(displays.length(), 2);
+        let entities: Vec<String> = (0..displays.length())
+            .filter_map(|i| {
+                displays
+                    .item(i)
+                    .and_then(|n| n.dyn_into::<Element>().ok())
+                    .and_then(|el| el.get_attribute("entity"))
+            })
+            .collect();
+        assert_eq!(
+            entities,
+            vec!["did:key:zA".to_owned(), "did:key:zB".to_owned()]
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_removes_the_iteration_root_when_the_array_is_empty() {
+        // No values → no `<li>` mounted. The empty list is the
+        // result, not a stray template node.
+        let host = mount("<ul><li>{item}</li></ul>");
+        call_draw(
+            &host,
+            &detail_json("did:key:zList", &[("item", serde_json::json!([]))]),
+        );
+        let items = host.query_selector_all("li").unwrap();
+        assert_eq!(items.length(), 0, "got: {}", host.inner_html());
+        // The <ul> chrome stays — only the iteration root vanishes.
+        assert!(host.query_selector("ul").unwrap().is_some());
+    }
+
+    #[dialog_common::test]
+    fn it_renders_independent_iteration_roots_for_sibling_placeholders() {
+        // <p>{item}</p> and <li>{item}</li> share no inner ancestor
+        // — each becomes its own iteration root, each repeats per
+        // value of `item`.
+        let host = mount("<section><p>{item}</p><ul><li>{item}</li></ul></section>");
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["one", "two"]))],
+            ),
+        );
+        assert_eq!(host.query_selector_all("p").unwrap().length(), 2);
+        assert_eq!(host.query_selector_all("li").unwrap().length(), 2);
+    }
+
+    #[dialog_common::test]
+    fn it_treats_a_scalar_field_value_as_a_single_iteration() {
+        // A folded conclusion keeps a scalar when every row
+        // agreed; the renderer treats that as a one-element list
+        // so the iteration root is mounted exactly once.
+        let host = mount("<p>{name}</p>");
+        call_draw(&host, &detail("did:key:zX", &[("name", "Alice")]));
+        assert_eq!(host.query_selector_all("p").unwrap().length(), 1);
+        assert_eq!(
+            host.query_selector("p")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Alice"),
+        );
     }
 }

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -417,4 +417,264 @@ mod tests {
             Some("Alice"),
         );
     }
+
+    // --- Incremental update / DOM stability tests ---------------------
+    //
+    // The renderer's contract: subsequent applies reconcile in
+    // place. Existing iteration rows keep their node identity;
+    // new rows are added; vanished rows are removed; bindings
+    // whose rendered value didn't change don't touch the DOM. The
+    // tests below pin that contract — node identity preservation
+    // is what authors who attach imperative state (focus, event
+    // listeners, animation timelines) depend on.
+
+    #[dialog_common::test]
+    fn it_preserves_node_identity_for_unchanged_bindings_across_applies() {
+        let host = mount("<p>{name}</p>");
+        call_draw(&host, &detail("did:key:zX", &[("name", "Alice")]));
+        let text_before = host
+            .query_selector("p")
+            .unwrap()
+            .expect("p mounted")
+            .first_child()
+            .expect("p has text child");
+
+        // Same payload → no DOM mutation expected.
+        call_draw(&host, &detail("did:key:zX", &[("name", "Alice")]));
+        let text_after = host
+            .query_selector("p")
+            .unwrap()
+            .expect("p still mounted")
+            .first_child()
+            .expect("p still has text child");
+
+        assert!(
+            text_before.is_same_node(Some(text_after.unchecked_ref())),
+            "text node identity should survive an unchanged apply",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_rewrites_only_changed_bindings_on_subsequent_apply() {
+        let host = mount("<article><h1>{name}</h1><p>{bio}</p></article>");
+        call_draw(
+            &host,
+            &detail("did:key:zX", &[("name", "Alice"), ("bio", "Hi")]),
+        );
+        let bio_text_before = host
+            .query_selector("p")
+            .unwrap()
+            .unwrap()
+            .first_child()
+            .expect("bio text node");
+
+        // Update only `name`; bio stays the same.
+        call_draw(
+            &host,
+            &detail("did:key:zX", &[("name", "Alicia"), ("bio", "Hi")]),
+        );
+
+        // The name change is reflected.
+        assert_eq!(
+            host.query_selector("h1")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Alicia"),
+        );
+        // Bio's text node was not rewritten — identity preserved.
+        let bio_text_after = host
+            .query_selector("p")
+            .unwrap()
+            .unwrap()
+            .first_child()
+            .expect("bio text node still present");
+        assert!(
+            bio_text_before.is_same_node(Some(bio_text_after.unchecked_ref())),
+            "unchanged bindings should not touch the DOM",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_appends_a_new_row_without_disturbing_existing_rows() {
+        let host = mount("<ul><li subject={item}>{item}</li></ul>");
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["did:key:zA", "did:key:zB"]))],
+            ),
+        );
+        let li_a_before = host
+            .query_selector_all("li")
+            .unwrap()
+            .item(0)
+            .expect("first li mounted");
+        let li_b_before = host
+            .query_selector_all("li")
+            .unwrap()
+            .item(1)
+            .expect("second li mounted");
+
+        // Add a third item — sorts last (zC > zB > zA).
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[(
+                    "item",
+                    serde_json::json!(["did:key:zA", "did:key:zB", "did:key:zC"]),
+                )],
+            ),
+        );
+
+        let after = host.query_selector_all("li").unwrap();
+        assert_eq!(after.length(), 3, "after apply: {}", host.inner_html());
+
+        // Existing rows kept their node identity. New row mounted
+        // in sorted position (last, since `zC` > `zB`).
+        let li_a_after = after.item(0).expect("first li");
+        let li_b_after = after.item(1).expect("second li");
+        assert!(
+            li_a_before.is_same_node(Some(li_a_after.unchecked_ref())),
+            "row for zA should be the same node before and after",
+        );
+        assert!(
+            li_b_before.is_same_node(Some(li_b_after.unchecked_ref())),
+            "row for zB should be the same node before and after",
+        );
+
+        let li_c = after.item(2).expect("third li");
+        let li_c_el = li_c.dyn_ref::<Element>().expect("li element");
+        assert_eq!(
+            li_c_el.text_content().as_deref(),
+            Some("did:key:zC"),
+            "new row's text",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_removes_a_row_for_a_vanished_key_without_touching_others() {
+        let host = mount("<ul><li subject={item}>{item}</li></ul>");
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[(
+                    "item",
+                    serde_json::json!(["did:key:zA", "did:key:zB", "did:key:zC"]),
+                )],
+            ),
+        );
+        let li_a_before = host
+            .query_selector_all("li")
+            .unwrap()
+            .item(0)
+            .expect("zA row");
+        let li_c_before = host
+            .query_selector_all("li")
+            .unwrap()
+            .item(2)
+            .expect("zC row");
+
+        // Drop zB.
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["did:key:zA", "did:key:zC"]))],
+            ),
+        );
+
+        let after = host.query_selector_all("li").unwrap();
+        assert_eq!(after.length(), 2);
+        let li_a_after = after.item(0).expect("first li");
+        let li_c_after = after.item(1).expect("second li");
+        assert!(
+            li_a_before.is_same_node(Some(li_a_after.unchecked_ref())),
+            "zA row identity preserved",
+        );
+        assert!(
+            li_c_before.is_same_node(Some(li_c_after.unchecked_ref())),
+            "zC row identity preserved",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_handles_successive_appends_without_duplicating_existing_rows() {
+        // Simulates the user-reported bug shape: list starts with
+        // one item, items get appended over multiple applies.
+        // After three appends we should have four distinct rows
+        // with no duplication or content bleed.
+        let host = mount("<ul><li subject={item}>{item}</li></ul>");
+        call_draw(
+            &host,
+            &detail_json("did:key:zList", &[("item", serde_json::json!(["zA"]))]),
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["zA", "zB"]))],
+            ),
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["zA", "zB", "zC"]))],
+            ),
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["zA", "zB", "zC", "zD"]))],
+            ),
+        );
+
+        let items = host.query_selector_all("li").unwrap();
+        let texts: Vec<String> = (0..items.length())
+            .filter_map(|i| items.item(i).and_then(|n| n.text_content()))
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["zA", "zB", "zC", "zD"],
+            "expected four distinct rows in sorted order, got: {}",
+            host.inner_html(),
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_inserts_new_rows_in_sorted_key_order() {
+        // Start with the middle key; add a key that sorts before
+        // it and one that sorts after.
+        let host = mount("<ul><li subject={item}>{item}</li></ul>");
+        call_draw(
+            &host,
+            &detail_json("did:key:zList", &[("item", serde_json::json!(["zB"]))]),
+        );
+        call_draw(
+            &host,
+            &detail_json(
+                "did:key:zList",
+                &[("item", serde_json::json!(["zB", "zA", "zC"]))],
+            ),
+        );
+
+        let items: Vec<String> = (0..host.query_selector_all("li").unwrap().length())
+            .filter_map(|i| {
+                host.query_selector_all("li")
+                    .unwrap()
+                    .item(i)
+                    .and_then(|n| n.text_content())
+            })
+            .collect();
+        assert_eq!(
+            items,
+            vec!["zA".to_owned(), "zB".to_owned(), "zC".to_owned()],
+            "rows should appear in sorted-key order regardless of input array order",
+        );
+    }
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -174,6 +174,18 @@ tonk-view,
 tonk-notation {
     display: block;
     width: 100%;
+}
+
+/* When a view or notation slide lives inside the carousel
+   fallback (no explicit `view` attribute on `<tonk-display>`),
+   it has to fill the carousel-item's slot for the carousel's
+   aspect ratio to work. Outside that context — e.g. a single-mode
+   `<tonk-display view=…>` mounted inside a host template's `<li>`
+   — the elements flow at content size, which lets nested
+   `<tonk-display>` instances stack naturally without each one
+   claiming a full slide's worth of vertical space. */
+wa-carousel-item tonk-view,
+wa-carousel-item tonk-notation {
     height: 100%;
 }
 

--- a/rust/tonk-worker/src/reactor/branch/state.rs
+++ b/rust/tonk-worker/src/reactor/branch/state.rs
@@ -64,6 +64,19 @@ impl BranchState {
     /// expected to follow up with
     /// `branch_session.subscription(hash).poll().perform(&env)`
     /// so the new subscriber's first event is the current snapshot.
+    ///
+    /// Query identity is the blake3 hash of the serialized
+    /// [`Query`] projection. We **don't** re-check `PartialEq`
+    /// against the registered query, even though earlier
+    /// revisions did: `NamedAttributes` in dialog-query derives
+    /// `PartialEq` over a `Vec` whose order is randomized by the
+    /// `HashMap`-mediated `Serialize` / `Deserialize` impls, so
+    /// the same query round-tripped through ser/de can compare
+    /// `!=` even though the hashes match. A genuine blake3
+    /// collision is cryptographically impossible, so trusting
+    /// the hash is the right move here. Track the upstream fix
+    /// in dialog-db (make `NamedAttributes::PartialEq`
+    /// order-insensitive, or serialize in sorted order).
     pub fn subscribe(&self, query: ConceptQuery) -> Result<Subscriber, ReactorError> {
         let hash = QueryHash::from(&query);
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -75,9 +88,6 @@ impl BranchState {
             last_hash: None,
             subscribers: Vec::new(),
         });
-        if subscription.query != query {
-            return Err(ReactorError::QueryHashCollision);
-        }
         subscription.subscribers.push(SubscriberSession {
             sender,
             status: Status::Pending,

--- a/rust/tonk-worker/src/reactor/error.rs
+++ b/rust/tonk-worker/src/reactor/error.rs
@@ -29,9 +29,4 @@ pub enum ReactorError {
     /// A push to upstream failed.
     #[error("push failed: {0}")]
     Push(#[from] PushError),
-    /// Two distinct queries produced the same blake3 hash. The
-    /// second subscribe attempt is rejected so the colliding
-    /// queries don't share a subscription.
-    #[error("query hash collision (extremely unlikely — please report)")]
-    QueryHashCollision,
 }

--- a/rust/tonk-worker/src/router/query.rs
+++ b/rust/tonk-worker/src/router/query.rs
@@ -120,7 +120,6 @@ fn reactor_to_error(err: ReactorError) -> TonkWorkerError {
         ReactorError::QueryFailed(_)
         | ReactorError::Commit(_)
         | ReactorError::Pull(_)
-        | ReactorError::Push(_)
-        | ReactorError::QueryHashCollision => TonkWorkerError::Internal(err.to_string()),
+        | ReactorError::Push(_) => TonkWorkerError::Internal(err.to_string()),
     }
 }


### PR DESCRIPTION
## Why

Cardinality-many fields didn't render. A todo list with three todos showed one todo. The worker dutifully streamed three rows for the same `this` (one per `(entity, item)` tuple) and `<tonk-display>` quietly took the first and discarded the rest.

Fixing that meant teaching the template engine to *repeat*, which meant deciding what "repeat" looks like in markup. We chose: any element whose attributes / inner text contain a `{X}` placeholder for a cardinality-many field becomes an iteration root for X. When multiple placeholders for the same field share an enclosing ancestor below the fragment root, they merge into one iteration; siblings without a shared inner ancestor repeat independently. Authors can lift the iteration up one level by adding a marker placeholder on the wrapper (`<li subject={item}>`) — most often to make the wrapper rather than the inner element the unit of repetition. This is the lowest-ceremony scheme that handles the cases I tried; the `<template for= select= sort=>` follow-up will be a larger redesign once we have evidence the simple form is constraining.

## How

Three layers, each shipping in its own commit:

1. **Iteration-aware planning.** `BindingPlan` becomes a tree of `Binding | Iteration` nodes. `extract_plan` walks every `{X}` placeholder, groups by field, computes the LCA of the host elements, and emits one `Iteration` per non-empty LCA. The renderer walks the tree, clones iteration roots per value, and shadows the field inside each clone. `tonk-display` folds the worker's N-row SSE frame into a single conclusion whose differing fields become arrays before handing it off.

2. **A worker-side fix.** The reactor was paranoid about blake3 collisions and rejected resubscribes whose `ConceptQuery` compared `!=` even after their hashes agreed. In practice every `<tonk-display>` resubscribe hit this — `NamedAttributes` upstream derives `PartialEq` over a `Vec` whose order is randomised by its own `HashMap`-routed `Serialize`/`Deserialize`. A real blake3 collision is cryptographically impossible, so we drop the comparison.

3. **Keyed incremental updates.** The renderer holds a mounted tree mirroring the plan tree: per-binding `last_value` caches so writes only happen when the rendered string changes, and per-iteration `BTreeMap<key, MountedRow>` so adding an item mounts one new row, removing one detaches one row, identical applies are no-ops. The key lesson was that **DOM moves fire `disconnectedCallback`/`connectedCallback`** on every custom element in the moved subtree. The earlier draft inserted a new row before the anchor, then "moved" it to the sorted position — that move caused inner `<tonk-display>` instances to spin up *twice* and mount two `<tonk-view>` slides per row. The fix is to build the row detached, finish all attribute writes off-DOM, and insert exactly once at the sorted position. Defence in depth: a generation counter + disposed flag on `<tonk-display>`'s state lets stale async chains bail before mutating a host that's moved on.

Same renderer algorithm in `tonk-display` (single-entity) and `tonk-concept` (multi-row); kept duplicated to avoid pulling wasm-only DOM types into a shared crate.

## Tested

- Native unit tests cover LCA discovery, plan-tree assembly, the row-fold, and the notation tokenizer / formatter (63 tests across `tonk-display` + `tonk-concept`).
- Wasm-bindgen tests cover the renderer's DOM contract: node identity preserved across no-op applies, append/remove without disturbing siblings, sorted insertion, scalar-as-singleton-iteration, etc.
- Manual: a todo-list view with N todo items inside `<tonk-display>` carousel + nested `<tonk-display>` per item, adding / removing items and confirming the list reflects the change without re-rendering existing rows or duplicating `<tonk-view>` slides.

## Follow-ups

- The marker-attribute scheme (`subject={item}`) is what's shipping. The `<template for= select= sort=>` redesign — where `<template>` owns iteration, per-item projection, view selection, and sort — is the right destination; deferring it because it's a meaningful refactor and the current approach unblocks the demo.
- Sort-by-inner-field still requires either (a) the redesigned `<template>` with a separate projection concept on the outer scope, or (b) dialog-query nested projection landing upstream. Both are on the roadmap; neither is in this PR.
- The query-hash mismatch in step 2 is a local workaround. The proper fix is upstream in dialog-query — make `NamedAttributes::PartialEq` order-insensitive, or serialize in sorted order so hash collisions actually mean what they say.
