### PR TITLE
feat: command notation for transient concepts

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -3559,6 +3559,64 @@ pong!:
         );
     }
 
+    /// `command!:` is a transient concept: the same body written as
+    /// `command!:` and as `concept!:` + `transient:` must derive the
+    /// same concept entity and the same transient classification, so
+    /// the committed facts (and the wire shape) are identical.
+    #[dialog_common::test]
+    async fn it_defines_command_as_transient_concept() {
+        let command_doc = must_parse(
+            r#"
+command!: &ping
+  with:
+    tag:
+      description: "Tag"
+      the:         io.gozala.ping/tag
+      as:          Text
+      cardinality: one
+ping!:
+  this: did:key:zPingSubject
+  tag:  "hi"
+"#,
+        );
+        let concept_doc = must_parse(
+            r#"
+concept!: &ping
+  transient:
+  with:
+    tag:
+      description: "Tag"
+      the:         io.gozala.ping/tag
+      as:          Text
+      cardinality: one
+ping!:
+  this: did:key:zPingSubject
+  tag:  "hi"
+"#,
+        );
+
+        let command_transient = analyze_empty(&command_doc)
+            .await
+            .unwrap()
+            .analysis
+            .transient_entities();
+        let concept_transient = analyze_empty(&concept_doc)
+            .await
+            .unwrap()
+            .analysis
+            .transient_entities();
+
+        assert_eq!(
+            command_transient.len(),
+            1,
+            "the command's concept entity is transient; got {command_transient:?}"
+        );
+        assert_eq!(
+            command_transient, concept_transient,
+            "command!: and concept!: + transient: derive the same transient concept entity"
+        );
+    }
+
     /// `has_statements()` is the `/evaluate` route's commit
     /// signal. A query-only document reports `false`; a
     /// `rule!:`-only document reports `true` (a rule is a

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -95,9 +95,13 @@ struct PendingDeclaration {
     kind: DeclarationKind,
 }
 
+#[derive(Clone, Copy)]
 enum DeclarationKind {
     Attribute,
     Concept,
+    /// A `command!:` head — parsed exactly like `Concept` but
+    /// always transient (a command *is* a transient concept).
+    Command,
 }
 
 /// The dependency graph `push` builds: the external needs to
@@ -250,6 +254,16 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
                     });
                     continue;
                 }
+                "command" => {
+                    if let Expression::Claim(Effectful { inner: a, .. }) = expression {
+                        collect_concept_with_needs(a, &mut needs);
+                    }
+                    declarations.push(PendingDeclaration {
+                        index,
+                        kind: DeclarationKind::Command,
+                    });
+                    continue;
+                }
                 _ => {}
             }
         }
@@ -269,7 +283,7 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
 
         // Head concept name (non-meta) — may be a branch concept.
         if let HeadName::Concept(name) = &head.name
