### PR TITLE
feat: interactive workspace tabs, AnchorName type, graceful SSE teardown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,6 +5228,7 @@ dependencies = [
  "dialog-common",
  "tonk-core",
  "tonk-macros",
+ "tonk-schema",
  "wasm-bindgen-test",
 ]
 

--- a/rust/tonk-analyzer/src/analysis.rs
+++ b/rust/tonk-analyzer/src/analysis.rs
@@ -228,10 +228,40 @@ impl DocumentAnalysis {
         let transient = self.transient_entities();
         let mut claims = Vec::new();
         for planned in self.statements() {
+            // Rule installs/retracts have no `Claim` representation;
+            // they are carried out-of-band by `lower_to_rules`. Skip
+            // them here so a bootstrap that mixes concept claims and
+            // `rule!:` blocks still lowers its claims cleanly.
+            if matches!(
+                &planned.statement,
+                Statement::Assert(Application::Rule { .. })
+                    | Statement::Retract(Application::Rule { .. })
+            ) {
+                continue;
+            }
             let claim = lower_statement(&planned.statement, &transient)?;
             claims.push(claim);
         }
         Ok(TransactRequest { claims })
+    }
+
+    /// Lift every `rule!:` install in the document into a
+    /// [`Rule`](tonk_schema::rule::Rule), in the same
+    /// document/eval order as [`statements`](Self::statements). These
+    /// have no [`TransactRequest`] representation (the `Claim` wire
+    /// can't carry `dialog.effect/*` triples), so they are returned
+    /// separately for a seed loop to `assert` directly.
+    ///
+    /// Only `assert` rule installs are returned; a rule retract has
+    /// no place in a fresh bootstrap.
+    pub fn rule_installs(&self) -> Vec<tonk_schema::rule::Rule> {
+        let mut rules = Vec::new();
+        for planned in self.statements() {
+            if let Statement::Assert(Application::Rule { rule, .. }) = &planned.statement {
+                rules.push((**rule).clone());
+            }
+        }
+        rules
     }
 }
 

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -711,6 +711,7 @@ mod tests {
     use dialog_query::{ConceptDescriptor, Term, the};
     use dialog_repository::Branch;
     use dialog_repository::helpers::{test_operator_with_profile, test_repo};
+    use tonk_core::meta::AnchorName;
     use tonk_notation::parse;
     use tonk_schema::concept::AnonymousConcept;
 
@@ -1203,7 +1204,7 @@ concept!: &person
         else {
             panic!("expected Assert(Concept) for concept");
         };
-        assert_eq!(name.as_deref(), Some("person"));
+        assert_eq!(name.as_ref().map(AnchorName::as_str), Some("person"));
     }
 
     /// A bare symbol in field-value position resolves through the
@@ -1329,7 +1330,7 @@ attribute!: &person-name
             panic!("expected Assert(Concept)");
         };
         assert!(query.terms.get("name").is_none());
-        assert_eq!(name.as_deref(), Some("person-name"));
+        assert_eq!(name.as_ref().map(AnchorName::as_str), Some("person-name"));
     }
 
     /// Two meta heads of different kinds (`attribute!` and
@@ -1828,7 +1829,7 @@ person!: &alice
         else {
             panic!("expected Assert(Concept)");
         };
-        assert_eq!(name.as_deref(), Some("alice"));
+        assert_eq!(name.as_ref().map(AnchorName::as_str), Some("alice"));
         assert!(matches!(this, ThisIntent::Derived));
     }
 
@@ -1856,7 +1857,7 @@ person!: &alice
         else {
             panic!("expected Assert(Concept)");
         };
-        assert_eq!(name.as_deref(), Some("alice"));
+        assert_eq!(name.as_ref().map(AnchorName::as_str), Some("alice"));
         match this {
             ThisIntent::Uri(e) => assert!(e.to_string().starts_with("did:key:")),
             other => panic!("expected ThisIntent::Uri, got {other:?}"),
@@ -1895,7 +1896,7 @@ person!: &latest-alice
         else {
             panic!("expected Assert(Concept)");
         };
-        assert_eq!(name.as_deref(), Some("latest-alice"));
+        assert_eq!(name.as_ref().map(AnchorName::as_str), Some("latest-alice"));
         assert!(matches!(this, ThisIntent::Variable(s) if s == "alice"));
         assert!(analysis.mutate.requires.contains("alice"));
     }
@@ -2453,7 +2454,7 @@ view!:
             ConceptDescriptor as WireDescriptor, PredicateApplication, ValueMap,
         };
         use tonk_schema::transact::{
-            ApplicationPlan, ConceptPlan, application_plan_from_predicate, derive_this,
+            ApplicationPlan, application_plan_from_predicate, derive_this,
         };
 
         let pinned: Entity = "tonk:view".parse().unwrap();
@@ -2482,10 +2483,10 @@ view!:
             parameters: params_with_this,
             name: None,
         });
-        let ApplicationPlan::Concept(ConceptPlan { statement, .. }) = &plan else {
+        let ApplicationPlan::Concept(plan) = &plan else {
             panic!("expected concept plan");
         };
-        let wire_this = match statement.terms.get("this").expect("this present") {
+        let wire_this = match plan.statement.terms.get("this").expect("this present") {
             dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
             other => panic!("expected entity constant, got {other:?}"),
         };
@@ -2503,10 +2504,10 @@ view!:
             parameters: params_no_this,
             name: None,
         });
-        let ApplicationPlan::Concept(ConceptPlan { statement, .. }) = &plan else {
+        let ApplicationPlan::Concept(plan) = &plan else {
             panic!("expected concept plan");
         };
-        let wire_this_no_pin = match statement.terms.get("this").expect("this present") {
+        let wire_this_no_pin = match plan.statement.terms.get("this").expect("this present") {
             dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
             other => panic!("expected entity constant, got {other:?}"),
         };
@@ -2761,7 +2762,11 @@ concept!: &person
                     "statement {i} (inline attr) should publish no name"
                 );
             } else {
-                assert_eq!(name.as_deref(), Some("person"), "concept itself anchored");
+                assert_eq!(
+                    name.as_ref().map(AnchorName::as_str),
+                    Some("person"),
+                    "concept itself anchored"
+                );
             }
         }
     }

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -15,6 +15,7 @@ use super::field::{field_value_to_term, is_meta_field, validate_claim_attribute}
 use super::scope::Scope;
 use crate::analyzer::Working;
 use tonk_core::claim::ValueMap;
+use tonk_core::meta::AnchorName;
 use tonk_schema::prelude::EntityExt;
 use tonk_schema::transact::{Application, DomainApplication, ThisIntent, derive_this};
 
