### PR TITLE
feat(tonk-ui,worker,slide): background sync and status

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,12 +85,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-chromedriver": {
+      "locked": {
+        "lastModified": 1780531915,
+        "narHash": "sha256-1A1ciKeRhy4Nr4gv/SK0zzmUKdXGr9Gke/ujBGs4YeU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "19c56ae874977658f33ab06c04520b1848c3e4b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-chromedriver": "nixpkgs-chromedriver",
         "rust-overlay": "rust-overlay",
         "wrangler-flake": "wrangler-flake"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     crane.url = "github:ipetkov/crane";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-chromedriver.url = "github:NixOS/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -21,6 +22,7 @@
       self,
       crane,
       nixpkgs,
+      nixpkgs-chromedriver,
       flake-utils,
       rust-overlay,
       nix-filter,
@@ -41,6 +43,8 @@
         # We get wrangler from a 3P crate because nixpkgs#wrangler lags
         # the latest release
         wrangler = wrangler-flake.packages.${system}.wrangler;
+
+        chromedriverDarwin = nixpkgs-chromedriver.legacyPackages.${system}.chromedriver;
 
         # Common build inputs for all dev shells
         commonBuildInputs =
@@ -117,10 +121,13 @@
           // lib.optionalAttrs stdenv.isLinux {
             "CHROME" = "${chromium}/bin/chromium";
             "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
+          }
+          // lib.optionalAttrs stdenv.isDarwin {
+            "CHROMEDRIVER" = "${chromedriverDarwin}/bin/chromedriver";
           };
 
         # Import menu helpers (e.g., colorful Tonk Shell commands)
-        menuHelpers = (import ./nix/menu.nix { inherit pkgs; });
+        menuHelpers = (import ./nix/menu.nix { inherit pkgs chromedriverDarwin; });
 
         inherit (menuHelpers) makeMenu makeDevShellHook menuTestCommand;
 

--- a/nix/menu.nix
+++ b/nix/menu.nix
@@ -1,6 +1,11 @@
 # This module contains helpers for assembling and printing
 # the Tonk Shell menu.
-{ pkgs, ... }:
+{
+  pkgs,
+  # chromedriver for macOS test commands; null on Linux (see flake.nix).
+  chromedriverDarwin ? null,
+  ...
+}:
 let
   tonkFlower = ''
                                   .-            
@@ -139,6 +144,9 @@ let
     lib.optionalAttrs stdenv.isLinux {
       "CHROME" = "${chromium}/bin/chromium";
       "CHROMEDRIVER" = "${chromedriver}/bin/chromedriver";
+    }
+    // lib.optionalAttrs stdenv.isDarwin {
+      "CHROMEDRIVER" = "${chromedriverDarwin}/bin/chromedriver";
     };
 
   menuTestCommand =

--- a/rust/slide/Cargo.toml
+++ b/rust/slide/Cargo.toml
@@ -25,6 +25,10 @@ path = "tests/site.rs"
 name = "notation"
 path = "tests/notation.rs"
 
+[[test]]
+name = "sync"
+path = "tests/sync.rs"
+
 [features]
 integration-tests = []
 

--- a/rust/slide/SYNC.md
+++ b/rust/slide/SYNC.md
@@ -63,10 +63,21 @@ slide remote add <name> <url> [--subject <did>]
 slide remote list
 slide remote set-upstream <remote>            # links main → <remote>/main
 
+slide eval [--no-sync] …                       # auto pull-before / push-after by default
 slide push                                    # pushes main to its upstream
 slide pull                                    # pulls main from its upstream
