### PR TITLE
fix(tonk-analyzer): derive entity from resolved reference fields

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -1911,7 +1911,7 @@ attribute:
     /// `this: alice` (bare symbol) resolves through the name
     /// table — Stage 2.5. A bare symbol that doesn't match any
     /// in-doc declaration or branch name surfaces
-    /// `UnknownBookmark` with `field: "this"`.
+    /// `UnknownNameReference` with `field: "this"`.
     #[dialog_common::test]
     async fn it_rejects_unresolvable_bare_symbol_in_this() {
         let syntax = must_parse(
@@ -1924,8 +1924,8 @@ person!:
         let resolver = fixed_concept("person", &[("name", "io.gozala.person/name")]);
         let err = analyze_with(&syntax, &resolver).await.unwrap_err();
         assert!(
-            matches!(&err.kind, AnalyzeErrorKind::UnknownBookmark { field, bookmark } if field == "this" && bookmark == "ghost"),
-            "expected UnknownBookmark on `this` with bookmark=\"ghost\", got {err:?}"
+            matches!(&err.kind, AnalyzeErrorKind::UnknownNameReference { field, name } if field == "this" && name == "ghost"),
+            "expected UnknownNameReference on `this` with name=\"ghost\", got {err:?}"
         );
     }
 
@@ -2292,7 +2292,7 @@ concept!:
     }
 
     /// A bare symbol that doesn't resolve anywhere surfaces
