### PR TITLE
feat: declarative views identified by anchor name

### DIFF
--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -201,14 +201,15 @@ enum ShareCommand {
         /// forwarded as `?view=`. `<tonk-display>` resolves it to
         /// the view entity the name points at and reads that
         /// view's own `model`. Omit it for carousel mode (every
-        /// view published for `--model`).
-        #[arg(long, value_name = "NAME")]
+        /// view published for `--model`). Mutually exclusive with
+        /// `--model`: a named view declares its own model.
+        #[arg(long, value_name = "NAME", conflicts_with = "model")]
         view: Option<String>,
         /// Concept name (validated locally) or URI for carousel
         /// mode, forwarded as `?model=`. Not needed with `--view`
         /// (the view declares its own model); required when
         /// `--view` is omitted.
-        #[arg(long, value_name = "CONCEPT")]
+        #[arg(long, value_name = "CONCEPT", required_unless_present = "view")]
         model: Option<String>,
         /// Override the URL prefix the launcher is built against.
         #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -17,7 +17,7 @@ use slide::invite::{self, ClaimOutcome, InviteOutcome};
 use slide::migrate::{self, Mode as MigrateMode};
 use slide::output::Format;
 use slide::remote::{self, AddOutcome, RemoteRecord, UpstreamOutcome};
-use slide::share::{self, ShareOptions, ShareOutcome, ShareViewOutcome};
+use slide::share::{self, ShareDisplayOutcome, ShareOptions, ShareOutcome, ShareViewOutcome};
 use slide::sync::{self, SyncOutcome};
 use slide::views::{self, ViewSummary};
 use slide::{ExitCode, guide, identity, schema, site};
@@ -172,6 +172,44 @@ enum ShareCommand {
         /// `slide views` lists what's available.
         #[arg(value_name = "NAME_OR_ENTITY")]
         target: String,
+        /// Override the URL prefix the launcher is built against.
+        #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
+        ui_base: String,
+        /// Suggested local name for the recipient's space.
+        #[arg(long, value_name = "NAME")]
+        space_name: Option<String>,
+        /// Embed an explicit remote's endpoint.
+        #[arg(long, value_name = "NAME")]
+        remote: Option<String>,
+    },
+
+    /// Share an entity rendered through `<tonk-display>`. The
+    /// recipient lands on
+    /// `/space/<space-name>/branch/main/display/<subject>` with
+    /// the supplied `--view` carried across as a query parameter.
+    /// Use this for declarative views built against the `view`
+    /// concept (`{model, display}`), identified by their anchor
+    /// name — `share view` is for the iframe viewer.
+    Display {
+        /// Bookmark name or `did:key:…` entity URI for the
+        /// entity to render. Names survive entity-URI changes
+        /// (re-asserting a view body) so they're usually the
+        /// better choice.
+        #[arg(value_name = "NAME_OR_ENTITY")]
+        subject: String,
+        /// The view's anchor name (the `&name` on its `view!:`),
+        /// forwarded as `?view=`. `<tonk-display>` resolves it to
+        /// the view entity the name points at and reads that
+        /// view's own `model`. Omit it for carousel mode (every
+        /// view published for `--model`).
+        #[arg(long, value_name = "NAME")]
+        view: Option<String>,
+        /// Concept name (validated locally) or URI for carousel
+        /// mode, forwarded as `?model=`. Not needed with `--view`
+        /// (the view declares its own model); required when
+        /// `--view` is omitted.
+        #[arg(long, value_name = "CONCEPT")]
+        model: Option<String>,
         /// Override the URL prefix the launcher is built against.
         #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
         ui_base: String,
@@ -572,6 +610,38 @@ async fn share_op(command: ShareCommand) -> ExitCode {
                 }
             }
         }
+        ShareCommand::Display {
+            subject,
+            view,
+            model,
+            ui_base,
+            space_name,
+            remote,
+        } => {
+            let options = ShareOptions {
+                ui_base: Some(ui_base),
+                remote,
+                space_name,
+            };
+            match share::share_display(
+                &site,
+                &subject,
+                view.as_deref(),
+                model.as_deref(),
+                options,
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    print_share_display_outcome(&outcome);
+                    ExitCode::Success
+                }
+                Err(err) => {
+                    eprintln!("error: {err}");
+                    err.exit_code()
+                }
+            }
+        }
     }
 }
 
