### PR TITLE
fix(tonk-display): fall through unresolvable bindings, parse descriptors once

### DIFF
--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -669,8 +669,8 @@ fn schedule_delegate_refresh(host: &Element, state: &Rc<RefCell<Inner>>) {
 }
 
 async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_generation: u64) {
-    use crate::events::delegate::Delegate;
-    use std::collections::{BTreeSet, HashMap};
+    use crate::events::delegate::{Delegate, Descriptors};
+    use std::collections::BTreeSet;
 
     // Snapshot the view elements so we don't hold the borrow
     // across awaits. The delegate's `claim` calls dispatch on the
@@ -724,8 +724,10 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
     }
 
     // Resolve each concept's descriptor via the host's
-    // `tonk-query` event. The host annotates space/branch.
-    let mut descriptors: HashMap<String, String> = HashMap::new();
+    // `tonk-query` event. The host annotates space/branch. The
+    // descriptor JSON is parsed once here so click-time event
+    // handlers don't pay the parse cost.
+    let mut descriptors: Descriptors = Descriptors::new();
     for name in &concept_names {
         // Bail mid-loop if a newer refresh has started — no point
         // resolving descriptors for a snapshot we won't install.
@@ -744,7 +746,16 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
         match host_consumer::query(host, &body_val).await {
             Ok(result) => {
                 if let Ok((_entity, descriptor_json)) = extract_phase1(&result) {
-                    descriptors.insert(name.clone(), descriptor_json);
+                    match serde_json::from_str::<serde_json::Value>(&descriptor_json) {
+                        Ok(value) => {
+                            descriptors.insert(name.clone(), value);
+                        }
+                        Err(e) => {
+                            web_sys::console::warn_1(&JsValue::from_str(&format!(
+                                "<tonk-display>: descriptor for `{name}` is not valid JSON: {e}",
+                            )));
+                        }
+                    }
                 }
             }
             Err(_) => {

--- a/rust/tonk-display/src/events/delegate.rs
+++ b/rust/tonk-display/src/events/delegate.rs
@@ -22,6 +22,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use serde_json::Value;
 use tonk_host::consumer as host_consumer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
@@ -29,6 +30,11 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, Event};
 
 use super::extract::build_transact_body;
+
+/// Concept name → pre-parsed descriptor. Built once at mount time
+/// from the worker's phase-1 results; each click reads from this
+/// map directly, no per-click JSON parse.
+pub type Descriptors = HashMap<String, Value>;
 
 /// Per-listener pair: the event-type name and the JS-side closure
 /// whose lifetime owns its memory.
@@ -49,7 +55,9 @@ pub struct Delegate {
 impl Delegate {
     /// Install delegation listeners on `host` for every event
     /// type in `event_types`. `descriptors` maps a concept name to
-    /// its resolved descriptor JSON. Claims dispatch as `tonk-claim`
+    /// its pre-parsed descriptor (the caller parsed the worker's
+    /// phase-1 JSON once at mount time so the click handler avoids
+    /// the parse cost on every fire). Claims dispatch as `tonk-claim`
     /// events on `host`; the `<tonk-host>` ancestor routes them to
     /// `/transact` against the ambient `(space, branch)`.
     ///
@@ -59,7 +67,7 @@ impl Delegate {
     pub fn install(
         host: Element,
         event_types: impl IntoIterator<Item = String>,
-        descriptors: HashMap<String, String>,
+        descriptors: Descriptors,
     ) -> Self {
         let descriptors = Rc::new(descriptors);
         let mut listeners: Vec<ListenerEntry> = Vec::new();
@@ -92,47 +100,20 @@ impl Drop for Delegate {
     }
 }
 
-/// One event fire. Walk up to find the binding, look up the
-/// descriptor, build the body, POST. Side effects (action
-/// attributes) are applied inside `build_transact_body` during
-/// the descriptor walk, so they happen before the POST kicks off
-/// — which means `preventDefault` lands within the synchronous
-/// handler tick, as required.
-fn handle_event(
-    event: &Event,
-    attr_name: &str,
-    descriptors: &HashMap<String, String>,
-    host: &Element,
-) {
-    let Some(target) = event.target() else {
+/// One event fire. Walk up from `event.target` collecting every
+/// ancestor that carries the `data-on<event>` attribute (up to and
+/// including the host). Try each in innermost-first order; the
+/// first one that resolves to a complete, well-typed transact body
+/// wins and posts. Bindings whose concept isn't in the descriptors
+/// map or whose `dom.event*` fields fail to project fall through
+/// to the next ancestor, so a typo or a missing `data-*` on the
+/// inner binding doesn't swallow an outer binding's click. Action
+/// side effects (`preventDefault`, `stopPropagation`) only fire for
+/// the binding that wins, because `build_transact_body` queues them
+/// and applies them only after the body is known-good.
+fn handle_event(event: &Event, attr_name: &str, descriptors: &Descriptors, host: &Element) {
+    let Some(body) = resolve_actionable_binding(event, attr_name, descriptors, host) else {
         return;
-    };
-    let Some(target_el) = target.dyn_ref::<Element>() else {
-        return;
-    };
-    let selector = format!("[{attr_name}]");
-    let Some(bound) = closest(target_el, &selector) else {
-        return;
-    };
-    let Some(concept) = bound.get_attribute(attr_name) else {
-        return;
-    };
-    let Some(descriptor_json) = descriptors.get(&concept) else {
-        // Binding referenced a concept we couldn't resolve at
-        // mount time. Silently ignore the click — the renderer
-        // will already have logged the resolve failure.
-        return;
-    };
-    // `dom:event` is the conventional `this:` for event-derived
-    // transient assertions. Rules match on the asserted concept's
-    // *fields*, not on `this`, so a fixed entity is fine — and
-    // the assertion sweeps before the durable commit either way.
-    let body = match build_transact_body(descriptor_json, &concept, EVENT_ENTITY, event, &bound) {
-        Ok(b) => b,
-        Err(e) => {
-            log_error(format!("event handler: build body for {concept}: {e}"));
-            return;
-        }
     };
     let request_js = match serde_wasm_bindgen::to_value(&body) {
         Ok(v) => v,
@@ -149,6 +130,66 @@ fn handle_event(
     });
 }
 
+/// Walk ancestors of `event.target` in innermost-first order,
+/// trying each one that matches `[data-on<event>]`. Returns the
+/// first transact body that builds cleanly. Skips bindings whose
+/// concept isn't in `descriptors`, whose descriptor can't build a
+/// body, or whose `dom.event*` fields fail to project. Stops once
+/// `closest` walks past `host`.
+///
+/// Action side effects only fire for the binding that wins, because
+/// `build_transact_body` queues actions and applies them only after
+/// the body is known-good.
+pub(super) fn resolve_actionable_binding(
+    event: &Event,
+    attr_name: &str,
+    descriptors: &Descriptors,
+    host: &Element,
+) -> Option<serde_json::Value> {
+    let target_el = event.target()?.dyn_ref::<Element>()?.clone();
+    let selector = format!("[{attr_name}]");
+
+    let mut cursor: Option<Element> = Some(target_el);
+    while let Some(current) = cursor {
+        let bound = closest(&current, &selector)?;
+        // Bindings outside the host belong to a different view or
+        // to nothing at all — `Node::contains` includes equality,
+        // so the host itself counts as in-scope.
+        if !host.contains(Some(bound.unchecked_ref())) {
+            return None;
+        }
+        if let Some(body) = try_binding(attr_name, descriptors, event, &bound) {
+            return Some(body);
+        }
+        // Move up: next iteration's `closest` starts from `bound`'s
+        // parent so we skip past the binding we just tried (and
+        // don't get the same answer again).
+        cursor = bound.parent_element();
+    }
+    None
+}
+
+fn try_binding(
+    attr_name: &str,
+    descriptors: &Descriptors,
+    event: &Event,
+    bound: &Element,
+) -> Option<serde_json::Value> {
+    let concept = bound.get_attribute(attr_name)?;
+    let descriptor = descriptors.get(&concept)?;
+    // `dom:event` is the conventional `this:` for event-derived
+    // transient assertions. Rules match on the asserted concept's
+    // *fields*, not on `this`, so a fixed entity is fine — and
+    // the assertion sweeps before the durable commit either way.
+    match build_transact_body(descriptor, &concept, EVENT_ENTITY, event, bound) {
+        Ok(body) => Some(body),
+        Err(e) => {
+            log_error(format!("event handler: build body for {concept}: {e}"));
+            None
+        }
+    }
+}
+
 /// `Element.closest(selector)` — walks up the parent chain until
 /// it finds an element matching `selector`, or returns `None`.
 fn closest(start: &Element, selector: &str) -> Option<Element> {
@@ -163,4 +204,295 @@ const EVENT_ENTITY: &str = "dom:event";
 
 fn log_error(message: String) {
     web_sys::console::warn_1(&wasm_bindgen::JsValue::from_str(&message));
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use web_sys::{Event, EventInit, window};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Build a click event whose `event.target` is `target_el`.
+    /// Done by defining an own `target` property on the event JS
+    /// object — `Reflect::get` and the web-sys getter both check
+    /// own props before falling through to the readonly getter
+    /// inherited from `Event.prototype`.
+    fn click_event_targeting(target_el: &Element) -> Event {
+        let event = Event::new_with_event_init_dict("click", &EventInit::new()).expect("Event");
+        let event_js: &JsValue = event.as_ref();
+        let descriptor = Object::new();
+        Reflect::set(&descriptor, &JsValue::from_str("value"), target_el.as_ref()).unwrap();
+        Reflect::set(
+            &descriptor,
+            &JsValue::from_str("configurable"),
+            &JsValue::TRUE,
+        )
+        .unwrap();
+        Reflect::set(&descriptor, &JsValue::from_str("writable"), &JsValue::TRUE).unwrap();
+        Reflect::set(
+            &descriptor,
+            &JsValue::from_str("enumerable"),
+            &JsValue::TRUE,
+        )
+        .unwrap();
+        let _ = Object::define_property(
+            event_js.unchecked_ref::<Object>(),
+            &JsValue::from_str("target"),
+            &descriptor,
+        );
+        event
+    }
+
+    /// Mount a fresh host div under `<body>` and append `markup`
+    /// inside. The host is the element listeners would normally
+    /// be installed on; here we just need it as the boundary the
+    /// ancestor walk respects.
+    fn mount(markup: &str) -> Element {
+        let document = window().expect("window").document().expect("document");
+        let host = document.create_element("div").expect("create host");
+        host.set_inner_html(markup);
+        document.body().expect("body").append_child(&host).unwrap();
+        host
+    }
+
+    /// Build a [`Descriptors`] map from `(concept_name, json_text)`
+    /// pairs, parsing each descriptor once just like `element.rs`
+    /// does at mount.
+    fn descriptors(pairs: &[(&str, &str)]) -> Descriptors {
+        let mut out: Descriptors = HashMap::new();
+        for (name, json_text) in pairs {
+            let value: Value = serde_json::from_str(json_text).expect("descriptor parses");
+            out.insert((*name).to_owned(), value);
+        }
+        out
+    }
+
+    #[dialog_common::test]
+    fn it_falls_through_when_inner_concept_is_unknown() {
+        // Outer binding is the only one in `descriptors`. Inner has
+        // a `data-onclick` referencing a concept we never resolved
+        // at mount time; the click should still reach outer.
+        let host = mount(
+            r#"<div data-onclick="outer" data-counter="did:key:zOuter">
+                 <span data-onclick="unknown">click</span>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        let descriptors = descriptors(&[(
+            "outer",
+            r#"{ "with": {
+                "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+            } }"#,
+        )]);
+        let body = resolve_actionable_binding(&event, "data-onclick", &descriptors, &host)
+            .expect("outer should resolve");
+        assert_eq!(
+            body["claims"][0]["application"]["parameters"]["counter"],
+            serde_json::json!("did:key:zOuter"),
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_falls_through_when_inner_field_does_not_resolve() {
+        // Inner concept *is* known, but its descriptor requires a
+        // `data-todo` attribute the inner element doesn't carry.
+        // Outer is well-formed; outer should win.
+        let host = mount(
+            r#"<div data-onclick="outer" data-counter="did:key:zOuter">
+                 <span data-onclick="inner">click</span>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        let descriptors = descriptors(&[
+            (
+                "inner",
+                r#"{ "with": {
+                    "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+            (
+                "outer",
+                r#"{ "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+        ]);
+        let body = resolve_actionable_binding(&event, "data-onclick", &descriptors, &host)
+            .expect("outer should resolve after inner unresolved-field");
+        let params = &body["claims"][0]["application"]["parameters"];
+        assert!(params.get("todo").is_none(), "inner field must not leak");
+        assert_eq!(params["counter"], serde_json::json!("did:key:zOuter"));
+    }
+
+    #[dialog_common::test]
+    fn it_picks_innermost_when_both_resolve() {
+        // Inner and outer both have well-formed descriptors with
+        // their required data-* present. Inner should win.
+        let host = mount(
+            r#"<div data-onclick="outer" data-counter="did:key:zOuter">
+                 <span data-onclick="inner" data-todo="did:key:zTodo">click</span>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        let descriptors = descriptors(&[
+            (
+                "inner",
+                r#"{ "with": {
+                    "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+            (
+                "outer",
+                r#"{ "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+        ]);
+        let body = resolve_actionable_binding(&event, "data-onclick", &descriptors, &host)
+            .expect("inner should resolve");
+        let params = &body["claims"][0]["application"]["parameters"];
+        assert_eq!(params["todo"], serde_json::json!("did:key:zTodo"));
+        assert!(
+            params.get("counter").is_none(),
+            "outer must not be consulted when inner wins",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_returns_none_when_no_ancestor_resolves() {
+        let host = mount(
+            r#"<div data-onclick="outer">
+                 <span data-onclick="inner">click</span>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        // Inner needs a data-todo it doesn't have; outer needs a
+        // data-counter it doesn't have. Neither can resolve.
+        let descriptors = descriptors(&[
+            (
+                "inner",
+                r#"{ "with": {
+                    "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+            (
+                "outer",
+                r#"{ "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+        ]);
+        assert!(
+            resolve_actionable_binding(&event, "data-onclick", &descriptors, &host).is_none(),
+            "no binding should resolve, fallthrough exhausts ancestors",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_falls_through_three_levels_with_each_binding_carrying_real_data() {
+        // The shape that prompted this test:
+        //   <div data-onclick=outer data-subject=...>
+        //     <div data-onclick=inner data-subject=...>
+        //       <span>click me</span>
+        //     </div>
+        //   </div>
+        //
+        // Both handler elements carry a real `data-subject`. Inner's
+        // descriptor still fails because it requires a different
+        // field (`ready`) which the inner element doesn't carry.
+        // Outer's descriptor reads `subject` off its own element and
+        // resolves cleanly.
+        //
+        // Exercises two things the simpler tests didn't:
+        //  1. The click target is a non-handler descendant (`<span>`),
+        //     so `closest` has to walk past it before finding inner.
+        //  2. Inner *has* data on it (just not the field the
+        //     descriptor wants), so the failure is a missing required
+        //     field rather than a wholly-absent dataset.
+        let host = mount(
+            r#"<div data-onclick="report-outer" data-subject="did:key:zOuter">
+                 <div data-onclick="report-inner" data-subject="did:key:zHeader">
+                   <span>click me</span>
+                 </div>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        let descriptors = descriptors(&[
+            (
+                "report-inner",
+                r#"{ "with": {
+                    "subject": { "the": "dom.event.current-target.dataset/subject", "as": "Entity", "cardinality": "one" },
+                    "ready":   { "the": "dom.event.current-target.dataset/ready",   "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+            (
+                "report-outer",
+                r#"{ "with": {
+                    "subject": { "the": "dom.event.current-target.dataset/subject", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+        ]);
+        let body = resolve_actionable_binding(&event, "data-onclick", &descriptors, &host)
+            .expect("outer should resolve after inner falls through on missing `ready`");
+        let params = &body["claims"][0]["application"]["parameters"];
+        assert_eq!(
+            params["subject"],
+            serde_json::json!("did:key:zOuter"),
+            "outer should read its own data-subject, not inner's",
+        );
+        assert!(
+            params.get("ready").is_none(),
+            "inner's unresolved field must not leak into the posted body",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_apply_actions_for_a_failed_binding() {
+        // Inner has both an Action (`stop-propagation`) and a Read
+        // field that won't resolve. The action must NOT fire,
+        // because the body fails to build and we fall through. We
+        // verify by checking that the event isn't marked as
+        // "propagation stopped" — `cancelBubble` reflects
+        // stopPropagation() having been called.
+        let host = mount(
+            r#"<div data-onclick="outer" data-counter="did:key:zOuter">
+                 <span data-onclick="inner">click</span>
+               </div>"#,
+        );
+        let target = host.query_selector("span").unwrap().expect("span");
+        let event = click_event_targeting(&target);
+        let descriptors = descriptors(&[
+            (
+                "inner",
+                r#"{ "with": {
+                    "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" },
+                    "stop": { "the": "dom.event.do/stop-propagation" }
+                } }"#,
+            ),
+            (
+                "outer",
+                r#"{ "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                } }"#,
+            ),
+        ]);
+        let _ = resolve_actionable_binding(&event, "data-onclick", &descriptors, &host)
+            .expect("outer should resolve");
+        // `Event::cancel_bubble` returns true iff stopPropagation
+        // has been called on this event. Inner's action queued but
+        // we bailed before applying it.
+        assert!(
+            !event.cancel_bubble(),
+            "stopPropagation must not fire when the binding falls through",
+        );
+    }
 }

--- a/rust/tonk-display/src/events/extract.rs
+++ b/rust/tonk-display/src/events/extract.rs
@@ -40,11 +40,11 @@ use super::path::{Classification, EventAction, EventPath, classify};
 
 /// Build a `TransactRequest`-shaped JSON value for a single
 /// `assert` of `concept_name` populated from `event`, using the
-/// concept's `descriptor_json` schema.
+/// concept's `descriptor` schema.
 ///
-/// `descriptor_json` is the dialog descriptor as returned by
-/// `phase1_lookup` — its top-level `with` field is the attribute
-/// map.
+/// `descriptor` is the dialog descriptor as returned by
+/// `phase1_lookup`, pre-parsed once at delegate-install time. Its
+/// top-level `with` field is the attribute map.
 ///
 /// `this` is the entity URI the assertion's `this:` slot binds to.
 /// It does not need to be in the descriptor (every concept has an
@@ -52,18 +52,18 @@ use super::path::{Classification, EventAction, EventPath, classify};
 /// being acted on — typically the view's rendered entity, surfaced
 /// to the DOM via a `data-*` attribute the concept also reads.
 ///
-/// Returns `Err` if the descriptor JSON can't be parsed. Action
-/// attributes are applied to the event as a side effect during the
-/// walk; an action's failure (method not present on this event
-/// type) is silently ignored.
+/// Returns `Err` when the descriptor has no `with` field or a
+/// `dom.event*` field's path didn't resolve. Action attributes
+/// queue during the walk and only fire after every Read field has
+/// resolved — a `preventDefault` never lands for a binding that
+/// the caller is about to skip on fallthrough.
 pub fn build_transact_body(
-    descriptor_json: &str,
+    descriptor: &Value,
     concept_name_or_uri: &str,
     this: &str,
     event: &Event,
     binding: &Element,
 ) -> Result<Value, ExtractError> {
-    let descriptor: Value = serde_json::from_str(descriptor_json).map_err(ExtractError::Parse)?;
     let with = descriptor
         .get("with")
         .and_then(Value::as_object)
@@ -77,6 +77,13 @@ pub fn build_transact_body(
 
     let event_js: &JsValue = event.as_ref();
     let binding_js: &JsValue = binding.as_ref();
+
+    // Actions queue up during the descriptor walk and only fire
+    // after every Read field has resolved. If a field is unresolved
+    // we bail with `UnresolvedField` and the caller falls through
+    // to the next matching ancestor; we don't want preventDefault /
+    // stopPropagation to land for a binding we're about to skip.
+    let mut pending_actions: Vec<EventAction> = Vec::new();
 
     for (field_name, attr_value) in with {
         // Skip an explicitly-declared `this` slot — we just set it.
@@ -102,8 +109,7 @@ pub fn build_transact_body(
                 parameters.insert(field_name.clone(), value);
             }
             Classification::Action(action) => {
-                apply_action(event_js, &action);
-                // Actions contribute no parameter.
+                pending_actions.push(action);
             }
             Classification::Other => {
                 // The field's the: doesn't point into the event,
@@ -114,6 +120,11 @@ pub fn build_transact_body(
         }
     }
 
+    // Body is known-good; commit the side effects on the event.
+    for action in &pending_actions {
+        apply_action(event_js, action);
+    }
+
     // The wrapper around the dialog descriptor: tonk's
     // `ConceptDescriptor` enum, with `kind` + `concept`. We mark
     // event-derived assertions as transient (commands / intents,
@@ -121,7 +132,7 @@ pub fn build_transact_body(
     // descriptor JSON — exactly what phase1 returned.
     let predicate = json!({
         "kind": "transient",
-        "concept": descriptor,
+        "concept": descriptor.clone(),
     });
 
     let claim = json!({
@@ -282,10 +293,7 @@ fn apply_action(event: &JsValue, action: &EventAction) {
 /// Errors building a transact body.
 #[derive(Debug)]
 pub enum ExtractError {
-    /// Descriptor JSON didn't parse.
-    Parse(serde_json::Error),
-    /// Descriptor parsed but has no `with` field — not a concept
-    /// descriptor.
+    /// Descriptor has no `with` field — not a concept descriptor.
     MissingWith,
     /// A `dom.event*` field's path resolved to `undefined`/`null`
     /// or didn't coerce to the declared `as:` type. We refuse to
@@ -301,7 +309,6 @@ pub enum ExtractError {
 impl std::fmt::Display for ExtractError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Parse(e) => write!(f, "descriptor JSON parse: {e}"),
             Self::MissingWith => write!(f, "descriptor missing `with` field"),
             Self::UnresolvedField { field, identifier } => write!(
                 f,
@@ -386,17 +393,23 @@ mod tests {
         el
     }
 
+    fn descriptor(json_text: &str) -> Value {
+        serde_json::from_str(json_text).expect("descriptor parses")
+    }
+
     #[dialog_common::test]
     fn it_builds_a_transact_body_from_current_target_dataset() {
-        let descriptor = r#"{
-            "with": {
-                "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]);
         let binding = binding_element(&[("data-counter", "did:key:zCounter")]);
         let body = build_transact_body(
-            descriptor,
+            &descriptor,
             "increment",
             "did:key:zCounter",
             &event,
@@ -418,14 +431,16 @@ mod tests {
 
     #[dialog_common::test]
     fn it_reads_top_level_event_fields() {
-        let descriptor = r#"{
-            "with": {
-                "kind": { "the": "dom.event/type", "as": "Text", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "kind": { "the": "dom.event/type", "as": "Text", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]);
         let binding = binding_element(&[]);
-        let body = build_transact_body(descriptor, "noop", "did:key:zSubject", &event, &binding)
+        let body = build_transact_body(&descriptor, "noop", "did:key:zSubject", &event, &binding)
             .expect("build_transact_body");
         let params = &body["claims"][0]["application"]["parameters"];
         assert_eq!(params["kind"], json!("click"));
@@ -433,14 +448,16 @@ mod tests {
 
     #[dialog_common::test]
     fn it_errors_when_a_required_field_does_not_resolve() {
-        let descriptor = r#"{
-            "with": {
-                "missing": { "the": "dom.event/pressure", "as": "Float", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "missing": { "the": "dom.event/pressure", "as": "Float", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]);
         let binding = binding_element(&[]);
-        let err = build_transact_body(descriptor, "noop", "did:key:zSubject", &event, &binding)
+        let err = build_transact_body(&descriptor, "noop", "did:key:zSubject", &event, &binding)
             .expect_err("expected UnresolvedField");
         match err {
             ExtractError::UnresolvedField { field, identifier } => {
@@ -453,14 +470,16 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_non_dom_event_fields() {
-        let descriptor = r#"{
-            "with": {
-                "name": { "the": "xyz.tonk.user/name", "as": "Text", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "name": { "the": "xyz.tonk.user/name", "as": "Text", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]);
         let binding = binding_element(&[]);
-        let body = build_transact_body(descriptor, "noop", "did:key:zSubject", &event, &binding)
+        let body = build_transact_body(&descriptor, "noop", "did:key:zSubject", &event, &binding)
             .expect("build_transact_body");
         let params = &body["claims"][0]["application"]["parameters"];
         assert!(params.get("name").is_none());
@@ -468,15 +487,17 @@ mod tests {
 
     #[dialog_common::test]
     fn it_errors_when_entity_coercion_fails() {
-        let descriptor = r#"{
-            "with": {
-                "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "counter": { "the": "dom.event.current-target.dataset/counter", "as": "Entity", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]);
         let binding = binding_element(&[("data-counter", "not-a-uri")]);
         let err = build_transact_body(
-            descriptor,
+            &descriptor,
             "increment",
             "did:key:zCounter",
             &event,
@@ -495,14 +516,16 @@ mod tests {
         // real `event.currentTarget` (the host where delegation was
         // installed) carries no data-* attrs — only the binding
         // element does. The projector must read from `binding`.
-        let descriptor = r#"{
-            "with": {
-                "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" }
-            }
-        }"#;
+        let descriptor = descriptor(
+            r#"{
+                "with": {
+                    "todo": { "the": "dom.event.current-target.dataset/todo", "as": "Entity", "cardinality": "one" }
+                }
+            }"#,
+        );
         let event = synthetic_event(&[]); // no target.dataset.todo either
         let binding = binding_element(&[("data-todo", "did:key:zTodo")]);
-        let body = build_transact_body(descriptor, "toggle", "did:key:zTodo", &event, &binding)
+        let body = build_transact_body(&descriptor, "toggle", "did:key:zTodo", &event, &binding)
             .expect("build_transact_body");
         let params = &body["claims"][0]["application"]["parameters"];
         assert_eq!(params["todo"], json!("did:key:zTodo"));

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -523,10 +523,9 @@ fn update_iteration(
                 .iter()
                 .find(|(k, _)| !rows.contains_key(*k))
                 .map(|(k, v)| (k.clone(), v.clone()))
+            && let Some(row) = rows.remove(&old_key)
         {
-            if let Some(row) = rows.remove(&old_key) {
-                rows.insert(new_key, row);
-            }
+            rows.insert(new_key, row);
         }
     }
 


### PR DESCRIPTION
Nested handlers had a swallowing problem: when an inner `data-onclick` binding pointed at a concept the renderer never resolved (typo, rename), or a `dom.event*` field didn't project (missing `data-*` on the inner element), the whole click went nowhere. The handler stopped at the first ancestor matching the selector and bailed on its own failure without considering whether an outer binding would have worked. For a list with item-level handlers nested inside a container handler, one stale concept name on the inner element meant the container handler stopped firing for any item — silent, and the only diagnostic was a console warning that's easy to miss.

Approach: walk every matching ancestor in innermost-first order and stop at the first binding that can produce a complete transact body. Failures (unknown concept, `UnresolvedField`) fall through to the next ancestor. The walk stops at the host element, so bindings outside this view never get touched. Behaviour for the common case (one well-formed binding above the click target) is unchanged.

Action side effects (`preventDefault`, `stopPropagation`) move to the end of the descriptor walk. Today they fire interleaved with Read field resolution, meaning a binding that ultimately failed could still have called `preventDefault`; now they queue and only fire once the body is known-good. The winning binding's actions run; skipped bindings' actions don't. Verified by a test that primes inner with `stop-propagation` plus an unresolved Read field and checks the event's `cancelBubble` stays false after the fallthrough.

While restructuring, `Delegate` swapped its descriptor map from `HashMap<String, String>` to `HashMap<String, serde_json::Value>` (aliased `Descriptors`). The worker's phase-1 result is already JSON text, and `build_transact_body` was re-parsing it on every click. Parse moved to `element.rs::refresh_delegate`, where the descriptor is fetched anyway. `ExtractError::Parse` is gone; a malformed descriptor logs at mount and the entry is dropped, which then takes the same fallthrough path as a missing descriptor. `build_transact_body` now takes `&Value`.

Drive-by: collapse a nested `if let` in `render.rs` that newly-warns under `clippy::collapsible-if` so the wasm clippy gate passes.

Tests added in `events/delegate.rs` cover: inner-concept unknown falls through; inner field unresolved falls through; both resolve picks innermost; nothing resolves returns None; actions don't fire on a failed binding; and a three-level shape with the click target as a non-handler descendant of two nested handlers. The existing `extract.rs` tests were updated to pass `&Value` and now exercise the post-parse path.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of event delegation in the `tonk-display` library, specifically improving descriptor parsing and action handling for events.

### Detailed summary
- Improved event handling by using pre-parsed `Descriptors` instead of JSON strings.
- Added error handling for invalid JSON descriptors.
- Refactored `handle_event` to use `resolve_actionable_binding`.
- Updated tests to reflect changes in descriptor handling and ensure correctness.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->