### PR TITLE
chore: bump dialog-db to tonk-2026-05-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1124,7 +1124,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-trait",
  "base58",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-trait",
  "base58",
@@ -1188,7 +1188,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1445,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "async-trait",
  "base58",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-22#ef8d8cdf05400c294edbde3a2af76dab4b818f66"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-28#876e7c91f3bf957b88583df464e87616c6aabe10"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,20 +137,20 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-22" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-05-28" }
 
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
Picks up the latest dialog-db release. Bumps all dialog-db git dependencies from `tonk-2026-05-22` to `tonk-2026-05-28` and refreshes the lockfile; the full workspace still compiles cleanly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Cargo.toml` file to change the version tags of various `dialog` dependencies from `tonk-2026-05-22` to `tonk-2026-05-28`, indicating an upgrade to a newer version of the `dialog-db` repository.

### Detailed summary
- Updated version tags for the following dependencies to `tonk-2026-05-28`:
  - `dialog-artifacts`
  - `dialog-capability`
  - `dialog-common`
  - `dialog-credentials`
  - `dialog-effects`
  - `dialog-operator`
  - `dialog-query`
  - `dialog-remote-s3`
  - `dialog-remote-ucan-s3`
  - `dialog-repository`
  - `dialog-storage`
  - `dialog-ucan`
  - `dialog-ucan-core`
  - `dialog-varsig`
- Updated `source` URLs in `Cargo.lock` for all packages to reflect the new tag.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->