### PR TITLE
feat(tonk-concept): dispatch interpolated attributes as properties wh…

### DIFF
--- a/rust/tonk-concept/Cargo.toml
+++ b/rust/tonk-concept/Cargo.toml
@@ -30,6 +30,7 @@ web-sys = { workspace = true, features = [
     "DocumentFragment",
     "Element",
     "HtmlElement",
+    "HtmlInputElement",
     "HtmlScriptElement",
     "HtmlTemplateElement",
     "NamedNodeMap",

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -18,7 +18,8 @@ use wasm_bindgen::JsCast;
 use web_sys::{Document, DocumentFragment, Element, Node, window};
 
 use crate::template::{
-    Binding, BindingKind, BindingPlan, PlanNode, navigate, render_segments_with_shadow,
+    Binding, BindingKind, BindingPlan, PlanNode, apply_attribute_binding, navigate,
+    render_segments_with_shadow, single_field_value,
 };
 
 /// One rendered row keyed by its `this` URI. Owns the live
@@ -241,7 +242,7 @@ fn build_mounted_node(
     match plan {
         PlanNode::Binding(b) => {
             let rendered = render_binding(b, conclusion, shadow);
-            write_binding(scope_root, b, &rendered);
+            write_binding(scope_root, b, &rendered, conclusion, shadow);
             MountedNode::Binding {
                 last_value: rendered,
             }
@@ -326,7 +327,7 @@ fn update_node(
         (PlanNode::Binding(b), MountedNode::Binding { last_value }) => {
             let rendered = render_binding(b, conclusion, shadow);
             if *last_value != rendered {
-                write_binding(scope_root, b, &rendered);
+                write_binding(scope_root, b, &rendered, conclusion, shadow);
                 *last_value = rendered;
             }
         }
@@ -500,16 +501,22 @@ fn render_binding(
     render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow)
 }
 
-fn write_binding(scope_root: &Node, binding: &Binding, rendered: &str) {
-    let Some(target) = navigate(scope_root, &binding.path) else {
-        return;
-    };
+fn write_binding(
+    scope_root: &Node,
+    binding: &Binding,
+    rendered: &str,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
     match &binding.kind {
-        BindingKind::Text { .. } => target.set_text_content(Some(rendered)),
-        BindingKind::Attribute { attr_name, .. } => {
-            if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, rendered);
+        BindingKind::Text { .. } => {
+            if let Some(target) = navigate(scope_root, &binding.path) {
+                target.set_text_content(Some(rendered));
             }
+        }
+        BindingKind::Attribute { .. } => {
+            let value = single_field_value(binding, &conclusion.this, &conclusion.fields, shadow);
+            apply_attribute_binding(scope_root, binding, rendered, value.as_ref());
         }
     }
 }
@@ -729,6 +736,142 @@ mod tests {
         assert!(
             text_before.is_same_node(Some(text_after.unchecked_ref())),
             "unchanged binding should not rewrite the text node",
+        );
+    }
+
+    /// Like [`conclusion`] but accepts arbitrary JSON values so
+    /// tests can drive boolean / numeric properties.
+    fn conclusion_json(this: &str, fields: &[(&str, serde_json::Value)]) -> Conclusion {
+        let mut map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        for (k, v) in fields {
+            map.insert((*k).to_owned(), v.clone());
+        }
+        Conclusion {
+            this: this.to_owned(),
+            fields: map,
+        }
+    }
+
+    /// Look up the live `<input type=checkbox>` under `host` and
+    /// return its `.checked` property. Re-queries each call because
+    /// the iteration renderer may swap the input node on each apply.
+    fn checkbox_checked(host: &Element) -> bool {
+        let input: web_sys::HtmlInputElement = host
+            .query_selector(r#"input[type="checkbox"]"#)
+            .unwrap()
+            .expect("checkbox")
+            .dyn_into()
+            .expect("HtmlInputElement");
+        input.checked()
+    }
+
+    #[dialog_common::test]
+    fn it_sets_a_boolean_field_as_property_on_a_checkbox() {
+        // `checked` on <input> is a property name — bool value must
+        // flow to el.checked, not to a "true"/"false" attribute the
+        // browser would treat as always-checked.
+        let (host, mut renderer) =
+            mount(r#"<label><input type="checkbox" checked={done} /><span>{label}</span></label>"#);
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[
+                ("done", serde_json::Value::Bool(true)),
+                ("label", serde_json::Value::String("ship it".to_owned())),
+            ],
+        )]);
+        assert!(
+            checkbox_checked(&host),
+            "el.checked should be true for done=true",
+        );
+
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[
+                ("done", serde_json::Value::Bool(false)),
+                ("label", serde_json::Value::String("ship it".to_owned())),
+            ],
+        )]);
+        assert!(
+            !checkbox_checked(&host),
+            "el.checked should flip to false for done=false",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_sets_a_string_field_as_attribute_when_name_not_on_element() {
+        // aria-hidden is not a property name on a span (camelCase
+        // `ariaHidden` is, but the in-element check uses the literal
+        // attribute name). Should round-trip as an attribute.
+        let (host, mut renderer) = mount(r#"<span aria-hidden="{hidden}">x</span>"#);
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[("hidden", serde_json::Value::String("true".to_owned()))],
+        )]);
+        let span = host.query_selector("span").unwrap().expect("span");
+        assert_eq!(
+            span.get_attribute("aria-hidden").as_deref(),
+            Some("true"),
+            "aria-hidden should be set as an attribute",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_honours_html_prefix_as_force_attribute() {
+        // `html:class={cls}` is the escape hatch: even though
+        // `class` is a property name on every element, the prefix
+        // pins the write to setAttribute. Use a string value so the
+        // type-dispatch path doesn't already pick "attribute"; this
+        // exercises the prefix.
+        let (host, mut renderer) = mount(r#"<div html:id="{id}">x</div>"#);
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[("id", serde_json::Value::String("forced".to_owned()))],
+        )]);
+        let div = host.query_selector("div").unwrap().expect("div");
+        assert_eq!(
+            div.get_attribute("id").as_deref(),
+            Some("forced"),
+            "html: prefix should write a real attribute named `id`",
+        );
+        assert!(
+            div.get_attribute("html:id").is_none(),
+            "the html: prefix itself must not leak into the live attribute name",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_uses_html_prefix_with_boolean_for_presence_absence() {
+        // Force-attribute path with a bool value: presence/absence
+        // per HTML's bool-attribute convention. Wrap the div in a
+        // host element that survives iteration node swaps so we can
+        // re-query the (potentially fresh) inner div each apply.
+        let (host, mut renderer) = mount(r#"<section><div html:hidden="{flag}">x</div></section>"#);
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[("flag", serde_json::Value::Bool(true))],
+        )]);
+        assert_eq!(
+            host.query_selector("div")
+                .unwrap()
+                .expect("div")
+                .get_attribute("hidden")
+                .as_deref(),
+            Some(""),
+            "true should set an empty `hidden` attribute",
+        );
+
+        renderer.apply(&[conclusion_json(
+            "did:key:zAlice",
+            &[("flag", serde_json::Value::Bool(false))],
+        )]);
+        let div = host.query_selector("div").unwrap().expect("div");
+        assert!(
+            div.get_attribute("hidden").is_none(),
+            "false should remove the `hidden` attribute",
+        );
+        assert!(
+            div.get_attribute("html:hidden").is_none(),
+            "the html: prefix attribute must not survive on the cloned element",
         );
     }
 }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -89,13 +89,35 @@ pub enum BindingKind {
         /// originally just `{name}`.
         segments: Vec<Segment>,
     },
-    /// Sets `attr_name` on the target element to the rendered
-    /// segment list.
+    /// Binds a value to the target element. The renderer dispatches
+    /// per value at apply time:
+    ///
+    /// * `force_attribute = true` (template author wrote
+    ///   `html:foo={x}`): always `setAttribute(name, rendered)`;
+    ///   booleans map to presence/absence.
+    /// * Single-field segment with a non-string JSON value
+    ///   (bool/number/array/object): set as a JS property via
+    ///   `Reflect.set` with a typed `JsValue`.
+    /// * Single-field segment with a string value, or multi-segment
+    ///   (literal text mixed with fields): check whether `name`
+    ///   exists on the element. If yes, assign as a property; if no,
+    ///   `setAttribute`.
+    ///
+    /// The variant is named `Attribute` for historical reasons; the
+    /// runtime semantics are property-or-attribute per the rules
+    /// above.
     Attribute {
-        /// Attribute name (e.g. `href`).
+        /// Binding name. With `force_attribute = false` this may be
+        /// applied as either an attribute or a property at render
+        /// time. With `force_attribute = true` the source `html:`
+        /// prefix has already been stripped.
         attr_name: String,
         /// Segment list to render per row.
         segments: Vec<Segment>,
+        /// `true` when the template author wrote `html:foo={x}` —
+        /// the renderer must use `setAttribute` regardless of value
+        /// type.
+        force_attribute: bool,
     },
 }
 
