### PR TITLE
feat: iframe `postMessage` bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "lsp-types",
  "parking_lot",
  "rand 0.9.2",
+ "send_wrapper",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5044,6 +5044,7 @@ dependencies = [
  "rand 0.9.2",
  "send_wrapper",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,8 +4821,10 @@ dependencies = [
 name = "tonk-concept"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "custom-elements",
  "dialog-common",
+ "futures",
  "indexmap",
  "js-sys",
  "serde",
@@ -4833,6 +4835,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4840,10 +4843,8 @@ dependencies = [
 name = "tonk-display"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "custom-elements",
  "dialog-common",
- "futures",
  "indexmap",
  "js-sys",
  "lsp-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,10 +4821,8 @@ dependencies = [
 name = "tonk-concept"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "custom-elements",
  "dialog-common",
- "futures",
  "indexmap",
  "js-sys",
  "serde",
@@ -4835,7 +4833,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-streams",
  "web-sys",
 ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,12 +46,13 @@
         commonBuildInputs =
           with pkgs;
           [
-            tailwindcss_4
-            trunk
             binaryen
             cachix
             cargo-nextest
             esbuild
+            python3
+            tailwindcss_4
+            trunk
             worker-build
           ]
           ++ lib.optionals stdenv.isLinux [

--- a/rust/slide/src/guide-views-dynamic.md
+++ b/rust/slide/src/guide-views-dynamic.md
@@ -1,0 +1,105 @@
+## Interactive views with `globalThis.tonk`
+
+`<tonk-concept>` covers lists and grids where every row fits a
+`<template>`. When you need a form, a button, or any UI whose logic
+doesn't fit the row-template model, drop into JavaScript and use the
+`globalThis.tonk` API the host injects into every view iframe.
+
+Three methods, all return Promises (or, for `subscribe`, a cancel
+function). No handshake, no initialisation — call them at the top of
+your script:
+
+- `tonk.query(body)` — one-shot query. Resolves to an array of rows.
+- `tonk.subscribe(body, onFrame, onError?)` — live query. `onFrame`
+  fires on every branch change. Returns an unsubscribe function.
+- `tonk.evaluate(body, transact = true)` — run a notation document
+  (assertions, queries, retractions). Resolves to the evaluate result.
+
+The `body` for `query` / `subscribe` is the same `ConceptQuery` JSON
+shape `/api/.../query` accepts. The `body` for `evaluate` is a string
+of notation — the same syntax `slide eval` consumes.
+
+You don't pass a repo or branch — the iframe is already scoped to one.
+
+### Reading data
+
+```yaml
+view!: &person-counter
+  body: |
+    <p>People online: <span id="count">…</span></p>
+    <script type="module">
+      tonk.subscribe(
+        { terms: { this: "?p" }, predicate: { with: { name: "?n" } } },
+        rows => {
+          document.getElementById("count").textContent = rows.length;
+        },
+        err => console.error("count subscription failed:", err),
+      );
+    </script>
+```
+
+For a one-shot read:
+
+```js
+const rows = await tonk.query({
+  terms:     { this: "?p" },
+  predicate: { with: { name: "?n" } },
+});
+```
+
+### Writing data
+
+`evaluate` accepts any notation document — including assertions that
+write claims:
+
+```yaml
+view!: &add-person
+  body: |
+    <form id="add">
+      <input name="name" placeholder="Name" required>
+      <button>Add</button>
+    </form>
+    <script type="module">
+      document.getElementById("add").addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const name = e.target.name.value;
+        await tonk.evaluate(`person!:\n  name: "${name}"\n`);
+        e.target.reset();
+      });
+    </script>
+```
+
+Notation strings let you assert, query, and retract in one document,
+exactly as you would with `slide eval`. Quote string values so the
+parser doesn't read them as symbols.
+
+### Errors
+
+Bad bodies and worker-side failures surface as Promise rejections (or
+`onError` callbacks for `subscribe`). Treat them like any other JS
+error:
+
+```js
+try {
+  await tonk.evaluate(`person!:\n  name: ${unquoted}\n`);
+} catch (e) {
+  alert(`couldn't save: ${e.message}`);
+}
+```
+
+If `globalThis.tonk` is undefined entirely, the view is being mounted
+outside a host iframe and the bridge module never loaded.
+
+### Choosing between `<tonk-concept>` and `tonk.*`
+
+| Reach for `<tonk-concept>` when | Reach for `globalThis.tonk` when |
+|----------------------------------|----------------------------------|
+| You're rendering rows from a query | You're handling user input |
+| Each row fits a `<template>` | The UI doesn't decompose into rows |
+| No write path needed | You need `evaluate` (assertions, retractions) |
+| You want zero JS | You're already writing JS for other reasons |
+
+They compose: a view can declaratively render a list with
+`<tonk-concept>` *and* run a script that calls `tonk.evaluate` to
+append to that list. The subscription `<tonk-concept>` holds will
+re-render automatically once the write commits.

--- a/rust/slide/src/guide-views-dynamic.md
+++ b/rust/slide/src/guide-views-dynamic.md
@@ -5,13 +5,13 @@
 doesn't fit the row-template model, drop into JavaScript and use the
 `globalThis.tonk` API the host injects into every view iframe.
 
-Three methods, all return Promises (or, for `subscribe`, a cancel
-function). No handshake, no initialisation — call them at the top of
-your script:
+Three methods, all return Promises. No handshake, no initialisation —
+call them at the top of your script:
 
 - `tonk.query(body)` — one-shot query. Resolves to an array of rows.
-- `tonk.subscribe(body, onFrame, onError?)` — live query. `onFrame`
-  fires on every branch change. Returns an unsubscribe function.
+- `tonk.subscribe(body)` — live query. Resolves to a
+  `ReadableStream` whose chunks are arrays of rows, one per branch
+  change. Cancel the stream to unsubscribe.
 - `tonk.evaluate(body, transact = true)` — run a notation document
   (assertions, queries, retractions). Resolves to the evaluate result.
 
@@ -28,15 +28,23 @@ view!: &person-counter
   body: |
     <p>People online: <span id="count">…</span></p>
     <script type="module">
-      tonk.subscribe(
-        { terms: { this: "?p" }, predicate: { with: { name: "?n" } } },
-        rows => {
+      const stream = await tonk.subscribe({
+        terms: { this: "?p" },
+        predicate: { with: { name: "?n" } },
+      });
+      try {
+        for await (const rows of stream) {
           document.getElementById("count").textContent = rows.length;
-        },
-        err => console.error("count subscription failed:", err),
-      );
+        }
+      } catch (err) {
+        console.error("count subscription failed:", err);
+      }
     </script>
 ```
+
+Cancel a subscription by calling `stream.cancel()` (or by aborting
+the reader). The unsubscribe envelope to the worker is posted
+automatically.
 
 For a one-shot read:
 
@@ -75,9 +83,9 @@ parser doesn't read them as symbols.
 
 ### Errors
 
-Bad bodies and worker-side failures surface as Promise rejections (or
-`onError` callbacks for `subscribe`). Treat them like any other JS
-error:
+Bad bodies and worker-side failures surface as Promise rejections —
+for `subscribe`, errors raise on the stream and propagate out of the
+`for await` loop. Treat them like any other JS error:
 
 ```js
 try {

--- a/rust/slide/src/guide-views.md
+++ b/rust/slide/src/guide-views.md
@@ -51,14 +51,18 @@ view!: &my-task-list
     </tonk-concept>
 ```
 
-Do **not** write `<!doctype>`, `<html>`, `<head>`, `<body>`, `<title>`,
-or `<script>` tags yourself. They will either be stripped or
-double-wrapped — neither does what you want. If you need page-level
+Do **not** write `<!doctype>`, `<html>`, `<head>`, `<body>`, or
+`<title>` tags yourself — the host wraps your body in its own
+shell, so writing chrome doubles it up. If you need page-level
 styling, put a `<style>` tag at the top of the body fragment.
 
 The runtime that activates `<tonk-concept>` is provided by the host
 and ships with every served view. You don't import it, link to it,
 or include it — assume it's there.
+
+For interactive views (forms, buttons, custom write flows), drop
+into a `<script type="module">` and use `globalThis.tonk` directly.
+See the next section.
 
 Git-tag semantics apply: re-asserting the same body is idempotent
 (same content → same content-derived entity), a different body

--- a/rust/slide/src/guide.rs
+++ b/rust/slide/src/guide.rs
@@ -10,7 +10,11 @@
 //!    covering the view convention that `slide share view`
 //!    relies on. Kept out of the upstream notation guide so the
 //!    notation reference stays a clean syntax doc.
-//! 3. `tonk-concept/SPEC.md` — the `<tonk-concept>` custom
+//! 3. `slide/src/guide-views-dynamic.md` — companion to the views
+//!    addendum that documents the `globalThis.tonk` API agents
+//!    can call from `<script type="module">` inside a view body
+//!    when the declarative `<tonk-concept>` element doesn't fit.
+//! 4. `tonk-concept/SPEC.md` — the `<tonk-concept>` custom
 //!    element reference: source-attribute grammar, template
 //!    detection, `{field}` substitution. Relevant whenever an
 //!    agent authors an HTML view body that embeds a live
@@ -28,6 +32,8 @@ pub const GUIDE: &str = concat!(
     include_str!("../../tonk-notation/guide.md"),
     "\n",
     include_str!("guide-views.md"),
+    "\n",
+    include_str!("guide-views-dynamic.md"),
     "\n",
     include_str!("../../tonk-concept/SPEC.md"),
 );

--- a/rust/tonk-concept/Cargo.toml
+++ b/rust/tonk-concept/Cargo.toml
@@ -10,9 +10,7 @@ description = "<tonk-concept> custom element — live-subscribes to a tonk-worke
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bytes = { workspace = true }
 custom-elements = { workspace = true }
-futures = { workspace = true }
 indexmap = { workspace = true }
 js-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -21,10 +19,7 @@ serde_json = { workspace = true }
 tonk-schema = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-wasm-streams = { workspace = true }
 web-sys = { workspace = true, features = [
-    "AbortController",
-    "AbortSignal",
     "Attr",
     "Comment",
     "CustomElementRegistry",
@@ -33,7 +28,6 @@ web-sys = { workspace = true, features = [
     "Document",
     "DocumentFragment",
     "Element",
-    "Headers",
     "HtmlElement",
     "HtmlScriptElement",
     "HtmlTemplateElement",
@@ -41,10 +35,6 @@ web-sys = { workspace = true, features = [
     "Node",
     "NodeFilter",
     "NodeList",
-    "ReadableStream",
-    "Request",
-    "RequestInit",
-    "Response",
     "Text",
     "TreeWalker",
     "Window",

--- a/rust/tonk-concept/Cargo.toml
+++ b/rust/tonk-concept/Cargo.toml
@@ -10,7 +10,9 @@ description = "<tonk-concept> custom element — live-subscribes to a tonk-worke
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+bytes = { workspace = true }
 custom-elements = { workspace = true }
+futures = { workspace = true }
 indexmap = { workspace = true }
 js-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -19,7 +21,10 @@ serde_json = { workspace = true }
 tonk-schema = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
+wasm-streams = { workspace = true }
 web-sys = { workspace = true, features = [
+    "AbortController",
+    "AbortSignal",
     "Attr",
     "Comment",
     "CustomElementRegistry",
@@ -28,6 +33,7 @@ web-sys = { workspace = true, features = [
     "Document",
     "DocumentFragment",
     "Element",
+    "Headers",
     "HtmlElement",
     "HtmlScriptElement",
     "HtmlTemplateElement",
@@ -35,6 +41,10 @@ web-sys = { workspace = true, features = [
     "Node",
     "NodeFilter",
     "NodeList",
+    "ReadableStream",
+    "Request",
+    "RequestInit",
+    "Response",
     "Text",
     "TreeWalker",
     "Window",

--- a/rust/tonk-concept/Cargo.toml
+++ b/rust/tonk-concept/Cargo.toml
@@ -42,6 +42,7 @@ web-sys = { workspace = true, features = [
     "NodeFilter",
     "NodeList",
     "ReadableStream",
+    "ReadableStreamDefaultReader",
     "Request",
     "RequestInit",
     "Response",

--- a/rust/tonk-concept/src/bridge.rs
+++ b/rust/tonk-concept/src/bridge.rs
@@ -5,8 +5,8 @@
 
 use crate::error::{ErrorDetail, ErrorKind};
 use js_sys::{Function, Promise, Reflect};
-use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::window;
 
@@ -100,14 +100,12 @@ pub fn subscribe(
             on_error_cb.as_ref().unchecked_ref(),
         )
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.subscribe call: {e:?}")))?;
-    let unsub: Function = unsub_value
-        .dyn_into()
-        .map_err(|_| {
-            ErrorDetail::new(
-                ErrorKind::Network,
-                "tonk.subscribe did not return a function",
-            )
-        })?;
+    let unsub: Function = unsub_value.dyn_into().map_err(|_| {
+        ErrorDetail::new(
+            ErrorKind::Network,
+            "tonk.subscribe did not return a function",
+        )
+    })?;
 
     Ok(SubscribeHandle {
         unsub,

--- a/rust/tonk-concept/src/bridge.rs
+++ b/rust/tonk-concept/src/bridge.rs
@@ -8,7 +8,7 @@ use js_sys::{Function, Promise, Reflect};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::window;
+use web_sys::{ReadableStream, ReadableStreamDefaultReader, window};
 
 /// Look up the `tonk` binding on the global object. Returns an
 /// error if the bridge module hasn't loaded yet — the wrapper
@@ -37,6 +37,16 @@ fn tonk_method(name: &str) -> Result<Function, ErrorDetail> {
         .map_err(|_| ErrorDetail::new(ErrorKind::Network, format!("tonk.{name} is not a function")))
 }
 
+/// Await a JS Promise and downcast its resolved value.
+async fn await_promise(promise_value: JsValue, what: &str) -> Result<JsValue, ErrorDetail> {
+    let promise: Promise = promise_value.dyn_into().map_err(|_| {
+        ErrorDetail::new(ErrorKind::Network, format!("{what} did not return Promise"))
+    })?;
+    JsFuture::from(promise)
+        .await
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("{what} await: {e:?}")))
+}
+
 /// `tonk.query(body)` — one-shot. Body is a `serde_json::Value`.
 /// Returns the result as a `serde_json::Value` (typically
 /// `Vec<Conclusion>`-shaped — caller deserialises).
@@ -48,85 +58,78 @@ pub async fn query(body: &serde_json::Value) -> Result<serde_json::Value, ErrorD
     let promise_value = method
         .call1(&tonk, &body_js)
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.query call: {e:?}")))?;
-    let promise: Promise = promise_value
-        .dyn_into()
-        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "tonk.query did not return Promise"))?;
-    let result_js = JsFuture::from(promise)
-        .await
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.query await: {e:?}")))?;
+    let result_js = await_promise(promise_value, "tonk.query").await?;
     serde_wasm_bindgen::from_value(result_js)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("query result deserialise: {e}")))
 }
 
-/// `tonk.subscribe(body, onFrame, onError)` — streaming. Returns a
-/// [`SubscribeHandle`] that the caller must keep alive for the
-/// duration of the subscription.
+/// `tonk.subscribe(body)` — streaming. Resolves to a
+/// [`Subscription`] backed by the underlying `ReadableStream`.
 ///
-/// `on_frame` is invoked per emission with a `serde_json::Value`.
-/// `on_error` is invoked with a `String` on bridge-reported errors.
-///
-/// Dropping the handle calls the unsubscribe function automatically.
-pub fn subscribe(
-    body: &serde_json::Value,
-    on_frame: impl Fn(serde_json::Value) + 'static,
-    on_error: impl Fn(String) + 'static,
-) -> Result<SubscribeHandle, ErrorDetail> {
+/// The caller drives the subscription via [`Subscription::next`].
+/// Dropping the [`Subscription`] cancels the stream, which posts
+/// the corresponding `unsubscribe` envelope to the SW.
+pub async fn subscribe(body: &serde_json::Value) -> Result<Subscription, ErrorDetail> {
     let tonk = tonk_global()?;
     let method = tonk_method("subscribe")?;
     let body_js = serde_wasm_bindgen::to_value(body)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body serialise: {e}")))?;
-
-    // `on_error` is shared between both closures so we wrap it in
-    // Rc<dyn Fn(String)> to avoid a move conflict.
-    let on_error = std::rc::Rc::new(on_error);
-    let on_error_for_frame = on_error.clone();
-
-    let on_frame_cb: Closure<dyn FnMut(JsValue)> = Closure::new(move |frame_js: JsValue| {
-        match serde_wasm_bindgen::from_value::<serde_json::Value>(frame_js) {
-            Ok(v) => on_frame(v),
-            Err(e) => on_error_for_frame(format!("frame deserialise: {e}")),
-        }
-    });
-    let on_error_cb: Closure<dyn FnMut(JsValue)> = Closure::new(move |err_js: JsValue| {
-        let message = err_js.as_string().unwrap_or_else(|| format!("{err_js:?}"));
-        on_error(message);
-    });
-
-    let unsub_value = method
-        .call3(
-            &tonk,
-            &body_js,
-            on_frame_cb.as_ref().unchecked_ref(),
-            on_error_cb.as_ref().unchecked_ref(),
-        )
+    let promise_value = method
+        .call1(&tonk, &body_js)
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.subscribe call: {e:?}")))?;
-    let unsub: Function = unsub_value.dyn_into().map_err(|_| {
+    let stream_js = await_promise(promise_value, "tonk.subscribe").await?;
+    let stream: ReadableStream = stream_js.dyn_into().map_err(|_| {
         ErrorDetail::new(
             ErrorKind::Network,
-            "tonk.subscribe did not return a function",
+            "tonk.subscribe did not yield a ReadableStream",
         )
     })?;
-
-    Ok(SubscribeHandle {
-        unsub,
-        _on_frame: on_frame_cb,
-        _on_error: on_error_cb,
-    })
+    let reader: ReadableStreamDefaultReader = stream.get_reader().dyn_into().map_err(|_| {
+        ErrorDetail::new(
+            ErrorKind::Network,
+            "stream.getReader did not return a default reader",
+        )
+    })?;
+    Ok(Subscription { reader })
 }
 
-/// Handle returned by [`subscribe`]. Holds the unsubscribe function
-/// and the closures so they remain live while JS might invoke them.
-///
-/// Dropping this value calls the unsubscribe function automatically.
-pub struct SubscribeHandle {
-    unsub: Function,
-    _on_frame: Closure<dyn FnMut(JsValue)>,
-    _on_error: Closure<dyn FnMut(JsValue)>,
+/// A live subscription. `next` yields one frame; `Ok(None)` signals
+/// the stream closed normally. Dropping the value cancels the
+/// stream and posts an `unsubscribe` envelope.
+pub struct Subscription {
+    reader: ReadableStreamDefaultReader,
 }
 
-impl Drop for SubscribeHandle {
+impl Subscription {
+    /// Pull the next frame. `Ok(None)` means the stream closed.
+    pub async fn next(&self) -> Result<Option<serde_json::Value>, ErrorDetail> {
+        let promise = self.reader.read();
+        let result_js = JsFuture::from(promise)
+            .await
+            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("reader.read: {e:?}")))?;
+        let done = Reflect::get(&result_js, &JsValue::from_str("done"))
+            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read.done: {e:?}")))?
+            .as_bool()
+            .unwrap_or(false);
+        if done {
+            return Ok(None);
+        }
+        let value_js = Reflect::get(&result_js, &JsValue::from_str("value"))
+            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read.value: {e:?}")))?;
+        let value = serde_wasm_bindgen::from_value(value_js)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("frame deserialise: {e}")))?;
+        Ok(Some(value))
+    }
+
+    /// Cancel the underlying stream. Idempotent — the JS `cancel`
+    /// returns a Promise that we discard.
+    pub fn cancel(&self) {
+        let _ = self.reader.cancel();
+    }
+}
+
+impl Drop for Subscription {
     fn drop(&mut self) {
-        // Best-effort: ignore the result.
-        let _ = self.unsub.call0(&JsValue::UNDEFINED);
+        self.cancel();
     }
 }

--- a/rust/tonk-concept/src/bridge.rs
+++ b/rust/tonk-concept/src/bridge.rs
@@ -3,6 +3,8 @@
 //! previous direct `fetch()` calls so the bridge can route every
 //! data-plane request through postMessage to the service worker.
 
+use std::cell::Cell;
+
 use crate::error::{ErrorDetail, ErrorKind};
 use js_sys::{Function, Promise, Reflect};
 use wasm_bindgen::JsCast;
@@ -90,19 +92,30 @@ pub async fn subscribe(body: &serde_json::Value) -> Result<Subscription, ErrorDe
             "stream.getReader did not return a default reader",
         )
     })?;
-    Ok(Subscription { reader })
+    Ok(Subscription {
+        reader,
+        cancelled: Cell::new(false),
+    })
 }
 
-/// A live subscription. `next` yields one frame; `Ok(None)` signals
-/// the stream closed normally. Dropping the value cancels the
-/// stream and posts an `unsubscribe` envelope.
+/// A live subscription. `next` yields one frame as its raw JSON
+/// string; `Ok(None)` signals the stream closed normally. Dropping
+/// the value cancels the stream and posts an `unsubscribe` envelope.
 pub struct Subscription {
     reader: ReadableStreamDefaultReader,
+    // Set on first `cancel()` so the second call (from the other
+    // `Drop` path, when both `SubscriptionAbort::Bridge` and the
+    // last `Rc<Subscription>` go away) doesn't allocate a redundant
+    // `reader.cancel()` Promise.
+    cancelled: Cell<bool>,
 }
 
 impl Subscription {
-    /// Pull the next frame. `Ok(None)` means the stream closed.
-    pub async fn next(&self) -> Result<Option<serde_json::Value>, ErrorDetail> {
+    /// Pull the next frame as its JSON-stringified form. `Ok(None)`
+    /// means the stream closed. The string is produced by
+    /// `JSON.stringify` on the raw `value` so the JSON tree never
+    /// has to be walked in Rust.
+    pub async fn next(&self) -> Result<Option<String>, ErrorDetail> {
         let promise = self.reader.read();
         let result_js = JsFuture::from(promise)
             .await
@@ -116,14 +129,20 @@ impl Subscription {
         }
         let value_js = Reflect::get(&result_js, &JsValue::from_str("value"))
             .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read.value: {e:?}")))?;
-        let value = serde_wasm_bindgen::from_value(value_js)
-            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("frame deserialise: {e}")))?;
-        Ok(Some(value))
+        let stringified = js_sys::JSON::stringify(&value_js)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("JSON.stringify: {e:?}")))?;
+        let s = stringified.as_string().ok_or_else(|| {
+            ErrorDetail::new(ErrorKind::Parse, "JSON.stringify yielded non-string")
+        })?;
+        Ok(Some(s))
     }
 
-    /// Cancel the underlying stream. Idempotent — the JS `cancel`
-    /// returns a Promise that we discard.
+    /// Cancel the underlying stream. Safe to call multiple times;
+    /// subsequent calls are no-ops.
     pub fn cancel(&self) {
+        if self.cancelled.replace(true) {
+            return;
+        }
         let _ = self.reader.cancel();
     }
 }

--- a/rust/tonk-concept/src/bridge.rs
+++ b/rust/tonk-concept/src/bridge.rs
@@ -1,0 +1,134 @@
+//! Iframe-side bridge interop. Calls into `globalThis.tonk` (set
+//! by `/__tonk/bridge.js`) for query and subscribe — replacing the
+//! previous direct `fetch()` calls so the bridge can route every
+//! data-plane request through postMessage to the service worker.
+
+use crate::error::{ErrorDetail, ErrorKind};
+use js_sys::{Function, Promise, Reflect};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::window;
+
+/// Look up the `tonk` binding on the global object. Returns an
+/// error if the bridge module hasn't loaded yet — the wrapper
+/// injected by `host::wrap_html_body` loads bridge.js before this
+/// crate's runtime, so the only way this should fail is if a
+/// caller mounted `<tonk-concept>` outside the iframe shell.
+fn tonk_global() -> Result<JsValue, ErrorDetail> {
+    let win = window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no window"))?;
+    let tonk = Reflect::get(&win, &JsValue::from_str("tonk"))
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk lookup: {e:?}")))?;
+    if tonk.is_undefined() || tonk.is_null() {
+        return Err(ErrorDetail::new(
+            ErrorKind::Network,
+            "globalThis.tonk is not defined — is the bridge module loaded?",
+        ));
+    }
+    Ok(tonk)
+}
+
+fn tonk_method(name: &str) -> Result<Function, ErrorDetail> {
+    let tonk = tonk_global()?;
+    let method = Reflect::get(&tonk, &JsValue::from_str(name))
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.{name} lookup: {e:?}")))?;
+    method
+        .dyn_into::<Function>()
+        .map_err(|_| ErrorDetail::new(ErrorKind::Network, format!("tonk.{name} is not a function")))
+}
+
+/// `tonk.query(body)` — one-shot. Body is a `serde_json::Value`.
+/// Returns the result as a `serde_json::Value` (typically
+/// `Vec<Conclusion>`-shaped — caller deserialises).
+pub async fn query(body: &serde_json::Value) -> Result<serde_json::Value, ErrorDetail> {
+    let tonk = tonk_global()?;
+    let method = tonk_method("query")?;
+    let body_js = serde_wasm_bindgen::to_value(body)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body serialise: {e}")))?;
+    let promise_value = method
+        .call1(&tonk, &body_js)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.query call: {e:?}")))?;
+    let promise: Promise = promise_value
+        .dyn_into()
+        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "tonk.query did not return Promise"))?;
+    let result_js = JsFuture::from(promise)
+        .await
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.query await: {e:?}")))?;
+    serde_wasm_bindgen::from_value(result_js)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("query result deserialise: {e}")))
+}
+
+/// `tonk.subscribe(body, onFrame, onError)` — streaming. Returns a
+/// [`SubscribeHandle`] that the caller must keep alive for the
+/// duration of the subscription.
+///
+/// `on_frame` is invoked per emission with a `serde_json::Value`.
+/// `on_error` is invoked with a `String` on bridge-reported errors.
+///
+/// Dropping the handle calls the unsubscribe function automatically.
+pub fn subscribe(
+    body: &serde_json::Value,
+    on_frame: impl Fn(serde_json::Value) + 'static,
+    on_error: impl Fn(String) + 'static,
+) -> Result<SubscribeHandle, ErrorDetail> {
+    let tonk = tonk_global()?;
+    let method = tonk_method("subscribe")?;
+    let body_js = serde_wasm_bindgen::to_value(body)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body serialise: {e}")))?;
+
+    // `on_error` is shared between both closures so we wrap it in
+    // Rc<dyn Fn(String)> to avoid a move conflict.
+    let on_error = std::rc::Rc::new(on_error);
+    let on_error_for_frame = on_error.clone();
+
+    let on_frame_cb: Closure<dyn FnMut(JsValue)> = Closure::new(move |frame_js: JsValue| {
+        match serde_wasm_bindgen::from_value::<serde_json::Value>(frame_js) {
+            Ok(v) => on_frame(v),
+            Err(e) => on_error_for_frame(format!("frame deserialise: {e}")),
+        }
+    });
+    let on_error_cb: Closure<dyn FnMut(JsValue)> = Closure::new(move |err_js: JsValue| {
+        let message = err_js.as_string().unwrap_or_else(|| format!("{err_js:?}"));
+        on_error(message);
+    });
+
+    let unsub_value = method
+        .call3(
+            &tonk,
+            &body_js,
+            on_frame_cb.as_ref().unchecked_ref(),
+            on_error_cb.as_ref().unchecked_ref(),
+        )
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("tonk.subscribe call: {e:?}")))?;
+    let unsub: Function = unsub_value
+        .dyn_into()
+        .map_err(|_| {
+            ErrorDetail::new(
+                ErrorKind::Network,
+                "tonk.subscribe did not return a function",
+            )
+        })?;
+
+    Ok(SubscribeHandle {
+        unsub,
+        _on_frame: on_frame_cb,
+        _on_error: on_error_cb,
+    })
+}
+
+/// Handle returned by [`subscribe`]. Holds the unsubscribe function
+/// and the closures so they remain live while JS might invoke them.
+///
+/// Dropping this value calls the unsubscribe function automatically.
+pub struct SubscribeHandle {
+    unsub: Function,
+    _on_frame: Closure<dyn FnMut(JsValue)>,
+    _on_error: Closure<dyn FnMut(JsValue)>,
+}
+
+impl Drop for SubscribeHandle {
+    fn drop(&mut self) {
+        // Best-effort: ignore the result.
+        let _ = self.unsub.call0(&JsValue::UNDEFINED);
+    }
+}