@@ -366,8 +367,25 @@ pub(crate) fn derive_head_intent(
     fields: &[Field],
     anchor: Option<&Anchor>,
     scope: &Scope,
-) -> Result<(ThisIntent, Option<String>), AnalyzeError> {
-    let name = anchor.map(|a| a.name.clone());
+) -> Result<(ThisIntent, Option<AnchorName>), AnalyzeError> {
+    // The anchor desugars to a `dialog.meta/name` claim on
+    // `id:<name>`. Validate it into an `AnchorName` here — the one
+    // place the name is parsed — so a name that can't be published
+    // surfaces as a clear error rather than being silently dropped at
+    // write time. Everything downstream converts to the entity
+    // infallibly.
+    let name = match anchor {
+        None => None,
+        Some(anchor) => Some(AnchorName::try_from(anchor.name.as_str()).map_err(|e| {
+            AnalyzeError::at(
+                AnalyzeErrorKind::InvalidAnchorName {
+                    name: e.name,
+                    reason: e.reason,
+                },
+                anchor.range,
+            )
+        })?),
+    };
     let this = match fields.iter().find(|f| f.name == "this") {
         None => ThisIntent::Derived,
         Some(field) => match &field.value {
@@ -444,7 +462,7 @@ pub(crate) fn derive_head_intent(
 ///   the "publish a name pointing at an existing entity" form.
 fn this_term_for_assertion(
     this: &ThisIntent,
-    name: &Option<String>,
+    name: &Option<AnchorName>,
     fields: &[Field],
     predicate_entity: &Entity,
     scope: &Scope,
@@ -455,15 +473,18 @@ fn this_term_for_assertion(
         ThisIntent::Derived => {
             let entity = derive_this(predicate_entity, &body_digest(fields, scope)?);
             if let Some(name) = name {
-                if let Some(prior) = analysis.declarations.get(name)
+                let key = name.as_str();
+                if let Some(prior) = analysis.declarations.get(key)
                     && prior != &entity
                 {
                     return Err(AnalyzeError::at(
-                        AnalyzeErrorKind::DuplicateName { name: name.clone() },
+                        AnalyzeErrorKind::DuplicateName {
+                            name: key.to_owned(),
+                        },
                         name_range,
                     ));
                 }
-                analysis.declarations.insert(name.clone(), entity.clone());
+                analysis.declarations.insert(key.to_owned(), entity.clone());
             }
             Term::Constant(Value::Entity(entity))
         }

--- a/rust/tonk-analyzer/src/analyzer/declaration.rs
+++ b/rust/tonk-analyzer/src/analyzer/declaration.rs
@@ -12,6 +12,7 @@ use tonk_notation::{Application as SyntaxApplication, FieldValue, Scalar};
 use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::field::{is_meta_field, scalar_to_string};
 use super::scope::Scope;
+use tonk_core::meta::AnchorName;
 use tonk_schema::resolution::AttributeDefinition;
 use tonk_schema::transact::{Application, ThisIntent};
 
@@ -371,7 +372,7 @@ fn resolve_concept_field(
 pub(crate) fn attribute_application(
     descriptor: &AttributeDescriptor,
     entity: &Entity,
-    name: Option<String>,
+    name: Option<AnchorName>,
 ) -> Application {
     let mut terms = Parameters::new();
     terms.insert("this".into(), Term::Constant(Value::Entity(entity.clone())));
@@ -421,7 +422,7 @@ pub(crate) fn attribute_application(
 pub(crate) fn concept_application(
     descriptor: &ConceptDescriptor,
     entity: &Entity,
-    name: Option<String>,
+    name: Option<AnchorName>,
     transient: bool,
 ) -> Application {
     let mut terms = Parameters::new();

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -260,6 +260,20 @@ pub enum AnalyzeErrorKind {
         /// Underlying parse error.
         reason: String,
     },
+    /// An `&anchor` name doesn't form a valid `id:<name>` entity
+    /// URI. The anchor desugars to a `dialog.meta/name` claim on
+    /// `id:<name>`; if that URI can't be built the name could never
+    /// be published or resolved. Caught here so it's a clear error
+    /// rather than a silently-dropped name at write time.
+    #[error(
+        "anchor name {name:?} can't be published — `id:{name}` is not a valid entity URI: {reason}"
+    )]
+    InvalidAnchorName {
+        /// The anchor name written after `&`.
+        name: String,
+        /// Underlying `id:<name>` parse error.
+        reason: String,
+    },
     /// Assertion body had no fields — nothing to write.
     #[error("assertion `{head}!` has no fields — at least one is required")]
     AssertionWithoutFields {
@@ -442,6 +456,7 @@ impl AnalyzeErrorKind {
             Self::NameShadowing { .. } => "E_NAME_SHADOWING",
             Self::UnboundMutationVariable { .. } => "E_UNBOUND_MUTATION_VARIABLE",
             Self::InvalidSubjectUri { .. } => "E_INVALID_SUBJECT_URI",
+            Self::InvalidAnchorName { .. } => "E_INVALID_ANCHOR_NAME",
             Self::AssertionWithoutFields { .. } => "E_ASSERTION_WITHOUT_FIELDS",
             Self::InvalidAttributeBody { .. } => "E_INVALID_ATTRIBUTE_BODY",
             Self::InvalidConceptBody { .. } => "E_INVALID_CONCEPT_BODY",

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -44,6 +44,7 @@ use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::rule::{collect_rule_concepts, is_rule_retract_body, parse_rule_this_entity};
 use super::scope::Scope;
 use tonk_core::claim::ConceptDescriptor as DurableConceptDescriptor;
+use tonk_core::meta::AnchorName;
 use tonk_schema::prelude::EntityExt;
 use tonk_schema::resolution::{AttributeDefinition as AttrDef, ConceptDefinition as ConceptDef};
 use tonk_schema::transact::{ThisIntent, derive_this};
@@ -455,12 +456,17 @@ impl Graph {
                         .map(|f| f.value_range)
                         .unwrap_or(a.predicate.range);
                     if let Some(name) = &name {
-                        scope.declare(name, entity.clone(), anchor_range)?;
+                        scope.declare(name.as_str(), entity.clone(), anchor_range)?;
                     }
                     if let Some(name) = &variable {
                         scope.bind_variable(name, entity.clone(), variable_range)?;
                     }
-                    scope.record_attribute(name.as_deref().or(variable.as_deref()), attribute);
+                    scope.record_attribute(
+                        name.as_ref()
+                            .map(AnchorName::as_str)
+                            .or(variable.as_deref()),
+                        attribute,
+                    );
                     let application = attribute_application(&plan.descriptor, &entity, name);
                     declared.insert(
                         pending.index,
@@ -500,12 +506,17 @@ impl Graph {
                         .map(|f| f.value_range)
                         .unwrap_or(a.predicate.range);
                     if let Some(name) = &name {
-                        scope.declare(name, entity.clone(), anchor_range)?;
+                        scope.declare(name.as_str(), entity.clone(), anchor_range)?;
                     }
                     if let Some(name) = &variable {
                         scope.bind_variable(name, entity.clone(), variable_range)?;
                     }
-                    scope.record_concept(name.as_deref().or(variable.as_deref()), concept);
+                    scope.record_concept(
+                        name.as_ref()
+                            .map(AnchorName::as_str)
+                            .or(variable.as_deref()),
+                        concept,
+                    );
                     let inline_attributes = plan
                         .inline_attributes
                         .into_iter()

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -1312,7 +1312,7 @@ rule!:\n\
             ConceptDescriptor as DurableConceptDescriptor, PredicateApplication, ValueMap,
         };
         use tonk_schema::transact::{
-            Application, ApplicationPlan, ConceptPlan, Statement, application_plan_from_predicate,
+            Application, ApplicationPlan, Statement, application_plan_from_predicate,
         };
 
         let fixture = new_fixture().await;
@@ -1351,10 +1351,10 @@ view!:\n\
             name: None,
         });
         let wire_this = {
-            let ApplicationPlan::Concept(ConceptPlan { statement, .. }) = &wire_plan else {
+            let ApplicationPlan::Concept(plan) = &wire_plan else {
                 panic!("expected concept plan");
             };
-            match statement.terms.get("this").expect("this present") {
+            match plan.statement.terms.get("this").expect("this present") {
                 dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
                 other => panic!("expected entity constant, got {other:?}"),
             }
@@ -1385,7 +1385,7 @@ view!:\n\
             ConceptDescriptor as DurableConceptDescriptor, PredicateApplication, ValueMap,
         };
         use tonk_schema::transact::{
-            Application, ApplicationPlan, ConceptPlan, Statement, application_plan_from_predicate,
+            Application, ApplicationPlan, Statement, application_plan_from_predicate,
         };
 
         let fixture = new_fixture().await;
@@ -1447,10 +1447,10 @@ view!:\n\
             name: None,
         });
         let wire_this = {
-            let ApplicationPlan::Concept(ConceptPlan { statement, .. }) = &wire_plan else {
+            let ApplicationPlan::Concept(plan) = &wire_plan else {
                 panic!("expected concept plan");
             };
-            match statement.terms.get("this").expect("this present") {
+            match plan.statement.terms.get("this").expect("this present") {
                 dialog_query::Term::Constant(Value::Entity(e)) => e.clone(),
                 other => panic!("expected entity constant, got {other:?}"),
             }

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -598,6 +598,49 @@ mod tests {
     }
 
     #[dialog_common::test]
+    fn it_interpolates_slash_values_into_attributes() {
+        // Regression: `model={model} view={view}` where the field
+        // values contain slashes (namespaced concept names like
+        // `trip/stop`, `workspace/tab`) must land on the element
+        // as the exact, whole attribute value — not truncated at the
+        // slash, not corrupted with a trailing slash from an adjacent
+        // self-close. A self-closing `/>` is used deliberately to
+        // mirror the artifact view template.
+        let (host, mut renderer) =
+            mount("<tonk-display entity={entity} model={model} view={view} />");
+        renderer.apply(&[conclusion(
+            "id:demo/sheet",
+            &[
+                ("entity", "id:demo/itinerary"),
+                ("model", "trip/stop"),
+                ("view", "workspace/tab"),
+            ],
+        )]);
+        let el = host
+            .query_selector("tonk-display")
+            .unwrap()
+            .expect("tonk-display present");
+        assert_eq!(
+            el.get_attribute("model").as_deref(),
+            Some("trip/stop"),
+            "model attribute must keep its slash value, got {:?} (html: {})",
+            el.get_attribute("model"),
+            host.inner_html(),
+        );
+        assert_eq!(
+            el.get_attribute("view").as_deref(),
+            Some("workspace/tab"),
+            "view attribute must keep its slash value, got {:?}",
+            el.get_attribute("view"),
+        );
+        assert_eq!(
+            el.get_attribute("entity").as_deref(),
+            Some("id:demo/itinerary"),
+            "entity attribute must keep its slash value",
+        );
+    }
+
+    #[dialog_common::test]
     fn it_updates_a_row_in_place_on_subsequent_frame() {
         // With incremental updates, an existing row's article
         // node has its identity preserved across applies — only

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -276,9 +276,37 @@ pub fn build_plan_nodes(bindings: Vec<Binding>) -> Vec<PlanNode> {
     let mut iter_roots: Vec<(String, Vec<usize>)> = Vec::new();
     for (field, hosts) in field_hosts {
         let lca = longest_common_path_prefix(&hosts);
-        if !lca.is_empty() {
-            // Shared inner ancestor — single iteration root.
+        // A binding whose host *is* the LCA element (e.g. `for={f}`
+        // on the shared ancestor, or a `{f}` directly on it) pins the
+        // iteration to that one element — a single root carrying the
+        // whole subtree.
+        let bound_on_lca = hosts.contains(&lca);
+        if !lca.is_empty() && bound_on_lca {
+            // Shared inner ancestor that is itself a host — single
+            // iteration root rooted at the LCA.
             iter_roots.push((field, lca));
+        } else if !lca.is_empty() {
+            // Shared inner ancestor, but no binding sits on it: the
+            // occurrences live in disjoint subtrees below the LCA
+            // (e.g. the same field iterated in two sibling sections).
+            // Root each disjoint cluster separately so the LCA element
+            // is NOT cloned per item — otherwise the whole shared
+            // ancestor repeats once per value. Cluster by the first
+            // path segment past the LCA; the per-cluster root is the
+            // LCA of that cluster's hosts.
+            let mut clusters: std::collections::BTreeMap<usize, Vec<Vec<usize>>> =
+                std::collections::BTreeMap::new();
+            for host in &hosts {
+                let key = host[lca.len()];
+                clusters.entry(key).or_default().push(host.clone());
+            }
+            for (_, cluster_hosts) in clusters {
+                let root = longest_common_path_prefix(&cluster_hosts);
+                if root.is_empty() {
+                    continue;
+                }
+                iter_roots.push((field.clone(), root));
+            }
         } else {
             // No shared inner ancestor. Each distinct host path
             // becomes its own iteration root (a placeholder at
@@ -1229,6 +1257,40 @@ mod tests {
             }
             other => panic!("expected single Iteration, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn it_splits_same_field_across_disjoint_sibling_sections() {
+        // <div class=workspace>            path [0]
+        //   <div class=canvas>             path [0, 0]
+        //     <div subtree>{sheet}</div>   path [0, 0, 0, 0]
+        //   <div class=tabs>               path [0, 1]
+        //     <div subtree>{sheet}</div>   path [0, 1, 0, 0]
+        // Both occurrences reference `sheet` and their LCA is the
+        // outer `.workspace` ([0]) — but nothing is bound ON [0], so
+        // collapsing there would clone the whole workspace per sheet.
+        // Expect TWO roots, one per sibling section, NOT one at [0].
+        let nodes = build_plan_nodes(vec![
+            text_binding(&[0, 0, 0, 0], "sheet"),
+            text_binding(&[0, 1, 0, 0], "sheet"),
+        ]);
+
+        let roots: Vec<_> = nodes
+            .iter()
+            .filter_map(|n| match n {
+                PlanNode::Iteration { field, path, .. } => Some((field.clone(), path.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            roots,
+            vec![
+                ("sheet".to_owned(), vec![0, 0, 0]),
+                ("sheet".to_owned(), vec![0, 1, 0]),
+            ],
+            "two sibling sections iterating the same field must get \
+             separate roots, not one at the shared ancestor",
+        );
     }
 
     #[test]

--- a/rust/tonk-core/src/claim.rs
+++ b/rust/tonk-core/src/claim.rs
@@ -11,6 +11,7 @@
 //! before durable write). The reactor reads this classification
 //! to bucket transients without re-querying the schema.
 
+use crate::meta::AnchorName;
 use dialog_artifacts::Value;
 use dialog_query::ConceptDescriptor as DialogConceptDescriptor;
 use indexmap::IndexMap;
@@ -90,8 +91,12 @@ pub struct PredicateApplication {
     /// `dialog.name/referent` fact on `id:<name>` pointing at the
     /// `this` entity so the concept resolves by name. Mirrors
     /// the `name` slot on `tonk_schema::transact::Application`.
+    ///
+    /// An [`AnchorName`], so the `id:<name>` entity is validated when
+    /// the claim is built or deserialized — a malformed name fails at
+    /// that boundary rather than being silently dropped downstream.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: Option<AnchorName>,
 }
 
 impl PredicateApplication {

--- a/rust/tonk-core/src/meta.rs
+++ b/rust/tonk-core/src/meta.rs
@@ -31,6 +31,92 @@ pub mod name {
     pub struct Referent(pub Entity);
 }
 
+/// A validated published name (`&anchor` in notation, the `name`
+/// slot on a claim). Constructing one parses `id:<name>` into the
+/// [`Entity`] it desugars to, so the parse happens exactly once, at
+/// the boundary; everything downstream converts to the entity
+/// infallibly via [`AnchorName::entity`]. An invalid name is a hard
+/// error at construction (and at serde deserialization), never a
+/// silently-dropped publication later.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct AnchorName {
+    name: String,
+    entity: Entity,
+}
+
+/// Why a string isn't a usable [`AnchorName`].
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "anchor name {name:?} can't be published — `id:{name}` is not a valid entity URI: {reason}"
+)]
+pub struct AnchorNameError {
+    /// The rejected name.
+    pub name: String,
+    /// The underlying `id:<name>` parse error.
+    pub reason: String,
+}
+
+impl AnchorName {
+    /// The published name string (no `id:` prefix), as written
+    /// after `&`.
+    pub fn as_str(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Validate a name by parsing `id:<name>` into its entity. The only
+/// fallible step in the name's lifetime.
+impl TryFrom<&str> for AnchorName {
+    type Error = AnchorNameError;
+
+    fn try_from(name: &str) -> Result<Self, Self::Error> {
+        let entity = format!("id:{name}")
+            .parse::<Entity>()
+            .map_err(|e| AnchorNameError {
+                name: name.to_owned(),
+                reason: e.to_string(),
+            })?;
+        Ok(Self {
+            name: name.to_owned(),
+            entity,
+        })
+    }
+}
+
+impl TryFrom<String> for AnchorName {
+    type Error = AnchorNameError;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        AnchorName::try_from(name.as_str())
+    }
+}
+
+/// The `id:<name>` entity this name publishes against. Infallible:
+/// the entity was parsed and stored when the [`AnchorName`] was
+/// validated into existence.
+impl From<AnchorName> for Entity {
+    fn from(anchor: AnchorName) -> Self {
+        anchor.entity
+    }
+}
+
+impl From<&AnchorName> for Entity {
+    fn from(anchor: &AnchorName) -> Self {
+        anchor.entity.clone()
+    }
+}
+
+/// Wire form is the bare name string (compatible with the prior
+/// `Option<String>` name slot); `#[serde(into = "String")]` uses
+/// this, and `#[serde(try_from = "String")]` validates on the way
+/// back in.
+impl From<AnchorName> for String {
+    fn from(anchor: AnchorName) -> Self {
+        anchor.name
+    }
+}
+
 /// A user-published name — an `id:<n>` entity carrying a
 /// single `entity` claim that points at the target the name
 /// currently identifies.

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -423,7 +423,7 @@ impl<'s, 'a> Evaluate<'s, 'a> {
                             match plan {
                                 ApplicationPlan::Concept(concept_plan) => {
                                     let resolved =
-                                        resolve_retraction_targets(concept_plan, &txn, env).await?;
+                                        resolve_retraction_targets(*concept_plan, &txn, env).await?;
                                     claim_count += resolved.len();
                                     retract_claims.extend(resolved);
                                 }

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -423,7 +423,8 @@ impl<'s, 'a> Evaluate<'s, 'a> {
                             match plan {
                                 ApplicationPlan::Concept(concept_plan) => {
                                     let resolved =
-                                        resolve_retraction_targets(*concept_plan, &txn, env).await?;
+                                        resolve_retraction_targets(*concept_plan, &txn, env)
+                                            .await?;
                                     claim_count += resolved.len();
                                     retract_claims.extend(resolved);
                                 }

--- a/rust/tonk-host/src/bridge.rs
+++ b/rust/tonk-host/src/bridge.rs
@@ -102,6 +102,40 @@ pub async fn subscribe(body: &Ipld) -> Result<Subscription, ErrorDetail> {
     })
 }
 
+/// Open a bridge subscription as a uniform **frame stream** plus a
+/// teardown closure for [`crate::sse::Subscription`].
+///
+/// Each `tonk.subscribe` value is a parsed conclusion batch; we
+/// re-stringify it so the frame shape matches the fetch path (raw
+/// JSON string). The teardown cancels the underlying
+/// `ReadableStream`, which posts the `unsubscribe` envelope to the
+/// SW. Cancelling resolves the reader's pending `read()` with
+/// `done = true`, so the stream ends without yielding an error.
+pub(crate) async fn frame_stream(
+    body: &Ipld,
+) -> Result<
+    (
+        futures::stream::LocalBoxStream<'static, Result<String, ErrorDetail>>,
+        impl FnOnce() + 'static,
+    ),
+    ErrorDetail,
+> {
+    use futures::StreamExt as _;
+
+    let subscription = std::rc::Rc::new(subscribe(body).await?);
+    let teardown_handle = subscription.clone();
+    let frames = futures::stream::unfold(subscription, |sub| async move {
+        match sub.next().await {
+            Ok(Some(frame)) => Some((Ok(frame), sub)),
+            Ok(None) => None,
+            Err(e) => Some((Err(e), sub)),
+        }
+    })
+    .boxed_local();
+    let teardown = move || teardown_handle.cancel();
+    Ok((frames, teardown))
+}
+
 /// A live subscription. `next` yields one frame as its raw JSON
 /// string; `Ok(None)` signals the stream closed normally. Dropping
 /// the value cancels the stream and posts an `unsubscribe` envelope.

--- a/rust/tonk-host/src/http.rs
+++ b/rust/tonk-host/src/http.rs
@@ -72,18 +72,28 @@ pub(crate) async fn post_json(url: &str, body: &str) -> Result<String, ErrorDeta
 }
 
 /// Open an SSE subscription against `url`, sending `body` as the
-/// JSON request body. The future resolves once the initial fetch
-/// succeeds; subsequent frames flow through `on_frame`. Cancel by
-/// calling `.abort()` on the returned `AbortController`.
+/// JSON request body, and return it as a uniform **frame stream**
+/// plus a teardown closure for [`crate::sse::Subscription`].
 ///
-/// Errors during streaming are reported via `on_error`; the future
-/// returns `Err` only for the initial fetch failure.
-pub(crate) async fn open_sse(
+/// The future resolves once the initial fetch succeeds (so an
+/// initial failure is an `Err` here, not a stream item). Each stream
+/// item is one complete SSE frame's JSON payload, or a transport
+/// error. The teardown aborts the in-flight fetch; the
+/// [`crate::sse::Subscription`] reader stops on its drop signal
+/// before the resulting abort-rejected read is observed, and the
+/// `is_abort_error` filter below drops any abort rejection that still
+/// races through — so a deliberate teardown never yields an error
+/// item.
+pub(crate) async fn frame_stream(
     url: &str,
     body: &str,
-    on_frame: impl FnMut(&str) + 'static,
-    on_error: impl FnMut(ErrorDetail) + 'static,
-) -> Result<AbortController, ErrorDetail> {
+) -> Result<
+    (
+        futures::stream::LocalBoxStream<'static, Result<String, ErrorDetail>>,
+        impl FnOnce() + 'static,
+    ),
+    ErrorDetail,
+> {
     ready::wait().await;
     let abort = AbortController::new()
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("AbortController: {e:?}")))?;
@@ -123,52 +133,86 @@ pub(crate) async fn open_sse(
     let body_stream = resp
         .body()
         .ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "response has no body stream"))?;
-    let stream = ReadableStream::from_raw(body_stream).into_stream();
-    spawn_reader(stream, on_frame, on_error);
-    Ok(abort)
+    let byte_stream = ReadableStream::from_raw(body_stream).into_stream();
+    let frames = sse_frames(byte_stream).boxed_local();
+    let teardown = move || abort.abort();
+    Ok((frames, teardown))
 }
 
-fn spawn_reader(
-    mut stream: impl futures::Stream<Item = Result<JsValue, JsValue>> + Unpin + 'static,
-    mut on_frame: impl FnMut(&str) + 'static,
-    mut on_error: impl FnMut(ErrorDetail) + 'static,
-) {
-    wasm_bindgen_futures::spawn_local(async move {
-        let mut buffer = BytesMut::new();
-        while let Some(chunk) = stream.next().await {
-            match chunk {
-                Ok(value) => {
-                    let array: Uint8Array = match value.dyn_into() {
-                        Ok(a) => a,
-                        Err(_) => continue,
-                    };
-                    buffer.extend_from_slice(&array.to_vec());
-                    drain_frames(&mut buffer, &mut on_frame);
+/// Adapt a raw byte stream of SSE bytes into a stream of complete
+/// frame payloads. Buffers across chunks, splits on `\n\n`, strips
+/// the `data:` prefix. A read that fails because we aborted the
+/// fetch ourselves (`AbortError`) ends the stream silently; any
+/// other read failure is forwarded as a transport error.
+fn sse_frames(
+    byte_stream: impl futures::Stream<Item = Result<JsValue, JsValue>> + Unpin + 'static,
+) -> impl futures::Stream<Item = Result<String, ErrorDetail>> {
+    let state = (
+        byte_stream,
+        BytesMut::new(),
+        std::collections::VecDeque::new(),
+    );
+    futures::stream::unfold(
+        state,
+        |(mut byte_stream, mut buffer, mut ready)| async move {
+            loop {
+                // Drain any already-buffered complete frames first.
+                if let Some(frame) = ready.pop_front() {
+                    return Some((Ok(frame), (byte_stream, buffer, ready)));
                 }
-                Err(e) => {
-                    on_error(ErrorDetail::new(
-                        ErrorKind::Network,
-                        format!("stream read failed: {e:?}"),
-                    ));
-                    break;
+                match byte_stream.next().await {
+                    Some(Ok(value)) => {
+                        if let Ok(array) = value.dyn_into::<Uint8Array>() {
+                            buffer.extend_from_slice(&array.to_vec());
+                            collect_frames(&mut buffer, &mut ready);
+                        }
+                        // Loop to emit a newly-completed frame (or read more).
+                    }
+                    Some(Err(e)) => {
+                        if is_abort_error(&e) {
+                            // Deliberate teardown — end the stream cleanly.
+                            return None;
+                        }
+                        return Some((
+                            Err(ErrorDetail::new(
+                                ErrorKind::Network,
+                                format!("stream read failed: {e:?}"),
+                            )),
+                            (byte_stream, buffer, ready),
+                        ));
+                    }
+                    None => return None,
                 }
             }
-        }
-    });
+        },
+    )
+}
+
+/// True when a rejected stream read is the `AbortError` raised by
+/// our own `AbortController::abort()` (the subscription was torn
+/// down deliberately), rather than a real transport failure.
+///
+/// An aborted `fetch` body read rejects with a `DOMException` whose
+/// `name` is `"AbortError"`. We match on that name; anything else
+/// (or a non-exception value) is treated as a genuine error.
+fn is_abort_error(value: &JsValue) -> bool {
+    value
+        .dyn_ref::<web_sys::DomException>()
+        .is_some_and(|exception| exception.name() == "AbortError")
 }
 
 /// Pull every complete SSE event (terminated by `\n\n`) out of
 /// `buffer`, strip its `data: ` prefix, and invoke `on_frame` with
 /// the inner JSON. Whatever bytes are left after the last `\n\n`
 /// stay in the buffer for the next chunk.
-fn drain_frames(buffer: &mut BytesMut, on_frame: &mut impl FnMut(&str)) {
+fn collect_frames(buffer: &mut BytesMut, out: &mut std::collections::VecDeque<String>) {
     while let Some(idx) = find_double_newline(buffer) {
         let frame = buffer.split_to(idx);
         let _ = buffer.split_to(2); // discard "\n\n"
         if let Ok(text) = std::str::from_utf8(&frame)
             && let Some(payload) = strip_sse_data_prefix(text)
         {
-            on_frame(payload);
+            out.push_back(payload.to_owned());
         }
     }
 }

--- a/rust/tonk-host/src/registry.rs
+++ b/rust/tonk-host/src/registry.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::sse::SubscriptionAbort;
+use crate::sse::EventSource;
 use wasm_bindgen::JsValue;
 use web_sys::Element;
 
@@ -46,7 +46,7 @@ pub(crate) struct Entry {
     /// shallowest-first refresh ordering.
     pub depth: u32,
     /// Upstream transport handle. Dropping it cancels the SSE.
-    pub abort: Option<SubscriptionAbort>,
+    pub abort: Option<EventSource>,
 }
 
 /// The host's subscription table.
@@ -75,7 +75,7 @@ impl Registry {
     /// is gone (canceled during the await that produced the
     /// handle), the handle is dropped immediately, cancelling the
     /// upstream.
-    pub(crate) fn install_abort(&mut self, id: EntryId, abort: SubscriptionAbort) {
+    pub(crate) fn install_abort(&mut self, id: EntryId, abort: EventSource) {
         match self.entries.get_mut(&id) {
             Some(e) => e.abort = Some(abort),
             None => drop(abort),

--- a/rust/tonk-host/src/sse.rs
+++ b/rust/tonk-host/src/sse.rs
@@ -1,44 +1,114 @@
-//! Subscription helper — selects bridge or fetch transport at
-//! runtime and exposes a uniform `SubscriptionAbort` handle.
+//! Transport-agnostic SSE subscription.
 //!
-//! When `globalThis.tonk` is present (the iframe shell has loaded
-//! `bridge.js`) the bridge path is used: `globalThis.tonk.subscribe`
-//! returns a `ReadableStream` whose chunks are routed to the
-//! caller's `on_frame` callback by a pump spawned in
-//! `wasm_bindgen_futures::spawn_local`.
+//! [`open_sse`] selects a transport at runtime — the iframe bridge
+//! (`globalThis.tonk`, via [`crate::bridge`]) or a direct `fetch()`
+//! SSE reader (via [`crate::http`]) — and drives it through one
+//! [`EventSource`] abstraction.
 //!
-//! When `globalThis.tonk` is absent (the shell mounts these elements
-//! directly in its own DOM, outside any iframe) the legacy
-//! `fetch()`-based SSE reader in [`crate::fetch`] is used instead.
-//! The caller is responsible for supplying a non-empty `url` in
-//! that case (built from the `space`/`branch` HTML attributes).
+//! Each transport exposes its output as a uniform **frame stream**
+//! (`Stream<Item = Result<String, ErrorDetail>>`, one already-framed
+//! JSON conclusion batch per item) plus a teardown action. The
+//! abstraction owns the single drop-safety invariant:
+//!
+//! > **Dropping a [`EventSource`] never invokes `on_error`.**
+//!
+//! Teardown (an unmount or a re-subscribe) is a graceful close, not a
+//! transport failure. The reader races the frame stream against a
+//! drop signal, so the moment the handle is dropped the reader stops
+//! on the drop branch — before any abort-rejected read can reach
+//! `on_error`. There is no per-transport error suppression: the rule
+//! lives here, once.
 
-use std::rc::Rc;
-
+use futures::StreamExt as _;
+use futures::future::{Either, select};
+use futures::stream::LocalBoxStream;
 use ipld_core::ipld::Ipld;
-use web_sys::AbortController;
 
-use crate::bridge::{Subscription, subscribe};
 use crate::error::{ErrorDetail, ErrorKind};
 
-/// Transport handle returned by [`open_sse`].
-///
-/// Dropping this value cancels the subscription regardless of which
-/// transport is active.
-pub enum SubscriptionAbort {
-    /// Bridge path — `Drop` cancels the underlying `ReadableStream`,
-    /// which posts an `unsubscribe` envelope to the SW. The pump
-    /// task's pending `read()` resolves with `done=true` and exits.
-    Bridge(Rc<Subscription>),
-    /// Fetch/SSE path — `Drop` calls `AbortController::abort()`.
-    Fetch(AbortController),
+/// A live subscription. The reader task runs until the frame stream
+/// ends, errors, or this handle is dropped. Dropping it stops the
+/// reader cleanly (no `on_error`) and runs the transport teardown.
+pub struct EventSource {
+    /// Held only for its `Drop`: dropping the sender resolves the
+    /// reader's drop-signal receiver, so the reader exits on the
+    /// drop branch instead of seeing the teardown as a read error.
+    _shutdown: futures::channel::oneshot::Sender<()>,
+    /// Transport-specific teardown (abort the fetch / cancel the
+    /// bridge reader), run on drop alongside the shutdown signal.
+    teardown: Option<Box<dyn FnOnce()>>,
 }
 
-impl Drop for SubscriptionAbort {
+impl EventSource {
+    /// Spawn a reader over `frames`, dispatching each `Ok` frame to
+    /// `on_frame` and each `Err` to `on_error`. `teardown` runs when
+    /// the returned handle is dropped.
+    ///
+    /// The reader races `frames.next()` against the drop signal, so a
+    /// dropped handle stops the reader on the drop branch — the
+    /// teardown-induced read rejection is never observed, hence never
+    /// reported. This is the one place the "drop ⇒ no error"
+    /// invariant is enforced.
+    fn spawn(
+        mut frames: LocalBoxStream<'static, Result<String, ErrorDetail>>,
+        on_frame: impl Fn(&str) + 'static,
+        on_error: impl Fn(ErrorDetail) + 'static,
+        teardown: impl FnOnce() + 'static,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = futures::channel::oneshot::channel::<()>();
+        wasm_bindgen_futures::spawn_local(async move {
+            // `select` isn't biased: when the handle is dropped and a
+            // teardown-induced error become ready in the same tick, it
+            // can pick the error arm. So when a stream item wins we
+            // re-check the shutdown receiver and let a fired shutdown
+            // override the item — a dropped handle never surfaces an
+            // error, which is exactly the spurious error this
+            // abstraction exists to prevent.
+            let mut shutdown = shutdown_rx;
+            loop {
+                let next = frames.next();
+                futures::pin_mut!(next);
+                match select(next, &mut shutdown).await {
+                    // Shutdown fired — the handle was dropped. Exit
+                    // cleanly without touching `on_error`.
+                    Either::Right(_) => break,
+                    // A stream item resolved first. But the drop and a
+                    // teardown-induced error can become ready in the
+                    // same tick and `select` isn't biased, so re-check
+                    // shutdown before reporting any error: a fired
+                    // shutdown always wins.
+                    Either::Left((item, shutdown_fut)) => {
+                        // Shutdown has fired if the sender was dropped
+                        // (`Err(Canceled)`) or signalled (`Ok(Some)`);
+                        // only `Ok(None)` means "still live". If it
+                        // fired, exit clean regardless of `item`.
+                        let shutdown_fired = !matches!(shutdown_fut.try_recv(), Ok(None));
+                        match item {
+                            _ if shutdown_fired => break,
+                            Some(Ok(frame)) => on_frame(&frame),
+                            Some(Err(e)) => {
+                                on_error(e);
+                                break;
+                            }
+                            None => break,
+                        }
+                    }
+                }
+            }
+        });
+        EventSource {
+            _shutdown: shutdown_tx,
+            teardown: Some(Box::new(teardown)),
+        }
+    }
+}
+
+impl Drop for EventSource {
     fn drop(&mut self) {
-        match self {
-            SubscriptionAbort::Bridge(sub) => sub.cancel(),
-            SubscriptionAbort::Fetch(ctrl) => ctrl.abort(),
+        // Dropping `_shutdown` already signalled the reader to stop;
+        // now release the transport (abort fetch / cancel reader).
+        if let Some(teardown) = self.teardown.take() {
+            teardown();
         }
     }
 }
@@ -63,55 +133,102 @@ pub fn use_bridge() -> bool {
 /// Open a streaming subscription using whichever transport is
 /// available.
 ///
-/// `url` is only used on the legacy fetch path. `body` is the
-/// query as an [`Ipld`] value; on the fetch path it is encoded
-/// once as DAG-JSON for the request body. The DAG-JSON encoding
-/// gives a canonical, codec-agnostic wire shape regardless of
-/// which transport runs underneath.
+/// `url` is only used on the fetch path. `body` is the query as an
+/// [`Ipld`] value; on the fetch path it is encoded once as DAG-JSON
+/// for the request body.
 ///
-/// `on_frame` is called for each emitted frame with the raw JSON
-/// string of a `Vec<Conclusion>`. `on_error` is called on transport
-/// errors.
-///
-/// Returns a [`SubscriptionAbort`] that the caller must keep alive;
-/// dropping it cancels the subscription.
+/// `on_frame` is called for each emitted frame (the raw JSON string
+/// of a `Vec<Conclusion>`); `on_error` for genuine transport errors.
+/// Dropping the returned [`EventSource`] tears the stream down
+/// without reporting an error.
 pub async fn open_sse(
     url: &str,
     body: &Ipld,
     on_frame: impl Fn(&str) + 'static,
     on_error: impl Fn(ErrorDetail) + 'static,
-) -> Result<SubscriptionAbort, ErrorDetail> {
+) -> Result<EventSource, ErrorDetail> {
     if use_bridge() {
-        let subscription = Rc::new(subscribe(body).await?);
-        let pump_sub = subscription.clone();
-        wasm_bindgen_futures::spawn_local(async move {
-            let result: Result<(), ErrorDetail> = async {
-                while let Some(frame) = pump_sub.next().await? {
-                    on_frame(&frame);
-                }
-                Ok(())
-            }
-            .await;
-            if let Err(e) = result {
-                on_error(e);
-            }
-        });
-        Ok(SubscriptionAbort::Bridge(subscription))
+        let (frames, teardown) = crate::bridge::frame_stream(body).await?;
+        Ok(EventSource::spawn(frames, on_frame, on_error, teardown))
     } else {
         let body_bytes = serde_ipld_dagjson::to_vec(body)
             .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body dag-json: {e}")))?;
         let body_str = String::from_utf8(body_bytes)
             .map_err(|e| ErrorDetail::new(ErrorKind::Parse, format!("body utf8: {e}")))?;
-        // on_frame / on_error must be FnMut for the SSE reader loop.
-        let on_frame_cell = std::cell::RefCell::new(on_frame);
-        let on_error_cell = std::cell::RefCell::new(on_error);
-        let ctrl = crate::http::open_sse(
-            url,
-            &body_str,
-            move |frame| (on_frame_cell.borrow())(frame),
-            move |err| (on_error_cell.borrow())(err),
-        )
-        .await?;
-        Ok(SubscriptionAbort::Fetch(ctrl))
+        let (frames, teardown) = crate::http::frame_stream(url, &body_str).await?;
+        Ok(EventSource::spawn(frames, on_frame, on_error, teardown))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Dropping an `EventSource` must never surface an error, even
+    /// when the underlying frame stream would error on the next read
+    /// (as an aborted `fetch` body read does). This is the
+    /// regression guard for the spurious "Connection failed /
+    /// AbortError" that a tab switch produced when tonk-host aborted
+    /// its own subscription.
+    #[dialog_common::test]
+    async fn it_reports_no_error_when_dropped() {
+        use futures::channel::mpsc;
+
+        // A frame stream the test controls. The reader is parked on
+        // `recv` (no frame yet) exactly like a live SSE awaiting the
+        // next event; then we drop the handle.
+        let (mut tx, rx) = mpsc::unbounded::<Result<String, ErrorDetail>>();
+        let frames = rx.boxed_local();
+
+        let errored = Rc::new(Cell::new(false));
+        let saw_error = errored.clone();
+        let torn_down = Rc::new(Cell::new(false));
+        let did_teardown = torn_down.clone();
+
+        let sub = EventSource::spawn(
+            frames,
+            |_frame| {},
+            move |_e| saw_error.set(true),
+            move || did_teardown.set(true),
+        );
+
+        // Let the reader park on the stream, then drop the handle —
+        // the teardown-equivalent close.
+        flush().await;
+        drop(sub);
+
+        // Simulate the transport erroring on the now-abandoned read,
+        // the way an aborted fetch rejects. The reader must already
+        // be gone via the drop signal, so this is never observed.
+        let _ = tx.unbounded_send(Err(ErrorDetail::new(
+            ErrorKind::Network,
+            "stream read failed: AbortError (simulated)",
+        )));
+        flush().await;
+
+        assert!(
+            !errored.get(),
+            "dropping an EventSource must not invoke on_error",
+        );
+        assert!(torn_down.get(), "drop must run the transport teardown");
+    }
+
+    /// Yield to the microtask queue so spawned reader tasks make
+    /// progress between steps.
+    async fn flush() {
+        for _ in 0..4 {
+            let (tx, rx) = futures::channel::oneshot::channel::<()>();
+            wasm_bindgen_futures::spawn_local(async move {
+                let _ = tx.send(());
+            });
+            let _ = rx.await;
+        }
     }
 }

--- a/rust/tonk-macros/src/lib.rs
+++ b/rust/tonk-macros/src/lib.rs
@@ -42,6 +42,32 @@ pub fn claim(input: TokenStream) -> TokenStream {
     }
 }
 
+/// Compile the `rule!:` installs in a notation file into a
+/// `Vec<tonk_schema::rule::Rule>` at build time.
+///
+/// The companion to [`claim!`]: where `claim!` lowers concept claims
+/// to a [`tonk_core::claim::TransactRequest`], `effects!` lifts the
+/// document's rule installs (which have no `TransactRequest`
+/// representation — the `Claim` wire can't carry `dialog.effect/*`
+/// triples). Each rule is embedded as its `(source, polarity, this)`
+/// and rebuilt at runtime via
+/// [`tonk_core::effect::Effect::from_source`] +
+/// `tonk_schema::rule::Rule::asserting_at`. A seed loop can then
+/// `assert` each rule directly.
+///
+/// Same path convention and build-dependency tracking as [`claim!`].
+/// A document with no `rule!:` yields an empty `Vec`.
+#[proc_macro]
+pub fn effects(input: TokenStream) -> TokenStream {
+    let lit = parse_macro_input!(input as LitStr);
+    match build_effects(&lit) {
+        Ok(tokens) => tokens,
+        Err(message) => syn::Error::new(lit.span(), message)
+            .to_compile_error()
+            .into(),
+    }
+}
+
 fn build(lit: &LitStr) -> Result<TokenStream, String> {
     let manifest = std::env::var("CARGO_MANIFEST_DIR")
         .map_err(|_| "claim!: CARGO_MANIFEST_DIR is not set".to_owned())?;
@@ -83,6 +109,64 @@ fn build(lit: &LitStr) -> Result<TokenStream, String> {
         {
             const _: &[u8] = include_bytes!(#path_str);
             ::tonk_core::claim::TransactRequest::from_dagjson_bytes(#byte_literal)
+        }
+    };
+    Ok(expanded.into())
+}
+
+fn build_effects(lit: &LitStr) -> Result<TokenStream, String> {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .map_err(|_| "effects!: CARGO_MANIFEST_DIR is not set".to_owned())?;
+    let path = PathBuf::from(manifest).join(lit.value());
+
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("effects!: cannot read {}: {e}", path.display()))?;
+
+    let parsed = tonk_notation::parse(&text);
+    let syntax = parsed.syntax.ok_or_else(|| {
+        let detail = parsed
+            .diagnostics
+            .first()
+            .map(|d| d.message.clone())
+            .unwrap_or_else(|| "no parseable document".to_owned());
+        format!("effects!: parse failed in {}: {detail}", path.display())
+    })?;
+
+    let tree = tonk_analyzer::analyzer::analyze_local(&syntax)
+        .map_err(|e| format!("effects!: analysis failed in {}: {e}", path.display()))?;
+
+    // Capture each install rule's `(source, polarity, this)` — the
+    // round-trip carrier (see `Rule::source` / `Effect::from_source`).
+    let rules = tree.analysis.rule_installs();
+    let entries: Vec<_> = rules
+        .iter()
+        .map(|rule| {
+            let source = rule.source().to_owned();
+            let polarity = rule.polarity().as_str().to_owned();
+            // The demo rules install at the effect's content-derived
+            // entity (no `this:` pin), so `Rule::asserting` reproduces
+            // the same `this` from the rebuilt effect — no entity
+            // round-trip needed.
+            quote! {
+                {
+                    let effect = ::tonk_core::effect::Effect::from_source(
+                        #source,
+                        ::tonk_core::effect::EffectPolarity::parse(#polarity)
+                            .expect("embedded polarity always parses"),
+                    )
+                    .expect("embedded effect source always deserializes");
+                    ::tonk_schema::rule::Rule::asserting(effect)
+                }
+            }
+        })
+        .collect();
+
+    // `include_bytes!` for build-dependency tracking, same as claim!.
+    let path_str = path.to_string_lossy();
+    let expanded = quote! {
+        {
+            const _: &[u8] = include_bytes!(#path_str);
+            ::std::vec![ #( #entries ),* ]
         }
     };
     Ok(expanded.into())

--- a/rust/tonk-macros/src/lib.rs
+++ b/rust/tonk-macros/src/lib.rs
@@ -72,8 +72,18 @@ fn build(lit: &LitStr) -> Result<TokenStream, String> {
         .map_err(|e| format!("claim!: serialization failed: {e}"))?;
 
     let byte_literal = proc_macro2::Literal::byte_string(&bytes);
+    // Emit an `include_bytes!` of the source path so the COMPILER
+    // records it as a build dependency. A proc-macro reading a file
+    // with `std::fs` is invisible to cargo's dependency graph, so
+    // editing the notation document would NOT trigger a rebuild and
+    // the stale lowered bytes would keep being served. `include_bytes!`
+    // makes the build correctly re-run when the document changes.
+    let path_str = path.to_string_lossy();
     let expanded = quote! {
-        ::tonk_core::claim::TransactRequest::from_dagjson_bytes(#byte_literal)
+        {
+            const _: &[u8] = include_bytes!(#path_str);
+            ::tonk_core::claim::TransactRequest::from_dagjson_bytes(#byte_literal)
+        }
     };
     Ok(expanded.into())
 }

--- a/rust/tonk-schema/src/rule.rs
+++ b/rust/tonk-schema/src/rule.rs
@@ -145,6 +145,22 @@ impl Rule {
     pub fn this(&self) -> Entity {
         self.this.clone()
     }
+
+    /// The exact `dialog.effect/source` string (JSON-encoded
+    /// [`InductiveRuleDescriptor`]). Paired with [`Rule::polarity`]
+    /// this round-trips through
+    /// [`Effect::from_source`](tonk_core::effect::Effect::from_source),
+    /// so a rule can be embedded as `(source, polarity, this)` and
+    /// rebuilt at runtime — the carrier the `effects!` macro emits.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// The polarity tag (`assert` / `retract`) carried on
+    /// `dialog.effect/polarity`.
+    pub fn polarity(&self) -> EffectPolarity {
+        self.polarity
+    }
 }
 
 impl dialog_artifacts::Statement for Rule {

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -351,10 +351,12 @@ impl Planner for Application {
 
     fn plan(self, bindings: &Parameters) -> Result<ApplicationPlan, PlanError> {
         match self {
-            Self::Concept { query, name, .. } => Ok(ApplicationPlan::Concept(Box::new(ConceptPlan {
-                statement: substitute_concept_query(query, bindings)?,
-                name,
-            }))),
+            Self::Concept { query, name, .. } => {
+                Ok(ApplicationPlan::Concept(Box::new(ConceptPlan {
+                    statement: substitute_concept_query(query, bindings)?,
+                    name,
+                })))
+            }
             Self::Domain {
                 application, name, ..
             } => Ok(ApplicationPlan::Concept(Box::new(ConceptPlan {

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -34,7 +34,7 @@ use crate::rule::Rule;
 use indexmap::IndexMap;
 use serde::Serialize;
 use tonk_core::claim::{ConceptDescriptor, PredicateApplication, ValueMap};
-use tonk_core::meta::{Name, name};
+use tonk_core::meta::{AnchorName, Name, name};
 
 /// Project a wire-format [`PredicateApplication`] into the
 /// concept-shaped [`ApplicationPlan`] the dialog emitter consumes.
@@ -62,13 +62,13 @@ pub fn application_plan_from_predicate(application: PredicateApplication) -> App
     for (key, value) in parameters {
         terms.insert(key, Term::Constant(value));
     }
-    ApplicationPlan::Concept(ConceptPlan {
+    ApplicationPlan::Concept(Box::new(ConceptPlan {
         statement: ConceptQuery {
             terms,
             predicate: descriptor,
         },
         name,
-    })
+    }))
 }
 
 /// Hash a `(predicate, payload)` pair to the entity URI that
@@ -147,7 +147,7 @@ pub enum Application {
         /// `&anchor` on the value side, if any. The planner
         /// emits a desugared `name!` assertion against `id:<n>`
         /// for each `Some(n)`.
-        name: Option<String>,
+        name: Option<AnchorName>,
     },
     /// `xyz.tonk …:` head — claim domain with applied terms;
     /// descriptor is synthesized at planning time from
@@ -158,7 +158,7 @@ pub enum Application {
         /// Where the entity in `parameters["this"]` comes from.
         this: ThisIntent,
         /// `&anchor` on the value side, if any.
-        name: Option<String>,
+        name: Option<AnchorName>,
     },
     /// `rule!:` head — an installed or to-be-installed rule.
     /// Distinct from `Concept` because a rule's storage shape is
@@ -215,7 +215,9 @@ impl Application {
     /// `&anchor`, so always `None` for [`Application::Rule`].
     pub fn name(&self) -> Option<&str> {
         match self {
-            Self::Concept { name, .. } | Self::Domain { name, .. } => name.as_deref(),
+            Self::Concept { name, .. } | Self::Domain { name, .. } => {
+                name.as_ref().map(AnchorName::as_str)
+            }
             Self::Rule { .. } => None,
         }
     }
@@ -349,16 +351,16 @@ impl Planner for Application {
 
     fn plan(self, bindings: &Parameters) -> Result<ApplicationPlan, PlanError> {
         match self {
-            Self::Concept { query, name, .. } => Ok(ApplicationPlan::Concept(ConceptPlan {
+            Self::Concept { query, name, .. } => Ok(ApplicationPlan::Concept(Box::new(ConceptPlan {
                 statement: substitute_concept_query(query, bindings)?,
                 name,
-            })),
+            }))),
             Self::Domain {
                 application, name, ..
-            } => Ok(ApplicationPlan::Concept(ConceptPlan {
+            } => Ok(ApplicationPlan::Concept(Box::new(ConceptPlan {
                 statement: substitute_concept_query(ConceptQuery::from(application), bindings)?,
                 name,
-            })),
+            }))),
             Self::Rule { rule, .. } => Ok(ApplicationPlan::Rule(rule)),
         }
     }
@@ -376,7 +378,11 @@ impl Planner for Application {
 /// shape.
 pub enum ApplicationPlan {
     /// Per-attribute concept storage (concept / domain / built-in).
-    Concept(ConceptPlan),
+    /// Boxed to keep the enum small: [`ConceptPlan`] now carries the
+    /// validated published-name [`Entity`], which (alongside the
+    /// `Rule` variant) would otherwise leave a large size gap between
+    /// variants.
+    Concept(Box<ConceptPlan>),
     /// `dialog.effect/*` rule storage. Boxed because [`Rule`]'s
     /// embedded [`InductiveRule`] would otherwise inflate every
     /// concept-shaped plan to rule-storage size.
@@ -395,7 +401,7 @@ pub struct ConceptPlan {
     pub statement: ConceptQuery,
     /// `&name` published by this expression, if any. Triggers
     /// the desugared `name!` assertion against `id:<name>`.
-    pub name: Option<String>,
+    pub name: Option<AnchorName>,
 }
 
 impl ArtifactsStatement for ApplicationPlan {
@@ -416,11 +422,11 @@ impl ArtifactsStatement for ApplicationPlan {
 impl ArtifactsStatement for ConceptPlan {
     fn assert(self, update: &mut impl Update) {
         emit_predicate_facts(&self.statement, update, true);
-        emit_name_assertion(self.name.as_deref(), &self.statement.terms, update, true);
+        emit_name_assertion(self.name.as_ref(), &self.statement.terms, update, true);
     }
     fn retract(self, update: &mut impl Update) {
         emit_predicate_facts(&self.statement, update, false);
-        emit_name_assertion(self.name.as_deref(), &self.statement.terms, update, false);
+        emit_name_assertion(self.name.as_ref(), &self.statement.terms, update, false);
     }
 }
 
@@ -455,24 +461,23 @@ fn entity_of_this(terms: &Parameters) -> Option<Entity> {
 /// keeps a hypothetical bad case from poisoning the surrounding
 /// transaction.
 fn emit_name_assertion<U: Update>(
-    name: Option<&str>,
+    name: Option<&AnchorName>,
     terms: &Parameters,
     update: &mut U,
     assert: bool,
 ) {
     use dialog_artifacts::Statement as _;
 
-    let Some(name_str) = name else {
+    let Some(name) = name else {
         return;
     };
     let Some(target) = entity_of_this(terms) else {
         return;
     };
-    let Ok(id_entity) = format!("id:{name_str}").parse::<Entity>() else {
-        return;
-    };
+    // The `id:<name>` entity was validated when the `AnchorName` was
+    // built, so this conversion is infallible — no re-parse, no skip.
     let claim = Name {
-        this: id_entity,
+        this: name.into(),
         entity: name::Referent(target),
     };
     if assert {
@@ -597,13 +602,13 @@ mod tests {
         let mut terms = Parameters::new();
         terms.insert("this".into(), Term::Constant(Value::Entity(target_entity)));
         terms.insert("name".into(), Term::Constant(Value::String("x".into())));
-        ApplicationPlan::Concept(ConceptPlan {
+        ApplicationPlan::Concept(Box::new(ConceptPlan {
             statement: ConceptQuery {
                 terms,
                 predicate: descriptor,
             },
-            name: Some(anchor_name.into()),
-        })
+            name: Some(AnchorName::try_from(anchor_name).expect("valid anchor name in test")),
+        }))
     }
 
     /// A cardinality-one `unsigned-integer` field (the column
@@ -624,13 +629,13 @@ mod tests {
         let mut terms = Parameters::new();
         terms.insert("this".into(), Term::Constant(Value::Entity(target.clone())));
         terms.insert("width".into(), Term::Constant(Value::UnsignedInt(12)));
-        let plan = ApplicationPlan::Concept(ConceptPlan {
+        let plan = ApplicationPlan::Concept(Box::new(ConceptPlan {
             statement: ConceptQuery {
                 terms,
                 predicate: descriptor,
             },
             name: None,
-        });
+        }));
 
         let mut changes = Changes::new();
         plan.assert(&mut changes);
@@ -733,13 +738,13 @@ mod tests {
         let mut terms = Parameters::new();
         terms.insert("this".into(), Term::Constant(Value::Entity(target)));
         terms.insert("name".into(), Term::Constant(Value::String("x".into())));
-        let plan = ApplicationPlan::Concept(ConceptPlan {
+        let plan = ApplicationPlan::Concept(Box::new(ConceptPlan {
             statement: ConceptQuery {
                 terms,
                 predicate: descriptor,
             },
             name: None,
-        });
+        }));
 
         let mut changes = Changes::new();
         plan.assert(&mut changes);

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -3,7 +3,7 @@ use leptos::{logging::log, prelude::window};
 use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_worker::{
-    BranchConfiguration, CreateInviteRequest, CreateInviteResponse, EvaluateResponse,
+    BranchConfiguration, CreateInviteRequest, CreateInviteResponse, EffectSource, EvaluateResponse,
     IdentifyResponse, JoinRequest, JoinResponse, ProfileInfo, QueryResponse, RemoteConfiguration,
     RepositoryConfiguration, RepositoryInfo, SyncResponse,
 };
@@ -155,7 +155,15 @@ pub async fn init() -> Result<String, TonkUiError> {
                 // concepts (pinned to `tonk:view`/`tonk:artifact`)
                 // plus demo artifacts. `bootstrap` merges, so this
                 // folds in alongside the board schema.
-                .bootstrap(tonk_workspace::BOOTSTRAP.clone()),
+                .bootstrap(tonk_workspace::BOOTSTRAP.clone())
+                // The workspace's inductive rules (e.g. activate-sheet
+                // tab selection) ride as their (source, polarity)
+                // carriers — rules have no TransactRequest shape — and
+                // are rebuilt + asserted in the repository seed loop.
+                .rules(tonk_workspace::RULES.iter().map(|rule| EffectSource {
+                    source: rule.source().to_owned(),
+                    polarity: rule.polarity().as_str().to_owned(),
+                })),
         );
 
     let response = reqwest::Client::new()

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -21,8 +21,8 @@ pub use inspect::{BranchStatusResponse, RemoteBranchStatusResponse, RemoteStatus
 
 mod repository;
 pub use repository::{
-    BranchConfiguration, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,
-    UpstreamConfiguration, bootstrap_profile_meta,
+    BranchConfiguration, EffectSource, RemoteConfiguration, RepositoryConfiguration,
+    RepositoryInfo, UpstreamConfiguration, bootstrap_profile_meta,
 };
 
 mod sync;

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -228,6 +228,7 @@ pub async fn join(
                     upstream: Some(UpstreamConfiguration::new(DEFAULT_REMOTE, DEFAULT_BRANCH)),
                     revision: None,
                     bootstrap: None,
+                    rules: Vec::new(),
                 },
             );
     } else {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -104,6 +104,29 @@ pub struct BranchConfiguration {
     /// response never populates it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bootstrap: Option<TransactRequest>,
+    /// Inductive rules (`rule!:` installs) to seed on this branch at
+    /// creation, alongside [`bootstrap`](Self::bootstrap). Rules have
+    /// no [`TransactRequest`] representation — the `Claim` wire can't
+    /// carry the `dialog.effect/*` triples a rule writes — so they
+    /// ride as their `(source, polarity)` and are rebuilt + asserted
+    /// server-side in the seed loop. A UI element lifts these from its
+    /// bootstrap document via `tonk_macros::effects!`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<EffectSource>,
+}
+
+/// A seedable inductive rule, as the two strings that round-trip
+/// through [`Effect::from_source`](tonk_core::effect::Effect::from_source):
+/// the JSON-encoded rule descriptor and its polarity tag. The
+/// serializable carrier for a `rule!:` install across the repository
+/// PUT wire (a [`tonk_schema::rule::Rule`] itself is not
+/// `Serialize`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EffectSource {
+    /// The `dialog.effect/source` string (JSON `InductiveRuleDescriptor`).
+    pub source: String,
+    /// The polarity tag — `"assert"` or `"retract"`.
+    pub polarity: String,
 }
 
 impl BranchConfiguration {
@@ -121,6 +144,14 @@ impl BranchConfiguration {
             Some(existing) => existing.claims.extend(request.claims),
             none => *none = Some(request),
         }
+        self
+    }
+
+    /// Attach inductive rules to seed at creation, as their
+    /// `(source, polarity)` carriers. Appends, so several elements'
+    /// rules fold in alongside their bootstraps.
+    pub fn rules(mut self, rules: impl IntoIterator<Item = EffectSource>) -> Self {
+        self.rules.extend(rules);
         self
     }
 }
@@ -252,19 +283,47 @@ pub async fn put_repository(
     // `bootstrap` here instead of re-evaluating them on every
     // mount.
     for (branch_name, settings) in &configuration.branch {
-        let Some(bootstrap) = &settings.bootstrap else {
+        let claims = settings.bootstrap.as_ref().map(|b| &b.claims);
+        let has_claims = claims.is_some_and(|c| !c.is_empty());
+        let has_rules = !settings.rules.is_empty();
+        if !has_claims && !has_rules {
             continue;
-        };
-        if bootstrap.claims.is_empty() {
-            continue;
+        }
+        // Rebuild each rule from its embedded source/polarity. A bad
+        // carrier is a programming error in the shipping element, not
+        // a client fault, so surface it as an internal error.
+        let mut rules = Vec::with_capacity(settings.rules.len());
+        for effect_source in &settings.rules {
+            let polarity = tonk_schema::effect::EffectPolarity::parse(&effect_source.polarity)
+                .ok_or_else(|| {
+                    TonkWorkerError::Internal(format!(
+                        "invalid rule polarity '{}' on branch '{branch_name}'",
+                        effect_source.polarity
+                    ))
+                })?;
+            let effect = tonk_schema::effect::Effect::from_source(&effect_source.source, polarity)
+                .map_err(|e| {
+                    TonkWorkerError::Internal(format!(
+                        "invalid rule source on branch '{branch_name}': {e}"
+                    ))
+                })?;
+            rules.push(tonk_schema::rule::Rule::asserting(effect));
         }
         let mut builder = tonk
             .reactor
             .repository(&name)
             .branch(branch_name)
             .transaction();
-        for claim in &bootstrap.claims {
-            builder = builder.apply(claim.clone());
+        if let Some(claims) = claims {
+            for claim in claims {
+                builder = builder.apply(claim.clone());
+            }
+        }
+        // Rules install last so any concept facts their premises read
+        // are already on the branch (matches the analyzer's statement
+        // ordering).
+        for rule in rules {
+            builder = builder.assert(rule);
         }
         builder
             .commit()
@@ -905,6 +964,7 @@ where
                 upstream,
                 revision,
                 bootstrap: None,
+                rules: Vec::new(),
             },
         );
     }

--- a/rust/tonk-workspace/Cargo.toml
+++ b/rust/tonk-workspace/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 tonk-core = { workspace = true }
 tonk-macros = { workspace = true }
+tonk-schema = { workspace = true }
 
 [dev-dependencies]
 dialog-common = { workspace = true, features = ["helpers"] }

--- a/rust/tonk-workspace/bootstrap.yaml
+++ b/rust/tonk-workspace/bootstrap.yaml
@@ -49,6 +49,11 @@ concept!: &artifact
       the: xyz.tonk.artifact/title
       cardinality: one
       as: text
+    subtitle:
+      description: Dimmed metadata line shown after the name in the card header
+      the: xyz.tonk.artifact/subtitle
+      cardinality: one
+      as: text
     icon:
       description: Icon shown in the tab
       the: xyz.tonk.artifact/icon
@@ -69,6 +74,276 @@ concept!: &artifact
       the: xyz.tonk.artifact/view
       cardinality: one
       as: entity
+
+# The `workspace` concept: the UI surface below the header. It owns
+# its sheets (cardinality-many). Pinned to `tonk:workspace` so the
+# shell can query a workspace by a stable concept entity.
+concept!: &workspace
+  this: tonk:workspace
+  description: A workspace surface - a named set of sheets shown as tabs.
+  with:
+    name:
+      description: Workspace name, shown in the header
+      the: xyz.tonk.workspace/name
+      cardinality: one
+      as: text
+    sheet:
+      description: The sheets (tabs) in this workspace
+      the: xyz.tonk.workspace/sheet
+      cardinality: many
+      as: entity
+    active:
+      description: >
+        The currently selected sheet, shown in the canvas. Cardinality
+        one, so re-asserting it replaces the previous selection - a
+        single moving pointer driven by the `activate-sheet` command.
+      the: xyz.tonk.workspace/active
+      cardinality: one
+      as: entity
+
+# The `sheet` concept: one tab in a workspace. A sheet is an
+# artifact (same title/icon/entity/model/view fields, same attribute
+# URIs) plus an `order` lexicographic key that positions the tab. So
+# every sheet is also a valid artifact; the extra `order` field is
+# what makes it a workspace member.
+concept!: &workspace/sheet
+  this: tonk:sheet
+  description: A workspace tab - an artifact plus a lexicographic order key.
+  with:
+    title:
+      description: Title shown in the tab
+      the: xyz.tonk.artifact/title
+      cardinality: one
+      as: text
+    subtitle:
+      description: Dimmed metadata line shown after the name in the card header
+      the: xyz.tonk.artifact/subtitle
+      cardinality: one
+      as: text
+    icon:
+      description: Icon shown in the tab
+      the: xyz.tonk.artifact/icon
+      cardinality: one
+      as: text
+    entity:
+      description: Entity displayed in the sheet
+      the: xyz.tonk.artifact/entity
+      cardinality: one
+      as: entity
+    model:
+      description: Model concept used to display the entity
+      the: xyz.tonk.artifact/model
+      cardinality: one
+      as: entity
+    view:
+      description: View concept used to display the entity
+      the: xyz.tonk.artifact/view
+      cardinality: one
+      as: entity
+    order:
+      description: Lexicographic order key positioning the tab
+      the: xyz.tonk.sheet/order
+      cardinality: one
+      as: text
+
+# A `tab` view kind: a concept with its own display attribute
+# (`xyz.tonk.tab/display`) so an artifact can have BOTH a default
+# (canvas) view and a `tab` view without collision.
+concept!: &workspace/tab
+  this: tonk:tab
+  description: A tab presentation of a concept (alternate to the default view).
+  with:
+    model:
+      description: Concept this tab view is for
+      the: xyz.tonk.view/model
+      cardinality: one
+      as: entity
+    display:
+      description: HTML template for the tab
+      the: xyz.tonk.tab/display
+      cardinality: one
+      as: text
+
+# Tab selection. Clicking a tab fires the transient `activate-sheet`
+# command, reading which sheet was clicked from the bound element's
+# `data-sheet`. The inductive rule below finds the workspace that owns
+# that sheet and points its cardinality-one `active` field at the
+# clicked sheet (replacing the prior selection). The command itself is
+# swept after the cycle - only the `active` pointer persists.
+command!: &workspace/activate-sheet
+  description: A click asking to make `sheet` the active sheet of its workspace.
+  with:
+    sheet:
+      description: The sheet to activate
+      the: dom.event.current-target.dataset/sheet
+      as: entity
+
+# A minimal projection of the workspace's `active` pointer: the
+# workspace entity (`this`) and its `active` sheet, on the same
+# `xyz.tonk.workspace/active` attribute the `workspace` concept reads.
+# The rule asserts THIS (binding only `this` + `active`), rather than
+# re-asserting the whole `workspace` concept (which would force
+# binding every field). Writing `active` here updates the same triple
+# the workspace view sees.
+concept!: &workspace/active-sheet
+  description: The active-sheet pointer of a workspace, as a standalone fact.
+  with:
+    active:
+      description: The selected sheet
+      the: xyz.tonk.workspace/active
+      cardinality: one
+      as: entity
+
+# The inductive rule: when an `activate-sheet` command fires, find the
+# workspace that owns the clicked sheet and point its `active` field at
+# that sheet. Binding `?this` through the `workspace` membership means
+# the command needs only the sheet - no workspace id plumbed through
+# the DOM. The command is transient (satisfies the install-time
+# trigger gate, swept after commit); only the `active` pointer
+# persists. Shipped via `tonk_macros::effects!` (rules have no
+# TransactRequest shape).
+rule!:
+  assert!: workspace/active-sheet
+  when:
+    - assert: workspace/activate-sheet
+      where: { sheet: ?active }
+    - assert: workspace
+      where: { this: ?this, sheet: ?active }
+
+# The workspace view: a canvas region with the sheets on top and a
+# bottom tab strip, matching the wireframe's Layout F. Two
+# iterations of `{sheet}` (cardinality-many): the canvas uses each
+# sheet's default (artifact) view; the strip uses each sheet's `tab`
+# view. Tab selection isn't wired yet (a future interactive pass),
+# so all canvases stack.
+view!: &workspace/view
+  model: workspace
+  display: |
+    <div class="workspace">
+      <style>
+        .workspace {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          color: inherit;
+          font-family: inherit;
+          background: color-mix(in srgb, currentColor 4%, transparent);
+        }
+        .workspace__canvas {
+          flex: 1;
+          min-height: 0;
+          overflow: auto;
+          padding: 20px;
+        }
+        /* The canvas shows the single active sheet (the workspace's
+           command-driven `active` pointer). */
+        .workspace__canvas > tonk-display { display: contents; }
+        /* Flat bottom strip of bullet-prefixed tabs, matching the
+           wireframe's Layout F (no browser-tab chrome). */
+        .workspace__tabs {
+          display: flex;
+          align-items: stretch;
+          gap: 4px;
+          padding: 7px 14px;
+          border-top: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+          background: color-mix(in srgb, currentColor 3%, transparent);
+        }
+        /* Each tab is wrapped in a .workspace__tab iteration item.
+           Flatten the inner display wrappers so the buttons sit
+           directly in the flex strip. The wrapper stays a click
+           target carrying the workspace + sheet ids. */
+        .workspace__tabs tonk-display,
+        .workspace__tabs tonk-view { display: contents; }
+        .workspace__tab { display: contents; }
+        .tab {
+          display: inline-flex;
+          align-items: center;
+          gap: 7px;
+          padding: 5px 12px;
+          font-size: 13px;
+          color: inherit;
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          opacity: 0.6;
+          white-space: nowrap;
+        }
+        /* The leading status bullet (hollow when inactive). */
+        .tab::before {
+          content: "";
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          border: 1px solid currentColor;
+          background: transparent;
+          flex: none;
+        }
+        .tab:hover { opacity: 1; background: color-mix(in srgb, currentColor 7%, transparent); }
+        .tab__icon { opacity: 0.7; }
+      </style>
+      <div class="workspace__canvas">
+        <tonk-display entity={active} model=artifact />
+      </div>
+      <div class="workspace__tabs">
+        <div class="workspace__tab" onclick=workspace/activate-sheet data-sheet={sheet}>
+          <tonk-display entity={sheet} model=artifact view=workspace/tab />
+        </div>
+      </div>
+    </div>
+
+# The artifact's default (canvas) view: a status-strip header (the
+# sheet's name + a status dot, matching the wireframe's card header)
+# above the artifact's own entity/model/view render.
+view!:
+  this: id:tonk-workspace/artifact-view
+  model: artifact
+  display: |
+    <div class="artifact">
+      <style>
+        .artifact {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          color: inherit;
+          font-family: inherit;
+          border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+          overflow: hidden;
+        }
+        .artifact__head {
+          display: flex;
+          align-items: center;
+          gap: 9px;
+          padding: 11px 16px;
+          border-bottom: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+        }
+        .artifact__dot {
+          width: 7px; height: 7px; border-radius: 50%;
+          background: currentColor; flex: none; opacity: 0.85;
+        }
+        .artifact__name { font-size: 13px; font-weight: 600; }
+        .artifact__meta { font-size: 12px; opacity: 0.5; }
+        .artifact__body { flex: 1; min-height: 0; overflow: auto; }
+        .artifact__body > tonk-display { display: contents; }
+      </style>
+      <div class="artifact__head">
+        <span class="artifact__dot"></span>
+        <span class="artifact__name">{title}</span>
+        <span class="artifact__meta">{subtitle}</span>
+      </div>
+      <div class="artifact__body">
+        <tonk-display entity={entity} model={model} view={view} />
+      </div>
+    </div>
+
+# The artifact's `tab` view: one bottom-strip tab.
+workspace/tab!:
+  this: id:tonk-workspace/artifact-tab
+  model: artifact
+  display: |
+    <button class="tab" title={title}>
+      <wa-icon class="tab__icon" name={icon}></wa-icon>
+      <span class="tab__name">{title}</span>
+    </button>
 
 # ============================================================
 # DEMO CONTENT - DELETE before shipping
@@ -150,14 +425,11 @@ view!:
         .sheet {
           display: flex;
           flex-direction: column;
-          max-width: 760px;
-          padding: 24px 28px;
+          padding: 16px 20px;
           color: inherit;
           font-family: inherit;
           font-size: 13.5px;
-          border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
         }
-        .sheet__title { margin: 0 0 16px; font-size: 22px; font-weight: 600; }
         .sheet__head,
         .sheet__row {
           display: grid;
@@ -183,13 +455,28 @@ view!:
           opacity: 0.55;
         }
         .sheet__head span:nth-child(4),
-        .sheet__row span:nth-child(4) { text-align: right; }
+        .sheet__row span:nth-child(4),
+        .sheet__total span:last-child { text-align: right; }
+        /* A summary footer row, matching the wireframe's "total" line. */
+        .sheet__total {
+          display: grid;
+          grid-template-columns: 60px 1fr 90px 90px;
+          gap: 12px;
+          padding: 10px 0 0;
+          font-weight: 600;
+        }
+        .sheet__total span:first-child {
+          grid-column: 1 / 3;
+          opacity: 0.55;
+        }
       </style>
-      <h2 class="sheet__title">{title}</h2>
       <div class="sheet__head">
         <span>day</span><span>item</span><span>time</span><span>cost</span>
       </div>
       <tonk-display entity={stop} model=stop></tonk-display>
+      <div class="sheet__total">
+        <span>total</span><span></span><span>-</span>
+      </div>
     </div>
 
 # The stop-row view, published under the built-in `view` concept
@@ -292,9 +579,54 @@ trip!:
   stop: id:tonk-workspace/stop/zoo
 
 
-artifact!:
+# A second demo trip entity so there's more than one tab. A bare
+# trip with a title and one stop.
+trip-title!:
+  this: id:tonk-workspace/lodging
+  title: "Lodging"
+
+trip!:
+  this: id:tonk-workspace/lodging
+  stop: id:tonk-workspace/stop/casa
+
+stop!:
+  this: id:tonk-workspace/stop/casa
+  day: "all"
+  item: "Casa Calugi, 5 nights"
+  time: "-"
+  cost: "EUR 820"
+
+# Two sheets (= artifacts + order). Each sheet's `entity`/`model`/
+# `view` point at the trip it displays; `order` positions the tab.
+workspace/sheet!:
+  this: id:tonk-workspace/sheet/itinerary
   title: "Itinerary"
-  icon: "sheet"
+  subtitle: "day-by-day plan - 5 days - 7 stops"
+  icon: "table-list"
   entity: id:tonk-workspace/itinerary
   model: trip
-  view: id:tonk-workspace/trip-view
+  view: tonk:view
+  order: "a"
+
+workspace/sheet!:
+  this: id:tonk-workspace/sheet/lodging
+  title: "Lodging"
+  subtitle: "where we sleep - 1 booking"
+  icon: "table-list"
+  entity: id:tonk-workspace/lodging
+  model: trip
+  view: tonk:view
+  order: "b"
+
+# The demo workspace owns both trip sheets, with the itinerary
+# selected as the initial active sheet (a click on a tab re-points
+# `active` via the activate-sheet command + rule).
+workspace!:
+  this: work:space
+  name: "Trip planning"
+  active: id:tonk-workspace/sheet/itinerary
+  sheet: id:tonk-workspace/sheet/itinerary
+
+workspace!:
+  this: work:space
+  sheet: id:tonk-workspace/sheet/lodging

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -30,9 +30,17 @@ use tonk_core::claim::TransactRequest;
 pub static BOOTSTRAP: LazyLock<TransactRequest> =
     LazyLock::new(|| tonk_macros::claim!("bootstrap.yaml"));
 
+/// The `rule!:` installs from `bootstrap.yaml`, lifted at compile
+/// time by `effects!`. Rules have no [`TransactRequest`] shape (the
+/// `Claim` wire can't carry `dialog.effect/*` triples), so the shell
+/// asserts these alongside the [`BOOTSTRAP`] claims when seeding the
+/// repository — the seam that makes interactive tab selection live.
+pub static RULES: LazyLock<Vec<tonk_schema::rule::Rule>> =
+    LazyLock::new(|| tonk_macros::effects!("bootstrap.yaml"));
+
 #[cfg(test)]
 mod tests {
-    use super::BOOTSTRAP;
+    use super::{BOOTSTRAP, RULES};
 
     // Run wasm32 tests in the browser (ChromeDriver), matching the
     // sibling tonk-* crates. Without this the default wasm-bindgen
@@ -48,6 +56,19 @@ mod tests {
         assert!(
             !BOOTSTRAP.claims.is_empty(),
             "bootstrap should lower to at least one claim",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_lifts_the_activate_sheet_rule() {
+        // The `rule!:` install is lifted out-of-band by `effects!`
+        // (rules have no TransactRequest shape). Tab selection is
+        // inert without it, so the bootstrap must carry the rule.
+        assert_eq!(
+            RULES.len(),
+            1,
+            "expected the activate-sheet rule to lift, got {}",
+            RULES.len(),
         );
     }
 
@@ -81,12 +102,12 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_accumulates_every_stop_on_the_trip() {
+    fn it_accumulates_every_stop_on_the_itinerary() {
         use tonk_core::claim::Claim;
-        // The trip is asserted once per stop (a field value can't be
-        // a list in notation, and `stop` is cardinality-many). Each
-        // assertion adds one stop, so the bootstrap must carry a
-        // distinct `stop` value for all seven wireframe stops.
+        // The itinerary trip is asserted once per stop (a field value
+        // can't be a list, and `stop` is cardinality-many). Counting
+        // the `stop` values on the itinerary entity must total all
+        // seven wireframe stops.
         let mut stops: Vec<String> = BOOTSTRAP
             .claims
             .iter()
@@ -94,6 +115,10 @@ mod tests {
                 let Claim::Assert(app) = claim else {
                     return None;
                 };
+                let this = app.parameters.get("this").map(|v| format!("{v:?}"))?;
+                if !this.contains("tonk-workspace/itinerary") {
+                    return None;
+                }
                 app.parameters.get("stop").map(|v| format!("{v:?}"))
             })
             .collect();
@@ -102,7 +127,32 @@ mod tests {
         assert_eq!(
             stops.len(),
             7,
-            "expected seven distinct stops on the trip, got {stops:?}",
+            "expected seven distinct stops on the itinerary, got {stops:?}",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_collects_the_workspace_sheets() {
+        use tonk_core::claim::Claim;
+        // The demo workspace is asserted once per sheet (cardinality
+        // -many `sheet`), so the bootstrap must carry both distinct
+        // sheet members for the tab strip to render.
+        let mut sheets: Vec<String> = BOOTSTRAP
+            .claims
+            .iter()
+            .filter_map(|claim| {
+                let Claim::Assert(app) = claim else {
+                    return None;
+                };
+                app.parameters.get("sheet").map(|v| format!("{v:?}"))
+            })
+            .collect();
+        sheets.sort();
+        sheets.dedup();
+        assert_eq!(
+            sheets.len(),
+            2,
+            "expected two workspace sheets, got {sheets:?}",
         );
     }
 }


### PR DESCRIPTION
Follow-up to #482. Three independent improvements on top of the merged artifact base.

## Interactive tabs need an inductive rule — so make rules shippable
Tab selection is modeled the right way: a transient `activate-sheet` command (fired by a tab click) plus an inductive rule that points the workspace's `active` sheet, with the rule joining workspace membership so the command only carries the clicked sheet. Inductive rules had no way to ride the bootstrap (the `claim!` macro lowers to a `TransactRequest`, which has no slot for `dialog.effect/*`), so this adds an `effects!` macro that lifts `rule!` installs and a `rules` carrier on the repository bootstrap that the seed loop asserts. Concepts are namespaced (`workspace/sheet`, `workspace/tab`, `workspace/view`, `workspace/activate-sheet`, `workspace/active-sheet`) to avoid `id:` collisions, and the template planner now splits same-field iterations across sibling sections so the canvas and tab strip stop double-mounting the whole workspace.

## Published names: parse, don't validate
`PredicateApplication.name` was an `Option<String>` whose `id:<name>` entity was re-derived (and silently dropped on failure) deep in the write path. It is now an `AnchorName` newtype that parses the entity once at the boundary (`TryFrom`) and converts infallibly (`From`), validated at the serde edge and at analysis time — no silent skip, no re-parse downstream.

## Graceful SSE teardown
Switching tabs surfaced a spurious full-view "Connection failed / AbortError: BodyStreamBuffer was aborted": tonk-host aborts its own subscription on teardown, and the reader reported that abort as a transport error. Both SSE transports (direct fetch and the iframe bridge) now map to a uniform Rust frame stream behind one `EventSource` abstraction that owns a single invariant — **dropping it never invokes `on_error`** — by racing the stream against a drop signal and re-checking it before reporting. A wasm regression test drops a live `EventSource` mid-read and asserts no error is reported.

Still open (not in this PR): subscription *genuine* failures still render a full-view error rather than a small callout + reconnect.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `tonk-schema` crate to the workspace, enhances the handling of inductive rules, and refines the use of `AnchorName` throughout the codebase, ensuring better validation and error handling for names.

### Detailed summary
- Added `tonk-schema` to the workspace.
- Introduced `rules` in `BranchConfiguration` for inductive rules.
- Implemented `AnchorName` for better name validation.
- Updated various functions to use `AnchorName` instead of `String`.
- Enhanced error handling for invalid anchor names.
- Refined SSE stream handling to prevent errors on drop.
- Improved tests for workspace and sheet functionalities.

> The following files were skipped due to too many changes: `rust/tonk-workspace/bootstrap.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->