@@ -580,11 +602,30 @@ mod dom {
                 if !has_field(&segments) {
                     continue;
                 }
+                // `html:foo={x}` is the explicit "force attribute"
+                // escape hatch — reads as the HTML-attribute
+                // namespace. Strip the prefix so the renderer writes
+                // the real name; remember the intent. The prefixed
+                // attribute (left over from the parsed template) is
+                // removed from the fragment so cloned rows don't
+                // carry the literal `html:foo="{x}"` placeholder.
+                let (attr_name, force_attribute) = match name.strip_prefix("html:") {
+                    Some(stripped) => {
+                        if let Some(node) = navigate(fragment.unchecked_ref::<Node>(), &path)
+                            && let Some(el) = node.dyn_ref::<Element>()
+                        {
+                            let _ = el.remove_attribute(&name);
+                        }
+                        (stripped.to_string(), true)
+                    }
+                    None => (name, false),
+                };
                 bindings.push(Binding {
                     path: path.clone(),
                     kind: BindingKind::Attribute {
-                        attr_name: name,
+                        attr_name,
                         segments,
+                        force_attribute,
                     },
                 });
             }
@@ -679,12 +720,142 @@ mod dom {
             other => out.push_str(&other.to_string()),
         }
     }
+
+    /// Apply an attribute-form binding to the element identified by
+    /// `binding.path` under `scope_root`, dispatching between
+    /// property and attribute per the rules documented on
+    /// [`BindingKind::Attribute`].
+    ///
+    /// `rendered` is the already-stringified value (computed for
+    /// cache-equality checks by the caller); single-field bindings
+    /// also receive the underlying [`serde_json::Value`] so the
+    /// dispatcher can choose typed property assignment for
+    /// non-strings without re-parsing.
+    pub fn apply_attribute_binding(
+        scope_root: &Node,
+        binding: &Binding,
+        rendered: &str,
+        single_field_value: Option<&serde_json::Value>,
+    ) {
+        let BindingKind::Attribute {
+            attr_name,
+            force_attribute,
+            ..
+        } = &binding.kind
+        else {
+            return;
+        };
+        let Some(target) = navigate(scope_root, &binding.path) else {
+            return;
+        };
+        let Some(el) = target.dyn_ref::<Element>() else {
+            return;
+        };
+
+        if *force_attribute {
+            write_forced_attribute(el, attr_name, rendered, single_field_value);
+            return;
+        }
+
+        // Typed property path: a single `{field}` binding whose
+        // value is anything other than a JSON string assigns the
+        // typed value as a property via Reflect.set. Strings (and
+        // multi-segment bindings, which always stringify) fall
+        // through to the name-in-element dispatch below.
+        if let Some(value) = single_field_value
+            && !matches!(value, serde_json::Value::String(_))
+        {
+            let js_value = json_to_js_value(value);
+            let key = js_sys::JsString::from(attr_name.as_str()).into();
+            let _ = js_sys::Reflect::set(el.as_ref(), &key, &js_value);
+            return;
+        }
+
+        // String value (single-field) or multi-segment binding —
+        // the result is the rendered string. Use a property when
+        // the name exists on the element, otherwise setAttribute.
+        let key = js_sys::JsString::from(attr_name.as_str()).into();
+        let is_property = js_sys::Reflect::has(el.as_ref(), &key).unwrap_or(false);
+        if is_property {
+            let value: wasm_bindgen::JsValue = js_sys::JsString::from(rendered).into();
+            let _ = js_sys::Reflect::set(el.as_ref(), &key, &value);
+        } else {
+            let _ = el.set_attribute(attr_name, rendered);
+        }
+    }
+
+    /// Force-attribute path: `setAttribute` semantics, but with
+    /// HTML's bool-attribute convention when the underlying value
+    /// is a JSON bool — `true` adds the empty attribute, `false`
+    /// removes it.
+    fn write_forced_attribute(
+        el: &Element,
+        attr_name: &str,
+        rendered: &str,
+        single_field_value: Option<&serde_json::Value>,
+    ) {
+        if let Some(serde_json::Value::Bool(b)) = single_field_value {
+            if *b {
+                let _ = el.set_attribute(attr_name, "");
+            } else {
+                let _ = el.remove_attribute(attr_name);
+            }
+            return;
+        }
+        let _ = el.set_attribute(attr_name, rendered);
+    }
+
+    /// Convert a JSON value to a typed `JsValue` for property
+    /// assignment. Strings are handled by the caller (the property
+    /// path is only used for non-strings); arrays/objects pass
+    /// through serde-wasm-bindgen so they reach the DOM as real JS
+    /// arrays/objects rather than JSON-stringified blobs.
+    fn json_to_js_value(value: &serde_json::Value) -> wasm_bindgen::JsValue {
+        use wasm_bindgen::JsValue;
+        match value {
+            serde_json::Value::Bool(b) => JsValue::from_bool(*b),
+            serde_json::Value::Number(n) => {
+                if let Some(f) = n.as_f64() {
+                    JsValue::from_f64(f)
+                } else {
+                    JsValue::from_str(&n.to_string())
+                }
+            }
+            serde_json::Value::String(s) => JsValue::from_str(s),
+            serde_json::Value::Null => JsValue::NULL,
+            other => serde_wasm_bindgen::to_value(other).unwrap_or(JsValue::NULL),
+        }
+    }
+
+    /// Resolve a binding's single `{field}` reference to its
+    /// underlying JSON value. Returns `None` when the binding has
+    /// multiple segments or any literal text — in that case the
+    /// rendered string is the only well-defined value, and typed
+    /// dispatch isn't possible.
+    pub fn single_field_value<'a>(
+        binding: &Binding,
+        row_this: &'a str,
+        row_fields: &'a BTreeMap<String, serde_json::Value>,
+        shadow: &'a BTreeMap<String, serde_json::Value>,
+    ) -> Option<serde_json::Value> {
+        let segments = match &binding.kind {
+            BindingKind::Text { segments } => segments,
+            BindingKind::Attribute { segments, .. } => segments,
+        };
+        let [Segment::Field(name)] = segments.as_slice() else {
+            return None;
+        };
+        if name == "this" {
+            return Some(serde_json::Value::String(row_this.to_string()));
+        }
+        shadow.get(name).or_else(|| row_fields.get(name)).cloned()
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 pub use dom::{
-    Snapshot, extract_plan, navigate, render_segments, render_segments_with_shadow,
-    snapshot_template,
+    Snapshot, apply_attribute_binding, extract_plan, navigate, render_segments,
+    render_segments_with_shadow, single_field_value, snapshot_template,
 };
 
 #[cfg(test)]
@@ -781,6 +952,7 @@ mod tests {
             kind: BindingKind::Attribute {
                 attr_name: attr.into(),
                 segments: vec![Segment::Field(field.into())],
+                force_attribute: false,
             },
         }
     }

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -28,8 +28,8 @@
 use std::collections::BTreeMap;
 
 use tonk_concept::template::{
-    Binding, BindingKind, BindingPlan, PlanNode, Snapshot, extract_plan, navigate,
-    render_segments_with_shadow,
+    Binding, BindingKind, BindingPlan, PlanNode, Snapshot, apply_attribute_binding, extract_plan,
+    navigate, render_segments_with_shadow, single_field_value,
 };
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
@@ -295,7 +295,7 @@ fn build_mounted_node(
     match plan {
         PlanNode::Binding(b) => {
             let rendered = render_binding(b, conclusion, shadow);
-            write_binding(scope_root, b, &rendered);
+            write_binding(scope_root, b, &rendered, conclusion, shadow);
             MountedNode::Binding {
                 last_value: rendered,
             }
@@ -389,7 +389,7 @@ fn update_node(
         (PlanNode::Binding(b), MountedNode::Binding { last_value }) => {
             let rendered = render_binding(b, conclusion, shadow);
             if *last_value != rendered {
-                write_binding(scope_root, b, &rendered);
+                write_binding(scope_root, b, &rendered, conclusion, shadow);
                 *last_value = rendered;
             }
         }
@@ -596,17 +596,25 @@ fn render_binding(
 }
 
 /// Write a binding's rendered value to the target DOM node
-/// identified by its path within `scope_root`.
-fn write_binding(scope_root: &Node, binding: &Binding, rendered: &str) {
-    let Some(target) = navigate(scope_root, &binding.path) else {
-        return;
-    };
+/// identified by its path within `scope_root`. Attribute-form
+/// bindings flow through [`apply_attribute_binding`] which decides
+/// between property and attribute assignment per value type.
+fn write_binding(
+    scope_root: &Node,
+    binding: &Binding,
+    rendered: &str,
+    conclusion: &Conclusion,
+    shadow: &BTreeMap<String, serde_json::Value>,
+) {
     match &binding.kind {
-        BindingKind::Text { .. } => target.set_text_content(Some(rendered)),
-        BindingKind::Attribute { attr_name, .. } => {
-            if let Some(el) = target.dyn_ref::<Element>() {
-                let _ = el.set_attribute(attr_name, rendered);
+        BindingKind::Text { .. } => {
+            if let Some(target) = navigate(scope_root, &binding.path) {
+                target.set_text_content(Some(rendered));
             }
+        }
+        BindingKind::Attribute { .. } => {
+            let value = single_field_value(binding, &conclusion.this, &conclusion.fields, shadow);
+            apply_attribute_binding(scope_root, binding, rendered, value.as_ref());
         }
     }
 }


### PR DESCRIPTION
HTML attributes and DOM properties aren't the same thing, and the template engine was conflating them: `<input checked={done} />` set the attribute to the literal string `"true"` / `"false"`, but the browser only looks at the *presence* of `checked` and ignores its value, so `done=false` left the box checked. The same wrongness existed for `value`, `disabled`, `selected`, and every other attribute that's actually a property on its element. Author intent was always "set the property" — the renderer just had no way to express that.

Approach: decide at apply time based on what the value actually is.

- **Non-string JSON value** (bool / number / array / object) → assign as a JS property via `Reflect.set` with a typed `JsValue`. The common form `checked={done}` flows through here and just works.
- **String value, single `{field}` binding** → check `Reflect.has(el, name)`. If the name is a property on the target, assign as property; otherwise `setAttribute`. This handles `value={text}` on inputs (property) and `aria-hidden={x}` / `data-id={x}` (attribute) without per-name special-casing.
- **Multi-segment binding** (`href="/x/{id}"`) → always stringified, falls through the same name-in-element check.

`html:foo={x}` is the explicit escape hatch when an author needs the attribute path on a name that happens to be a property (`html:class={cls}` to set the literal attribute, e.g. for CSS-side selectors that care). Booleans on that path follow HTML's presence/absence convention. The `html:` prefix attribute is stripped from the template fragment at parse time so cloned rows don't carry the literal `html:foo="{x}"` placeholder.

The dispatch helper lives in `tonk-concept::template` and both renderers (`<tonk-display>` single-row, `<tonk-concept>` list) delegate to it — same algorithm in both.

Browser tests cover boolean → property on checkbox, string → attribute on `aria-hidden`, `html:` forced attribute, and `html:` + bool presence/absence.