--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -3,18 +3,18 @@
 //! Wires the static-side modules ([`crate::resolve`],
 //! [`crate::template`], [`crate::render`], [`crate::sse`]) into a
 //! lifecycle: snapshot the row template once, resolve `source`
-//! into a wire query, open an SSE subscription, and diff each
-//! frame into the live DOM.
+//! into a wire query, open an SSE subscription, and diff each frame
+//! into the live DOM.
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use custom_elements::CustomElement;
 use wasm_bindgen::JsValue;
-use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
-use web_sys::{AbortController, CustomEvent, CustomEventInit, Element, HtmlElement, window};
+use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, window};
 
+use crate::bridge::SubscribeHandle;
 use crate::error::{ErrorDetail, ErrorKind};
 use crate::render::Renderer;
 use crate::resolve::{ParsedSource, parse_source, phase1_query, phase2_query};
@@ -32,9 +32,8 @@ struct Inner {
     container: Option<Element>,
     /// Active diff renderer once Phase 2 has started.
     renderer: Option<Renderer>,
-    /// Aborts the in-flight Phase-2 SSE fetch when the element
-    /// disconnects or an attribute changes.
-    abort: Option<AbortController>,
+    /// Active subscription handle — dropping it cancels the stream.
+    abort: Option<SubscribeHandle>,
 }
 
 impl Inner {
@@ -64,7 +63,7 @@ impl CustomElement for TonkConcept {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["source", "space", "branch"]
+        &["source"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -93,10 +92,9 @@ impl CustomElement for TonkConcept {
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
-        if let Some(state) = self.inner.borrow_mut().take()
-            && let Some(abort) = state.borrow_mut().abort.take()
-        {
-            abort.abort();
+        if let Some(state) = self.inner.borrow_mut().take() {
+            // Drop the SubscribeHandle — its Drop impl calls unsub().
+            state.borrow_mut().abort.take();
         }
     }
 
@@ -114,9 +112,8 @@ impl CustomElement for TonkConcept {
         // Cancel any in-flight stream, drop existing rows, restart.
         {
             let mut s = state.borrow_mut();
-            if let Some(abort) = s.abort.take() {
-                abort.abort();
-            }
+            // Drop the handle — this triggers the unsubscribe call.
+            s.abort.take();
             if let Some(mut renderer) = s.renderer.take() {
                 renderer.clear();
             }
@@ -160,34 +157,13 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     }
     let parsed: ParsedSource = parse_source(&source_attr);
 
-    // Either-or override: if the author sets `space` or `branch`,
-    // build an absolute `/api/repository/{space}/branch/{branch}/query`
-    // URL — missing half defaults to `home`/`main`. With neither
-    // attribute set, a relative `/query` URL lets the service
-    // worker's guest-iframe rewrite resolve the request under
-    // whatever branch the iframe is actually rooted at, which is
-    // rarely `home`/`main`.
-    let space_attr = host.get_attribute("space");
-    let branch_attr = host.get_attribute("branch");
-    let url = match (&space_attr, &branch_attr) {
-        (None, None) => "/query".to_owned(),
-        _ => format!(
-            "/api/repository/{}/branch/{}/query",
-            space_attr.as_deref().unwrap_or("home"),
-            branch_attr.as_deref().unwrap_or("main"),
-        ),
-    };
-
-    // Phase 1 — one-shot resolve via plain JSON request.
-    let phase1_body = serde_json::to_string(&phase1_query(&parsed))
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-    let descriptor_json = phase1_lookup(&url, &phase1_body).await?;
+    // Phase 1 — one-shot resolve via the bridge query method.
+    let phase1_body = phase1_query(&parsed);
+    let descriptor_json = phase1_lookup(&phase1_body).await?;
 
     // Phase 2 — build the actual subscription query and stream it.
     let phase2 = phase2_query(&descriptor_json, &parsed.filters)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("phase2: {e}")))?;
-    let phase2_body = serde_json::to_string(&phase2)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 body: {e}")))?;
 
     // Initialise the renderer now that we know the descriptor.
     {
@@ -211,9 +187,12 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     let host_for_err = host.clone();
     let state_for_frame = state.clone();
     let state_for_err = state.clone();
-    let abort = open_sse(
-        &url,
-        &phase2_body,
+
+    let phase2_value = serde_json::to_value(&phase2)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 serialise: {e}")))?;
+
+    let handle = open_sse(
+        &phase2_value,
         move |frame: &str| {
             let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
                 match serde_json::from_str(frame) {
@@ -240,76 +219,37 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
             // Drop renderer on persistent stream error.
             state_for_err.borrow_mut().renderer = None;
         },
-    )
-    .await?;
+    )?;
 
-    state.borrow_mut().abort = Some(abort);
+    state.borrow_mut().abort = Some(handle);
     dispatch_event(host, "tonk-concept:connected", None);
     Ok(())
 }
 
-/// Phase-1 helper — POST the query as JSON, parse one
-/// `Conclusion`, return its `source` field.
-async fn phase1_lookup(url: &str, body: &str) -> Result<String, ErrorDetail> {
-    use wasm_bindgen_futures::JsFuture;
-    use web_sys::{Headers, Request, RequestInit, Response};
-
-    let init = RequestInit::new();
-    init.set_method("POST");
-    let headers = Headers::new()
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers: {e:?}")))?;
-    headers
-        .append("content-type", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
-    headers
-        .append("accept", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
-    init.set_headers(&headers);
-    init.set_body(&JsValue::from_str(body));
-
-    let request = Request::new_with_str_and_init(url, &init)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Request: {e:?}")))?;
-
-    let win = window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no window"))?;
-    let resp_value = JsFuture::from(win.fetch_with_request(&request))
-        .await
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
-    let resp: Response = resp_value
-        .dyn_into()
-        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return Response"))?;
-    if !resp.ok() {
-        return Err(ErrorDetail::new(
-            ErrorKind::Network,
-            format!("phase1 HTTP {}", resp.status()),
-        ));
-    }
-    let text = JsFuture::from(
-        resp.text()
-            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("text: {e:?}")))?,
-    )
-    .await
-    .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read body: {e:?}")))?;
-    let body_text = text
-        .as_string()
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
-    let conclusions: Vec<tonk_schema::conclusion::Conclusion> = serde_json::from_str(&body_text)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
-    let first = conclusions
-        .into_iter()
-        .next()
+/// Phase-1 helper — call `globalThis.tonk.query` with the given
+/// query body, parse the first `Conclusion`, return its `source`
+/// field (the descriptor JSON for Phase 2).
+async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<String, ErrorDetail> {
+    let body = serde_json::to_value(query)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+    let result = crate::bridge::query(&body).await?;
+    let arr = result.as_array().ok_or_else(|| {
+        ErrorDetail::new(ErrorKind::Descriptor, "phase1: expected array of conclusions")
+    })?;
+    let first = arr
+        .first()
         .ok_or_else(|| ErrorDetail::new(ErrorKind::UnknownSource, "no concept matched"))?;
     let source = first
-        .fields
-        .get("source")
+        .get("fields")
+        .and_then(|f| f.get("source"))
         .and_then(|v| v.as_str())
-        .map(str::to_owned)
         .ok_or_else(|| {
             ErrorDetail::new(
                 ErrorKind::Descriptor,
                 "phase1 row missing `source` field — worker may not be on the AnonymousConceptQuery build",
             )
         })?;
-    Ok(source)
+    Ok(source.to_owned())
 }
 
 fn dispatch_error(host: &Element, err: ErrorDetail) {

--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -234,7 +234,10 @@ async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<String, Erro
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
     let result = crate::bridge::query(&body).await?;
     let arr = result.as_array().ok_or_else(|| {
-        ErrorDetail::new(ErrorKind::Descriptor, "phase1: expected array of conclusions")
+        ErrorDetail::new(
+            ErrorKind::Descriptor,
+            "phase1: expected array of conclusions",
+        )
     })?;
     let first = arr
         .first()

--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -36,7 +36,7 @@ struct Inner {
     template: Option<web_sys::DocumentFragment>,
     /// Where rendered rows are appended.
     container: Option<Element>,
-    /// Active diff renderer once Phase 2 has started.
+    /// Active diff renderer once the subscription has opened.
     renderer: Option<Renderer>,
     /// Active subscription handle — dropping it cancels the stream.
     abort: Option<SubscriptionAbort>,
@@ -99,7 +99,6 @@ impl CustomElement for TonkConcept {
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
         if let Some(state) = self.inner.borrow_mut().take() {
-            // Drop the SubscriptionAbort — its Drop impl cancels the stream.
             state.borrow_mut().abort.take();
         }
     }
@@ -115,10 +114,8 @@ impl CustomElement for TonkConcept {
         let Some(state) = self.inner.borrow().clone() else {
             return;
         };
-        // Cancel any in-flight stream, drop existing rows, restart.
         {
             let mut s = state.borrow_mut();
-            // Drop the handle — this triggers cancellation.
             s.abort.take();
             if let Some(mut renderer) = s.renderer.take() {
                 renderer.clear();
@@ -143,7 +140,6 @@ fn already_registered() -> bool {
     !win.custom_elements().get("tonk-concept").is_undefined()
 }
 
-/// Kick off Phase 1 → Phase 2.
 fn start_subscription(host: &Element, state: Rc<RefCell<Inner>>) {
     let host = host.clone();
     spawn_local(async move {
@@ -180,7 +176,6 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
         ),
     };
 
-    // Phase 1 — one-shot resolve.
     let phase1_body_query = phase1_query(&parsed);
     let descriptor_json = if use_bridge() {
         let body_val = serde_json::to_value(&phase1_body_query)
@@ -189,10 +184,10 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     } else {
         let body_str = serde_json::to_string(&phase1_body_query)
             .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-        crate::fetch::phase1_lookup(&url, &body_str).await?
+        let (_this, source) = crate::fetch::phase1_lookup(&url, &body_str).await?;
+        source
     };
 
-    // Phase 2 — build the actual subscription query and stream it.
     let phase2 = phase2_query(&descriptor_json, &parsed.filters)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("phase2: {e}")))?;
 
@@ -221,12 +216,9 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
 
     let phase2_value = serde_json::to_value(&phase2)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 serialise: {e}")))?;
-    let phase2_body = serde_json::to_string(&phase2)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 body: {e}")))?;
 
     let handle = open_sse(
         &url,
-        &phase2_body,
         &phase2_value,
         move |frame: &str| {
             let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
@@ -262,8 +254,8 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     Ok(())
 }
 
-/// Phase-1 helper for the bridge path — call `globalThis.tonk.query`
-/// and extract the `source` field from the first returned conclusion.
+/// Bridge-side resolver — call `globalThis.tonk.query` and extract the
+/// `source` field from the first returned conclusion.
 async fn bridge_phase1_lookup(body: &serde_json::Value) -> Result<String, ErrorDetail> {
     let result = crate::bridge::query(body).await?;
     let arr = result.as_array().ok_or_else(|| {

--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -3,8 +3,15 @@
 //! Wires the static-side modules ([`crate::resolve`],
 //! [`crate::template`], [`crate::render`], [`crate::sse`]) into a
 //! lifecycle: snapshot the row template once, resolve `source`
-//! into a wire query, open an SSE subscription, and diff each frame
+//! into a wire query, open a subscription, and diff each frame
 //! into the live DOM.
+//!
+//! Transport selection: if `globalThis.tonk` is defined (iframe
+//! context with bridge loaded), the bridge is used. Otherwise the
+//! legacy fetch/SSE path is used — in that case the `space` and
+//! `branch` HTML attributes are read to build an absolute
+//! `/api/repository/{space}/branch/{branch}/query` URL that the
+//! service worker serves directly to the shell.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -14,11 +21,10 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, window};
 
-use crate::bridge::SubscribeHandle;
 use crate::error::{ErrorDetail, ErrorKind};
 use crate::render::Renderer;
 use crate::resolve::{ParsedSource, parse_source, phase1_query, phase2_query};
-use crate::sse::open_sse;
+use crate::sse::{SubscriptionAbort, open_sse, use_bridge};
 use crate::template::{BindingPlan, extract_plan, snapshot_template};
 
 /// Internal lifecycle state shared across async closures.
@@ -33,7 +39,7 @@ struct Inner {
     /// Active diff renderer once Phase 2 has started.
     renderer: Option<Renderer>,
     /// Active subscription handle — dropping it cancels the stream.
-    abort: Option<SubscribeHandle>,
+    abort: Option<SubscriptionAbort>,
 }
 
 impl Inner {
@@ -63,7 +69,7 @@ impl CustomElement for TonkConcept {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["source"]
+        &["source", "space", "branch"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -93,7 +99,7 @@ impl CustomElement for TonkConcept {
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
         if let Some(state) = self.inner.borrow_mut().take() {
-            // Drop the SubscribeHandle — its Drop impl calls unsub().
+            // Drop the SubscriptionAbort — its Drop impl cancels the stream.
             state.borrow_mut().abort.take();
         }
     }
@@ -112,7 +118,7 @@ impl CustomElement for TonkConcept {
         // Cancel any in-flight stream, drop existing rows, restart.
         {
             let mut s = state.borrow_mut();
-            // Drop the handle — this triggers the unsubscribe call.
+            // Drop the handle — this triggers cancellation.
             s.abort.take();
             if let Some(mut renderer) = s.renderer.take() {
                 renderer.clear();
@@ -157,9 +163,34 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
     }
     let parsed: ParsedSource = parse_source(&source_attr);
 
-    // Phase 1 — one-shot resolve via the bridge query method.
-    let phase1_body = phase1_query(&parsed);
-    let descriptor_json = phase1_lookup(&phase1_body).await?;
+    // Either-or override: if the author sets `space` or `branch`,
+    // build an absolute `/api/repository/{space}/branch/{branch}/query`
+    // URL — the missing half defaults to `home`/`main`. With neither
+    // attribute set, a relative `/query` URL lets the service worker's
+    // guest-iframe rewrite resolve the request under whatever branch
+    // the iframe is actually rooted at.
+    let space_attr = host.get_attribute("space");
+    let branch_attr = host.get_attribute("branch");
+    let url = match (&space_attr, &branch_attr) {
+        (None, None) => "/query".to_owned(),
+        _ => format!(
+            "/api/repository/{}/branch/{}/query",
+            space_attr.as_deref().unwrap_or("home"),
+            branch_attr.as_deref().unwrap_or("main"),
+        ),
+    };
+
+    // Phase 1 — one-shot resolve.
+    let phase1_body_query = phase1_query(&parsed);
+    let descriptor_json = if use_bridge() {
+        let body_val = serde_json::to_value(&phase1_body_query)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+        bridge_phase1_lookup(&body_val).await?
+    } else {
+        let body_str = serde_json::to_string(&phase1_body_query)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+        crate::fetch::phase1_lookup(&url, &body_str).await?
+    };
 
     // Phase 2 — build the actual subscription query and stream it.
     let phase2 = phase2_query(&descriptor_json, &parsed.filters)
@@ -190,8 +221,12 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
 
     let phase2_value = serde_json::to_value(&phase2)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 serialise: {e}")))?;
+    let phase2_body = serde_json::to_string(&phase2)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase2 body: {e}")))?;
 
     let handle = open_sse(
+        &url,
+        &phase2_body,
         &phase2_value,
         move |frame: &str| {
             let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
@@ -219,20 +254,18 @@ async fn subscribe(host: &Element, state: Rc<RefCell<Inner>>) -> Result<(), Erro
             // Drop renderer on persistent stream error.
             state_for_err.borrow_mut().renderer = None;
         },
-    )?;
+    )
+    .await?;
 
     state.borrow_mut().abort = Some(handle);
     dispatch_event(host, "tonk-concept:connected", None);
     Ok(())
 }
 
-/// Phase-1 helper — call `globalThis.tonk.query` with the given
-/// query body, parse the first `Conclusion`, return its `source`
-/// field (the descriptor JSON for Phase 2).
-async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<String, ErrorDetail> {
-    let body = serde_json::to_value(query)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-    let result = crate::bridge::query(&body).await?;
+/// Phase-1 helper for the bridge path — call `globalThis.tonk.query`
+/// and extract the `source` field from the first returned conclusion.
+async fn bridge_phase1_lookup(body: &serde_json::Value) -> Result<String, ErrorDetail> {
+    let result = crate::bridge::query(body).await?;
     let arr = result.as_array().ok_or_else(|| {
         ErrorDetail::new(
             ErrorKind::Descriptor,

--- a/rust/tonk-concept/src/fetch.rs
+++ b/rust/tonk-concept/src/fetch.rs
@@ -1,0 +1,268 @@
+//! Legacy `fetch()`-based transports — used when `globalThis.tonk`
+//! is not available (e.g. the shell mounts `<tonk-concept>` or
+//! `<tonk-display>` directly in its own DOM, outside an iframe).
+//!
+//! The shell sets `space` and `branch` HTML attributes so these
+//! functions can build absolute
+//! `/api/repository/{space}/branch/{branch}/query` URLs that the
+//! service worker serves without going through the iframe bridge.
+//!
+//! `wasm_streams::ReadableStream::from_raw(...)` adapts the JS
+//! `ReadableStream` returned by `Response::body()` into a Rust
+//! `Stream<Item = Result<JsValue, JsValue>>`. Each chunk is a
+//! `Uint8Array`; we accumulate bytes into a buffer, split on
+//! `\n\n` (SSE event delimiter), strip the leading `data: ` from
+//! each event's payload line, and hand the remaining JSON to the
+//! callback.
+
+use bytes::BytesMut;
+use futures::StreamExt as _;
+use js_sys::Uint8Array;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use wasm_streams::ReadableStream;
+use web_sys::{AbortController, Headers, Request, RequestInit, Response, Window, window as get_window};
+
+use crate::error::{ErrorDetail, ErrorKind};
+
+/// Phase-1 helper — POST `body` as JSON to `url`, parse the
+/// returned `Vec<Conclusion>`, return the `source` field from the
+/// first row (the descriptor JSON for Phase 2).
+pub async fn phase1_lookup(url: &str, body: &str) -> Result<String, ErrorDetail> {
+    let init = RequestInit::new();
+    init.set_method("POST");
+    let headers = Headers::new()
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers: {e:?}")))?;
+    headers
+        .append("content-type", "application/json")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
+    headers
+        .append("accept", "application/json")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
+    init.set_headers(&headers);
+    init.set_body(&JsValue::from_str(body));
+
+    let request = Request::new_with_str_and_init(url, &init)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Request: {e:?}")))?;
+    let win = window_handle()?;
+    let resp_value = JsFuture::from(win.fetch_with_request(&request))
+        .await
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return Response"))?;
+    if !resp.ok() {
+        return Err(ErrorDetail::new(
+            ErrorKind::Network,
+            format!("phase1 HTTP {}", resp.status()),
+        ));
+    }
+    let text = JsFuture::from(
+        resp.text()
+            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("text: {e:?}")))?,
+    )
+    .await
+    .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read body: {e:?}")))?;
+    let body_text = text
+        .as_string()
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
+    let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
+        serde_json::from_str(&body_text)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
+    let first = conclusions
+        .into_iter()
+        .next()
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::UnknownSource, "no concept matched"))?;
+    let source = first
+        .fields
+        .get("source")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            ErrorDetail::new(
+                ErrorKind::Descriptor,
+                "phase1 row missing `source` field — worker may not be on the AnonymousConceptQuery build",
+            )
+        })?;
+    Ok(source)
+}
+
+/// Phase-1 helper (display variant) — like [`phase1_lookup`] but
+/// also returns the `this` field (the concept entity URI) needed by
+/// `<tonk-display>` to build view and entity queries.
+pub async fn phase1_lookup_with_entity(
+    url: &str,
+    body: &str,
+) -> Result<(String, String), ErrorDetail> {
+    let init = RequestInit::new();
+    init.set_method("POST");
+    let headers = Headers::new()
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers: {e:?}")))?;
+    headers
+        .append("content-type", "application/json")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
+    headers
+        .append("accept", "application/json")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
+    init.set_headers(&headers);
+    init.set_body(&JsValue::from_str(body));
+
+    let request = Request::new_with_str_and_init(url, &init)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Request: {e:?}")))?;
+    let win = window_handle()?;
+    let resp_value = JsFuture::from(win.fetch_with_request(&request))
+        .await
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return Response"))?;
+    if !resp.ok() {
+        return Err(ErrorDetail::new(
+            ErrorKind::Network,
+            format!("phase1 HTTP {}", resp.status()),
+        ));
+    }
+    let text = JsFuture::from(
+        resp.text()
+            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("text: {e:?}")))?,
+    )
+    .await
+    .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read body: {e:?}")))?;
+    let body_text = text
+        .as_string()
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
+    let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
+        serde_json::from_str(&body_text)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
+    let first = conclusions
+        .into_iter()
+        .next()
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::UnknownSource, "no concept matched"))?;
+    let source = first
+        .fields
+        .get("source")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `source` field")
+        })?;
+    Ok((first.this, source))
+}
+
+/// Open an SSE subscription against `url`, sending `body` as the
+/// JSON request body. The future resolves once the initial fetch
+/// succeeds; subsequent frames flow through `on_frame`. Cancel by
+/// calling `.abort()` on the returned [`AbortController`].
+///
+/// Errors during streaming are reported via `on_error`; the future
+/// returns `Err` only for the initial fetch failure.
+pub async fn open_sse(
+    url: &str,
+    body: &str,
+    on_frame: impl FnMut(&str) + 'static,
+    on_error: impl FnMut(ErrorDetail) + 'static,
+) -> Result<AbortController, ErrorDetail> {
+    let abort = AbortController::new()
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("AbortController: {e:?}")))?;
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    let headers = Headers::new()
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers::new: {e:?}")))?;
+    headers
+        .append("accept", "text/event-stream")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
+    headers
+        .append("content-type", "application/json")
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
+    init.set_headers(&headers);
+    init.set_body(&JsValue::from_str(body));
+    init.set_signal(Some(&abort.signal()));
+
+    let request = Request::new_with_str_and_init(url, &init).map_err(|e| {
+        ErrorDetail::new(ErrorKind::Network, format!("Request construction: {e:?}"))
+    })?;
+
+    let win = window_handle()?;
+    let resp_value = JsFuture::from(win.fetch_with_request(&request))
+        .await
+        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
+    let resp: Response = resp_value
+        .dyn_into()
+        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return a Response"))?;
+    if !resp.ok() {
+        return Err(ErrorDetail::new(
+            ErrorKind::Network,
+            format!("HTTP {}", resp.status()),
+        ));
+    }
+
+    let body_stream = resp
+        .body()
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "response has no body stream"))?;
+    let stream = ReadableStream::from_raw(body_stream).into_stream();
+    spawn_reader(stream, on_frame, on_error);
+    Ok(abort)
+}
+
+fn window_handle() -> Result<Window, ErrorDetail> {
+    get_window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no `window` available"))
+}
+
+fn spawn_reader(
+    mut stream: impl futures::Stream<Item = Result<JsValue, JsValue>> + Unpin + 'static,
+    mut on_frame: impl FnMut(&str) + 'static,
+    mut on_error: impl FnMut(ErrorDetail) + 'static,
+) {
+    wasm_bindgen_futures::spawn_local(async move {
+        let mut buffer = BytesMut::new();
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(value) => {
+                    let array: Uint8Array = match value.dyn_into() {
+                        Ok(a) => a,
+                        Err(_) => continue,
+                    };
+                    buffer.extend_from_slice(&array.to_vec());
+                    drain_frames(&mut buffer, &mut on_frame);
+                }
+                Err(e) => {
+                    on_error(ErrorDetail::new(
+                        ErrorKind::Network,
+                        format!("stream read failed: {e:?}"),
+                    ));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Pull every complete SSE event (terminated by `\n\n`) out of
+/// `buffer`, strip its `data: ` prefix, and invoke `on_frame` with
+/// the inner JSON. Whatever bytes are left after the last `\n\n`
+/// stay in the buffer for the next chunk.
+fn drain_frames(buffer: &mut BytesMut, on_frame: &mut impl FnMut(&str)) {
+    while let Some(idx) = find_double_newline(buffer) {
+        let frame = buffer.split_to(idx);
+        let _ = buffer.split_to(2); // discard "\n\n"
+        if let Ok(text) = std::str::from_utf8(&frame)
+            && let Some(payload) = strip_sse_data_prefix(text)
+        {
+            on_frame(payload);
+        }
+    }
+}
+
+fn find_double_newline(b: &[u8]) -> Option<usize> {
+    b.windows(2).position(|w| w == b"\n\n")
+}
+
+/// `data: {…}\n` → `{…}`. Multi-line `data:` events are joined
+/// with literal `\n` per the SSE spec, but the worker emits
+/// single-line frames so the simple form is enough.
+fn strip_sse_data_prefix(frame: &str) -> Option<&str> {
+    frame
+        .strip_prefix("data: ")
+        .or_else(|| frame.strip_prefix("data:"))
+}

--- a/rust/tonk-concept/src/fetch.rs
+++ b/rust/tonk-concept/src/fetch.rs
@@ -21,14 +21,16 @@ use js_sys::Uint8Array;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use wasm_streams::ReadableStream;
-use web_sys::{AbortController, Headers, Request, RequestInit, Response, Window, window as get_window};
+use web_sys::{
+    AbortController, Headers, Request, RequestInit, Response, Window, window as get_window,
+};
 
 use crate::error::{ErrorDetail, ErrorKind};
 
-/// Phase-1 helper — POST `body` as JSON to `url`, parse the
-/// returned `Vec<Conclusion>`, return the `source` field from the
-/// first row (the descriptor JSON for Phase 2).
-pub async fn phase1_lookup(url: &str, body: &str) -> Result<String, ErrorDetail> {
+/// POST `body` as JSON to `url`, parse the returned `Vec<Conclusion>`,
+/// and return the first row's `this` (concept entity URI) plus its
+/// `source` field (the descriptor JSON the next step needs).
+pub async fn phase1_lookup(url: &str, body: &str) -> Result<(String, String), ErrorDetail> {
     let init = RequestInit::new();
     init.set_method("POST");
     let headers = Headers::new()
@@ -66,9 +68,8 @@ pub async fn phase1_lookup(url: &str, body: &str) -> Result<String, ErrorDetail>
     let body_text = text
         .as_string()
         .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
-    let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
-        serde_json::from_str(&body_text)
-            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
+    let conclusions: Vec<tonk_schema::conclusion::Conclusion> = serde_json::from_str(&body_text)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
     let first = conclusions
         .into_iter()
         .next()
@@ -83,68 +84,6 @@ pub async fn phase1_lookup(url: &str, body: &str) -> Result<String, ErrorDetail>
                 ErrorKind::Descriptor,
                 "phase1 row missing `source` field — worker may not be on the AnonymousConceptQuery build",
             )
-        })?;
-    Ok(source)
-}
-
-/// Phase-1 helper (display variant) — like [`phase1_lookup`] but
-/// also returns the `this` field (the concept entity URI) needed by
-/// `<tonk-display>` to build view and entity queries.
-pub async fn phase1_lookup_with_entity(
-    url: &str,
-    body: &str,
-) -> Result<(String, String), ErrorDetail> {
-    let init = RequestInit::new();
-    init.set_method("POST");
-    let headers = Headers::new()
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers: {e:?}")))?;
-    headers
-        .append("content-type", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
-    headers
-        .append("accept", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
-    init.set_headers(&headers);
-    init.set_body(&JsValue::from_str(body));
-
-    let request = Request::new_with_str_and_init(url, &init)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Request: {e:?}")))?;
-    let win = window_handle()?;
-    let resp_value = JsFuture::from(win.fetch_with_request(&request))
-        .await
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
-    let resp: Response = resp_value
-        .dyn_into()
-        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return Response"))?;
-    if !resp.ok() {
-        return Err(ErrorDetail::new(
-            ErrorKind::Network,
-            format!("phase1 HTTP {}", resp.status()),
-        ));
-    }
-    let text = JsFuture::from(
-        resp.text()
-            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("text: {e:?}")))?,
-    )
-    .await
-    .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read body: {e:?}")))?;
-    let body_text = text
-        .as_string()
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
-    let conclusions: Vec<tonk_schema::conclusion::Conclusion> =
-        serde_json::from_str(&body_text)
-            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
-    let first = conclusions
-        .into_iter()
-        .next()
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::UnknownSource, "no concept matched"))?;
-    let source = first
-        .fields
-        .get("source")
-        .and_then(|v| v.as_str())
-        .map(str::to_owned)
-        .ok_or_else(|| {
-            ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `source` field")
         })?;
     Ok((first.this, source))
 }

--- a/rust/tonk-concept/src/lib.rs
+++ b/rust/tonk-concept/src/lib.rs
@@ -20,6 +20,8 @@ pub mod resolve;
 pub mod template;
 
 #[cfg(target_arch = "wasm32")]
+mod bridge;
+#[cfg(target_arch = "wasm32")]
 mod element;
 #[cfg(target_arch = "wasm32")]
 mod render;

--- a/rust/tonk-concept/src/lib.rs
+++ b/rust/tonk-concept/src/lib.rs
@@ -20,7 +20,7 @@ pub mod resolve;
 pub mod template;
 
 #[cfg(target_arch = "wasm32")]
-mod bridge;
+pub mod bridge;
 #[cfg(target_arch = "wasm32")]
 mod element;
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-concept/src/lib.rs
+++ b/rust/tonk-concept/src/lib.rs
@@ -24,6 +24,8 @@ pub mod bridge;
 #[cfg(target_arch = "wasm32")]
 mod element;
 #[cfg(target_arch = "wasm32")]
+pub mod fetch;
+#[cfg(target_arch = "wasm32")]
 mod render;
 #[cfg(target_arch = "wasm32")]
 pub mod sse;

--- a/rust/tonk-concept/src/sse.rs
+++ b/rust/tonk-concept/src/sse.rs
@@ -8,9 +8,8 @@
 //! When `globalThis.tonk` is absent (the shell mounts these elements
 //! directly in its own DOM, outside any iframe) the legacy
 //! `fetch()`-based SSE reader in [`crate::fetch`] is used instead.
-//! The caller is responsible for supplying a non-empty `url` and
-//! `body_str` in that case (built from the `space`/`branch` HTML
-//! attributes).
+//! The caller is responsible for supplying a non-empty `url` in
+//! that case (built from the `space`/`branch` HTML attributes).
 
 use std::rc::Rc;
 
@@ -63,9 +62,9 @@ pub fn use_bridge() -> bool {
 /// Open a streaming subscription using whichever transport is
 /// available.
 ///
-/// `url` and `body_str` are used on the legacy fetch path; `body`
-/// (the `serde_json::Value` form) is used on the bridge path.
-/// When `use_bridge()` is true `url`/`body_str` are ignored.
+/// `url` is only used on the legacy fetch path. `body` is the
+/// query as a `serde_json::Value`; on the fetch path it is
+/// stringified once for the request body.
 ///
 /// `on_frame` is called for each emitted frame with the raw JSON
 /// string of a `Vec<Conclusion>`. `on_error` is called on transport
@@ -75,26 +74,22 @@ pub fn use_bridge() -> bool {
 /// dropping it cancels the subscription.
 pub async fn open_sse(
     url: &str,
-    body_str: &str,
     body: &serde_json::Value,
     on_frame: impl Fn(&str) + 'static,
     on_error: impl Fn(ErrorDetail) + 'static,
 ) -> Result<SubscriptionAbort, ErrorDetail> {
     if use_bridge() {
-        // Bridge path — synchronous setup via globalThis.tonk.subscribe.
         let on_error = Rc::new(on_error);
         let on_error_for_frame = on_error.clone();
         let handle = subscribe(
             body,
-            move |frame_value| {
-                match serde_json::to_string(&frame_value) {
-                    Ok(s) => on_frame(&s),
-                    Err(e) => {
-                        on_error_for_frame(ErrorDetail::new(
-                            ErrorKind::Parse,
-                            format!("frame stringify: {e}"),
-                        ));
-                    }
+            move |frame_value| match serde_json::to_string(&frame_value) {
+                Ok(s) => on_frame(&s),
+                Err(e) => {
+                    on_error_for_frame(ErrorDetail::new(
+                        ErrorKind::Parse,
+                        format!("frame stringify: {e}"),
+                    ));
                 }
             },
             move |message| {
@@ -103,14 +98,14 @@ pub async fn open_sse(
         )?;
         Ok(SubscriptionAbort::Bridge(handle))
     } else {
-        // Fetch/SSE path — async, awaits the initial HTTP response.
+        let body_str = serde_json::to_string(body)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body stringify: {e}")))?;
         // on_frame / on_error must be FnMut for the SSE reader loop.
-        // Wrap in a flag to adapt Fn → FnMut.
         let on_frame_cell = std::cell::RefCell::new(on_frame);
         let on_error_cell = std::cell::RefCell::new(on_error);
         let ctrl = crate::fetch::open_sse(
             url,
-            body_str,
+            &body_str,
             move |frame| (on_frame_cell.borrow())(frame),
             move |err| (on_error_cell.borrow())(err),
         )

--- a/rust/tonk-concept/src/sse.rs
+++ b/rust/tonk-concept/src/sse.rs
@@ -3,7 +3,9 @@
 //!
 //! When `globalThis.tonk` is present (the iframe shell has loaded
 //! `bridge.js`) the bridge path is used: `globalThis.tonk.subscribe`
-//! routes every data request over postMessage to the service worker.
+//! returns a `ReadableStream` whose chunks are routed to the
+//! caller's `on_frame` callback by a pump spawned in
+//! `wasm_bindgen_futures::spawn_local`.
 //!
 //! When `globalThis.tonk` is absent (the shell mounts these elements
 //! directly in its own DOM, outside any iframe) the legacy
@@ -15,7 +17,7 @@ use std::rc::Rc;
 
 use web_sys::AbortController;
 
-use crate::bridge::{SubscribeHandle, subscribe};
+use crate::bridge::{Subscription, subscribe};
 use crate::error::{ErrorDetail, ErrorKind};
 
 /// Transport handle returned by [`open_sse`].
@@ -23,8 +25,10 @@ use crate::error::{ErrorDetail, ErrorKind};
 /// Dropping this value cancels the subscription regardless of which
 /// transport is active.
 pub enum SubscriptionAbort {
-    /// Bridge path — `Drop` calls the bridge's unsubscribe function.
-    Bridge(SubscribeHandle),
+    /// Bridge path — `Drop` cancels the underlying `ReadableStream`,
+    /// which posts an `unsubscribe` envelope to the SW. The pump
+    /// task's pending `read()` resolves with `done=true` and exits.
+    Bridge(Rc<Subscription>),
     /// Fetch/SSE path — `Drop` calls `AbortController::abort()`.
     Fetch(AbortController),
 }
@@ -32,12 +36,8 @@ pub enum SubscriptionAbort {
 impl Drop for SubscriptionAbort {
     fn drop(&mut self) {
         match self {
-            SubscriptionAbort::Bridge(_handle) => {
-                // SubscribeHandle's own Drop impl calls unsub().
-            }
-            SubscriptionAbort::Fetch(ctrl) => {
-                ctrl.abort();
-            }
+            SubscriptionAbort::Bridge(sub) => sub.cancel(),
+            SubscriptionAbort::Fetch(ctrl) => ctrl.abort(),
         }
     }
 }
@@ -79,24 +79,30 @@ pub async fn open_sse(
     on_error: impl Fn(ErrorDetail) + 'static,
 ) -> Result<SubscriptionAbort, ErrorDetail> {
     if use_bridge() {
-        let on_error = Rc::new(on_error);
-        let on_error_for_frame = on_error.clone();
-        let handle = subscribe(
-            body,
-            move |frame_value| match serde_json::to_string(&frame_value) {
-                Ok(s) => on_frame(&s),
-                Err(e) => {
-                    on_error_for_frame(ErrorDetail::new(
-                        ErrorKind::Parse,
-                        format!("frame stringify: {e}"),
-                    ));
+        let subscription = Rc::new(subscribe(body).await?);
+        let pump_sub = subscription.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            loop {
+                match pump_sub.next().await {
+                    Ok(Some(value)) => match serde_json::to_string(&value) {
+                        Ok(s) => on_frame(&s),
+                        Err(e) => {
+                            on_error(ErrorDetail::new(
+                                ErrorKind::Parse,
+                                format!("frame stringify: {e}"),
+                            ));
+                            break;
+                        }
+                    },
+                    Ok(None) => break,
+                    Err(e) => {
+                        on_error(e);
+                        break;
+                    }
                 }
-            },
-            move |message| {
-                on_error(ErrorDetail::new(ErrorKind::Network, message));
-            },
-        )?;
-        Ok(SubscriptionAbort::Bridge(handle))
+            }
+        });
+        Ok(SubscriptionAbort::Bridge(subscription))
     } else {
         let body_str = serde_json::to_string(body)
             .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body stringify: {e}")))?;

--- a/rust/tonk-concept/src/sse.rs
+++ b/rust/tonk-concept/src/sse.rs
@@ -1,140 +1,49 @@
-//! `fetch()`-driven Server-Sent Events reader.
+//! Bridge-driven subscription helper.
 //!
-//! `wasm_streams::ReadableStream::from_raw(...)` adapts the JS
-//! `ReadableStream` returned by `Response::body()` into a Rust
-//! `Stream<Item = Result<JsValue, JsValue>>`. Each chunk is a
-//! `Uint8Array`; we accumulate bytes into a buffer, split on
-//! `\n\n` (SSE event delimiter), strip the leading `data: ` from
-//! each event's payload line, and hand the remaining JSON to a
-//! callback.
+//! Replaces the previous `fetch()`-based SSE reader. All streaming
+//! data now flows through `globalThis.tonk.subscribe`, which the
+//! bridge module routes over postMessage to the service worker.
 
-use bytes::BytesMut;
-use futures::StreamExt as _;
-use js_sys::Uint8Array;
-use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
-use wasm_streams::ReadableStream;
-use web_sys::{
-    AbortController, Headers, Request, RequestInit, Response, Window, window as get_window,
-};
+use std::rc::Rc;
 
+use crate::bridge::{SubscribeHandle, subscribe};
 use crate::error::{ErrorDetail, ErrorKind};
 
-/// Open an SSE subscription against `url`, sending `body` as the
-/// JSON request body. The future resolves once the first read
-/// completes; subsequent frames flow through `on_frame`. Cancel
-/// by calling `.abort()` on the returned [`AbortController`].
+/// Open a streaming subscription via the postMessage bridge.
 ///
-/// Errors during streaming are reported via the `on_error`
-/// callback; the future itself returns `Err` only for the
-/// initial fetch failure.
-pub async fn open_sse(
-    url: &str,
-    body: &str,
-    on_frame: impl FnMut(&str) + 'static,
-    on_error: impl FnMut(ErrorDetail) + 'static,
-) -> Result<AbortController, ErrorDetail> {
-    let abort = AbortController::new()
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("AbortController: {e:?}")))?;
+/// `body` is the wire query to send. `on_frame` is called for each
+/// emitted frame (the raw JSON string of a `Vec<Conclusion>`).
+/// `on_error` is called on bridge-reported transport errors.
+///
+/// Returns a [`SubscribeHandle`] that the caller must keep alive;
+/// dropping it cancels the subscription.
+pub fn open_sse(
+    body: &serde_json::Value,
+    on_frame: impl Fn(&str) + 'static,
+    on_error: impl Fn(ErrorDetail) + 'static,
+) -> Result<SubscribeHandle, ErrorDetail> {
+    // Wrap on_error in Rc so it can be shared between the two bridge
+    // callbacks without cloning the underlying value.
+    let on_error = Rc::new(on_error);
+    let on_error_for_frame = on_error.clone();
 
-    let init = RequestInit::new();
-    init.set_method("POST");
-    let headers = Headers::new()
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers::new: {e:?}")))?;
-    headers
-        .append("accept", "text/event-stream")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
-    headers
-        .append("content-type", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
-    init.set_headers(&headers);
-    init.set_body(&JsValue::from_str(body));
-    init.set_signal(Some(&abort.signal()));
-
-    let request = Request::new_with_str_and_init(url, &init).map_err(|e| {
-        ErrorDetail::new(ErrorKind::Network, format!("Request construction: {e:?}"))
-    })?;
-
-    let win = window_handle()?;
-    let resp_value = JsFuture::from(win.fetch_with_request(&request))
-        .await
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
-    let resp: Response = resp_value
-        .dyn_into()
-        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return a Response"))?;
-    if !resp.ok() {
-        return Err(ErrorDetail::new(
-            ErrorKind::Network,
-            format!("HTTP {}", resp.status()),
-        ));
-    }
-
-    let body_stream = resp
-        .body()
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "response has no body stream"))?;
-    let stream = ReadableStream::from_raw(body_stream).into_stream();
-    spawn_reader(stream, on_frame, on_error);
-    Ok(abort)
-}
-
-fn window_handle() -> Result<Window, ErrorDetail> {
-    get_window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no `window` available"))
-}
-
-fn spawn_reader(
-    mut stream: impl futures::Stream<Item = Result<JsValue, JsValue>> + Unpin + 'static,
-    mut on_frame: impl FnMut(&str) + 'static,
-    mut on_error: impl FnMut(ErrorDetail) + 'static,
-) {
-    wasm_bindgen_futures::spawn_local(async move {
-        let mut buffer = BytesMut::new();
-        while let Some(chunk) = stream.next().await {
-            match chunk {
-                Ok(value) => {
-                    let array: Uint8Array = match value.dyn_into() {
-                        Ok(a) => a,
-                        Err(_) => continue,
-                    };
-                    buffer.extend_from_slice(&array.to_vec());
-                    drain_frames(&mut buffer, &mut on_frame);
-                }
+    subscribe(
+        body,
+        move |frame_value| {
+            // Re-serialise to a string so that the call site
+            // (which expects `&str`) doesn't need to change shape.
+            match serde_json::to_string(&frame_value) {
+                Ok(s) => on_frame(&s),
                 Err(e) => {
-                    on_error(ErrorDetail::new(
-                        ErrorKind::Network,
-                        format!("stream read failed: {e:?}"),
+                    on_error_for_frame(ErrorDetail::new(
+                        ErrorKind::Parse,
+                        format!("frame stringify: {e}"),
                     ));
-                    break;
                 }
             }
-        }
-    });
-}
-
-/// Pull every complete SSE event (terminated by `\n\n`) out of
-/// `buffer`, strip its `data: ` prefix, and invoke `on_frame` with
-/// the inner JSON. Whatever bytes are left after the last `\n\n`
-/// stay in the buffer for the next chunk.
-fn drain_frames(buffer: &mut BytesMut, on_frame: &mut impl FnMut(&str)) {
-    while let Some(idx) = find_double_newline(buffer) {
-        let frame = buffer.split_to(idx);
-        let _ = buffer.split_to(2); // discard "\n\n"
-        if let Ok(text) = std::str::from_utf8(&frame)
-            && let Some(payload) = strip_sse_data_prefix(text)
-        {
-            on_frame(payload);
-        }
-    }
-}
-
-fn find_double_newline(b: &[u8]) -> Option<usize> {
-    b.windows(2).position(|w| w == b"\n\n")
-}
-
-/// `data: {…}\n` → `{…}`. Multi-line `data:` events are joined
-/// with literal `\n` per the SSE spec, but the worker emits
-/// single-line frames so the simple form is enough.
-fn strip_sse_data_prefix(frame: &str) -> Option<&str> {
-    frame
-        .strip_prefix("data: ")
-        .or_else(|| frame.strip_prefix("data:"))
+        },
+        move |message| {
+            on_error(ErrorDetail::new(ErrorKind::Network, message));
+        },
+    )
 }

--- a/rust/tonk-concept/src/sse.rs
+++ b/rust/tonk-concept/src/sse.rs
@@ -82,24 +82,15 @@ pub async fn open_sse(
         let subscription = Rc::new(subscribe(body).await?);
         let pump_sub = subscription.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            loop {
-                match pump_sub.next().await {
-                    Ok(Some(value)) => match serde_json::to_string(&value) {
-                        Ok(s) => on_frame(&s),
-                        Err(e) => {
-                            on_error(ErrorDetail::new(
-                                ErrorKind::Parse,
-                                format!("frame stringify: {e}"),
-                            ));
-                            break;
-                        }
-                    },
-                    Ok(None) => break,
-                    Err(e) => {
-                        on_error(e);
-                        break;
-                    }
+            let result: Result<(), ErrorDetail> = async {
+                while let Some(frame) = pump_sub.next().await? {
+                    on_frame(&frame);
                 }
+                Ok(())
+            }
+            .await;
+            if let Err(e) = result {
+                on_error(e);
             }
         });
         Ok(SubscriptionAbort::Bridge(subscription))

--- a/rust/tonk-concept/src/sse.rs
+++ b/rust/tonk-concept/src/sse.rs
@@ -1,49 +1,120 @@
-//! Bridge-driven subscription helper.
+//! Subscription helper — selects bridge or fetch transport at
+//! runtime and exposes a uniform `SubscriptionAbort` handle.
 //!
-//! Replaces the previous `fetch()`-based SSE reader. All streaming
-//! data now flows through `globalThis.tonk.subscribe`, which the
-//! bridge module routes over postMessage to the service worker.
+//! When `globalThis.tonk` is present (the iframe shell has loaded
+//! `bridge.js`) the bridge path is used: `globalThis.tonk.subscribe`
+//! routes every data request over postMessage to the service worker.
+//!
+//! When `globalThis.tonk` is absent (the shell mounts these elements
+//! directly in its own DOM, outside any iframe) the legacy
+//! `fetch()`-based SSE reader in [`crate::fetch`] is used instead.
+//! The caller is responsible for supplying a non-empty `url` and
+//! `body_str` in that case (built from the `space`/`branch` HTML
+//! attributes).
 
 use std::rc::Rc;
+
+use web_sys::AbortController;
 
 use crate::bridge::{SubscribeHandle, subscribe};
 use crate::error::{ErrorDetail, ErrorKind};
 
-/// Open a streaming subscription via the postMessage bridge.
+/// Transport handle returned by [`open_sse`].
 ///
-/// `body` is the wire query to send. `on_frame` is called for each
-/// emitted frame (the raw JSON string of a `Vec<Conclusion>`).
-/// `on_error` is called on bridge-reported transport errors.
+/// Dropping this value cancels the subscription regardless of which
+/// transport is active.
+pub enum SubscriptionAbort {
+    /// Bridge path — `Drop` calls the bridge's unsubscribe function.
+    Bridge(SubscribeHandle),
+    /// Fetch/SSE path — `Drop` calls `AbortController::abort()`.
+    Fetch(AbortController),
+}
+
+impl Drop for SubscriptionAbort {
+    fn drop(&mut self) {
+        match self {
+            SubscriptionAbort::Bridge(_handle) => {
+                // SubscribeHandle's own Drop impl calls unsub().
+            }
+            SubscriptionAbort::Fetch(ctrl) => {
+                ctrl.abort();
+            }
+        }
+    }
+}
+
+/// Pick a transport. Prefer the iframe bridge if it's loaded
+/// (`globalThis.tonk` is defined and not null); otherwise fall back
+/// to direct fetch against `url`. The shell mounts these elements
+/// with `space`/`branch` attributes set; the iframe-wrapped body
+/// mounts them without (and has `globalThis.tonk` available).
+pub fn use_bridge() -> bool {
+    use js_sys::Reflect;
+    use wasm_bindgen::JsValue;
+    let Some(win) = web_sys::window() else {
+        return false;
+    };
+    let Ok(tonk) = Reflect::get(&win, &JsValue::from_str("tonk")) else {
+        return false;
+    };
+    !tonk.is_undefined() && !tonk.is_null()
+}
+
+/// Open a streaming subscription using whichever transport is
+/// available.
 ///
-/// Returns a [`SubscribeHandle`] that the caller must keep alive;
+/// `url` and `body_str` are used on the legacy fetch path; `body`
+/// (the `serde_json::Value` form) is used on the bridge path.
+/// When `use_bridge()` is true `url`/`body_str` are ignored.
+///
+/// `on_frame` is called for each emitted frame with the raw JSON
+/// string of a `Vec<Conclusion>`. `on_error` is called on transport
+/// errors.
+///
+/// Returns a [`SubscriptionAbort`] that the caller must keep alive;
 /// dropping it cancels the subscription.
-pub fn open_sse(
+pub async fn open_sse(
+    url: &str,
+    body_str: &str,
     body: &serde_json::Value,
     on_frame: impl Fn(&str) + 'static,
     on_error: impl Fn(ErrorDetail) + 'static,
-) -> Result<SubscribeHandle, ErrorDetail> {
-    // Wrap on_error in Rc so it can be shared between the two bridge
-    // callbacks without cloning the underlying value.
-    let on_error = Rc::new(on_error);
-    let on_error_for_frame = on_error.clone();
-
-    subscribe(
-        body,
-        move |frame_value| {
-            // Re-serialise to a string so that the call site
-            // (which expects `&str`) doesn't need to change shape.
-            match serde_json::to_string(&frame_value) {
-                Ok(s) => on_frame(&s),
-                Err(e) => {
-                    on_error_for_frame(ErrorDetail::new(
-                        ErrorKind::Parse,
-                        format!("frame stringify: {e}"),
-                    ));
+) -> Result<SubscriptionAbort, ErrorDetail> {
+    if use_bridge() {
+        // Bridge path — synchronous setup via globalThis.tonk.subscribe.
+        let on_error = Rc::new(on_error);
+        let on_error_for_frame = on_error.clone();
+        let handle = subscribe(
+            body,
+            move |frame_value| {
+                match serde_json::to_string(&frame_value) {
+                    Ok(s) => on_frame(&s),
+                    Err(e) => {
+                        on_error_for_frame(ErrorDetail::new(
+                            ErrorKind::Parse,
+                            format!("frame stringify: {e}"),
+                        ));
+                    }
                 }
-            }
-        },
-        move |message| {
-            on_error(ErrorDetail::new(ErrorKind::Network, message));
-        },
-    )
+            },
+            move |message| {
+                on_error(ErrorDetail::new(ErrorKind::Network, message));
+            },
+        )?;
+        Ok(SubscriptionAbort::Bridge(handle))
+    } else {
+        // Fetch/SSE path — async, awaits the initial HTTP response.
+        // on_frame / on_error must be FnMut for the SSE reader loop.
+        // Wrap in a flag to adapt Fn → FnMut.
+        let on_frame_cell = std::cell::RefCell::new(on_frame);
+        let on_error_cell = std::cell::RefCell::new(on_error);
+        let ctrl = crate::fetch::open_sse(
+            url,
+            body_str,
+            move |frame| (on_frame_cell.borrow())(frame),
+            move |err| (on_error_cell.borrow())(err),
+        )
+        .await?;
+        Ok(SubscriptionAbort::Fetch(ctrl))
+    }
 }

--- a/rust/tonk-display/Cargo.toml
+++ b/rust/tonk-display/Cargo.toml
@@ -10,9 +10,7 @@ description = "<tonk-display> custom element — renders a single entity using a
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bytes = { workspace = true }
 custom-elements = { workspace = true }
-futures = { workspace = true }
 indexmap = { workspace = true }
 js-sys = { workspace = true }
 lsp-types = { workspace = true }
@@ -25,8 +23,6 @@ tonk-schema = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [
-    "AbortController",
-    "AbortSignal",
     "Attr",
     "Comment",
     "CustomElementRegistry",
@@ -35,7 +31,6 @@ web-sys = { workspace = true, features = [
     "Document",
     "DocumentFragment",
     "Element",
-    "Headers",
     "HtmlElement",
     "HtmlTemplateElement",
     "MutationObserver",
@@ -43,9 +38,6 @@ web-sys = { workspace = true, features = [
     "NamedNodeMap",
     "Node",
     "NodeList",
-    "Request",
-    "RequestInit",
-    "Response",
     "Text",
     "Window",
 ] }

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -314,7 +314,7 @@ async fn run(
         ),
     };
 
-    // Phase 1 — resolve the model concept's entity + descriptor.
+    // Resolve the model concept's entity + descriptor.
     let parsed: ParsedSource = parse_source(&model);
     let phase1_q = phase1_query(&parsed);
     let (model_entity, descriptor_json) = if use_bridge() {
@@ -324,7 +324,7 @@ async fn run(
     } else {
         let body_str = serde_json::to_string(&phase1_q)
             .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-        tonk_concept::fetch::phase1_lookup_with_entity(&url, &body_str).await?
+        tonk_concept::fetch::phase1_lookup(&url, &body_str).await?
     };
     check_generation(&state, generation)?;
 
@@ -339,15 +339,11 @@ async fn run(
     };
     let view_body = serde_json::to_value(&view_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body: {e}")))?;
-    let view_body_str = serde_json::to_string(&view_q)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body str: {e}")))?;
 
     let entity_q = entity_query(&descriptor_json, &entity)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
     let entity_body = serde_json::to_value(&entity_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body: {e}")))?;
-    let entity_body_str = serde_json::to_string(&entity_q)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body str: {e}")))?;
 
     // Always mount the `<wa-carousel>` so the slot geometry is
     // identical regardless of mode. The only user-visible
@@ -358,8 +354,7 @@ async fn run(
     ensure_carousel(host, &state, single_mode);
 
     let view_abort =
-        open_view_stream(&url, &view_body_str, &view_body, host.clone(), state.clone(), generation)
-            .await?;
+        open_view_stream(&url, &view_body, host.clone(), state.clone(), generation).await?;
     // Check generation again — between opening view and entity
     // streams, attribute_changed_callback may have fired and
     // superseded us. If so, drop the view handle we just opened
@@ -369,8 +364,7 @@ async fn run(
         return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
     }
     let entity_abort =
-        open_entity_stream(&url, &entity_body_str, &entity_body, host.clone(), state.clone(), generation)
-            .await?;
+        open_entity_stream(&url, &entity_body, host.clone(), state.clone(), generation).await?;
 
     {
         let mut s = state.borrow_mut();
@@ -392,7 +386,6 @@ async fn run(
 
 async fn open_view_stream(
     url: &str,
-    body_str: &str,
     body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
@@ -404,7 +397,6 @@ async fn open_view_stream(
     let state_for_frame = state.clone();
     open_sse(
         url,
-        body_str,
         body,
         move |frame: &str| {
             // Discard frames from a superseded or disposed flow
@@ -446,7 +438,6 @@ async fn open_view_stream(
 
 async fn open_entity_stream(
     url: &str,
-    body_str: &str,
     body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
@@ -458,7 +449,6 @@ async fn open_entity_stream(
     let state_for_frame = state.clone();
     open_sse(
         url,
-        body_str,
         body,
         move |frame: &str| {
             // Same stale-frame guard as in `open_view_stream`.
@@ -745,11 +735,9 @@ fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
     serde_wasm_bindgen::to_value(conclusion).unwrap_or(JsValue::NULL)
 }
 
-/// Phase-1 lookup via the postMessage bridge.
-///
-/// Returns `(this, source)` from the first matching row — `this` is
-/// the concept entity URI, `source` is the raw descriptor JSON the
-/// worker put in the row's `source` field.
+/// Bridge-side resolver — returns `(this, source)` from the first
+/// matching row. `this` is the concept entity URI; `source` is the
+/// raw descriptor JSON the worker put in the row's `source` field.
 async fn bridge_phase1_lookup(body: &serde_json::Value) -> Result<(String, String), ErrorDetail> {
     let result = tonk_concept::bridge::query(body).await?;
     let arr = result.as_array().ok_or_else(|| {

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -28,10 +28,9 @@ use std::rc::Rc;
 
 use custom_elements::CustomElement;
 use js_sys::{Function, Reflect};
-use tonk_concept::bridge::{SubscribeHandle, query as bridge_query};
 use tonk_concept::error::{ErrorDetail, ErrorKind};
 use tonk_concept::resolve::{ParsedSource, parse_source, phase1_query};
-use tonk_concept::sse::open_sse;
+use tonk_concept::sse::{SubscriptionAbort, open_sse, use_bridge};
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -80,12 +79,12 @@ struct Inner {
     /// detaches and re-attaches.
     generation: u64,
     /// Cancels the view (or views-for-model) subscription on
-    /// disconnect / attribute change. Dropping the handle calls
-    /// the bridge's unsubscribe function.
-    view_abort: Option<SubscribeHandle>,
+    /// disconnect / attribute change. Dropping the handle cancels
+    /// the active transport (bridge or fetch).
+    view_abort: Option<SubscriptionAbort>,
     /// Cancels the entity subscription on disconnect / attribute
     /// change.
-    entity_abort: Option<SubscribeHandle>,
+    entity_abort: Option<SubscriptionAbort>,
     /// Last entity conclusion seen; replayed when a fresh slide
     /// is mounted so it picks up the current data without waiting
     /// for the next entity frame.
@@ -300,9 +299,33 @@ async fn run(
     // `view` is optional — its absence triggers carousel mode.
     let view = host.get_attribute("view").filter(|s| !s.is_empty());
 
+    // Build the query URL from `space`/`branch` attributes (shell
+    // path). When neither is set a relative `/query` is used. In
+    // bridge mode this URL is passed along but is unused — the
+    // bridge routes every request through postMessage.
+    let space_attr = host.get_attribute("space");
+    let branch_attr = host.get_attribute("branch");
+    let url = match (&space_attr, &branch_attr) {
+        (None, None) => "/query".to_owned(),
+        _ => format!(
+            "/api/repository/{}/branch/{}/query",
+            space_attr.as_deref().unwrap_or("home"),
+            branch_attr.as_deref().unwrap_or("main"),
+        ),
+    };
+
     // Phase 1 — resolve the model concept's entity + descriptor.
     let parsed: ParsedSource = parse_source(&model);
-    let (model_entity, descriptor_json) = phase1_lookup(&phase1_query(&parsed)).await?;
+    let phase1_q = phase1_query(&parsed);
+    let (model_entity, descriptor_json) = if use_bridge() {
+        let body_val = serde_json::to_value(&phase1_q)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+        bridge_phase1_lookup(&body_val).await?
+    } else {
+        let body_str = serde_json::to_string(&phase1_q)
+            .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+        tonk_concept::fetch::phase1_lookup_with_entity(&url, &body_str).await?
+    };
     check_generation(&state, generation)?;
 
     // Build the view subscription query: pin-by-name in single
@@ -316,11 +339,15 @@ async fn run(
     };
     let view_body = serde_json::to_value(&view_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body: {e}")))?;
+    let view_body_str = serde_json::to_string(&view_q)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body str: {e}")))?;
 
     let entity_q = entity_query(&descriptor_json, &entity)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
     let entity_body = serde_json::to_value(&entity_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body: {e}")))?;
+    let entity_body_str = serde_json::to_string(&entity_q)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body str: {e}")))?;
 
     // Always mount the `<wa-carousel>` so the slot geometry is
     // identical regardless of mode. The only user-visible
@@ -330,16 +357,20 @@ async fn run(
     let single_mode = view.is_some();
     ensure_carousel(host, &state, single_mode);
 
-    let view_abort = open_view_stream(&view_body, host.clone(), state.clone(), generation)?;
+    let view_abort =
+        open_view_stream(&url, &view_body_str, &view_body, host.clone(), state.clone(), generation)
+            .await?;
     // Check generation again — between opening view and entity
     // streams, attribute_changed_callback may have fired and
     // superseded us. If so, drop the view handle we just opened
-    // (its Drop impl calls unsubscribe), and bail.
+    // (its Drop impl cancels the transport), and bail.
     if check_generation(&state, generation).is_err() {
         drop(view_abort);
         return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
     }
-    let entity_abort = open_entity_stream(&entity_body, host.clone(), state.clone(), generation)?;
+    let entity_abort =
+        open_entity_stream(&url, &entity_body_str, &entity_body, host.clone(), state.clone(), generation)
+            .await?;
 
     {
         let mut s = state.borrow_mut();
@@ -359,17 +390,21 @@ async fn run(
     Ok(())
 }
 
-fn open_view_stream(
+async fn open_view_stream(
+    url: &str,
+    body_str: &str,
     body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
     generation: u64,
-) -> Result<SubscribeHandle, ErrorDetail> {
+) -> Result<SubscriptionAbort, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
     let state_for_frame = state.clone();
     open_sse(
+        url,
+        body_str,
         body,
         move |frame: &str| {
             // Discard frames from a superseded or disposed flow
@@ -406,19 +441,24 @@ fn open_view_stream(
             fail(&host_for_err, &state_for_err, err);
         },
     )
+    .await
 }
 
-fn open_entity_stream(
+async fn open_entity_stream(
+    url: &str,
+    body_str: &str,
     body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
     generation: u64,
-) -> Result<SubscribeHandle, ErrorDetail> {
+) -> Result<SubscriptionAbort, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
     let state_for_frame = state.clone();
     open_sse(
+        url,
+        body_str,
         body,
         move |frame: &str| {
             // Same stale-frame guard as in `open_view_stream`.
@@ -450,6 +490,7 @@ fn open_entity_stream(
             fail(&host_for_err, &state_for_err, err);
         },
     )
+    .await
 }
 
 /// Diff the incoming view frame against currently mounted slides.
@@ -704,15 +745,13 @@ fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
     serde_wasm_bindgen::to_value(conclusion).unwrap_or(JsValue::NULL)
 }
 
-/// One-shot Phase-1 lookup via the postMessage bridge.
+/// Phase-1 lookup via the postMessage bridge.
 ///
 /// Returns `(this, source)` from the first matching row — `this` is
 /// the concept entity URI, `source` is the raw descriptor JSON the
 /// worker put in the row's `source` field.
-async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<(String, String), ErrorDetail> {
-    let body = serde_json::to_value(query)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-    let result = bridge_query(&body).await?;
+async fn bridge_phase1_lookup(body: &serde_json::Value) -> Result<(String, String), ErrorDetail> {
+    let result = tonk_concept::bridge::query(body).await?;
     let arr = result.as_array().ok_or_else(|| {
         ErrorDetail::new(
             ErrorKind::Descriptor,

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -28,17 +28,15 @@ use std::rc::Rc;
 
 use custom_elements::CustomElement;
 use js_sys::{Function, Reflect};
+use tonk_concept::bridge::{SubscribeHandle, query as bridge_query};
 use tonk_concept::error::{ErrorDetail, ErrorKind};
 use tonk_concept::resolve::{ParsedSource, parse_source, phase1_query};
 use tonk_concept::sse::open_sse;
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::{JsFuture, spawn_local};
-use web_sys::{
-    AbortController, CustomEvent, CustomEventInit, Element, Headers, HtmlElement, Node, Request,
-    RequestInit, Response, window,
-};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, Node, window};
 
 use crate::resolve::{entity_query, looks_like_uri, view_query, views_for_model_query};
 use crate::state::{self, State};
@@ -81,12 +79,13 @@ struct Inner {
     /// covers the cross-`Inner` race where a custom element
     /// detaches and re-attaches.
     generation: u64,
-    /// Aborts the view (or views-for-model) subscription on
-    /// disconnect / attribute change.
-    view_abort: Option<AbortController>,
-    /// Aborts the entity subscription on disconnect / attribute
+    /// Cancels the view (or views-for-model) subscription on
+    /// disconnect / attribute change. Dropping the handle calls
+    /// the bridge's unsubscribe function.
+    view_abort: Option<SubscribeHandle>,
+    /// Cancels the entity subscription on disconnect / attribute
     /// change.
-    entity_abort: Option<AbortController>,
+    entity_abort: Option<SubscribeHandle>,
     /// Last entity conclusion seen; replayed when a fresh slide
     /// is mounted so it picks up the current data without waiting
     /// for the next entity frame.
@@ -125,12 +124,9 @@ impl Inner {
     }
 
     fn abort_all(&mut self) {
-        if let Some(a) = self.view_abort.take() {
-            a.abort();
-        }
-        if let Some(a) = self.entity_abort.take() {
-            a.abort();
-        }
+        // Dropping the handles triggers the bridge unsubscribe call.
+        self.view_abort.take();
+        self.entity_abort.take();
     }
 }
 
@@ -304,19 +300,9 @@ async fn run(
     // `view` is optional — its absence triggers carousel mode.
     let view = host.get_attribute("view").filter(|s| !s.is_empty());
 
-    let space = host
-        .get_attribute("space")
-        .unwrap_or_else(|| "home".to_owned());
-    let branch = host
-        .get_attribute("branch")
-        .unwrap_or_else(|| "main".to_owned());
-    let url = format!("/api/repository/{space}/branch/{branch}/query");
-
     // Phase 1 — resolve the model concept's entity + descriptor.
     let parsed: ParsedSource = parse_source(&model);
-    let phase1_body = serde_json::to_string(&phase1_query(&parsed))
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-    let (model_entity, descriptor_json) = phase1_lookup(&url, &phase1_body).await?;
+    let (model_entity, descriptor_json) = phase1_lookup(&phase1_query(&parsed)).await?;
     check_generation(&state, generation)?;
 
     // Build the view subscription query: pin-by-name in single
@@ -328,12 +314,12 @@ async fn run(
             ErrorDetail::new(ErrorKind::Descriptor, format!("views-for-model query: {e}"))
         })?,
     };
-    let view_body = serde_json::to_string(&view_q)
+    let view_body = serde_json::to_value(&view_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body: {e}")))?;
 
     let entity_q = entity_query(&descriptor_json, &entity)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
-    let entity_body = serde_json::to_string(&entity_q)
+    let entity_body = serde_json::to_value(&entity_q)
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body: {e}")))?;
 
     // Always mount the `<wa-carousel>` so the slot geometry is
@@ -345,27 +331,27 @@ async fn run(
     ensure_carousel(host, &state, single_mode);
 
     let view_abort =
-        open_view_stream(&url, &view_body, host.clone(), state.clone(), generation).await?;
+        open_view_stream(&view_body, host.clone(), state.clone(), generation)?;
     // Check generation again — between opening view and entity
     // streams, attribute_changed_callback may have fired and
-    // superseded us. If so, abort the view stream we just opened
-    // (otherwise its handler keeps pushing slides), and bail.
+    // superseded us. If so, drop the view handle we just opened
+    // (its Drop impl calls unsubscribe), and bail.
     if check_generation(&state, generation).is_err() {
-        view_abort.abort();
+        drop(view_abort);
         return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
     }
     let entity_abort =
-        open_entity_stream(&url, &entity_body, host.clone(), state.clone(), generation).await?;
+        open_entity_stream(&entity_body, host.clone(), state.clone(), generation)?;
 
     {
         let mut s = state.borrow_mut();
         // Final generation check — if a newer flow ran between
-        // opening entity_stream and storing the controllers,
-        // abort what we just opened so we don't orphan them
-        // (the newer flow's controllers are already stored).
+        // opening entity_stream and storing the handles, drop them
+        // so we don't orphan them (the newer flow's handles are
+        // already stored).
         if s.generation != generation {
-            view_abort.abort();
-            entity_abort.abort();
+            drop(view_abort);
+            drop(entity_abort);
             return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
         }
         s.view_abort = Some(view_abort);
@@ -375,19 +361,17 @@ async fn run(
     Ok(())
 }
 
-async fn open_view_stream(
-    url: &str,
-    body: &str,
+fn open_view_stream(
+    body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
     generation: u64,
-) -> Result<AbortController, ErrorDetail> {
+) -> Result<SubscribeHandle, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
     let state_for_frame = state.clone();
     open_sse(
-        url,
         body,
         move |frame: &str| {
             // Discard frames from a superseded or disposed flow
@@ -424,22 +408,19 @@ async fn open_view_stream(
             fail(&host_for_err, &state_for_err, err);
         },
     )
-    .await
 }
 
-async fn open_entity_stream(
-    url: &str,
-    body: &str,
+fn open_entity_stream(
+    body: &serde_json::Value,
     host: Element,
     state: Rc<RefCell<Inner>>,
     generation: u64,
-) -> Result<AbortController, ErrorDetail> {
+) -> Result<SubscribeHandle, ErrorDetail> {
     let host_for_frame = host.clone();
     let host_for_err = host.clone();
     let state_for_err = state.clone();
     let state_for_frame = state.clone();
     open_sse(
-        url,
         body,
         move |frame: &str| {
             // Same stale-frame guard as in `open_view_stream`.
@@ -471,7 +452,6 @@ async fn open_entity_stream(
             fail(&host_for_err, &state_for_err, err);
         },
     )
-    .await
 }
 
 /// Diff the incoming view frame against currently mounted slides.
@@ -726,62 +706,35 @@ fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
     serde_wasm_bindgen::to_value(conclusion).unwrap_or(JsValue::NULL)
 }
 
-/// One-shot Phase-1 lookup. Returns `(this, source)` from the first
-/// matching row — `this` is the concept entity URI, `source` is the
-/// raw descriptor JSON the worker put in the row's `source` field.
-async fn phase1_lookup(url: &str, body: &str) -> Result<(String, String), ErrorDetail> {
-    let init = RequestInit::new();
-    init.set_method("POST");
-    let headers = Headers::new()
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Headers: {e:?}")))?;
-    headers
-        .append("content-type", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
-    headers
-        .append("accept", "application/json")
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
-    init.set_headers(&headers);
-    init.set_body(&JsValue::from_str(body));
-
-    let request = Request::new_with_str_and_init(url, &init)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("Request: {e:?}")))?;
-    let win = window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no window"))?;
-    let resp_value = JsFuture::from(win.fetch_with_request(&request))
-        .await
-        .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("fetch: {e:?}")))?;
-    let resp: Response = resp_value
-        .dyn_into()
-        .map_err(|_| ErrorDetail::new(ErrorKind::Network, "fetch did not return Response"))?;
-    if !resp.ok() {
-        return Err(ErrorDetail::new(
-            ErrorKind::Network,
-            format!("phase1 HTTP {}", resp.status()),
-        ));
-    }
-    let text = JsFuture::from(
-        resp.text()
-            .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("text: {e:?}")))?,
-    )
-    .await
-    .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("read body: {e:?}")))?;
-    let body_text = text
-        .as_string()
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "body was not a string"))?;
-    let conclusions: Vec<Conclusion> = serde_json::from_str(&body_text)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("parse: {e}")))?;
-    let first = conclusions
-        .into_iter()
-        .next()
+/// One-shot Phase-1 lookup via the postMessage bridge.
+///
+/// Returns `(this, source)` from the first matching row — `this` is
+/// the concept entity URI, `source` is the raw descriptor JSON the
+/// worker put in the row's `source` field.
+async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<(String, String), ErrorDetail> {
+    let body = serde_json::to_value(query)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
+    let result = bridge_query(&body).await?;
+    let arr = result.as_array().ok_or_else(|| {
+        ErrorDetail::new(ErrorKind::Descriptor, "phase1: expected array of conclusions")
+    })?;
+    let first = arr
+        .first()
         .ok_or_else(|| ErrorDetail::new(ErrorKind::UnknownSource, "no concept matched"))?;
+    let this = first
+        .get("this")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .ok_or_else(|| ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `this` field"))?;
     let source = first
-        .fields
-        .get("source")
+        .get("fields")
+        .and_then(|f| f.get("source"))
         .and_then(|v| v.as_str())
         .map(str::to_owned)
         .ok_or_else(|| {
             ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `source` field")
         })?;
-    Ok((first.this, source))
+    Ok((this, source))
 }
 
 fn dispatch_error(host: &Element, err: ErrorDetail) {

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -330,8 +330,7 @@ async fn run(
     let single_mode = view.is_some();
     ensure_carousel(host, &state, single_mode);
 
-    let view_abort =
-        open_view_stream(&view_body, host.clone(), state.clone(), generation)?;
+    let view_abort = open_view_stream(&view_body, host.clone(), state.clone(), generation)?;
     // Check generation again — between opening view and entity
     // streams, attribute_changed_callback may have fired and
     // superseded us. If so, drop the view handle we just opened
@@ -340,8 +339,7 @@ async fn run(
         drop(view_abort);
         return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
     }
-    let entity_abort =
-        open_entity_stream(&entity_body, host.clone(), state.clone(), generation)?;
+    let entity_abort = open_entity_stream(&entity_body, host.clone(), state.clone(), generation)?;
 
     {
         let mut s = state.borrow_mut();
@@ -716,7 +714,10 @@ async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<(String, Str
         .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
     let result = bridge_query(&body).await?;
     let arr = result.as_array().ok_or_else(|| {
-        ErrorDetail::new(ErrorKind::Descriptor, "phase1: expected array of conclusions")
+        ErrorDetail::new(
+            ErrorKind::Descriptor,
+            "phase1: expected array of conclusions",
+        )
     })?;
     let first = arr
         .first()
@@ -725,7 +726,9 @@ async fn phase1_lookup(query: &tonk_schema::query::Query) -> Result<(String, Str
         .get("this")
         .and_then(|v| v.as_str())
         .map(str::to_owned)
-        .ok_or_else(|| ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `this` field"))?;
+        .ok_or_else(|| {
+            ErrorDetail::new(ErrorKind::Descriptor, "phase1 row missing `this` field")
+        })?;
     let source = first
         .get("fields")
         .and_then(|f| f.get("source"))

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -2,6 +2,8 @@ import init, { activate } from "./worker.js";
 
 const log = (...args) => console.log("[Tonk Service Worker]", ...args);
 
+log("script loaded — version: bridge-diag-1");
+
 let tonkServiceWorkerResolves;
 
 async function activateWorker() {
@@ -68,8 +70,17 @@ self.onfetch = event => {
 // worker's `onmessage` stashes the port against the client id and
 // routes per-envelope dispatch from there.
 self.onmessage = event => {
+    log("onmessage received", { data: event.data, hasPort: event.ports?.length > 0 });
     event.waitUntil?.(
-        (async () => (await activateWorker()).onmessage(event))(),
+        (async () => {
+            try {
+                const worker = await activateWorker();
+                await worker.onmessage(event);
+                log("onmessage dispatched to wasm worker");
+            } catch (err) {
+                log("onmessage dispatch failed:", err);
+            }
+        })(),
     );
 };
 

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -2,8 +2,6 @@ import init, { activate } from "./worker.js";
 
 const log = (...args) => console.log("[Tonk Service Worker]", ...args);
 
-log("script loaded — version: bridge-diag-1");
-
 let tonkServiceWorkerResolves;
 
 async function activateWorker() {
@@ -70,13 +68,11 @@ self.onfetch = event => {
 // worker's `onmessage` stashes the port against the client id and
 // routes per-envelope dispatch from there.
 self.onmessage = event => {
-    log("onmessage received", { data: event.data, hasPort: event.ports?.length > 0 });
     event.waitUntil?.(
         (async () => {
             try {
                 const worker = await activateWorker();
                 await worker.onmessage(event);
-                log("onmessage dispatched to wasm worker");
             } catch (err) {
                 log("onmessage dispatch failed:", err);
             }

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -62,6 +62,17 @@ self.onfetch = event => {
     );
 };
 
+// Iframe-side bridge messages. The iframe sends `{v:1,type:"hello"}`
+// at boot (with a transferred MessagePort) and then dispatches
+// query/subscribe/evaluate envelopes over the port. The Rust
+// worker's `onmessage` stashes the port against the client id and
+// routes per-envelope dispatch from there.
+self.onmessage = event => {
+    event.waitUntil?.(
+        (async () => (await activateWorker()).onmessage(event))(),
+    );
+};
+
 // Background Sync API event handler
 self.onsync = event => {
     log("Background sync event:", event.tag);

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -131,6 +131,11 @@
        into this page. -->
   <link data-trunk rel="rust" data-bin="tonk-concept" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
 
+  <!-- Bridge module injected by host::wrap_html_body into iframe srcdoc.
+       Served at `/__tonk/bridge.js` by the dev server / CDN so the
+       service-worker passthrough route can reach it without the SW
+       needing to bundle and serve it internally. -->
+  <link data-trunk rel="copy-file" href="../tonk-worker/assets/bridge.js" data-target-path="__tonk" />
   <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
   <link data-trunk rel="copy-dir" href="./assets/images" />
   <link data-trunk rel="copy-dir" href="./assets/webawesome" />

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -41,6 +41,7 @@ http-body-util = { workspace = true }
 js-sys = { workspace = true }
 lsp-types = { workspace = true }
 rand = { workspace = true }
+send_wrapper = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -59,9 +59,14 @@ wasm-bindgen-futures = { workspace = true }
 wasm-streams = { workspace = true }
 web-sys = { workspace = true, features = [
     "BroadcastChannel",
+    "Client",
     "CryptoKey",
+    "ExtendableMessageEvent",
     "FetchEvent",
     "Headers",
+    "MessageChannel",
+    "MessageEvent",
+    "MessagePort",
     "Request",
     "RequestInit",
     "RequestMode",

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -44,6 +44,7 @@ rand = { workspace = true }
 send_wrapper = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -62,6 +62,7 @@ wasm-streams = { workspace = true }
 web-sys = { workspace = true, features = [
     "BroadcastChannel",
     "Client",
+    "Clients",
     "CryptoKey",
     "ExtendableMessageEvent",
     "FetchEvent",

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -3,7 +3,10 @@ var Bridge = class {
   port;
   nextId = 0;
   pendingOnce = /* @__PURE__ */ new Map();
-  pendingStream = /* @__PURE__ */ new Map();
+  // One controller per active subscription, keyed by correlation id.
+  // Populated in the stream's `start`, removed when the stream is
+  // cancelled or the SW reports an error.
+  streamControllers = /* @__PURE__ */ new Map();
   resolveReady;
   rejectReady;
   ready;
@@ -35,32 +38,25 @@ var Bridge = class {
       this.port.postMessage({ v: 1, type: "query", id, body });
     });
   }
-  subscribe(body, onFrame, onError) {
+  async subscribe(body) {
+    await this.ready;
     const id = this.mintId();
-    this.pendingStream.set(id, { onFrame, onError });
-    this.ready.then(
-      () => {
-        if (this.pendingStream.has(id)) {
-          this.port.postMessage({ v: 1, type: "subscribe", id, body });
-        }
+    const port = this.port;
+    const controllers = this.streamControllers;
+    return new ReadableStream({
+      start(controller) {
+        controllers.set(id, controller);
+        port.postMessage(
+          { v: 1, type: "subscribe", id, body }
+        );
       },
-      (err) => {
-        if (this.pendingStream.delete(id)) {
-          const message = err.message ?? String(err);
-          if (onError) onError(message);
-          else console.error("[tonk] subscribe failed:", message);
-        }
+      cancel() {
+        controllers.delete(id);
+        port.postMessage(
+          { v: 1, type: "unsubscribe", id }
+        );
       }
-    );
-    return () => {
-      if (!this.pendingStream.delete(id)) return;
-      this.ready.then(
-        () => {
-          this.port.postMessage({ v: 1, type: "unsubscribe", id });
-        },
-        () => {}
-      );
-    };
+    });
   }
   async evaluate(body, transact = true) {
     await this.ready;
@@ -109,29 +105,23 @@ var Bridge = class {
         return;
       }
       case "subscribe-event": {
-        const handler = this.pendingStream.get(envelope.id);
-        if (!handler) {
+        const controller = this.streamControllers.get(envelope.id);
+        if (!controller) {
           return;
         }
         try {
-          handler.onFrame(envelope.rows);
+          controller.enqueue(envelope.rows);
         } catch (e) {
-          console.error("[tonk] subscribe frame handler threw", e);
+          this.streamControllers.delete(envelope.id);
+          console.error("[tonk] subscribe enqueue failed", e);
         }
         return;
       }
       case "subscribe-error": {
-        const handler = this.pendingStream.get(envelope.id);
-        if (!handler) return;
-        if (handler.onError) {
-          try {
-            handler.onError(envelope.error);
-          } catch (e) {
-            console.error("[tonk] subscribe error handler threw", e);
-          }
-        } else {
-          console.error("[tonk] subscribe error", envelope.error);
-        }
+        const controller = this.streamControllers.get(envelope.id);
+        if (!controller) return;
+        this.streamControllers.delete(envelope.id);
+        controller.error(new Error(envelope.error));
         return;
       }
     }

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -3,9 +3,6 @@ var Bridge = class {
   port;
   nextId = 0;
   pendingOnce = /* @__PURE__ */ new Map();
-  // One controller per active subscription, keyed by correlation id.
-  // Populated in the stream's `start`, removed when the stream is
-  // cancelled or the SW reports an error.
   streamControllers = /* @__PURE__ */ new Map();
   resolveReady;
   rejectReady;

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -1,0 +1,86 @@
+// rust/tonk-worker/assets/bridge.ts
+var Signal = class {
+  value = void 0;
+  listeners = /* @__PURE__ */ new Set();
+  errorListeners = /* @__PURE__ */ new Set();
+  get() {
+    return this.value;
+  }
+  set(value) {
+    this.value = value;
+    for (const listener of this.listeners) {
+      try {
+        listener(value);
+      } catch (e) {
+        console.error("[tonk] signal listener threw", e);
+      }
+    }
+  }
+  fireError(message) {
+    for (const listener of this.errorListeners) {
+      try {
+        listener(message);
+      } catch (e) {
+        console.error("[tonk] error listener threw", e);
+      }
+    }
+  }
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+  subscribeError(listener) {
+    this.errorListeners.add(listener);
+    return () => {
+      this.errorListeners.delete(listener);
+    };
+  }
+};
+var subscriptions = {};
+var resolveReady;
+var ready = new Promise((resolve) => {
+  resolveReady = resolve;
+});
+globalThis.tonk = { ready, subscriptions };
+function handle(envelope) {
+  switch (envelope.type) {
+    case "ready":
+      for (const name of envelope.subscriptions) {
+        subscriptions[name] = new Signal();
+      }
+      resolveReady();
+      return;
+    case "data": {
+      const signal = subscriptions[envelope.name];
+      if (!signal) {
+        console.warn("[tonk] data for unknown subscription", envelope.name);
+        return;
+      }
+      signal.set(envelope.rows);
+      return;
+    }
+    case "error": {
+      if (envelope.name) {
+        const signal = subscriptions[envelope.name];
+        if (signal) {
+          signal.fireError(envelope.error);
+          return;
+        }
+      }
+      console.error("[tonk] bridge error", envelope.error);
+      return;
+    }
+  }
+}
+var channel = new MessageChannel();
+channel.port1.onmessage = (event) => {
+  handle(event.data);
+};
+var controller = navigator.serviceWorker?.controller;
+if (!controller) {
+  console.error("[tonk] no service worker controller; bridge inactive");
+} else {
+  controller.postMessage({ v: 1, type: "hello" }, [channel.port2]);
+}

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -1,86 +1,120 @@
 // rust/tonk-worker/assets/bridge.ts
-var Signal = class {
-  value = void 0;
-  listeners = /* @__PURE__ */ new Set();
-  errorListeners = /* @__PURE__ */ new Set();
-  get() {
-    return this.value;
-  }
-  set(value) {
-    this.value = value;
-    for (const listener of this.listeners) {
-      try {
-        listener(value);
-      } catch (e) {
-        console.error("[tonk] signal listener threw", e);
-      }
-    }
-  }
-  fireError(message) {
-    for (const listener of this.errorListeners) {
-      try {
-        listener(message);
-      } catch (e) {
-        console.error("[tonk] error listener threw", e);
-      }
-    }
-  }
-  subscribe(listener) {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
+var Bridge = class {
+  port;
+  nextId = 0;
+  pendingOnce = /* @__PURE__ */ new Map();
+  pendingStream = /* @__PURE__ */ new Map();
+  resolveReady;
+  ready;
+  constructor() {
+    this.ready = new Promise((resolve) => {
+      this.resolveReady = resolve;
+    });
+    const channel = new MessageChannel();
+    this.port = channel.port1;
+    this.port.onmessage = (event) => {
+      this.dispatch(event.data);
     };
-  }
-  subscribeError(listener) {
-    this.errorListeners.add(listener);
-    return () => {
-      this.errorListeners.delete(listener);
-    };
-  }
-};
-var subscriptions = {};
-var resolveReady;
-var ready = new Promise((resolve) => {
-  resolveReady = resolve;
-});
-globalThis.tonk = { ready, subscriptions };
-function handle(envelope) {
-  switch (envelope.type) {
-    case "ready":
-      for (const name of envelope.subscriptions) {
-        subscriptions[name] = new Signal();
-      }
-      resolveReady();
+    const controller = navigator.serviceWorker?.controller;
+    if (!controller) {
+      console.error("[tonk] bridge: no service worker controller; calls will hang");
       return;
-    case "data": {
-      const signal = subscriptions[envelope.name];
-      if (!signal) {
-        console.warn("[tonk] data for unknown subscription", envelope.name);
+    }
+    controller.postMessage(
+      { v: 1, type: "hello" },
+      [channel.port2]
+    );
+  }
+  query(body) {
+    const id = this.mintId();
+    return new Promise((resolve, reject) => {
+      this.pendingOnce.set(id, { resolve, reject, kind: "query" });
+      this.port.postMessage({ v: 1, type: "query", id, body });
+    });
+  }
+  subscribe(body, onFrame, onError) {
+    const id = this.mintId();
+    this.pendingStream.set(id, { onFrame, onError });
+    this.port.postMessage({ v: 1, type: "subscribe", id, body });
+    return () => {
+      if (!this.pendingStream.delete(id)) return;
+      this.port.postMessage({ v: 1, type: "unsubscribe", id });
+    };
+  }
+  evaluate(body, contentType = "application/yaml", transact = true) {
+    const id = this.mintId();
+    return new Promise((resolve, reject) => {
+      this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });
+      this.port.postMessage({
+        v: 1,
+        type: "evaluate",
+        id,
+        body,
+        contentType,
+        transact
+      });
+    });
+  }
+  mintId() {
+    this.nextId += 1;
+    return `r${this.nextId}`;
+  }
+  dispatch(envelope) {
+    switch (envelope.type) {
+      case "ready":
+        this.resolveReady();
         return;
-      }
-      signal.set(envelope.rows);
-      return;
-    }
-    case "error": {
-      if (envelope.name) {
-        const signal = subscriptions[envelope.name];
-        if (signal) {
-          signal.fireError(envelope.error);
+      case "query-result":
+      case "evaluate-result": {
+        const handler = this.pendingOnce.get(envelope.id);
+        if (!handler) {
+          console.warn("[tonk] result for unknown id", envelope.id);
           return;
         }
+        this.pendingOnce.delete(envelope.id);
+        const payload = "rows" in envelope ? envelope.rows : envelope.result;
+        handler.resolve(payload);
+        return;
       }
-      console.error("[tonk] bridge error", envelope.error);
-      return;
+      case "query-error":
+      case "evaluate-error": {
+        const handler = this.pendingOnce.get(envelope.id);
+        if (!handler) {
+          console.warn("[tonk] error for unknown id", envelope.id);
+          return;
+        }
+        this.pendingOnce.delete(envelope.id);
+        handler.reject(new Error(envelope.error));
+        return;
+      }
+      case "subscribe-event": {
+        const handler = this.pendingStream.get(envelope.id);
+        if (!handler) {
+          return;
+        }
+        try {
+          handler.onFrame(envelope.rows);
+        } catch (e) {
+          console.error("[tonk] subscribe frame handler threw", e);
+        }
+        return;
+      }
+      case "subscribe-error": {
+        const handler = this.pendingStream.get(envelope.id);
+        if (!handler) return;
+        if (handler.onError) {
+          try {
+            handler.onError(envelope.error);
+          } catch (e) {
+            console.error("[tonk] subscribe error handler threw", e);
+          }
+        } else {
+          console.error("[tonk] subscribe error", envelope.error);
+        }
+        return;
+      }
     }
   }
-}
-var channel = new MessageChannel();
-channel.port1.onmessage = (event) => {
-  handle(event.data);
 };
-var controller = navigator.serviceWorker?.controller;
-if (!controller) {
-  console.error("[tonk] no service worker controller; bridge inactive");
-} else {
-  controller.postMessage({ v: 1, type: "hello" }, [channel.port2]);
-}
+var bridge = new Bridge();
+globalThis.tonk = bridge;

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -41,7 +41,7 @@ var Bridge = class {
       this.port.postMessage({ v: 1, type: "unsubscribe", id });
     };
   }
-  evaluate(body, contentType = "application/yaml", transact = true) {
+  evaluate(body, transact = true) {
     const id = this.mintId();
     return new Promise((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });
@@ -50,7 +50,6 @@ var Bridge = class {
         type: "evaluate",
         id,
         body,
-        contentType,
         transact
       });
     });

--- a/rust/tonk-worker/assets/bridge.js
+++ b/rust/tonk-worker/assets/bridge.js
@@ -5,10 +5,12 @@ var Bridge = class {
   pendingOnce = /* @__PURE__ */ new Map();
   pendingStream = /* @__PURE__ */ new Map();
   resolveReady;
+  rejectReady;
   ready;
   constructor() {
-    this.ready = new Promise((resolve) => {
+    this.ready = new Promise((resolve, reject) => {
       this.resolveReady = resolve;
+      this.rejectReady = reject;
     });
     const channel = new MessageChannel();
     this.port = channel.port1;
@@ -17,7 +19,7 @@ var Bridge = class {
     };
     const controller = navigator.serviceWorker?.controller;
     if (!controller) {
-      console.error("[tonk] bridge: no service worker controller; calls will hang");
+      this.rejectReady(new Error("[tonk] bridge: no service worker controller"));
       return;
     }
     controller.postMessage(
@@ -25,7 +27,8 @@ var Bridge = class {
       [channel.port2]
     );
   }
-  query(body) {
+  async query(body) {
+    await this.ready;
     const id = this.mintId();
     return new Promise((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "query" });
@@ -35,13 +38,32 @@ var Bridge = class {
   subscribe(body, onFrame, onError) {
     const id = this.mintId();
     this.pendingStream.set(id, { onFrame, onError });
-    this.port.postMessage({ v: 1, type: "subscribe", id, body });
+    this.ready.then(
+      () => {
+        if (this.pendingStream.has(id)) {
+          this.port.postMessage({ v: 1, type: "subscribe", id, body });
+        }
+      },
+      (err) => {
+        if (this.pendingStream.delete(id)) {
+          const message = err.message ?? String(err);
+          if (onError) onError(message);
+          else console.error("[tonk] subscribe failed:", message);
+        }
+      }
+    );
     return () => {
       if (!this.pendingStream.delete(id)) return;
-      this.port.postMessage({ v: 1, type: "unsubscribe", id });
+      this.ready.then(
+        () => {
+          this.port.postMessage({ v: 1, type: "unsubscribe", id });
+        },
+        () => {}
+      );
     };
   }
-  evaluate(body, transact = true) {
+  async evaluate(body, transact = true) {
+    await this.ready;
     const id = this.mintId();
     return new Promise((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -22,7 +22,6 @@ type EvaluateEnvelope  = {
   type: "evaluate";
   id: string;
   body: string;
-  contentType: string;
   transact: boolean;
 };
 
@@ -101,7 +100,7 @@ class Bridge {
     };
   }
 
-  evaluate(body: string, contentType = "application/yaml", transact = true): Promise<unknown> {
+  evaluate(body: string, transact = true): Promise<unknown> {
     const id = this.mintId();
     return new Promise<unknown>((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });
@@ -110,7 +109,6 @@ class Bridge {
         type: "evaluate",
         id,
         body,
-        contentType,
         transact,
       } satisfies EvaluateEnvelope);
     });

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -1,0 +1,138 @@
+// rust/tonk-worker/assets/bridge.ts
+//
+// Iframe-side bridge module. Served by the SW at
+// /__tonk/bridge.js (the .ts is compiled by the Trunk hook in
+// build.rs / Trunk.toml; see Task 14).
+//
+// On load:
+//   1. Open a MessageChannel.
+//   2. Send port2 to navigator.serviceWorker.controller with a
+//      `hello` envelope.
+//   3. Wait for `ready` over port1. Materialise tonk.subscriptions
+//      with one Signal per declared name.
+//   4. Apply each subsequent `data` envelope to its matching
+//      signal; surface `error` envelopes via signal error listeners.
+//
+// The agent's body only sees `globalThis.tonk` — never postMessage,
+// MessageChannel, or navigator.serviceWorker.
+
+type Row = { this: string; [field: string]: unknown };
+
+type ReadyEnvelope = {
+  v: 1;
+  type: "ready";
+  subscriptions: string[];
+};
+
+type DataEnvelope = {
+  v: 1;
+  type: "data";
+  name: string;
+  rows: Row[];
+};
+
+type ErrorEnvelope = {
+  v: 1;
+  type: "error";
+  name?: string;
+  error: string;
+};
+
+type InboundEnvelope = ReadyEnvelope | DataEnvelope | ErrorEnvelope;
+
+class Signal<T> {
+  private value: T | undefined = undefined;
+  private listeners = new Set<(value: T) => void>();
+  private errorListeners = new Set<(message: string) => void>();
+
+  get(): T | undefined {
+    return this.value;
+  }
+
+  set(value: T): void {
+    this.value = value;
+    for (const listener of this.listeners) {
+      try {
+        listener(value);
+      } catch (e) {
+        console.error("[tonk] signal listener threw", e);
+      }
+    }
+  }
+
+  fireError(message: string): void {
+    for (const listener of this.errorListeners) {
+      try {
+        listener(message);
+      } catch (e) {
+        console.error("[tonk] error listener threw", e);
+      }
+    }
+  }
+
+  subscribe(listener: (value: T) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  subscribeError(listener: (message: string) => void): () => void {
+    this.errorListeners.add(listener);
+    return () => {
+      this.errorListeners.delete(listener);
+    };
+  }
+}
+
+const subscriptions: Record<string, Signal<Row[]>> = {};
+
+let resolveReady!: () => void;
+const ready = new Promise<void>(resolve => {
+  resolveReady = resolve;
+});
+
+(globalThis as any).tonk = { ready, subscriptions };
+
+function handle(envelope: InboundEnvelope): void {
+  switch (envelope.type) {
+    case "ready":
+      for (const name of envelope.subscriptions) {
+        subscriptions[name] = new Signal<Row[]>();
+      }
+      resolveReady();
+      return;
+    case "data": {
+      const signal = subscriptions[envelope.name];
+      if (!signal) {
+        console.warn("[tonk] data for unknown subscription", envelope.name);
+        return;
+      }
+      signal.set(envelope.rows);
+      return;
+    }
+    case "error": {
+      if (envelope.name) {
+        const signal = subscriptions[envelope.name];
+        if (signal) {
+          signal.fireError(envelope.error);
+          return;
+        }
+      }
+      console.error("[tonk] bridge error", envelope.error);
+      return;
+    }
+  }
+}
+
+const channel = new MessageChannel();
+channel.port1.onmessage = (event: MessageEvent<InboundEnvelope>) => {
+  handle(event.data);
+};
+
+const controller = navigator.serviceWorker?.controller;
+if (!controller) {
+  console.error("[tonk] no service worker controller; bridge inactive");
+} else {
+  controller.postMessage({ v: 1, type: "hello" }, [channel.port2]);
+}

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -58,9 +58,6 @@ class Bridge {
     reject: (error: Error) => void;
     kind: "query" | "evaluate";
   }>();
-  // One controller per active subscription, keyed by correlation id.
-  // Populated in the stream's `start`, removed when the stream is
-  // cancelled or the SW reports an error.
   private streamControllers = new Map<
     string,
     ReadableStreamDefaultController<unknown>

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -12,6 +12,12 @@
 //
 // All envelopes carry a correlation `id` so the same port can multiplex
 // many in-flight queries / subscriptions without ordering assumptions.
+//
+// Each public method internally awaits `this.ready` before posting, so
+// authors call `tonk.query(...)` / `tonk.subscribe(...)` directly from
+// a `<script type="module">` without writing handshake boilerplate.
+// Failures (no SW controller, bad query, evaluate error) surface as
+// Promise rejections.
 
 type HelloEnvelope     = { v: 1; type: "hello" };
 type QueryEnvelope     = { v: 1; type: "query";     id: string; body: unknown };
@@ -51,11 +57,13 @@ class Bridge {
     onError?: (message: string) => void;
   }>();
   private resolveReady!: () => void;
+  private rejectReady!: (err: Error) => void;
   ready: Promise<void>;
 
   constructor() {
-    this.ready = new Promise<void>(resolve => {
+    this.ready = new Promise<void>((resolve, reject) => {
       this.resolveReady = resolve;
+      this.rejectReady = reject;
     });
 
     const channel = new MessageChannel();
@@ -66,10 +74,10 @@ class Bridge {
 
     const controller = navigator.serviceWorker?.controller;
     if (!controller) {
-      // No SW yet — the iframe was opened in a tab that hasn't
-      // claimed control. The bridge is inert; method calls will
-      // hang. Surface the situation clearly in devtools.
-      console.error("[tonk] bridge: no service worker controller; calls will hang");
+      // No SW controlling this page — every method will reject from
+      // the awaited ready promise so callers see a clear error
+      // instead of an indefinite hang.
+      this.rejectReady(new Error("[tonk] bridge: no service worker controller"));
       return;
     }
     controller.postMessage(
@@ -78,7 +86,8 @@ class Bridge {
     );
   }
 
-  query(body: unknown): Promise<unknown> {
+  async query(body: unknown): Promise<unknown> {
+    await this.ready;
     const id = this.mintId();
     return new Promise<unknown>((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "query" });
@@ -93,14 +102,40 @@ class Bridge {
   ): () => void {
     const id = this.mintId();
     this.pendingStream.set(id, { onFrame, onError });
-    this.port.postMessage({ v: 1, type: "subscribe", id, body } satisfies SubscribeEnvelope);
+    this.ready.then(
+      () => {
+        // Cancelled before ready resolved — skip the send entirely.
+        if (this.pendingStream.has(id)) {
+          this.port.postMessage({ v: 1, type: "subscribe", id, body } satisfies SubscribeEnvelope);
+        }
+      },
+      (err: Error) => {
+        // Bridge never came up. Surface to the caller's onError so a
+        // failed subscribe looks like every other reportable failure
+        // instead of silently dropping.
+        if (this.pendingStream.delete(id)) {
+          const message = err.message ?? String(err);
+          if (onError) onError(message);
+          else console.error("[tonk] subscribe failed:", message);
+        }
+      },
+    );
     return () => {
       if (!this.pendingStream.delete(id)) return;
-      this.port.postMessage({ v: 1, type: "unsubscribe", id } satisfies UnsubscribeEnvelope);
+      // If the subscribe envelope never went out (cancelled before
+      // ready), the SW will treat unsubscribe-for-unknown-id as a
+      // no-op — see router::bridge::handle_unsubscribe.
+      this.ready.then(
+        () => {
+          this.port.postMessage({ v: 1, type: "unsubscribe", id } satisfies UnsubscribeEnvelope);
+        },
+        () => { /* bridge never came up — nothing to unsubscribe */ },
+      );
     };
   }
 
-  evaluate(body: string, transact = true): Promise<unknown> {
+  async evaluate(body: string, transact = true): Promise<unknown> {
+    await this.ready;
     const id = this.mintId();
     return new Promise<unknown>((resolve, reject) => {
       this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -13,6 +13,12 @@
 // All envelopes carry a correlation `id` so the same port can multiplex
 // many in-flight queries / subscriptions without ordering assumptions.
 //
+// `subscribe` returns a `ReadableStream<unknown>` whose chunks are the
+// `rows` payloads of `subscribe-event` envelopes. The stream's
+// `cancel` posts an `unsubscribe` envelope, so dropping/cancelling
+// the stream is the only teardown surface — no separate unsubscribe
+// function is exposed.
+//
 // Each public method internally awaits `this.ready` before posting, so
 // authors call `tonk.query(...)` / `tonk.subscribe(...)` directly from
 // a `<script type="module">` without writing handshake boilerplate.
@@ -52,10 +58,13 @@ class Bridge {
     reject: (error: Error) => void;
     kind: "query" | "evaluate";
   }>();
-  private pendingStream = new Map<string, {
-    onFrame: (rows: unknown) => void;
-    onError?: (message: string) => void;
-  }>();
+  // One controller per active subscription, keyed by correlation id.
+  // Populated in the stream's `start`, removed when the stream is
+  // cancelled or the SW reports an error.
+  private streamControllers = new Map<
+    string,
+    ReadableStreamDefaultController<unknown>
+  >();
   private resolveReady!: () => void;
   private rejectReady!: (err: Error) => void;
   ready: Promise<void>;
@@ -95,43 +104,25 @@ class Bridge {
     });
   }
 
-  subscribe(
-    body: unknown,
-    onFrame: (rows: unknown) => void,
-    onError?: (message: string) => void,
-  ): () => void {
+  async subscribe(body: unknown): Promise<ReadableStream<unknown>> {
+    await this.ready;
     const id = this.mintId();
-    this.pendingStream.set(id, { onFrame, onError });
-    this.ready.then(
-      () => {
-        // Cancelled before ready resolved — skip the send entirely.
-        if (this.pendingStream.has(id)) {
-          this.port.postMessage({ v: 1, type: "subscribe", id, body } satisfies SubscribeEnvelope);
-        }
+    const port = this.port;
+    const controllers = this.streamControllers;
+    return new ReadableStream<unknown>({
+      start(controller) {
+        controllers.set(id, controller);
+        port.postMessage(
+          { v: 1, type: "subscribe", id, body } satisfies SubscribeEnvelope,
+        );
       },
-      (err: Error) => {
-        // Bridge never came up. Surface to the caller's onError so a
-        // failed subscribe looks like every other reportable failure
-        // instead of silently dropping.
-        if (this.pendingStream.delete(id)) {
-          const message = err.message ?? String(err);
-          if (onError) onError(message);
-          else console.error("[tonk] subscribe failed:", message);
-        }
+      cancel() {
+        controllers.delete(id);
+        port.postMessage(
+          { v: 1, type: "unsubscribe", id } satisfies UnsubscribeEnvelope,
+        );
       },
-    );
-    return () => {
-      if (!this.pendingStream.delete(id)) return;
-      // If the subscribe envelope never went out (cancelled before
-      // ready), the SW will treat unsubscribe-for-unknown-id as a
-      // no-op — see router::bridge::handle_unsubscribe.
-      this.ready.then(
-        () => {
-          this.port.postMessage({ v: 1, type: "unsubscribe", id } satisfies UnsubscribeEnvelope);
-        },
-        () => { /* bridge never came up — nothing to unsubscribe */ },
-      );
-    };
+    });
   }
 
   async evaluate(body: string, transact = true): Promise<unknown> {
@@ -183,30 +174,26 @@ class Bridge {
         return;
       }
       case "subscribe-event": {
-        const handler = this.pendingStream.get(envelope.id);
-        if (!handler) {
-          // Late frame after unsubscribe; drop silently.
+        const controller = this.streamControllers.get(envelope.id);
+        if (!controller) {
+          // Late frame after cancel/error; drop silently.
           return;
         }
         try {
-          handler.onFrame(envelope.rows);
+          controller.enqueue(envelope.rows);
         } catch (e) {
-          console.error("[tonk] subscribe frame handler threw", e);
+          // enqueue throws if the stream is already closed/errored —
+          // drop the controller so subsequent frames are ignored.
+          this.streamControllers.delete(envelope.id);
+          console.error("[tonk] subscribe enqueue failed", e);
         }
         return;
       }
       case "subscribe-error": {
-        const handler = this.pendingStream.get(envelope.id);
-        if (!handler) return;
-        if (handler.onError) {
-          try {
-            handler.onError(envelope.error);
-          } catch (e) {
-            console.error("[tonk] subscribe error handler threw", e);
-          }
-        } else {
-          console.error("[tonk] subscribe error", envelope.error);
-        }
+        const controller = this.streamControllers.get(envelope.id);
+        if (!controller) return;
+        this.streamControllers.delete(envelope.id);
+        controller.error(new Error(envelope.error));
         return;
       }
     }

--- a/rust/tonk-worker/assets/bridge.ts
+++ b/rust/tonk-worker/assets/bridge.ts
@@ -1,138 +1,184 @@
 // rust/tonk-worker/assets/bridge.ts
 //
-// Iframe-side bridge module. Served by the SW at
-// /__tonk/bridge.js (the .ts is compiled by the Trunk hook in
-// build.rs / Trunk.toml; see Task 14).
+// Iframe-side bridge. Loaded as an ES module from /__tonk/bridge.js;
+// the wrapper injected by host::wrap_html_body imports it before any
+// iframe-authored script runs.
 //
-// On load:
-//   1. Open a MessageChannel.
-//   2. Send port2 to navigator.serviceWorker.controller with a
-//      `hello` envelope.
-//   3. Wait for `ready` over port1. Materialise tonk.subscriptions
-//      with one Signal per declared name.
-//   4. Apply each subsequent `data` envelope to its matching
-//      signal; surface `error` envelopes via signal error listeners.
+// Publishes globalThis.tonk with three methods that mirror today's
+// `/api/.../query` and `/api/.../evaluate` HTTP shapes — same input
+// payloads, same output payloads, just over postMessage instead of
+// fetch. The SW dispatches each envelope to the existing axum
+// handlers using the iframe's bound {repo, branch}.
 //
-// The agent's body only sees `globalThis.tonk` — never postMessage,
-// MessageChannel, or navigator.serviceWorker.
+// All envelopes carry a correlation `id` so the same port can multiplex
+// many in-flight queries / subscriptions without ordering assumptions.
 
-type Row = { this: string; [field: string]: unknown };
-
-type ReadyEnvelope = {
+type HelloEnvelope     = { v: 1; type: "hello" };
+type QueryEnvelope     = { v: 1; type: "query";     id: string; body: unknown };
+type SubscribeEnvelope = { v: 1; type: "subscribe"; id: string; body: unknown };
+type UnsubscribeEnvelope = { v: 1; type: "unsubscribe"; id: string };
+type EvaluateEnvelope  = {
   v: 1;
-  type: "ready";
-  subscriptions: string[];
+  type: "evaluate";
+  id: string;
+  body: string;
+  contentType: string;
+  transact: boolean;
 };
 
-type DataEnvelope = {
-  v: 1;
-  type: "data";
-  name: string;
-  rows: Row[];
-};
+type ReadyResponse           = { v: 1; type: "ready" };
+type QueryResultResponse     = { v: 1; type: "query-result";     id: string; rows: unknown };
+type QueryErrorResponse      = { v: 1; type: "query-error";      id: string; error: string };
+type SubscribeEventResponse  = { v: 1; type: "subscribe-event";  id: string; rows: unknown };
+type SubscribeErrorResponse  = { v: 1; type: "subscribe-error";  id: string; error: string };
+type EvaluateResultResponse  = { v: 1; type: "evaluate-result";  id: string; result: unknown };
+type EvaluateErrorResponse   = { v: 1; type: "evaluate-error";   id: string; error: string };
+type Inbound =
+  | ReadyResponse
+  | QueryResultResponse | QueryErrorResponse
+  | SubscribeEventResponse | SubscribeErrorResponse
+  | EvaluateResultResponse | EvaluateErrorResponse;
 
-type ErrorEnvelope = {
-  v: 1;
-  type: "error";
-  name?: string;
-  error: string;
-};
+class Bridge {
+  private port: MessagePort;
+  private nextId = 0;
+  private pendingOnce = new Map<string, {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+    kind: "query" | "evaluate";
+  }>();
+  private pendingStream = new Map<string, {
+    onFrame: (rows: unknown) => void;
+    onError?: (message: string) => void;
+  }>();
+  private resolveReady!: () => void;
+  ready: Promise<void>;
 
-type InboundEnvelope = ReadyEnvelope | DataEnvelope | ErrorEnvelope;
+  constructor() {
+    this.ready = new Promise<void>(resolve => {
+      this.resolveReady = resolve;
+    });
 
-class Signal<T> {
-  private value: T | undefined = undefined;
-  private listeners = new Set<(value: T) => void>();
-  private errorListeners = new Set<(message: string) => void>();
-
-  get(): T | undefined {
-    return this.value;
-  }
-
-  set(value: T): void {
-    this.value = value;
-    for (const listener of this.listeners) {
-      try {
-        listener(value);
-      } catch (e) {
-        console.error("[tonk] signal listener threw", e);
-      }
-    }
-  }
-
-  fireError(message: string): void {
-    for (const listener of this.errorListeners) {
-      try {
-        listener(message);
-      } catch (e) {
-        console.error("[tonk] error listener threw", e);
-      }
-    }
-  }
-
-  subscribe(listener: (value: T) => void): () => void {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
+    const channel = new MessageChannel();
+    this.port = channel.port1;
+    this.port.onmessage = (event: MessageEvent<Inbound>) => {
+      this.dispatch(event.data);
     };
-  }
 
-  subscribeError(listener: (message: string) => void): () => void {
-    this.errorListeners.add(listener);
-    return () => {
-      this.errorListeners.delete(listener);
-    };
-  }
-}
-
-const subscriptions: Record<string, Signal<Row[]>> = {};
-
-let resolveReady!: () => void;
-const ready = new Promise<void>(resolve => {
-  resolveReady = resolve;
-});
-
-(globalThis as any).tonk = { ready, subscriptions };
-
-function handle(envelope: InboundEnvelope): void {
-  switch (envelope.type) {
-    case "ready":
-      for (const name of envelope.subscriptions) {
-        subscriptions[name] = new Signal<Row[]>();
-      }
-      resolveReady();
+    const controller = navigator.serviceWorker?.controller;
+    if (!controller) {
+      // No SW yet — the iframe was opened in a tab that hasn't
+      // claimed control. The bridge is inert; method calls will
+      // hang. Surface the situation clearly in devtools.
+      console.error("[tonk] bridge: no service worker controller; calls will hang");
       return;
-    case "data": {
-      const signal = subscriptions[envelope.name];
-      if (!signal) {
-        console.warn("[tonk] data for unknown subscription", envelope.name);
+    }
+    controller.postMessage(
+      { v: 1, type: "hello" } satisfies HelloEnvelope,
+      [channel.port2],
+    );
+  }
+
+  query(body: unknown): Promise<unknown> {
+    const id = this.mintId();
+    return new Promise<unknown>((resolve, reject) => {
+      this.pendingOnce.set(id, { resolve, reject, kind: "query" });
+      this.port.postMessage({ v: 1, type: "query", id, body } satisfies QueryEnvelope);
+    });
+  }
+
+  subscribe(
+    body: unknown,
+    onFrame: (rows: unknown) => void,
+    onError?: (message: string) => void,
+  ): () => void {
+    const id = this.mintId();
+    this.pendingStream.set(id, { onFrame, onError });
+    this.port.postMessage({ v: 1, type: "subscribe", id, body } satisfies SubscribeEnvelope);
+    return () => {
+      if (!this.pendingStream.delete(id)) return;
+      this.port.postMessage({ v: 1, type: "unsubscribe", id } satisfies UnsubscribeEnvelope);
+    };
+  }
+
+  evaluate(body: string, contentType = "application/yaml", transact = true): Promise<unknown> {
+    const id = this.mintId();
+    return new Promise<unknown>((resolve, reject) => {
+      this.pendingOnce.set(id, { resolve, reject, kind: "evaluate" });
+      this.port.postMessage({
+        v: 1,
+        type: "evaluate",
+        id,
+        body,
+        contentType,
+        transact,
+      } satisfies EvaluateEnvelope);
+    });
+  }
+
+  private mintId(): string {
+    this.nextId += 1;
+    return `r${this.nextId}`;
+  }
+
+  private dispatch(envelope: Inbound): void {
+    switch (envelope.type) {
+      case "ready":
+        this.resolveReady();
         return;
-      }
-      signal.set(envelope.rows);
-      return;
-    }
-    case "error": {
-      if (envelope.name) {
-        const signal = subscriptions[envelope.name];
-        if (signal) {
-          signal.fireError(envelope.error);
+      case "query-result":
+      case "evaluate-result": {
+        const handler = this.pendingOnce.get(envelope.id);
+        if (!handler) {
+          console.warn("[tonk] result for unknown id", envelope.id);
           return;
         }
+        this.pendingOnce.delete(envelope.id);
+        const payload = "rows" in envelope ? envelope.rows : envelope.result;
+        handler.resolve(payload);
+        return;
       }
-      console.error("[tonk] bridge error", envelope.error);
-      return;
+      case "query-error":
+      case "evaluate-error": {
+        const handler = this.pendingOnce.get(envelope.id);
+        if (!handler) {
+          console.warn("[tonk] error for unknown id", envelope.id);
+          return;
+        }
+        this.pendingOnce.delete(envelope.id);
+        handler.reject(new Error(envelope.error));
+        return;
+      }
+      case "subscribe-event": {
+        const handler = this.pendingStream.get(envelope.id);
+        if (!handler) {
+          // Late frame after unsubscribe; drop silently.
+          return;
+        }
+        try {
+          handler.onFrame(envelope.rows);
+        } catch (e) {
+          console.error("[tonk] subscribe frame handler threw", e);
+        }
+        return;
+      }
+      case "subscribe-error": {
+        const handler = this.pendingStream.get(envelope.id);
+        if (!handler) return;
+        if (handler.onError) {
+          try {
+            handler.onError(envelope.error);
+          } catch (e) {
+            console.error("[tonk] subscribe error handler threw", e);
+          }
+        } else {
+          console.error("[tonk] subscribe error", envelope.error);
+        }
+        return;
+      }
     }
   }
 }
 
-const channel = new MessageChannel();
-channel.port1.onmessage = (event: MessageEvent<InboundEnvelope>) => {
-  handle(event.data);
-};
-
-const controller = navigator.serviceWorker?.controller;
-if (!controller) {
-  console.error("[tonk] no service worker controller; bridge inactive");
-} else {
-  controller.postMessage({ v: 1, type: "hello" }, [channel.port2]);
-}
+const bridge = new Bridge();
+(globalThis as any).tonk = bridge;

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -46,7 +46,7 @@ pub use evaluate::{CommitSummary, EvaluatePath, EvaluateResponse, QueryMatchBloc
 mod query;
 pub use query::QueryPath;
 
-mod bridge;
+pub mod bridge;
 pub use bridge::BridgeRegistry;
 
 mod host;

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -2587,5 +2587,4 @@ person:
             row.fields,
         );
     }
-
 }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -88,7 +88,6 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
     let factory = lsp_introspection::ReactorIntrospectionFactory::new(state.clone());
     let (lsp_routes, lsp_hub) = lsp::lsp_router_with_introspection(factory);
     let router = Router::new()
-        .route("/__tonk/bridge.js", get(bridge::serve_bridge_js))
         .route("/api", get(root))
         .route("/api/identify", get(identify::identify))
         .route("/api/profile", get(profile::get_profile))
@@ -2589,32 +2588,4 @@ person:
         );
     }
 
-    #[dialog_common::test]
-    async fn it_serves_bridge_js_with_correct_content_type() {
-        let state = test_state().await;
-        let (app, _lsp) = api_router(state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/__tonk/bridge.js")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response
-                .headers()
-                .get(axum::http::header::CONTENT_TYPE)
-                .unwrap(),
-            "application/javascript",
-        );
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        assert!(!body_bytes.is_empty(), "bridge.js body must not be empty");
-    }
 }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -47,7 +47,7 @@ mod query;
 pub use query::QueryPath;
 
 mod host;
-pub use host::{ClientId, GuestBinding, GuestBindings};
+pub use host::{ClientId, ViewBinding, ViewBindings};
 
 /// Shared application state containing profile and operator.
 pub type AppState = Arc<RwLock<TonkState>>;
@@ -254,7 +254,7 @@ pub mod tests {
             operator,
             profile_name: "test-tonk".to_string(),
             reactor,
-            guests: Default::default(),
+            view_bindings: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -46,6 +46,8 @@ pub use evaluate::{CommitSummary, EvaluatePath, EvaluateResponse, QueryMatchBloc
 mod query;
 pub use query::QueryPath;
 
+mod bridge;
+
 mod host;
 pub use host::{ClientId, ViewBinding, ViewBindings};
 
@@ -85,6 +87,7 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
     let factory = lsp_introspection::ReactorIntrospectionFactory::new(state.clone());
     let (lsp_routes, lsp_hub) = lsp::lsp_router_with_introspection(factory);
     let router = Router::new()
+        .route("/__tonk/bridge.js", get(bridge::serve_bridge_js))
         .route("/api", get(root))
         .route("/api/identify", get(identify::identify))
         .route("/api/profile", get(profile::get_profile))
@@ -2582,5 +2585,34 @@ person:
             "blank `age: _` field must still surface the matched value; got {:?}",
             row.fields,
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_serves_bridge_js_with_correct_content_type() {
+        let state = test_state().await;
+        let (app, _lsp) = api_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/__tonk/bridge.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            "application/javascript",
+        );
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(!body_bytes.is_empty(), "bridge.js body must not be empty");
     }
 }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -47,6 +47,7 @@ mod query;
 pub use query::QueryPath;
 
 mod bridge;
+pub use bridge::BridgeRegistry;
 
 mod host;
 pub use host::{ClientId, ViewBinding, ViewBindings};
@@ -258,6 +259,7 @@ pub mod tests {
             profile_name: "test-tonk".to_string(),
             reactor,
             view_bindings: Default::default(),
+            bridges: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -540,6 +540,96 @@ async fn send_envelope(
     }
 }
 
+/// Walk every entry in `BridgeRegistry` and `ViewBindings`, drop any
+/// whose client id isn't in the SW's `matchAll()` live set.
+///
+/// Best-effort — runs opportunistically from `on_fetch` so idle SWs
+/// may accumulate stale entries briefly.
+///
+/// For each dropped `BridgeSession`, abort flags are set so pump
+/// tasks exit on their next iteration.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn sweep_stale_clients(state: &crate::router::AppState) {
+    use wasm_bindgen::JsCast;
+
+    let global: web_sys::ServiceWorkerGlobalScope = match js_sys::global().dyn_into() {
+        Ok(g) => g,
+        Err(_) => {
+            log!("sweep: not in a service worker scope");
+            return;
+        }
+    };
+    let live_promise = global.clients().match_all();
+    let live_value = match wasm_bindgen_futures::JsFuture::from(live_promise).await {
+        Ok(v) => v,
+        Err(e) => {
+            log!("sweep: clients.matchAll failed: {e:?}");
+            return;
+        }
+    };
+    let live_array = js_sys::Array::from(&live_value);
+    let live_ids: std::collections::HashSet<String> = live_array
+        .iter()
+        .filter_map(|v| v.dyn_into::<web_sys::Client>().ok().map(|c| c.id()))
+        .collect();
+
+    let (stale_bridges, stale_views) = {
+        let snap = state.read().await;
+        let bridges_arc = snap.bridges.clone();
+        let views_arc = snap.view_bindings.clone();
+        drop(snap);
+
+        let stale_bridges: Vec<ClientId> = {
+            let guard = bridges_arc.read().await;
+            guard
+                .keys()
+                .filter(|c| !live_ids.contains(&c.0))
+                .cloned()
+                .collect()
+        };
+        let stale_views: Vec<ClientId> = {
+            let guard = views_arc.read().await;
+            guard
+                .keys()
+                .filter(|c| !live_ids.contains(&c.0))
+                .cloned()
+                .collect()
+        };
+        (stale_bridges, stale_views)
+    };
+
+    if stale_bridges.is_empty() && stale_views.is_empty() {
+        return;
+    }
+
+    let bridges_arc = state.read().await.bridges.clone();
+    let views_arc = state.read().await.view_bindings.clone();
+
+    {
+        let mut guard = bridges_arc.write().await;
+        for client in &stale_bridges {
+            if let Some(session) = guard.remove(client) {
+                for (_id, flag) in session.subscriptions.iter() {
+                    flag.store(true, Ordering::Release);
+                }
+                // session.port drops here.
+            }
+        }
+    }
+    {
+        let mut guard = views_arc.write().await;
+        for client in &stale_views {
+            guard.remove(client);
+        }
+    }
+
+    log!(
+        "sweep: dropped {} bridge sessions, {} view bindings",
+        stale_bridges.len(),
+        stale_views.len(),
+    );
+}
+
 /// Post an error envelope back to the client.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn send_error(

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -13,9 +13,18 @@
 //! Increment 1 ships only the serve route; the message handler
 //! lives in later tasks.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use ::axum::body::Body;
 use ::axum::http::{HeaderValue, StatusCode, header};
 use ::axum::response::{IntoResponse, Response};
+use send_wrapper::SendWrapper;
+use tokio::sync::RwLock;
+use tokio::task::AbortHandle;
+use web_sys::MessagePort;
+
+use crate::router::ClientId;
 
 const BRIDGE_JS: &str = include_str!("../../assets/bridge.js");
 
@@ -33,3 +42,32 @@ pub async fn serve_bridge_js() -> Response {
     );
     response
 }
+
+/// One per connected iframe. Owns the transferred `MessagePort`
+/// plus abort handles keyed by correlation id — one per in-flight
+/// subscribe. `query` and `evaluate` are one-shot and don't need
+/// to be tracked.
+///
+/// `MessagePort` is `!Send + !Sync`; wrap it in `SendWrapper` to
+/// satisfy the trait bounds the registry imposes. The SW runtime
+/// is single-threaded so SendWrapper's panic-on-cross-thread
+/// guard never fires.
+pub(crate) struct BridgeSession {
+    pub port: SendWrapper<MessagePort>,
+    pub subscriptions: HashMap<String, AbortHandle>,
+}
+
+impl BridgeSession {
+    pub fn new(port: MessagePort) -> Self {
+        Self {
+            port: SendWrapper::new(port),
+            subscriptions: HashMap::new(),
+        }
+    }
+}
+
+/// Per-SW registry: ClientId → BridgeSession. Held behind an
+/// `RwLock` so multiple in-flight message-dispatch tasks can read
+/// the port concurrently and only contend when adding/removing
+/// sessions.
+pub type BridgeRegistry = Arc<RwLock<HashMap<ClientId, BridgeSession>>>;

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -15,9 +15,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use std::sync::atomic::Ordering;
-use std::sync::atomic::AtomicBool;
 
 use ::axum::body::Body;
 use ::axum::http::{HeaderValue, StatusCode, header};
@@ -102,10 +102,7 @@ pub async fn handle_message(
     envelope: serde_json::Value,
     ports: js_sys::Array,
 ) {
-    let envelope_type = envelope
-        .get("type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let envelope_type = envelope.get("type").and_then(|v| v.as_str()).unwrap_or("");
     match envelope_type {
         "hello" => handle_hello(state, client, ports).await,
         "query" => handle_query(state, client, envelope).await,
@@ -123,11 +120,7 @@ pub async fn handle_message(
 /// id, and posts a `ready` envelope back so the iframe-side
 /// `tonk.ready` promise resolves.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn handle_hello(
-    state: crate::router::AppState,
-    client: ClientId,
-    ports: js_sys::Array,
-) {
+async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: js_sys::Array) {
     if ports.length() == 0 {
         log!("bridge: hello from {client:?} had no transferred port; dropping");
         return;
@@ -405,14 +398,7 @@ async fn handle_subscribe(
             if session.subscriptions.contains_key(&id) {
                 log!("bridge: subscribe id '{id}' already active for {client:?}");
                 drop(guard);
-                send_error(
-                    &state,
-                    &client,
-                    "subscribe-error",
-                    &id,
-                    "id already in use",
-                )
-                .await;
+                send_error(&state, &client, "subscribe-error", &id, "id already in use").await;
                 return;
             }
         }

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -47,15 +47,27 @@ pub struct BridgeSession {
     /// an abort flag; setting it to `true` causes the pump task to
     /// exit on its next iteration.
     pub subscriptions: HashMap<String, Arc<AtomicBool>>,
+    /// Closure attached to `port.onmessage`. Kept here so it stays
+    /// alive for the session's lifetime and is dropped (detaching
+    /// the listener) when the session is removed from the registry.
+    ///
+    /// `Closure` is `!Send + !Sync` (holds JS state); `SendWrapper`
+    /// makes it acceptable to the single-threaded SW registry.
+    pub _on_message:
+        SendWrapper<wasm_bindgen::closure::Closure<dyn FnMut(web_sys::MessageEvent)>>,
 }
 
 impl BridgeSession {
-    /// Create a new session wrapping the given port with no active
-    /// subscriptions.
-    pub fn new(port: MessagePort) -> Self {
+    /// Create a new session wrapping the port and its `onmessage`
+    /// closure with no active subscriptions.
+    pub fn new(
+        port: MessagePort,
+        on_message: wasm_bindgen::closure::Closure<dyn FnMut(web_sys::MessageEvent)>,
+    ) -> Self {
         Self {
             port: SendWrapper::new(port),
             subscriptions: HashMap::new(),
+            _on_message: SendWrapper::new(on_message),
         }
     }
 }
@@ -66,8 +78,12 @@ impl BridgeSession {
 /// sessions.
 pub type BridgeRegistry = Arc<RwLock<HashMap<ClientId, BridgeSession>>>;
 
-/// Top-level dispatcher invoked from `worker::on_message`. Routes
-/// the envelope to the right per-type handler.
+/// Top-level dispatcher invoked from `worker::on_message` for the SW
+/// global `message` event. Only `hello` arrives this way — all
+/// subsequent envelopes (`query`, `subscribe`, `evaluate`,
+/// `unsubscribe`) travel over the transferred `MessagePort` and are
+/// handled by the per-port `onmessage` closure attached in
+/// `handle_hello`.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub async fn handle_message(
     state: crate::router::AppState,
@@ -78,22 +94,24 @@ pub async fn handle_message(
     let envelope_type = envelope.get("type").and_then(|v| v.as_str()).unwrap_or("");
     match envelope_type {
         "hello" => handle_hello(state, client, ports).await,
-        "query" => handle_query(state, client, envelope).await,
-        "evaluate" => handle_evaluate(state, client, envelope).await,
-        "subscribe" => handle_subscribe(state, client, envelope).await,
-        "unsubscribe" => handle_unsubscribe(state, client, envelope).await,
         other => {
-            log!("bridge: ignoring envelope type '{other}'");
+            log!(
+                "bridge: SW global received unexpected envelope type '{other}' from {client:?} \
+                 (post-hello messages should go through the port, not the SW global)"
+            );
         }
     }
 }
 
 /// `hello` handler. Extracts the transferred port (index 0 of the
-/// `ports` array), registers a `BridgeSession` against the client
-/// id, and posts a `ready` envelope back so the iframe-side
-/// `tonk.ready` promise resolves.
+/// `ports` array), attaches an `onmessage` listener that dispatches
+/// subsequent envelopes from the iframe, registers a `BridgeSession`
+/// (which keeps the closure alive), and posts a `ready` envelope so
+/// the iframe-side `tonk.ready` promise resolves.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: js_sys::Array) {
+    use wasm_bindgen::closure::Closure;
+
     if ports.length() == 0 {
         log!("bridge: hello from {client:?} had no transferred port; dropping");
         return;
@@ -107,12 +125,57 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
         }
     };
 
-    // Stash the session BEFORE posting `ready` so any immediate
-    // query/subscribe that follows finds the binding.
+    // Build the per-port message handler. Each envelope arriving on
+    // the port (query / subscribe / evaluate / unsubscribe) is
+    // dispatched asynchronously. The closure is stored on
+    // BridgeSession to keep it alive; dropping the session drops the
+    // closure and detaches the listener.
+    let state_for_handler = state.clone();
+    let client_for_handler = client.clone();
+    let on_message = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
+        let state = state_for_handler.clone();
+        let client = client_for_handler.clone();
+        let data = event.data();
+        wasm_bindgen_futures::spawn_local(async move {
+            let envelope: serde_json::Value = match serde_wasm_bindgen::from_value(data) {
+                Ok(v) => v,
+                Err(e) => {
+                    log!("bridge port: malformed envelope from {client:?}: {e:?}");
+                    return;
+                }
+            };
+            let envelope_type = envelope
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match envelope_type {
+                "query" => handle_query(state, client, envelope).await,
+                "evaluate" => handle_evaluate(state, client, envelope).await,
+                "subscribe" => handle_subscribe(state, client, envelope).await,
+                "unsubscribe" => handle_unsubscribe(state, client, envelope).await,
+                "hello" => {
+                    log!(
+                        "bridge port: ignoring 'hello' on established port from {client:?}"
+                    );
+                }
+                other => {
+                    log!("bridge port: ignoring envelope type '{other}' from {client:?}");
+                }
+            }
+        });
+    }) as Box<dyn FnMut(web_sys::MessageEvent)>);
+
+    // Attach the listener. Setting onmessage auto-starts the port,
+    // so no explicit port.start() call is needed.
+    port.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
+
+    // Stash the session (holding port + closure) BEFORE posting
+    // `ready` so any immediate query/subscribe that follows finds
+    // the binding.
     let bridges = state.read().await.bridges.clone();
     {
         let mut guard = bridges.write().await;
-        guard.insert(client.clone(), BridgeSession::new(port.clone()));
+        guard.insert(client.clone(), BridgeSession::new(port.clone(), on_message));
     }
 
     let envelope = serde_json::json!({

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -148,6 +148,7 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
                 .get("type")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+            log!("bridge port: received '{envelope_type}' from {client:?}");
             match envelope_type {
                 "query" => handle_query(state, client, envelope).await,
                 "evaluate" => handle_evaluate(state, client, envelope).await,

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -22,6 +22,10 @@ use ::axum::response::{IntoResponse, Response};
 use send_wrapper::SendWrapper;
 use tokio::sync::RwLock;
 use tokio::task::AbortHandle;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tonk_common::log;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen::JsCast;
 use web_sys::MessagePort;
 
 use crate::router::ClientId;
@@ -71,3 +75,78 @@ impl BridgeSession {
 /// the port concurrently and only contend when adding/removing
 /// sessions.
 pub type BridgeRegistry = Arc<RwLock<HashMap<ClientId, BridgeSession>>>;
+
+/// Top-level dispatcher invoked from `worker::on_message`. Routes
+/// the envelope to the right per-type handler.
+///
+/// Increment 1 ships `hello` (port handoff) only. The other types
+/// log "not yet implemented" — they'll be filled in by follow-up
+/// tasks in the same PR.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn handle_message(
+    state: crate::router::AppState,
+    client: ClientId,
+    envelope: serde_json::Value,
+    ports: js_sys::Array,
+) {
+    let envelope_type = envelope
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match envelope_type {
+        "hello" => handle_hello(state, client, ports).await,
+        "query" | "subscribe" | "unsubscribe" | "evaluate" => {
+            log!("bridge: envelope type '{envelope_type}' is not yet wired");
+        }
+        other => {
+            log!("bridge: ignoring envelope type '{other}'");
+        }
+    }
+}
+
+/// `hello` handler. Extracts the transferred port (index 0 of the
+/// `ports` array), registers a `BridgeSession` against the client
+/// id, and posts a `ready` envelope back so the iframe-side
+/// `tonk.ready` promise resolves.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn handle_hello(
+    state: crate::router::AppState,
+    client: ClientId,
+    ports: js_sys::Array,
+) {
+    if ports.length() == 0 {
+        log!("bridge: hello from {client:?} had no transferred port; dropping");
+        return;
+    }
+    let port_value = ports.get(0);
+    let port: MessagePort = match port_value.dyn_into() {
+        Ok(p) => p,
+        Err(_) => {
+            log!("bridge: hello from {client:?} transferred a non-MessagePort; dropping");
+            return;
+        }
+    };
+
+    // Stash the session BEFORE posting `ready` so any immediate
+    // query/subscribe that follows finds the binding.
+    let bridges = state.read().await.bridges.clone();
+    {
+        let mut guard = bridges.write().await;
+        guard.insert(client.clone(), BridgeSession::new(port.clone()));
+    }
+
+    let envelope = serde_json::json!({
+        "v": 1,
+        "type": "ready",
+    });
+    let js = match serde_wasm_bindgen::to_value(&envelope) {
+        Ok(v) => v,
+        Err(e) => {
+            log!("bridge: ready envelope serialise failed: {e:?}");
+            return;
+        }
+    };
+    if let Err(e) = port.post_message(&js) {
+        log!("bridge: failed to post ready to {client:?}: {e:?}");
+    }
+}

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -15,13 +15,13 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use ::axum::body::Body;
 use ::axum::http::{HeaderValue, StatusCode, header};
 use ::axum::response::{IntoResponse, Response};
 use send_wrapper::SendWrapper;
 use tokio::sync::RwLock;
-use tokio::task::AbortHandle;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tonk_common::log;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -48,7 +48,7 @@ pub async fn serve_bridge_js() -> Response {
 }
 
 /// One per connected iframe. Owns the transferred `MessagePort`
-/// plus abort handles keyed by correlation id — one per in-flight
+/// plus abort flags keyed by correlation id — one per in-flight
 /// subscribe. `query` and `evaluate` are one-shot and don't need
 /// to be tracked.
 ///
@@ -56,9 +56,16 @@ pub async fn serve_bridge_js() -> Response {
 /// satisfy the trait bounds the registry imposes. The SW runtime
 /// is single-threaded so SendWrapper's panic-on-cross-thread
 /// guard never fires.
+///
+/// Each active subscription is represented by an `Arc<AtomicBool>`
+/// abort flag. Setting the flag to `true` causes the pump task to
+/// exit on its next iteration. We use this instead of a tokio
+/// `AbortHandle` because `wasm_bindgen_futures::spawn_local` (the
+/// only spawn primitive available in the WASM service-worker
+/// environment) returns `()` rather than a join-handle.
 pub(crate) struct BridgeSession {
     pub port: SendWrapper<MessagePort>,
-    pub subscriptions: HashMap<String, AbortHandle>,
+    pub subscriptions: HashMap<String, Arc<AtomicBool>>,
 }
 
 impl BridgeSession {
@@ -93,9 +100,8 @@ pub async fn handle_message(
         "hello" => handle_hello(state, client, ports).await,
         "query" => handle_query(state, client, envelope).await,
         "evaluate" => handle_evaluate(state, client, envelope).await,
-        "subscribe" | "unsubscribe" => {
-            log!("bridge: envelope type '{envelope_type}' is not yet wired");
-        }
+        "subscribe" => handle_subscribe(state, client, envelope).await,
+        "unsubscribe" => handle_unsubscribe(state, client, envelope).await,
         other => {
             log!("bridge: ignoring envelope type '{other}'");
         }
@@ -328,6 +334,173 @@ async fn handle_evaluate(
         Err(e) => {
             send_error(&state, &client, "evaluate-error", &id, &format!("{e}")).await;
         }
+    }
+}
+
+/// `subscribe` handler. Opens a reactor subscription for the
+/// client's bound branch, spawns a pump task that posts each
+/// emission as `subscribe-event` over the port. A shared
+/// `Arc<AtomicBool>` abort flag is stored against
+/// `BridgeSession.subscriptions` keyed by the correlation `id` so
+/// `handle_unsubscribe` can stop the pump.
+///
+/// Re-subscribing with the same `id` is treated as a programmer
+/// error: we log and return an error envelope without disturbing
+/// the existing pump. The client should `unsubscribe` first.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn handle_subscribe(
+    state: crate::router::AppState,
+    client: ClientId,
+    envelope: serde_json::Value,
+) {
+    let id = envelope
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .unwrap_or_default();
+    let body = match envelope.get("body") {
+        Some(b) => b.clone(),
+        None => {
+            send_error(&state, &client, "subscribe-error", &id, "missing body").await;
+            return;
+        }
+    };
+
+    let Some(binding) = lookup_binding(&state, &client).await else {
+        send_error(&state, &client, "subscribe-error", &id, "no view binding").await;
+        return;
+    };
+
+    let wire: crate::reactor::Query = match serde_json::from_value(body) {
+        Ok(w) => w,
+        Err(e) => {
+            send_error(
+                &state,
+                &client,
+                "subscribe-error",
+                &id,
+                &format!("invalid ConceptQuery: {e}"),
+            )
+            .await;
+            return;
+        }
+    };
+    let query: dialog_query::ConceptQuery = wire.into();
+
+    // Bail early if this id is already pumping.
+    {
+        let bridges = state.read().await.bridges.clone();
+        let guard = bridges.read().await;
+        if let Some(session) = guard.get(&client) {
+            if session.subscriptions.contains_key(&id) {
+                log!("bridge: subscribe id '{id}' already active for {client:?}");
+                drop(guard);
+                send_error(
+                    &state,
+                    &client,
+                    "subscribe-error",
+                    &id,
+                    "id already in use",
+                )
+                .await;
+                return;
+            }
+        }
+    }
+
+    let subscriber = {
+        let tonk = state.read().await;
+        match tonk
+            .reactor
+            .repository(&binding.repo)
+            .branch(&binding.branch)
+            .subscribe(query)
+            .perform(&tonk.operator)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                send_error(
+                    &state,
+                    &client,
+                    "subscribe-error",
+                    &id,
+                    &format!("reactor subscribe: {e}"),
+                )
+                .await;
+                return;
+            }
+        }
+    };
+
+    let mut receiver = subscriber.receiver;
+    let pump_state = state.clone();
+    let pump_client = client.clone();
+    let pump_id = id.clone();
+
+    let abort_flag = Arc::new(AtomicBool::new(false));
+    let pump_flag = abort_flag.clone();
+
+    wasm_bindgen_futures::spawn_local(async move {
+        while !pump_flag.load(Ordering::Acquire) {
+            let Some(bytes) = receiver.recv().await else {
+                break;
+            };
+            if pump_flag.load(Ordering::Acquire) {
+                break;
+            }
+            // The reactor emits a JSON-serialised `Vec<Conclusion>`
+            // per frame. Decode and re-wrap as a subscribe-event.
+            let rows: serde_json::Value = match serde_json::from_slice(&bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    log!("bridge: subscribe frame for id '{pump_id}' was not JSON: {e}");
+                    continue;
+                }
+            };
+            send_envelope(
+                &pump_state,
+                &pump_client,
+                serde_json::json!({
+                    "v": 1,
+                    "type": "subscribe-event",
+                    "id": pump_id,
+                    "rows": rows,
+                }),
+            )
+            .await;
+        }
+    });
+
+    let bridges = state.read().await.bridges.clone();
+    let mut guard = bridges.write().await;
+    if let Some(session) = guard.get_mut(&client) {
+        session.subscriptions.insert(id, abort_flag);
+    }
+}
+
+/// `unsubscribe` handler. Sets the pump task's abort flag and
+/// removes the subscription entry. Idempotent — calling it with
+/// an unknown id is a no-op (no error envelope sent back).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn handle_unsubscribe(
+    state: crate::router::AppState,
+    client: ClientId,
+    envelope: serde_json::Value,
+) {
+    let id = envelope
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .unwrap_or_default();
+
+    let bridges = state.read().await.bridges.clone();
+    let mut guard = bridges.write().await;
+    let Some(session) = guard.get_mut(&client) else {
+        return;
+    };
+    if let Some(flag) = session.subscriptions.remove(&id) {
+        flag.store(true, Ordering::Release);
     }
 }
 

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -1,0 +1,35 @@
+//! Iframe ↔ service-worker bridge.
+//!
+//! Two responsibilities in Increment 1:
+//!
+//! 1. Serve the iframe-side bridge module at `/__tonk/bridge.js`.
+//!    The wrapper injected by `host::wrap_html_body` loads it as
+//!    an ES module.
+//! 2. Handle `message` events from view clients. The iframe sends
+//!    `{v:1,type:"hello"}` with a transferred `MessagePort`; the
+//!    SW enumerates the view's subscription claims, opens reactor
+//!    subscriptions, and pumps snapshots back over the port.
+//!
+//! Increment 1 ships only the serve route; the message handler
+//! lives in later tasks.
+
+use ::axum::body::Body;
+use ::axum::http::{HeaderValue, StatusCode, header};
+use ::axum::response::{IntoResponse, Response};
+
+const BRIDGE_JS: &str = include_str!("../../assets/bridge.js");
+
+/// `GET /__tonk/bridge.js`.
+///
+/// Serves the compiled bridge module as a JavaScript ES module.
+/// Bytes are bundled into the wasm artefact at build time so the
+/// route resolves without touching the network even when the SW
+/// is running cold.
+pub async fn serve_bridge_js() -> Response {
+    let mut response = (StatusCode::OK, Body::from(BRIDGE_JS)).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/javascript"),
+    );
+    response
+}

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -78,10 +78,6 @@ pub type BridgeRegistry = Arc<RwLock<HashMap<ClientId, BridgeSession>>>;
 
 /// Top-level dispatcher invoked from `worker::on_message`. Routes
 /// the envelope to the right per-type handler.
-///
-/// Increment 1 ships `hello` (port handoff) only. The other types
-/// log "not yet implemented" — they'll be filled in by follow-up
-/// tasks in the same PR.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub async fn handle_message(
     state: crate::router::AppState,
@@ -95,7 +91,9 @@ pub async fn handle_message(
         .unwrap_or("");
     match envelope_type {
         "hello" => handle_hello(state, client, ports).await,
-        "query" | "subscribe" | "unsubscribe" | "evaluate" => {
+        "query" => handle_query(state, client, envelope).await,
+        "evaluate" => handle_evaluate(state, client, envelope).await,
+        "subscribe" | "unsubscribe" => {
             log!("bridge: envelope type '{envelope_type}' is not yet wired");
         }
         other => {
@@ -149,4 +147,244 @@ async fn handle_hello(
     if let Err(e) = port.post_message(&js) {
         log!("bridge: failed to post ready to {client:?}: {e:?}");
     }
+}
+
+/// `query` handler. Looks up the client's `ViewBinding`, runs a
+/// one-shot reactor query, and posts `{query-result, id, rows}` (or
+/// `{query-error, id, error}`) back over the port.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn handle_query(
+    state: crate::router::AppState,
+    client: ClientId,
+    envelope: serde_json::Value,
+) {
+    let id = envelope
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .unwrap_or_default();
+    let body = match envelope.get("body") {
+        Some(b) => b.clone(),
+        None => {
+            send_error(&state, &client, "query-error", &id, "missing body").await;
+            return;
+        }
+    };
+
+    let Some(binding) = lookup_binding(&state, &client).await else {
+        send_error(&state, &client, "query-error", &id, "no view binding").await;
+        return;
+    };
+
+    let wire: crate::reactor::Query = match serde_json::from_value(body) {
+        Ok(w) => w,
+        Err(e) => {
+            send_error(
+                &state,
+                &client,
+                "query-error",
+                &id,
+                &format!("invalid ConceptQuery: {e}"),
+            )
+            .await;
+            return;
+        }
+    };
+    let query: dialog_query::ConceptQuery = wire.into();
+
+    // Run the one-shot path — same as `router::query::query` does
+    // when the request did not ask for a stream.
+    let conclusions = {
+        let tonk = state.read().await;
+        let session = match tonk
+            .reactor
+            .repository(&binding.repo)
+            .branch(&binding.branch)
+            .acquire(&tonk.operator)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                send_error(
+                    &state,
+                    &client,
+                    "query-error",
+                    &id,
+                    &format!("reactor acquire: {e}"),
+                )
+                .await;
+                return;
+            }
+        };
+        let terms = query.terms.clone();
+        use dialog_query::Output as _;
+        match session
+            .handle()
+            .select(tonk_schema::concept::QueryPlan::from(query))
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+        {
+            Ok(rows) => rows
+                .iter()
+                .map(|c| crate::reactor::Conclusion::project(c, &terms))
+                .collect::<Vec<_>>(),
+            Err(e) => {
+                send_error(
+                    &state,
+                    &client,
+                    "query-error",
+                    &id,
+                    &format!("query exec: {e}"),
+                )
+                .await;
+                return;
+            }
+        }
+    };
+
+    send_envelope(
+        &state,
+        &client,
+        serde_json::json!({
+            "v": 1,
+            "type": "query-result",
+            "id": id,
+            "rows": conclusions,
+        }),
+    )
+    .await;
+}
+
+/// `evaluate` handler. Looks up the client's `ViewBinding`, runs
+/// the evaluate pipeline against the supplied body, and posts
+/// `{evaluate-result, id, result}` (or `{evaluate-error, id, error}`).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn handle_evaluate(
+    state: crate::router::AppState,
+    client: ClientId,
+    envelope: serde_json::Value,
+) {
+    let id = envelope
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .unwrap_or_default();
+    let body = match envelope.get("body").and_then(|v| v.as_str()) {
+        Some(b) => b.to_owned(),
+        None => {
+            send_error(
+                &state,
+                &client,
+                "evaluate-error",
+                &id,
+                "missing body string",
+            )
+            .await;
+            return;
+        }
+    };
+    let content_type = envelope
+        .get("contentType")
+        .and_then(|v| v.as_str())
+        .unwrap_or("application/yaml")
+        .to_owned();
+    let transact = envelope
+        .get("transact")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let Some(binding) = lookup_binding(&state, &client).await else {
+        send_error(&state, &client, "evaluate-error", &id, "no view binding").await;
+        return;
+    };
+
+    let result = {
+        let tonk = state.read().await;
+        crate::router::evaluate::evaluate_body(
+            &tonk,
+            &binding.repo,
+            &binding.branch,
+            body,
+            &content_type,
+            transact,
+        )
+        .await
+    };
+    match result {
+        Ok(response) => {
+            send_envelope(
+                &state,
+                &client,
+                serde_json::json!({
+                    "v": 1,
+                    "type": "evaluate-result",
+                    "id": id,
+                    "result": response,
+                }),
+            )
+            .await;
+        }
+        Err(e) => {
+            send_error(&state, &client, "evaluate-error", &id, &format!("{e}")).await;
+        }
+    }
+}
+
+/// Look up the `ViewBinding` for the given client.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn lookup_binding(
+    state: &crate::router::AppState,
+    client: &ClientId,
+) -> Option<crate::router::ViewBinding> {
+    let bindings = state.read().await.view_bindings.clone();
+    let guard = bindings.read().await;
+    guard.get(client).cloned()
+}
+
+/// Serialize `envelope` and post it over the client's bridge port.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn send_envelope(
+    state: &crate::router::AppState,
+    client: &ClientId,
+    envelope: serde_json::Value,
+) {
+    let bridges = state.read().await.bridges.clone();
+    let guard = bridges.read().await;
+    let Some(session) = guard.get(client) else {
+        log!("bridge: tried to send to {client:?} but no session");
+        return;
+    };
+    let js = match serde_wasm_bindgen::to_value(&envelope) {
+        Ok(v) => v,
+        Err(e) => {
+            log!("bridge: envelope serialise failed: {e:?}");
+            return;
+        }
+    };
+    if let Err(e) = session.port.post_message(&js) {
+        log!("bridge: post_message to {client:?} failed: {e:?}");
+    }
+}
+
+/// Post an error envelope back to the client.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn send_error(
+    state: &crate::router::AppState,
+    client: &ClientId,
+    error_type: &str,
+    id: &str,
+    message: &str,
+) {
+    send_envelope(
+        state,
+        client,
+        serde_json::json!({
+            "v": 1,
+            "type": error_type,
+            "id": id,
+            "error": message,
+        }),
+    )
+    .await;
 }

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -1,10 +1,12 @@
 //! Iframe ↔ service-worker bridge.
 //!
-//! Handles `message` events from view clients. The iframe loads
-//! `/__tonk/bridge.js` (served from dist by the dev server / CDN)
-//! and sends `{v:1,type:"hello"}` with a transferred `MessagePort`;
-//! the SW enumerates the view's subscription claims, opens reactor
-//! subscriptions, and pumps snapshots back over the port.
+//! The iframe loads `/__tonk/bridge.js` and posts a
+//! `{v:1,type:"hello"}` envelope to the SW with a transferred
+//! `MessagePort`. The SW stashes the port against the iframe's
+//! ClientId and replies with `ready`; the iframe then drives
+//! `query` / `subscribe` / `unsubscribe` / `evaluate` envelopes
+//! over the port, which this module dispatches to the reactor
+//! against the bound `{repo, branch}`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -53,8 +55,7 @@ pub struct BridgeSession {
     ///
     /// `Closure` is `!Send + !Sync` (holds JS state); `SendWrapper`
     /// makes it acceptable to the single-threaded SW registry.
-    pub _on_message:
-        SendWrapper<wasm_bindgen::closure::Closure<dyn FnMut(web_sys::MessageEvent)>>,
+    pub _on_message: SendWrapper<wasm_bindgen::closure::Closure<dyn FnMut(web_sys::MessageEvent)>>,
 }
 
 impl BridgeSession {
@@ -69,6 +70,15 @@ impl BridgeSession {
             subscriptions: HashMap::new(),
             _on_message: SendWrapper::new(on_message),
         }
+    }
+}
+
+impl Drop for BridgeSession {
+    fn drop(&mut self) {
+        // Clear `onmessage` before the closure inside `_on_message`
+        // drops, so the port doesn't transiently point at freed
+        // wasm memory between the two drops.
+        self.port.set_onmessage(None);
     }
 }
 
@@ -125,11 +135,6 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
         }
     };
 
-    // Build the per-port message handler. Each envelope arriving on
-    // the port (query / subscribe / evaluate / unsubscribe) is
-    // dispatched asynchronously. The closure is stored on
-    // BridgeSession to keep it alive; dropping the session drops the
-    // closure and detaches the listener.
     let state_for_handler = state.clone();
     let client_for_handler = client.clone();
     let on_message = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
@@ -144,10 +149,7 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
                     return;
                 }
             };
-            let envelope_type = envelope
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+            let envelope_type = envelope.get("type").and_then(|v| v.as_str()).unwrap_or("");
             log!("bridge port: received '{envelope_type}' from {client:?}");
             match envelope_type {
                 "query" => handle_query(state, client, envelope).await,
@@ -155,9 +157,7 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
                 "subscribe" => handle_subscribe(state, client, envelope).await,
                 "unsubscribe" => handle_unsubscribe(state, client, envelope).await,
                 "hello" => {
-                    log!(
-                        "bridge port: ignoring 'hello' on established port from {client:?}"
-                    );
+                    log!("bridge port: ignoring 'hello' on established port from {client:?}");
                 }
                 other => {
                     log!("bridge port: ignoring envelope type '{other}' from {client:?}");
@@ -166,13 +166,11 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
         });
     }) as Box<dyn FnMut(web_sys::MessageEvent)>);
 
-    // Attach the listener. Setting onmessage auto-starts the port,
-    // so no explicit port.start() call is needed.
+    // Setting onmessage auto-starts the port; no port.start() needed.
     port.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
 
-    // Stash the session (holding port + closure) BEFORE posting
-    // `ready` so any immediate query/subscribe that follows finds
-    // the binding.
+    // Stash the session before posting `ready` so any immediate
+    // query/subscribe that follows finds the binding.
     let bridges = state.read().await.bridges.clone();
     {
         let mut guard = bridges.write().await;
@@ -330,11 +328,6 @@ async fn handle_evaluate(
             return;
         }
     };
-    let content_type = envelope
-        .get("contentType")
-        .and_then(|v| v.as_str())
-        .unwrap_or("application/yaml")
-        .to_owned();
     let transact = envelope
         .get("transact")
         .and_then(|v| v.as_bool())
@@ -352,7 +345,6 @@ async fn handle_evaluate(
             &binding.repo,
             &binding.branch,
             body,
-            &content_type,
             transact,
         )
         .await
@@ -482,8 +474,6 @@ async fn handle_subscribe(
             if pump_flag.load(Ordering::Acquire) {
                 break;
             }
-            // The reactor emits a JSON-serialised `Vec<Conclusion>`
-            // per frame. Decode and re-wrap as a subscribe-event.
             let rows: serde_json::Value = match serde_json::from_slice(&bytes) {
                 Ok(v) => v,
                 Err(e) => {
@@ -509,6 +499,11 @@ async fn handle_subscribe(
     let mut guard = bridges.write().await;
     if let Some(session) = guard.get_mut(&client) {
         session.subscriptions.insert(id, abort_flag);
+    } else {
+        // Session was swept (or never existed) between subscribe and
+        // insert — flag the pump so it exits on the next iteration
+        // instead of running orphaned forever.
+        abort_flag.store(true, Ordering::Release);
     }
 }
 
@@ -649,8 +644,10 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         return;
     }
 
-    let bridges_arc = state.read().await.bridges.clone();
-    let views_arc = state.read().await.view_bindings.clone();
+    let (bridges_arc, views_arc) = {
+        let snap = state.read().await;
+        (snap.bridges.clone(), snap.view_bindings.clone())
+    };
 
     {
         let mut guard = bridges_arc.write().await;

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -182,7 +182,7 @@ async fn handle_hello(state: crate::router::AppState, client: ClientId, ports: j
         "v": 1,
         "type": "ready",
     });
-    let js = match serde_wasm_bindgen::to_value(&envelope) {
+    let js = match envelope_to_js(&envelope) {
         Ok(v) => v,
         Err(e) => {
             log!("bridge: ready envelope serialise failed: {e:?}");
@@ -547,6 +547,20 @@ async fn lookup_binding(
     guard.get(client).cloned()
 }
 
+/// Serialise an envelope as a plain JS object (not a `Map`) so
+/// the iframe-side `Bridge.dispatch` can read fields via dot
+/// access. `serde_wasm_bindgen::to_value` defaults to producing
+/// `Map`s for `serde_json::Value::Object`, which would make every
+/// dispatched envelope's `.type` come out `undefined` on the
+/// iframe side.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn envelope_to_js(
+    envelope: &serde_json::Value,
+) -> Result<wasm_bindgen::JsValue, serde_wasm_bindgen::Error> {
+    use serde::Serialize;
+    envelope.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+}
+
 /// Serialize `envelope` and post it over the client's bridge port.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn send_envelope(
@@ -560,7 +574,7 @@ async fn send_envelope(
         log!("bridge: tried to send to {client:?} but no session");
         return;
     };
-    let js = match serde_wasm_bindgen::to_value(&envelope) {
+    let js = match envelope_to_js(&envelope) {
         Ok(v) => v,
         Err(e) => {
             log!("bridge: envelope serialise failed: {e:?}");

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -1,17 +1,10 @@
 //! Iframe ↔ service-worker bridge.
 //!
-//! Two responsibilities in Increment 1:
-//!
-//! 1. Serve the iframe-side bridge module at `/__tonk/bridge.js`.
-//!    The wrapper injected by `host::wrap_html_body` loads it as
-//!    an ES module.
-//! 2. Handle `message` events from view clients. The iframe sends
-//!    `{v:1,type:"hello"}` with a transferred `MessagePort`; the
-//!    SW enumerates the view's subscription claims, opens reactor
-//!    subscriptions, and pumps snapshots back over the port.
-//!
-//! Increment 1 ships only the serve route; the message handler
-//! lives in later tasks.
+//! Handles `message` events from view clients. The iframe loads
+//! `/__tonk/bridge.js` (served from dist by the dev server / CDN)
+//! and sends `{v:1,type:"hello"}` with a transferred `MessagePort`;
+//! the SW enumerates the view's subscription claims, opens reactor
+//! subscriptions, and pumps snapshots back over the port.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,9 +12,6 @@ use std::sync::atomic::AtomicBool;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use std::sync::atomic::Ordering;
 
-use ::axum::body::Body;
-use ::axum::http::{HeaderValue, StatusCode, header};
-use ::axum::response::{IntoResponse, Response};
 use send_wrapper::SendWrapper;
 use tokio::sync::RwLock;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -31,23 +21,6 @@ use wasm_bindgen::JsCast;
 use web_sys::MessagePort;
 
 use crate::router::ClientId;
-
-const BRIDGE_JS: &str = include_str!("../../assets/bridge.js");
-
-/// `GET /__tonk/bridge.js`.
-///
-/// Serves the compiled bridge module as a JavaScript ES module.
-/// Bytes are bundled into the wasm artefact at build time so the
-/// route resolves without touching the network even when the SW
-/// is running cold.
-pub async fn serve_bridge_js() -> Response {
-    let mut response = (StatusCode::OK, Body::from(BRIDGE_JS)).into_response();
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/javascript"),
-    );
-    response
-}
 
 /// One per connected iframe. Owns the transferred `MessagePort`
 /// plus abort flags keyed by correlation id — one per in-flight

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -15,7 +15,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use std::sync::atomic::Ordering;
+use std::sync::atomic::AtomicBool;
 
 use ::axum::body::Body;
 use ::axum::http::{HeaderValue, StatusCode, header};
@@ -63,12 +65,20 @@ pub async fn serve_bridge_js() -> Response {
 /// `AbortHandle` because `wasm_bindgen_futures::spawn_local` (the
 /// only spawn primitive available in the WASM service-worker
 /// environment) returns `()` rather than a join-handle.
-pub(crate) struct BridgeSession {
+pub struct BridgeSession {
+    /// The `MessagePort` end transferred from the iframe's bridge
+    /// module on `hello`. Used to send response envelopes back to
+    /// the iframe.
     pub port: SendWrapper<MessagePort>,
+    /// Active subscriptions keyed by correlation id. Each value is
+    /// an abort flag; setting it to `true` causes the pump task to
+    /// exit on its next iteration.
     pub subscriptions: HashMap<String, Arc<AtomicBool>>,
 }
 
 impl BridgeSession {
+    /// Create a new session wrapping the given port with no active
+    /// subscriptions.
     pub fn new(port: MessagePort) -> Self {
         Self {
             port: SendWrapper::new(port),

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -174,6 +174,26 @@ async fn evaluate_on_branch<'a>(
     Ok(Json(outcome.response))
 }
 
+/// Bridge-callable wrapper around the evaluate pipeline. Runs
+/// the same logic as [`evaluate_on_branch`] but accepts plain
+/// `String` arguments instead of HTTP-level types so the bridge
+/// handler can call it without constructing an axum request.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn evaluate_body(
+    tonk_state: &crate::worker::TonkState,
+    repo: &str,
+    branch: &str,
+    body: String,
+    transact: bool,
+) -> Result<EvaluateResponse, TonkWorkerError> {
+    let tonk_branch = tonk_state.reactor.repository(repo).branch(branch);
+    let query = EvaluateQuery { transact };
+    let bytes = Bytes::from(body.into_bytes());
+    evaluate_on_branch(tonk_state, tonk_branch, bytes, query)
+        .await
+        .map(|Json(r)| r)
+}
+
 /// Project [`Parsed`] onto a successful syntax or a 400 error
 /// carrying the first diagnostic's structure (code + range +
 /// message) so the editor can route it to a positioned

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -183,7 +183,6 @@ pub async fn evaluate_body(
     repo: &str,
     branch: &str,
     body: String,
-    _content_type: &str,
     transact: bool,
 ) -> Result<EvaluateResponse, TonkWorkerError> {
     let tonk_branch = tonk_state.reactor.repository(repo).branch(branch);

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -174,25 +174,6 @@ async fn evaluate_on_branch<'a>(
     Ok(Json(outcome.response))
 }
 
-/// Bridge-callable wrapper around the evaluate pipeline. Runs
-/// the same logic as [`evaluate_on_branch`] but accepts plain
-/// `String` arguments instead of HTTP-level types so the bridge
-/// handler can call it without constructing an axum request.
-pub async fn evaluate_body(
-    tonk_state: &crate::worker::TonkState,
-    repo: &str,
-    branch: &str,
-    body: String,
-    transact: bool,
-) -> Result<EvaluateResponse, TonkWorkerError> {
-    let tonk_branch = tonk_state.reactor.repository(repo).branch(branch);
-    let query = EvaluateQuery { transact };
-    let bytes = Bytes::from(body.into_bytes());
-    evaluate_on_branch(tonk_state, tonk_branch, bytes, query)
-        .await
-        .map(|Json(r)| r)
-}
-
 /// Project [`Parsed`] onto a successful syntax or a 400 error
 /// carrying the first diagnostic's structure (code + range +
 /// message) so the editor can route it to a positioned

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -174,6 +174,26 @@ async fn evaluate_on_branch<'a>(
     Ok(Json(outcome.response))
 }
 
+/// Bridge-callable wrapper around the evaluate pipeline. Runs
+/// the same logic as [`evaluate_on_branch`] but accepts plain
+/// `String` arguments instead of HTTP-level types so the bridge
+/// handler can call it without constructing an axum request.
+pub async fn evaluate_body(
+    tonk_state: &crate::worker::TonkState,
+    repo: &str,
+    branch: &str,
+    body: String,
+    _content_type: &str,
+    transact: bool,
+) -> Result<EvaluateResponse, TonkWorkerError> {
+    let tonk_branch = tonk_state.reactor.repository(repo).branch(branch);
+    let query = EvaluateQuery { transact };
+    let bytes = Bytes::from(body.into_bytes());
+    evaluate_on_branch(tonk_state, tonk_branch, bytes, query)
+        .await
+        .map(|Json(r)| r)
+}
+
 /// Project [`Parsed`] onto a successful syntax or a 400 error
 /// carrying the first diagnostic's structure (code + range +
 /// message) so the editor can route it to a positioned

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -8,8 +8,8 @@
 //! When the browser issues the initial navigation fetch for that
 //! URL the service worker:
 //!
-//! - records `resulting_client_id → {repo, branch}` in the
-//!   [`GuestBindings`] map hanging off `TonkState`, so any
+//! - records `resulting_client_id → {repo, branch, view_entity}` in the
+//!   [`ViewBindings`] map hanging off `TonkState`, so any
 //!   subsequent subresource fetch from the same iframe can be
 //!   identified by client id alone without re-parsing the URL;
 //! - serves the entity's body by selecting the claim
@@ -25,8 +25,6 @@
 //! it was loaded from, so `<script src="/foo.js">` resolves to
 //! `/api/repository/{repo}/branch/{branch}/foo.js`.
 
-use std::{collections::HashMap, sync::Arc};
-
 use ::axum::{
     body::Body,
     extract::{Path, Request, State},
@@ -38,7 +36,6 @@ use dialog_artifacts::{ArtifactSelector, Attribute, Entity, Value};
 use dialog_repository::RepositoryExt as _;
 use futures_util::StreamExt;
 use serde::Deserialize;
-use tokio::sync::RwLock;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
@@ -56,25 +53,24 @@ use crate::TonkWorkerError;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ClientId(pub String);
 
-/// Binding that records which repository and branch an iframe
-/// client is associated with.
-///
-/// Populated on the iframe's initial navigation fetch; looked up
-/// on every subsequent subresource fetch from the same client.
+/// Binding that records which repository, branch, and view entity
+/// an iframe is bound to. Populated on the iframe's initial
+/// navigation fetch; looked up when `on_message` receives a `hello`
+/// from the same client.
 #[derive(Clone, Debug)]
-pub struct GuestBinding {
+pub struct ViewBinding {
     /// The repository name the iframe is scoped to.
     pub repo: String,
     /// The branch name the iframe is scoped to.
     pub branch: String,
+    /// The view entity URI. The bridge enumerates this entity's
+    /// `dialog.view.subscription/*` claims when the iframe connects.
+    pub view_entity: dialog_artifacts::Entity,
 }
 
-/// Shared map of guest `ClientId → GuestBinding`.
-///
-/// Lives on [`TonkState::guests`] behind its own interior
-/// `RwLock`, so guest registration / lookup doesn't serialize
-/// against profile or operator access on the outer state lock.
-pub type GuestBindings = Arc<RwLock<HashMap<ClientId, GuestBinding>>>;
+/// Shared map of `ClientId → ViewBinding`. Lives on
+/// `TonkState::view_bindings` (renamed from `guests`).
+pub type ViewBindings = std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<ClientId, ViewBinding>>>;
 
 /// Path parameters for the bridge route.
 #[derive(Debug, Deserialize)]
@@ -221,23 +217,24 @@ pub async fn guest(
         client_id,
     );
 
-    if let Some(client) = client_id {
-        let guests = state.read().await.guests.clone();
-        guests.write().await.insert(
-            client,
-            GuestBinding {
-                repo: params.repo.clone(),
-                branch: params.branch.clone(),
-            },
-        );
-    }
-
     let attribute: Attribute = attribute_str.parse().map_err(|e| {
         TonkWorkerError::Router(format!("Invalid attribute '{}': {}", attribute_str, e))
     })?;
     let entity: Entity = entity_str
         .parse()
         .map_err(|e| TonkWorkerError::Router(format!("Invalid entity '{}': {}", entity_str, e)))?;
+
+    if let Some(client) = client_id {
+        let bindings = state.read().await.view_bindings.clone();
+        bindings.write().await.insert(
+            client,
+            ViewBinding {
+                repo: params.repo.clone(),
+                branch: params.branch.clone(),
+                view_entity: entity.clone(),
+            },
+        );
+    }
 
     let tonk = state.read().await;
 

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -8,7 +8,7 @@
 //! When the browser issues the initial navigation fetch for that
 //! URL the service worker:
 //!
-//! - records `resulting_client_id → {repo, branch, view_entity}` in the
+//! - records `resulting_client_id → {repo, branch}` in the
 //!   [`ViewBindings`] map hanging off `TonkState`, so any
 //!   subsequent subresource fetch from the same iframe can be
 //!   identified by client id alone without re-parsing the URL;
@@ -53,19 +53,16 @@ use crate::TonkWorkerError;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ClientId(pub String);
 
-/// Binding that records which repository, branch, and view entity
-/// an iframe is bound to. Populated on the iframe's initial
-/// navigation fetch; looked up when `on_message` receives a `hello`
-/// from the same client.
+/// Binding that records which repository and branch an iframe is
+/// bound to. Populated on the iframe's initial navigation fetch;
+/// looked up when `on_message` receives a `hello` from the same
+/// client.
 #[derive(Clone, Debug)]
 pub struct ViewBinding {
     /// The repository name the iframe is scoped to.
     pub repo: String,
     /// The branch name the iframe is scoped to.
     pub branch: String,
-    /// The view entity URI. The bridge enumerates this entity's
-    /// `dialog.view.subscription/*` claims when the iframe connects.
-    pub view_entity: dialog_artifacts::Entity,
 }
 
 /// Shared map of `ClientId → ViewBinding`. Lives on
@@ -244,7 +241,6 @@ pub async fn guest(
             ViewBinding {
                 repo: params.repo.clone(),
                 branch: params.branch.clone(),
-                view_entity: entity.clone(),
             },
         );
     }
@@ -283,12 +279,6 @@ pub async fn guest(
     while let Some(result) = stream.next().await {
         match result {
             Ok(artifact) => {
-                // Agent-authored HTML is treated as a body
-                // fragment: wrap it with the doctype, the
-                // `<tonk-concept>` runtime, and the `<body>`
-                // boundary before serving. The agent never sees
-                // these — it writes the body of a layout and the
-                // host hydrates it.
                 let body = if attribute_str == "text/html"
                     && let Value::String(s) = &artifact.is
                 {

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -161,14 +161,25 @@ fn body_for(value: Value) -> Body {
 /// `<body>` content; we provide the doctype, the script, and the
 /// `<body>` boundary.
 ///
-/// The script imports the standalone `<tonk-concept>` web-target
-/// build from `/tonk-concept.js`. `init()` instantiates the wasm
-/// module and the bin shim's `main` registers the element in the
+/// The bridge module's top-level installs `globalThis.tonk` and
+/// posts the `hello` handshake to the SW — loading it as a plain
+/// `<script type="module" src>` is enough.
+///
+/// `tonk-concept.js` is a wasm-bindgen web-target build: importing
+/// it merely binds the exports, so we use an inline module to
+/// `await init()`. That instantiates the wasm and runs the bin
+/// shim's `#[wasm_bindgen(main)]`, which calls
+/// `tonk_concept::register()` and defines `<tonk-concept>` in the
 /// iframe's own `customElements` registry — the parent shell's
 /// registration doesn't reach across documents. The path is
 /// exempted from the iframe-branch rewrite in the worker's fetch
 /// router so the request reaches the dist-root asset rather than
 /// a guest entity lookup.
+///
+/// Module-script order matters: bridge.js's `<script>` tag comes
+/// first so `globalThis.tonk` is populated before the
+/// `tonk_concept` element's `connected_callback` runs and reaches
+/// for it.
 fn wrap_html_body(body: &str) -> String {
     format!(
         "<!doctype html>\n\
@@ -176,7 +187,10 @@ fn wrap_html_body(body: &str) -> String {
          <head>\n\
          <meta charset=\"utf-8\">\n\
          <script type=\"module\" src=\"/__tonk/bridge.js\"></script>\n\
-         <script type=\"module\" src=\"/tonk-concept.js\"></script>\n\
+         <script type=\"module\">\n\
+         import init from '/tonk-concept.js';\n\
+         await init();\n\
+         </script>\n\
          </head>\n\
          <body>\n\
          {body}\n\
@@ -333,6 +347,29 @@ mod wrapper_tests {
         assert!(
             bridge_idx < concept_idx,
             "bridge module must be loaded before tonk-concept runtime: {wrapped}",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_invokes_tonk_concept_init() {
+        // The trunk-built `tonk-concept.js` (data-type="worker") only
+        // exports `__wbg_init`/`initSync`; nothing in the file
+        // auto-instantiates the wasm module. A bare
+        // `<script type="module" src="/tonk-concept.js">` therefore
+        // binds the exports but never runs `#[wasm_bindgen(main)]`,
+        // so `tonk_concept::register()` never fires and
+        // `<tonk-concept>` is never defined.
+        //
+        // Guard against that regression by asserting the wrapper
+        // imports the default export and awaits it.
+        let wrapped = wrap_html_body("");
+        assert!(
+            wrapped.contains("import init from '/tonk-concept.js'"),
+            "wrapper must import init from /tonk-concept.js: {wrapped}",
+        );
+        assert!(
+            wrapped.contains("await init()"),
+            "wrapper must await init() to instantiate wasm: {wrapped}",
         );
     }
 }

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -70,7 +70,8 @@ pub struct ViewBinding {
 
 /// Shared map of `ClientId → ViewBinding`. Lives on
 /// `TonkState::view_bindings` (renamed from `guests`).
-pub type ViewBindings = std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<ClientId, ViewBinding>>>;
+pub type ViewBindings =
+    std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<ClientId, ViewBinding>>>;
 
 /// Path parameters for the bridge route.
 #[derive(Debug, Deserialize)]
@@ -174,10 +175,8 @@ fn wrap_html_body(body: &str) -> String {
          <html>\n\
          <head>\n\
          <meta charset=\"utf-8\">\n\
-         <script type=\"module\">\n\
-         import init from '/tonk-concept.js';\n\
-         await init();\n\
-         </script>\n\
+         <script type=\"module\" src=\"/__tonk/bridge.js\"></script>\n\
+         <script type=\"module\" src=\"/tonk-concept.js\"></script>\n\
          </head>\n\
          <body>\n\
          {body}\n\
@@ -299,4 +298,41 @@ pub async fn guest(
         "No claim found for entity={} attribute={}",
         entity_str, attribute_str,
     )))
+}
+
+#[cfg(test)]
+mod wrapper_tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_injects_the_bridge_module_in_head() {
+        let body = "<h1>hi</h1>";
+        let wrapped = wrap_html_body(body);
+        assert!(wrapped.contains("<!doctype html>"));
+        assert!(wrapped.contains("<head>"));
+        assert!(
+            wrapped.contains("src=\"/__tonk/bridge.js\""),
+            "bridge module script tag missing: {wrapped}",
+        );
+        assert!(wrapped.contains("<body>"));
+        assert!(wrapped.contains("<h1>hi</h1>"));
+    }
+
+    #[dialog_common::test]
+    fn it_also_loads_tonk_concept_runtime() {
+        let wrapped = wrap_html_body("");
+        // Both the bridge module and the tonk-concept module are
+        // loaded. The bridge MUST come first so `globalThis.tonk` is
+        // populated by the time tonk-concept's init runs.
+        let bridge_idx = wrapped
+            .find("/__tonk/bridge.js")
+            .expect("bridge loader missing");
+        let concept_idx = wrapped
+            .find("/tonk-concept.js")
+            .expect("tonk-concept loader missing");
+        assert!(
+            bridge_idx < concept_idx,
+            "bridge module must be loaded before tonk-concept runtime: {wrapped}",
+        );
+    }
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -8,7 +8,7 @@ use crate::{
     LspHub,
     axum::{RequestConversion, ResponseConversion},
     bootstrap_profile_meta,
-    router::{AppState, ClientId, GuestBindings, api_router_with_state},
+    router::{AppState, ClientId, ViewBindings, api_router_with_state},
 };
 use axum::{
     Router,
@@ -95,8 +95,8 @@ async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
     }
 
     let binding = {
-        let guests = state.read().await.guests.clone();
-        let guard = guests.read().await;
+        let view_bindings = state.read().await.view_bindings.clone();
+        let guard = view_bindings.read().await;
         guard.get(&ClientId(client_id.to_string())).cloned()
     };
 
@@ -257,11 +257,11 @@ pub struct TonkState {
     /// mutate a branch flow through `reactor.repository(r).branch(b)`
     /// so subscription broadcasts happen automatically.
     pub reactor: crate::TonkReactor,
-    /// Guest-iframe bindings keyed by service-worker Client ID.
-    /// Behind its own interior lock so guest registration /
+    /// View-iframe bindings keyed by service-worker Client ID.
+    /// Behind its own interior lock so binding registration /
     /// lookup doesn't contend with profile/operator access on
     /// the outer state lock.
-    pub guests: GuestBindings,
+    pub view_bindings: ViewBindings,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -340,7 +340,7 @@ impl TonkServiceWorker {
             operator,
             profile_name: PROFILE_NAME.to_string(),
             reactor,
-            guests: Default::default(),
+            view_bindings: Default::default(),
         };
         bootstrap_profile_meta(&state, PROFILE_NAME)
             .await

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -573,6 +573,40 @@ impl TonkServiceWorker {
         })
     }
 
+    /// Handles `message` events from view clients. Routes the
+    /// initial `hello` envelope (and future query/subscribe/evaluate
+    /// envelopes) to the bridge module.
+    ///
+    /// Wired into the SW global by the same JS bootstrap that sets
+    /// `self.onfetch`.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    #[wasm_bindgen(js_name = "onmessage")]
+    pub fn on_message(&self, event: web_sys::ExtendableMessageEvent) -> Promise {
+        let state = self.state.clone();
+        let source_client_id = event_source_client_id(&event);
+        let data = event.data();
+        let ports = event.ports();
+
+        future_to_promise(async move {
+            let envelope: serde_json::Value = match serde_wasm_bindgen::from_value(data) {
+                Ok(v) => v,
+                Err(e) => {
+                    log!("on_message: malformed envelope: {e:?}");
+                    return Ok(JsValue::UNDEFINED);
+                }
+            };
+
+            let Some(client_id) = source_client_id else {
+                log!("on_message: envelope has no source client id");
+                return Ok(JsValue::UNDEFINED);
+            };
+
+            crate::router::bridge::handle_message(state, ClientId(client_id), envelope, ports)
+                .await;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
     /// Performs a full sync operation (pull then push) with the upstream remote.
     ///
     /// This method dispatches to the `/api/repository/home/branch/main/sync`
@@ -612,4 +646,18 @@ impl TonkServiceWorker {
             }
         })
     }
+}
+
+/// Extracts the `source.id` string from an `ExtendableMessageEvent`.
+///
+/// The source of a service-worker message event is a `Client`; we
+/// need its id so we can look up (or create) the `BridgeSession` in
+/// the registry. Returns `None` if the source is absent or cannot be
+/// cast to a `Client`.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn event_source_client_id(event: &web_sys::ExtendableMessageEvent) -> Option<String> {
+    use wasm_bindgen::JsCast;
+    let source = event.source()?;
+    let client: web_sys::Client = source.dyn_into().ok()?;
+    Some(client.id())
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -340,7 +340,6 @@ mod route_for_tests {
             router::ViewBinding {
                 repo: repo.to_owned(),
                 branch: branch.to_owned(),
-                view_entity: "concept:test".parse().unwrap(),
             },
         );
         app_state

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -145,7 +145,10 @@ async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
 /// JS shims that the element's glue imports (e.g. for the
 /// `custom-elements` crate).
 fn is_shared_asset(path: &str) -> bool {
-    matches!(path, "/tonk-concept.js" | "/tonk-concept_bg.wasm") || path.starts_with("/snippets/")
+    matches!(
+        path,
+        "/tonk-concept.js" | "/tonk-concept_bg.wasm" | "/__tonk/bridge.js"
+    ) || path.starts_with("/snippets/")
 }
 
 /// Route the request through the axum router, apply response
@@ -374,6 +377,16 @@ mod route_for_tests {
         assert!(
             matches!(r, Route::Handle { rewritten_path: Some(_) }),
             "view client static subresource should be rewritten, got {r:?}",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_through_bridge_js_for_view_clients() {
+        let state = state_with_view_client("c1", "r", "main").await;
+        let r = route_for("/__tonk/bridge.js", "c1", &state).await;
+        assert!(
+            matches!(r, Route::Passthrough),
+            "bridge module must bypass the rewrite, got {r:?}",
         );
     }
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -333,8 +333,7 @@ mod route_for_tests {
 
     async fn state_with_view_client(client: &str, repo: &str, branch: &str) -> AppState {
         let state = router::tests::test_state().await;
-        let app_state: AppState =
-            std::sync::Arc::new(tokio::sync::RwLock::new(state));
+        let app_state: AppState = std::sync::Arc::new(tokio::sync::RwLock::new(state));
         let bindings = app_state.read().await.view_bindings.clone();
         bindings.write().await.insert(
             ClientId(client.to_owned()),
@@ -360,8 +359,7 @@ mod route_for_tests {
     #[dialog_common::test]
     async fn it_lets_non_view_clients_through_to_api() {
         let state = router::tests::test_state().await;
-        let app_state: AppState =
-            std::sync::Arc::new(tokio::sync::RwLock::new(state));
+        let app_state: AppState = std::sync::Arc::new(tokio::sync::RwLock::new(state));
         let r = route_for(
             "/api/repository/r/branch/main/query",
             "no-such-client",
@@ -369,7 +367,12 @@ mod route_for_tests {
         )
         .await;
         assert!(
-            matches!(r, Route::Handle { rewritten_path: None }),
+            matches!(
+                r,
+                Route::Handle {
+                    rewritten_path: None
+                }
+            ),
             "non-view client should pass through to axum, got {r:?}",
         );
     }
@@ -379,7 +382,12 @@ mod route_for_tests {
         let state = state_with_view_client("c1", "r", "main").await;
         let r = route_for("/foo.js", "c1", &state).await;
         assert!(
-            matches!(r, Route::Handle { rewritten_path: Some(_) }),
+            matches!(
+                r,
+                Route::Handle {
+                    rewritten_path: Some(_)
+                }
+            ),
             "view client static subresource should be rewritten, got {r:?}",
         );
     }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -563,6 +563,11 @@ impl TonkServiceWorker {
                 effective_client_id,
             );
 
+            // Opportunistic cleanup of stale bridge sessions and view
+            // bindings. Cheap enough to run on every fetch.
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            crate::router::bridge::sweep_stale_clients(&state).await;
+
             match route_for(&path, &effective_client_id, &state).await {
                 Route::Handle { rewritten_path } => {
                     handle_via_router(router, request, effective_client_id, rewritten_path).await

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -57,6 +57,7 @@ fn event_resulting_client_id(event: &FetchEvent) -> String {
 
 /// Outcome of the routing decision made in
 /// [`TonkServiceWorker::on_fetch`].
+#[derive(Clone, Debug)]
 enum Route {
     /// Dispatch through the axum router. `rewritten_path` is
     /// `Some` only when the request originated from a registered
@@ -65,11 +66,20 @@ enum Route {
     Handle { rewritten_path: Option<String> },
     /// Pass the request through to the network.
     Passthrough,
+    /// Returned for view clients trying to reach the data plane
+    /// directly. The SW synthesises a 404 response without
+    /// invoking axum.
+    Reject,
 }
 
 /// Decides how the Rust side should route this request.
 ///
-/// - Paths under `/api/` are handled by the axum router as-is.
+/// - View clients (registered via `view_bindings`) hitting `/api/`
+///   paths receive [`Route::Reject`] — the SW returns a synthetic
+///   404 without invoking axum. The data plane is not reachable
+///   directly from an iframe; only the bridge is.
+/// - Paths under `/api/` from non-view clients are handled by the
+///   axum router as-is.
 /// - A small allow-list of shared dist-root assets (the
 ///   `<tonk-concept>` web-target build and the wasm-bindgen
 ///   `/snippets/*` shims it pulls in) is passed straight through,
@@ -82,6 +92,24 @@ enum Route {
 ///   `/foo.js` lands at `/api/repository/{repo}/branch/{branch}/foo.js`.
 /// - Everything else falls through to the network.
 async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
+    // Look up the view binding early; we need it both for the
+    // reject check and for the later path-rewrite.
+    let view_binding = if client_id.is_empty() {
+        None
+    } else {
+        let bindings = state.read().await.view_bindings.clone();
+        let guard = bindings.read().await;
+        guard.get(&ClientId(client_id.to_string())).cloned()
+    };
+
+    // View clients are walled off from the data plane. Any
+    // `/api/...` from a registered view client is a code path
+    // we deliberately removed; surface it as a 404 so the
+    // iframe-side bug is visible.
+    if view_binding.is_some() && path.starts_with("/api/") {
+        return Route::Reject;
+    }
+
     if path.starts_with("/api/") {
         return Route::Handle {
             rewritten_path: None,
@@ -90,17 +118,7 @@ async fn route_for(path: &str, client_id: &str, state: &AppState) -> Route {
     if is_shared_asset(path) {
         return Route::Passthrough;
     }
-    if client_id.is_empty() {
-        return Route::Passthrough;
-    }
-
-    let binding = {
-        let view_bindings = state.read().await.view_bindings.clone();
-        let guard = view_bindings.read().await;
-        guard.get(&ClientId(client_id.to_string())).cloned()
-    };
-
-    let Some(binding) = binding else {
+    let Some(binding) = view_binding else {
         return Route::Passthrough;
     };
 
@@ -206,6 +224,31 @@ async fn handle_via_router(
         .map_err(JsValue::from)
 }
 
+/// Synthesise a 404 response for view clients hitting `/api/...`.
+///
+/// The bridge is the only data plane an iframe gets; everything
+/// else is closed off so the iframe-side bug — "tried to fetch
+/// the API directly" — surfaces immediately.
+///
+/// Only reachable at runtime from `on_fetch`, which is invoked
+/// exclusively in a WASM service-worker context.
+fn reject_404() -> Result<JsValue, JsValue> {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let init = web_sys::ResponseInit::new();
+        init.set_status(404);
+        let response = web_sys::Response::new_with_opt_str_and_init(
+            Some("view clients cannot reach /api/; use the bridge"),
+            &init,
+        )?;
+        return Ok(JsValue::from(response));
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        unreachable!("reject_404 is only callable in a WASM service-worker context")
+    }
+}
+
 /// Pass the request through to the network by calling
 /// `self.fetch(request)` from inside the service worker. Such
 /// fetches bypass the SW's own `onfetch` handler (per spec), so
@@ -272,6 +315,68 @@ pub struct TonkState {
 unsafe impl Send for TonkState {}
 #[cfg(target_arch = "wasm32")]
 unsafe impl Sync for TonkState {}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod route_for_tests {
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use super::*;
+    use crate::router;
+
+    async fn state_with_view_client(client: &str, repo: &str, branch: &str) -> AppState {
+        let state = router::tests::test_state().await;
+        let app_state: AppState =
+            std::sync::Arc::new(tokio::sync::RwLock::new(state));
+        let bindings = app_state.read().await.view_bindings.clone();
+        bindings.write().await.insert(
+            ClientId(client.to_owned()),
+            router::ViewBinding {
+                repo: repo.to_owned(),
+                branch: branch.to_owned(),
+                view_entity: "concept:test".parse().unwrap(),
+            },
+        );
+        app_state
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_api_paths_from_view_clients() {
+        let state = state_with_view_client("c1", "r", "main").await;
+        let r = route_for("/api/repository/r/branch/main/query", "c1", &state).await;
+        assert!(
+            matches!(r, Route::Reject),
+            "view client should be rejected, got {r:?}",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_lets_non_view_clients_through_to_api() {
+        let state = router::tests::test_state().await;
+        let app_state: AppState =
+            std::sync::Arc::new(tokio::sync::RwLock::new(state));
+        let r = route_for(
+            "/api/repository/r/branch/main/query",
+            "no-such-client",
+            &app_state,
+        )
+        .await;
+        assert!(
+            matches!(r, Route::Handle { rewritten_path: None }),
+            "non-view client should pass through to axum, got {r:?}",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_still_rewrites_static_subresources_for_view_clients() {
+        let state = state_with_view_client("c1", "r", "main").await;
+        let r = route_for("/foo.js", "c1", &state).await;
+        assert!(
+            matches!(r, Route::Handle { rewritten_path: Some(_) }),
+            "view client static subresource should be rewritten, got {r:?}",
+        );
+    }
+}
 
 /// The main Tonk service worker that handles browser fetch events.
 ///
@@ -445,6 +550,7 @@ impl TonkServiceWorker {
                     handle_via_router(router, request, effective_client_id, rewritten_path).await
                 }
                 Route::Passthrough => passthrough(request, is_navigation).await,
+                Route::Reject => reject_404(),
             }
         })
     }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -8,7 +8,7 @@ use crate::{
     LspHub,
     axum::{RequestConversion, ResponseConversion},
     bootstrap_profile_meta,
-    router::{AppState, ClientId, ViewBindings, api_router_with_state},
+    router::{AppState, BridgeRegistry, ClientId, ViewBindings, api_router_with_state},
 };
 use axum::{
     Router,
@@ -308,6 +308,10 @@ pub struct TonkState {
     /// lookup doesn't contend with profile/operator access on
     /// the outer state lock.
     pub view_bindings: ViewBindings,
+    /// Per-client bridge sessions keyed by service-worker Client
+    /// ID. Each session owns the transferred `MessagePort` and the
+    /// abort handles for any open subscriptions on that client.
+    pub bridges: BridgeRegistry,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -459,6 +463,7 @@ impl TonkServiceWorker {
             profile_name: PROFILE_NAME.to_string(),
             reactor,
             view_bindings: Default::default(),
+            bridges: Default::default(),
         };
         bootstrap_profile_meta(&state, PROFILE_NAME)
             .await


### PR DESCRIPTION
Each iframe gets a `MessageChannel`. The iframe sends a "hello" to SW on load, SW responds "ready," then they multiplex requests over the port using a unique ID per iframe.

If an iframe wants to query for all people named "Alice," it looks like this:

```ts
const rows = await globalThis.tonk.query({
  terms: { this: "?p" },
  predicate: { with: { name: "Alice" } },
});
```

The above returns an envelope containing a structured JS object like `[{this: "concept:abc...", fields: {name: "Alice"}}, ...]`.

Iframes are biased toward dynamic API use while components like `<tonk-display>` are more declarative. [[Slide]] is updated to reflect that, with a simple `tonk` API injected that exposes methods for `query`, `evaluate`, `subscribe` and `unsubscribe`.

Each method call internally awaits `tonk.ready` so agents won't get caught by boilerplate and can skip to directly querying.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk` framework by introducing a new bridge for communication between the iframe and the service worker, adding new functionalities, and refining existing code for better maintainability.

### Detailed summary
- Added `bridge` module for iframe-side communication.
- Introduced `ReadableStreamDefaultReader` and related features.
- Updated `Cargo.toml` and `Cargo.lock` with new dependencies.
- Renamed `GuestBinding` to `ViewBinding` and updated related structures.
- Changed subscription handling to use `SubscriptionAbort`.
- Improved error handling and logging in various modules.
- Enhanced documentation and comments for clarity.

> The following files were skipped due to too many changes: `rust/tonk-display/src/element.rs`, `rust/tonk-worker/src/worker.rs`, `rust/tonk-worker/src/router/bridge.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->