-            && !matches!(name.as_str(), "attribute" | "concept")
+            && !matches!(name.as_str(), "attribute" | "concept" | "command")
         {
             needs.push(Need::Concept {
                 name: name.clone(),
@@ -456,10 +470,15 @@ impl Graph {
                         },
                     );
                 }
-                DeclarationKind::Concept => {
+                kind @ (DeclarationKind::Concept | DeclarationKind::Command) => {
                     let plan = parse_concept_body(a, scope)?;
                     let entity = plan.entity.clone();
-                    let descriptor = if plan.transient {
+                    // `command!:` is transient by definition; a
+                    // `concept!:` reads its `transient:` tag. An
+                    // explicit `transient:` inside a `command!:`
+                    // body is redundant and silently ignored.
+                    let transient = matches!(kind, DeclarationKind::Command) || plan.transient;
+                    let descriptor = if transient {
                         DurableConceptDescriptor::Transient(plan.descriptor.clone())
                     } else {
                         DurableConceptDescriptor::Durable(plan.descriptor.clone())
@@ -493,7 +512,7 @@ impl Graph {
                         .map(|attr| attribute_application(&attr.descriptor, &attr.entity, None))
                         .collect();
                     let application =
-                        concept_application(&plan.descriptor, &entity, name, plan.transient);
+                        concept_application(&plan.descriptor, &entity, name, transient);
                     declared.insert(
                         pending.index,
                         DeclaredApplication {

--- a/rust/tonk-schema/src/builtin.rs
+++ b/rust/tonk-schema/src/builtin.rs
@@ -25,7 +25,7 @@ use std::sync::OnceLock;
 use dialog_artifacts::Entity;
 use dialog_query::ConceptDescriptor as DialogConceptDescriptor;
 
-use crate::concept::concept_of_concept_descriptor;
+use crate::concept::{command_of_command_descriptor, concept_of_concept_descriptor};
 use crate::resolution::ConceptDefinition;
 use crate::rule_query::rule_of_rule_descriptor;
 use crate::{BranchQuery, RemoteQuery, ReplicaQuery, TrackingBranchQuery};
@@ -56,6 +56,7 @@ fn build_registry() -> Vec<(&'static str, ConceptDefinition)> {
     vec![
         ("attribute", builtin::<AnonymousAttributeQuery>("attribute")),
         ("concept", concept_descriptor()),
+        ("command", command_descriptor()),
         ("rule", rule_descriptor()),
         ("name", builtin::<NameQuery>("name")),
         ("branch", builtin::<BranchQuery>("branch")),
@@ -87,6 +88,27 @@ fn concept_descriptor() -> ConceptDefinition {
             .parse()
             .expect("`db:concept` is a valid entity URI"),
         descriptor: ConceptDescriptor::Durable(concept_of_concept_descriptor().clone()),
+    }
+}
+
+/// Built-in `command` view — the command-of-command descriptor.
+///
+/// Resolves to the sentinel descriptor whose `this()` triggers
+/// dispatch to [`crate::concept::AnonymousConceptQuery::commands`]
+/// in [`crate::concept::QueryPlan::from`], so a `command:` head at
+/// query time enumerates every *transient* concept (the commands)
+/// on the branch — the transient-only sibling of
+/// [`concept_descriptor`].
+///
+/// Kept as a hand-built descriptor for the same reason
+/// [`concept_descriptor`] is: its `with:` synthesises fields with
+/// no fixed-record Rust shape the derive can express.
+fn command_descriptor() -> ConceptDefinition {
+    ConceptDefinition {
+        entity: "db:command"
+            .parse()
+            .expect("`db:command` is a valid entity URI"),
+        descriptor: ConceptDescriptor::Durable(command_of_command_descriptor().clone()),
     }
 }
 

--- a/rust/tonk-schema/src/concept.rs
+++ b/rust/tonk-schema/src/concept.rs
@@ -598,6 +598,17 @@ impl Statement for TransientConcept {
     }
 }
 
+/// A **command** — the `command!:` notation's write-type.
+///
+/// A command *is* a transient concept: facts of this concept exist
+/// for one commit cycle and are swept before the branch state is
+/// written. The keyword is a clearer surface for the event-shaped
+/// data that stimulates system behavior, but the storage and wire
+/// representation are identical to [`TransientConcept`]. Aliasing
+/// rather than wrapping keeps it interchangeable with every
+/// existing `TransientConcept` call site.
+pub type Command = TransientConcept;
+
 // `Predicate` + `Concept` so `AnonymousConcept` plugs into the
 // same query machinery as a `#[derive(Concept)]` type. The
 // `Application` is [`AnonymousConceptQuery`] — a custom query
@@ -651,12 +662,31 @@ pub struct AnonymousConceptQuery {
     /// `this` (entity), `name` (bookmark name), `source`
     /// (descriptor as JSON string).
     pub terms: Parameters,
+    /// When `true`, restrict enumeration to transient (command)
+    /// concepts: skip the always-durable built-ins entirely and
+    /// drop any branch concept lacking the
+    /// `dialog.concept/transient` marker. This is what backs the
+    /// `command:` head — see [`AnonymousConceptQuery::commands`].
+    pub transient_only: bool,
 }
 
 impl AnonymousConceptQuery {
-    /// Construct a new query from a parameter map.
+    /// Construct a new query from a parameter map. Enumerates every
+    /// concept on the branch (built-in + durable + transient).
     pub fn new(terms: Parameters) -> Self {
-        Self { terms }
+        Self {
+            terms,
+            transient_only: false,
+        }
+    }
+
+    /// Construct a `command:`-flavoured query: same enumeration but
+    /// restricted to transient concepts only.
+    pub fn commands(terms: Parameters) -> Self {
+        Self {
+            terms,
+            transient_only: true,
+        }
     }
 }
 
@@ -685,7 +715,12 @@ impl Application for AnonymousConceptQuery {
                 let mut emitted_names: HashSet<String> = HashSet::new();
 
                 // ---- Built-in source ----
+                // Built-ins are always durable, so a `command:`
+                // query (transient-only) skips them entirely.
                 for (builtin_name, resolved) in concept_registry().iter() {
+                    if app.transient_only {
+                        break;
+                    }
                     if let Some(ref e) = this_filter
                         && e != &resolved.entity
                     {
@@ -735,9 +770,12 @@ impl Application for AnonymousConceptQuery {
 
                 // Bulk-load the set of transient-marked entities
                 // once per evaluation pass so the per-row check is
-                // a HashSet lookup, not a fresh query. Only fetch
-                // when the caller actually asked for `transient`.
-                let transient_entities: HashSet<Entity> = if transient_term.is_some() {
+                // a HashSet lookup, not a fresh query. Fetch when
+                // the caller asked for `transient` *or* when this is
+                // a command query (which filters on the set).
+                let transient_entities: HashSet<Entity> = if transient_term.is_some()
+                    || app.transient_only
+                {
                     let transient_marker = transient_marker_entity();
                     let transient_claims: Vec<Claim> = the!("dialog.concept/transient")
                         .of(Term::<Entity>::var("__concept_query_transient_this"))
@@ -752,6 +790,10 @@ impl Application for AnonymousConceptQuery {
 
                 for claim in claims {
                     let entity = claim.of.clone();
+                    // `command:` enumerates transient concepts only.
+                    if app.transient_only && !transient_entities.contains(&entity) {
+                        continue;
+                    }
                     let descriptor = match resolve_branch_descriptor(&entity, env).await? {
                         Some(d) => d,
                         None => continue,
@@ -852,6 +894,45 @@ fn concept_of_concept_entity() -> &'static Entity {
     ENTITY.get_or_init(|| concept_of_concept_descriptor().this())
 }
 
+/// The well-known descriptor for the "command of command" head —
+/// the `command:` query sentinel.
+///
+/// A command is a transient concept, so this enumerates the same
+/// rows as the concept-of-concept query but filtered to transient
+/// concepts only (see [`AnonymousConceptQuery::commands`]). Its
+/// `with` map mirrors [`concept_of_concept_descriptor`] *plus* a
+/// `command` marker field — the extra `dialog.meta/command`
+/// attribute URI is what makes this descriptor's content-derived
+/// `this()` distinct from the concept sentinel's. Without it the
+/// two would share an entity (identity is the attribute-URI set,
+/// not field names or description) and `command:` would mis-dispatch
+/// to the unfiltered concept enumeration.
+pub fn command_of_command_descriptor() -> &'static ConceptDescriptor {
+    static DESCRIPTOR: std::sync::OnceLock<ConceptDescriptor> = std::sync::OnceLock::new();
+    DESCRIPTOR.get_or_init(|| {
+        serde_json::from_value(serde_json::json!({
+            "description": "Every transient (command) concept asserted on a branch.",
+            "with": {
+                "command":     { "the": "dialog.meta/command",      "as": "Entity",  "cardinality": "one" },
+                "concept":     { "the": "dialog.meta/concept",      "as": "Entity",  "cardinality": "one" },
+                "name":        { "the": "dialog.meta/name",         "as": "Text",    "cardinality": "one" },
+                "description": { "the": "dialog.meta/description",   "as": "Text",    "cardinality": "one" },
+                "source":      { "the": "dialog.meta/source",       "as": "Text",    "cardinality": "one" },
+                "transient":   { "the": "dialog.concept/transient", "as": "Boolean", "cardinality": "one" }
+            }
+        }))
+        .expect("command-of-command descriptor is well-formed")
+    })
+}
+
+/// Cached `this()` of [`command_of_command_descriptor`] — the
+/// dispatch sentinel that routes a `command:` head to the
+/// transient-only [`AnonymousConceptQuery::commands`] enumeration.
+fn command_of_command_entity() -> &'static Entity {
+    static ENTITY: std::sync::OnceLock<Entity> = std::sync::OnceLock::new();
+    ENTITY.get_or_init(|| command_of_command_descriptor().this())
+}
+
 /// Resolved query — what actually runs against the engine after
 /// built-in dispatch.
 ///
@@ -872,6 +953,9 @@ pub enum QueryPlan {
     Standard(ConceptQuery),
     /// Concept-of-concept enumeration via [`AnonymousConceptQuery`].
     AnonymousConcept(AnonymousConceptQuery),
+    /// Command-of-command enumeration — transient concepts only,
+    /// via [`AnonymousConceptQuery::commands`].
+    AnonymousCommand(AnonymousConceptQuery),
     /// Rule-of-rule enumeration via [`AnonymousRuleQuery`].
     AnonymousRule(AnonymousRuleQuery),
 }
@@ -899,6 +983,8 @@ impl From<ConceptQuery> for QueryPlan {
     fn from(query: ConceptQuery) -> Self {
         if &query.predicate.this() == concept_of_concept_entity() {
             QueryPlan::AnonymousConcept(AnonymousConceptQuery::new(query.terms))
+        } else if &query.predicate.this() == command_of_command_entity() {
+            QueryPlan::AnonymousCommand(AnonymousConceptQuery::commands(query.terms))
         } else if &query.predicate.this() == rule_of_rule_entity() {
             QueryPlan::AnonymousRule(AnonymousRuleQuery::new(query.terms))
         } else {
@@ -937,6 +1023,12 @@ impl Application for QueryPlan {
                         yield each?;
                     }
                 }
+                QueryPlan::AnonymousCommand(q) => {
+                    let stream = q.evaluate(selection, env);
+                    for await each in stream {
+                        yield each?;
+                    }
+                }
                 QueryPlan::AnonymousRule(q) => {
                     let stream = q.evaluate(selection, env);
                     for await each in stream {
@@ -951,6 +1043,7 @@ impl Application for QueryPlan {
         match self {
             QueryPlan::Standard(q) => Application::realize(q, source),
             QueryPlan::AnonymousConcept(q) => Application::realize(q, source),
+            QueryPlan::AnonymousCommand(q) => Application::realize(q, source),
             QueryPlan::AnonymousRule(q) => Application::realize(q, source),
         }
     }
@@ -1225,44 +1318,49 @@ fn meta_attr(domain: &str, name: &str) -> ArtifactsAttribute {
 mod tests {
     use super::*;
 
-    #[test]
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
     fn with_constructs_namespaced_relation() {
         let the = with("title").unwrap();
         assert_eq!(String::from(&the), "dialog.concept.with/title");
     }
 
-    #[test]
+    #[dialog_common::test]
     fn maybe_constructs_namespaced_relation() {
         let the = maybe("subtitle").unwrap();
         assert_eq!(String::from(&the), "dialog.concept.maybe/subtitle");
     }
 
-    #[test]
+    #[dialog_common::test]
     fn parse_with_round_trips() {
         let the = with("ingredient-name").unwrap();
         assert_eq!(parse_with(&the).as_deref(), Some("ingredient-name"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn parse_maybe_round_trips() {
         let the = maybe("notes").unwrap();
         assert_eq!(parse_maybe(&the).as_deref(), Some("notes"));
     }
 
-    #[test]
+    #[dialog_common::test]
     fn parse_with_rejects_other_domains() {
         let the: ArtifactsAttribute = "dialog.meta/name".parse().unwrap();
         assert_eq!(parse_with(&the), None);
         assert_eq!(parse_maybe(&the), None);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn parse_with_rejects_maybe_domain() {
         let the = maybe("x").unwrap();
         assert_eq!(parse_with(&the), None);
     }
 
-    #[test]
+    #[dialog_common::test]
     fn descriptor_round_trips_through_json() {
         let json = r#"{
             "description": "A cooking recipe",
@@ -1280,7 +1378,7 @@ mod tests {
     /// `dialog.meta/description` when set, plus the marker
     /// claim `dialog.meta/concept = db:concept` that lets
     /// branch-wide concept enumeration find this entity.
-    #[test]
+    #[dialog_common::test]
     fn anonymous_concept_writes_with_claims_and_description() {
         use dialog_artifacts::Changes;
         let json = r#"{
@@ -1304,7 +1402,7 @@ mod tests {
     /// triple. The marker is what the reactor reads at commit
     /// time to decide which facts to strip from the persistable
     /// delta.
-    #[test]
+    #[dialog_common::test]
     fn transient_concept_writes_transient_marker() {
         use dialog_artifacts::{Changes, Instruction};
         let json = r#"{
@@ -1356,7 +1454,7 @@ mod tests {
     /// `(?this, dialog.meta/concept, db:concept)` marker so
     /// `concept:` queries with `?this` unbound can drive
     /// selection from a single bound triple.
-    #[test]
+    #[dialog_common::test]
     fn anonymous_concept_writes_marker_claim() {
         use dialog_artifacts::{Changes, Instruction};
         let json = r#"{
@@ -1386,7 +1484,7 @@ mod tests {
     /// Retract path mirrors assert: the marker dissociation must
     /// be emitted alongside the with-claim retractions so the
     /// branch ends up clean.
-    #[test]
+    #[dialog_common::test]
     fn anonymous_concept_retracts_marker_claim() {
         use dialog_artifacts::{Changes, Instruction};
         let json = r#"{
@@ -1417,7 +1515,7 @@ mod tests {
     /// dialog `Concept` trait (and its `Predicate` supertrait),
     /// so it slots into query and rule machinery the same way
     /// `#[derive(Concept)]` types do.
-    #[test]
+    #[dialog_common::test]
     fn concept_wrapper_satisfies_concept_trait() {
         fn requires_concept<C: dialog_query::Concept>(_: &C)
         where
@@ -1435,7 +1533,7 @@ mod tests {
     /// [`AnonymousConceptQuery`] branch when the wire query's
     /// predicate is the concept-of-concept descriptor; otherwise
     /// it stays a [`ConceptQuery`].
-    #[test]
+    #[dialog_common::test]
     fn it_dispatches_concept_of_concept_to_anonymous_query() {
         // Concept-of-concept predicate → AnonymousConcept variant.
         let plan = QueryPlan::from(ConceptQuery {
@@ -1461,9 +1559,40 @@ mod tests {
         );
     }
 
+    /// The command sentinel must not collide with the concept
+    /// sentinel — identity is the attribute-URI set, so the extra
+    /// `dialog.meta/command` marker attribute is load-bearing.
+    #[dialog_common::test]
+    fn it_distinguishes_command_sentinel_from_concept_sentinel() {
+        assert_ne!(
+            command_of_command_descriptor().this(),
+            concept_of_concept_descriptor().this(),
+            "command and concept sentinels must hash to distinct entities",
+        );
+    }
+
+    /// `QueryPlan::from(ConceptQuery)` dispatches to the
+    /// transient-only [`AnonymousConceptQuery`] (via the
+    /// `AnonymousCommand` variant) when the wire query's predicate
+    /// is the command-of-command descriptor.
+    #[dialog_common::test]
+    fn it_dispatches_command_of_command_to_anonymous_command_query() {
+        let plan = QueryPlan::from(ConceptQuery {
+            terms: dialog_query::Parameters::new(),
+            predicate: command_of_command_descriptor().clone(),
+        });
+        match plan {
+            QueryPlan::AnonymousCommand(q) => assert!(
+                q.transient_only,
+                "command dispatch must produce a transient-only query",
+            ),
+            _ => panic!("command-of-command predicate should dispatch to AnonymousCommand"),
+        }
+    }
+
     /// `assert` then `retract` should leave nothing — every
     /// claim that goes in comes back out.
-    #[test]
+    #[dialog_common::test]
     fn anonymous_concept_assert_then_retract_balances() {
         use dialog_artifacts::Changes;
         let json = r#"{
@@ -1735,6 +1864,124 @@ mod tests {
                 .source()
                 .lookup(&Term::<Any>::var("transient"))?,
             dialog_query::Value::Boolean(false),
+        );
+
+        Ok(())
+    }
+
+    /// A `command:` query (the transient-only enumeration) surfaces
+    /// only transient concepts: a transient concept appears, the
+    /// durable concept on the same branch does not.
+    #[dialog_common::test]
+    async fn it_queries_command_returns_only_transient_concepts() -> anyhow::Result<()> {
+        use dialog_query::{Any, Output as _, Parameters, Term};
+        use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+
+        let (operator, profile) = test_operator_with_profile().await;
+        let repo = test_repo(&operator, &profile).await;
+        let branch = repo.branch("main").open().perform(&operator).await?;
+
+        let command_descriptor: ConceptDescriptor = serde_json::from_str(
+            r#"{
+                "with": {
+                    "subject": { "the": "xyz.tonk.ping/subject", "as": "Entity", "cardinality": "one" }
+                }
+            }"#,
+        )?;
+        let durable_descriptor: ConceptDescriptor = serde_json::from_str(
+            r#"{
+                "with": {
+                    "name": { "the": "xyz.tonk.person/name", "as": "Text", "cardinality": "one" }
+                }
+            }"#,
+        )?;
+
+        let (_, c_attr) = command_descriptor.with().iter().next().expect("one field");
+        let (_, d_attr) = durable_descriptor.with().iter().next().expect("one field");
+        let c_attr_entity: Entity = c_attr.to_uri().parse()?;
+        let d_attr_entity: Entity = d_attr.to_uri().parse()?;
+
+        // `Command` is the command write-type — a transient concept.
+        let command = Command::new(command_descriptor.clone());
+        let durable_concept = AnonymousConcept::new(durable_descriptor.clone());
+        let command_entity = command.this.clone();
+        let durable_entity = durable_concept.this.clone();
+
+        branch
+            .transaction()
+            .assert(
+                dialog_query::the!("dialog.attribute/id")
+                    .of(c_attr_entity.clone())
+                    .is(format!("{}/{}", c_attr.domain(), c_attr.name())),
+            )
+            .assert(
+                dialog_query::the!("dialog.attribute/type")
+                    .of(c_attr_entity.clone())
+                    .is("Entity".to_string()),
+            )
+            .assert(
+                dialog_query::the!("dialog.attribute/cardinality")
+                    .of(c_attr_entity.clone())
+                    .is("one".to_string()),
+            )
+            .assert(
+                dialog_query::the!("dialog.meta/description")
+                    .of(c_attr_entity)
+                    .is(String::new()),
+            )
+            .assert(
+                dialog_query::the!("dialog.attribute/id")
+                    .of(d_attr_entity.clone())
+                    .is(format!("{}/{}", d_attr.domain(), d_attr.name())),
+            )
+            .assert(
+                dialog_query::the!("dialog.attribute/type")
+                    .of(d_attr_entity.clone())
+                    .is("Text".to_string()),
+            )
+            .assert(
+                dialog_query::the!("dialog.attribute/cardinality")
+                    .of(d_attr_entity.clone())
+                    .is("one".to_string()),
+            )
+            .assert(
+                dialog_query::the!("dialog.meta/description")
+                    .of(d_attr_entity)
+                    .is(String::new()),
+            )
+            .assert(command)
+            .assert(durable_concept)
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let mut terms = Parameters::new();
+        terms.insert("this".to_string(), Term::<Any>::var("this"));
+
+        let conclusions: Vec<ConceptConclusion> = branch
+            .query()
+            .select(AnonymousConceptQuery::commands(terms))
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        let entities: HashSet<Entity> = conclusions
+            .iter()
+            .filter_map(|c| {
+                c.source()
+                    .lookup(&Term::<Any>::var("this"))
+                    .ok()
+                    .and_then(|v| Entity::try_from(v).ok())
+            })
+            .collect();
+
+        assert!(
+            entities.contains(&command_entity),
+            "command query must surface the transient concept",
+        );
+        assert!(
+            !entities.contains(&durable_entity),
+            "command query must not surface the durable concept",
         );
 
         Ok(())

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -1434,10 +1434,13 @@ fn render_match_block_notation(blocks: Vec<tonk_worker::QueryMatchBlock>) -> imp
             { blocks.into_iter().flat_map(|block| {
                 let label = block.label;
                 let is_concept = label == CONCEPT_LABEL;
+                let is_command = label == COMMAND_LABEL;
                 let is_rule = label == RULE_LABEL;
                 block.results.into_iter().map(move |result| {
                     if is_concept {
-                        render_concept_record(result).into_any()
+                        render_concept_record(result, CONCEPT_LABEL).into_any()
+                    } else if is_command {
+                        render_concept_record(result, COMMAND_LABEL).into_any()
                     } else if is_rule {
                         render_rule_record(result).into_any()
                     } else {
@@ -1454,6 +1457,13 @@ fn render_match_block_notation(blocks: Vec<tonk_worker::QueryMatchBlock>) -> imp
 /// assertions (the `source` descriptor expanded as notation)
 /// rather than the generic field-by-field record.
 const CONCEPT_LABEL: &str = "concept";
+
+/// Block label of a `command:` query. A command *is* a transient
+/// concept, so results render as `command!:` definitions — same
+/// descriptor expansion as a concept, but with the `command!:`
+/// head and without the redundant `transient:` row (the keyword
+/// already implies it).
+const COMMAND_LABEL: &str = "command";
 
 /// Block label of a `rule:` query. Results in a block with this
 /// label are inductive-rule definitions and render as `rule!:`
@@ -1528,6 +1538,7 @@ fn notation_normalize(value: &mut serde_json::Value) {
 /// parse as a JSON object.
 fn concept_descriptor(
     result: &tonk_worker::QueryResult,
+    show_transient: bool,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let value = result.fields.get("source")?.clone();
     let map = match value {
@@ -1546,10 +1557,14 @@ fn concept_descriptor(
         serde_json::Value::Object(map) => map,
         _ => unreachable!("value was constructed as an object"),
     };
-    if matches!(
-        result.fields.get("transient"),
-        Some(serde_json::Value::Bool(true))
-    ) {
+    // A `command!:` head already implies transience, so only the
+    // `concept!:` rendering surfaces the explicit `transient:` row.
+    if show_transient
+        && matches!(
+            result.fields.get("transient"),
+            Some(serde_json::Value::Bool(true))
+        )
+    {
         map.insert("transient".to_owned(), serde_json::Value::Bool(true));
     }
     Some(map)
@@ -1560,13 +1575,15 @@ fn concept_descriptor(
 /// descriptor's own keys (`description`, `with`, …) expanded as
 /// nested notation. The `name`/`concept` projection fields are
 /// vestigial here — the descriptor in `source` is the definition.
-fn render_concept_record(result: tonk_worker::QueryResult) -> impl IntoView {
-    let descriptor = concept_descriptor(&result);
+fn render_concept_record(result: tonk_worker::QueryResult, head: &'static str) -> impl IntoView {
+    // `command!:` implies transience; only `concept!:` shows the row.
+    let show_transient = head == CONCEPT_LABEL;
+    let descriptor = concept_descriptor(&result, show_transient);
     let entity = result.this;
     view! {
         <div class="notation-record">
             <div class="notation-row">
-                <span class="tonk-cm-effect">"concept!:"</span>
+                <span class="tonk-cm-effect">{ format!("{head}!:") }</span>
             </div>
             { render_notation_field_at(
                 1,
@@ -1891,13 +1908,16 @@ fn render_match_block_list(blocks: Vec<tonk_worker::QueryMatchBlock>) -> impl In
         <wa-tree class="query-tree">
             { blocks.into_iter().map(|block| {
                 let is_concept = block.label == CONCEPT_LABEL;
+                let is_command = block.label == COMMAND_LABEL;
                 let is_rule = block.label == RULE_LABEL;
                 view! {
                     <wa-tree-item expanded>
                         <span class="tonk-cm-effect">{ block.label }</span><span class="tonk-cm-plain">":"</span>
                         { block.results.into_iter().map(move |result| {
                             if is_concept {
-                                render_concept_tree_item(result).into_any()
+                                render_concept_tree_item(result, CONCEPT_LABEL).into_any()
+                            } else if is_command {
+                                render_concept_tree_item(result, COMMAND_LABEL).into_any()
                             } else if is_rule {
                                 render_rule_tree_item(result).into_any()
                             } else {
@@ -1933,12 +1953,13 @@ fn render_result_tree_item(result: tonk_worker::QueryResult) -> impl IntoView {
 /// One concept result as a `concept!:` tree item: a `this:` child
 /// for the entity, then the `source` descriptor's keys expanded as
 /// nested tree items so `with:` reads as a notation block.
-fn render_concept_tree_item(result: tonk_worker::QueryResult) -> impl IntoView {
-    let descriptor = concept_descriptor(&result);
+fn render_concept_tree_item(result: tonk_worker::QueryResult, head: &'static str) -> impl IntoView {
+    let show_transient = head == CONCEPT_LABEL;
+    let descriptor = concept_descriptor(&result, show_transient);
     let entity = result.this;
     view! {
         <wa-tree-item expanded>
-            <span class="tonk-cm-effect">"concept!"</span><span class="tonk-cm-plain">":"</span>
+            <span class="tonk-cm-effect">{ head }</span><span class="tonk-cm-plain">"!:"</span>
             { render_notation_tree_item(
                 "this".to_owned(),
                 serde_json::Value::String(entity),
@@ -2495,7 +2516,7 @@ mod tests {
     /// the rendered descriptor map.
     #[dialog_common::test]
     fn it_renders_transient_true_on_transient_concept_row() {
-        let map = concept_descriptor(&concept_row(Some(true))).expect("descriptor projects");
+        let map = concept_descriptor(&concept_row(Some(true)), true).expect("descriptor projects");
         assert_eq!(map.get("transient"), Some(&Value::Bool(true)));
     }
 
@@ -2504,7 +2525,7 @@ mod tests {
     /// durable; affirmative is the only marker).
     #[dialog_common::test]
     fn it_omits_transient_on_durable_concept_row() {
-        let map = concept_descriptor(&concept_row(Some(false))).expect("descriptor projects");
+        let map = concept_descriptor(&concept_row(Some(false)), true).expect("descriptor projects");
         assert!(
             !map.contains_key("transient"),
             "durable concepts must not surface a transient row",
@@ -2515,7 +2536,19 @@ mod tests {
     /// behaves the same as `Bool(false)`: no row.
     #[dialog_common::test]
     fn it_omits_transient_when_binding_absent() {
-        let map = concept_descriptor(&concept_row(None)).expect("descriptor projects");
+        let map = concept_descriptor(&concept_row(None), true).expect("descriptor projects");
         assert!(!map.contains_key("transient"));
+    }
+
+    /// A `command!:` rendering (`show_transient = false`) never
+    /// surfaces the `transient:` row — the keyword already implies
+    /// it — even when the row carries `Bool(true)`.
+    #[dialog_common::test]
+    fn it_omits_transient_row_on_command_render() {
+        let map = concept_descriptor(&concept_row(Some(true)), false).expect("descriptor projects");
+        assert!(
+            !map.contains_key("transient"),
+            "command rendering must not surface a redundant transient row",
+        );
     }
 }


### PR DESCRIPTION
Talking about "transient concepts" to mean commands has been a recurring source of confusion: the word describes a storage property, not intent, and it's easy to forget the `transient:` tag and silently get a durable concept instead. The design notes already reach for `command!:` / `command:` as the surface we want, so this makes that real.

A command is exactly a transient concept, just spelled `command!:` (define) and `command:` (query). Definitions force transience without a tag; queries enumerate only transient concepts. The write path and the wire shape (`{ kind: "transient", concept: … }`) are untouched, so nothing downstream of the analyzer has to learn the keyword.

The one subtlety is query dispatch. Concept identity is the attribute-URI set, so a command query sentinel that reused the concept sentinel's attributes would hash to the same entity and mis-dispatch to the unfiltered concept enumeration. The command sentinel carries an extra `dialog.meta/command` marker attribute to keep its `this()` distinct, and the shared enumeration grew a transient-only mode that skips the always-durable built-ins and filters branch concepts by the `dialog.concept/transient` marker. `Command` is a type alias of the existing `TransientConcept`, and the inspector renders `command:` results as `command!:` definitions (dropping the now-redundant `transient:` row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the concept of `command!:` as a transient concept in the codebase, ensuring it behaves similarly to `concept!:` while maintaining distinct handling in queries and representations.

### Detailed summary
- Added a test `it_defines_command_as_transient_concept` to verify `command!:` as a transient concept.
- Introduced `DeclarationKind::Command` to handle command declarations.
- Implemented `command_descriptor()` to define command behavior.
- Updated query handling to distinguish between commands and concepts.
- Enhanced rendering functions to accommodate `command!:`.
- Added tests to ensure command queries return only transient concepts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->