-slide sync                                    # pull then push (the agent loop)
+slide status                                  # synced / ahead / behind / diverged / no-upstream
 ```
+
+Auto-sync: a committing `slide eval` pulls its upstream in before
+evaluating and pushes the resulting commit back out afterward,
+when an upstream is configured. Opt out per-invocation with
+`--no-sync`, or for a whole session with the `SLIDE_NO_SYNC`
+environment variable (any value other than empty / `0` / `false` /
+`no`). A branch with no upstream is a silent skip; sync failures
+warn on stderr but never fail the command — the local write is
+already committed, so the manual `slide push` / `slide pull` flow
+stays fully recoverable.
 
 Reasoning for each:
 
@@ -211,12 +222,16 @@ more, it errors out asking for an explicit `set-upstream`. The
 agent's normal flow — one remote, set once at site creation
 or by `slide join` — never hits the explicit path.
 
-**Phase 3 — agent loop polish.** `slide sync` (pull then
-push). Catch authorization failures from the access service
-and emit a friendlier message ("remote rejected the operator's
-authority — re-check the endpoint or delegation") rather than
-the raw dialog error. A `slide doctor`-style check that
-confirms the remote handshake without writing.
+**Phase 3 — agent loop polish.** ✅ auto-sync + status shipped
+(see `plan/background-sync.md`): a committing `slide eval`
+pulls-before / pushes-after by default (`--no-sync` /
+`SLIDE_NO_SYNC` to opt out), and `slide status` prints the
+classified relationship to the upstream. Still open: catch
+authorization failures from the access service and emit a
+friendlier message ("remote rejected the operator's authority —
+re-check the endpoint or delegation") rather than the raw dialog
+error, plus a `slide doctor`-style check that confirms the
+remote handshake without writing.
 
 ## Deferred
 

--- a/rust/slide/src/auto_sync.rs
+++ b/rust/slide/src/auto_sync.rs
@@ -35,7 +35,10 @@ pub fn enabled(no_sync_flag: bool) -> bool {
 /// environment.
 fn env_value_opts_out(value: Option<&str>) -> bool {
     match value {
-        Some(raw) => !matches!(raw.trim().to_ascii_lowercase().as_str(), "" | "0" | "false" | "no"),
+        Some(raw) => !matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no"
+        ),
         None => false,
     }
 }

--- a/rust/slide/src/auto_sync.rs
+++ b/rust/slide/src/auto_sync.rs
@@ -1,0 +1,125 @@
+//! Auto-sync — pull-before / push-after around `slide eval`.
+//!
+//! When an upstream is configured, a mutating `eval` pulls the
+//! upstream in before evaluating (so the write lands on top of the
+//! latest shared state) and pushes the resulting commit back out
+//! after. This makes data reach the remote without anyone running
+//! `slide push` by hand.
+//!
+//! Escape hatch: `--no-sync` on the command, or the `SLIDE_NO_SYNC`
+//! environment variable. A branch with no upstream is a silent skip
+//! (slide's pre-auto-sync behavior). Sync failures are warnings on
+//! stderr — the local write is already committed, so the command
+//! still succeeds and the user can recover with the manual
+//! `slide pull` / `slide push` flow.
+
+use crate::eval::{self, Options, Outcome, Source};
+use crate::site::SlideSite;
+use crate::sync::{self, SyncError};
+
+/// Environment variable that opts a slide invocation out of
+/// auto-sync, mirroring the `--no-sync` flag.
+pub const NO_SYNC_ENV: &str = "SLIDE_NO_SYNC";
+
+/// Whether auto-sync should run for this invocation.
+///
+/// Off when `--no-sync` was passed (`no_sync_flag`) or when
+/// [`NO_SYNC_ENV`] is set to a value other than empty / `0` /
+/// `false` / `no`.
+pub fn enabled(no_sync_flag: bool) -> bool {
+    !no_sync_flag && !env_value_opts_out(std::env::var(NO_SYNC_ENV).ok().as_deref())
+}
+
+/// Whether a [`NO_SYNC_ENV`] value opts out of auto-sync. Pure so
+/// the truthiness rule is testable without mutating the process
+/// environment.
+fn env_value_opts_out(value: Option<&str>) -> bool {
+    match value {
+        Some(raw) => !matches!(raw.trim().to_ascii_lowercase().as_str(), "" | "0" | "false" | "no"),
+        None => false,
+    }
+}
+
+/// Evaluate `source` against `site`, syncing around the write when
+/// `sync` is on.
+///
+/// Pull-before brings the local branch up to date; push-after sends
+/// the new commit back. Both are no-ops when no upstream is
+/// configured. The eval result is returned unchanged — sync wraps
+/// it without altering success or output.
+pub async fn run_eval(
+    site: &SlideSite,
+    source: Source,
+    options: Options,
+    sync: bool,
+) -> Result<Outcome, eval::EvalError> {
+    if sync {
+        pull_before(site).await;
+    }
+    let outcome = eval::run_against_site(site, source, options).await?;
+    if sync && outcome.committed {
+        push_after(site).await;
+    }
+    Ok(outcome)
+}
+
+/// Pull the upstream into the local branch before a write. A
+/// missing upstream is a silent skip; any other failure is a
+/// warning — the command proceeds either way.
+async fn pull_before(site: &SlideSite) {
+    match sync::pull(site).await {
+        Ok(_) | Err(SyncError::UpstreamNotConfigured { .. }) => {}
+        Err(err) => warn("pull", &err),
+    }
+}
+
+/// Push the local branch to its upstream after a write. A missing
+/// upstream is a silent skip; any other failure is a warning — the
+/// local write is already committed.
+async fn push_after(site: &SlideSite) {
+    match sync::push(site).await {
+        Ok(_) | Err(SyncError::UpstreamNotConfigured { .. }) => {}
+        Err(err) => warn("push", &err),
+    }
+}
+
+fn warn(op: &str, err: &SyncError) {
+    eprintln!("warning: auto-sync {op} failed: {err}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_treats_an_absent_env_value_as_opt_in() {
+        assert!(!env_value_opts_out(None));
+    }
+
+    #[dialog_common::test]
+    fn it_treats_falsey_env_values_as_opt_in() {
+        assert!(!env_value_opts_out(Some("")));
+        assert!(!env_value_opts_out(Some("0")));
+        assert!(!env_value_opts_out(Some("false")));
+        assert!(!env_value_opts_out(Some("no")));
+        assert!(!env_value_opts_out(Some("  FALSE  ")));
+    }
+
+    #[dialog_common::test]
+    fn it_treats_other_env_values_as_opt_out() {
+        assert!(env_value_opts_out(Some("1")));
+        assert!(env_value_opts_out(Some("true")));
+        assert!(env_value_opts_out(Some("yes")));
+    }
+
+    #[dialog_common::test]
+    fn it_disables_auto_sync_when_the_flag_is_set() {
+        // The flag forces off regardless of the environment.
+        assert!(!enabled(true));
+    }
+}

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -101,6 +101,11 @@ enum Command {
     /// Pull the local main branch from its upstream.
     Pull,
 
+    /// Print how the local main branch relates to its upstream:
+    /// `synced`, `ahead`, `behind`, `diverged`, or `no-upstream`.
+    /// Read-only — fetches the upstream head without merging.
+    Status,
+
     /// Mint a UCAN delegation chain over the local repo and
     /// print a paste-able invite URL. The default form is
     /// audience-open: anyone holding the URL can claim by
@@ -313,6 +318,7 @@ async fn main() {
         Command::Migrate { from, do_move } => migrate(from, do_move).await,
         Command::Push => sync_op(SyncOp::Push).await,
         Command::Pull => sync_op(SyncOp::Pull).await,
+        Command::Status => status_op().await,
         Command::Invite { base_url, remote } => mint_invite(base_url, remote).await,
         Command::Join { url } => claim_invite(url).await,
         Command::Remote { command } => remote_op(command).await,
@@ -484,6 +490,41 @@ fn print_sync_outcome(op: SyncOp, outcome: &SyncOutcome) {
         );
     } else {
         println!("{verb}");
+    }
+}
+
+async fn status_op() -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+    };
+    let site = match site::SlideSite::discover_and_open(&cwd).await {
+        Ok(s) => s,
+        Err(err) => return print_error(err.to_string()),
+    };
+
+    match sync::status(&site).await {
+        Ok(state) => {
+            println!("{}", render_sync_state(state));
+            ExitCode::Success
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            err.exit_code()
+        }
+    }
+}
+
+/// One-line rendering of a [`tonk_schema::SyncState`]: the
+/// kebab-case token plus a short gloss of what to do about it.
+fn render_sync_state(state: tonk_schema::SyncState) -> &'static str {
+    use tonk_schema::SyncState;
+    match state {
+        SyncState::NoUpstream => "no-upstream (set one with `slide remote set-upstream <name>`)",
+        SyncState::Synced => "synced",
+        SyncState::Ahead => "ahead (local has unpushed commits; run `slide push`)",
+        SyncState::Behind => "behind (upstream has new commits; run `slide pull`)",
+        SyncState::Diverged => "diverged (run `slide pull` to merge, then `slide push`)",
     }
 }
 

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 
+use slide::auto_sync;
 use slide::eval::{self, EvalError, Source};
 use slide::invite::{self, ClaimOutcome, InviteOutcome};
 use slide::migrate::{self, Mode as MigrateMode};
@@ -274,6 +275,13 @@ struct EvalArgs {
     /// Omit to read from a piped stdin.
     #[arg(value_name = "PATH")]
     path: Option<String>,
+
+    /// Skip the automatic pull-before / push-after that wraps a
+    /// committing eval when an upstream is configured. The manual
+    /// `slide pull` / `slide push` flow stays available. Also
+    /// settable via the `SLIDE_NO_SYNC` environment variable.
+    #[arg(long = "no-sync")]
+    no_sync: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -365,7 +373,13 @@ async fn eval(args: EvalArgs) -> ExitCode {
         quiet: args.quiet,
     };
 
-    match eval::run_against_cwd(&cwd, source, options).await {
+    let site = match site::SlideSite::discover_and_open(&cwd).await {
+        Ok(s) => s,
+        Err(err) => return print_error(err.to_string()),
+    };
+
+    let sync = auto_sync::enabled(args.no_sync);
+    match auto_sync::run_eval(&site, source, options, sync).await {
         Ok(outcome) => {
             let mut stdout = std::io::stdout().lock();
             if let Err(e) = stdout.write_all(outcome.stdout.as_bytes()) {

--- a/rust/slide/src/eval.rs
+++ b/rust/slide/src/eval.rs
@@ -1,7 +1,7 @@
 //! `slide eval` — read a notation document, evaluate it against
 //! the local site, and render the response.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use thiserror::Error;
 use tokio::io::AsyncReadExt as _;
@@ -89,8 +89,8 @@ pub struct Outcome {
     pub committed: bool,
 }
 
-/// Failure modes for [`run_against_cwd`] / [`run_against_site`].
-/// Each maps onto a CLI exit code via [`Self::exit_code`].
+/// Failure modes for [`run_against_site`]. Each maps onto a CLI
+/// exit code via [`Self::exit_code`].
 #[derive(Debug, Error)]
 pub enum EvalError {
     /// Source failed to parse — diagnostics are joined into the
@@ -121,20 +121,6 @@ impl EvalError {
             EvalError::Io(_) => ExitCode::IoError,
         }
     }
-}
-
-/// Evaluate `source` against the site discovered by walking up
-/// from `start`. Convenience wrapper around
-/// [`run_against_site`].
-pub async fn run_against_cwd(
-    start: &Path,
-    source: Source,
-    options: Options,
-) -> Result<Outcome, EvalError> {
-    let site = SlideSite::discover_and_open(start)
-        .await
-        .map_err(|e| EvalError::Io(e.to_string()))?;
-    run_against_site(&site, source, options).await
 }
 
 /// Evaluate `source` against an already-opened [`SlideSite`].

--- a/rust/slide/src/lib.rs
+++ b/rust/slide/src/lib.rs
@@ -18,6 +18,7 @@
 //! - [`migrate`] — copy a `.carry/` directory to `.tonk/`.
 //! - [`guide`] — the asserted-notation reference, baked in.
 
+pub mod auto_sync;
 pub mod eval;
 pub mod guide;
 pub mod identity;

--- a/rust/slide/src/sync.rs
+++ b/rust/slide/src/sync.rs
@@ -8,8 +8,9 @@
 //! no SSE clients), so this skips the reactor wrapper the
 //! worker uses.
 
-use dialog_repository::{PullError, PushError, Revision};
+use dialog_repository::{FetchError, PullError, PushError, Revision};
 use thiserror::Error;
+use tonk_schema::{SyncState, classify};
 
 use crate::ExitCode;
 use crate::site::SlideSite;
@@ -106,6 +107,34 @@ pub async fn pull(site: &SlideSite) -> Result<SyncOutcome, SyncError> {
         // signal, more reliable than revision comparison.
         advanced: merged.is_some(),
     })
+}
+
+/// Classify the site's main branch against its upstream without
+/// mutating local state.
+///
+/// Reads the local head, fetches the upstream head read-only, and
+/// runs the shared classifier. A branch with no upstream is
+/// [`SyncState::NoUpstream`] — not an error — so `slide status`
+/// always has something to print.
+pub async fn status(site: &SlideSite) -> Result<SyncState, SyncError> {
+    let local = site.branch.revision();
+    if site.branch.upstream().is_none() {
+        return Ok(SyncState::NoUpstream);
+    }
+    let remote = site
+        .branch
+        .fetch()
+        .perform(&site.operator)
+        .await
+        .map_err(map_fetch_error)?;
+    Ok(classify(local.as_ref(), remote.as_ref()))
+}
+
+fn map_fetch_error(error: FetchError) -> SyncError {
+    match error {
+        FetchError::BranchHasNoUpstream { branch } => SyncError::UpstreamNotConfigured { branch },
+        other => SyncError::Io(other.to_string()),
+    }
 }
 
 fn map_push_error(error: PushError) -> SyncError {

--- a/rust/slide/src/sync.rs
+++ b/rust/slide/src/sync.rs
@@ -36,7 +36,7 @@ pub struct SyncOutcome {
 pub enum SyncError {
     /// `branch.upstream()` returned `None` — the local branch
     /// has no upstream linkage. The caller should set one with
-    /// `slide remote set-upstream` (Phase 2).
+    /// `slide remote set-upstream`.
     #[error(
         "branch '{branch}' has no upstream configured; \
          set one with `slide remote set-upstream <name>`"
@@ -127,7 +127,7 @@ pub async fn status(site: &SlideSite) -> Result<SyncState, SyncError> {
         .perform(&site.operator)
         .await
         .map_err(map_fetch_error)?;
-    Ok(classify(local.as_ref(), remote.as_ref()))
+    Ok(classify(local.as_ref(), remote.as_ref()).into())
 }
 
 fn map_fetch_error(error: FetchError) -> SyncError {

--- a/rust/slide/tests/sync.rs
+++ b/rust/slide/tests/sync.rs
@@ -1,0 +1,94 @@
+//! Auto-sync behaviour for `slide eval`: a write reaches the
+//! upstream on its own, and `--no-sync` suppresses it.
+
+mod common;
+
+use anyhow::Result;
+use dialog_repository::Revision;
+use slide::auto_sync;
+use slide::eval::{Options, Source};
+
+use crate::common::{ATTRIBUTE_DECL, TestSite};
+
+/// Wire `main`'s upstream to a sibling branch in the same repo —
+/// the cheap in-process stand-in for a real remote, so a push has
+/// somewhere local to land.
+async fn wire_sibling_upstream(test: &TestSite) -> Result<()> {
+    let upstream = test
+        .site
+        .repository
+        .branch("upstream")
+        .open()
+        .perform(&test.site.operator)
+        .await?;
+    test.site
+        .branch
+        .set_upstream(&upstream)
+        .perform(&test.site.operator)
+        .await?;
+    Ok(())
+}
+
+/// Read the sibling upstream branch's current head by re-opening it.
+async fn upstream_revision(test: &TestSite) -> Result<Option<Revision>> {
+    let upstream = test
+        .site
+        .repository
+        .branch("upstream")
+        .open()
+        .perform(&test.site.operator)
+        .await?;
+    Ok(upstream.revision())
+}
+
+mod when_evaluating_with_an_upstream {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_auto_pushes_the_commit_to_the_upstream() -> Result<()> {
+        let test = TestSite::new().await?;
+        wire_sibling_upstream(&test).await?;
+        assert!(
+            upstream_revision(&test).await?.is_none(),
+            "upstream starts empty"
+        );
+
+        auto_sync::run_eval(
+            &test.site,
+            Source::Inline(ATTRIBUTE_DECL.to_string()),
+            Options::default(),
+            true,
+        )
+        .await?;
+
+        let pushed = upstream_revision(&test)
+            .await?
+            .expect("auto-sync should have pushed the commit");
+        let local = test.site.branch.revision().expect("eval committed locally");
+        assert_eq!(
+            pushed.tree, local.tree,
+            "the upstream head matches the local head after auto-push"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_push_when_sync_is_disabled() -> Result<()> {
+        let test = TestSite::new().await?;
+        wire_sibling_upstream(&test).await?;
+
+        auto_sync::run_eval(
+            &test.site,
+            Source::Inline(ATTRIBUTE_DECL.to_string()),
+            Options::default(),
+            false,
+        )
+        .await?;
+
+        assert!(
+            upstream_revision(&test).await?.is_none(),
+            "nothing reaches the upstream when sync is disabled"
+        );
+        Ok(())
+    }
+}

--- a/rust/slide/tests/sync.rs
+++ b/rust/slide/tests/sync.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use dialog_repository::Revision;
 use slide::auto_sync;
 use slide::eval::{Options, Source};
+use slide::sync;
+use tonk_schema::SyncState;
 
 use crate::common::{ATTRIBUTE_DECL, TestSite};
 
@@ -89,6 +91,41 @@ mod when_evaluating_with_an_upstream {
             upstream_revision(&test).await?.is_none(),
             "nothing reaches the upstream when sync is disabled"
         );
+        Ok(())
+    }
+}
+
+mod when_reporting_status {
+    use super::*;
+    use crate::common::CONCEPT_DECL;
+
+    #[dialog_common::test]
+    async fn it_reports_no_upstream_when_none_is_configured() -> Result<()> {
+        let test = TestSite::new().await?;
+        assert_eq!(sync::status(&test.site).await?, SyncState::NoUpstream);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_synced_after_pushing() -> Result<()> {
+        let test = TestSite::new().await?;
+        wire_sibling_upstream(&test).await?;
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        sync::push(&test.site).await?;
+        assert_eq!(sync::status(&test.site).await?, SyncState::Synced);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_ahead_when_local_has_unpushed_commits() -> Result<()> {
+        let test = TestSite::new().await?;
+        wire_sibling_upstream(&test).await?;
+        // Establish a shared base on the upstream, then advance the
+        // local branch past it.
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        sync::push(&test.site).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+        assert_eq!(sync::status(&test.site).await?, SyncState::Ahead);
         Ok(())
     }
 }

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -60,6 +60,9 @@ pub mod query;
 
 pub mod query_source;
 
+pub mod sync;
+pub use sync::*;
+
 pub mod replica;
 pub use replica::*;
 

--- a/rust/tonk-schema/src/sync.rs
+++ b/rust/tonk-schema/src/sync.rs
@@ -1,0 +1,141 @@
+//! Sync-state classification.
+//!
+//! A pure, I/O-free comparison of a branch's local head against its
+//! upstream head. Both the native CLI and the wasm worker call this to
+//! drive a synced/ahead/behind/diverged indicator and to decide whether
+//! a sync would do anything.
+
+use dialog_repository::Revision;
+
+/// How a branch's local head relates to its upstream head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncState {
+    /// No upstream is configured for this branch. Supplied by the caller
+    /// (which knows the branch's configuration); never inferred here.
+    NoUpstream,
+    /// Local and upstream heads are identical — nothing to do.
+    Synced,
+    /// Local is strictly ahead: a push would fast-forward the upstream.
+    Ahead,
+    /// Local is strictly behind: a pull would fast-forward the local head.
+    Behind,
+    /// The two heads have diverged, or their relationship can't be proven
+    /// from the heads alone. The safe fallback — a sync needs a merge.
+    Diverged,
+}
+
+/// Classify `local` against `remote` from the two heads alone.
+///
+/// This is the cheap variant: one [`Revision`] from each side, no history
+/// walk. It only reports a direction it can *prove*:
+///
+/// - identical trees (including both heads absent) → [`SyncState::Synced`];
+/// - one side absent and the other present → the present side leads;
+/// - the remote head is the local head's recorded parent → [`SyncState::Ahead`];
+/// - the local head is the remote head's recorded parent → [`SyncState::Behind`].
+///
+/// Anything else is [`SyncState::Diverged`]. In particular the logical
+/// clocks (`period`, `moment`) are deliberately *not* used as a tiebreak:
+/// two replicas that fork while the same issuer keeps committing produce
+/// the same clock signature as a genuine linear lead, so the clocks can't
+/// distinguish "ahead" from "diverged". Reporting `Diverged` there keeps
+/// the invariant that we never claim a direction we can't back up.
+///
+/// [`SyncState::NoUpstream`] is never returned — the caller supplies it
+/// when no upstream is configured.
+pub fn classify(local: Option<&Revision>, remote: Option<&Revision>) -> SyncState {
+    match (local, remote) {
+        (None, None) => SyncState::Synced,
+        (Some(_), None) => SyncState::Ahead,
+        (None, Some(_)) => SyncState::Behind,
+        (Some(local), Some(remote)) => {
+            if local.tree == remote.tree {
+                SyncState::Synced
+            } else if local.cause.contains(&remote.tree) {
+                SyncState::Ahead
+            } else if remote.cause.contains(&local.tree) {
+                SyncState::Behind
+            } else {
+                SyncState::Diverged
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_capability::Did;
+    use dialog_repository::TreeReference;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn did() -> Did {
+        "did:key:test".parse().unwrap()
+    }
+
+    fn tree(byte: u8) -> TreeReference {
+        TreeReference::from([byte; 32])
+    }
+
+    /// A revision with the given head tree and recorded parent trees.
+    fn rev(head: TreeReference, cause: &[TreeReference]) -> Revision {
+        Revision {
+            subject: did(),
+            issuer: did(),
+            authority: did(),
+            tree: head,
+            cause: cause.iter().cloned().collect(),
+            period: 0,
+            moment: 0,
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_is_synced_when_heads_match() {
+        let local = rev(tree(1), &[]);
+        let remote = rev(tree(1), &[]);
+        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Synced);
+    }
+
+    #[dialog_common::test]
+    fn it_is_synced_when_both_heads_are_absent() {
+        assert_eq!(classify(None, None), SyncState::Synced);
+    }
+
+    #[dialog_common::test]
+    fn it_is_ahead_when_remote_is_absent() {
+        let local = rev(tree(1), &[]);
+        assert_eq!(classify(Some(&local), None), SyncState::Ahead);
+    }
+
+    #[dialog_common::test]
+    fn it_is_behind_when_local_is_absent() {
+        let remote = rev(tree(1), &[]);
+        assert_eq!(classify(None, Some(&remote)), SyncState::Behind);
+    }
+
+    #[dialog_common::test]
+    fn it_is_ahead_when_remote_is_the_local_parent() {
+        let remote = rev(tree(1), &[]);
+        let local = rev(tree(2), &[tree(1)]);
+        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Ahead);
+    }
+
+    #[dialog_common::test]
+    fn it_is_behind_when_local_is_the_remote_parent() {
+        let local = rev(tree(1), &[]);
+        let remote = rev(tree(2), &[tree(1)]);
+        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Behind);
+    }
+
+    #[dialog_common::test]
+    fn it_is_diverged_when_heads_are_unrelated() {
+        let local = rev(tree(1), &[tree(3)]);
+        let remote = rev(tree(2), &[tree(4)]);
+        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Diverged);
+    }
+}

--- a/rust/tonk-schema/src/sync.rs
+++ b/rust/tonk-schema/src/sync.rs
@@ -13,11 +13,16 @@ use serde::{Deserialize, Serialize};
 /// Serializes kebab-case (`no-upstream`, `synced`, `ahead`,
 /// `behind`, `diverged`) so the wire shape reads the same as the
 /// states the UI and `slide status` render.
+///
+/// [`classify`] derives the four head-comparison states as a
+/// [`Comparison`]; the configuration state `NoUpstream` is supplied
+/// by the caller (which knows the branch's configuration) by
+/// widening a `Comparison` through [`From`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SyncState {
-    /// No upstream is configured for this branch. Supplied by the caller
-    /// (which knows the branch's configuration); never inferred here.
+    /// No upstream is configured for this branch. Supplied by the caller;
+    /// never produced by [`classify`].
     NoUpstream,
     /// Local and upstream heads are identical — nothing to do.
     Synced,
@@ -30,39 +35,77 @@ pub enum SyncState {
     Diverged,
 }
 
+/// The relationship [`classify`] can prove between a branch's local and
+/// upstream heads.
+///
+/// Exactly [`SyncState`] minus the configuration state `NoUpstream`, so
+/// the classifier's return type matches what it can actually produce.
+/// Callers widen into [`SyncState`] (adding `NoUpstream` when no upstream
+/// is configured) via the [`From`] impl below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Comparison {
+    /// Local and upstream heads are identical.
+    Synced,
+    /// Local is strictly ahead by one proven commit.
+    Ahead,
+    /// Local is strictly behind by one proven commit.
+    Behind,
+    /// The relationship can't be proven from the two heads alone.
+    Diverged,
+}
+
+impl From<Comparison> for SyncState {
+    fn from(comparison: Comparison) -> Self {
+        match comparison {
+            Comparison::Synced => SyncState::Synced,
+            Comparison::Ahead => SyncState::Ahead,
+            Comparison::Behind => SyncState::Behind,
+            Comparison::Diverged => SyncState::Diverged,
+        }
+    }
+}
+
 /// Classify `local` against `remote` from the two heads alone.
 ///
 /// This is the cheap variant: one [`Revision`] from each side, no history
 /// walk. It only reports a direction it can *prove*:
 ///
-/// - identical trees (including both heads absent) → [`SyncState::Synced`];
+/// - identical trees (including both heads absent) → [`Comparison::Synced`];
 /// - one side absent and the other present → the present side leads;
-/// - the remote head is the local head's recorded parent → [`SyncState::Ahead`];
-/// - the local head is the remote head's recorded parent → [`SyncState::Behind`].
+/// - the remote head is the local head's recorded parent → [`Comparison::Ahead`];
+/// - the local head is the remote head's recorded parent → [`Comparison::Behind`].
 ///
-/// Anything else is [`SyncState::Diverged`]. In particular the logical
-/// clocks (`period`, `moment`) are deliberately *not* used as a tiebreak:
-/// two replicas that fork while the same issuer keeps committing produce
-/// the same clock signature as a genuine linear lead, so the clocks can't
-/// distinguish "ahead" from "diverged". Reporting `Diverged` there keeps
-/// the invariant that we never claim a direction we can't back up.
+/// Anything else is [`Comparison::Diverged`]. Two deliberate limits feed
+/// that fallback:
 ///
-/// [`SyncState::NoUpstream`] is never returned — the caller supplies it
-/// when no upstream is configured.
-pub fn classify(local: Option<&Revision>, remote: Option<&Revision>) -> SyncState {
+/// - **One-commit horizon.** [`Revision::cause`] records only the immediate
+///   parent, so the ahead/behind checks span a single commit. A strictly
+///   linear branch two or more commits ahead of (or behind) its upstream
+///   reads as `Diverged`, not `Ahead`/`Behind` — proving the longer
+///   relationship would need the history walk this function avoids. A
+///   pull-then-push still reconciles such a branch correctly; only the
+///   reported label is conservative.
+/// - **No clock tiebreak.** The logical clocks (`period`, `moment`) are not
+///   consulted: two replicas that fork while the same issuer keeps committing
+///   produce the same clock signature as a genuine linear lead, so the clocks
+///   can't distinguish "ahead" from "diverged".
+///
+/// Reporting `Diverged` in both cases keeps the invariant that we never claim
+/// a direction we can't back up from the heads alone.
+pub fn classify(local: Option<&Revision>, remote: Option<&Revision>) -> Comparison {
     match (local, remote) {
-        (None, None) => SyncState::Synced,
-        (Some(_), None) => SyncState::Ahead,
-        (None, Some(_)) => SyncState::Behind,
+        (None, None) => Comparison::Synced,
+        (Some(_), None) => Comparison::Ahead,
+        (None, Some(_)) => Comparison::Behind,
         (Some(local), Some(remote)) => {
             if local.tree == remote.tree {
-                SyncState::Synced
+                Comparison::Synced
             } else if local.cause.contains(&remote.tree) {
-                SyncState::Ahead
+                Comparison::Ahead
             } else if remote.cause.contains(&local.tree) {
-                SyncState::Behind
+                Comparison::Behind
             } else {
-                SyncState::Diverged
+                Comparison::Diverged
             }
         }
     }
@@ -104,45 +147,65 @@ mod tests {
     fn it_is_synced_when_heads_match() {
         let local = rev(tree(1), &[]);
         let remote = rev(tree(1), &[]);
-        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Synced);
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Synced);
     }
 
     #[dialog_common::test]
     fn it_is_synced_when_both_heads_are_absent() {
-        assert_eq!(classify(None, None), SyncState::Synced);
+        assert_eq!(classify(None, None), Comparison::Synced);
     }
 
     #[dialog_common::test]
     fn it_is_ahead_when_remote_is_absent() {
         let local = rev(tree(1), &[]);
-        assert_eq!(classify(Some(&local), None), SyncState::Ahead);
+        assert_eq!(classify(Some(&local), None), Comparison::Ahead);
     }
 
     #[dialog_common::test]
     fn it_is_behind_when_local_is_absent() {
         let remote = rev(tree(1), &[]);
-        assert_eq!(classify(None, Some(&remote)), SyncState::Behind);
+        assert_eq!(classify(None, Some(&remote)), Comparison::Behind);
     }
 
     #[dialog_common::test]
     fn it_is_ahead_when_remote_is_the_local_parent() {
         let remote = rev(tree(1), &[]);
         let local = rev(tree(2), &[tree(1)]);
-        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Ahead);
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Ahead);
     }
 
     #[dialog_common::test]
     fn it_is_behind_when_local_is_the_remote_parent() {
         let local = rev(tree(1), &[]);
         let remote = rev(tree(2), &[tree(1)]);
-        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Behind);
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Behind);
     }
 
     #[dialog_common::test]
     fn it_is_diverged_when_heads_are_unrelated() {
         let local = rev(tree(1), &[tree(3)]);
         let remote = rev(tree(2), &[tree(4)]);
-        assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Diverged);
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Diverged);
+    }
+
+    #[dialog_common::test]
+    fn it_is_diverged_when_local_leads_by_more_than_one_commit() {
+        // `cause` records only the immediate parent, so a strictly
+        // linear branch two commits ahead reads as Diverged: the shared
+        // base tree(1) is the grandparent, absent from tree(3)'s cause.
+        // This pins the documented one-commit horizon (a pull-then-push
+        // still reconciles it; only the reported label is conservative).
+        let remote = rev(tree(1), &[]);
+        let local = rev(tree(3), &[tree(2)]);
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Diverged);
+    }
+
+    #[dialog_common::test]
+    fn it_widens_each_comparison_into_the_matching_sync_state() {
+        assert_eq!(SyncState::from(Comparison::Synced), SyncState::Synced);
+        assert_eq!(SyncState::from(Comparison::Ahead), SyncState::Ahead);
+        assert_eq!(SyncState::from(Comparison::Behind), SyncState::Behind);
+        assert_eq!(SyncState::from(Comparison::Diverged), SyncState::Diverged);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-schema/src/sync.rs
+++ b/rust/tonk-schema/src/sync.rs
@@ -6,9 +6,15 @@
 //! a sync would do anything.
 
 use dialog_repository::Revision;
+use serde::{Deserialize, Serialize};
 
 /// How a branch's local head relates to its upstream head.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializes kebab-case (`no-upstream`, `synced`, `ahead`,
+/// `behind`, `diverged`) so the wire shape reads the same as the
+/// states the UI and `slide status` render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SyncState {
     /// No upstream is configured for this branch. Supplied by the caller
     /// (which knows the branch's configuration); never inferred here.
@@ -137,5 +143,20 @@ mod tests {
         let local = rev(tree(1), &[tree(3)]);
         let remote = rev(tree(2), &[tree(4)]);
         assert_eq!(classify(Some(&local), Some(&remote)), SyncState::Diverged);
+    }
+
+    #[dialog_common::test]
+    fn it_serializes_states_kebab_case() {
+        // The UI badges and `slide status` read these exact strings.
+        let cases = [
+            (SyncState::NoUpstream, "\"no-upstream\""),
+            (SyncState::Synced, "\"synced\""),
+            (SyncState::Ahead, "\"ahead\""),
+            (SyncState::Behind, "\"behind\""),
+            (SyncState::Diverged, "\"diverged\""),
+        ];
+        for (state, expected) in cases {
+            assert_eq!(serde_json::to_string(&state).unwrap(), expected);
+        }
     }
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -491,17 +491,31 @@ pub async fn push(repo: &str, branch: &str) -> Result<SyncResponse, TonkUiError>
     sync_op(repo, branch, "push").await
 }
 
+/// Full sync (pull then push) of a branch against its upstream.
+///
+/// `POST /api/repository/{repo}/branch/{branch}/sync`. Used by the
+/// background [`crate::sync_controller`] so a tick reconciles a
+/// branch in both directions in one round-trip.
+pub async fn sync(repo: &str, branch: &str) -> Result<SyncResponse, TonkUiError> {
+    sync_op(repo, branch, "").await
+}
+
+/// POST a sync route. `op` is `"pull"` / `"push"` for the
+/// directional routes, or `""` for the combined `/sync` route.
 async fn sync_op(repo: &str, branch: &str, op: &str) -> Result<SyncResponse, TonkUiError> {
     tonk_host::ready::wait().await;
     log!("Sync ({}) repo='{}' branch='{}'", op, repo, branch);
+    // `op` is a directional suffix (`/pull`, `/push`); the combined
+    // sync route is the bare `/sync` path, so an empty `op` drops
+    // the trailing segment entirely.
+    let suffix = if op.is_empty() {
+        String::new()
+    } else {
+        format!("/{op}")
+    };
+    let path = format!("/api/repository/{repo}/branch/{branch}/sync{suffix}");
     let response = reqwest::Client::new()
-        .post(format!(
-            "{}/api/repository/{}/branch/{}/sync/{}",
-            origin(),
-            repo,
-            branch,
-            op,
-        ))
+        .post(format!("{}{}", origin(), path))
         .send()
         .await
         .map_err(into_api_error)?;
@@ -510,8 +524,7 @@ async fn sync_op(repo: &str, branch: &str, op: &str) -> Result<SyncResponse, Ton
         let status = response.status();
         let text = response.text().await.unwrap_or_default();
         return Err(TonkUiError::ApiError(format!(
-            "POST /api/repository/{}/branch/{}/sync/{} returned {}: {}",
-            repo, branch, op, status, text
+            "POST {path} returned {status}: {text}"
         )));
     }
     response

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use tonk_worker::{
     BranchConfiguration, CreateInviteRequest, CreateInviteResponse, EvaluateResponse,
     IdentifyResponse, JoinRequest, JoinResponse, ProfileInfo, QueryResponse, RemoteConfiguration,
-    RepositoryConfiguration, RepositoryInfo, SyncResponse,
+    RepositoryConfiguration, RepositoryInfo, SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -498,6 +498,32 @@ pub async fn push(repo: &str, branch: &str) -> Result<SyncResponse, TonkUiError>
 /// branch in both directions in one round-trip.
 pub async fn sync(repo: &str, branch: &str) -> Result<SyncResponse, TonkUiError> {
     sync_op(repo, branch, "").await
+}
+
+/// Read a branch's sync state relative to its upstream.
+///
+/// `GET /api/repository/{repo}/branch/{branch}/sync/status`. Read
+/// only — fetches the upstream head without merging — so the badge
+/// can refresh without moving any data.
+pub async fn sync_status(repo: &str, branch: &str) -> Result<SyncStatusResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let path = format!("/api/repository/{repo}/branch/{branch}/sync/status");
+    let response = reqwest::Client::new()
+        .get(format!("{}{}", origin(), path))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(TonkUiError::ApiError(format!(
+            "GET {path} returned {status}: {text}"
+        )));
+    }
+    response
+        .json::<SyncStatusResponse>()
+        .await
+        .map_err(into_api_error)
 }
 
 /// POST a sync route. `op` is `"pull"` / `"push"` for the

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -360,9 +360,9 @@ mod tests {
 
     /// A local write reaches the `origin` remote on its own — no
     /// Pull/Push button — once the background sync controller's
-    /// commit trigger fires. Exercises the Phase 1 default-on
-    /// controller end to end: commit locally, signal it the way a
-    /// real editor commit does, then watch the remote catch up.
+    /// commit trigger fires. Exercises the default-on controller end
+    /// to end: commit locally, signal it the way a real editor commit
+    /// does, then watch the remote catch up.
     #[dialog_common::test]
     async fn it_auto_syncs_a_local_write_to_the_remote(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
@@ -448,7 +448,7 @@ mod tests {
 
     /// With auto-sync paused for a repository, a local write does
     /// *not* reach the remote on its own — only the manual buttons
-    /// act. The Phase 2 per-repository pause preference, honored by
+    /// act. Exercises the per-repository pause preference, honored by
     /// the controller on every sweep.
     #[dialog_common::test]
     async fn it_does_not_auto_sync_a_paused_repository(env: TestEnvironment) -> Result<()> {

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -446,6 +446,85 @@ mod tests {
         Ok(())
     }
 
+    /// With auto-sync paused for a repository, a local write does
+    /// *not* reach the remote on its own — only the manual buttons
+    /// act. The Phase 2 per-repository pause preference, honored by
+    /// the controller on every sweep.
+    #[dialog_common::test]
+    async fn it_does_not_auto_sync_a_paused_repository(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        driver.query(By::Css(".space-banner-title")).first().await?;
+
+        // Pause auto-sync for `home` before writing anything.
+        driver
+            .execute(
+                "localStorage.setItem('tonk:auto-sync:home', 'off'); return true;",
+                vec![],
+            )
+            .await?;
+
+        // Commit locally — `home/main` is now ahead of `origin`.
+        let commit = driver
+            .execute(
+                r#"
+                const body = `attribute!: &paused-probe
+  the:         test.tonk/paused-probe
+  as:          text
+  cardinality: one
+  description: marker asserted by the paused auto-sync test
+`;
+                const response = await fetch('/api/repository/home/branch/main/evaluate', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/yaml' },
+                    body,
+                });
+                return response.ok;
+                "#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(commit.json().as_bool(), Some(true), "local commit succeeds");
+
+        // Fire the commit signal, then wait well past the controller's
+        // debounce. A paused repo must leave the remote untouched.
+        driver
+            .execute(
+                &format!(
+                    "window.dispatchEvent(new CustomEvent('{}'));",
+                    crate::sync_controller::COMMITTED_EVENT
+                ),
+                vec![],
+            )
+            .await?;
+
+        let synced = driver
+            .execute(
+                r#"
+                const localResp = await fetch('/api/repository/home');
+                const localInfo = await localResp.json();
+                const localTree = JSON.stringify(localInfo.branch.main.revision.tree);
+
+                // Generous margin past the 1s commit debounce.
+                await new Promise(res => setTimeout(res, 5000));
+
+                const r = await fetch('/api/inspect/repository/home/remote/origin/branch/main');
+                const s = await r.json();
+                return !!(s.success && s.revision && JSON.stringify(s.revision.tree) === localTree);
+                "#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(
+            synced.json().as_bool(),
+            Some(false),
+            "a paused repository must not auto-sync the local write to the remote"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     /// Test the `<tonk-code>` editor mounts inside the default
     /// branch row and exercises its public contract end-to-end:
     /// `value` round-trip, `change` event firing on user input,

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -358,6 +358,94 @@ mod tests {
         Ok(())
     }
 
+    /// A local write reaches the `origin` remote on its own — no
+    /// Pull/Push button — once the background sync controller's
+    /// commit trigger fires. Exercises the Phase 1 default-on
+    /// controller end to end: commit locally, signal it the way a
+    /// real editor commit does, then watch the remote catch up.
+    #[dialog_common::test]
+    async fn it_auto_syncs_a_local_write_to_the_remote(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Banner ⇒ the home space mounted, and with it the
+        // background controller for its branches.
+        driver.query(By::Css(".space-banner-title")).first().await?;
+
+        // Commit a fact locally. The worker's evaluate route defaults
+        // to transact=true, so this lands a commit on `main` — local
+        // is now ahead of the auto-configured `origin` remote.
+        let commit = driver
+            .execute(
+                r#"
+                const body = `attribute!: &auto-sync-probe
+  the:         test.tonk/auto-sync-probe
+  as:          text
+  cardinality: one
+  description: marker asserted by the auto-sync test
+`;
+                const response = await fetch('/api/repository/home/branch/main/evaluate', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/yaml' },
+                    body,
+                });
+                return response.ok;
+                "#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(
+            commit.json().as_bool(),
+            Some(true),
+            "local commit should succeed"
+        );
+
+        // Fire the same signal a real editor commit dispatches — no
+        // button is pressed. The controller debounces, then syncs
+        // every upstream branch of the active repository.
+        driver
+            .execute(
+                &format!(
+                    "window.dispatchEvent(new CustomEvent('{}'));",
+                    crate::sync_controller::COMMITTED_EVENT
+                ),
+                vec![],
+            )
+            .await?;
+
+        // Poll the remote until its head matches the local head. The
+        // `tree` reference serializes as a byte array, so compare the
+        // JSON encodings rather than identity.
+        let caught_up = driver
+            .execute(
+                r#"
+                const localResp = await fetch('/api/repository/home');
+                const localInfo = await localResp.json();
+                const localTree = JSON.stringify(localInfo.branch.main.revision.tree);
+
+                const deadline = Date.now() + 15000;
+                while (Date.now() < deadline) {
+                    const r = await fetch('/api/inspect/repository/home/remote/origin/branch/main');
+                    const s = await r.json();
+                    if (s.success && s.revision && JSON.stringify(s.revision.tree) === localTree) {
+                        return true;
+                    }
+                    await new Promise(res => setTimeout(res, 500));
+                }
+                return false;
+                "#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(
+            caught_up.json().as_bool(),
+            Some(true),
+            "remote should catch up to the local head via background sync, no button press"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     /// Test the `<tonk-code>` editor mounts inside the default
     /// branch row and exercises its public contract end-to-end:
     /// `value` round-trip, `change` event firing on user input,

--- a/rust/tonk-ui/src/components/profile.rs
+++ b/rust/tonk-ui/src/components/profile.rs
@@ -1,11 +1,8 @@
 use leptos::{either::Either, prelude::*};
 
-use crate::{
-    api,
-    components::{
-        ProfileResource,
-        space::{BranchOwner, BranchRow, RemoteCard},
-    },
+use crate::components::{
+    ProfileResource,
+    space::{BranchOwner, BranchRow, RemoteCard},
 };
 
 /// Profile view, rendered at `/profile`.
@@ -18,25 +15,11 @@ use crate::{
 /// [`ProfileResource`] (`info.profile`), which the shell already
 /// keeps fresh on `/api/profile` broadcasts.
 ///
-/// We still spin up a `LocalResource` keyed on the profile's
-/// local name so [`BranchRow`]'s sync handlers can refetch the
-/// repository representation after a Pull/Push without invalidating
-/// the whole profile resource. Today the profile has no upstream,
-/// so the refetch is rarely exercised — but the wiring keeps the
-/// component honest if/when profile-level sync arrives.
-///
 /// [`ProfileResource`]: super::ProfileResource
 #[component]
 pub fn TonkProfile() -> impl IntoView {
     let profile_resource =
         use_context::<ProfileResource>().expect("ProfileResource provided by TonkShell");
-
-    // Per-route resource so `BranchRow` can `.refetch()` the
-    // profile's repository representation after a sync. Mirrors
-    // what `TonkSpace` does, but hits the dedicated
-    // `/api/profile/repository` route — the profile lives
-    // outside the named-repo namespace.
-    let repository = LocalResource::new(move || async move { api::profile_repository().await });
 
     view! {
         <Suspense fallback=|| view! { <wa-spinner></wa-spinner> }>
@@ -47,7 +30,7 @@ pub fn TonkProfile() -> impl IntoView {
                 </wa-callout>
             }>
                 { move || profile_resource.get().map(|result| result.map(|info| match info {
-                    Some(info) => Either::Left(render_profile(info.profile, repository)),
+                    Some(info) => Either::Left(render_profile(info.profile)),
                     None => Either::Right(view! {
                         <wa-callout variant="neutral">
                             <wa-icon slot="icon" name="circle-info"></wa-icon>
@@ -64,12 +47,7 @@ pub fn TonkProfile() -> impl IntoView {
 /// name, branches list, remotes list. Mirrors `render_space_view`
 /// minus the share button (you don't share a profile the way you
 /// share a space).
-fn render_profile(
-    info: tonk_worker::RepositoryInfo,
-    repository: LocalResource<
-        Result<Option<tonk_worker::RepositoryInfo>, crate::error::TonkUiError>,
-    >,
-) -> impl IntoView {
+fn render_profile(info: tonk_worker::RepositoryInfo) -> impl IntoView {
     let local_subject = info.subject.to_string();
     let title_attr = local_subject.clone();
     let banner_title = info.name.clone();
@@ -90,7 +68,6 @@ fn render_profile(
                     name=name
                     config=config
                     owner=BranchOwner::Profile
-                    repository=repository
                     force_open=force_open_solo
                 />
             }

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -199,6 +199,20 @@ where
     let local_subject = info.subject.to_string();
     let space_title = info.name.clone();
 
+    // Per-repository auto-sync toggle. Seeded from the stored
+    // preference; flipping it writes through so the running
+    // controller honors the change on its next sweep.
+    let sync_repo = info.name.clone();
+    let auto_sync_on = RwSignal::new(crate::sync_controller::is_enabled(&sync_repo));
+    let on_toggle_sync = {
+        let sync_repo = sync_repo.clone();
+        move |_ev: leptos::ev::MouseEvent| {
+            let next = !auto_sync_on.get_untracked();
+            auto_sync_on.set(next);
+            crate::sync_controller::set_enabled(&sync_repo, next);
+        }
+    };
+
     // Sort branches/remotes for stable rendering — `HashMap`
     // iteration order is otherwise nondeterministic.
     let mut branches: Vec<(String, BranchConfiguration)> = info.branch.into_iter().collect();
@@ -250,6 +264,24 @@ where
             <h1 class="space-banner-title" title=title_attr>
                 { space_title }
             </h1>
+            <wa-button
+                class="auto-sync-toggle"
+                variant="neutral"
+                appearance="plain"
+                size="small"
+                title=move || if auto_sync_on.get() {
+                    "Auto-sync on — click to pause"
+                } else {
+                    "Auto-sync paused — click to resume"
+                }
+                on:click=on_toggle_sync
+            >
+                <wa-icon
+                    name=move || if auto_sync_on.get() { "arrows-rotate" } else { "pause" }
+                    variant="solid"
+                    label="Toggle auto-sync"
+                ></wa-icon>
+            </wa-button>
             <wa-button
                 variant="neutral"
                 appearance="accent"

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -135,6 +135,12 @@ pub fn TonkInspector(
         }
     });
 
+    // Background sync for the active repository's upstream branches —
+    // a local write reaches the remote (and remote changes reach this
+    // tab) without anyone clicking Pull/Push. Registered under this
+    // component's owner, so it tears down when the inspector unmounts.
+    crate::sync_controller::mount(source, repository);
+
     // Open the shared invite dialog when the user clicks the
     // share affordance. Dialog itself drives the mint and renders
     // the URL.
@@ -709,6 +715,10 @@ where
                         clear_pushed_diagnostics(&editor_source);
                         last_response.set(Some(Box::new(response)));
                         transact_state.set(TransactState::Idle);
+                        // Nudge the background controller so this
+                        // commit reaches the remote without a manual
+                        // push (debounced controller-side).
+                        crate::sync_controller::notify_committed();
                         // Seal this cell and spawn a fresh one
                         // below — the user is moving on.
                         on_sealed();

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -7,6 +7,7 @@ use leptos_router::{
 };
 use tonk_worker::{
     BranchConfiguration, EvaluateResponse, RemoteConfiguration, RepositoryInfo, Revision,
+    SyncState as UpstreamState,
 };
 use wasm_bindgen::JsCast;
 
@@ -264,36 +265,38 @@ where
             <h1 class="space-banner-title" title=title_attr>
                 { space_title }
             </h1>
-            <wa-button
-                class="auto-sync-toggle"
-                variant="neutral"
-                appearance="plain"
-                size="small"
-                title=move || if auto_sync_on.get() {
-                    "Auto-sync on — click to pause"
-                } else {
-                    "Auto-sync paused — click to resume"
-                }
-                on:click=on_toggle_sync
-            >
-                <wa-icon
-                    name=move || if auto_sync_on.get() { "arrows-rotate" } else { "pause" }
-                    variant="solid"
-                    label="Toggle auto-sync"
-                ></wa-icon>
-            </wa-button>
-            <wa-button
-                variant="neutral"
-                appearance="accent"
-                size="small"
-                on:click=on_share
-            >
-                <wa-icon
-                    name="share-nodes"
-                    variant="solid"
-                    label="Invite someone to this space"
-                ></wa-icon>
-            </wa-button>
+            <div class="space-banner-actions">
+                <wa-button
+                    class="auto-sync-toggle"
+                    variant="neutral"
+                    appearance="accent"
+                    size="small"
+                    title=move || if auto_sync_on.get() {
+                        "Auto-sync on — click to pause"
+                    } else {
+                        "Auto-sync paused — click to resume"
+                    }
+                    on:click=on_toggle_sync
+                >
+                    <wa-icon
+                        name=move || if auto_sync_on.get() { "arrows-rotate" } else { "pause" }
+                        variant="solid"
+                        label="Toggle auto-sync"
+                    ></wa-icon>
+                </wa-button>
+                <wa-button
+                    variant="neutral"
+                    appearance="accent"
+                    size="small"
+                    on:click=on_share
+                >
+                    <wa-icon
+                        name="share-nodes"
+                        variant="solid"
+                        label="Invite someone to this space"
+                    ></wa-icon>
+                </wa-button>
+            </div>
         </header>
         <main class="wa-stack space-view">
             <section class="wa-stack">
@@ -393,6 +396,24 @@ pub(super) fn BranchRow(
     let branch_name = name.clone();
 
     let sync_state = RwSignal::new(SyncState::Idle);
+
+    // Where the local head sits relative to its upstream
+    // (synced/ahead/behind/diverged). Fetched read-only on mount;
+    // since the rows remount whenever the repository resource
+    // refetches — which the background controller does after every
+    // sweep — the badge stays current on the controller's tick.
+    let upstream_state = RwSignal::new(None::<UpstreamState>);
+    if has_upstream
+        && let BranchOwner::Repository(space_name) = &owner
+        && let Some(repo) = space_name.get_untracked()
+    {
+        let branch = branch_name.clone();
+        spawn_local(async move {
+            if let Ok(status) = api::sync_status(&repo, &branch).await {
+                upstream_state.set(Some(status.state));
+            }
+        });
+    }
 
     let trigger_sync = {
         let branch_name = branch_name.clone();
@@ -520,6 +541,11 @@ pub(super) fn BranchRow(
                         }),
                     } }
                 </span>
+                // Upstream relationship (synced / ahead / behind /
+                // diverged) reads as a property of the branch+rev,
+                // so it sits with them on the left rather than out
+                // by the action buttons.
+                { move || upstream_state_badge(upstream_state.get()) }
                 // Sync buttons render unconditionally so the row
                 // shape stays uniform across branches. With an
                 // upstream they're full accent buttons; without
@@ -2156,6 +2182,33 @@ fn sync_chip(state: SyncState) -> impl IntoView {
     }
 }
 
+/// Per-branch badge for how the local head sits relative to its
+/// upstream. A not-yet-fetched status (`None`) and `NoUpstream`
+/// render nothing — there's no relationship to show.
+fn upstream_state_badge(state: Option<UpstreamState>) -> impl IntoView {
+    match state.and_then(upstream_state_chip) {
+        Some((label, variant)) => Either::Left(view! {
+            <wa-badge class="upstream-state" variant=variant appearance="filled">
+                { label }
+            </wa-badge>
+        }),
+        None => Either::Right(()),
+    }
+}
+
+/// Label and `<wa-badge>` variant for an upstream relationship, or
+/// `None` for states with nothing to show (`NoUpstream`). Pure so
+/// the mapping is unit-tested without a browser.
+fn upstream_state_chip(state: UpstreamState) -> Option<(&'static str, &'static str)> {
+    match state {
+        UpstreamState::Synced => Some(("synced", "success")),
+        UpstreamState::Ahead => Some(("ahead", "warning")),
+        UpstreamState::Behind => Some(("behind", "warning")),
+        UpstreamState::Diverged => Some(("diverged", "danger")),
+        UpstreamState::NoUpstream => None,
+    }
+}
+
 /// Compact `before → after` summary for a finished sync. Falls
 /// back to a single revision label when the operation didn't
 /// change the local branch (before == after) or when one side is
@@ -2431,12 +2484,37 @@ mod tests {
     use serde_json::{Value, json};
     use tonk_worker::QueryResult;
 
-    use super::{concept_descriptor, rule_definition};
+    use super::{UpstreamState, concept_descriptor, rule_definition, upstream_state_chip};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_maps_directional_upstream_states_to_badges() {
+        assert_eq!(
+            upstream_state_chip(UpstreamState::Synced),
+            Some(("synced", "success"))
+        );
+        assert_eq!(
+            upstream_state_chip(UpstreamState::Ahead),
+            Some(("ahead", "warning"))
+        );
+        assert_eq!(
+            upstream_state_chip(UpstreamState::Behind),
+            Some(("behind", "warning"))
+        );
+        assert_eq!(
+            upstream_state_chip(UpstreamState::Diverged),
+            Some(("diverged", "danger"))
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_renders_no_badge_without_an_upstream() {
+        assert_eq!(upstream_state_chip(UpstreamState::NoUpstream), None);
+    }
 
     /// Build a `rule:` result row whose `definition` field carries
     /// the JSON-stringified `RuleDefinition` an `AnonymousRuleQuery`

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -6,8 +6,8 @@ use leptos_router::{
     params::Params,
 };
 use tonk_worker::{
-    BranchConfiguration, EvaluateResponse, RemoteConfiguration, RepositoryInfo, Revision,
-    SyncState as UpstreamState,
+    BranchConfiguration, EvaluateResponse, Notification, RemoteConfiguration, RepositoryInfo,
+    Revision, SyncState as UpstreamState,
 };
 use wasm_bindgen::JsCast;
 
@@ -16,6 +16,7 @@ use crate::{
     components::{HostId, InviteSpace},
     did,
     error::TonkUiError,
+    watch::watch,
 };
 
 /// The currently-running (or last-completed) sync operation for a
@@ -140,7 +141,7 @@ pub fn TonkInspector(
     // a local write reaches the remote (and remote changes reach this
     // tab) without anyone clicking Pull/Push. Registered under this
     // component's owner, so it tears down when the inspector unmounts.
-    crate::sync_controller::mount(source, repository);
+    crate::sync_controller::mount(source);
 
     // Open the shared invite dialog when the user clicks the
     // share affordance. Dialog itself drives the mint and renders
@@ -166,7 +167,6 @@ pub fn TonkInspector(
                     Some(info) => Either::Left(render_space_view(
                         info,
                         source,
-                        repository,
                         on_share,
                     )),
                     None => Either::Right(view! {
@@ -191,7 +191,6 @@ pub fn TonkInspector(
 fn render_space_view<F>(
     info: RepositoryInfo,
     space_name: Signal<Option<String>, LocalStorage>,
-    repository: LocalResource<Result<Option<RepositoryInfo>, crate::error::TonkUiError>>,
     on_share: F,
 ) -> impl IntoView
 where
@@ -245,7 +244,6 @@ where
                     name=name
                     config=config
                     owner=BranchOwner::Repository(space_name)
-                    repository=repository
                     force_open=force_open_solo
                 />
             }
@@ -379,7 +377,6 @@ pub(super) fn BranchRow(
     /// Identifies which routing namespace this branch belongs
     /// to — see [`BranchOwner`].
     owner: BranchOwner,
-    repository: LocalResource<Result<Option<RepositoryInfo>, crate::error::TonkUiError>>,
     /// Caller may force the row to render expanded — used by the
     /// space view when there's only one branch, so a solo `meta`
     /// (or any other lone branch) still pops open by default.
@@ -395,10 +392,6 @@ pub(super) fn BranchRow(
     let upstream_label = upstream
         .as_ref()
         .map(|(remote, branch)| format!("{remote}/{branch}"));
-    let tree_pair = config.revision.as_ref().map(|rev| {
-        let full = rev.tree.to_string();
-        (full.clone(), abbreviate_tree(&full))
-    });
 
     let has_upstream = upstream.is_some();
     let is_default = force_open || name == DEFAULT_OPEN_BRANCH;
@@ -406,11 +399,15 @@ pub(super) fn BranchRow(
 
     let sync_state = RwSignal::new(SyncState::Idle);
 
+    // Local branch head, rendered as the revision badge. Seeded from
+    // the loaded config and kept live by the branch's broadcast
+    // channel (wired below), so a pull/commit/sync updates the badge
+    // in place — no resource refetch, no row remount.
+    let revision = RwSignal::new(config.revision.clone());
+
     // Where the local head sits relative to its upstream
-    // (synced/ahead/behind/diverged). Fetched read-only on mount;
-    // since the rows remount whenever the repository resource
-    // refetches — which the background controller does after every
-    // sweep — the badge stays current on the controller's tick.
+    // (synced/ahead/behind/diverged). Fetched read-only on mount,
+    // then refreshed by the same broadcast channel as the revision.
     let upstream_state = RwSignal::new(None::<UpstreamState>);
     if has_upstream
         && let BranchOwner::Repository(space_name) = &owner
@@ -421,6 +418,48 @@ pub(super) fn BranchRow(
             if let Ok(status) = api::sync_status(&repo, &branch).await {
                 upstream_state.set(Some(status.state));
             }
+        });
+    }
+
+    // Keep the revision and sync-state badges live without tearing
+    // the row down. The worker posts on this branch's channel after
+    // every pull, push, sync, and commit that moves the head (see
+    // `router::sync` / `router::evaluate`); we read the new revision
+    // straight off the payload and re-read the read-only sync status.
+    // The status round-trip is skipped when nothing could have
+    // changed — the head didn't move and we're already synced — so an
+    // idle background sync tick costs nothing.
+    if let BranchOwner::Repository(space_name) = &owner
+        && let Some(repo) = space_name.get_untracked()
+    {
+        let channel = format!("/api/repository/{repo}/branch/{branch_name}");
+        let head = watch::<Notification>(&channel);
+        let status_branch = branch_name.clone();
+        Effect::new(move |_| {
+            let Some(notification) = head.get() else {
+                return;
+            };
+            let moved =
+                revision.with_untracked(|current| current.as_ref() != Some(&notification.revision));
+            if moved {
+                revision.set(Some(notification.revision.clone()));
+            }
+            // Branches without an upstream have no sync-state badge.
+            if !has_upstream {
+                return;
+            }
+            if !moved && upstream_state.get_untracked() == Some(UpstreamState::Synced) {
+                return;
+            }
+            let repo = repo.clone();
+            let branch = status_branch.clone();
+            spawn_local(async move {
+                if let Ok(status) = api::sync_status(&repo, &branch).await
+                    && upstream_state.get_untracked() != Some(status.state)
+                {
+                    upstream_state.set(Some(status.state));
+                }
+            });
         });
     }
 
@@ -456,7 +495,12 @@ pub(super) fn BranchRow(
                             before: response.before.map(Box::new),
                             after: response.after.map(Box::new),
                         });
-                        repository.refetch();
+                        // The revision and sync-state badges refresh
+                        // off the worker's broadcast on this branch's
+                        // channel (see the subscription above), so the
+                        // success path no longer refetches the whole
+                        // repository — that would tear down the editor
+                        // cells in this row.
                     }
                     Ok(response) => {
                         sync_state.set(SyncState::Failed {
@@ -529,26 +573,7 @@ pub(super) fn BranchRow(
                         ></wa-icon>
                         { name }
                     </wa-badge>
-                    { match tree_pair.clone() {
-                        Some((full, short)) => Either::Left(view! {
-                            <wa-badge
-                                variant="neutral"
-                                appearance="filled"
-                                title=full
-                            >
-                                <wa-icon name="code-commit" slot="start"></wa-icon>
-                                { short }
-                            </wa-badge>
-                        }),
-                        None => Either::Right(view! {
-                            <wa-badge
-                                variant="neutral"
-                                appearance="filled"
-                            >
-                                "no commits"
-                            </wa-badge>
-                        }),
-                    } }
+                    { move || revision_badge(revision.get()) }
                 </span>
                 // Upstream relationship (synced / ahead / behind /
                 // diverged) reads as a property of the branch+rev,

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -202,15 +202,24 @@ where
 
     // Per-repository auto-sync toggle. Seeded from the stored
     // preference; flipping it writes through so the running
-    // controller honors the change on its next sweep.
+    // controller honors the change on its next sweep. The controller
+    // reads the persisted preference, not this signal, so we only
+    // move the badge once the write lands — otherwise a rejected
+    // write (no localStorage, quota) would show "paused" while the
+    // controller kept syncing.
     let sync_repo = info.name.clone();
     let auto_sync_on = RwSignal::new(crate::sync_controller::is_enabled(&sync_repo));
     let on_toggle_sync = {
         let sync_repo = sync_repo.clone();
         move |_ev: leptos::ev::MouseEvent| {
             let next = !auto_sync_on.get_untracked();
-            auto_sync_on.set(next);
-            crate::sync_controller::set_enabled(&sync_repo, next);
+            if crate::sync_controller::set_enabled(&sync_repo, next) {
+                auto_sync_on.set(next);
+            } else {
+                leptos::logging::log!(
+                    "auto-sync preference for '{sync_repo}' could not be saved; leaving it unchanged"
+                );
+            }
         }
     };
 

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -12,6 +12,10 @@ pub mod broadcast;
 
 /// UI components for the Tonk application.
 pub mod components;
+
+/// Background sync controller — automatic push/pull for the active
+/// repository's upstream branches.
+pub mod sync_controller;
 /// Leptos bridge over [`broadcast`] — exposes a channel's latest
 /// message as a reactive signal.
 pub mod watch;

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -14,8 +14,9 @@
 //! - a local commit, debounced by [`COMMIT_DEBOUNCE_MS`] so a burst
 //!   of edits collapses into a single sync.
 //!
-//! Phase 1 is always on; the per-repository pause control is a
-//! later phase.
+//! On by default for every repository; an explicit per-repository
+//! `off` preference pauses it (see [`is_enabled`] / [`set_enabled`]),
+//! leaving only the manual Pull/Push buttons.
 
 use std::collections::HashMap;
 
@@ -64,14 +65,22 @@ pub fn is_enabled(repo: &str) -> bool {
     pref_is_enabled(stored.as_deref())
 }
 
-/// Persist whether background sync is enabled for `repo`. The
-/// running controller reads this fresh on its next sweep, so the
-/// change takes effect without re-mounting.
-pub fn set_enabled(repo: &str, enabled: bool) {
-    if let Ok(Some(storage)) = window().local_storage() {
-        let value = if enabled { "on" } else { "off" };
-        let _ = storage.set_item(&pref_key(repo), value);
-    }
+/// Persist whether background sync is enabled for `repo`, returning
+/// whether the preference was actually written. The running
+/// controller reads this fresh on its next sweep, so the change
+/// takes effect without re-mounting.
+///
+/// A `false` return means the write did not land (localStorage
+/// unavailable or rejected, e.g. quota or a privacy mode). Callers
+/// must not show the new state as in effect when that happens — the
+/// controller still reads the old, unchanged preference.
+#[must_use]
+pub fn set_enabled(repo: &str, enabled: bool) -> bool {
+    let Ok(Some(storage)) = window().local_storage() else {
+        return false;
+    };
+    let value = if enabled { "on" } else { "off" };
+    storage.set_item(&pref_key(repo), value).is_ok()
 }
 
 /// Branch names in `branches` that have an upstream, sorted for a
@@ -170,8 +179,20 @@ async fn sweep_repository(repo: &str) {
         }
     };
     for branch in branches_to_sync(&info.branch) {
-        if let Err(err) = api::sync(repo, &branch).await {
-            log!("background sync of {repo}/{branch} failed: {err}");
+        // The `/sync` route reports pull/push failures as a 200 with
+        // `success: false` (a non-fast-forward push after divergence,
+        // a fetch failure), so a transport-level `Ok` is not proof the
+        // sync landed — inspect `success` too. Background failures are
+        // logged, never surfaced, but they must not vanish silently.
+        match api::sync(repo, &branch).await {
+            Ok(response) if !response.success => {
+                let detail = response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string());
+                log!("background sync of {repo}/{branch} did not complete: {detail}");
+            }
+            Ok(_) => {}
+            Err(err) => log!("background sync of {repo}/{branch} failed: {err}"),
         }
     }
 }

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -1,0 +1,193 @@
+//! Background sync controller.
+//!
+//! Drives automatic reconciliation of the active repository's
+//! upstream branches so a local write reaches the remote — and
+//! remote changes reach the tab — without anyone clicking Pull or
+//! Push. The manual buttons in [`crate::components::space`] stay as
+//! they are; this sits on top of the same `/sync` routes.
+//!
+//! Triggers, all funneling into one re-entrancy-guarded sweep:
+//!
+//! - a steady [`TICK_INTERVAL_MS`] interval;
+//! - the window coming back `online`;
+//! - the tab becoming visible again;
+//! - a local commit, debounced by [`COMMIT_DEBOUNCE_MS`] so a burst
+//!   of edits collapses into a single sync.
+//!
+//! Phase 1 is always on; the per-repository pause control is a
+//! later phase.
+
+use std::collections::HashMap;
+
+use leptos::ev;
+use leptos::logging::log;
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+use leptos_use::{use_debounce_fn, use_event_listener, use_interval_fn};
+use tonk_worker::{BranchConfiguration, RepositoryInfo};
+
+use crate::api;
+use crate::error::TonkUiError;
+
+/// How often the controller sweeps the active repository's branches.
+/// One knob, tuned in one place.
+const TICK_INTERVAL_MS: u64 = 20_000;
+
+/// Debounce window after a local commit before syncing — coalesces
+/// a burst of writes into one sweep.
+const COMMIT_DEBOUNCE_MS: f64 = 1_000.0;
+
+/// DOM event a successful local commit dispatches on `window`. The
+/// controller listens for it to sync shortly after a write.
+pub const COMMITTED_EVENT: &str = "tonk:committed";
+
+/// Branch names in `branches` that have an upstream, sorted for a
+/// stable sweep order. Branches without an upstream have nowhere to
+/// sync to, so they're skipped.
+pub fn branches_to_sync(branches: &HashMap<String, BranchConfiguration>) -> Vec<String> {
+    let mut names: Vec<String> = branches
+        .iter()
+        .filter(|(_, config)| config.upstream.is_some())
+        .map(|(name, _)| name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Notify the background controller that a local commit just landed,
+/// so it can sync shortly after. Called from the editor's commit
+/// path; a no-op if no controller is listening.
+pub fn notify_committed() {
+    let Ok(event) = web_sys::CustomEvent::new(COMMITTED_EVENT) else {
+        return;
+    };
+    let _ = window().dispatch_event(&event);
+}
+
+/// Wire the background sync triggers for the active repository.
+///
+/// Call once from the component that owns the active-repository
+/// signal. The interval and event listeners are registered under
+/// the current reactive owner, so they're torn down automatically
+/// when that component unmounts. After each sweep the `repository`
+/// resource is refetched so revisions in the view reflect the new
+/// state.
+pub fn mount(
+    source: Signal<Option<String>, LocalStorage>,
+    repository: LocalResource<Result<Option<RepositoryInfo>, TonkUiError>>,
+) {
+    // One sweep at a time — a slow sync must not stack ticks.
+    let syncing = RwSignal::new(false);
+
+    let sweep = move || {
+        if syncing.get_untracked() {
+            return;
+        }
+        let Some(repo) = source.get_untracked() else {
+            return;
+        };
+        syncing.set(true);
+        spawn_local(async move {
+            sweep_repository(&repo).await;
+            repository.refetch();
+            syncing.set(false);
+        });
+    };
+
+    // Steady interval.
+    use_interval_fn(sweep, TICK_INTERVAL_MS);
+
+    // Back online — reconcile whatever drifted while offline.
+    let _ = use_event_listener(window(), ev::online, move |_| sweep());
+
+    // Tab refocused — pick up changes made elsewhere.
+    let _ = use_event_listener(document(), ev::visibilitychange, move |_| {
+        if document().visibility_state() == web_sys::VisibilityState::Visible {
+            sweep();
+        }
+    });
+
+    // Local commit — debounced so a burst of edits syncs once.
+    let debounced = use_debounce_fn(sweep, COMMIT_DEBOUNCE_MS);
+    let _ = use_event_listener(
+        window(),
+        ev::Custom::<web_sys::Event>::new(COMMITTED_EVENT),
+        move |_| {
+            debounced();
+        },
+    );
+}
+
+/// Fetch the repository's current branch set and sync every branch
+/// that has an upstream. Failures are logged, not surfaced — a
+/// background sweep must never interrupt the user.
+async fn sweep_repository(repo: &str) {
+    let info = match api::repository(repo).await {
+        Ok(Some(info)) => info,
+        Ok(None) => return,
+        Err(err) => {
+            log!("background sync: could not load '{repo}': {err}");
+            return;
+        }
+    };
+    for branch in branches_to_sync(&info.branch) {
+        if let Err(err) = api::sync(repo, &branch).await {
+            log!("background sync of {repo}/{branch} failed: {err}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonk_worker::UpstreamConfiguration;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn with_upstream() -> BranchConfiguration {
+        BranchConfiguration {
+            upstream: Some(UpstreamConfiguration {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            }),
+            revision: None,
+        }
+    }
+
+    fn without_upstream() -> BranchConfiguration {
+        BranchConfiguration {
+            upstream: None,
+            revision: None,
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_selects_only_branches_with_an_upstream() {
+        let branches = HashMap::from([
+            ("main".to_string(), with_upstream()),
+            ("scratch".to_string(), without_upstream()),
+        ]);
+        assert_eq!(branches_to_sync(&branches), vec!["main".to_string()]);
+    }
+
+    #[dialog_common::test]
+    fn it_returns_branches_sorted_for_a_stable_sweep_order() {
+        let branches = HashMap::from([
+            ("zeta".to_string(), with_upstream()),
+            ("alpha".to_string(), with_upstream()),
+        ]);
+        assert_eq!(
+            branches_to_sync(&branches),
+            vec!["alpha".to_string(), "zeta".to_string()]
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_returns_empty_when_no_branch_has_an_upstream() {
+        let branches = HashMap::from([("main".to_string(), without_upstream())]);
+        assert!(branches_to_sync(&branches).is_empty());
+    }
+}

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -25,10 +25,9 @@ use leptos::logging::log;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos_use::{use_debounce_fn, use_event_listener, use_interval_fn};
-use tonk_worker::{BranchConfiguration, RepositoryInfo};
+use tonk_worker::BranchConfiguration;
 
 use crate::api;
-use crate::error::TonkUiError;
 
 /// How often the controller sweeps the active repository's branches.
 /// One knob, tuned in one place.
@@ -111,13 +110,15 @@ pub fn notify_committed() {
 /// Call once from the component that owns the active-repository
 /// signal. The interval and event listeners are registered under
 /// the current reactive owner, so they're torn down automatically
-/// when that component unmounts. After each sweep the `repository`
-/// resource is refetched so revisions in the view reflect the new
-/// state.
-pub fn mount(
-    source: Signal<Option<String>, LocalStorage>,
-    repository: LocalResource<Result<Option<RepositoryInfo>, TonkUiError>>,
-) {
+/// when that component unmounts.
+///
+/// A sweep reconciles upstream but does *not* refetch any UI
+/// resource: subscribed components update from the worker's
+/// subscription re-poll, and the branch rows refresh their revision
+/// and sync-state badges off the per-branch broadcast the `/sync`
+/// route posts (see [`crate::components::space`]). Refetching here
+/// would tear down in-flight editor state on every tick.
+pub fn mount(source: Signal<Option<String>, LocalStorage>) {
     // One sweep at a time — a slow sync must not stack ticks.
     let syncing = RwSignal::new(false);
 
@@ -137,7 +138,6 @@ pub fn mount(
         syncing.set(true);
         spawn_local(async move {
             sweep_repository(&repo).await;
-            repository.refetch();
             syncing.set(false);
         });
     };

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -41,6 +41,39 @@ const COMMIT_DEBOUNCE_MS: f64 = 1_000.0;
 /// controller listens for it to sync shortly after a write.
 pub const COMMITTED_EVENT: &str = "tonk:committed";
 
+/// Per-repository `localStorage` key holding the auto-sync pause
+/// preference. Absent means on (the default).
+fn pref_key(repo: &str) -> String {
+    format!("tonk:auto-sync:{repo}")
+}
+
+/// Interpret a stored auto-sync preference. Default on — only an
+/// explicit `"off"` pauses, so a missing or unrecognized value
+/// leaves background sync running.
+fn pref_is_enabled(stored: Option<&str>) -> bool {
+    stored != Some("off")
+}
+
+/// Whether background sync is enabled for `repo` (default on).
+pub fn is_enabled(repo: &str) -> bool {
+    let stored = window()
+        .local_storage()
+        .ok()
+        .flatten()
+        .and_then(|s| s.get_item(&pref_key(repo)).ok().flatten());
+    pref_is_enabled(stored.as_deref())
+}
+
+/// Persist whether background sync is enabled for `repo`. The
+/// running controller reads this fresh on its next sweep, so the
+/// change takes effect without re-mounting.
+pub fn set_enabled(repo: &str, enabled: bool) {
+    if let Ok(Some(storage)) = window().local_storage() {
+        let value = if enabled { "on" } else { "off" };
+        let _ = storage.set_item(&pref_key(repo), value);
+    }
+}
+
 /// Branch names in `branches` that have an upstream, sorted for a
 /// stable sweep order. Branches without an upstream have nowhere to
 /// sync to, so they're skipped.
@@ -86,6 +119,12 @@ pub fn mount(
         let Some(repo) = source.get_untracked() else {
             return;
         };
+        // Honor the per-repository pause preference, read fresh so a
+        // toggle takes effect on the very next trigger. Paused means
+        // only the manual Pull/Push buttons act.
+        if !is_enabled(&repo) {
+            return;
+        }
         syncing.set(true);
         spawn_local(async move {
             sweep_repository(&repo).await;
@@ -189,5 +228,21 @@ mod tests {
     fn it_returns_empty_when_no_branch_has_an_upstream() {
         let branches = HashMap::from([("main".to_string(), without_upstream())]);
         assert!(branches_to_sync(&branches).is_empty());
+    }
+
+    #[dialog_common::test]
+    fn it_defaults_to_enabled_when_no_preference_is_stored() {
+        assert!(pref_is_enabled(None));
+    }
+
+    #[dialog_common::test]
+    fn it_is_disabled_only_for_an_explicit_off() {
+        assert!(!pref_is_enabled(Some("off")));
+    }
+
+    #[dialog_common::test]
+    fn it_stays_enabled_for_on_or_unrecognized_values() {
+        assert!(pref_is_enabled(Some("on")));
+        assert!(pref_is_enabled(Some("anything-else")));
     }
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -436,6 +436,13 @@ tonk-notation .tonk-cm-variable {
     height: 8rem;
     padding-inline: var(--wa-space-xl);
 }
+/* Banner actions (auto-sync toggle + share) cluster on the right;
+   the title takes the remaining space on the left. */
+.space-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+}
 /* Headline-cover treatment after Tachyons'
    `title-highlight-header-cover` example: the dark fill wraps
    the *text* (an inner `<span>`) rather than the heading box.

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -27,7 +27,10 @@ pub use repository::{
 
 mod sync;
 pub use dialog_repository::Revision;
-pub use sync::SyncResponse;
+pub use sync::{SyncResponse, SyncStatusResponse};
+// Re-exported so API consumers (the UI) can name the state without
+// depending on `tonk-schema` directly.
+pub use tonk_schema::SyncState;
 
 mod identify;
 pub use identify::IdentifyResponse;
@@ -137,6 +140,10 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route(
             "/api/repository/{repo}/branch/{branch}/sync/push",
             post(sync::push),
+        )
+        .route(
+            "/api/repository/{repo}/branch/{branch}/sync/status",
+            get(sync::sync_status),
         )
         // Claim operations
         .route(
@@ -735,6 +742,58 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_no_upstream_status_for_an_unconfigured_branch() {
+        let state = test_state().await;
+        let (app, _lsp) = api_router(state);
+        let repo = "test-sync-status";
+
+        put_repo(&app, repo).await;
+
+        // Land a commit so the branch has a local revision — the
+        // status route should still report `no-upstream` (none is
+        // configured) while surfacing the local head.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/repository/{}/branch/main/claim/assert/test:status/test/value",
+                        repo
+                    ))
+                    .method("POST")
+                    .header("content-type", "text/plain")
+                    .body(Body::from("status test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{}/branch/main/sync/status", repo))
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let status: super::SyncStatusResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(status.state, tonk_schema::SyncState::NoUpstream);
+        assert!(
+            status.local.is_some(),
+            "the local head should be reported even with no upstream"
+        );
+        assert!(status.remote.is_none(), "no upstream means no remote head");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -796,6 +796,154 @@ pub mod tests {
         assert!(status.remote.is_none(), "no upstream means no remote head");
     }
 
+    /// Wire `main`'s upstream to a sibling `upstream` branch in the
+    /// same repo — the in-process stand-in for a real remote, the
+    /// same pattern the slide sync tests use — so the status route's
+    /// fetch + classify path has somewhere local to read from.
+    /// Returns the router for driving the HTTP surface.
+    async fn repo_with_sibling_upstream(repo: &str) -> Router {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let tonk = test_state().await;
+        let app_state: crate::router::AppState = Arc::new(RwLock::new(tonk));
+        let (app, _lsp) = crate::api_router_from_state(app_state.clone());
+        put_repo(&app, repo).await;
+
+        let guard = app_state.read().await;
+        let repo_state = guard
+            .reactor
+            .repository(repo)
+            .acquire(&guard.operator)
+            .await
+            .expect("acquire repository");
+        let upstream = repo_state
+            .repository()
+            .branch("upstream")
+            .open()
+            .perform(&guard.operator)
+            .await
+            .expect("open sibling upstream branch");
+        let main = guard
+            .reactor
+            .repository(repo)
+            .branch("main")
+            .acquire(&guard.operator)
+            .await
+            .expect("acquire main branch");
+        main.handle()
+            .set_upstream(&upstream)
+            .perform(&guard.operator)
+            .await
+            .expect("set main's upstream to the sibling");
+        app
+    }
+
+    /// Land a commit on `main` by asserting one marker fact. Each
+    /// distinct `marker` is its own entity, so successive calls
+    /// advance the tree.
+    async fn commit_marker(app: &Router, repo: &str, marker: &str) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/repository/{repo}/branch/main/claim/assert/test:{marker}/test/value"
+                    ))
+                    .method("POST")
+                    .header("content-type", "text/plain")
+                    .body(Body::from(marker.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "commit '{marker}' should land"
+        );
+    }
+
+    /// Push `main` to its upstream over the HTTP sync route, asserting
+    /// the push reports success.
+    async fn push_main(app: &Router, repo: &str) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/sync/push"))
+                    .method("POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let sync: super::SyncResponse = serde_json::from_slice(&body).unwrap();
+        assert!(sync.success, "push should succeed: {:?}", sync.error);
+    }
+
+    /// GET the sync status of `main` and deserialize the response.
+    async fn get_main_status(app: &Router, repo: &str) -> super::SyncStatusResponse {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/sync/status"))
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_synced_status_after_pushing_to_the_upstream() {
+        let repo = "test-sync-status-synced";
+        let app = repo_with_sibling_upstream(repo).await;
+
+        commit_marker(&app, repo, "synced-probe").await;
+        push_main(&app, repo).await;
+
+        // Both heads now populated and equal — exercises the route's
+        // fetch + classify path and the both-revisions-present JSON
+        // shape, not just the no-upstream early return.
+        let status = get_main_status(&app, repo).await;
+        assert_eq!(status.state, tonk_schema::SyncState::Synced);
+        let local = status.local.expect("local head present");
+        let remote = status.remote.expect("remote head present after push");
+        assert_eq!(local.tree, remote.tree, "synced means the heads match");
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_ahead_status_when_local_leads_the_upstream() {
+        let repo = "test-sync-status-ahead";
+        let app = repo_with_sibling_upstream(repo).await;
+
+        // Establish a shared base on the upstream, then advance main
+        // one commit past it.
+        commit_marker(&app, repo, "base").await;
+        push_main(&app, repo).await;
+        commit_marker(&app, repo, "ahead-probe").await;
+
+        let status = get_main_status(&app, repo).await;
+        assert_eq!(status.state, tonk_schema::SyncState::Ahead);
+        assert!(status.local.is_some(), "local head present");
+        assert!(
+            status.remote.is_some(),
+            "remote head present — the shared base the upstream still points at"
+        );
+    }
+
     #[dialog_common::test]
     async fn it_inspects_branch_after_commit() {
         let state = test_state().await;

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -28,6 +28,7 @@ use tonk_notation::{Parsed, Syntax, parse};
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::broadcast::{Notification, broadcast};
 
 // Re-export the response and match types so router consumers
 // (router.rs, browser clients via wasm-bindgen) name them
@@ -136,7 +137,26 @@ pub async fn evaluate(
         .reactor
         .repository(&path.repo)
         .branch(&path.branch);
-    evaluate_on_branch(&tonk_state, tonk_branch, body, query).await
+    let result = evaluate_on_branch(&tonk_state, tonk_branch, body, query).await;
+
+    // A commit moves the branch head. Announce it on the branch's
+    // channel so subscribed UIs refresh their revision/sync-state
+    // badges without a full refetch (which would tear down the
+    // editor). Pure queries and dry runs leave `revision_after ==
+    // revision_before`, so they announce nothing.
+    if let Ok(Json(response)) = &result
+        && let Some(revision) = &response.revision_after
+        && response.revision_before.as_ref() != Some(revision)
+    {
+        broadcast(
+            &format!("/api/repository/{}/branch/{}", path.repo, path.branch),
+            &Notification {
+                branch: path.branch.clone(),
+                revision: revision.clone(),
+            },
+        );
+    }
+    result
 }
 
 /// `POST /api/profile/branch/{branch}/evaluate`

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -19,6 +19,29 @@ use tonk_schema::{SyncState, classify};
 
 use super::AppState;
 use crate::TonkWorkerError;
