### PR TITLE
fix(tonk-concept,tonk-display): emit CustomEvent detail as plain objects

### DIFF
--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -337,13 +337,23 @@ fn on_reset(host: &Element, state: &Rc<RefCell<Inner>>, payload: JsValue) {
     dispatch_event(
         host,
         "tonk-concept:result",
-        Some(serde_wasm_bindgen::to_value(&conclusions).unwrap_or(JsValue::NULL)),
+        Some(event_detail(&conclusions)),
     );
 }
 
 fn dispatch_error(host: &Element, err: ErrorDetail) {
-    let detail = serde_wasm_bindgen::to_value(&err).unwrap_or(JsValue::NULL);
-    dispatch_event(host, "tonk-concept:error", Some(detail));
+    dispatch_event(host, "tonk-concept:error", Some(event_detail(&err)));
+}
+
+/// Serialize an event detail as a plain JS object (not a `Map`) so
+/// consumers can read fields via dot access (`event.detail.<field>`).
+/// `serde_wasm_bindgen::to_value` renders structs/maps as a JS `Map`,
+/// which makes `detail.<field>` come out `undefined`; the
+/// json-compatible serializer emits a plain object instead.
+fn event_detail<T: serde::Serialize>(value: &T) -> JsValue {
+    value
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .unwrap_or(JsValue::NULL)
 }
 
 fn dispatch_event(host: &Element, name: &str, detail: Option<JsValue>) {
@@ -357,4 +367,30 @@ fn dispatch_event(host: &Element, name: &str, detail: Option<JsValue>) {
         return;
     };
     let _ = host.dispatch_event(&event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Outbound `tonk-concept:result` / `:error` details must be plain
+    /// JS objects so consumers can read `event.detail.<field>`.
+    /// `serde_wasm_bindgen::to_value` renders them as a `Map`, where
+    /// `Reflect`/dot access reads `undefined`.
+    #[dialog_common::test]
+    fn it_serializes_event_detail_as_a_dot_accessible_object() {
+        #[derive(serde::Serialize)]
+        struct Probe {
+            label: String,
+        }
+        let detail = event_detail(&Probe {
+            label: "hi".to_owned(),
+        });
+        let field = Reflect::get(&detail, &JsValue::from_str("label")).expect("reflect get");
+        assert_eq!(field.as_string().as_deref(), Some("hi"));
+    }
 }

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -800,8 +800,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
     if !s.slides.is_empty() || s.notation_source.is_some() {
         state::set(host, State::Ready);
     }
-    let event_detail = serde_wasm_bindgen::to_value(&conclusion).unwrap_or(JsValue::NULL);
-    dispatch_event(host, "tonk-display:result", Some(event_detail));
+    dispatch_event(host, "tonk-display:result", Some(event_detail(&conclusion)));
 }
 
 /// Refresh the trailing notation slide's source `<script>` with
@@ -931,8 +930,18 @@ fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
 }
 
 fn dispatch_error(host: &Element, err: ErrorDetail) {
-    let detail = serde_wasm_bindgen::to_value(&err).unwrap_or(JsValue::NULL);
-    dispatch_event(host, "tonk-display:error", Some(detail));
+    dispatch_event(host, "tonk-display:error", Some(event_detail(&err)));
+}
+
+/// Serialize an event detail as a plain JS object (not a `Map`) so
+/// consumers can read fields via dot access (`event.detail.<field>`).
+/// `serde_wasm_bindgen::to_value` renders structs/maps as a JS `Map`,
+/// which makes `detail.<field>` come out `undefined`; the
+/// json-compatible serializer emits a plain object instead.
+fn event_detail<T: serde::Serialize>(value: &T) -> JsValue {
+    value
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .unwrap_or(JsValue::NULL)
 }
 
 fn dispatch_event(host: &Element, name: &str, detail: Option<JsValue>) {
@@ -946,4 +955,30 @@ fn dispatch_event(host: &Element, name: &str, detail: Option<JsValue>) {
         return;
     };
     let _ = host.dispatch_event(&event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Outbound `tonk-display:result` / `:error` details must be plain
+    /// JS objects so consumers can read `event.detail.<field>`.
+    /// `serde_wasm_bindgen::to_value` renders them as a `Map`, where
+    /// `Reflect`/dot access reads `undefined`.
+    #[dialog_common::test]
+    fn it_serializes_event_detail_as_a_dot_accessible_object() {
+        #[derive(serde::Serialize)]
+        struct Probe {
+            label: String,
+        }
+        let detail = event_detail(&Probe {
+            label: "hi".to_owned(),
+        });
+        let field = Reflect::get(&detail, &JsValue::from_str("label")).expect("reflect get");
+        assert_eq!(field.as_string().as_deref(), Some("hi"));
+    }
 }


### PR DESCRIPTION
serde_wasm_bindgen::to_value renders structs/maps as a JS Map, so view JS reading event.detail.<field> on the outbound :result / :error events got undefined. Route both crates outbound dispatch through a json_compatible event_detail helper (the same fix tonk-worker's bridge applies). The internal serialize_conclusion render feed is unchanged.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the serialization of event details in the `tonk-concept` and `tonk-display` modules, ensuring they can be accessed as plain JS objects rather than `Map` types.

### Detailed summary
- Introduced `event_detail` function to serialize values as plain JS objects.
- Updated `dispatch_event` calls in both `rust/tonk-concept/src/element.rs` and `rust/tonk-display/src/element.rs` to use `event_detail`.
- Added tests to verify that serialized event details are accessible via dot notation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->