@@ -591,6 +661,26 @@ fn print_share_view_outcome(outcome: &ShareViewOutcome) {
         eprintln!("view:    {} ({})", name, outcome.entity);
     } else {
         eprintln!("view:    {}", outcome.entity);
+    }
+    eprintln!("space:   {}", outcome.space_name);
+    eprintln!(
+        "remote:  {} -> {}",
+        outcome.remote_name, outcome.remote_endpoint,
+    );
+}
+
+fn print_share_display_outcome(outcome: &ShareDisplayOutcome) {
+    println!("{}", outcome.url);
+    if let Some(name) = &outcome.subject_name {
+        eprintln!("subject: {} ({})", name, outcome.subject_entity);
+    } else {
+        eprintln!("subject: {}", outcome.subject_entity);
+    }
+    if let Some(view) = &outcome.view_name {
+        eprintln!("view:    {}", view);
+    }
+    if let Some(model) = &outcome.model {
+        eprintln!("model:   {}", model);
     }
     eprintln!("space:   {}", outcome.space_name);
     eprintln!(

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -623,14 +623,8 @@ async fn share_op(command: ShareCommand) -> ExitCode {
                 remote,
                 space_name,
             };
-            match share::share_display(
-                &site,
-                &subject,
-                view.as_deref(),
-                model.as_deref(),
-                options,
-            )
-            .await
+            match share::share_display(&site, &subject, view.as_deref(), model.as_deref(), options)
+                .await
             {
                 Ok(outcome) => {
                     print_share_display_outcome(&outcome);

--- a/rust/slide/src/guide-views-dynamic.md
+++ b/rust/slide/src/guide-views-dynamic.md
@@ -26,7 +26,7 @@ call.
 ```yaml
 attribute!: &count
   the: xyz.tonk.counter/count
-  as:  integer
+  as:  unsigned-integer
 
 concept!: &counter
   with:
@@ -38,7 +38,7 @@ concept!: &increment
   transient: true
   with:
     subject:
-      the: dom.event.target.dataset/subject
+      the: dom.event.current-target.dataset/subject
       as:  entity
 
 rule!:
@@ -68,7 +68,7 @@ replace in place, so there are never stale duplicates to pick
 between.
 
 A click on the button asserts an `increment` whose `subject`
-reads from `event.target.dataset.subject` (which the template
+reads from the bound button's `data-subject` (which the template
 populated from the row's `{this}`). The rule reads the
 `increment` together with the current `counter`, computes the
 new total, and asserts the updated `counter`. The subscription
@@ -81,10 +81,12 @@ behind the view sees the new count and patches the DOM. The
   that should produce two facts means two elements.
 - The right-hand side is a concept name (`increment`) or an
   entity URI (anything containing `:`, e.g.
-  `did:key:zHj…`). Names resolve through the branch's name
-  table; URIs skip the lookup.
-- A bare `onclick` with no concept is rejected — there's no
-  schema to walk and no obvious default.
+  `did:key:zHj…`). Both go through a phase-1 descriptor
+  lookup — a name resolves through the branch's name table, a
+  URI resolves directly by entity.
+- A bare `onclick` with no concept is ignored: it resolves to
+  no descriptor, so the click is a silent no-op rather than an
+  error.
 - Any DOM event name works: `onclick`, `onsubmit`,
   `onkeydown`, `onpointerdown`. The runtime registers a
   listener for the literal type.
@@ -94,15 +96,15 @@ behind the view sees the new count and patches the DOM. The
 A transient concept's attributes describe what to read out of
 the live JS event. The `the:` identifier names a path:
 
-| `the:` identifier                        | reads                              |
-|------------------------------------------|------------------------------------|
-| `dom.event/type`                         | `event.type`                       |
-| `dom.event/key`                          | `event.key`                        |
-| `dom.event/shift-key`                    | `event.shiftKey`                   |
-| `dom.event/client-x`                     | `event.clientX`                    |
-| `dom.event.target/value`                 | `event.target.value`               |
-| `dom.event.target.dataset/subject`       | `event.target.dataset.subject`     |
-| `dom.event.target.dataset/item-id`       | `event.target.dataset.itemId`      |
+| `the:` identifier                             | reads                                |
+|-----------------------------------------------|--------------------------------------|
+| `dom.event/type`                              | `event.type`                         |
+| `dom.event/key`                               | `event.key`                          |
+| `dom.event/shift-key`                         | `event.shiftKey`                     |
+| `dom.event/client-x`                          | `event.clientX`                      |
+| `dom.event.target/value`                      | `event.target.value`                 |
+| `dom.event.current-target.dataset/subject`    | the bound element's `data-subject`   |
+| `dom.event.current-target.dataset/item-id`    | the bound element's `data-item-id`   |
 
 Rules of the translation:
 
@@ -110,18 +112,30 @@ Rules of the translation:
   successive property step on the event object.
 - Within a segment, kebab-case becomes camelCase before lookup
   (`shift-key` → `shiftKey`, `item-id` → `itemId`).
+- A leading `target` segment is `event.target` — the *deepest*
+  node the event fired on. A leading `current-target` segment
+  is the **bound element**: the closest ancestor of
+  `event.target` that carries the `on<event>` you authored.
+  (This is not the literal `event.currentTarget`, which points
+  at the host where the delegated listener lives.) To read a
+  `data-*` you put on the element with the handler, always use
+  `current-target` — `target` may be a child you didn't author
+  (e.g. a `<span>` inside the button).
 - The path is evaluated live, at handler-fire time. A missing
   path (e.g. `event.pressure` on a `MouseEvent`) omits that
   field from the asserted fact.
 - The `as:` type drives coercion: `text` → string, `entity` →
-  parse as URI, `integer` / `float` → number, `boolean` →
-  truthy.
+  string parsed as a URI (rejected if it has no `:`),
+  `unsigned-integer` / `signed-integer` / `float` → number,
+  `boolean` → the JS value must already be a boolean (e.g.
+  `event.shiftKey`); a non-boolean fails to resolve rather than
+  being coerced.
 
 ### Passing view context via `data-*`
 
 A click handler doesn't implicitly know the row it was rendered
 for. Surface what you need on the element with `data-*` and
-read it back through `dom.event.target.dataset/<name>`:
+read it back through `dom.event.current-target.dataset/<name>`:
 
 ```yaml
 view!: &todo-row
@@ -136,14 +150,17 @@ concept!: &complete
   transient: true
   with:
     todo:
-      the: dom.event.target.dataset/todo
+      the: dom.event.current-target.dataset/todo
       as:  entity
 ```
 
-The chain `data-todo={this}` → `event.target.dataset.todo` →
-`?todo` is visible at every step. The template author decides
-what to surface; the concept author decides what to read; both
-sides have to agree on the `data-<name>`.
+The chain `data-todo={this}` → the bound button's
+`data-todo` → `?todo` is visible at every step. `current-target`
+(not `target`) reads the `data-*` off the element the handler
+was authored on, so a click that lands on a child node — say a
+`<span>` inside the button — still resolves. The template author
+decides what to surface; the concept author decides what to
+read; both sides have to agree on the `data-<name>`.
 
 ### Side effects: `preventDefault` and friends
 
@@ -169,7 +186,7 @@ concept!: &save
   transient: true
   with:
     body:
-      the: dom.event.target/value
+      the: dom.event.current-target.elements.body/value
       as:  text
     prevent-default:
       the: dom.event.do/prevent-default
@@ -185,9 +202,10 @@ view!: &save-form
     </form>
 ```
 
-The submit asserts `save` with the textarea value, and
-`preventDefault` fires synchronously so the page doesn't
-reload.
+The submit fires on the `<form>`, so `current-target` is the
+form and `elements.body` is the named `<textarea>` — its
+`value` becomes the `body` field. `preventDefault` fires
+synchronously so the page doesn't reload.
 
 ### `rule!:` — the reactive layer
 

--- a/rust/slide/src/guide-views-dynamic.md
+++ b/rust/slide/src/guide-views-dynamic.md
@@ -1,113 +1,324 @@
-## Interactive views with `globalThis.tonk`
+## Reactive views: events and effects
 
-`<tonk-concept>` covers lists and grids where every row fits a
-`<template>`. When you need a form, a button, or any UI whose logic
-doesn't fit the row-template model, drop into JavaScript and use the
-`globalThis.tonk` API the host injects into every view iframe.
+Templates with `{field}` interpolation cover the read path: a
+view subscribes to a query and re-renders rows in place when the
+data changes. Interactivity — clicks, form submits, anything a
+user does — flows the other direction, and it is also fully
+declarative.
 
-Three methods, all return Promises. No handshake, no initialisation —
-call them at the top of your script:
+The model has three pieces:
 
-- `tonk.query(body)` — one-shot query. Resolves to an array of rows.
-- `tonk.subscribe(body)` — live query. Resolves to a
-  `ReadableStream` whose chunks are arrays of rows, one per branch
-  change. Cancel the stream to unsubscribe.
-- `tonk.evaluate(body, transact = true)` — run a notation document
-  (assertions, queries, retractions). Resolves to the evaluate result.
+1. **`on<event>=<concept>`** on a template element names the
+   concept a DOM event produces.
+2. A **transient concept** describes the shape of that event-
+   derived fact and where each field reads from.
+3. A **rule** (`rule!:`) watches for the transient and asserts
+   downstream state. The transient is the trigger; its one-cycle
+   lifetime makes the rule fire exactly once per event.
 
-The `body` for `query` / `subscribe` is the same `ConceptQuery` JSON
-shape `/api/.../query` accepts. The `body` for `evaluate` is a string
-of notation — the same syntax `slide eval` consumes.
+No JavaScript. No `fetch`. No `globalThis.tonk`. The bridge into
+the worker is the transient assertion, posted by the runtime
+when the event fires; you describe the projection, not the wire
+call.
 
-You don't pass a repo or branch — the iframe is already scoped to one.
-
-### Reading data
-
-```yaml
-view!: &person-counter
-  body: |
-    <p>People online: <span id="count">…</span></p>
-    <script type="module">
-      const stream = await tonk.subscribe({
-        terms: { this: "?p" },
-        predicate: { with: { name: "?n" } },
-      });
-      try {
-        for await (const rows of stream) {
-          document.getElementById("count").textContent = rows.length;
-        }
-      } catch (err) {
-        console.error("count subscription failed:", err);
-      }
-    </script>
-```
-
-Cancel a subscription by calling `stream.cancel()` (or by aborting
-the reader). The unsubscribe envelope to the worker is posted
-automatically.
-
-For a one-shot read:
-
-```js
-const rows = await tonk.query({
-  terms:     { this: "?p" },
-  predicate: { with: { name: "?n" } },
-});
-```
-
-### Writing data
-
-`evaluate` accepts any notation document — including assertions that
-write claims:
+### Wiring a click
 
 ```yaml
-view!: &add-person
-  body: |
-    <form id="add">
-      <input name="name" placeholder="Name" required>
-      <button>Add</button>
+attribute!: &count
+  the: xyz.tonk.counter/count
+  as:  integer
+
+concept!: &counter
+  with:
+    count: count
+
+# The event-derived concept. `transient: true` is what tells the
+# reactor not to persist it.
+concept!: &increment
+  transient: true
+  with:
+    subject:
+      the: dom.event.target.dataset/subject
+      as:  entity
+
+rule!:
+  assert!: counter
+  when:
+    - assert: increment
+      where: { subject: ?this }
+    - assert: counter
+      where: { this: ?this, count: ?old }
+    - assert: math/sum
+      where: { of: ?old, with: 1, is: ?count }
+
+view!: &counter-basic
+  model: counter
+  display: !text/html |
+    <p>{count}
+      <button onclick=increment data-subject={this}>+</button>
+    </p>
+```
+
+A view is identified by its **anchor name** (`&counter-basic`
+publishes it under `id:counter-basic`). It declares the `model`
+it renders and the `display` template; `<tonk-display>` resolves
+the view by that name. Re-asserting the same anchor with a
+different `display` re-points the name to the new entity — edits
+replace in place, so there are never stale duplicates to pick
+between.
+
+A click on the button asserts an `increment` whose `subject`
+reads from `event.target.dataset.subject` (which the template
+populated from the row's `{this}`). The rule reads the
+`increment` together with the current `counter`, computes the
+new total, and asserts the updated `counter`. The subscription
+behind the view sees the new count and patches the DOM. The
+`increment` fact is gone next cycle — it never reaches storage.
+
+### `on<event>=<concept>` syntax
+
+- One event attribute per event type per element. Two clicks
+  that should produce two facts means two elements.
+- The right-hand side is a concept name (`increment`) or an
+  entity URI (anything containing `:`, e.g.
+  `did:key:zHj…`). Names resolve through the branch's name
+  table; URIs skip the lookup.
+- A bare `onclick` with no concept is rejected — there's no
+  schema to walk and no obvious default.
+- Any DOM event name works: `onclick`, `onsubmit`,
+  `onkeydown`, `onpointerdown`. The runtime registers a
+  listener for the literal type.
+
+### The `dom.event` namespace
+
+A transient concept's attributes describe what to read out of
+the live JS event. The `the:` identifier names a path:
+
+| `the:` identifier                        | reads                              |
+|------------------------------------------|------------------------------------|
+| `dom.event/type`                         | `event.type`                       |
+| `dom.event/key`                          | `event.key`                        |
+| `dom.event/shift-key`                    | `event.shiftKey`                   |
+| `dom.event/client-x`                     | `event.clientX`                    |
+| `dom.event.target/value`                 | `event.target.value`               |
+| `dom.event.target.dataset/subject`       | `event.target.dataset.subject`     |
+| `dom.event.target.dataset/item-id`       | `event.target.dataset.itemId`      |
+
+Rules of the translation:
+
+- Split the identifier on `.` and `/`. Each segment is a
+  successive property step on the event object.
+- Within a segment, kebab-case becomes camelCase before lookup
+  (`shift-key` → `shiftKey`, `item-id` → `itemId`).
+- The path is evaluated live, at handler-fire time. A missing
+  path (e.g. `event.pressure` on a `MouseEvent`) omits that
+  field from the asserted fact.
+- The `as:` type drives coercion: `text` → string, `entity` →
+  parse as URI, `integer` / `float` → number, `boolean` →
+  truthy.
+
+### Passing view context via `data-*`
+
+A click handler doesn't implicitly know the row it was rendered
+for. Surface what you need on the element with `data-*` and
+read it back through `dom.event.target.dataset/<name>`:
+
+```yaml
+view!: &todo-row
+  model: todo
+  display: !text/html |
+    <li>
+      <span>{title}</span>
+      <button onclick=complete data-todo={this}>done</button>
+    </li>
+
+concept!: &complete
+  transient: true
+  with:
+    todo:
+      the: dom.event.target.dataset/todo
+      as:  entity
+```
+
+The chain `data-todo={this}` → `event.target.dataset.todo` →
+`?todo` is visible at every step. The template author decides
+what to surface; the concept author decides what to read; both
+sides have to agree on the `data-<name>`.
+
+### Side effects: `preventDefault` and friends
+
+`preventDefault()` and `stopPropagation()` are method calls,
+not values. They have to run synchronously inside the event
+handler — by the time the worker responds to the assertion,
+the event is gone. Declare them as attributes under the
+`dom.event.do` namespace:
+
+| `the:` identifier                          | calls                              |
+|--------------------------------------------|------------------------------------|
+| `dom.event.do/prevent-default`             | `event.preventDefault()`           |
+| `dom.event.do/stop-propagation`            | `event.stopPropagation()`          |
+| `dom.event.do/stop-immediate-propagation`  | `event.stopImmediatePropagation()` |
+
+The attribute's presence in the concept's `with:` map is the
+signal — no value, no `as:` (there's nothing to read). The
+runtime sees a `the:` under `dom.event.do` and calls the method
+before the handler returns.
+
+```yaml
+concept!: &save
+  transient: true
+  with:
+    body:
+      the: dom.event.target/value
+      as:  text
+    prevent-default:
+      the: dom.event.do/prevent-default
+```
+
+```yaml
+view!: &save-form
+  model: note
+  display: !text/html |
+    <form onsubmit=save>
+      <textarea name="body"></textarea>
+      <button type="submit">save</button>
     </form>
-    <script type="module">
-      document.getElementById("add").addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const name = e.target.name.value;
-        await tonk.evaluate(`person!:\n  name: "${name}"\n`);
-        e.target.reset();
-      });
-    </script>
 ```
 
-Notation strings let you assert, query, and retract in one document,
-exactly as you would with `slide eval`. Quote string values so the
-parser doesn't read them as symbols.
+The submit asserts `save` with the textarea value, and
+`preventDefault` fires synchronously so the page doesn't
+reload.
 
-### Errors
+### `rule!:` — the reactive layer
 
-Bad bodies and worker-side failures surface as Promise rejections —
-for `subscribe`, errors raise on the stream and propagate out of the
-`for await` loop. Treat them like any other JS error:
+A rule has a head with one polarity and a body of premises:
 
-```js
-try {
-  await tonk.evaluate(`person!:\n  name: ${unquoted}\n`);
-} catch (e) {
-  alert(`couldn't save: ${e.message}`);
-}
+```yaml
+rule!:
+  assert!: <head-concept>      # or `retract!: <head-concept>`
+  when:
+    - assert: <concept>
+      where: { <field>: ?var, ... }
+    - ...
+  unless:                       # optional negative premises
+    - assert: <concept>
+      where: { ... }
 ```
 
-If `globalThis.tonk` is undefined entirely, the view is being mounted
-outside a host iframe and the bridge module never loaded.
+Three things to know:
 
-### Choosing between `<tonk-concept>` and `tonk.*`
+- **Head fields come from variable names in the body.** If the
+  head is `counter` (fields `this`, `count`) and the body binds
+  `?this` and `?count`, the head asserts `counter{this: ?this,
+  count: ?count}`. No explicit `where:` on the head.
+- **At least one positive `when:` premise must read a transient
+  concept.** This is the trigger. A rule with only persistent
+  premises is rejected at install time (the reactor can't tell
+  when it should fire). If you find yourself wanting a rule
+  without a trigger, you usually want a deductive query
+  instead.
+- **`assert!:` produces new facts; `retract!:` removes them.**
+  Multiple rules can share a head and compose by disjunction —
+  adding a new event means adding a new rule, not editing
+  existing ones.
 
-| Reach for `<tonk-concept>` when | Reach for `globalThis.tonk` when |
-|----------------------------------|----------------------------------|
-| You're rendering rows from a query | You're handling user input |
-| Each row fits a `<template>` | The UI doesn't decompose into rows |
-| No write path needed | You need `evaluate` (assertions, retractions) |
-| You want zero JS | You're already writing JS for other reasons |
+Built-in formulas like `math/sum` (`{of: ?a, with: ?b, is:
+?c}`) and comparisons participate as premises, threading values
+between bindings.
 
-They compose: a view can declaratively render a list with
-`<tonk-concept>` *and* run a script that calls `tonk.evaluate` to
-append to that list. The subscription `<tonk-concept>` holds will
-re-render automatically once the write commits.
+### Retracting from a rule
+
+To remove a fact in response to a transient, use `retract!:`:
+
+```yaml
+concept!: &complete
+  transient: true
+  with:
+    todo:
+      the: dom.event.target.dataset/todo
+      as:  entity
+
+rule!:
+  retract!: todo
+  when:
+    - assert: complete
+      where: { todo: ?this }
+```
+
+The rule fires on the click-derived `complete` transient and
+retracts the matched `todo`. The view's subscription sees the
+row disappear.
+
+### Opening the view in tonk-ui
+
+Once the view and the entity it renders are asserted, push the
+repo and mint a launcher URL with `slide share display`:
+
+```
+slide share display <subject> --view <view-name>
+```
+
+- `<subject>` is the bookmark name or `did:key:…` URI of the
+  entity to render — the value `<tonk-display>` reads as its
+  `entity` attribute.
+- `--view <view-name>` is the view's **anchor name** (the `&name`
+  on its `view!:`). `<tonk-display>` resolves it to the view
+  entity the name currently points at, then reads that view's
+  `model` (to project the subject's fields) and `display` (the
+  template). Omit `--view` and the element falls back to
+  carousel mode — every view published for the subject's model.
+
+There is no `--model`: the view declares its own `model`, so the
+caller never repeats it. The `view` concept is `{model,
+display}`; identity lives in the anchor name, not a `name` field.
+
+Concrete example, given the counter setup above:
+
+```
+slide share display my-counter --view counter-basic
+```
+
+The launcher URL points at the recipient's
+`/space/<space-name>/branch/main/display/my-counter?view=counter-basic`
+route. `<tonk-display>` resolves `id:counter-basic` to the
+current view entity, opens its subscriptions, and the
+`on<event>=<concept>` bindings in the template fire rules
+end-to-end. Edit the view by re-asserting `view!: &counter-basic`
+with new `display` — the name re-points and a refresh shows the
+latest, with no duplicate rows accumulating.
+
+Two related verbs to keep apart:
+
+- `slide share view` targets the iframe viewer
+  (`/branch/main/view/<entity>`), driven off entities carrying a
+  `text/html` claim. Useful for one-off HTML pages, but the
+  shell that route serves doesn't currently register
+  `<tonk-display>`, so events won't fire.
+- `slide share concept` targets the auto-rendered concept
+  listing — no template authoring, no events.
+
+`slide share display` is the verb that pairs with this guide.
+
+### What this replaces
+
+Earlier drafts of this guide pointed at a `globalThis.tonk` API
+(`tonk.query`, `tonk.subscribe`, `tonk.evaluate`) that lived on
+the window inside the served view iframe. That API still backs
+the host elements internally, but it is no longer the agent
+surface: writing views as `<script type="module">` blocks that
+call into it is a stopgap, not a pattern to lean on.
+
+The declarative path is the right one because every piece is
+the same machinery the rest of the system already uses:
+concepts, rules, queries, subscriptions. Adding a new
+interaction means adding a transient concept and a rule, not
+inventing a new request shape on the wire.
+
+### When the declarative path doesn't fit
+
+Anything that needs to render arbitrary HTML/CSS/JS without
+going through the concept-and-rule pipeline — third-party
+embeds, complex canvas drawing, a charting library — belongs
+in a sandboxed iframe view rather than in the main view body.
+That sandbox is a separate piece (`<tonk-portal>`) outside the
+scope of this guide.

--- a/rust/slide/src/guide-views.md
+++ b/rust/slide/src/guide-views.md
@@ -60,9 +60,10 @@ The runtime that activates `<tonk-concept>` is provided by the host
 and ships with every served view. You don't import it, link to it,
 or include it — assume it's there.
 
-For interactive views (forms, buttons, custom write flows), drop
-into a `<script type="module">` and use `globalThis.tonk` directly.
-See the next section.
+For interactive views (forms, buttons, custom write flows), wire
+DOM events declaratively with `on<event>=<concept>` attributes and
+let a rule pick up the resulting transient assertion. See the next
+section.
 
 Git-tag semantics apply: re-asserting the same body is idempotent
 (same content → same content-derived entity), a different body

--- a/rust/slide/src/guide.rs
+++ b/rust/slide/src/guide.rs
@@ -11,9 +11,10 @@
 //!    relies on. Kept out of the upstream notation guide so the
 //!    notation reference stays a clean syntax doc.
 //! 3. `slide/src/guide-views-dynamic.md` — companion to the views
-//!    addendum that documents the `globalThis.tonk` API agents
-//!    can call from `<script type="module">` inside a view body
-//!    when the declarative `<tonk-concept>` element doesn't fit.
+//!    addendum that documents the declarative reactivity surface:
+//!    `on<event>=<concept>` template attributes, the `dom.event`
+//!    namespace transient concepts read from, and `rule!:` heads
+//!    that turn those transients into downstream state.
 //! 4. `tonk-concept/SPEC.md` — the `<tonk-concept>` custom
 //!    element reference: source-attribute grammar, template
 //!    detection, `{field}` substitution. Relevant whenever an

--- a/rust/slide/src/share.rs
+++ b/rust/slide/src/share.rs
@@ -3,13 +3,17 @@
 //! upstream's URL, and return a launcher URL the human can paste
 //! into a browser.
 //!
-//! Two flavours, sharing a common skeleton:
+//! Three flavours, sharing a common skeleton:
 //!
 //! - [`share_concept`] points at tonk-ui's auto-rendered concept
 //!   route — `then=branch/main/concept/<name>`.
 //! - [`share_view`] points at the iframe viewer route — the
 //!   target resolves to an entity URI carrying a `text/html`
 //!   claim, and `then=branch/main/view/<entity>`.
+//! - [`share_display`] points at the `<tonk-display>` route —
+//!   `then=branch/main/display/<subject>?view=<view-name>`, the
+//!   declarative single-entity renderer. `<view-name>` is the
+//!   view's anchor name; the view carries its own `model`.
 //!
 //! The launcher URL extends the standard invite URL with two
 //! extra query parameters:
@@ -34,7 +38,7 @@
 
 use dialog_artifacts::Entity;
 use thiserror::Error;
-use url::Url;
+use url::{Url, form_urlencoded};
 
 use crate::ExitCode;
 use crate::invite::{self, InviteError};
@@ -88,6 +92,35 @@ pub struct ShareOutcome {
     pub space_name: String,
 }
 
+/// Outcome of [`share_display`].
+#[derive(Debug)]
+pub struct ShareDisplayOutcome {
+    /// The launcher URL — `then=` resolves to the
+    /// `<tonk-display>` route with `?view=…` (the view's anchor
+    /// name), and `?model=…` only in carousel mode.
+    pub url: String,
+    /// Local name of the remote whose endpoint got embedded.
+    pub remote_name: String,
+    /// Endpoint URL.
+    pub remote_endpoint: String,
+    /// Bookmark the subject was resolved through, when the caller
+    /// passed a name rather than a raw entity URI. `None` when
+    /// the caller passed `did:key:…` directly.
+    pub subject_name: Option<String>,
+    /// Entity URI the subject resolved to. Always populated, even
+    /// when the URL carries the bookmark name verbatim (tonk-ui
+    /// resolves the bookmark client-side).
+    pub subject_entity: Entity,
+    /// View anchor name forwarded as `?view=`, when supplied.
+    pub view_name: Option<String>,
+    /// Model (concept name or URI) forwarded as `?model=`, when
+    /// supplied — carousel mode only; with `--view` the view
+    /// declares its own model. Mirrors what the caller passed.
+    pub model: Option<String>,
+    /// `name=` value embedded into the URL.
+    pub space_name: String,
+}
+
 /// Outcome of [`share_view`].
 #[derive(Debug)]
 pub struct ShareViewOutcome {
@@ -129,6 +162,15 @@ pub enum ShareError {
          run `slide views` to see what's available"
     )]
     ViewNotFound {
+        /// The bookmark or entity URI that didn't resolve.
+        target: String,
+    },
+    /// A bookmark name passed to [`share_display`] didn't resolve
+    /// to any entity. Distinct from [`Self::ViewNotFound`] so the
+    /// error message doesn't misdirect the agent to `slide views`,
+    /// which only lists `text/html`-bearing entities.
+    #[error("subject '{target}' is not bookmarked on this branch")]
+    SubjectNotFound {
         /// The bookmark or entity URI that didn't resolve.
         target: String,
     },
@@ -291,7 +333,8 @@ pub async fn share_view(
     target: &str,
     options: ShareOptions,
 ) -> Result<ShareViewOutcome, ShareError> {
-    let (entity, view_name) = resolve_view_target(site, target).await?;
+    let (entity, view_name) =
+        resolve_bookmark_or_uri(site, target, |t| ShareError::ViewNotFound { target: t }).await?;
     if !views::entity_has_text_html(site, &entity)
         .await
         .map_err(|e| ShareError::Io(format!("text/html lookup failed: {e}")))?
@@ -323,12 +366,118 @@ pub async fn share_view(
     })
 }
 
+/// Push the local repo and mint a launcher URL that points at
+/// the `<tonk-display>` route with the supplied view and model
+/// selectors baked into the query string.
+///
+/// Subject resolution is identical to [`share_view`] (bookmark
+/// name or `did:key:…` URI). The model argument can be a concept
+/// name (validated against the local schema) or a URI (passed
+/// through verbatim). The view argument is forwarded without
+/// validation — `<tonk-display>` falls back to a generic
+/// per-field rendering when the named view doesn't resolve, so a
+/// typo surfaces in the UI rather than failing the share.
+///
+/// Steps parallel [`share_view`]:
+///
+/// 1. Resolve the subject to an entity + optional bookmark.
+/// 2. Validate the model when it looks like a name.
+/// 3. Run the shared share prep.
+/// 4. Mint the invite.
+/// 5. Compose the launcher URL with the `?view=&model=` suffix.
+pub async fn share_display(
+    site: &SlideSite,
+    subject: &str,
+    view_name: Option<&str>,
+    model: Option<&str>,
+    options: ShareOptions,
+) -> Result<ShareDisplayOutcome, ShareError> {
+    let (entity, subject_name) =
+        resolve_bookmark_or_uri(site, subject, |t| ShareError::SubjectNotFound { target: t })
+            .await?;
+
+    // Validate the model when it's a bare identifier. URI-shaped
+    // models (anything containing `:`) pass through — same
+    // convention as `did:key:…` subjects.
+    if let Some(name) = model.filter(|m| !m.contains(':')) {
+        let concepts = schema::list_concepts(site)
+            .await
+            .map_err(|e| ShareError::Io(format!("failed to list concepts: {e}")))?;
+        if !concepts.iter().any(|c| c.name == name) {
+            return Err(ShareError::ConceptNotFound {
+                name: name.to_owned(),
+            });
+        }
+    }
+
+    let remote_record = prepare_share(site, options.remote.as_deref()).await?;
+    let space_name = effective_space_name(options.space_name.as_deref());
+
+    // Prefer the bookmark name in the URL when the caller passed
+    // one — tonk-ui resolves it back through the same Name index.
+    // Bookmarks survive entity-URI changes (re-asserting a view
+    // body produces a new entity); the name does not.
+    let subject_segment = subject_name.as_deref().unwrap_or(subject);
+    let then = compose_display_then(subject_segment, view_name, model);
+    let url = mint_and_compose(
+        site,
+        options.ui_base.as_deref(),
+        &remote_record,
+        &space_name,
+        &then,
+    )
+    .await?;
+
+    Ok(ShareDisplayOutcome {
+        url,
+        remote_name: remote_record.name,
+        remote_endpoint: remote_record.endpoint,
+        subject_name,
+        subject_entity: entity,
+        view_name: view_name.map(str::to_owned),
+        model: model.map(str::to_owned),
+        space_name,
+    })
+}
+
+/// Build the `then=` suffix for a display share: a path under the
+/// recipient's space root with optional `view` / `model` query
+/// parameters appended. Values are form-urlencoded so a stray `&`
+/// or `?` in a name doesn't corrupt the inner query when tonk-ui
+/// pastes it onto its space-root path.
+fn compose_display_then(subject: &str, view: Option<&str>, model: Option<&str>) -> String {
+    let mut path = format!(
+        "branch/{branch}/display/{subject}",
+        branch = site::BRANCH_NAME,
+    );
+    let mut pairs = form_urlencoded::Serializer::new(String::new());
+    let mut has_any = false;
+    if let Some(view) = view {
+        pairs.append_pair("view", view);
+        has_any = true;
+    }
+    if let Some(model) = model {
+        pairs.append_pair("model", model);
+        has_any = true;
+    }
+    if has_any {
+        path.push('?');
+        path.push_str(&pairs.finish());
+    }
+    path
+}
+
 /// Map a `<target>` argument into an `(entity, optional_name)`
 /// pair. `did:key:…` strings are taken as URIs; everything else
-/// is looked up as a `dialog.meta/name` bookmark.
-async fn resolve_view_target(
+/// is looked up as a `dialog.meta/name` bookmark. `missing` is
+/// invoked when the bookmark doesn't resolve — callers choose
+/// between [`ShareError::ViewNotFound`] and
+/// [`ShareError::SubjectNotFound`] so the message matches the
+/// verb the user typed.
+async fn resolve_bookmark_or_uri(
     site: &SlideSite,
     target: &str,
+    missing: fn(String) -> ShareError,
 ) -> Result<(Entity, Option<String>), ShareError> {
     if target.is_empty() {
         return Err(ShareError::InvalidTarget {
@@ -350,9 +499,7 @@ async fn resolve_view_target(
     let entity = views::entity_for_name(site, target)
         .await
         .map_err(|e| ShareError::Io(format!("bookmark lookup failed: {e}")))?
-        .ok_or_else(|| ShareError::ViewNotFound {
-            target: target.to_owned(),
-        })?;
+        .ok_or_else(|| missing(target.to_owned()))?;
     Ok((entity, Some(target.to_owned())))
 }
 

--- a/rust/slide/src/share.rs
+++ b/rust/slide/src/share.rs
@@ -141,7 +141,8 @@ pub struct ShareViewOutcome {
     pub space_name: String,
 }
 
-/// Failure modes for [`share_concept`] and [`share_view`].
+/// Failure modes for [`share_concept`], [`share_view`], and
+/// [`share_display`].
 #[derive(Debug, Error)]
 pub enum ShareError {
     /// `<name>` doesn't resolve to a concept on the local
@@ -374,9 +375,12 @@ pub async fn share_view(
 /// name or `did:key:…` URI). The model argument can be a concept
 /// name (validated against the local schema) or a URI (passed
 /// through verbatim). The view argument is forwarded without
-/// validation — `<tonk-display>` falls back to a generic
-/// per-field rendering when the named view doesn't resolve, so a
-/// typo surfaces in the UI rather than failing the share.
+/// validation: `<tonk-display>` resolves the name to a view
+/// entity at render time, and a name that doesn't resolve
+/// surfaces as an error in the UI (not a generic fallback) — so
+/// a typo isn't caught here, it fails on the recipient's screen.
+/// Omitting `--view` entirely is the only thing that selects
+/// carousel mode.
 ///
 /// Steps parallel [`share_view`]:
 ///
@@ -442,9 +446,12 @@ pub async fn share_display(
 
 /// Build the `then=` suffix for a display share: a path under the
 /// recipient's space root with optional `view` / `model` query
-/// parameters appended. Values are form-urlencoded so a stray `&`
-/// or `?` in a name doesn't corrupt the inner query when tonk-ui
-/// pastes it onto its space-root path.
+/// parameters appended. The `view`/`model` values are
+/// form-urlencoded so a stray `&` or `?` in a name doesn't corrupt
+/// the inner query when tonk-ui pastes it onto its space-root path.
+/// The `subject` is left verbatim as a path segment — `did:key:…`
+/// URIs need their `:` intact and bookmark names don't carry query
+/// delimiters.
 fn compose_display_then(subject: &str, view: Option<&str>, model: Option<&str>) -> String {
     let mut path = format!(
         "branch/{branch}/display/{subject}",

--- a/rust/slide/tests/site.rs
+++ b/rust/slide/tests/site.rs
@@ -1209,7 +1209,9 @@ mod when_sharing_a_display {
         // the inner query, with no extra parameters leaking in.
         let inner = then.split_once('?').expect("inner query").1;
         let inner_pairs: std::collections::HashMap<_, _> =
-            url::form_urlencoded::parse(inner.as_bytes()).into_owned().collect();
+            url::form_urlencoded::parse(inner.as_bytes())
+                .into_owned()
+                .collect();
         assert_eq!(inner_pairs.get("view").map(String::as_str), Some("a&b=c?d"));
         assert!(!inner_pairs.contains_key("b"));
         Ok(())

--- a/rust/slide/tests/site.rs
+++ b/rust/slide/tests/site.rs
@@ -1173,13 +1173,45 @@ mod when_sharing_a_display {
             .query_pairs()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect();
-        // No trailing `?` when neither selector is present —
-        // tonk-ui's element fallbacks (carousel for missing view,
-        // all-attributes query for missing model) light up.
+        // No trailing `?` when neither selector is present. The
+        // library `share_display` stays permissive here (it only
+        // composes the URL); the CLI is where exactly-one-of is
+        // enforced, so a neither-selector launcher isn't reachable
+        // from `slide share display`.
         assert_eq!(
             pairs.get("then").map(String::as_str),
             Some("branch/main/display/buy-milk"),
         );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_form_encodes_query_delimiters_in_a_view_name() -> Result<()> {
+        // A view name carrying `&`/`?`/`=` must be form-encoded so it
+        // can't corrupt or inject into the inner query string. The
+        // round-trip through `Url::query_pairs` recovers the original.
+        let test = shareable_display_site().await?;
+        let outcome = share::share_display(
+            &test.site,
+            "buy-milk",
+            Some("a&b=c?d"),
+            None,
+            ShareOptions::default(),
+        )
+        .await?;
+        let url = Url::parse(&outcome.url)?;
+        let pairs: std::collections::HashMap<_, _> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        let then = pairs.get("then").map(String::as_str).expect("then param");
+        // The view value survives intact after tonk-ui would re-parse
+        // the inner query, with no extra parameters leaking in.
+        let inner = then.split_once('?').expect("inner query").1;
+        let inner_pairs: std::collections::HashMap<_, _> =
+            url::form_urlencoded::parse(inner.as_bytes()).into_owned().collect();
+        assert_eq!(inner_pairs.get("view").map(String::as_str), Some("a&b=c?d"));
+        assert!(!inner_pairs.contains_key("b"));
         Ok(())
     }
 

--- a/rust/slide/tests/site.rs
+++ b/rust/slide/tests/site.rs
@@ -1208,7 +1208,10 @@ mod when_sharing_a_display {
         // URI subjects land in `then=` verbatim — no bookmark to
         // prefer over them.
         let expected = format!("branch/main/display/{entity}?view=basic&model=task");
-        assert_eq!(pairs.get("then").map(String::as_str), Some(expected.as_str()));
+        assert_eq!(
+            pairs.get("then").map(String::as_str),
+            Some(expected.as_str())
+        );
         Ok(())
     }
 

--- a/rust/slide/tests/site.rs
+++ b/rust/slide/tests/site.rs
@@ -1081,6 +1081,199 @@ mod when_sharing_a_concept {
     }
 }
 
+mod when_sharing_a_display {
+    use anyhow::Result;
+    use dialog_repository::Branch;
+    use slide::remote;
+    use slide::share::{self, ShareError, ShareOptions};
+    use slide::views;
+    use url::Url;
+
+    use crate::common::{self, ATTRIBUTE_DECL, CONCEPT_DECL};
+
+    const ENDPOINT: &str = "https://access.example.test/ucan/";
+
+    async fn wire_local_upstream(test: &common::TestSite) -> Result<Branch> {
+        let upstream = test
+            .site
+            .repository
+            .branch("upstream")
+            .open()
+            .perform(&test.site.operator)
+            .await?;
+        test.site
+            .branch
+            .set_upstream(&upstream)
+            .perform(&test.site.operator)
+            .await?;
+        Ok(upstream)
+    }
+
+    /// Site with a `task` concept, a bookmarked `task` instance,
+    /// one remote, and an in-process upstream — the shape
+    /// `share_display` expects.
+    async fn shareable_display_site() -> Result<common::TestSite> {
+        let test = common::TestSite::new().await?;
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+        test.eval_inline(
+            r#"task!: &buy-milk
+  title: "Buy milk"
+  done:  false
+"#,
+        )
+        .await?;
+        wire_local_upstream(&test).await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+        Ok(test)
+    }
+
+    #[dialog_common::test]
+    async fn it_produces_a_launcher_url_with_view_and_model_in_the_then_suffix() -> Result<()> {
+        let test = shareable_display_site().await?;
+        let outcome = share::share_display(
+            &test.site,
+            "buy-milk",
+            Some("basic"),
+            Some("task"),
+            ShareOptions {
+                ui_base: Some("https://ui.example.test/join".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(outcome.subject_name.as_deref(), Some("buy-milk"));
+        assert_eq!(outcome.view_name.as_deref(), Some("basic"));
+        assert_eq!(outcome.model.as_deref(), Some("task"));
+        assert_eq!(outcome.remote_name, "origin");
+
+        let url = Url::parse(&outcome.url)?;
+        let pairs: std::collections::HashMap<_, _> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        // `then=` carries the bookmark (not the resolved entity)
+        // so the URL survives entity-URI churn.
+        assert_eq!(
+            pairs.get("then").map(String::as_str),
+            Some("branch/main/display/buy-milk?view=basic&model=task"),
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_omits_query_params_when_neither_view_nor_model_is_supplied() -> Result<()> {
+        let test = shareable_display_site().await?;
+        let outcome =
+            share::share_display(&test.site, "buy-milk", None, None, ShareOptions::default())
+                .await?;
+        let url = Url::parse(&outcome.url)?;
+        let pairs: std::collections::HashMap<_, _> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        // No trailing `?` when neither selector is present —
+        // tonk-ui's element fallbacks (carousel for missing view,
+        // all-attributes query for missing model) light up.
+        assert_eq!(
+            pairs.get("then").map(String::as_str),
+            Some("branch/main/display/buy-milk"),
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_raw_entity_uri_subject() -> Result<()> {
+        let test = shareable_display_site().await?;
+        let entity = views::entity_for_name(&test.site, "buy-milk")
+            .await?
+            .expect("buy-milk should resolve");
+        let outcome = share::share_display(
+            &test.site,
+            &entity.to_string(),
+            Some("basic"),
+            Some("task"),
+            ShareOptions::default(),
+        )
+        .await?;
+
+        assert!(outcome.subject_name.is_none());
+        assert_eq!(outcome.subject_entity, entity);
+        let url = Url::parse(&outcome.url)?;
+        let pairs: std::collections::HashMap<_, _> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        // URI subjects land in `then=` verbatim — no bookmark to
+        // prefer over them.
+        let expected = format!("branch/main/display/{entity}?view=basic&model=task");
+        assert_eq!(pairs.get("then").map(String::as_str), Some(expected.as_str()));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_when_the_subject_bookmark_does_not_resolve() -> Result<()> {
+        let test = shareable_display_site().await?;
+        let result = share::share_display(
+            &test.site,
+            "ghost",
+            Some("basic"),
+            Some("task"),
+            ShareOptions::default(),
+        )
+        .await;
+        match result {
+            Err(ShareError::SubjectNotFound { target }) => assert_eq!(target, "ghost"),
+            other => panic!("expected SubjectNotFound, got: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_when_the_model_concept_is_not_defined() -> Result<()> {
+        let test = shareable_display_site().await?;
+        let result = share::share_display(
+            &test.site,
+            "buy-milk",
+            Some("basic"),
+            Some("nope"),
+            ShareOptions::default(),
+        )
+        .await;
+        match result {
+            Err(ShareError::ConceptNotFound { name }) => assert_eq!(name, "nope"),
+            other => panic!("expected ConceptNotFound, got: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_uri_shaped_model_without_validation() -> Result<()> {
+        // A `:`-bearing model passes through without a concept
+        // lookup. Mirrors the convention for `did:key:…` subjects.
+        let test = shareable_display_site().await?;
+        let outcome = share::share_display(
+            &test.site,
+            "buy-milk",
+            None,
+            Some("did:key:zPretendConcept"),
+            ShareOptions::default(),
+        )
+        .await?;
+        let url = Url::parse(&outcome.url)?;
+        let pairs: std::collections::HashMap<_, _> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert_eq!(
+            pairs.get("then").map(String::as_str),
+            Some("branch/main/display/buy-milk?model=did%3Akey%3AzPretendConcept"),
+        );
+        Ok(())
+    }
+}
+
 mod when_migrating_from_carry {
     use anyhow::Result;
     use slide::migrate::{self, Mode};

--- a/rust/tonk-concept/src/resolve.rs
+++ b/rust/tonk-concept/src/resolve.rs
@@ -137,7 +137,7 @@ pub fn phase1_query(parsed: &ParsedSource) -> Query {
 pub fn phase2_query(
     descriptor_json: &str,
     filters: &BTreeMap<String, String>,
-) -> Result<Query, serde_json::Error> {
+) -> Result<Query, Phase2Error> {
     let predicate: serde_json::Value = serde_json::from_str(descriptor_json)?;
     // Discover the field names from the descriptor's `with` map
     // so we can put one term per field into the wire query.
@@ -152,7 +152,7 @@ pub fn phase2_query(
         let term = match filters.get(field) {
             Some(raw) => {
                 let as_type = spec.get("as").and_then(|v| v.as_str());
-                coerce_filter_value(as_type, raw)
+                coerce_filter_value(field, as_type, raw)?
             }
             None => json!({ "?": { "name": field } }),
         };
@@ -162,35 +162,94 @@ pub fn phase2_query(
         "terms": terms,
         "predicate": predicate
     });
-    serde_json::from_value(body)
+    Ok(serde_json::from_value(body)?)
 }
 
 /// Coerce a `?key=value` filter string to a JSON value matching the
 /// field's declared type (the descriptor's `as`), so the constant
 /// constraint compares against the stored value rather than a string.
-/// A value that doesn't parse for a numeric type falls back to a
-/// string — the constraint then simply fails to match instead of
-/// erroring.
-fn coerce_filter_value(as_type: Option<&str>, raw: &str) -> serde_json::Value {
-    match as_type {
-        Some("UnsignedInteger") => raw.parse::<u64>().map_or_else(|_| json!(raw), |n| json!(n)),
-        Some("SignedInteger") => raw.parse::<i64>().map_or_else(|_| json!(raw), |n| json!(n)),
-        Some("Float") => raw.parse::<f64>().map_or_else(|_| json!(raw), |n| json!(n)),
+///
+/// A value that doesn't parse for a numeric or boolean type is an
+/// error, not a string fallback: a string constant on a numeric
+/// field can never match the stored value, so the query would
+/// return nothing and the user couldn't tell a typo'd filter from
+/// a genuinely empty result. Surfacing it lets the caller render a
+/// visible error instead. Text/Entity/Symbol/Bytes (and unknown
+/// types) are inherently string-shaped, so they pass through.
+fn coerce_filter_value(
+    field: &str,
+    as_type: Option<&str>,
+    raw: &str,
+) -> Result<serde_json::Value, Phase2Error> {
+    let coerced = match as_type {
+        Some("UnsignedInteger") => raw.parse::<u64>().ok().map(|n| json!(n)),
+        Some("SignedInteger") => raw.parse::<i64>().ok().map(|n| json!(n)),
+        // Reject non-finite floats too: `serde_json` can't represent
+        // `inf`/`NaN` and would silently serialize them as `null`.
+        Some("Float") => raw.parse::<f64>().ok().filter(|n| n.is_finite()).map(|n| json!(n)),
         Some("Boolean") => match raw {
-            "true" => json!(true),
-            "false" => json!(false),
-            _ => json!(raw),
+            "true" => Some(json!(true)),
+            "false" => Some(json!(false)),
+            _ => None,
         },
         // Text, Entity, Symbol, Bytes, or unknown: keep as a string.
-        _ => json!(raw),
+        _ => return Ok(json!(raw)),
+    };
+    coerced.ok_or_else(|| Phase2Error::Filter {
+        field: field.to_owned(),
+        as_type: as_type.unwrap_or("Text").to_owned(),
+        value: raw.to_owned(),
+    })
+}
+
+/// Why [`phase2_query`] couldn't build a subscription query.
+#[derive(Debug)]
+pub enum Phase2Error {
+    /// The descriptor JSON or the assembled query body didn't
+    /// deserialize into the wire `Query` shape.
+    Json(serde_json::Error),
+    /// A `?field=value` filter targets a numeric or boolean field
+    /// but the value doesn't parse as that type.
+    Filter {
+        /// The descriptor field the filter constrains.
+        field: String,
+        /// The field's declared `as:` type.
+        as_type: String,
+        /// The raw filter value that failed to parse.
+        value: String,
+    },
+}
+
+impl std::fmt::Display for Phase2Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json(e) => write!(f, "{e}"),
+            Self::Filter {
+                field,
+                as_type,
+                value,
+            } => write!(f, "filter `{field}={value}` is not a valid {as_type}"),
+        }
+    }
+}
+
+impl std::error::Error for Phase2Error {}
+
+impl From<serde_json::Error> for Phase2Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
 
-    #[test]
+    #[dialog_common::test]
     fn it_parses_a_bare_name() {
         let parsed = parse_source("person");
         assert_eq!(parsed.name_or_uri, "person");
@@ -198,21 +257,21 @@ mod tests {
         assert!(!parsed.is_uri());
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_parses_a_uri() {
         let parsed = parse_source("did:key:zPerson");
         assert_eq!(parsed.name_or_uri, "did:key:zPerson");
         assert!(parsed.is_uri());
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_parses_a_name_with_one_filter() {
         let parsed = parse_source("person?name=Alice");
         assert_eq!(parsed.name_or_uri, "person");
         assert_eq!(parsed.filters.get("name"), Some(&"Alice".to_string()));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_parses_a_filter_with_projection_marker() {
         // The bare `&age` is ignored — projection is implicit.
         let parsed = parse_source("person?name=Alice&age");
@@ -220,19 +279,19 @@ mod tests {
         assert_eq!(parsed.filters.get("name"), Some(&"Alice".to_string()));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_decodes_percent_encoded_filter_values() {
         let parsed = parse_source("person?name=Alice%20B");
         assert_eq!(parsed.filters.get("name"), Some(&"Alice B".to_string()));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_decodes_plus_as_space() {
         let parsed = parse_source("person?name=Alice+B");
         assert_eq!(parsed.filters.get("name"), Some(&"Alice B".to_string()));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_a_phase1_query_filtered_by_name() {
         let parsed = parse_source("person");
         let q = phase1_query(&parsed);
@@ -242,7 +301,7 @@ mod tests {
         assert_eq!(value, json!("person"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_a_phase1_query_filtered_by_uri() {
         let parsed = parse_source("did:key:zPerson");
         let q = phase1_query(&parsed);
@@ -251,7 +310,7 @@ mod tests {
         assert_eq!(value, json!("did:key:zPerson"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_a_phase2_query_projecting_every_field() {
         let descriptor = r#"{"with":{
             "name": { "the": "person/name", "as": "Text",   "cardinality": "one" },
@@ -264,7 +323,7 @@ mod tests {
         assert!(q.terms.contains("age"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_a_phase2_query_constraining_filtered_fields() {
         let descriptor = r#"{"with":{
             "name": { "the": "person/name", "as": "Text", "cardinality": "one" }
@@ -277,12 +336,16 @@ mod tests {
         assert_eq!(value, json!("Alice"));
     }
 
-    fn filtered_term(as_type: &str, raw: &str) -> serde_json::Value {
+    fn filtered_query(as_type: &str, raw: &str) -> Result<Query, Phase2Error> {
         let descriptor =
             format!(r#"{{"with":{{"f":{{"the":"x/f","as":"{as_type}","cardinality":"one"}}}}}}"#);
         let mut filters = BTreeMap::new();
         filters.insert("f".to_string(), raw.to_string());
-        let q = phase2_query(&descriptor, &filters).unwrap();
+        phase2_query(&descriptor, &filters)
+    }
+
+    fn filtered_term(as_type: &str, raw: &str) -> serde_json::Value {
+        let q = filtered_query(as_type, raw).expect("query builds");
         let term = q.terms.get("f").expect("f term");
         serde_json::to_value(term).unwrap()
     }
@@ -290,36 +353,71 @@ mod tests {
     // An integer-typed field filtered via `?f=5` must constrain on
     // the number `5`, not the string `"5"` — otherwise it never
     // matches the stored integer value.
-    #[test]
+    #[dialog_common::test]
     fn it_coerces_an_unsigned_integer_filter_to_a_number() {
         assert_eq!(filtered_term("UnsignedInteger", "5"), json!(5));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_coerces_a_signed_integer_filter_to_a_number() {
         assert_eq!(filtered_term("SignedInteger", "-5"), json!(-5));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_coerces_a_float_filter_to_a_number() {
         assert_eq!(filtered_term("Float", "3.5"), json!(3.5));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_coerces_a_boolean_filter_to_a_bool() {
         assert_eq!(filtered_term("Boolean", "true"), json!(true));
     }
 
     // Text/Entity/etc. stay strings, as before.
-    #[test]
+    #[dialog_common::test]
     fn it_keeps_a_text_filter_as_a_string() {
         assert_eq!(filtered_term("Text", "5"), json!("5"));
     }
 
-    // A non-numeric value for a numeric field falls back to a
-    // string rather than panicking; it simply won't match.
-    #[test]
-    fn it_falls_back_to_a_string_for_an_unparseable_numeric_filter() {
-        assert_eq!(filtered_term("UnsignedInteger", "lots"), json!("lots"));
+    // A non-numeric value for a numeric field is rejected rather
+    // than coerced to a string constant that could never match the
+    // stored integer — that would render a blank result the user
+    // couldn't distinguish from a genuinely empty set.
+    #[dialog_common::test]
+    fn it_rejects_an_unparseable_unsigned_integer_filter() {
+        let err = filtered_query("UnsignedInteger", "lots").expect_err("should reject");
+        assert!(
+            matches!(&err, Phase2Error::Filter { field, as_type, value }
+                if field == "f" && as_type == "UnsignedInteger" && value == "lots"),
+            "got {err:?}",
+        );
+    }
+
+    // A negative value can't be an `UnsignedInteger`; it's rejected,
+    // not silently kept as a string.
+    #[dialog_common::test]
+    fn it_rejects_a_negative_value_for_an_unsigned_integer_filter() {
+        let err = filtered_query("UnsignedInteger", "-5").expect_err("should reject");
+        assert!(matches!(err, Phase2Error::Filter { .. }), "got {err:?}");
+    }
+
+    // `inf`/`NaN` parse as `f64` but `serde_json` can't represent
+    // them; rejecting avoids a silent `null` constant.
+    #[dialog_common::test]
+    fn it_rejects_a_non_finite_float_filter() {
+        for raw in ["inf", "NaN", "-inf"] {
+            let err = filtered_query("Float", raw).expect_err("should reject");
+            assert!(matches!(err, Phase2Error::Filter { .. }), "{raw}: got {err:?}");
+        }
+    }
+
+    // Boolean coercion is exact: only `true`/`false`. Anything else
+    // (`True`, `1`, `yes`) is rejected.
+    #[dialog_common::test]
+    fn it_rejects_a_non_boolean_value_for_a_boolean_filter() {
+        for raw in ["True", "1", "yes"] {
+            let err = filtered_query("Boolean", raw).expect_err("should reject");
+            assert!(matches!(err, Phase2Error::Filter { .. }), "{raw}: got {err:?}");
+        }
     }
 }

--- a/rust/tonk-concept/src/resolve.rs
+++ b/rust/tonk-concept/src/resolve.rs
@@ -186,7 +186,11 @@ fn coerce_filter_value(
         Some("SignedInteger") => raw.parse::<i64>().ok().map(|n| json!(n)),
         // Reject non-finite floats too: `serde_json` can't represent
         // `inf`/`NaN` and would silently serialize them as `null`.
-        Some("Float") => raw.parse::<f64>().ok().filter(|n| n.is_finite()).map(|n| json!(n)),
+        Some("Float") => raw
+            .parse::<f64>()
+            .ok()
+            .filter(|n| n.is_finite())
+            .map(|n| json!(n)),
         Some("Boolean") => match raw {
             "true" => Some(json!(true)),
             "false" => Some(json!(false)),
@@ -407,7 +411,10 @@ mod tests {
     fn it_rejects_a_non_finite_float_filter() {
         for raw in ["inf", "NaN", "-inf"] {
             let err = filtered_query("Float", raw).expect_err("should reject");
-            assert!(matches!(err, Phase2Error::Filter { .. }), "{raw}: got {err:?}");
+            assert!(
+                matches!(err, Phase2Error::Filter { .. }),
+                "{raw}: got {err:?}"
+            );
         }
     }
 
@@ -417,7 +424,10 @@ mod tests {
     fn it_rejects_a_non_boolean_value_for_a_boolean_filter() {
         for raw in ["True", "1", "yes"] {
             let err = filtered_query("Boolean", raw).expect_err("should reject");
-            assert!(matches!(err, Phase2Error::Filter { .. }), "{raw}: got {err:?}");
+            assert!(
+                matches!(err, Phase2Error::Filter { .. }),
+                "{raw}: got {err:?}"
+            );
         }
     }
 }

--- a/rust/tonk-concept/src/resolve.rs
+++ b/rust/tonk-concept/src/resolve.rs
@@ -148,9 +148,12 @@ pub fn phase2_query(
         .unwrap_or_default();
     let mut terms: IndexMap<String, serde_json::Value> = IndexMap::new();
     terms.insert("this".into(), json!({ "?": { "name": "this" } }));
-    for field in with.keys() {
+    for (field, spec) in &with {
         let term = match filters.get(field) {
-            Some(v) => json!(v),
+            Some(raw) => {
+                let as_type = spec.get("as").and_then(|v| v.as_str());
+                coerce_filter_value(as_type, raw)
+            }
             None => json!({ "?": { "name": field } }),
         };
         terms.insert(field.clone(), term);
@@ -160,6 +163,27 @@ pub fn phase2_query(
         "predicate": predicate
     });
     serde_json::from_value(body)
+}
+
+/// Coerce a `?key=value` filter string to a JSON value matching the
+/// field's declared type (the descriptor's `as`), so the constant
+/// constraint compares against the stored value rather than a string.
+/// A value that doesn't parse for a numeric type falls back to a
+/// string — the constraint then simply fails to match instead of
+/// erroring.
+fn coerce_filter_value(as_type: Option<&str>, raw: &str) -> serde_json::Value {
+    match as_type {
+        Some("UnsignedInteger") => raw.parse::<u64>().map_or_else(|_| json!(raw), |n| json!(n)),
+        Some("SignedInteger") => raw.parse::<i64>().map_or_else(|_| json!(raw), |n| json!(n)),
+        Some("Float") => raw.parse::<f64>().map_or_else(|_| json!(raw), |n| json!(n)),
+        Some("Boolean") => match raw {
+            "true" => json!(true),
+            "false" => json!(false),
+            _ => json!(raw),
+        },
+        // Text, Entity, Symbol, Bytes, or unknown: keep as a string.
+        _ => json!(raw),
+    }
 }
 
 #[cfg(test)]
@@ -251,5 +275,51 @@ mod tests {
         let term = q.terms.get("name").expect("name term");
         let value: serde_json::Value = serde_json::to_value(term).unwrap();
         assert_eq!(value, json!("Alice"));
+    }
+
+    fn filtered_term(as_type: &str, raw: &str) -> serde_json::Value {
+        let descriptor =
+            format!(r#"{{"with":{{"f":{{"the":"x/f","as":"{as_type}","cardinality":"one"}}}}}}"#);
+        let mut filters = BTreeMap::new();
+        filters.insert("f".to_string(), raw.to_string());
+        let q = phase2_query(&descriptor, &filters).unwrap();
+        let term = q.terms.get("f").expect("f term");
+        serde_json::to_value(term).unwrap()
+    }
+
+    // An integer-typed field filtered via `?f=5` must constrain on
+    // the number `5`, not the string `"5"` — otherwise it never
+    // matches the stored integer value.
+    #[test]
+    fn it_coerces_an_unsigned_integer_filter_to_a_number() {
+        assert_eq!(filtered_term("UnsignedInteger", "5"), json!(5));
+    }
+
+    #[test]
+    fn it_coerces_a_signed_integer_filter_to_a_number() {
+        assert_eq!(filtered_term("SignedInteger", "-5"), json!(-5));
+    }
+
+    #[test]
+    fn it_coerces_a_float_filter_to_a_number() {
+        assert_eq!(filtered_term("Float", "3.5"), json!(3.5));
+    }
+
+    #[test]
+    fn it_coerces_a_boolean_filter_to_a_bool() {
+        assert_eq!(filtered_term("Boolean", "true"), json!(true));
+    }
+
+    // Text/Entity/etc. stay strings, as before.
+    #[test]
+    fn it_keeps_a_text_filter_as_a_string() {
+        assert_eq!(filtered_term("Text", "5"), json!("5"));
+    }
+
+    // A non-numeric value for a numeric field falls back to a
+    // string rather than panicking; it simply won't match.
+    #[test]
+    fn it_falls_back_to_a_string_for_an_unparseable_numeric_filter() {
+        assert_eq!(filtered_term("UnsignedInteger", "lots"), json!("lots"));
     }
 }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -936,7 +936,9 @@ mod dom {
         // several non-component levels deep is still found.
         #[dialog_common::test]
         fn it_finds_an_own_template_nested_in_plain_wrappers() {
-            let host = host_with("<section><div><ul><template><li>{a}</li></template></ul></div></section>");
+            let host = host_with(
+                "<section><div><ul><template><li>{a}</li></template></ul></div></section>",
+            );
             assert!(find_template(&host).is_some());
         }
 
@@ -958,9 +960,7 @@ mod dom {
         #[dialog_common::test]
         fn it_skips_templates_nested_in_other_owning_components() {
             for tag in ["tonk-display", "tonk-view"] {
-                let host = host_with(&format!(
-                    "<{tag}><template><p>{{a}}</p></template></{tag}>"
-                ));
+                let host = host_with(&format!("<{tag}><template><p>{{a}}</p></template></{tag}>"));
                 assert!(
                     find_template(&host).is_none(),
                     "template nested in <{tag}> should be skipped",

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -510,6 +510,13 @@ mod dom {
     /// Custom elements that snapshot their own `<template>` child in
     /// their `connected_callback`. Their templates belong to them,
     /// so an ancestor's template search must skip their subtrees.
+    ///
+    /// Keep this list in sync with the elements that actually
+    /// register a template-snapshotting custom element: `tonk-concept`
+    /// here and `tonk-display` / `tonk-view` in the `tonk-display`
+    /// crate. A template-owning element missing from this list would
+    /// have its template stolen by an ancestor — the exact bug this
+    /// guard prevents.
     fn is_template_owning_component(el: &Element) -> bool {
         matches!(
             el.local_name().as_str(),
@@ -923,6 +930,42 @@ mod dom {
             );
             let found = find_template(&host).expect("a usable own template");
             assert_eq!(found.get_attribute("data-which").as_deref(), Some("own"));
+        }
+
+        // The walk recurses through plain wrappers, so an own template
+        // several non-component levels deep is still found.
+        #[dialog_common::test]
+        fn it_finds_an_own_template_nested_in_plain_wrappers() {
+            let host = host_with("<section><div><ul><template><li>{a}</li></template></ul></div></section>");
+            assert!(find_template(&host).is_some());
+        }
+
+        // The own template lives inside a plain wrapper that comes
+        // *before* a component sibling — recursion into the wrapper
+        // must win over (and precede) the skipped component subtree.
+        #[dialog_common::test]
+        fn it_finds_an_own_template_in_a_wrapper_preceding_a_component() {
+            let host = host_with(
+                "<div><template data-which=\"own\"><p>{a}</p></template></div><tonk-concept source=\"book\"><template data-which=\"nested\"><li>{b}</li></template></tonk-concept>",
+            );
+            let found = find_template(&host).expect("own template in the leading wrapper");
+            assert_eq!(found.get_attribute("data-which").as_deref(), Some("own"));
+        }
+
+        // The boundary applies to every template-owning component, not
+        // just `tonk-concept`: a template inside a nested `tonk-display`
+        // or `tonk-view` belongs to that component and must be skipped.
+        #[dialog_common::test]
+        fn it_skips_templates_nested_in_other_owning_components() {
+            for tag in ["tonk-display", "tonk-view"] {
+                let host = host_with(&format!(
+                    "<{tag}><template><p>{{a}}</p></template></{tag}>"
+                ));
+                assert!(
+                    find_template(&host).is_none(),
+                    "template nested in <{tag}> should be skipped",
+                );
+            }
         }
     }
 }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -402,7 +402,7 @@ mod dom {
 
     use indexmap::IndexMap;
     use ipld_core::ipld::Ipld;
-    use web_sys::{DocumentFragment, Element, HtmlTemplateElement, Node, NodeList, window};
+    use web_sys::{DocumentFragment, Element, HtmlTemplateElement, Node, window};
 
     use super::{Binding, BindingKind, BindingPlan, Segment, has_field, parse_segments};
     use crate::error::{ErrorDetail, ErrorKind};
@@ -483,11 +483,38 @@ mod dom {
         pub container: Element,
     }
 
-    /// Find a descendant `<template>` element. Returns the first
-    /// one in tree order.
+    /// Find the host's own row `<template>`: the first `<template>`
+    /// in tree order that is **not** inside a nested template-owning
+    /// component. A `<tonk-view>` display body embeds `<tonk-concept>`
+    /// shelves, each owning its own `<template>`; a plain
+    /// `query_selector_all("template")` would return the first
+    /// shelf's template and `snapshot_template` would then strip it,
+    /// breaking that shelf. The walk stops at component boundaries so
+    /// each element only ever claims a template it actually owns.
     fn find_template(host: &Element) -> Option<Element> {
-        let list: NodeList = host.query_selector_all("template").ok()?;
-        list.item(0).and_then(|n| n.dyn_into::<Element>().ok())
+        let mut child = host.first_element_child();
+        while let Some(el) = child {
+            if el.local_name() == "template" {
+                return Some(el);
+            }
+            if !is_template_owning_component(&el) {
+                if let Some(found) = find_template(&el) {
+                    return Some(found);
+                }
+            }
+            child = el.next_element_sibling();
+        }
+        None
+    }
+
+    /// Custom elements that snapshot their own `<template>` child in
+    /// their `connected_callback`. Their templates belong to them,
+    /// so an ancestor's template search must skip their subtrees.
+    fn is_template_owning_component(el: &Element) -> bool {
+        matches!(
+            el.local_name().as_str(),
+            "tonk-concept" | "tonk-display" | "tonk-view"
+        )
     }
 
     /// Walk a fragment, replace any text node containing
@@ -857,6 +884,46 @@ mod dom {
             return Some(Ipld::String(row_this.to_string()));
         }
         shadow.get(name).or_else(|| row_fields.get(name)).cloned()
+    }
+
+    #[cfg(test)]
+    mod find_template_tests {
+        use super::find_template;
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::wasm_bindgen_test_configure;
+        use web_sys::{Element, window};
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        fn host_with(inner_html: &str) -> Element {
+            let document = window().expect("window").document().expect("document");
+            let host: Element = document.create_element("div").expect("create div");
+            host.set_inner_html(inner_html);
+            host
+        }
+
+        // A display view embeds `<tonk-concept>` shelves, each owning
+        // its own `<template>`. A host's template snapshot must not
+        // adopt a nested component's template as its own — doing so
+        // strips the first shelf of its row template.
+        #[dialog_common::test]
+        fn it_skips_a_template_nested_in_a_tonk_concept() {
+            let host = host_with(
+                "<tonk-concept source=\"book\"><ul><template><li>{title}</li></template></ul></tonk-concept>",
+            );
+            assert!(find_template(&host).is_none());
+        }
+
+        // Tree order would pick the nested concept's template first;
+        // the search must skip it and reach the host's own template.
+        #[dialog_common::test]
+        fn it_prefers_an_own_template_over_one_inside_a_nested_concept() {
+            let host = host_with(
+                "<tonk-concept source=\"book\"><template data-which=\"nested\"><li>{b}</li></template></tonk-concept><template data-which=\"own\"><p>{a}</p></template>",
+            );
+            let found = find_template(&host).expect("a usable own template");
+            assert_eq!(found.get_attribute("data-which").as_deref(), Some("own"));
+        }
     }
 }
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -14,8 +14,8 @@
 //!   `<wa-carousel>` hosts one slide per view (each containing a
 //!   `<tonk-view>`) plus a final `<tonk-inspector>` slide. The view
 //!   subscription becomes a "views for model" query whose frames
-//!   carry every view row; we diff by name. Every entity frame
-//!   walks all slides and calls `.render(...)` on each.
+//!   carry every view row; we diff by view entity. Every entity
+//!   frame walks all slides and calls `.render(...)` on each.
 //!
 //! Subscriptions live in `<tonk-display>` only — slide elements
 //! never open their own. One model resolution + one views
@@ -39,12 +39,15 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, Node, window};
 
-use crate::resolve::{entity_query, looks_like_uri, view_query, views_for_model_query};
+use crate::resolve::{
+    entity_query, looks_like_uri, name_target_query, view_fields_query, views_for_model_query,
+};
 use crate::state::{self, State};
 
 /// One mounted slide in carousel mode (or the sole slide in
-/// single mode). Keyed by view name; `display` is the template
-/// HTML the slide's `<tonk-view>` was built with so we can detect
+/// single mode). Keyed by the `view` attribute (single mode) or the
+/// view entity URI (carousel mode); `display` is the template HTML
+/// the slide's `<tonk-view>` was built with so we can detect
 /// content changes and rebuild.
 struct Slide {
     /// The `display` HTML the slide's `<tonk-view>` was built
@@ -94,8 +97,8 @@ struct Inner {
     /// `<wa-carousel>` element when in carousel mode, `None` in
     /// single mode.
     carousel: Option<Element>,
-    /// Slides keyed by view name. In single mode there's exactly
-    /// one entry with whatever name the `view` attribute holds.
+    /// Slides keyed by the `view` attribute (single mode — exactly
+    /// one entry) or the view entity URI (carousel mode).
     slides: BTreeMap<String, Slide>,
     /// The trailing carousel slide's source `<script
     /// type="text/tonk-notation">` element. We update its
@@ -441,50 +444,81 @@ async fn run(
         ));
     }
 
-    // `model` is still required for v1 — without a concept
-    // descriptor we don't know which fields to project on the
-    // entity. A future fallback could query every claim on the
-    // entity directly; for now, require it.
-    let model = host
-        .get_attribute("model")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            ErrorDetail::new(
-                ErrorKind::Descriptor,
-                "<tonk-display> requires `model` (fallback for missing model is deferred)",
-            )
-        })?;
-    // `view` is optional — its absence triggers carousel mode.
+    // `view` selects single-view mode (resolve a view by its anchor
+    // name) vs carousel mode (enumerate every view for a `model`).
     let view = host.get_attribute("view").filter(|s| !s.is_empty());
 
-    // Resolve the model concept's entity + descriptor via
-    // `tonk-query`. The host annotates space/branch from the
-    // nearest <tonk-repository>/<tonk-branch> ancestors and
-    // returns the parsed conclusions as a JS value.
-    let parsed: ParsedSource = parse_source(&model);
-    let phase1_q = phase1_query(&parsed);
-    let phase1_body = serde_wasm_bindgen::to_value(&phase1_q)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("phase1 body: {e}")))?;
-    let phase1_result = host_consumer::query(host, &phase1_body).await?;
-    let (model_entity, descriptor_json) = extract_phase1(&phase1_result)?;
-    check_generation(&state, generation)?;
+    // Resolve the concept descriptor (to project the subject's
+    // fields) and the view subscription query. In single mode the
+    // view is found by its anchor name and declares its own `model`,
+    // so no `model` attribute is needed. In carousel mode there is no
+    // view to read a model from, so `model` is required.
+    let (descriptor_json, view_q) = match view.as_deref() {
+        Some(view_ref) => {
+            // 1. Resolve the view's name to the entity it points at.
+            //    Re-asserting the anchor re-points the name, so this
+            //    always lands on the latest view.
+            let name_uri = if view_ref.contains(':') {
+                view_ref.to_owned()
+            } else {
+                format!("id:{view_ref}")
+            };
+            let name_q = name_target_query(&name_uri)
+                .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("name query: {e}")))?;
+            let name_result = host_consumer::query(host, &to_body(&name_q)?).await?;
+            check_generation(&state, generation)?;
+            let view_entity = first_field(&name_result, "entity").ok_or_else(|| {
+                ErrorDetail::new(
+                    ErrorKind::UnknownSource,
+                    format!("no view named {name_uri}"),
+                )
+            })?;
 
-    // Build the view subscription query: pin-by-name in single
-    // mode, all-views-for-model in carousel mode.
-    let view_q = match view.as_deref() {
-        Some(name) => view_query(&model_entity, name)
-            .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("view query: {e}")))?,
-        None => views_for_model_query(&model_entity).map_err(|e| {
-            ErrorDetail::new(ErrorKind::Descriptor, format!("views-for-model query: {e}"))
-        })?,
+            // 2. Read the view's own `model` to project the subject.
+            let fields_q = view_fields_query(&view_entity).map_err(|e| {
+                ErrorDetail::new(ErrorKind::Descriptor, format!("view fields query: {e}"))
+            })?;
+            let fields_result = host_consumer::query(host, &to_body(&fields_q)?).await?;
+            check_generation(&state, generation)?;
+            let model_entity = first_field(&fields_result, "model").ok_or_else(|| {
+                ErrorDetail::new(
+                    ErrorKind::Descriptor,
+                    format!("view {view_entity} has no `model`"),
+                )
+            })?;
+
+            // 3. Resolve that model concept's descriptor.
+            let (_, descriptor_json) = resolve_model(host, &model_entity).await?;
+            check_generation(&state, generation)?;
+
+            // The view subscription is pinned to the resolved entity,
+            // so exactly one row flows back — no `(model, name)`
+            // duplicate ambiguity.
+            (descriptor_json, fields_q)
+        }
+        None => {
+            let model = host
+                .get_attribute("model")
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    ErrorDetail::new(
+                        ErrorKind::Descriptor,
+                        "<tonk-display> requires `view` (a named view) or `model` (carousel mode)",
+                    )
+                })?;
+            let (model_entity, descriptor_json) = resolve_model(host, &model).await?;
+            check_generation(&state, generation)?;
+            let view_q = views_for_model_query(&model_entity).map_err(|e| {
+                ErrorDetail::new(ErrorKind::Descriptor, format!("views-for-model query: {e}"))
+            })?;
+            (descriptor_json, view_q)
+        }
     };
-    let view_body = serde_wasm_bindgen::to_value(&view_q)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("view body: {e}")))?;
+    let view_body = to_body(&view_q)?;
 
     let entity_q = entity_query(&descriptor_json, &entity)
         .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
-    let entity_body = serde_wasm_bindgen::to_value(&entity_q)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("entity body: {e}")))?;
+    let entity_body = to_body(&entity_q)?;
 
     // Always mount the `<wa-carousel>` so the slot geometry is
     // identical regardless of mode. The only user-visible
@@ -548,33 +582,55 @@ fn ipld_str(value: Option<&Ipld>) -> Option<&str> {
     }
 }
 
+/// Serialize a wire query to the JS body the host bridge expects.
+fn to_body(query: &tonk_schema::query::Query) -> Result<JsValue, ErrorDetail> {
+    serde_wasm_bindgen::to_value(query)
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("query body: {e}")))
+}
+
+/// Pull a string field off the first conclusion of a one-shot query
+/// result (a `Vec<Conclusion>` serialized as a JS value). `None` if
+/// the result is empty or the field is missing / non-string.
+fn first_field(value: &JsValue, field: &str) -> Option<String> {
+    let conclusions: Vec<Conclusion> = serde_wasm_bindgen::from_value(value.clone()).ok()?;
+    let first = conclusions.into_iter().next()?;
+    ipld_str(first.fields.get(field)).map(str::to_owned)
+}
+
+/// Resolve a concept (bookmark name or entity URI) to its
+/// `(entity, descriptor_json)` via the Phase-1 concept-of-concepts
+/// query.
+async fn resolve_model(host: &Element, source: &str) -> Result<(String, String), ErrorDetail> {
+    let parsed: ParsedSource = parse_source(source);
+    let phase1_q = phase1_query(&parsed);
+    let result = host_consumer::query(host, &to_body(&phase1_q)?).await?;
+    extract_phase1(&result)
+}
+
 /// Diff the incoming view frame against currently mounted slides.
-/// Slides are keyed by view name; we add/remove/replace as needed,
-/// then push the cached entity conclusion into any fresh slide so
-/// it has data to render right away.
+/// Slides are keyed by the `view` attribute (single mode) or the
+/// view entity URI (carousel mode); we add/remove/replace as
+/// needed, then push the cached entity conclusion into any fresh
+/// slide so it has data to render right away.
 fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
     let mut s = state.borrow_mut();
 
-    // Extract (name, display) pairs from the incoming frame. When
-    // the `view` attribute is set, the subscription pinned `name`
-    // as a constant — so the server doesn't project it back. Fall
-    // back to the attribute value for that case. When `view` is
-    // absent, the views-for-model query left `name` as a variable
-    // and the server fills it.
+    // Key each slide by display target. Views no longer carry a
+    // `name` field: in single mode the subscription is pinned to one
+    // view entity, so the `view` attribute is the stable key; in
+    // carousel mode many views share a model, so key by the view
+    // entity URI (`this`).
     let view_attr = host.get_attribute("view").unwrap_or_default();
     let incoming: BTreeMap<String, String> = conclusions
         .into_iter()
         .filter_map(|c| {
             let display = ipld_str(c.fields.get("display")).map(str::to_owned)?;
-            let name = ipld_str(c.fields.get("name"))
-                .map(str::to_owned)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| view_attr.clone());
-            if name.is_empty() {
-                None
+            let key = if view_attr.is_empty() {
+                c.this.clone()
             } else {
-                Some((name, display))
-            }
+                view_attr.clone()
+            };
+            Some((key, display))
         })
         .collect();
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -467,7 +467,7 @@ async fn run(
                 .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("name query: {e}")))?;
             let name_result = host_consumer::query(host, &to_body(&name_q)?).await?;
             check_generation(&state, generation)?;
-            let view_entity = first_field(&name_result, "entity").ok_or_else(|| {
+            let view_entity = first_field(&name_result, "entity")?.ok_or_else(|| {
                 ErrorDetail::new(
                     ErrorKind::UnknownSource,
                     format!("no view named {name_uri}"),
@@ -480,12 +480,24 @@ async fn run(
             })?;
             let fields_result = host_consumer::query(host, &to_body(&fields_q)?).await?;
             check_generation(&state, generation)?;
-            let model_entity = first_field(&fields_result, "model").ok_or_else(|| {
+            let model_entity = first_field(&fields_result, "model")?.ok_or_else(|| {
                 ErrorDetail::new(
                     ErrorKind::Descriptor,
                     format!("view {view_entity} has no `model`"),
                 )
             })?;
+
+            // The same one-shot already carries `display`; if it's
+            // absent the subscription would deliver zero renderable
+            // rows and the host would sit blank with no callout. Catch
+            // it here so a view published without a template surfaces
+            // as a visible error instead.
+            if first_field(&fields_result, "display")?.is_none() {
+                return Err(ErrorDetail::new(
+                    ErrorKind::Descriptor,
+                    format!("view {view_entity} has no `display` template"),
+                ));
+            }
 
             // 3. Resolve that model concept's descriptor.
             let (_, descriptor_json) = resolve_model(host, &model_entity).await?;
@@ -589,12 +601,21 @@ fn to_body(query: &tonk_schema::query::Query) -> Result<JsValue, ErrorDetail> {
 }
 
 /// Pull a string field off the first conclusion of a one-shot query
-/// result (a `Vec<Conclusion>` serialized as a JS value). `None` if
-/// the result is empty or the field is missing / non-string.
-fn first_field(value: &JsValue, field: &str) -> Option<String> {
-    let conclusions: Vec<Conclusion> = serde_wasm_bindgen::from_value(value.clone()).ok()?;
-    let first = conclusions.into_iter().next()?;
-    ipld_str(first.fields.get(field)).map(str::to_owned)
+/// result (a `Vec<Conclusion>` serialized as a JS value).
+///
+/// `Err` is a decode failure — the result wasn't the
+/// `Vec<Conclusion>` shape we expect (a wire/protocol mismatch),
+/// which is distinct from a genuinely empty or field-less result.
+/// `Ok(None)` means the result was empty or the field is absent /
+/// non-string. Keeping the two apart stops a decode bug from
+/// masquerading as a "not found" further up the chain.
+fn first_field(value: &JsValue, field: &str) -> Result<Option<String>, ErrorDetail> {
+    let conclusions: Vec<Conclusion> = serde_wasm_bindgen::from_value(value.clone())
+        .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("query result: {e}")))?;
+    Ok(conclusions
+        .into_iter()
+        .next()
+        .and_then(|c| ipld_str(c.fields.get(field)).map(str::to_owned)))
 }
 
 /// Resolve a concept (bookmark name or entity URI) to its
@@ -607,6 +628,28 @@ async fn resolve_model(host: &Element, source: &str) -> Result<(String, String),
     extract_phase1(&result)
 }
 
+/// Key each incoming view-frame conclusion by its display target,
+/// paired with the `display` template. Views carry no `name`
+/// field: in single mode (`view_attr` non-empty) the subscription
+/// is pinned to one view entity, so the attribute is the stable
+/// key; in carousel mode (`view_attr` empty) many views share a
+/// model, so each keys by its own entity URI (`this`). A
+/// conclusion with no `display` string is dropped.
+fn slide_keys(view_attr: &str, conclusions: Vec<Conclusion>) -> BTreeMap<String, String> {
+    conclusions
+        .into_iter()
+        .filter_map(|c| {
+            let display = ipld_str(c.fields.get("display")).map(str::to_owned)?;
+            let key = if view_attr.is_empty() {
+                c.this
+            } else {
+                view_attr.to_owned()
+            };
+            Some((key, display))
+        })
+        .collect()
+}
+
 /// Diff the incoming view frame against currently mounted slides.
 /// Slides are keyed by the `view` attribute (single mode) or the
 /// view entity URI (carousel mode); we add/remove/replace as
@@ -615,24 +658,8 @@ async fn resolve_model(host: &Element, source: &str) -> Result<(String, String),
 fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
     let mut s = state.borrow_mut();
 
-    // Key each slide by display target. Views no longer carry a
-    // `name` field: in single mode the subscription is pinned to one
-    // view entity, so the `view` attribute is the stable key; in
-    // carousel mode many views share a model, so key by the view
-    // entity URI (`this`).
     let view_attr = host.get_attribute("view").unwrap_or_default();
-    let incoming: BTreeMap<String, String> = conclusions
-        .into_iter()
-        .filter_map(|c| {
-            let display = ipld_str(c.fields.get("display")).map(str::to_owned)?;
-            let key = if view_attr.is_empty() {
-                c.this.clone()
-            } else {
-                view_attr.clone()
-            };
-            Some((key, display))
-        })
-        .collect();
+    let incoming = slide_keys(&view_attr, conclusions);
 
     // Remove vanished slides.
     let stale: Vec<String> = s
@@ -1047,5 +1074,52 @@ mod tests {
         });
         let field = Reflect::get(&detail, &JsValue::from_str("label")).expect("reflect get");
         assert_eq!(field.as_string().as_deref(), Some("hi"));
+    }
+
+    fn view_row(this: &str, display: Option<&str>) -> Conclusion {
+        let mut fields = BTreeMap::new();
+        if let Some(d) = display {
+            fields.insert("display".to_owned(), Ipld::String(d.to_owned()));
+        }
+        Conclusion {
+            this: this.to_owned(),
+            fields,
+        }
+    }
+
+    // Carousel mode (empty `view` attribute): many views share a
+    // model, so each slide keys off its own view entity URI.
+    #[dialog_common::test]
+    fn it_keys_carousel_slides_by_view_entity() {
+        let rows = vec![
+            view_row("did:key:zViewA", Some("<p>A</p>")),
+            view_row("did:key:zViewB", Some("<p>B</p>")),
+        ];
+        let keyed = slide_keys("", rows);
+        assert_eq!(keyed.len(), 2);
+        assert_eq!(keyed.get("did:key:zViewA").map(String::as_str), Some("<p>A</p>"));
+        assert_eq!(keyed.get("did:key:zViewB").map(String::as_str), Some("<p>B</p>"));
+    }
+
+    // Single mode: the subscription is pinned to one view entity, so
+    // the slide keys off the `view` attribute, not the entity URI.
+    #[dialog_common::test]
+    fn it_keys_the_single_slide_by_the_view_attribute() {
+        let rows = vec![view_row("did:key:zView", Some("<p>only</p>"))];
+        let keyed = slide_keys("book-dashboard", rows);
+        assert_eq!(keyed.len(), 1);
+        assert_eq!(
+            keyed.get("book-dashboard").map(String::as_str),
+            Some("<p>only</p>"),
+        );
+        assert!(!keyed.contains_key("did:key:zView"));
+    }
+
+    // A frame row with no `display` field can't render; it's dropped
+    // rather than producing a blank slide.
+    #[dialog_common::test]
+    fn it_drops_a_frame_row_with_no_display_field() {
+        let rows = vec![view_row("did:key:zView", None)];
+        assert!(slide_keys("", rows).is_empty());
     }
 }

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1097,8 +1097,14 @@ mod tests {
         ];
         let keyed = slide_keys("", rows);
         assert_eq!(keyed.len(), 2);
-        assert_eq!(keyed.get("did:key:zViewA").map(String::as_str), Some("<p>A</p>"));
-        assert_eq!(keyed.get("did:key:zViewB").map(String::as_str), Some("<p>B</p>"));
+        assert_eq!(
+            keyed.get("did:key:zViewA").map(String::as_str),
+            Some("<p>A</p>")
+        );
+        assert_eq!(
+            keyed.get("did:key:zViewB").map(String::as_str),
+            Some("<p>B</p>")
+        );
     }
 
     // Single mode: the subscription is pinned to one view entity, so

--- a/rust/tonk-display/src/resolve.rs
+++ b/rust/tonk-display/src/resolve.rs
@@ -2,8 +2,11 @@
 //!
 //! Three builders:
 //!
-//! - [`view_query`] — subscribe to the `view` row matching a given
-//!   `(model, name)` pair, projecting the `display` field.
+//! - [`name_target_query`] — resolve a view's `id:` name to the
+//!   entity it currently points at (so re-asserting the anchor
+//!   always resolves to the latest view).
+//! - [`view_fields_query`] — subscribe to that view entity,
+//!   projecting `model` and `display`.
 //! - [`entity_query`] — subscribe to a single entity by URI,
 //!   projecting every field in the model concept's descriptor.
 //! - [`view_predicate`] — the predicate JSON of the `view` concept
@@ -15,21 +18,35 @@ use indexmap::IndexMap;
 use serde_json::{Value, json};
 use tonk_schema::query::Query;
 
-/// Build the live `view` subscription query: find the `view` row
-/// whose `model` field equals `model_entity` and whose `name` field
-/// equals `view_name`, projecting `display` (and `this`) as
-/// variables.
-///
-/// The predicate is the built-in `view` concept descriptor —
-/// `view_predicate`. The terms map nails `model` + `name` to
-/// constants and leaves `display` and `this` as variables so they
-/// flow back in every frame.
-pub fn view_query(model_entity: &str, view_name: &str) -> Result<Query, serde_json::Error> {
+/// Resolve a view's `id:` name to the entity it currently points
+/// at. A view is published under an anchor name (`view!:
+/// &book-dashboard`); this pins `this` to that name URI and reads
+/// back the `dialog.name/referent` claim (cardinality one) that the
+/// `Name` concept stores its target in.
+/// Re-asserting the anchor re-points the name, so the resolved
+/// entity is always the latest — older view entities linger
+/// unreferenced, never resolved.
+pub fn name_target_query(name_uri: &str) -> Result<Query, serde_json::Error> {
+    let predicate = json!({
+        "with": {
+            "entity": { "the": "dialog.name/referent", "as": "Entity", "cardinality": "one" }
+        }
+    });
+    let mut terms: IndexMap<String, Value> = IndexMap::new();
+    terms.insert("this".into(), json!(name_uri));
+    terms.insert("entity".into(), json!({ "?": { "name": "entity" } }));
+    serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
+}
+
+/// Build the live `view` subscription pinned to a specific view
+/// entity (the target of [`name_target_query`]), projecting `model`
+/// and `display`. Exactly one row, so there is no `(model, name)`
+/// ambiguity — the view to render is the one its name points at.
+pub fn view_fields_query(view_entity: &str) -> Result<Query, serde_json::Error> {
     let predicate = view_predicate();
     let mut terms: IndexMap<String, Value> = IndexMap::new();
-    terms.insert("this".into(), json!({ "?": { "name": "view" } }));
-    terms.insert("model".into(), json!(model_entity));
-    terms.insert("name".into(), json!(view_name));
+    terms.insert("this".into(), json!(view_entity));
+    terms.insert("model".into(), json!({ "?": { "name": "model" } }));
     terms.insert("display".into(), json!({ "?": { "name": "display" } }));
     serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
 }
@@ -46,7 +63,6 @@ pub fn views_for_model_query(model_entity: &str) -> Result<Query, serde_json::Er
     let mut terms: IndexMap<String, Value> = IndexMap::new();
     terms.insert("this".into(), json!({ "?": { "name": "view" } }));
     terms.insert("model".into(), json!(model_entity));
-    terms.insert("name".into(), json!({ "?": { "name": "name" } }));
     terms.insert("display".into(), json!({ "?": { "name": "display" } }));
     serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
 }
@@ -76,14 +92,14 @@ pub fn entity_query(descriptor_json: &str, entity: &str) -> Result<Query, serde_
 
 /// The descriptor of the `view` concept itself.
 ///
-/// Three fields: `name` (text — distinguishes views over the same
-/// concept), `model` (entity — the concept being displayed), and
-/// `display` (text — the HTML template). Attribute URIs follow the
-/// `xyz.tonk.view/*` namespace the user's design pins.
+/// Two fields: `model` (entity — the concept being displayed) and
+/// `display` (text — the HTML template). A view is identified by
+/// its anchor name (`view!: &book-dashboard`), not by a `name`
+/// field, so re-asserting the anchor replaces it in place. Attribute
+/// URIs follow the `xyz.tonk.view/*` namespace.
 pub fn view_predicate() -> Value {
     json!({
         "with": {
-            "name":    { "the": "xyz.tonk.view/name",    "as": "Text",   "cardinality": "one" },
             "model":   { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
             "display": { "the": "xyz.tonk.view/display", "as": "Text",   "cardinality": "one" }
         }
@@ -101,24 +117,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_builds_a_view_query_pinning_model_and_name() {
-        let q = view_query("concept:zGreeting", "basic").expect("view_query");
-        let model = q.terms.get("model").expect("model term");
-        let name = q.terms.get("name").expect("name term");
+    fn it_resolves_a_view_name_to_its_target_entity() {
+        // A view is published under an `id:` name; the lookup pins
+        // `this` to that name URI and projects the `entity` it
+        // currently points at, so re-asserting (which re-points the
+        // name) always resolves to the latest view entity.
+        let q = name_target_query("id:book-dashboard").expect("name_target_query");
+        let this = q.terms.get("this").expect("this term");
         assert_eq!(
-            serde_json::to_value(model).unwrap(),
-            json!("concept:zGreeting")
+            serde_json::to_value(this).unwrap(),
+            json!("id:book-dashboard")
         );
-        assert_eq!(serde_json::to_value(name).unwrap(), json!("basic"));
+        let entity = q.terms.get("entity").expect("entity term");
+        assert_eq!(
+            serde_json::to_value(entity).unwrap(),
+            json!({ "?": { "name": "entity" } })
+        );
+        // The target is carried by `dialog.name/referent` — the
+        // attribute `tonk_core::meta::Name` (and `lookup_named_entity`)
+        // store a name's current target in.
+        let predicate = serde_json::to_value(&q.predicate).unwrap();
+        assert_eq!(
+            predicate["with"]["entity"]["the"],
+            json!("dialog.name/referent")
+        );
     }
 
     #[test]
-    fn it_projects_display_as_a_variable_in_the_view_query() {
-        let q = view_query("concept:zGreeting", "basic").expect("view_query");
-        let display = q.terms.get("display").expect("display term");
-        let v = serde_json::to_value(display).unwrap();
-        // Variable terms shape as `{ "?": { "name": "display" } }`.
-        assert_eq!(v, json!({ "?": { "name": "display" } }));
+    fn it_builds_a_view_fields_query_pinned_to_the_view_entity() {
+        let q = view_fields_query("did:key:zView").expect("view_fields_query");
+        let this = q.terms.get("this").expect("this term");
+        assert_eq!(serde_json::to_value(this).unwrap(), json!("did:key:zView"));
+        // `model` and `display` flow back as variables.
+        for field in ["model", "display"] {
+            let term = q.terms.get(field).unwrap_or_else(|| panic!("{field} term"));
+            assert_eq!(
+                serde_json::to_value(term).unwrap(),
+                json!({ "?": { "name": field } })
+            );
+        }
+    }
+
+    #[test]
+    fn the_view_predicate_has_no_name_field() {
+        let p = view_predicate();
+        let with = p.get("with").and_then(|v| v.as_object()).expect("with");
+        assert!(with.contains_key("model"));
+        assert!(with.contains_key("display"));
+        assert!(
+            !with.contains_key("name"),
+            "view identity moved to the anchor name; the `name` field is gone"
+        );
     }
 
     #[test]
@@ -160,17 +209,14 @@ mod tests {
             serde_json::to_value(model).unwrap(),
             json!("concept:zGreeting"),
         );
-        // `name` and `display` must remain variables so the frame
-        // delivers one row per available view.
-        let name = q.terms.get("name").expect("name term");
-        assert_eq!(
-            serde_json::to_value(name).unwrap(),
-            json!({ "?": { "name": "name" } }),
-        );
+        // `display` (and `this`) stay variables so the frame delivers
+        // one row per view of the model; slides key off the view
+        // entity since views no longer carry a `name` field.
         let display = q.terms.get("display").expect("display term");
         assert_eq!(
             serde_json::to_value(display).unwrap(),
             json!({ "?": { "name": "display" } }),
         );
+        assert!(!q.terms.contains("name"));
     }
 }

--- a/rust/tonk-display/src/resolve.rs
+++ b/rust/tonk-display/src/resolve.rs
@@ -115,8 +115,12 @@ pub fn looks_like_uri(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
 
-    #[test]
+    #[dialog_common::test]
     fn it_resolves_a_view_name_to_its_target_entity() {
         // A view is published under an `id:` name; the lookup pins
         // `this` to that name URI and projects the `entity` it
@@ -143,7 +147,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_a_view_fields_query_pinned_to_the_view_entity() {
         let q = view_fields_query("did:key:zView").expect("view_fields_query");
         let this = q.terms.get("this").expect("this term");
@@ -158,7 +162,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[dialog_common::test]
     fn the_view_predicate_has_no_name_field() {
         let p = view_predicate();
         let with = p.get("with").and_then(|v| v.as_object()).expect("with");
@@ -170,7 +174,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_an_entity_query_pinning_this() {
         let descriptor = r#"{"with":{
             "message": { "the": "greeting/message", "as": "Text", "cardinality": "one" }
@@ -183,7 +187,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_projects_every_descriptor_field_in_the_entity_query() {
         let descriptor = r#"{"with":{
             "message":   { "the": "greeting/message",   "as": "Text", "cardinality": "one" },
@@ -194,14 +198,14 @@ mod tests {
         assert!(q.terms.contains("recipient"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_distinguishes_uri_from_bookmark() {
         assert!(looks_like_uri("did:key:zAlice"));
         assert!(looks_like_uri("concept:abc"));
         assert!(!looks_like_uri("greeting"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn it_builds_views_for_model_pinning_model_only() {
         let q = views_for_model_query("concept:zGreeting").expect("views_for_model_query");
         let model = q.terms.get("model").expect("model term");

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -265,6 +265,27 @@ mod tests {
         func.call1(&JsValue::NULL, detail).expect("call draw");
     }
 
+    // A display body that embeds `<tonk-concept>` shelves must not
+    // have its first shelf's `<template>` stolen by `<tonk-view>`'s
+    // own template snapshot. With the snapshot scoped to skip nested
+    // components, the view finds no template of its own, renders the
+    // subject once, and the shelf's `<template>` survives intact for
+    // the shelf to hydrate against.
+    #[dialog_common::test]
+    fn it_preserves_a_nested_tonk_concept_template() {
+        let host = mount(
+            "<div class=\"app\"><tonk-concept source=\"book\"><ul><template><li>{title}</li></template></ul></tonk-concept></div>",
+        );
+        call_draw(&host, &detail("did:key:zLibrary", &[]));
+        assert!(
+            host.query_selector("tonk-concept template")
+                .unwrap()
+                .is_some(),
+            "nested shelf template was stripped: {}",
+            host.inner_html(),
+        );
+    }
+
     #[dialog_common::test]
     fn it_installs_a_per_instance_draw_closure_on_connect() {
         let host = mount("<p>{name}</p>");

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -1,41 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Tell the browser to render native chrome (scrollbars, form
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Tell the browser to render native chrome (scrollbars, form
        controls, etc.) in either mode — the actual mode is selected
        reactively by the script below based on the OS preference. -->
-  <meta name="color-scheme" content="light dark">
-  <meta name="title" content="Tonk">
-  <meta name="description"
-    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-  <meta name="robots" content="index, follow">
+    <meta name="color-scheme" content="light dark" />
+    <meta name="title" content="Tonk" />
+    <meta
+      name="description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta name="robots" content="index, follow" />
 
-  <title>Tonk</title>
+    <title>Tonk</title>
 
-  <meta property="og:title" content="Tonk is impossible software">
-  <meta property="og:description"
-    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-  <meta property="og:url" content="https://tonk.xyz">
-  <meta property="og:site_name" content="Tonk">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:image" content="https://tonk.xyz/preview.png">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="Tonk is impossible software">
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Tonk is impossible software">
-  <meta name="twitter:description"
-    content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now.">
-  <meta name="twitter:image" content="https://tonk.xyz/preview.png">
+    <meta property="og:title" content="Tonk is impossible software" />
+    <meta
+      property="og:description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta property="og:url" content="https://tonk.xyz" />
+    <meta property="og:site_name" content="Tonk" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:image" content="https://tonk.xyz/preview.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Tonk is impossible software" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tonk is impossible software" />
+    <meta
+      name="twitter:description"
+      content="Locally multiplayer. Shared without servers. Free without ads. Impossible, until now."
+    />
+    <meta name="twitter:image" content="https://tonk.xyz/preview.png" />
 
-  <link rel="shortcut icon" href="/images/mark-white.svg">
-  <link rel="apple-touch-icon" href="/images/mark-white.svg">
+    <link rel="shortcut icon" href="/images/mark-white.svg" />
+    <link rel="apple-touch-icon" href="/images/mark-white.svg" />
 
-  <!-- Web Awesome: custom-element UI library (see .claude/skills/webawesome). The loader
+    <!-- Web Awesome: custom-element UI library (see .claude/skills/webawesome). The loader
        auto-registers any <wa-*> elements used in the DOM; `data-webawesome` tells it
        where its bundled assets (icons, etc.) live.
 
@@ -43,111 +48,141 @@
        local overrides layer on top (see styles.css): brutalist's
        fonts (Space Grotesk / IBM Plex Sans Condensed / Space Mono)
        and a zero border radius so nothing is rounded. -->
-  <link rel="stylesheet" href="/webawesome/styles/webawesome.css">
-  <link rel="stylesheet" href="/webawesome/styles/themes/default.css">
-  <link rel="stylesheet" href="/webawesome/styles/color/palettes/shoelace.css">
-  <!-- Brutalist-theme fonts (Space Grotesk / IBM Plex Sans
+    <link rel="stylesheet" href="/webawesome/styles/webawesome.css" />
+    <link rel="stylesheet" href="/webawesome/styles/themes/default.css" />
+    <link
+      rel="stylesheet"
+      href="/webawesome/styles/color/palettes/shoelace.css"
+    />
+    <!-- Brutalist-theme fonts (Space Grotesk / IBM Plex Sans
        Condensed / Space Mono) are self-hosted: see styles.css
        for the `@font-face` declarations. Files live in
        `assets/fonts/` and are copied into the dist by the
        Trunk `copy-dir` rule below. No external font CDN. -->
-  <!-- Preload the loader so it starts compiling alongside the
+    <!-- Preload the loader so it starts compiling alongside the
        Wasm bundle instead of after the HTML has finished parsing.
        The loader itself dynamically imports per-component chunks
        on demand, so preloading the loader is the highest-leverage
        step we can take without enumerating every chunk. -->
-  <link rel="modulepreload" href="/webawesome/webawesome.loader.js">
-  <script type="module" src="/webawesome/webawesome.loader.js" data-webawesome="/webawesome"></script>
+    <link rel="modulepreload" href="/webawesome/webawesome.loader.js" />
+    <script
+      type="module"
+      src="/webawesome/webawesome.loader.js"
+      data-webawesome="/webawesome"
+    ></script>
 
-  <!-- Inherit the OS light/dark preference. Web Awesome picks up its
+    <!-- Inherit the OS light/dark preference. Web Awesome picks up its
        theme from `.wa-light` / `.wa-dark` on the root element; toggle
        the class immediately (before paint) and keep it in sync with
        `prefers-color-scheme` changes. -->
-  <script>
-    (() => {
-      // Activate the default theme with the shoelace palette. Light/dark
-      // is toggled reactively on `prefers-color-scheme` changes.
-      document.documentElement.classList.add('wa-theme-default', 'wa-palette-shoelace');
+    <script>
+      (() => {
+        // Activate the default theme with the shoelace palette. Light/dark
+        // is toggled reactively on `prefers-color-scheme` changes.
+        document.documentElement.classList.add(
+          "wa-theme-default",
+          "wa-palette-shoelace",
+        );
 
-      const mq = window.matchMedia('(prefers-color-scheme: dark)');
-      const apply = (isDark) => {
-        const cls = document.documentElement.classList;
-        cls.toggle('wa-dark', isDark);
-        cls.toggle('wa-light', !isDark);
-      };
-      apply(mq.matches);
-      mq.addEventListener('change', (e) => apply(e.matches));
-    })();
-  </script>
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const apply = (isDark) => {
+          const cls = document.documentElement.classList;
+          cls.toggle("wa-dark", isDark);
+          cls.toggle("wa-light", !isDark);
+        };
+        apply(mq.matches);
+        mq.addEventListener("change", (e) => apply(e.matches));
+      })();
+    </script>
 
-  <!-- Must define `serviceWorkerActivates` before the Wasm blob loads:
+    <!-- Must define `serviceWorkerActivates` before the Wasm blob loads:
          the shell awaits it before issuing any /api/* fetch. -->
-  <script type="module">
-    // Resolve when the service worker is *controlling* this page.
-    //
-    // `controller` being non-null is the precise moment when
-    // `/api/*` fetches start routing through the worker. Three
-    // paths reach that state:
-    //
-    //   1. Already controlled (warm load) — return immediately.
-    //   2. Registration is in-flight — `controllerchange` fires
-    //      when the new SW claims this page during its install /
-    //      activate cycle.
-    //   3. SW activated in a previous session but this newly-
-    //      loaded document isn't being controlled — the SW's
-    //      `onactivate` doesn't refire, so without a nudge it
-    //      never calls `clients.claim()` for this client. We
-    //      send a `{type:"claim"}` message to the active worker
-    //      asking it to claim; the SW responds with
-    //      `self.clients.claim()`, which raises
-    //      `controllerchange` on this page.
-    //
-    // No reloads, no timeouts: the claim path is deterministic
-    // once the SW has a `message` handler that honors `claim`.
-    self.serviceWorkerActivates = async () => {
-      if (!('serviceWorker' in navigator)) {
-        throw new Error('Service workers not supported; Tonk will not work!');
-      }
-      if (navigator.serviceWorker.controller) return;
-
-      const controlled = new Promise(resolve => {
-        navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
-      });
-
-      // Nudge the active worker to claim this client.
-      navigator.serviceWorker.ready.then(reg => {
-        reg.active?.postMessage({ type: 'claim' });
-      });
-
-      await controlled;
-    };
-
-    // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
-    self.sync = async () => {
-      if ('serviceWorker' in navigator && 'SyncManager' in window) {
-        try {
-          const registration = await navigator.serviceWorker.ready;
-          await registration.sync.register('tonk-sync');
-          console.log('[Tonk] Background sync registered');
-          return;
-        } catch (e) {
-          console.warn('[Tonk] Background sync registration failed, falling back:', e);
+    <script type="module">
+      // Resolve when the service worker is *controlling* this page.
+      //
+      // `controller` being non-null is the precise moment when
+      // `/api/*` fetches start routing through the worker. Three
+      // paths reach that state:
+      //
+      //   1. Already controlled (warm load) — return immediately.
+      //   2. Registration is in-flight — `controllerchange` fires
+      //      when the new SW claims this page during its install /
+      //      activate cycle.
+      //   3. SW activated in a previous session but this newly-
+      //      loaded document isn't being controlled — the SW's
+      //      `onactivate` doesn't refire, so without a nudge it
+      //      never calls `clients.claim()` for this client. We
+      //      send a `{type:"claim"}` message to the active worker
+      //      asking it to claim; the SW responds with
+      //      `self.clients.claim()`, which raises
+      //      `controllerchange` on this page.
+      //
+      // No reloads, no timeouts: the claim path is deterministic
+      // once the SW has a `message` handler that honors `claim`.
+      self.serviceWorkerActivates = async () => {
+        if (!("serviceWorker" in navigator)) {
+          throw new Error("Service workers not supported; Tonk will not work!");
         }
-      }
-      // Fallback to direct sync call
-      const response = await fetch('/api/sync', {method: 'POST'});
-      if (!response.ok) {
-        throw new Error(`Sync failed: ${response.status}`);
-      }
-      console.log('[Tonk] Direct sync completed');
-    };
-  </script>
-  <!-- The following are load-bearing configuration for the Trunk build tool
+        if (navigator.serviceWorker.controller) return;
+
+        const controlled = new Promise((resolve) => {
+          navigator.serviceWorker.addEventListener(
+            "controllerchange",
+            resolve,
+            { once: true },
+          );
+        });
+
+        // Nudge the active worker to claim this client.
+        navigator.serviceWorker.ready.then((reg) => {
+          reg.active?.postMessage({ type: "claim" });
+        });
+
+        await controlled;
+      };
+
+      // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
+      self.sync = async () => {
+        if ("serviceWorker" in navigator && "SyncManager" in window) {
+          try {
+            const registration = await navigator.serviceWorker.ready;
+            await registration.sync.register("tonk-sync");
+            console.log("[Tonk] Background sync registered");
+            return;
+          } catch (e) {
+            console.warn(
+              "[Tonk] Background sync registration failed, falling back:",
+              e,
+            );
+          }
+        }
+        // Fallback to direct sync call
+        const response = await fetch("/api/sync", { method: "POST" });
+        if (!response.ok) {
+          throw new Error(`Sync failed: ${response.status}`);
+        }
+        console.log("[Tonk] Direct sync completed");
+      };
+    </script>
+    <!-- The following are load-bearing configuration for the Trunk build tool
          (https://trunkrs.dev/assets/); if you need to add build steps or copy
          static assets, you will want to modify this condiguration here. -->
-  <link data-trunk rel="rust" data-bin="ui" data-type="main" data-wasm-opt="z" />
-  <link data-trunk rel="rust" data-bin="worker" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
-  <!-- Standalone `<tonk-concept>` element module. The parent shell
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="ui"
+      data-type="main"
+      data-wasm-opt="z"
+    />
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="worker"
+      data-type="worker"
+      data-bindgen-target="web"
+      data-wasm-opt="z"
+    />
+    <!-- Standalone `<tonk-concept>` element module. The parent shell
        registers the element directly from its own bundle; this
        artefact exists so the tonk-worker HTML wrapper can also
        register it inside the iframe's separate `customElements`
@@ -156,38 +191,58 @@
        Trunk's `worker` type drops the file at a stable unhashed
        URL (`/tonk-concept.js`) without auto-injecting any script
        into this page. -->
-  <link data-trunk rel="rust" data-bin="tonk-concept" data-type="worker" data-bindgen-target="web" data-wasm-opt="z" />
+    <link
+      data-trunk
+      rel="rust"
+      data-bin="tonk-concept"
+      data-type="worker"
+      data-bindgen-target="web"
+      data-wasm-opt="z"
+    />
 
-  <!-- Bridge module injected by host::wrap_html_body into iframe srcdoc.
+    <!-- Bridge module injected by host::wrap_html_body into iframe srcdoc.
        Served at `/__tonk/bridge.js` by the dev server / CDN so the
        service-worker passthrough route can reach it without the SW
        needing to bundle and serve it internally. -->
-  <link data-trunk rel="copy-file" href="../tonk-worker/assets/bridge.js" data-target-path="__tonk" />
-  <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
-  <link data-trunk rel="copy-dir" href="./assets/fonts" />
-  <link data-trunk rel="copy-dir" href="./assets/images" />
-  <link data-trunk rel="copy-dir" href="./assets/webawesome" />
-  <link data-trunk rel="copy-file" href="../tonk-sigil/assets/sigils.svg" />
-  <!-- `<tonk-code>` web component bundle. The crate's `install()`
+    <link
+      data-trunk
+      rel="copy-file"
+      href="../tonk-worker/assets/bridge.js"
+      data-target-path="__tonk"
+    />
+    <link data-trunk rel="copy-file" href="./assets/service_worker.js" />
+    <link data-trunk rel="copy-dir" href="./assets/fonts" />
+    <link data-trunk rel="copy-dir" href="./assets/images" />
+    <link data-trunk rel="copy-dir" href="./assets/webawesome" />
+    <link data-trunk rel="copy-file" href="../tonk-sigil/assets/sigils.svg" />
+    <!-- `<tonk-code>` web component bundle. The crate's `install()`
        injects `<script type="module" src="/tonk-code/tonk-code.js">`
        at startup; chunked language packs (e.g.
        `tonk-code-lang-yaml.js`) are loaded on demand by the element
        via relative imports, so all chunks must sit next to the
        main bundle in the same directory. The trunk copy below
        preserves that layout. -->
-  <link data-trunk rel="copy-dir" href="../tonk-code/assets" data-target-path="tonk-code" />
+    <link
+      data-trunk
+      rel="copy-dir"
+      href="../tonk-code/assets"
+      data-target-path="tonk-code"
+    />
 
-  <link data-trunk rel="css" href="./styles.css" />
-</head>
+    <link data-trunk rel="css" href="./styles.css" />
+  </head>
 
-<body>
-  <script type="module">
-    if ("serviceWorker" in navigator) {
-      await navigator.serviceWorker.register("/service_worker.js", { type: "module" });
-    } else {
-      console.error("Service workers not supported; Tonk will not work!");
-    }
-  </script>
-</body>
-
+  <body>
+    <script type="module">
+      if ("serviceWorker" in navigator) {
+        await navigator.serviceWorker.register("/service_worker.js", {
+          type: "module",
+          updateViaCache: "none",
+        });
+      } else {
+        console.error("Service workers not supported; Tonk will not work!");
+      }
+    </script>
+  </body>
 </html>
+

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -526,12 +526,6 @@ mod tests {
         // `counter-name` is a bookmark we navigate to from the
         // display route.
         let setup = r#"
-attribute!: &view-name
-  description: "view name"
-  the:         xyz.tonk.view/name
-  as:          text
-  cardinality: one
-
 attribute!: &view-model
   description: "view model"
   the:         xyz.tonk.view/model
@@ -547,7 +541,6 @@ attribute!: &view-display
 concept!: &view
   description: "A rendered view of an entity"
   with:
-    name:    view-name
     model:   view-model
     display: view-display
 
@@ -579,7 +572,6 @@ rule!:
       where: { of: 1, with: ?m, is: ?count }
 
 view!: &counter-view
-  name:    "counter-view"
   model:   counter
   display: "<div><button onclick=increment data-counter={this}>+</button><span class=\"value\">{count}</span></div>"
 


### PR DESCRIPTION
Adds a declarative path for interactive, data-bound views and the
`slide share display` verb to launch them, then hardens the
`<tonk-display>`/`<tonk-concept>` runtime so embedded live shelves,
typed filters, and view edits all behave.

### Summary

- **Reactive views** — author a `view!:` (`{model, display}`) whose
  template wires DOM events declaratively with `on<event>=<concept>`,
  a `transient: true` concept that reads from the `dom.event`
  namespace, and a `rule!:` that turns the event into downstream
  facts. No JavaScript, no `fetch` — the bridge is a transient
  assertion. Full guide in `guide-views-dynamic.md`.
- **`slide share display <subject> --view <view-name>`** — mints a
  launcher URL onto the `<tonk-display>` route. The view is resolved
  by its **anchor name**; it declares its own `model`, so the caller
  doesn't pass `--model`.

### Views are identified by anchor name (replaces `(model, name)`)

A view is now `{model, display}` published under an anchor
(`view!: &book-dashboard`). `<tonk-display>` resolves `--view` as a
name → the entity it currently points at → that view's `model` +
`display`. Re-asserting the same anchor re-points the name (git-tag
semantics), so **edits replace in place** — the previous
`(model, name)` scheme minted a fresh row per edit and the runtime
picked one nondeterministically, silently serving stale templates.

### Bug fixes

- **`<tonk-view>` no longer steals a nested shelf's `<template>`.**
  `find_template` did a subtree-wide `querySelectorAll("template")`
  and removed the first match; when a display embedded
  `<tonk-concept>` shelves, the first shelf lost its template and
  rendered a blank row. The search now stops at nested
  template-owning components (`tonk-concept`/`tonk-display`/
  `tonk-view`).
- **`<tonk-concept>` filters coerce to the field's declared type.**
  `?rating=5` on an `unsigned-integer` field compared the string
  `"5"` against `5` and never matched. Filter values are now coerced
  per the concept descriptor (`UnsignedInteger`/`SignedInteger`/
  `Float`/`Boolean`); text/entity stay strings.

### Breaking changes

- The `view` concept drops its `name` field; views are identified by
  anchor name. Existing `{model, name, display}` views must be
  re-published under an anchor.
- `slide share display` no longer needs `--model` with `--view` (the
  view carries its model); `--model` now only applies to carousel
  mode (`--view` omitted).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk` framework's handling of interactive views and sharing display functionality, particularly through declarative event handling and improved URL sharing mechanisms.

### Detailed summary
- Updated instructions for interactive views to use `on<event>=<concept>` attributes.
- Added tests to ensure preservation of nested templates in `tonk-concept`.
- Introduced `ShareDisplayOutcome` for sharing display URLs with view and model parameters.
- Improved error handling for missing subjects and concepts in sharing.
- Refined queries for resolving view entities and filtering values in queries.

> The following files were skipped due to too many changes: `rust/tonk-ui/index.html`, `rust/slide/src/guide-views-dynamic.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->