-    /// `UnknownBookmark` (with the symbol's name in `bookmark`).
+    /// `UnknownNameReference` (with the symbol's name in `name`).
     #[dialog_common::test]
     async fn it_rejects_unresolvable_bare_symbol() {
         let syntax = must_parse(
@@ -2304,8 +2304,8 @@ person!:
         let resolver = fixed_concept("person", &[("name", "io.gozala.person/name")]);
         let err = analyze_with(&syntax, &resolver).await.unwrap_err();
         assert!(
-            matches!(&err.kind, AnalyzeErrorKind::UnknownBookmark { bookmark, .. } if bookmark == "ghost"),
-            "expected UnknownBookmark{{bookmark:\"ghost\"}}, got {err:?}"
+            matches!(&err.kind, AnalyzeErrorKind::UnknownNameReference { name, .. } if name == "ghost"),
+            "expected UnknownNameReference{{name:\"ghost\"}}, got {err:?}"
         );
     }
 

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -109,6 +109,7 @@ pub(crate) fn build_assertion_application(
                 &name,
                 &assertion.fields,
                 &predicate_entity,
+                scope,
                 analysis,
                 name_range,
             )?;
@@ -288,6 +289,7 @@ pub(crate) fn build_assertion_application(
                 &name,
                 &assertion.fields,
                 &predicate_entity,
+                scope,
                 analysis,
                 name_range,
             )?;
@@ -347,7 +349,7 @@ pub(crate) fn build_assertion_application(
 ///     [`ThisIntent::Uri(entity)`]. Resolution order matches
 ///     [`super::field::field_value_to_term`]: doc-local
 ///     declarations first, then the branch's `dialog.meta/name`
-///     index. Unresolvable symbols surface as `UnknownBookmark`.
+///     index. Unresolvable symbols surface as `UnknownNameReference`.
 ///
 /// - **Naming** — the `&name` on the value side, captured by the
 ///   parser as `Anchor`. Returned as `Some(name)` when present.
@@ -385,9 +387,9 @@ pub(crate) fn derive_head_intent(
                 // declarations + prefetched branch entities).
                 let entity = scope.symbol(name).ok_or_else(|| {
                     AnalyzeError::at(
-                        AnalyzeErrorKind::UnknownBookmark {
+                        AnalyzeErrorKind::UnknownNameReference {
                             field: "this".into(),
-                            bookmark: name.clone(),
+                            name: name.clone(),
                         },
                         field.value_range,
                     )
@@ -440,12 +442,13 @@ fn this_term_for_assertion(
     name: &Option<String>,
     fields: &[Field],
     predicate_entity: &Entity,
+    scope: &Scope,
     analysis: &mut Working,
     name_range: lsp_types::Range,
 ) -> Result<Term<dialog_query::Any>, AnalyzeError> {
     Ok(match this {
         ThisIntent::Derived => {
-            let entity = derive_this(predicate_entity, &body_digest(fields));
+            let entity = derive_this(predicate_entity, &body_digest(fields, scope)?);
             if let Some(name) = name {
                 if let Some(prior) = analysis.declarations.get(name)
                     && prior != &entity
@@ -469,7 +472,7 @@ fn this_term_for_assertion(
                 // First introduction — mint a body-derived
                 // entity and register it for later expressions
                 // that share `?name`.
-                let entity = derive_this(predicate_entity, &body_digest(fields));
+                let entity = derive_this(predicate_entity, &body_digest(fields, scope)?);
                 analysis.variables.insert(var.clone(), entity.clone());
                 Term::Constant(Value::Entity(entity))
             }
@@ -479,30 +482,72 @@ fn this_term_for_assertion(
 }
 
 /// Project an assertion body into the [`ValueMap`] shape fed to
-/// [`derive_this`] for entity derivation. Only literal scalars
-/// contribute; variables, references, blanks, and nested forms
-/// are skipped (they'd reference *other* entities, and including
-/// them would defeat the deterministic-rerun property).
+/// [`derive_this`] for entity derivation. Every field contributes
+/// its *resolved* value, with references (bare symbols, URIs)
+/// resolved to the entity they name — so a view's `model: counter`
+/// identifies the view by the concept it points at, not merely by
+/// the fields that happen to be literals.
+///
+/// Resolution goes through `scope`, which the resolve pass has
+/// already populated (in-doc declarations + prefetched branch
+/// names), so this never touches the branch. A reference that does
+/// **not** resolve is an error, not a skip: dropping it would fold
+/// the assertion into the entity it *would* have had without that
+/// field, silently deriving the wrong subject. Forms that carry no
+/// content identity — unbound variables (`?var` means "join with a
+/// query," not "part of my content"), blanks, premises, nested
+/// maps — are skipped. Meta fields (`this:`, `..:`) never
+/// contribute.
 ///
 /// The output is consumed by [`derive_this`] alongside the
-/// predicate's identity, so the resulting entity converges with
-/// the wire-path derivation in `application_plan_from_predicate`
-/// for matching `(predicate, payload)` pairs.
-///
-/// Pure function of `fields` (no scope, no resolver), so it's
-/// safe to call from Phase 1 to pre-compute the entity for an
-/// anchor declaration.
-pub(super) fn body_digest(fields: &[Field]) -> ValueMap {
+/// predicate's identity, and mirrors the resolved payload the
+/// wire path (`application_plan_from_predicate`) hashes, so the
+/// notation and wire paths converge on the same entity for a
+/// matching `(predicate, payload)` pair — references included.
+pub(super) fn body_digest(fields: &[Field], scope: &Scope) -> Result<ValueMap, AnalyzeError> {
     let mut out = ValueMap::new();
     for field in fields {
+        if is_meta_field(&field.name) {
+            continue;
+        }
         let value = match &field.value {
             FieldValue::Literal(scalar) => scalar_to_value(scalar),
-            // Skip variables, references, blanks, nested.
-            _ => continue,
+            FieldValue::Symbol(name) => {
+                let entity = scope.symbol(name).ok_or_else(|| {
+                    AnalyzeError::at(
+                        AnalyzeErrorKind::UnknownNameReference {
+                            field: field.name.clone(),
+                            name: name.clone(),
+                        },
+                        field.value_range,
+                    )
+                })?;
+                Value::Entity(entity)
+            }
+            FieldValue::Uri(uri) => {
+                let entity: Entity =
+                    uri.parse()
+                        .map_err(|e: dialog_artifacts::DialogArtifactsError| {
+                            AnalyzeError::at(
+                                AnalyzeErrorKind::InvalidSubjectUri {
+                                    subject: uri.clone(),
+                                    reason: e.to_string(),
+                                },
+                                field.value_range,
+                            )
+                        })?;
+                Value::Entity(entity)
+            }
+            // Unbound variables, blanks, premises and nested maps
+            // carry no content identity.
+            FieldValue::Variable(_)
+            | FieldValue::Blank
+            | FieldValue::Premises(_)
+            | FieldValue::Nested(_) => continue,
         };
         out.insert(field.name.clone(), value);
     }
-    out
+    Ok(out)
 }
 
 fn scalar_to_value(scalar: &Scalar) -> Value {

--- a/rust/tonk-analyzer/src/analyzer/declaration.rs
+++ b/rust/tonk-analyzer/src/analyzer/declaration.rs
@@ -283,9 +283,9 @@ fn resolve_concept_field(
     match value {
         FieldValue::Variable(name) | FieldValue::Symbol(name) => {
             scope.attribute(name).ok_or_else(|| {
-                AnalyzeErrorKind::UnknownBookmark {
+                AnalyzeErrorKind::UnknownNameReference {
                     field: field_name.into(),
-                    bookmark: name.clone(),
+                    name: name.clone(),
                 }
                 .into()
             })
@@ -300,9 +300,9 @@ fn resolve_concept_field(
                         }
                     })?;
             scope.attribute_by_entity(&entity).ok_or_else(|| {
-                AnalyzeErrorKind::UnknownBookmark {
+                AnalyzeErrorKind::UnknownNameReference {
                     field: field_name.into(),
-                    bookmark: uri.clone(),
+                    name: uri.clone(),
                 }
                 .into()
             })

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -327,14 +327,14 @@ pub enum AnalyzeErrorKind {
     /// be resolved through the in-doc declarations or branch
     /// name table.
     #[error(
-        "field {field:?} references unknown name {bookmark:?} \
+        "field {field:?} references unknown name {name:?} \
          — define it earlier in the document or as an attribute on the branch"
     )]
-    UnknownBookmark {
+    UnknownNameReference {
         /// Field where the reference appeared.
         field: String,
         /// The unresolved name.
-        bookmark: String,
+        name: String,
     },
     /// Claim head with no body fields — claims have no schema to
     /// fall back on.
@@ -449,7 +449,7 @@ impl AnalyzeErrorKind {
             Self::UnknownField { .. } => "E_UNKNOWN_FIELD",
             Self::UnknownFormulaOperand { .. } => "E_UNKNOWN_FORMULA_OPERAND",
             Self::MissingFormulaOperand { .. } => "E_MISSING_FORMULA_OPERAND",
-            Self::UnknownBookmark { .. } => "E_UNKNOWN_BOOKMARK",
+            Self::UnknownNameReference { .. } => "E_UNKNOWN_NAME_REFERENCE",
             Self::ClaimWithoutFields { .. } => "E_CLAIM_WITHOUT_FIELDS",
             Self::InvalidClaimAttribute { .. } => "E_INVALID_CLAIM_ATTRIBUTE",
             Self::UnsupportedFieldValue { .. } => "E_UNSUPPORTED_FIELD_VALUE",

--- a/rust/tonk-analyzer/src/analyzer/field.rs
+++ b/rust/tonk-analyzer/src/analyzer/field.rs
@@ -67,9 +67,9 @@ pub(crate) fn field_value_to_term(
                 Term::Constant(Value::Entity(entity))
             } else {
                 return Err(AnalyzeError::at(
-                    AnalyzeErrorKind::UnknownBookmark {
+                    AnalyzeErrorKind::UnknownNameReference {
                         field: field_name.into(),
-                        bookmark: name.clone(),
+                        name: name.clone(),
                     },
                     range,
                 ));

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -616,7 +616,7 @@ impl Graph {
                 HeadName::Claim(domain) => Entity::of(domain),
                 HeadName::Uri(_) => continue,
             };
-            let entity = derive_this(&predicate_entity, &body_digest(&a.fields));
+            let entity = derive_this(&predicate_entity, &body_digest(&a.fields, scope)?);
             scope.declare(&anchor.name, entity, anchor.range)?;
         }
 

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -838,6 +838,21 @@ mod tests {
         )])
     }
 
+    /// Build a `ConceptDescriptor` with one cardinality-one
+    /// entity-reference field. Used to exercise digest behaviour
+    /// for fields whose value names *another* entity.
+    fn one_entity_field(domain: &str, name: &str) -> ConceptDescriptor {
+        ConceptDescriptor::from(vec![(
+            name,
+            AttributeDescriptor::new(
+                format!("{domain}/{name}").parse().unwrap(),
+                "",
+                DialogCardinality::One,
+                Some(Type::Entity),
+            ),
+        )])
+    }
+
     /// Extract the lone `Statement::InstallEffect` from an
     /// analysis tree, panicking if the document does not lower to
     /// exactly one statement and it is not an effect install.
@@ -1348,6 +1363,136 @@ view!:\n\
         assert_eq!(
             notation_this, wire_this,
             "notation and wire paths must derive the same subject entity for the same (concept, payload)"
+        );
+    }
+
+    /// Entity derivation includes reference fields, not just
+    /// literals — so a concept identified by an entity *reference*
+    /// (e.g. a view's `model`) gets a distinct, correct entity.
+    ///
+    /// Regression guard for a `body_digest` defect: it used to
+    /// include only literal scalars and skip references, so two
+    /// assertions that differed *only* by a reference field hashed
+    /// to the **same** entity, and the notation path diverged from
+    /// the wire path (`application_plan_from_predicate`), which
+    /// always included the reference. Two facets are asserted:
+    ///   1. distinctness — different `model` ⇒ different entity;
+    ///   2. convergence  — notation and wire paths agree.
+    #[dialog_common::test]
+    async fn it_derives_distinct_entities_for_distinct_reference_fields() {
+        use dialog_artifacts::Value;
+        use tonk_core::claim::{
+            ConceptDescriptor as DurableConceptDescriptor, PredicateApplication, ValueMap,
+        };
+        use tonk_schema::transact::{
+            Application, ApplicationPlan, ConceptPlan, Statement, application_plan_from_predicate,
+        };
+
+        let fixture = new_fixture().await;
+
+        // A `view` concept whose sole field, `model`, is an entity
+        // reference, plus two distinct concepts it can point at.
+        let view = one_entity_field("xyz.tonk.view", "model");
+        fixture.declare("view", view.clone()).await;
+        fixture
+            .declare("counter", one_text_field("xyz.tonk.counter", "count"))
+            .await;
+        fixture
+            .declare("greeting", one_text_field("xyz.tonk.greeting", "message"))
+            .await;
+
+        // Helper: lower a `view!: { model: <name> }` document and
+        // pull the derived `this` entity out of the lone statement.
+        async fn notation_this_for(fixture: &Fixture<impl FixtureEnv>, model_name: &str) -> Entity {
+            let doc = format!("view!:\n  model: {model_name}\n");
+            let syntax = parse(&doc).syntax.expect("parsed syntax");
+            let analysis = fixture
+                .analyze(&syntax)
+                .await
+                .expect("notation document analyzes");
+            let stmts = analysis.analysis.statements();
+            assert_eq!(stmts.len(), 1, "expected one statement");
+            let Statement::Assert(Application::Concept { query, .. }) = &stmts[0].statement else {
+                panic!("expected concept assert, got {:?}", stmts[0].statement);
+            };
+            match query.terms.get("this").expect("this present") {
+                dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
+                other => panic!("expected entity constant, got {other:?}"),
+            }
+        }
+
+        let view_of_counter = notation_this_for(&fixture, "counter").await;
+        let view_of_greeting = notation_this_for(&fixture, "greeting").await;
+
+        // Facet 1 — distinctness. Today both drop `model` from the
+        // digest and collide on `derive_this(view, {})`.
+        assert_ne!(
+            view_of_counter, view_of_greeting,
+            "views for different models must be different entities; \
+             body_digest dropping the `model` reference makes them collide"
+        );
+
+        // Facet 2 — convergence with the wire path for the counter
+        // view. The notation analyzer resolves the bare symbol
+        // `counter` to its concept entity via the published
+        // `id:counter` name, which `declare` set to the descriptor's
+        // own `this()`. The wire payload carries that same resolved
+        // entity, so both paths see identical `(predicate, payload)`.
+        let counter_concept = one_text_field("xyz.tonk.counter", "count").this();
+        let mut parameters = ValueMap::new();
+        parameters.insert("model".into(), Value::Entity(counter_concept));
+        let wire_plan = application_plan_from_predicate(PredicateApplication {
+            predicate: DurableConceptDescriptor::Durable(view),
+            parameters,
+            name: None,
+        });
+        let wire_this = {
+            let ApplicationPlan::Concept(ConceptPlan { statement, .. }) = &wire_plan else {
+                panic!("expected concept plan");
+            };
+            match statement.terms.get("this").expect("this present") {
+                dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
+                other => panic!("expected entity constant, got {other:?}"),
+            }
+        };
+
+        assert_eq!(
+            view_of_counter, wire_this,
+            "notation and wire paths must derive the same entity when the body \
+             carries a `model` reference"
+        );
+    }
+
+    /// A reference field that doesn't resolve is an error, not a
+    /// silent skip. Dropping the unresolved `model` from the digest
+    /// would fold the view into the entity it would have had with
+    /// no model at all — deriving the wrong subject. The anchor
+    /// (`&broken`) routes derivation through `body_digest` in the
+    /// resolve pass, so this exercises that path specifically.
+    #[dialog_common::test]
+    async fn it_rejects_unresolved_reference_in_derived_entity() {
+        let fixture = new_fixture().await;
+        // Declare `view` (so the head concept resolves) but NOT the
+        // concept its `model` points at.
+        fixture
+            .declare("view", one_entity_field("xyz.tonk.view", "model"))
+            .await;
+
+        let doc = "\
+view!: &broken\n\
+\x20 model: nonexistent\n";
+        let syntax = parse(doc).syntax.expect("parsed syntax");
+        let err = fixture
+            .analyze(&syntax)
+            .await
+            .expect_err("unresolved reference in a derived entity must error");
+        assert!(
+            matches!(
+                err.kind,
+                AnalyzeErrorKind::UnknownNameReference { ref name, .. }
+                    if name == "nonexistent"
+            ),
+            "expected UnknownNameReference(nonexistent), got {err:?}"
         );
     }
 }

--- a/rust/tonk-language-server/src/server.rs
+++ b/rust/tonk-language-server/src/server.rs
@@ -443,7 +443,7 @@ impl Server {
 /// this document, additionally runs the full analyzer pass
 /// (`tonk_analyzer::analyze`) against its `(source, env)` pair
 /// to surface branch-dependent diagnostics (`UnknownConcept`,
-/// `UnknownBookmark`, `ResolverFailed`, `InvalidClaimAttribute`).
+/// `UnknownNameReference`, `ResolverFailed`, `InvalidClaimAttribute`).
 ///
 /// Without an opened env the analyzer pass is skipped — there's
 /// no `Source` to resolve references against — and the


### PR DESCRIPTION
## Why

Content-derived entity identity is what lets an assertion be addressed by its content without the author inventing an id, and what keeps the notation path and the `/transact` wire path agreeing on which entity a `(predicate, payload)` pair names. But the notation-side digest (`body_digest`) only hashed literal scalars and dropped reference fields.

The consequence bites exactly where we need identity most: a `view` is `{model, display}`, and a view identified by its `model` reference had that field silently dropped, so two views for different models collided on the same derived entity. Worse, the wire path *did* include the reference, so the same `view!:` written in notation and applied over the wire derived different entities. The code claimed these converge; they only did when the body had no references.

The reason for the skip was sequencing, not design: `body_digest` was kept resolver-free so it could run in an early phase before names resolve. That traded correctness for ordering convenience.

## Approach

Resolve reference fields through `scope` (already populated by the resolve pass before either derivation site runs) and include their resolved entity values in the digest, mirroring the resolved payload the wire path hashes — so the two paths converge by construction, references included.

An unresolvable reference is now an **error**, not a skip: dropping it would fold the assertion into the entity it would have had without that field, silently deriving the wrong subject. Forms that carry no content identity (unbound `?var`, blank, premises, nested) are still skipped.

Also renames the `UnknownBookmark` error variant to `UnknownNameReference` (field `bookmark` → `name`) — clearer jargon-free naming that reads with the diagnostic ("references unknown name").

Covered by three tests: distinct reference fields derive distinct entities, notation/wire convergence with a reference in the body, and an unresolvable reference erroring instead of skipping.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the error handling in the `tonk-analyzer` by replacing instances of `UnknownBookmark` with `UnknownNameReference`. This improves clarity in error reporting regarding unresolved names.

### Detailed summary
- Replaced `AnalyzeErrorKind::UnknownBookmark` with `AnalyzeErrorKind::UnknownNameReference` in multiple files.
- Updated error messages and comments to reflect the new terminology.
- Modified the `body_digest` function to handle unresolved references correctly.
- Adjusted tests to verify the new error handling for name references.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->