+use crate::broadcast::{Notification, broadcast};
+
+/// Announce on the branch's broadcast channel that its head may have
+/// moved, so subscribed UIs refresh their revision and sync-state
+/// badges without a full refetch. The channel mirrors the endpoint
+/// path ("channel name == endpoint path"). A `None` revision (branch
+/// with no commits) is skipped — there's nothing to announce.
+///
+/// Posted after a *successful* pull/push/sync. A push leaves the
+/// local head where it was, so its announcement carries the unchanged
+/// revision; listeners still re-read the read-only sync status, which
+/// is what actually flips (e.g. `ahead` → `synced`).
+fn announce_head(repo: &str, branch: &str, revision: Option<Revision>) {
+    if let Some(revision) = revision {
+        broadcast(
+            &format!("/api/repository/{repo}/branch/{branch}"),
+            &Notification {
+                branch: branch.to_string(),
+                revision,
+            },
+        );
+    }
+}
 
 /// Path parameters for sync endpoints.
 #[derive(Debug, Deserialize)]
@@ -82,6 +105,7 @@ pub async fn pull(
     {
         Ok(after) => {
             log!("Pull succeeded");
+            announce_head(&params.repo, &params.branch, after.clone());
             Ok(Json(SyncResponse {
                 success: true,
                 before,
@@ -135,10 +159,12 @@ pub async fn push(
     {
         Ok(_) => {
             log!("Push succeeded");
+            let after = session.handle().revision();
+            announce_head(&params.repo, &params.branch, after.clone());
             Ok(Json(SyncResponse {
                 success: true,
                 before: before.clone(),
-                after: session.handle().revision(),
+                after,
                 error: None,
             }))
         }
@@ -273,10 +299,12 @@ pub async fn sync(
     {
         Ok(_) => {
             log!("Push succeeded");
+            let after = session.handle().revision();
+            announce_head(&params.repo, &params.branch, after.clone());
             Ok(Json(SyncResponse {
                 success: true,
                 before,
-                after: session.handle().revision(),
+                after,
                 error: None,
             }))
         }

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -208,7 +208,7 @@ pub async fn sync_status(
         .await
         .map_err(|e| TonkWorkerError::Internal(e.to_string()))?;
 
-    let sync_state = classify(local.as_ref(), remote.as_ref());
+    let sync_state = SyncState::from(classify(local.as_ref(), remote.as_ref()));
     Ok(Json(SyncStatusResponse {
         state: sync_state,
         local,

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
+use tonk_schema::{SyncState, classify};
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -151,6 +152,68 @@ pub async fn push(
             }))
         }
     }
+}
+
+/// Sync-state of a branch relative to its upstream.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SyncStatusResponse {
+    /// How the local head relates to the upstream head.
+    pub state: SyncState,
+    /// Local branch revision, or `null` if it has no commits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local: Option<Revision>,
+    /// Upstream branch revision as last fetched, or `null` if the
+    /// upstream has no commits (or none is configured).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<Revision>,
+}
+
+/// Classify a branch against its upstream without mutating local
+/// state.
+///
+/// Reads the local head, fetches the upstream head read-only (no
+/// merge, no push), and runs the shared classifier. A branch with
+/// no upstream returns [`SyncState::NoUpstream`] rather than an
+/// error, so the indicator has something to render for every
+/// branch.
+#[wasm_compat]
+pub async fn sync_status(
+    State(state): State<AppState>,
+    Path(params): Path<SyncPath>,
+) -> Result<Json<SyncStatusResponse>, TonkWorkerError> {
+    let tonk_state = state.write().await;
+
+    let session = tonk_state
+        .reactor
+        .repository(&params.repo)
+        .branch(&params.branch)
+        .acquire(&tonk_state.operator)
+        .await
+        .map_err(|e| TonkWorkerError::NotFound(e.to_string()))?;
+
+    let handle = session.handle();
+    let local = handle.revision();
+
+    if handle.upstream().is_none() {
+        return Ok(Json(SyncStatusResponse {
+            state: SyncState::NoUpstream,
+            local,
+            remote: None,
+        }));
+    }
+
+    let remote = handle
+        .fetch()
+        .perform(&tonk_state.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(e.to_string()))?;
+
+    let sync_state = classify(local.as_ref(), remote.as_ref());
+    Ok(Json(SyncStatusResponse {
+        state: sync_state,
+        local,
+        remote,
+    }))
 }
 
 /// Full sync: pull then push.


### PR DESCRIPTION
## Background sync by default

Sync happens on its own now. Today it's manual everywhere — you click per-branch Pull/Push in the browser, or remember to run `slide sync` on the CLI — so replicas silently drift until someone acts. This drives reconciliation automatically across all three surfaces (`tonk-ui` + `tonk-worker` in the browser, `slide` headless), with an escape hatch on each and a synced/ahead/behind/diverged indicator.

This is a data-plane change (push/pull of repository state). It sits *on top of* the existing `pull`/`push`/`sync` routes and commands — the wire format, merge algorithm, and manual flows are untouched. Full design in `plan/background-sync.md`.

## What's in it

**Shared classifier (`tonk-schema`)** — a pure, I/O-free `classify(local, remote)` that compares two branch heads and returns `Comparison` (`Synced`/`Ahead`/`Behind`/`Diverged`); callers widen it into the wire `SyncState` (which adds `NoUpstream`). The cheap variant: one fetch, no history walk. It only reports a direction it can prove from the heads alone — `Diverged` is the safe fallback, so we never claim a direction we can't back up.

**slide auto-sync** — mutating `eval` gets an automatic pull-before / push-after when an upstream is configured. Opt out with `--no-sync` or `SLIDE_NO_SYNC`. No upstream → silent skip. Sync failures warn on stderr but don't fail the command (the local write already committed). New `slide status` prints the classification.

**Browser controller (`tonk-ui`)** — a Leptos-owned `SyncController` for the active repository. Triggers funnel into one re-entrancy-guarded sweep: a 20s interval, `online`, tab-visible, and a debounced post-commit nudge. On by default; a per-repository `off` preference (browser-local, with a toggle in the space banner) pauses it, leaving only the manual buttons.

**Worker status route (`tonk-worker`)** — `GET /sync/status` reads the local head, fetches the upstream head read-only (no merge, no mutation), and returns `classify(...)`. A branch with no upstream returns `NoUpstream` rather than erroring.

**Indicator** — per-branch badge in the browser (`synced`/`ahead`/`behind`/`diverged`), `slide status` on the CLI, and the `/sync/status` route behind both.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a background sync feature for the Tonk application, enabling automatic synchronization of local writes to remote branches without manual intervention. It enhances the user experience by ensuring that changes are reflected in real-time.

### Detailed summary
- Added `sync` module in `rust/tonk-schema/src/lib.rs`.
- Introduced `sync_controller` in `rust/tonk-ui/src/lib.rs` for automatic syncing.
- Updated `Cargo.toml` to include new tests for sync functionality.
- Implemented auto-sync behavior in `slide` commands and APIs.
- Created `sync_status` API to report branch sync states.
- Added tests for auto-sync functionality in `rust/slide/tests/sync.rs`.
- Enhanced UI components to reflect sync status and allow toggling of auto-sync.
- Updated Nix configurations to include `chromedriver` support for testing.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/components/space.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->