### PR TITLE
feat: directory views and a coherent repeat-node template engine

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -1018,6 +1018,63 @@ holder!: &my-holder
         );
     }
 
+    /// A pinned instance (`this: <uri>`) referenced by a later field
+    /// must resolve to that exact pinned URI — NOT a body-derived
+    /// entity. Regression: the anchor pass derived the entity from a
+    /// body digest that skips `this:`, so `target: my-thing` resolved
+    /// to a random `did:key` instead of the pin.
+    #[test]
+    fn it_resolves_a_pinned_instance_anchor_to_its_pinned_uri() {
+        let syntax = must_parse(
+            "\
+concept!: &thing
+  description: \"a thing\"
+  with:
+    source:
+      description: \"src\"
+      the: x.y/source
+      cardinality: one
+      as: text
+
+thing!: &my-thing
+  this: id:my-thing
+  source: \"home\"
+
+concept!: &holder
+  description: \"holds\"
+  with:
+    target:
+      description: \"e\"
+      the: x.y/target
+      cardinality: one
+      as: entity
+
+holder!: &my-holder
+  this: id:my-holder
+  target: my-thing
+",
+        );
+        let tree = super::analyze_local(&syntax).expect("analyzes");
+        // Find the `holder` assert and read its `target` term — it
+        // must be the pinned `id:my-thing`, not a derived entity.
+        let target = flat(tree)
+            .mutate
+            .statements
+            .iter()
+            .find_map(|s| match s {
+                Statement::Assert(Application::Concept { query, .. }) => {
+                    query.terms.get("target").and_then(as_constant_entity)
+                }
+                _ => None,
+            })
+            .expect("a holder assert with a resolved target entity");
+        let expected: Entity = "id:my-thing".parse().expect("valid uri");
+        assert_eq!(
+            target, expected,
+            "target must resolve to the pinned `id:my-thing`, not a derived entity",
+        );
+    }
+
     /// A small concept spec the tests pass into [`analyze_with`]:
     /// the published name plus the field set as `(field, the, type)`
     /// triples. Replaces the old `FixedConcept` struct.

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -606,11 +606,13 @@ impl Graph {
             }
         }
 
-        // Pass 4 — non-meta `&anchor` heads. With the head concept
-        // (or claim domain) in scope, derive the anchor's entity
-        // using the same `derive_this(predicate, body)` recipe the
-        // mutation pass and the wire path use, so all three
-        // converge on the same URI for the same `(predicate, body)`.
+        // Pass 4 — non-meta `&anchor` heads. The anchor's entity is
+        // the instance's `this`: a `this: <uri>` (or bare symbol
+        // resolving to one) pins it directly, so the anchor names that
+        // exact entity. Only an omitted/`?var` `this:` derives an
+        // entity, using the same `derive_this(predicate, body)` recipe
+        // the mutation pass and wire path use, so all three converge on
+        // the same URI for the same `(predicate, body)`.
         for index in &self.pending_anchors {
             let Expression::Claim(Effectful {
                 anchor: Some(anchor),
@@ -631,7 +633,18 @@ impl Graph {
                 HeadName::Claim(domain) => Entity::of(domain),
                 HeadName::Uri(_) => continue,
             };
-            let entity = derive_this(&predicate_entity, &body_digest(&a.fields, scope)?);
+            // A pinned `this:` IS the entity — don't compute one.
+            // Mirrors `this_term_for_assertion`'s `ThisIntent::Uri`
+            // arm; without this, the body digest (which skips `this:`)
+            // would mint a fresh entity and the anchor would name the
+            // wrong thing.
+            let (this, _) = derive_head_intent(&a.fields, Some(anchor), scope)?;
+            let entity = match this {
+                ThisIntent::Uri(entity) => entity,
+                ThisIntent::Derived | ThisIntent::Variable(_) => {
+                    derive_this(&predicate_entity, &body_digest(&a.fields, scope)?)
+                }
+            };
             scope.declare(&anchor.name, entity, anchor.range)?;
         }
 

--- a/rust/tonk-concept/src/element.rs
+++ b/rust/tonk-concept/src/element.rs
@@ -28,7 +28,7 @@ use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, window};
 use crate::error::{ErrorDetail, ErrorKind};
 use crate::render::Renderer;
 use crate::resolve::{ParsedSource, parse_source, phase1_query, phase2_query};
-use crate::template::{BindingPlan, extract_plan, snapshot_template};
+use crate::template::{BindingPlan, extract_row_plan, snapshot_template};
 
 /// Internal lifecycle state shared across async closures.
 struct Inner {
@@ -90,7 +90,7 @@ impl CustomElement for TonkConcept {
                 return;
             }
         };
-        let plan = extract_plan(&snapshot.fragment);
+        let plan = extract_row_plan(&snapshot.fragment);
 
         let state = Rc::new(RefCell::new(Inner::new()));
         {

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -921,4 +921,27 @@ mod tests {
             "the html: prefix attribute must not survive on the cloned element",
         );
     }
+
+    /// `{dom.host/model}` is a namespaced field name (with a dot and a
+    /// slash). `<tonk-display>` injects host attributes under such keys
+    /// so a directory template can thread the outer model into a nested
+    /// display: `<tonk-display model={dom.host/model}>`. Proves the
+    /// parser + substituter resolve the namespaced placeholder as an
+    /// ordinary field lookup — no special casing needed.
+    #[dialog_common::test]
+    fn it_resolves_a_dom_host_namespaced_field_in_an_attribute() {
+        let (host, mut renderer) = mount("<tonk-display entity={this} model={dom.host/model} />");
+        renderer.apply(&[conclusion("id:trip/a", &[("dom.host/model", "trip")])]);
+        let el = host
+            .query_selector("tonk-display")
+            .unwrap()
+            .expect("nested tonk-display present");
+        assert_eq!(
+            el.get_attribute("model").as_deref(),
+            Some("trip"),
+            "{{dom.host/model}} must resolve to the injected field; html: {}",
+            host.inner_html(),
+        );
+        assert_eq!(el.get_attribute("entity").as_deref(), Some("id:trip/a"));
+    }
 }

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -83,6 +83,13 @@ pub struct Renderer {
 
 impl Renderer {
     /// Construct a renderer over a snapshot.
+    ///
+    /// A `<tonk-concept>` shelf clones the **whole template** per
+    /// conclusion (its own row loop), so it consumes `plan.repeat.body`
+    /// — the per-conclusion body — and never the chrome/repeat split a
+    /// `<tonk-display>` uses. Concept row templates do not carry `{this}`
+    /// markers, so the split leaves every node in `repeat.body` with
+    /// fragment-relative paths (`repeat.path == None`).
     pub fn new(plan: BindingPlan, template: DocumentFragment, container: Element) -> Self {
         Self {
             plan,
@@ -123,7 +130,7 @@ impl Renderer {
             if let Some(row) = self.rows.get_mut(&conclusion.this) {
                 update_nodes(
                     &document,
-                    &self.plan.nodes,
+                    &self.plan.repeat.body,
                     &mut row.mounted,
                     &row.root,
                     &self.template,
@@ -159,7 +166,7 @@ impl Renderer {
         let root: Node = clone.clone().into();
         let mounted = build_mounted_nodes(
             document,
-            &self.plan.nodes,
+            &self.plan.repeat.body,
             &root,
             &self.template,
             conclusion,

--- a/rust/tonk-concept/src/render.rs
+++ b/rust/tonk-concept/src/render.rs
@@ -87,9 +87,13 @@ impl Renderer {
     /// A `<tonk-concept>` shelf clones the **whole template** per
     /// conclusion (its own row loop), so it consumes `plan.repeat.body`
     /// — the per-conclusion body — and never the chrome/repeat split a
-    /// `<tonk-display>` uses. Concept row templates do not carry `{this}`
-    /// markers, so the split leaves every node in `repeat.body` with
-    /// fragment-relative paths (`repeat.path == None`).
+    /// `<tonk-display>` uses. The plan must come from
+    /// [`crate::template::extract_row_plan`], which forces
+    /// `repeat.path == None` so every node stays in `repeat.body` with
+    /// fragment-relative paths the whole-fragment clone can navigate.
+    /// (Plain [`crate::template::extract_plan`] would rebase paths under
+    /// a subject ref like `model={model}`, which this renderer would
+    /// then mis-navigate.)
     pub fn new(plan: BindingPlan, template: DocumentFragment, container: Element) -> Self {
         Self {
             plan,
@@ -543,7 +547,7 @@ fn collect_values(value: Option<Ipld>) -> Vec<Ipld> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::template::{extract_plan, snapshot_template};
+    use crate::template::{extract_row_plan, snapshot_template};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -566,7 +570,7 @@ mod tests {
             .append_child(&host)
             .expect("attach host");
         let snapshot = snapshot_template(&host).expect("snapshot");
-        let plan = extract_plan(&snapshot.fragment);
+        let plan = extract_row_plan(&snapshot.fragment);
         (
             host,
             Renderer::new(plan, snapshot.fragment, snapshot.container),

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -121,23 +121,41 @@ pub enum BindingKind {
     },
 }
 
-/// All bindings extracted from a template fragment, plus the set
-/// of distinct field names referenced — the set is precomputed so
-/// the renderer can short-circuit when no field actually changed.
+/// All bindings extracted from a template fragment, partitioned into
+/// the render-once **chrome** and the per-conclusion **repeat body**.
+///
+/// A `<tonk-display>` frame is a list of folded conclusions (one per
+/// subject). The renderer renders `chrome` once, then clones the repeat
+/// element once per conclusion, rendering `body` against each. See
+/// [`this_repeat_root`] for how the repeat element is chosen and
+/// `tonk-core/docs/templates.md` for the model.
 #[derive(Debug, Clone, Default)]
 pub struct BindingPlan {
-    /// Top-level plan nodes — a tree, because iteration roots
-    /// (introduced for cardinality-many fields) contain nested
-    /// bindings whose paths are relative to the root.
-    pub nodes: Vec<PlanNode>,
-    /// The per-conclusion **repeat root**: the template path of the
-    /// outermost element that binds `{this}` (e.g.
-    /// `<tr data-subject={this}>`). The renderer clones *this element*
-    /// once per matched conclusion and renders everything outside it
-    /// once as chrome. `None` (no element binds `{this}`) means the
-    /// whole fragment is the repeat root — the entire template clones
-    /// per conclusion. See `tonk-core/docs/templates.md`.
-    pub repeat_root: Option<Vec<usize>>,
+    /// Plan nodes outside the repeat element — bindings and iterations
+    /// that render **once** against the lead conclusion (e.g. a sheet
+    /// title surrounding a repeated row). Empty when the whole fragment
+    /// repeats.
+    pub chrome: Vec<PlanNode>,
+    /// The per-conclusion repeat: the template path of the element to
+    /// clone once per conclusion, plus the plan applied inside each
+    /// clone (`body` paths relative to that element). `path` is `None`
+    /// when the whole fragment repeats (no single enclosing element);
+    /// then the renderer clones every top-level node.
+    pub repeat: RepeatPlan,
+}
+
+/// The per-conclusion repeat half of a [`BindingPlan`].
+#[derive(Debug, Clone, Default)]
+pub struct RepeatPlan {
+    /// Template path of the element cloned once per conclusion, or
+    /// `None` to repeat the whole fragment. The renderer stamps
+    /// `with=<this>` on each rendered clone so the repeat boundary is
+    /// inspectable in the DOM.
+    pub path: Option<Vec<usize>>,
+    /// Plan applied inside each clone. When `path` is `Some`, paths are
+    /// relative to that element; when `None`, they are fragment-root
+    /// relative (the whole fragment is the clone).
+    pub body: Vec<PlanNode>,
 }
 
 /// One node in the binding tree. Plain `Binding` nodes are
@@ -227,41 +245,119 @@ pub fn binding_fields(binding: &Binding) -> Vec<String> {
     out
 }
 
-/// Whether a binding is an attribute whose value is *exactly*
-/// `{this}` — the marker that makes its element a repeat root.
-///
-/// The attribute *name* is irrelevant (`subject={this}`,
-/// `data-with={this}`, `for={this}` are all equivalent); only the
-/// `{this}` reference matters. It must be an attribute (text nodes
-/// are value output, not iteration markers) AND a bare single
-/// `{this}` segment: a mixed value like `href="/entity/{this}"` is a
-/// URL substitution in a *detail* template, not a directory repeat
-/// boundary, so it must not count.
-fn is_this_repeat_marker(binding: &Binding) -> bool {
+/// A field name in the `dom.host/` namespace — the host element's own
+/// attributes injected into the conclusion (e.g. `{dom.host/model}`).
+/// These describe the *outer* host, not the repeated subject, so they
+/// never participate in repeat-node resolution.
+fn is_dom_host_field(name: &str) -> bool {
+    name.starts_with("dom.host/")
+}
+
+/// Whether a binding is an attribute whose value is *exactly* `{this}`
+/// (a bare single-segment `{this}`, attribute name irrelevant). This is
+/// the explicit repeat marker the author can write, e.g.
+/// `<tr subject={this}>`. A mixed value like `href="/entity/{this}"` is
+/// a URL substitution, not a marker, so it does not count.
+fn binds_this_marker(binding: &Binding) -> bool {
     let BindingKind::Attribute { segments, .. } = &binding.kind else {
         return false;
     };
     matches!(segments.as_slice(), [Segment::Field(name)] if name == "this")
 }
 
-/// Locate the per-conclusion **repeat root**: the element with an
-/// attribute whose value is exactly `{this}` (the attribute name is
-/// arbitrary, e.g. `<tr subject={this}>` or `<li for={this}>`). The
-/// renderer clones that element per matched conclusion; everything
-/// outside it is render-once chrome.
-///
-/// The **outermost** `{this}` marker sets the repeat boundary. When
-/// `{this}` is bound at several nesting levels, the shallowest element
-/// is the repeat root and any inner markers fall inside its per-row
-/// clone — the repeat point is the outer one, not the deepest. The
-/// shallowest (then earliest) path wins. `None` ⇒ nothing marks a
-/// repeat root ⇒ the whole fragment repeats per conclusion.
-pub fn this_repeat_root(bindings: &[Binding]) -> Option<Vec<usize>> {
-    bindings
+/// Whether a binding references any non-`{dom.host/*}` field — a
+/// subject field (`{title}`) or `{this}`, in text or attribute, bare or
+/// mixed. These are the references that pin the repeat node; host-attr
+/// references are excluded. Unlike [`binding_fields`] (which omits
+/// `{this}` because it is not a cardinality-many iteration target),
+/// this counts `{this}` — it is the primary repeat reference.
+fn refers_subject(binding: &Binding) -> bool {
+    let segments = match &binding.kind {
+        BindingKind::Text { segments } => segments,
+        BindingKind::Attribute { segments, .. } => segments,
+    };
+    segments
         .iter()
-        .filter(|b| is_this_repeat_marker(b))
+        .any(|seg| matches!(seg, Segment::Field(name) if !is_dom_host_field(name)))
+}
+
+/// Resolve the per-conclusion **repeat node**: the element the renderer
+/// clones once per folded conclusion. Everything outside it is rendered
+/// once as chrome.
+///
+/// The rule, from the smallest set of examples that pins it down:
+///
+/// 1. `<div><span>{count}</span></div>` — no `{this}`, one subject ref.
+///    Repeat node is the **fragment root** (`<div>`), with an implicit
+///    `with={this}`.
+/// 2. `<div subject={this}><span>{count}</span></div>` — `{this}` on the
+///    outermost ref-bearing element. Repeat node is that element
+///    (`<div>`). Whereas `<div><span data-this={this} data-name={name}>`
+///    has every reference on the inner `<span>`, so the `<span>` repeats.
+/// 3. `<div><button data-count={count}><span data-of={this}>{name}</span>`
+///    — `{this}` is *deeper* than `{count}`, so it is not on the
+///    outermost ref-bearing element. Repeat node falls back to the
+///    fragment root (`<div>`).
+/// 4. `<div data-model={dom.host/model}><span data-this={this} ...>` —
+///    the `{dom.host/*}` reference is ignored; the `<span>` holding
+///    `{this}` repeats.
+///
+/// Stated as one rule: among bindings that reference a subject field
+/// (anything but `{dom.host/*}`), find the **outermost** (shallowest)
+/// host element. If a bare `{this}` marker sits on *that* element, it is
+/// the repeat node. Otherwise — no `{this}`, or `{this}` nested below
+/// another reference — the **fragment-root element** containing the
+/// references is the repeat node.
+///
+/// `Some(path)` names the exact element to clone per conclusion.
+/// `None` means there is no single enclosing element (the references
+/// span sibling top-level nodes), so the whole fragment repeats.
+pub fn this_repeat_root(bindings: &[Binding]) -> Option<Vec<usize>> {
+    // Host paths of every reference that pins the repeat node.
+    let subject_hosts: Vec<Vec<usize>> = bindings
+        .iter()
+        .filter(|b| refers_subject(b))
         .map(host_element_path)
-        .min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
+        .collect();
+    if subject_hosts.is_empty() {
+        // Nothing references the subject — no repeat axis. (A template
+        // built only from `{dom.host/*}` refs, say.) Whole fragment.
+        return None;
+    }
+
+    // The outermost ref-bearing element is the shallowest host path,
+    // when it is unique. A `{this}` marker on *that* element makes the
+    // element itself the repeat node (examples 2b/4: every ref on the
+    // inner `<span>`; example 2a: `{this}` on the outer `<div>`).
+    let min_len = subject_hosts.iter().map(Vec::len).min().expect("non-empty");
+    let mut shallowest: Vec<Vec<usize>> = subject_hosts
+        .iter()
+        .filter(|h| h.len() == min_len)
+        .cloned()
+        .collect();
+    shallowest.sort();
+    shallowest.dedup();
+    if let [outermost] = shallowest.as_slice() {
+        let this_on_outermost = bindings
+            .iter()
+            .filter(|b| binds_this_marker(b))
+            .any(|b| &host_element_path(b) == outermost);
+        if this_on_outermost {
+            return Some(outermost.clone());
+        }
+    }
+
+    // No `{this}` on the outermost element (absent, nested deeper, or
+    // the outermost refs split across siblings). The repeat node is the
+    // fragment-root *element* that encloses every reference — the
+    // common length-1 prefix shared by all host paths. If they don't
+    // share one (genuine multi-root fragment), the whole fragment
+    // repeats (`None`).
+    let first = subject_hosts[0].first().copied();
+    match first {
+        Some(idx) if subject_hosts.iter().all(|h| h.first() == Some(&idx)) => Some(vec![idx]),
+        _ => None,
+    }
 }
 
 /// The path of the smallest enclosing element containing a
@@ -440,10 +536,66 @@ fn sort_nodes_by_path(nodes: &mut [PlanNode]) {
     nodes.sort_by(|a, b| node_path(a).cmp(node_path(b)));
 }
 
-fn node_path(node: &PlanNode) -> &[usize] {
+/// The template path of a top-level plan node — a `Binding`'s target
+/// path or an `Iteration` root's path. Used to partition a plan into
+/// the chrome (outside the repeat root) and the per-conclusion row
+/// (inside it).
+pub fn node_path(node: &PlanNode) -> &[usize] {
     match node {
         PlanNode::Binding(b) => &b.path,
         PlanNode::Iteration { path, .. } => path,
+    }
+}
+
+/// Partition the flat bindings around the per-conclusion repeat element
+/// and build a [`BindingPlan`]: the **chrome** (bindings outside the
+/// repeat element, planned and rendered once) and the **repeat body**
+/// (bindings at or under it, paths rebased relative to the repeat
+/// element, planned and rendered per conclusion).
+///
+/// Splitting the *flat bindings* — before [`build_plan_nodes`] folds
+/// them into iteration trees — is what keeps chrome and body
+/// independent. A cardinality-one chrome field (a sheet `title`) would
+/// otherwise be lifted into an iteration root that wraps the repeat
+/// element, swallowing the row into the title's subtree. Planning each
+/// side separately means the title iterates only its own value and the
+/// repeat element is the body's root.
+///
+/// `repeat_root` is `None` when the whole fragment repeats: there is no
+/// chrome, every binding is body, paths unchanged.
+pub fn split_plan(bindings: Vec<Binding>, repeat_root: Option<Vec<usize>>) -> BindingPlan {
+    let Some(root) = repeat_root else {
+        return BindingPlan {
+            chrome: Vec::new(),
+            repeat: RepeatPlan {
+                path: None,
+                body: build_plan_nodes(bindings),
+            },
+        };
+    };
+
+    let mut chrome_bindings = Vec::new();
+    let mut body_bindings = Vec::new();
+    for b in bindings {
+        // A binding belongs to the body when its target sits at or
+        // under the repeat element. Compare the *host element* path so
+        // an attribute on the repeat element itself (host == root) and
+        // a text node inside it both land in the body.
+        if host_element_path(&b).starts_with(&root) {
+            let mut rebased = b;
+            rebased.path = rebased.path[root.len()..].to_vec();
+            body_bindings.push(rebased);
+        } else {
+            chrome_bindings.push(b);
+        }
+    }
+
+    BindingPlan {
+        chrome: build_plan_nodes(chrome_bindings),
+        repeat: RepeatPlan {
+            path: Some(root),
+            body: build_plan_nodes(body_bindings),
+        },
     }
 }
 
@@ -741,20 +893,15 @@ mod dom {
             }
         }
 
-        // Fold flat bindings into the iteration-aware plan tree.
-        // Iteration roots are discovered by finding the LCA of
-        // every binding that references the same field — if that
-        // LCA sits strictly inside the fragment (not at the root),
-        // the element there becomes the iteration root and every
-        // binding under it is pulled into its body. The fold is
-        // pure (operates on the collected `bindings` vec), which
-        // is why the helper lives outside the wasm-only `dom`
-        // module and gets unit-tested natively.
+        // Fold flat bindings into the iteration-aware plan tree, then
+        // split it around the per-conclusion repeat element. Iteration
+        // roots inside the body are discovered by the LCA of every
+        // binding referencing the same field. The fold and split are
+        // pure (operate on the collected `bindings` vec), which is why
+        // they live outside the wasm-only `dom` module and get
+        // unit-tested natively.
         let repeat_root = super::this_repeat_root(&bindings);
-        BindingPlan {
-            nodes: super::build_plan_nodes(bindings),
-            repeat_root,
-        }
+        super::split_plan(bindings, repeat_root)
     }
 
     /// Walk a node and its descendants, calling `visit(path, node)`
@@ -1393,12 +1540,83 @@ mod tests {
         }
     }
 
-    // --- repeat-root ({this}) discovery ----------------------------------
+    // --- repeat-node resolution ------------------------------------------
+    //
+    // The repeat node is the element the renderer clones once per folded
+    // conclusion. These five cases pin the rule down (paths shown beside
+    // each element; `[0]` is the single top-level element of the
+    // fragment).
 
+    // 1. <div>                       [0]
+    //      <span>{count}</span>      [0, 0] text host [0, 0]
+    //    No {this}, one subject ref. The fragment-root <div> repeats and
+    //    gets an implicit with={this}.
     #[dialog_common::test]
-    fn it_has_no_repeat_root_when_this_is_unbound() {
-        // A detail template that never binds {this}: the whole
-        // fragment is the repeat root (None ⇒ clone-whole-fragment).
+    fn it_repeats_the_root_when_only_a_subject_field_is_bound() {
+        let root = this_repeat_root(&[text_binding(&[0, 0, 0], "count")]);
+        assert_eq!(root, Some(vec![0]));
+    }
+
+    // 2a. <div subject={this}>       [0]     attr {this}
+    //       <span>{count}</span>     [0, 0]  text host [0, 0]
+    //     {this} is on the outermost ref-bearing element (<div>), so the
+    //     <div> repeats.
+    #[dialog_common::test]
+    fn it_repeats_the_element_holding_this_when_this_is_outermost() {
+        let root = this_repeat_root(&[
+            attr_binding(&[0], "subject", "this"),
+            text_binding(&[0, 0, 0], "count"),
+        ]);
+        assert_eq!(root, Some(vec![0]));
+    }
+
+    // 2b. <div>                                  [0]
+    //       <span data-this={this} data-name={name}>  [0, 0] attrs
+    //     Every reference sits on the inner <span>, so the <span>
+    //     repeats — not the <div>.
+    #[dialog_common::test]
+    fn it_repeats_the_inner_element_when_all_refs_are_on_it() {
+        let root = this_repeat_root(&[
+            attr_binding(&[0, 0], "data-this", "this"),
+            attr_binding(&[0, 0], "data-name", "name"),
+        ]);
+        assert_eq!(root, Some(vec![0, 0]));
+    }
+
+    // 3. <div>                            [0]
+    //      <button data-count={count}>    [0, 0]    attr {count}
+    //        <span data-of={this}>{name}</span>  [0,0,0] attr {this}, text {name}
+    //    {this} is *deeper* than {count}, so it is not on the outermost
+    //    ref-bearing element (<button>). The repeat node falls back to
+    //    the fragment-root <div>.
+    #[dialog_common::test]
+    fn it_repeats_the_root_when_this_is_nested_below_another_ref() {
+        let root = this_repeat_root(&[
+            attr_binding(&[0, 0], "data-count", "count"),
+            attr_binding(&[0, 0, 0], "data-of", "this"),
+            text_binding(&[0, 0, 0, 0], "name"),
+        ]);
+        assert_eq!(root, Some(vec![0]));
+    }
+
+    // 4. <div data-model={dom.host/model}>    [0]     attr dom.host ref
+    //      <span data-this={this} data-name={name}>  [0, 0] attrs
+    //    The {dom.host/*} reference is ignored for repeat resolution, so
+    //    the inner <span> (holding {this} and {name}) repeats.
+    #[dialog_common::test]
+    fn it_ignores_dom_host_refs_when_resolving_the_repeat_node() {
+        let root = this_repeat_root(&[
+            attr_binding(&[0], "data-model", "dom.host/model"),
+            attr_binding(&[0, 0], "data-this", "this"),
+            attr_binding(&[0, 0], "data-name", "name"),
+        ]);
+        assert_eq!(root, Some(vec![0, 0]));
+    }
+
+    // Sibling top-level references with no shared enclosing element: the
+    // whole fragment repeats (`None`).
+    #[dialog_common::test]
+    fn it_repeats_the_whole_fragment_for_sibling_roots() {
         let root = this_repeat_root(&[
             text_binding(&[0, 0], "title"),
             text_binding(&[1, 0], "summary"),
@@ -1406,61 +1624,54 @@ mod tests {
         assert_eq!(root, None);
     }
 
+    // A {this} marker deep in a table still names its element as the
+    // repeat node when it is the outermost (and only) reference holder.
     #[dialog_common::test]
-    fn it_finds_the_element_that_binds_this_in_an_attribute() {
-        // <table>                     [0]
-        //   <tbody>                   [0, 0]
-        //     <tr data-subject={this}>  [0, 0, 0]  attr
-        //       <td>{title}</td>      [0, 0, 0, 0, 0] text
-        // The <tr> at [0, 0, 0] is the repeat root.
+    fn it_finds_a_this_marker_nested_in_chrome() {
+        // <table><tbody><tr subject={this}>  [0, 0, 0]
+        //   <td>{title}</td>                 [0, 0, 0, 0, 0]
         let root = this_repeat_root(&[
-            attr_binding(&[0, 0, 0], "data-subject", "this"),
+            attr_binding(&[0, 0, 0], "subject", "this"),
             text_binding(&[0, 0, 0, 0, 0], "title"),
         ]);
         assert_eq!(root, Some(vec![0, 0, 0]));
     }
 
+    // --- split_plan: chrome vs per-conclusion body -----------------------
+
     #[dialog_common::test]
-    fn it_ignores_this_in_text_for_repeat_root() {
-        // `{this}` in a bare text node is value output, not an
-        // iteration marker.
-        let text_this = Binding {
-            path: vec![0, 0],
-            kind: BindingKind::Text {
-                segments: vec![Segment::Field("this".into())],
-            },
-        };
-        assert_eq!(this_repeat_root(&[text_this]), None);
+    fn it_splits_chrome_from_the_repeat_body() {
+        // <tonk-sheet title={title}>      [0]     chrome (renders once)
+        //   <tr subject={this}>           [0, 0]  repeat element
+        //     <td>{name}</td>             [0, 0, 0, 0]
+        // The title binding stays chrome; the row binding rebases under
+        // the repeat element. Each side is planned independently so the
+        // cardinality-one title does not wrap the repeated row.
+        let plan = split_plan(
+            vec![
+                attr_binding(&[0], "title", "title"),
+                text_binding(&[0, 0, 0, 0], "name"),
+            ],
+            Some(vec![0, 0]),
+        );
+
+        assert_eq!(plan.repeat.path, Some(vec![0, 0]));
+        // Chrome holds the title — one iteration root at [0].
+        assert_eq!(plan.chrome.len(), 1);
+        assert_eq!(node_path(&plan.chrome[0]), &[0usize][..]);
+        // Body holds the name, rebased relative to the <tr>: the text
+        // node was [0,0,0,0], now [0,0]; its iteration root [0].
+        assert_eq!(plan.repeat.body.len(), 1);
+        assert_eq!(node_path(&plan.repeat.body[0]), &[0usize][..]);
     }
 
     #[dialog_common::test]
-    fn it_ignores_this_in_a_mixed_attribute_value() {
-        // <a href="/entity/{this}"> — a URL substitution in a detail
-        // template, NOT a directory repeat boundary. The value mixes
-        // literal text with {this}, so it must not mark a repeat root.
-        let href = Binding {
-            path: vec![0],
-            kind: BindingKind::Attribute {
-                attr_name: "href".into(),
-                segments: vec![
-                    Segment::Text("/entity/".into()),
-                    Segment::Field("this".into()),
-                ],
-                force_attribute: false,
-            },
-        };
-        assert_eq!(this_repeat_root(&[href]), None);
-    }
-
-    #[dialog_common::test]
-    fn it_picks_the_outermost_this_marker_as_the_repeat_root() {
-        // `{this}` bound at two nesting levels: the OUTERMOST
-        // (shallowest) element is the repeat boundary; the inner
-        // marker falls inside its per-row clone.
-        let root = this_repeat_root(&[
-            attr_binding(&[0, 1, 0], "data-subject", "this"),
-            attr_binding(&[0, 0], "data-subject", "this"),
-        ]);
-        assert_eq!(root, Some(vec![0, 0]));
+    fn it_puts_everything_in_the_body_when_the_fragment_repeats() {
+        // No repeat element: the whole fragment is the clone. Every
+        // binding is body, paths unchanged, RepeatPlan::path stays None.
+        let plan = split_plan(vec![text_binding(&[0, 0], "count")], None);
+        assert!(plan.chrome.is_empty());
+        assert_eq!(plan.repeat.path, None);
+        assert_eq!(plan.repeat.body.len(), 1);
     }
 }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -1220,11 +1220,19 @@ mod dom {
             let snapshot = snapshot_template(&host).expect("snapshot");
             let plan = extract_plan(&snapshot.fragment);
             // Only the `{title}` text binding — nothing from the CSS.
+            // `{title}` is a subject field with no `{this}`, so the
+            // fragment root repeats and the binding lives in the repeat
+            // body; chrome is empty.
+            assert!(
+                plan.chrome.is_empty(),
+                "expected no chrome, got {:?}",
+                plan.chrome,
+            );
             assert_eq!(
-                plan.nodes.len(),
+                plan.repeat.body.len(),
                 1,
                 "expected one plan node (the span's title), got {:?}",
-                plan.nodes,
+                plan.repeat.body,
             );
             // The stylesheet text is untouched.
             let style = snapshot

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -572,10 +572,10 @@ mod dom {
             if el.local_name() == "template" {
                 return Some(el);
             }
-            if !is_template_owning_component(&el) {
-                if let Some(found) = find_template(&el) {
-                    return Some(found);
-                }
+            if !is_template_owning_component(&el)
+                && let Some(found) = find_template(&el)
+            {
+                return Some(found);
             }
             child = el.next_element_sibling();
         }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -758,6 +758,36 @@ mod dom {
     ///
     /// Mutates `fragment` in place.
     pub fn extract_plan(fragment: &DocumentFragment) -> BindingPlan {
+        let bindings = collect_bindings(fragment);
+        // Fold flat bindings into the iteration-aware plan tree, then
+        // split it around the per-conclusion repeat element. Iteration
+        // roots inside the body are discovered by the LCA of every
+        // binding referencing the same field. The fold and split are
+        // pure (operate on the collected `bindings` vec), which is why
+        // they live outside the wasm-only `dom` module and get
+        // unit-tested natively.
+        let repeat_root = super::this_repeat_root(&bindings);
+        super::split_plan(bindings, repeat_root)
+    }
+
+    /// Like [`extract_plan`] but for a **self-repeating** consumer
+    /// (`<tonk-concept>`) that clones the whole template per conclusion
+    /// itself. It does not want the `{this}` chrome/repeat split — a
+    /// subject ref like `model={model}` would otherwise make the
+    /// fragment-root element the repeat node and rebase every binding's
+    /// path relative to it, which the whole-fragment-cloning concept
+    /// renderer would then mis-navigate. Forcing `repeat_root = None`
+    /// keeps every node in `repeat.body` with fragment-relative paths.
+    pub fn extract_row_plan(fragment: &DocumentFragment) -> BindingPlan {
+        let bindings = collect_bindings(fragment);
+        super::split_plan(bindings, None)
+    }
+
+    /// Walk a fragment, split interpolated text nodes into per-segment
+    /// text nodes (mutating `fragment` in place), and return the flat
+    /// list of bindings. Shared by [`extract_plan`] and
+    /// [`extract_row_plan`].
+    fn collect_bindings(fragment: &DocumentFragment) -> Vec<Binding> {
         let mut bindings: Vec<Binding> = Vec::new();
         // (Path, NodeKind) snapshot — collect first, mutate after,
         // because mutating during walk invalidates the iterator.
@@ -893,15 +923,7 @@ mod dom {
             }
         }
 
-        // Fold flat bindings into the iteration-aware plan tree, then
-        // split it around the per-conclusion repeat element. Iteration
-        // roots inside the body are discovered by the LCA of every
-        // binding referencing the same field. The fold and split are
-        // pure (operate on the collected `bindings` vec), which is why
-        // they live outside the wasm-only `dom` module and get
-        // unit-tested natively.
-        let repeat_root = super::this_repeat_root(&bindings);
-        super::split_plan(bindings, repeat_root)
+        bindings
     }
 
     /// Walk a node and its descendants, calling `visit(path, node)`
@@ -1254,7 +1276,7 @@ mod dom {
 
 #[cfg(target_arch = "wasm32")]
 pub use dom::{
-    Snapshot, apply_attribute_binding, extract_plan, navigate, render_segments,
+    Snapshot, apply_attribute_binding, extract_plan, extract_row_plan, navigate, render_segments,
     render_segments_with_shadow, single_field_value, snapshot_template,
 };
 

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -130,6 +130,14 @@ pub struct BindingPlan {
     /// (introduced for cardinality-many fields) contain nested
     /// bindings whose paths are relative to the root.
     pub nodes: Vec<PlanNode>,
+    /// The per-conclusion **repeat root**: the template path of the
+    /// outermost element that binds `{this}` (e.g.
+    /// `<tr data-subject={this}>`). The renderer clones *this element*
+    /// once per matched conclusion and renders everything outside it
+    /// once as chrome. `None` (no element binds `{this}`) means the
+    /// whole fragment is the repeat root — the entire template clones
+    /// per conclusion. See `tonk-core/docs/templates.md`.
+    pub repeat_root: Option<Vec<usize>>,
 }
 
 /// One node in the binding tree. Plain `Binding` nodes are
@@ -194,12 +202,14 @@ pub fn longest_common_path_prefix(paths: &[Vec<usize>]) -> Vec<usize> {
 /// ensures one field per text node); an attribute binding can
 /// mix multiple `{X}` placeholders, all collected here.
 ///
-/// `{this}` is **not** a real field — it's a reserved placeholder
-/// for the entity URI, always scalar, always single. Exclude it
-/// from iteration-root discovery so a template like
-/// `<a href="/entity/{this}">` doesn't get treated as a
-/// cardinality-many iteration target. The substituter still
-/// resolves `{this}` directly off the conclusion.
+/// `{this}` is **not** a field-iteration target — it's the root
+/// scope (one instance per matched conclusion), handled by the
+/// renderer's per-conclusion loop rather than `PlanNode::Iteration`.
+/// Excluding it here keeps a template like `<a href="/x/{this}">`
+/// from being treated as a cardinality-many field. The element that
+/// binds `{this}` becomes the per-conclusion *repeat root* (so
+/// surrounding chrome renders once); that is discovered separately.
+/// See `tonk-core/docs/templates.md`.
 pub fn binding_fields(binding: &Binding) -> Vec<String> {
     let segments = match &binding.kind {
         BindingKind::Text { segments } => segments,
@@ -215,6 +225,43 @@ pub fn binding_fields(binding: &Binding) -> Vec<String> {
         }
     }
     out
+}
+
+/// Whether a binding is an attribute whose value is *exactly*
+/// `{this}` — the marker that makes its element a repeat root.
+///
+/// The attribute *name* is irrelevant (`subject={this}`,
+/// `data-with={this}`, `for={this}` are all equivalent); only the
+/// `{this}` reference matters. It must be an attribute (text nodes
+/// are value output, not iteration markers) AND a bare single
+/// `{this}` segment: a mixed value like `href="/entity/{this}"` is a
+/// URL substitution in a *detail* template, not a directory repeat
+/// boundary, so it must not count.
+fn is_this_repeat_marker(binding: &Binding) -> bool {
+    let BindingKind::Attribute { segments, .. } = &binding.kind else {
+        return false;
+    };
+    matches!(segments.as_slice(), [Segment::Field(name)] if name == "this")
+}
+
+/// Locate the per-conclusion **repeat root**: the element with an
+/// attribute whose value is exactly `{this}` (the attribute name is
+/// arbitrary, e.g. `<tr subject={this}>` or `<li for={this}>`). The
+/// renderer clones that element per matched conclusion; everything
+/// outside it is render-once chrome.
+///
+/// The **outermost** `{this}` marker sets the repeat boundary. When
+/// `{this}` is bound at several nesting levels, the shallowest element
+/// is the repeat root and any inner markers fall inside its per-row
+/// clone — the repeat point is the outer one, not the deepest. The
+/// shallowest (then earliest) path wins. `None` ⇒ nothing marks a
+/// repeat root ⇒ the whole fragment repeats per conclusion.
+pub fn this_repeat_root(bindings: &[Binding]) -> Option<Vec<usize>> {
+    bindings
+        .iter()
+        .filter(|b| is_this_repeat_marker(b))
+        .map(host_element_path)
+        .min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
 }
 
 /// The path of the smallest enclosing element containing a
@@ -703,8 +750,10 @@ mod dom {
         // pure (operates on the collected `bindings` vec), which
         // is why the helper lives outside the wasm-only `dom`
         // module and gets unit-tested natively.
+        let repeat_root = super::this_repeat_root(&bindings);
         BindingPlan {
             nodes: super::build_plan_nodes(bindings),
+            repeat_root,
         }
     }
 
@@ -1342,5 +1391,76 @@ mod tests {
             }
             other => panic!("expected outer list iteration, got {other:?}"),
         }
+    }
+
+    // --- repeat-root ({this}) discovery ----------------------------------
+
+    #[dialog_common::test]
+    fn it_has_no_repeat_root_when_this_is_unbound() {
+        // A detail template that never binds {this}: the whole
+        // fragment is the repeat root (None ⇒ clone-whole-fragment).
+        let root = this_repeat_root(&[
+            text_binding(&[0, 0], "title"),
+            text_binding(&[1, 0], "summary"),
+        ]);
+        assert_eq!(root, None);
+    }
+
+    #[dialog_common::test]
+    fn it_finds_the_element_that_binds_this_in_an_attribute() {
+        // <table>                     [0]
+        //   <tbody>                   [0, 0]
+        //     <tr data-subject={this}>  [0, 0, 0]  attr
+        //       <td>{title}</td>      [0, 0, 0, 0, 0] text
+        // The <tr> at [0, 0, 0] is the repeat root.
+        let root = this_repeat_root(&[
+            attr_binding(&[0, 0, 0], "data-subject", "this"),
+            text_binding(&[0, 0, 0, 0, 0], "title"),
+        ]);
+        assert_eq!(root, Some(vec![0, 0, 0]));
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_this_in_text_for_repeat_root() {
+        // `{this}` in a bare text node is value output, not an
+        // iteration marker.
+        let text_this = Binding {
+            path: vec![0, 0],
+            kind: BindingKind::Text {
+                segments: vec![Segment::Field("this".into())],
+            },
+        };
+        assert_eq!(this_repeat_root(&[text_this]), None);
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_this_in_a_mixed_attribute_value() {
+        // <a href="/entity/{this}"> — a URL substitution in a detail
+        // template, NOT a directory repeat boundary. The value mixes
+        // literal text with {this}, so it must not mark a repeat root.
+        let href = Binding {
+            path: vec![0],
+            kind: BindingKind::Attribute {
+                attr_name: "href".into(),
+                segments: vec![
+                    Segment::Text("/entity/".into()),
+                    Segment::Field("this".into()),
+                ],
+                force_attribute: false,
+            },
+        };
+        assert_eq!(this_repeat_root(&[href]), None);
+    }
+
+    #[dialog_common::test]
+    fn it_picks_the_outermost_this_marker_as_the_repeat_root() {
+        // `{this}` bound at two nesting levels: the OUTERMOST
+        // (shallowest) element is the repeat boundary; the inner
+        // marker falls inside its per-row clone.
+        let root = this_repeat_root(&[
+            attr_binding(&[0, 1, 0], "data-subject", "this"),
+            attr_binding(&[0, 0], "data-subject", "this"),
+        ]);
+        assert_eq!(root, Some(vec![0, 0]));
     }
 }

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -38,6 +38,21 @@ concept!: &view
       cardinality: one
       as: text
 
+concept!: &view/directory
+  this: tonk:view/directory
+  description: A directory view used by tonk-display when entity is not set.
+  with:
+    model:
+      description: Concept this view renders
+      the: xyz.tonk.view/model
+      cardinality: one
+      as: entity
+    display:
+      description: HTML template for the view
+      the: xyz.tonk.view/directory
+      cardinality: one
+      as: text
+
 # ============================================================
 # WORKSPACE
 # ============================================================
@@ -544,27 +559,162 @@ concept!: &portal
 # `subject={field}` and bottoms out in the tile's content display.
 
 view!:
+  this: tonk:board
   model: board-view
   display: |
     <tonk-strip>
+      <style>
+        /* Board layout travels with the view, so any route that
+           mounts `model=board-view` renders the strip identically
+           (board route, bare display route, embedded tile). The
+           only thing a route still owns is giving this view a
+           full-height box to fill: the strip's `block-size: 100%`
+           resolves against whatever height its host establishes.
+
+           The `tonk-display`/`tonk-view` layers that wrap each
+           level are pure rendering wrappers, not layout boxes;
+           `display: contents` makes them transparent so the strip
+           is a flex container over real `<tonk-column>` items, and
+           so the strip itself inherits its host's height instead of
+           collapsing to content. */
+        tonk-display:has(> tonk-view > tonk-strip),
+        tonk-display > tonk-view:has(> tonk-strip) {
+          display: contents;
+        }
+
+        tonk-strip {
+          --pitch: 16px;
+          --cell: 64px;
+          /* Narrow gutter between columns — just enough that the
+             contrasting strip fill reads as a seam. */
+          --gap: 4px;
+
+          display: flex;
+          flex-direction: row;
+          align-items: stretch;
+          gap: var(--gap);
+          padding: 0;
+          box-sizing: border-box;
+          block-size: 100%;
+          inline-size: 100%;
+          overflow-x: auto;
+          overflow-y: hidden;
+          scroll-snap-type: x proximity;
+          /* The strip's fill shows through every seam — between
+             columns AND between tiles within a column (since
+             `<tonk-column>` is transparent). The neutral-fill token
+             adapts with dark / light mode. */
+          background-color: var(--wa-color-neutral-fill-normal);
+        }
+
+        /* The `tonk-display`/`tonk-view` wrappers between the strip
+           and each column are transparent to the strip's flex flow,
+           so each `<tonk-column>` is a direct flex item (its
+           `flex: 0 0 calc(--col-w * --cell)` sizes the column, not
+           the wrapping display). */
+        tonk-strip > tonk-display,
+        tonk-strip > tonk-display > tonk-view {
+          display: contents;
+        }
+      </style>
       <tonk-display entity={column} model=column-view />
     </tonk-strip>
 
 view!:
+  this: tonk:board/column
   model: column-view
   display: |
     <tonk-column style="--col-w: {width};">
+      <style>
+        tonk-column {
+          /* Width is driven by `--col-w` set on the element by this
+             template (one --cell unit is 64px). Tiles stack
+             top-to-bottom inside; overflow is handled here at the
+             column level so the column's dot-grid background scrolls
+             together with the tiles. */
+          flex: 0 0 calc(var(--col-w, 12) * 64px);
+          block-size: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          overflow-y: auto;
+          overflow-x: hidden;
+          scroll-snap-align: start;
+          min-block-size: 0;
+          /* Transparent so the strip's seam fill shows through the
+             column-to-column and tile-to-tile gaps. The column's
+             grid layer still paints (a `background-image`, not a
+             fill) against whatever the strip provides underneath. */
+          background-color: transparent;
+        }
+
+        tonk-column::-webkit-scrollbar { display: none; }
+
+        /* Tiles size to their content along the column's main axis
+           and stack top-to-bottom. Overflow happens at the COLUMN
+           level (the column is the scroller), never inside a tile,
+           so a tile renders its content unclipped and the user
+           scrolls the whole column. Tiles paint the dark canvas
+           fill; the gaps expose the strip's lighter seam fill. */
+        tonk-column > .tile {
+          flex: 0 0 auto;
+          inline-size: 100%;
+          box-sizing: border-box;
+          background-color: var(--wa-color-neutral-fill-quiet);
+
+          /* Two-layer engineering graph-paper background, applied to
+             each tile (the surface the dark canvas occupies). The
+             grid travels with the tile content because the tile is
+             the visible canvas. `background-attachment: local` ties
+             the grid to the column's scroll so the dots travel with
+             vertical scroll. */
+          --dot-gap: 16px;
+          --dot-size-dim: 0.5px;
+          --dot-size-bright: 0.5px;
+          --dot-color-dim: color-mix(in oklab, currentColor 16%, transparent);
+          --dot-color-bright: color-mix(in oklab, currentColor 25%, transparent);
+          background-image:
+            radial-gradient(
+              circle,
+              var(--dot-color-bright) var(--dot-size-bright),
+              transparent calc(var(--dot-size-bright) + 0.5px)
+            ),
+            radial-gradient(
+              circle,
+              var(--dot-color-dim) var(--dot-size-dim),
+              transparent calc(var(--dot-size-dim) + 0.5px)
+            );
+          background-size:
+            calc(var(--dot-gap) * 4) calc(var(--dot-gap) * 4),
+            var(--dot-gap) var(--dot-gap);
+          background-position:
+            calc(var(--dot-gap) * -2) calc(var(--dot-gap) * -2),
+            calc(var(--dot-gap) / -2) calc(var(--dot-gap) / -2);
+          background-attachment: local;
+        }
+
+        /* The inner `<tonk-display>` participates in the column's
+           scroll — it must NOT clip or scroll on its own. */
+        tonk-column > .tile > tonk-display,
+        tonk-column > .tile > tonk-display > tonk-view {
+          display: block;
+          inline-size: 100%;
+          overflow: visible;
+        }
+      </style>
       <div class="tile" subject={tile}>
         <tonk-display entity={tile} model=tile />
       </div>
     </tonk-column>
 
 view!:
+  this: tonk:board/tile
   model: tile
   display: |
     <tonk-display entity={entity} model={model} />
 
 view!:
+  this: tonk:inspector-view
   model: inspector-view
   display: |
     <tonk-inspector source={source} />
@@ -577,6 +727,7 @@ view!:
 # `<tonk-display model=portal>` over a portal entity resolves it by
 # model and renders it.
 view!:
+  this: tonk:portal
   model: portal
   display: |
     <tonk-portal html:content={content} html:height={height} />
@@ -924,17 +1075,17 @@ workspace/sheet!:
 # selected as the initial active sheet (a click on a tab re-points
 # `active` via the activate-sheet command + rule).
 workspace!:
-  this: work:space
+  this: about:blank
   name: "Trip planning"
   active: id:tonk-workspace/sheet/itinerary
   sheet: id:tonk-workspace/sheet/itinerary
 
 workspace!:
-  this: work:space
+  this: about:blank
   sheet: id:tonk-workspace/sheet/lodging
 
 workspace!:
-  this: work:space
+  this: about:blank
   sheet: id:tonk-workspace/sheet/sketch
 
 # A single-tile `demo` board: one column with one tile hosting
@@ -951,14 +1102,101 @@ tile!: &inspector-tile
   model: inspector-view
   entity: home-inspector
 
-column-view!: &demo-column
+tile!: &workspace-tile
+  order: "b"
+  model: workspace
+  entity: about:blank
+
+
+
+column-view!: &column-b
+  this: c:b
+  order: "aq"
+  width: 19
+  tile: workspace-tile
+
+column-view!: &column-a
+  this: c:a
   order: "a"
   width: 12
   tile: inspector-tile
 
 board-view!: &demo-board
+  this: about:blank
   name: "demo"
-  column: demo-column
+  column: column-a
+
+board-view!:
+  this: about:blank
+  column: column-b
 
 
 # test
+
+concept!: &db/session:
+  this: concept:session
+  description: Database session information
+  with:
+    profile:
+      description: |
+          Profile entity (as did:key) representing persistent identity on this device
+      the: dialog.session/profile
+      as: entity
+    operator:
+      description: |
+          Operator entity (as did:key) representing an identifier used in this session to query and commit
+      the: dialog.session/operator
+      as: entity
+    branch:
+      description: |
+          Active branch(es) in this session. Can be multiple when overlays are used.
+      the: dialog.session/branch
+      as: entity
+      cardinality: many
+
+concept!: &db/origin:
+  this: concept:origin
+  description: |
+      Entity representing unique identifier for the active repository on this device.
+
+      It can be used to assert/query device specific information.
+  with:
+    subject:
+      description: |
+          The repository subject (as did:key) representing it's unique identifier
+      the: dialog.origin/subject
+      as: entity
+    profile:
+      description: |
+          Profile entity (as did:key) representing persistent identity on this device
+      the: dialog.origin/profile
+      as: entity
+
+concept!: &db/branch:
+  this: concept:branch
+  description: |
+      This represents a branch on some origin.
+       Note that individual replicas can create same named branches and they
+       likely going to be an different revisions, which is why branch is unique
+       per origin as opposed to per repository.
+  with:
+    name:
+      description: The branch name
+      the: dialog.branch/name
+      as: text
+    origin:
+      description: The origin of this branch
+      the: dialog.branch/origin
+      as: entity
+    tree:
+      description: The tree root of this branch
+      the: dialog.branch/tree
+      as: entity
+    period:
+      description: Synchronization point with an upstream
+      the: dialog.branch/period
+      as: entity
+    moment:
+      description: Number of commits made since last synchronization
+      the: dialog.branch/moment
+      as: entity

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -53,6 +53,24 @@ concept!: &view/directory
       cardinality: one
       as: text
 
+# The default directory view: `model: _:_` matches any model with no
+# specific `view/directory`. <tonk-display> with no `entity` resolves a
+# directory view for the model first; finding none, it falls back to
+# this. It renders the model's instances in a <wa-carousel>, one slide
+# per instance, each a nested single-entity <tonk-display> (which then
+# resolves its own view, or this default's detail counterpart). The
+# nested `model` is threaded from the host via `{dom.host/model}`,
+# since an instance carries no pointer to its own model.
+view/directory!:
+  this: id:tonk:view/directory/default
+  model: _:_
+  display: |
+    <wa-carousel navigation>
+      <wa-carousel-item subject={this}>
+        <tonk-display entity={this} model={dom.host/model} />
+      </wa-carousel-item>
+    </wa-carousel>
+
 # ============================================================
 # WORKSPACE
 # ============================================================
@@ -1200,3 +1218,25 @@ concept!: &db/branch:
       description: Number of commits made since last synchronization
       the: dialog.branch/moment
       as: entity
+
+concept!: &person
+  description: Person
+  with:
+    name:
+      description: Name of the person
+      the: xyz.tonk.person/name
+      as: text
+    age:
+      description: Age of the person
+      the: xyz.tonk.person/age
+      as: text
+
+person!:
+   name: Alice
+   age: 3
+
+person!:
+  name: Bob
+  age: 40
+
+## V4

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -65,7 +65,7 @@ view/directory!:
   this: id:tonk:view/directory/default
   model: _:_
   display: |
-    <wa-carousel class="vertical" pagination orientation="vertical">
+    <wa-carousel class="vertical seamless" pagination orientation="vertical">
       <wa-carousel-item subject={this}>
         <tonk-display entity={this} model={dom.host/model} />
       </wa-carousel-item>

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -65,7 +65,7 @@ view/directory!:
   this: id:tonk:view/directory/default
   model: _:_
   display: |
-    <wa-carousel navigation>
+    <wa-carousel class="vertical" pagination orientation="vertical">
       <wa-carousel-item subject={this}>
         <tonk-display entity={this} model={dom.host/model} />
       </wa-carousel-item>

--- a/rust/tonk-core/docs/templates.md
+++ b/rust/tonk-core/docs/templates.md
@@ -1,0 +1,219 @@
+# View templates: interpolation, iteration, and directories
+
+This documents the template language that `<tonk-display>` and
+`<tonk-concept>` share: how an HTML template with `{placeholder}`
+holes is filled from a concept's fields, how cardinality-many fields
+make a subtree repeat, and how a single template renders either *one*
+entity or a *directory* of many.
+
+The engine lives in `tonk-concept` (`template.rs` plans, `render.rs`
+diffs into the DOM); `tonk-display` runs the same algorithm for its
+single-entity case. This doc lives in `tonk-core` because the model is
+grounded in `tonk-core`'s `conclusion` primitive, which is the unit a
+template renders.
+
+## The shape of a template
+
+A view's `display` field is an HTML fragment with `{field}` holes:
+
+```html
+<article>
+  <h1>{title}</h1>
+  <p>{summary}</p>
+</article>
+```
+
+Each hole names a field of the concept being rendered (a key in the
+concept's `with:` map), plus the reserved name `{this}` for the
+subject's own entity URI. A hole may appear in text (`<h1>{title}</h1>`)
+or in an attribute value (`<a href="/x/{this}">`, `data-id={this}`).
+
+Rendering binds the holes from a **conclusion** — the result of
+evaluating the concept against a subject:
+
+```
+conclusion.this    = the subject entity URI
+conclusion.fields  = { title: "...", summary: "...", ... }
+```
+
+`{this}` resolves to `conclusion.this`; `{field}` resolves to
+`conclusion.fields[field]`.
+
+## Cardinality drives iteration
+
+A field declared `cardinality: many` holds a *list* of values, not a
+scalar. The engine renders a many-field by **repeating the smallest
+subtree that contains the hole**, once per value:
+
+```html
+<ul>
+  <li>{ingredient}</li>   <!-- ingredient is cardinality-many -->
+</ul>
+```
+
+renders as one `<ul>` with one `<li>` per ingredient. The `<li>` is the
+**iteration root**: the outermost element whose content depends on the
+many-valued field, cloned per value.
+
+The rule that picks the iteration root is purely structural (it does
+*not* consult the descriptor at plan time):
+
+1. For each field referenced in the template, collect the host element
+   of every hole that mentions it (the smallest enclosing element).
+2. Take the **longest common ancestor** of those host elements. That
+   element is the field's single iteration root, and every hole
+   referencing the field is nested inside it.
+3. If two holes for the same field have no shared inner ancestor (they
+   are independent siblings), each becomes its own iteration root and
+   repeats independently.
+
+At **render** time the engine looks at the actual value: an
+`Ipld::List` iterates (one clone per item), a scalar renders once. So
+cardinality is observed from the data, not hard-coded in the plan — a
+`cardinality: one` field is simply the degenerate case that iterates
+exactly once.
+
+Inside a repeated clone, the iterating field is *shadowed* to the
+current item: `{ingredient}` resolves to this clone's value, while
+fields from the enclosing scope (e.g. `{title}`) stay visible. `{this}`
+inside the clone still refers to the subject (see below).
+
+### Choosing what repeats
+
+The iteration root is the *outermost* element that references the
+many-field, so you control the repeated unit by where you place the
+hole. Given a cardinality-many `step` field, to repeat list items but
+not the list:
+
+```html
+<ol class="recipe">
+  <li>{step}</li>
+</ol>
+```
+
+The `<li>` is the iteration root; the `<ol>` renders once and one `<li>`
+appears per step. Lift the hole to a wrapping element if you want a
+larger unit (e.g. a `<li>` containing several holes of the same field
+collapses to one `<li>` per value via the longest-common-ancestor
+rule).
+
+## `{this}` is the root scope, not a field
+
+`{this}` is the subject — the entity a conclusion is *about*. It is
+distinct from the cardinality-many field iteration above: a many-field
+repeats a subtree over a list of values *within one conclusion*, while
+`{this}` is the **root scope**, one instance per *conclusion*. The
+renderer already loops over a frame of conclusions and renders one unit
+per conclusion, keyed by `this`. That per-conclusion loop *is* the
+`this` iteration; views don't normally bind `{this}` to express it.
+
+A **directory** of N subjects is just N conclusions. To render them
+into one outer structure (a table, a list) with shared chrome, a
+template names the element that should repeat by binding `{this}` on it:
+
+```html
+<table>
+  <thead><tr><th>title</th></tr></thead>
+  <tbody>
+    <tr subject={this}>          <!-- the repeat root -->
+      <td>{title}</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+The element that binds `{this}` is the **repeat root**: everything
+outside it (`<table>`, `<thead>`, `<tbody>`) renders **once** as chrome,
+and the repeat root clones **once per conclusion**, each clone resolving
+`{this}`/`{field}` against its conclusion.
+
+The marker is *any attribute on the element whose value is exactly
+`{this}`* — the attribute's name doesn't matter (`subject={this}`,
+`data-with={this}`, `for={this}` are equivalent) and neither does the
+element (`<tr>`, `<li>`, `<div>`). What counts is that an attribute
+binds `{this}`, which is what lifts that element to be the repeat root.
+Use an attribute rather than a bare `{this}` text node so the whole
+element repeats, not just a text node inside it; a mixed value like
+`href="/x/{this}"` is a URL substitution, not a marker, so it does not
+lift a repeat root.
+
+When a template binds **no** `{this}`, the repeat root defaults to the
+whole fragment — the entire template clones per conclusion (the
+`<tonk-concept>` behavior that predates this). And in a **single-entity**
+render there is exactly one conclusion, so the template renders once
+whether or not it binds `{this}`. Single-entity is the one-conclusion
+case of the same per-conclusion loop.
+
+## Two renderers, one entity vs. a directory
+
+`<tonk-display>` resolves which view (template) to use by querying a
+`view` concept whose `model` matches the subject's model, then renders:
+
+- **Single entity** — `entity` attribute set. The query pins
+  `conclusion.this` to that one URI; the template renders once. Any
+  `{this}` iteration runs over a one-element set.
+
+- **Directory** — `entity` attribute *not* set. There is no single
+  subject, so the engine resolves a **directory view** for the model
+  (a `tonk:view/directory` whose template lives under
+  `xyz.tonk.view/directory`) and runs a query for *all* instances of
+  the model. The matched subjects arrive as a frame of N conclusions
+  (one per instance). The directory template's chrome renders once and
+  its `{this}` repeat root (the `<tr>`) clones per conclusion.
+
+  If no `tonk:view/directory` is defined for the model,
+  `<tonk-display>` falls back to a synthesized table (one column per
+  descriptor field, one row per instance) — the same default the
+  concept route renders today. A richer finder/spotlight fallback can
+  replace the table later without changing any view that ships its own
+  directory template.
+
+The `view` concept (`tonk:view`) and the directory view concept
+(`tonk:view/directory`) differ only in which attribute carries the
+template (`xyz.tonk.view/display` vs `xyz.tonk.view/directory`), so a
+model can declare a detail view and a directory view independently,
+both keyed by `model`.
+
+## Worked example
+
+A `trip` concept with `title` (one) and `stop` (many). Detail view:
+
+```yaml
+view!:
+  model: trip
+  display: |
+    <section>
+      <h1>{title}</h1>
+      <ol>
+        <li data-stop={stop}>{stop}</li>
+      </ol>
+    </section>
+```
+
+Rendered for one trip: one `<section>`, one `<h1>`, and one `<li>` per
+stop.
+
+Directory view over *all* trips:
+
+```yaml
+view/directory!:
+  model: trip
+  directory: |
+    <table>
+      <thead><tr><th>trip</th><th>title</th></tr></thead>
+      <tbody>
+        <tr subject={this}>
+          <td>{this}</td>
+          <td>{title}</td>
+        </tr>
+      </tbody>
+    </table>
+```
+
+`<tonk-display model=trip>` (no `entity`) runs the all-trips query and
+gets one conclusion per trip. The `<table>` chrome renders once; the
+`<tr subject={this}>` repeat root clones once per conclusion, each
+row's `{this}`/`{title}` resolving to that trip. The same template
+language; the only difference from a detail view is that the frame
+carries many conclusions instead of one, and the template names which
+element repeats.

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -38,7 +38,10 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, Node, window};
 
-use crate::resolve::{entity_query, looks_like_uri, view_by_model_query, view_predicate};
+use crate::resolve::{
+    directory_view_predicate, entity_query, instances_query, looks_like_uri, view_by_model_query,
+    view_predicate,
+};
 use crate::state::{self, State};
 
 /// Sentinel `view` value that selects carousel mode — enumerate
@@ -139,6 +142,24 @@ struct Inner {
     /// The resolved model entity, surfaced to the portal as its `model`
     /// attribute (the bridge's `context.model`).
     portal_model: Option<String>,
+    /// The view-concept descriptor used to resolve a view by model.
+    /// Retained so the `_:_` default-view fallback can re-query against
+    /// the same view concept when the model-specific view frame is
+    /// empty.
+    view_descriptor: Option<serde_json::Value>,
+    /// The resolved model entity (`model_entity`), retained for the
+    /// `_:_` fallback query and for comparison.
+    model_entity: Option<String>,
+    /// True when the currently-mounted slide came from the `_:_`
+    /// default view rather than a model-specific view. A non-empty
+    /// model-specific view frame replaces it (the specific view takes
+    /// over); set false then.
+    default_slide: bool,
+    /// Directory mode: `true` when the host has no `entity`, so the
+    /// entity subscription matches every instance of the model (`this`
+    /// unbound) and the frame is grouped by `this` (`select_rows`)
+    /// rather than folded to one conclusion.
+    directory: bool,
 }
 
 impl Inner {
@@ -158,6 +179,10 @@ impl Inner {
             depth_annotator: None,
             portal_descriptor: None,
             portal_model: None,
+            view_descriptor: None,
+            model_entity: None,
+            default_slide: false,
+            directory: false,
         }
     }
 
@@ -444,18 +469,19 @@ async fn run(
     state: Rc<RefCell<Inner>>,
     generation: u64,
 ) -> Result<(), ErrorDetail> {
-    let entity = host
-        .get_attribute("entity")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            ErrorDetail::new(ErrorKind::Descriptor, "<tonk-display> requires `entity`")
-        })?;
-    if !looks_like_uri(&entity) {
+    // `entity` is optional. Present → single mode: render that one
+    // entity. Absent → directory mode: render every instance of the
+    // model (`this` unbound) through the model's directory view.
+    let entity = host.get_attribute("entity").filter(|s| !s.is_empty());
+    if let Some(entity) = &entity
+        && !looks_like_uri(entity)
+    {
         return Err(ErrorDetail::new(
             ErrorKind::Descriptor,
             "`entity` must be an entity URI (contain `:`)",
         ));
     }
+    let directory = entity.is_none();
 
     // The `view` attribute names a view *concept* (named or URI);
     // when omitted, the built-in `view` concept (`tonk:view`) is
@@ -498,6 +524,11 @@ async fn run(
     // attribute that view kind declares it under, so `view_by_model`
     // reads the right template regardless of the kind.
     let view_descriptor: serde_json::Value = match view.as_deref() {
+        // No explicit `view`: the built-in detail view (`tonk:view`) in
+        // single mode, or the directory view (`tonk:view/directory`) in
+        // directory mode. Both fall back to their `_:_` default when
+        // the model has no specific view of that kind.
+        None if directory => directory_view_predicate(),
         None => view_predicate(),
         Some(view_ref) => {
             let (_, view_descriptor_json) = resolve_model(host, view_ref).await?;
@@ -512,8 +543,13 @@ async fn run(
     })?;
     let view_body = to_body(&view_q)?;
 
-    let entity_q = entity_query(&descriptor_json, &entity)
-        .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
+    // Single mode pins `this` to the entity; directory mode leaves
+    // `this` unbound so the query matches every instance of the model.
+    let entity_q = match &entity {
+        Some(entity) => entity_query(&descriptor_json, entity),
+        None => instances_query(&descriptor_json),
+    }
+    .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
     let entity_body = to_body(&entity_q)?;
 
     // The view query is model-constrained, so it resolves to one
@@ -542,6 +578,12 @@ async fn run(
         }
         s.view_sub = Some(view_sub);
         s.entity_sub = Some(entity_sub);
+        s.directory = directory;
+        // Retained for the `_:_` default-view fallback: if the
+        // model-specific view frame is empty, `handle_view_frame`
+        // re-queries the same view concept with `model = _:_`.
+        s.view_descriptor = Some(view_descriptor.clone());
+        s.model_entity = Some(model_entity.clone());
         // Context handed to a `<tonk-portal>` if a view frame routes
         // here in portal mode: the subject's model entity (the
         // bridge's `context.model`) and its descriptor (so the bridge
@@ -645,6 +687,28 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     // the view concept declares it (see `view_by_model_query`), so an
     // ordinary view never trips this; a `display` change just reloads
     // the portal's `content` in place.
+    // No model-specific view resolved: fall back to the `_:_` default
+    // view (a directory carousel, or the notation dump for a detail
+    // view). Re-query the same view concept with `model = _:_` and
+    // render its result. The model-specific subscription stays live, so
+    // if a view for this model is defined later its frame is non-empty
+    // and the branch below mounts it, replacing the default. Skip if
+    // we're already showing the default (avoid re-querying every empty
+    // frame).
+    if conclusions.is_empty() {
+        let need_default = !s.default_slide;
+        drop(s);
+        if need_default {
+            spawn_default_view(host, state);
+        }
+        return;
+    }
+    // A model-specific view arrived: it wins over any default slide.
+    // Clearing the flag lets the normal slide reconciliation below
+    // replace the default `<tonk-view>` (keyed differently) and the
+    // stale default slide is dropped as a vanished key.
+    s.default_slide = false;
+
     if conclusions
         .iter()
         .any(|c| ipld_str(c.fields.get("type")) == Some("text/html"))
@@ -720,6 +784,123 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     schedule_delegate_refresh(host, state);
 
     dispatch_event(host, "tonk-display:template", Some(JsValue::from_str("ok")));
+}
+
+/// The sentinel model entity for a default view: a `view!`/
+/// `view/directory!` declared with `model: _:_` matches any model that
+/// has no specific view of that kind. See `tonk-core/docs/templates.md`.
+const DEFAULT_MODEL: &str = "_:_";
+
+/// Query the `_:_` default view (same view concept, `model = _:_`) and
+/// mount its template as the default slide. Spawned from
+/// `handle_view_frame` when the model-specific view frame is empty. The
+/// model-specific subscription stays live; a later non-empty frame
+/// replaces this default (see the `default_slide` flag).
+fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
+    let descriptor = {
+        let s = state.borrow();
+        s.view_descriptor.clone()
+    };
+    let Some(descriptor) = descriptor else { return };
+
+    let host = host.clone();
+    let state = state.clone();
+    spawn_local(async move {
+        // If the default view can't be built or resolves to nothing,
+        // settle to Empty rather than leaving the element on `loading`
+        // forever — there is genuinely no presentation for this model
+        // (not even the `_:_` default is seeded).
+        let resolved = async {
+            let query = view_by_model_query(&descriptor, DEFAULT_MODEL).ok()?;
+            let body = to_body(&query).ok()?;
+            let result = host_consumer::query(&host, &body).await.ok()?;
+            first_field(&result, "display").ok().flatten()
+        }
+        .await;
+        let Some(display) = resolved else {
+            // No specific view and no `_:_` default view for this model.
+            // If the entity has data, fall back to a notation dump so
+            // it's still inspectable; otherwise settle (the entity
+            // frame decides not-found vs empty).
+            let conclusion = {
+                let s = state.borrow();
+                if s.disposed || s.default_slide || !s.slides.is_empty() {
+                    return;
+                }
+                s.last_conclusion.clone()
+            };
+            if let Some(conclusion) = conclusion {
+                mount_notation_fallback(&host, &state, &conclusion);
+            }
+            return;
+        };
+        // Another frame may have raced ahead while we were querying: if
+        // a model-specific view landed (default_slide cleared with a
+        // slide present), don't clobber it with the default.
+        let mut s = state.borrow_mut();
+        if s.disposed || (!s.default_slide && !s.slides.is_empty()) {
+            return;
+        }
+        // Replace any prior slides with the single default slide.
+        for (_, slide) in std::mem::take(&mut s.slides) {
+            if let Some(parent) = slide.item.parent_node() {
+                let _: Result<Node, _> = parent.remove_child(&slide.item);
+            }
+        }
+        if let Some(slide) = mount_view_slide(&host, &mut s, &display) {
+            if let Some(c) = s.last_conclusion.clone() {
+                let detail = serialize_conclusion(&with_host_attributes(&host, &c));
+                call_render(&slide.view_el, &detail);
+            }
+            s.slides.insert("__default__".to_owned(), slide);
+            s.default_slide = true;
+            state::set(&host, State::Ready);
+        }
+    });
+}
+
+/// Ultimate fallback when an entity has data but its model has no view
+/// (neither a specific view nor the `_:_` default): mount a
+/// `<tonk-notation>` rendering the conclusion as syntax-highlighted
+/// notation, so any entity is at least inspectable. `<tonk-notation>`
+/// is a passive renderer of notation *text* (via a
+/// `<script type="text/tonk-notation">` child), so we format the
+/// conclusion here (the same `notation_format` recipe carousel mode
+/// uses) and write it into that script.
+fn mount_notation_fallback(host: &Element, state: &Rc<RefCell<Inner>>, conclusion: &Conclusion) {
+    let Some(document) = window().and_then(|w| w.document()) else {
+        return;
+    };
+    let (Ok(notation), Ok(script)) = (
+        document.create_element("tonk-notation"),
+        document.create_element("script"),
+    ) else {
+        return;
+    };
+    let _ = script.set_attribute("type", "text/tonk-notation");
+    let head = host
+        .get_attribute("model")
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "concept".to_owned());
+    let text = crate::notation_format::format(&conclusion.this, &conclusion.fields, &head, None);
+    script.set_text_content(Some(&text));
+    let _ = notation.append_child(&script);
+
+    let mut s = state.borrow_mut();
+    if s.disposed || s.default_slide || !s.slides.is_empty() {
+        return;
+    }
+    let _ = host.append_child(&notation);
+    s.slides.insert(
+        "__notation__".to_owned(),
+        Slide {
+            display: String::new(),
+            item: notation.clone(),
+            view_el: notation,
+        },
+    );
+    s.default_slide = true;
+    state::set(host, State::Ready);
 }
 
 /// Diff a portal-mode view frame. Single-mode only, so at most one
@@ -951,9 +1132,23 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
 fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
     let Some(conclusion) = crate::fold::fold_rows(conclusions) else {
         let mut s = state.borrow_mut();
+        let directory = s.directory;
         s.last_conclusion = None;
         clear_host(host, &mut s);
-        state::set(host, State::Empty);
+        drop(s);
+        // Single mode: an empty entity frame means the entity has no
+        // data on this branch — it doesn't exist. Surface a clear
+        // not-found error rather than a silent empty. Directory mode:
+        // an empty frame is simply zero instances, which is Empty.
+        if directory {
+            state::set(host, State::Empty);
+        } else {
+            fail(
+                host,
+                state,
+                ErrorDetail::new(ErrorKind::UnknownSource, "entity not found"),
+            );
+        }
         return;
     };
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -96,10 +96,13 @@ struct Inner {
     /// Cancels the entity subscription on disconnect / attribute
     /// change.
     entity_sub: Option<HostSubscription>,
-    /// Last entity conclusion seen; replayed when a fresh slide
-    /// is mounted so it picks up the current data without waiting
-    /// for the next entity frame.
-    last_conclusion: Option<Conclusion>,
+    /// Last folded entity frame seen; replayed in full when a fresh
+    /// slide mounts so it picks up the current data without waiting for
+    /// the next entity frame. The whole frame matters in directory mode
+    /// (one conclusion per instance) — replaying only the lead would
+    /// drop every instance but the first. The lead conclusion (for
+    /// notation / the result event) is `last_frame.first()`.
+    last_frame: Vec<Conclusion>,
     /// `<wa-carousel>` element when in carousel mode, `None` in
     /// single mode.
     carousel: Option<Element>,
@@ -169,7 +172,7 @@ impl Inner {
             generation: 0,
             view_sub: None,
             entity_sub: None,
-            last_conclusion: None,
+            last_frame: Vec::new(),
             carousel: None,
             slides: BTreeMap::new(),
             notation_source: None,
@@ -252,7 +255,7 @@ impl CustomElement for TonkDisplay {
         {
             let mut s = state.borrow_mut();
             s.abort_all();
-            s.last_conclusion = None;
+            s.last_frame = Vec::new();
             // Tear down any mounted slide / carousel chrome so the
             // restart starts from a clean host.
             clear_host(&host, &mut s);
@@ -737,7 +740,14 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     }
 
     // Add or replace slides.
-    let cached = s.last_conclusion.clone();
+    let cached = s.last_frame.clone();
+    let cached_detail = (!cached.is_empty()).then(|| {
+        let augmented: Vec<Conclusion> = cached
+            .iter()
+            .map(|c| with_host_attributes(host, c))
+            .collect();
+        serialize_conclusions(&augmented)
+    });
     for (name, display) in incoming {
         let existing_matches = s
             .slides
@@ -756,13 +766,13 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
             let _: Result<Node, _> = parent.remove_child(&slide.item);
         }
         if let Some(new_slide) = mount_view_slide(host, &mut s, &display) {
-            // Push the cached entity conclusion if we have one,
-            // so the new slide renders immediately rather than
-            // waiting for the next entity frame. Augment with the
-            // host's `dom.host/*` attributes, matching the live path.
-            if let Some(c) = cached.as_ref() {
-                let detail = serialize_conclusion(&with_host_attributes(host, c));
-                call_render(&new_slide.view_el, &detail);
+            // Replay the cached frame so the new slide renders
+            // immediately rather than waiting for the next entity frame.
+            // The WHOLE frame is replayed — directory mode has one
+            // conclusion per instance, so a single-conclusion replay
+            // would drop every instance but the first.
+            if let Some(detail) = cached_detail.as_ref() {
+                call_render(&new_slide.view_el, detail);
             }
             s.slides.insert(name, new_slide);
         }
@@ -771,10 +781,10 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     // In single mode, mark Ready once the slide is mounted (with
     // or without an entity frame yet — empty content is fine).
     // In carousel mode, ensure the notation slide is fed.
-    if cached.is_some() && !s.slides.is_empty() {
+    if !cached.is_empty() && !s.slides.is_empty() {
         state::set(host, State::Ready);
     }
-    if let Some(c) = cached.as_ref() {
+    if let Some(c) = cached.first() {
         update_notation(host, &s, c);
     }
 
@@ -827,7 +837,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
                 if s.disposed || s.default_slide || !s.slides.is_empty() {
                     return;
                 }
-                s.last_conclusion.clone()
+                s.last_frame.first().cloned()
             };
             if let Some(conclusion) = conclusion {
                 mount_notation_fallback(&host, &state, &conclusion);
@@ -848,8 +858,16 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
             }
         }
         if let Some(slide) = mount_view_slide(&host, &mut s, &display) {
-            if let Some(c) = s.last_conclusion.clone() {
-                let detail = serialize_conclusion(&with_host_attributes(&host, &c));
+            // Replay the whole cached frame (directory mode has one
+            // conclusion per instance; a single replay would drop all
+            // but the first).
+            if !s.last_frame.is_empty() {
+                let augmented: Vec<Conclusion> = s
+                    .last_frame
+                    .iter()
+                    .map(|c| with_host_attributes(&host, c))
+                    .collect();
+                let detail = serialize_conclusions(&augmented);
                 call_render(&slide.view_el, &detail);
             }
             s.slides.insert("__default__".to_owned(), slide);
@@ -1130,16 +1148,21 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
 /// template renderer's iteration-aware walk does the per-value
 /// cloning from there.
 fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
-    let Some(conclusion) = crate::fold::fold_rows(conclusions) else {
+    // Everything is a list of folds: group the flat rows by `this` into
+    // one folded conclusion per subject. Cardinality-one is just a
+    // one-element frame; the renderer iterates `{this}` over the frame.
+    let frame = crate::fold::select_rows(conclusions);
+
+    if frame.is_empty() {
         let mut s = state.borrow_mut();
         let directory = s.directory;
-        s.last_conclusion = None;
+        s.last_frame = Vec::new();
         clear_host(host, &mut s);
         drop(s);
-        // Single mode: an empty entity frame means the entity has no
-        // data on this branch — it doesn't exist. Surface a clear
-        // not-found error rather than a silent empty. Directory mode:
-        // an empty frame is simply zero instances, which is Empty.
+        // An empty frame means no rows matched. With a specified
+        // `entity` (single subject) that is a missing entity — a clear
+        // not-found error. Without `entity` (a collection) it is simply
+        // zero instances, an empty container, which is Empty.
         if directory {
             state::set(host, State::Empty);
         } else {
@@ -1150,22 +1173,30 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
             );
         }
         return;
-    };
+    }
 
     let mut s = state.borrow_mut();
-    s.last_conclusion = Some(conclusion.clone());
-    // The slide sees the conclusion plus the host's own attributes
-    // under `dom.host/*` (for `{dom.host/model}` etc.); notation,
-    // caching, and the result event keep the unaugmented conclusion.
-    let detail = serialize_conclusion(&with_host_attributes(host, &conclusion));
+    // Cache the whole folded frame for the slide-mount replay (directory
+    // mode has one conclusion per instance). The lead conclusion drives
+    // notation + the result event.
+    let first = frame[0].clone();
+    s.last_frame = frame.clone();
+    // Each slide sees the whole frame, augmented with the host's own
+    // attributes under `dom.host/*`; notation, caching, and the result
+    // event keep the unaugmented conclusions.
+    let augmented: Vec<Conclusion> = frame
+        .iter()
+        .map(|c| with_host_attributes(host, c))
+        .collect();
+    let detail = serialize_conclusions(&augmented);
     for slide in s.slides.values() {
         call_render(&slide.view_el, &detail);
     }
-    update_notation(host, &s, &conclusion);
+    update_notation(host, &s, &first);
     if !s.slides.is_empty() || s.notation_source.is_some() {
         state::set(host, State::Ready);
     }
-    dispatch_event(host, "tonk-display:result", Some(event_detail(&conclusion)));
+    dispatch_event(host, "tonk-display:result", Some(event_detail(&first)));
 }
 
 /// Refresh the trailing notation slide's source `<script>` with
@@ -1288,10 +1319,10 @@ fn call_render(el: &Element, detail: &JsValue) {
     let _ = func.call1(&JsValue::NULL, detail);
 }
 
-/// Serialize a `Conclusion` into a JsValue with the shape
-/// `<tonk-view>` / `<tonk-inspector>` expect.
-fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
-    serde_wasm_bindgen::to_value(conclusion).unwrap_or(JsValue::NULL)
+/// Serialize a frame of conclusions as a JS array — the shape a
+/// slide's `draw` accepts (it renders one row per conclusion).
+fn serialize_conclusions(conclusions: &[Conclusion]) -> JsValue {
+    serde_wasm_bindgen::to_value(conclusions).unwrap_or(JsValue::NULL)
 }
 
 /// Return a copy of `conclusion` with the host `<tonk-display>`'s own

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -694,9 +694,11 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
         if let Some(new_slide) = mount_view_slide(host, &mut s, &display) {
             // Push the cached entity conclusion if we have one,
             // so the new slide renders immediately rather than
-            // waiting for the next entity frame.
+            // waiting for the next entity frame. Augment with the
+            // host's `dom.host/*` attributes, matching the live path.
             if let Some(c) = cached.as_ref() {
-                call_render(&new_slide.view_el, &serialize_conclusion(c));
+                let detail = serialize_conclusion(&with_host_attributes(host, c));
+                call_render(&new_slide.view_el, &detail);
             }
             s.slides.insert(name, new_slide);
         }
@@ -957,7 +959,10 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
 
     let mut s = state.borrow_mut();
     s.last_conclusion = Some(conclusion.clone());
-    let detail = serialize_conclusion(&conclusion);
+    // The slide sees the conclusion plus the host's own attributes
+    // under `dom.host/*` (for `{dom.host/model}` etc.); notation,
+    // caching, and the result event keep the unaugmented conclusion.
+    let detail = serialize_conclusion(&with_host_attributes(host, &conclusion));
     for slide in s.slides.values() {
         call_render(&slide.view_el, &detail);
     }
@@ -1092,6 +1097,32 @@ fn call_render(el: &Element, detail: &JsValue) {
 /// `<tonk-view>` / `<tonk-inspector>` expect.
 fn serialize_conclusion(conclusion: &Conclusion) -> JsValue {
     serde_wasm_bindgen::to_value(conclusion).unwrap_or(JsValue::NULL)
+}
+
+/// Return a copy of `conclusion` with the host `<tonk-display>`'s own
+/// attributes added to its fields under `dom.host/<attr>` keys, so a
+/// template can reference them with `{dom.host/model}` etc. — the
+/// render-time counterpart of the `dom.event/*` namespace (see
+/// `events::path`). Scalars, constant across the render: a directory
+/// template threads the outer model into each nested
+/// `<tonk-display entity={this} model={dom.host/model}>` this way,
+/// since an instance carries no pointer to its own model.
+///
+/// The augmentation is render-only — the cached/notation/event
+/// conclusion stays unaugmented. The substituter resolves
+/// `{dom.host/X}` by an ordinary field lookup, so no parser or
+/// substituter change is needed, only that these entries are present.
+fn with_host_attributes(host: &Element, conclusion: &Conclusion) -> Conclusion {
+    let mut augmented = conclusion.clone();
+    let attrs = host.attributes();
+    for i in 0..attrs.length() {
+        let Some(attr) = attrs.item(i) else { continue };
+        augmented.fields.insert(
+            format!("dom.host/{}", attr.name()),
+            Ipld::String(attr.value()),
+        );
+    }
+    augmented
 }
 
 fn dispatch_error(host: &Element, err: ErrorDetail) {

--- a/rust/tonk-display/src/fold.rs
+++ b/rust/tonk-display/src/fold.rs
@@ -1,41 +1,61 @@
-//! Fold a multi-row conclusion frame into a single conclusion
-//! with array-valued fields where the rows disagree.
+//! Project a flat conclusion frame into one conclusion per subject.
 //!
 //! The dialog query engine emits one row per tuple — for a
-//! cardinality-many attribute on a single entity, each value
-//! comes back as its own [`Conclusion`] sharing the same `this`
-//! and differing only in the projected field. `<tonk-display>`
-//! is a *single-entity* element, so it needs to collapse those
-//! rows into one conclusion the template renderer can iterate
-//! over.
+//! cardinality-many attribute, each value comes back as its own
+//! [`Conclusion`] sharing the same `this` and differing only in the
+//! projected field; for a many-instance query, rows span several
+//! subjects. [`select_rows`] groups by `this` and folds each group, so
+//! `<tonk-display>` always gets a frame of one folded conclusion per
+//! subject — cardinality-one is just a one-element frame.
 //!
 //! The fold preserves order: distinct values for the same field
-//! appear in the array in the order they first appeared across
-//! the rows. Identical values across all rows are kept as a
-//! scalar (no needless array wrapping).
+//! appear in the array in the order they first appeared across the
+//! rows. Identical values across all rows are kept as a scalar (no
+//! needless array wrapping).
 //!
-//! Target-independent so the fold logic can be unit-tested
-//! natively without spinning up the orchestrator.
+//! Target-independent so the fold logic can be unit-tested natively
+//! without spinning up the orchestrator.
 
 use std::collections::BTreeMap;
 
 use ipld_core::ipld::Ipld;
 use tonk_schema::conclusion::Conclusion;
 
-/// Fold a list of conclusions sharing the same `this` into one.
-/// If `conclusions` is empty, returns `None`. If all rows agree
-/// on every field, returns the first row unchanged. Differing
-/// rows collapse the disagreeing fields into `Array` values
-/// preserving first-seen order; identical values are
-/// deduplicated.
+/// Group a flat conclusion frame by `this` and fold each group,
+/// yielding **one conclusion per distinct subject** with its
+/// cardinality-many fields collapsed to `Ipld::List`. Groups appear in
+/// first-seen `this` order.
 ///
-/// Mixed-`this` input is **not** an error — the function uses
-/// the first row's `this` and folds across every row. Callers
-/// who care about identity should group upstream; in practice
-/// `<tonk-display>` only ever feeds rows for a single entity.
-pub fn fold_rows(conclusions: Vec<Conclusion>) -> Option<Conclusion> {
+/// This is the universal projection: the query engine emits one flat
+/// row per tuple, so a query returns rows for one or many subjects.
+/// Grouping by `this` turns that into the conclusion-per-subject frame
+/// the renderer iterates — cardinality-one is just a one-element frame.
+/// Models dialog's `select`/`merge`/`add` aggregation
+/// (`query/src/selector.js`): `this` is the grouping key, many-fields
+/// are the array accumulators.
+pub fn select_rows(conclusions: Vec<Conclusion>) -> Vec<Conclusion> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: BTreeMap<String, Vec<Conclusion>> = BTreeMap::new();
+    for row in conclusions {
+        if !groups.contains_key(&row.this) {
+            order.push(row.this.clone());
+        }
+        groups.entry(row.this.clone()).or_default().push(row);
+    }
+    order
+        .into_iter()
+        .filter_map(|this| groups.remove(&this))
+        .map(fold_group)
+        .collect()
+}
+
+/// Fold a non-empty group of conclusions (sharing one `this`, though
+/// only the first row's `this` is used) into one conclusion,
+/// accumulating distinct per-field values in first-seen order and
+/// collapsing multi-valued fields to `Ipld::List`.
+fn fold_group(conclusions: Vec<Conclusion>) -> Conclusion {
     let mut iter = conclusions.into_iter();
-    let first = iter.next()?;
+    let first = iter.next().expect("fold_group requires a non-empty group");
 
     // For every field, accumulate distinct values in first-seen
     // order. We only need to switch to a `List` representation
@@ -63,10 +83,10 @@ pub fn fold_rows(conclusions: Vec<Conclusion>) -> Option<Conclusion> {
         folded.insert(name, value);
     }
 
-    Some(Conclusion {
+    Conclusion {
         this: first.this,
         fields: folded,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -90,15 +110,22 @@ mod tests {
         }
     }
 
+    /// Fold a single-subject frame to its one conclusion (the common
+    /// shape these tests exercise). `select_rows` of one `this` yields
+    /// a one-element frame.
+    fn fold_one(rows: Vec<Conclusion>) -> Option<Conclusion> {
+        select_rows(rows).into_iter().next()
+    }
+
     #[test]
     fn it_returns_none_for_empty_input() {
-        assert!(fold_rows(vec![]).is_none());
+        assert!(fold_one(vec![]).is_none());
     }
 
     #[test]
     fn it_returns_a_single_row_unchanged() {
         let c = conclusion("did:key:zX", &[("name", json!("Alice"))]);
-        let folded = fold_rows(vec![c.clone()]).expect("single row folds");
+        let folded = fold_one(vec![c.clone()]).expect("single row folds");
         assert_eq!(folded.this, "did:key:zX");
         assert_eq!(folded.fields.get("name"), Some(&ipld(json!("Alice"))));
     }
@@ -109,7 +136,7 @@ mod tests {
             conclusion("did:key:zX", &[("name", json!("Alice"))]),
             conclusion("did:key:zX", &[("name", json!("Alice"))]),
         ];
-        let folded = fold_rows(rows).expect("rows fold");
+        let folded = fold_one(rows).expect("rows fold");
         // Both agree on `name` — should not become an array.
         assert_eq!(folded.fields.get("name"), Some(&ipld(json!("Alice"))));
     }
@@ -141,7 +168,7 @@ mod tests {
                 ],
             ),
         ];
-        let folded = fold_rows(rows).expect("rows fold");
+        let folded = fold_one(rows).expect("rows fold");
         assert_eq!(folded.fields.get("name"), Some(&ipld(json!("Groceries"))));
         assert_eq!(
             folded.fields.get("item"),
@@ -160,7 +187,7 @@ mod tests {
             conclusion("did:key:zX", &[("tag", json!("apple"))]),
             conclusion("did:key:zX", &[("tag", json!("mango"))]),
         ];
-        let folded = fold_rows(rows).expect("rows fold");
+        let folded = fold_one(rows).expect("rows fold");
         assert_eq!(
             folded.fields.get("tag"),
             Some(&ipld(json!(["zebra", "apple", "mango"]))),
@@ -174,7 +201,7 @@ mod tests {
             conclusion("did:key:zX", &[("tag", json!("beta"))]),
             conclusion("did:key:zX", &[("tag", json!("alpha"))]),
         ];
-        let folded = fold_rows(rows).expect("rows fold");
+        let folded = fold_one(rows).expect("rows fold");
         // `alpha` appears twice on the wire but is collapsed to
         // one entry in the folded array.
         assert_eq!(
@@ -194,7 +221,7 @@ mod tests {
             ),
             conclusion("did:key:zX", &[("name", json!("Bag"))]),
         ];
-        let folded = fold_rows(rows).expect("rows fold");
+        let folded = fold_one(rows).expect("rows fold");
         // `item` saw one value, stays scalar.
         assert_eq!(folded.fields.get("item"), Some(&ipld(json!("did:key:zA"))));
         assert_eq!(folded.fields.get("name"), Some(&ipld(json!("Bag"))));

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -1,36 +1,45 @@
-//! Single-row DOM renderer used by `<tonk-view>`. Maintains a
-//! mounted-state tree mirroring the [`BindingPlan`] tree, so
-//! repeated `apply` calls update the DOM in place rather than
-//! re-cloning the template every frame.
+//! DOM renderer for a `<tonk-view>` frame. A frame is a list of
+//! folded conclusions — one per subject — and the renderer maintains a
+//! mounted-state tree so repeated `apply` calls update the DOM in place
+//! rather than re-cloning the template every frame.
 //!
-//! Three primitives:
+//! The template is split (by [`tonk_concept::template::split_plan`])
+//! into two halves:
 //!
-//! - **MountedBinding** caches the last rendered string for each
-//!   placeholder; subsequent applies skip the write when the
-//!   value hasn't changed, preserving the text/attribute node's
-//!   identity (and any imperative state authors attached to it).
-//! - **MountedIteration** holds a `BTreeMap` of rows keyed by the
-//!   iteration value's string form, plus a comment-node anchor at
-//!   the iteration's slot in the DOM. New keys clone the template
-//!   and insert at the sorted position; vanished keys remove their
-//!   row; surviving keys recurse into their body to update inner
-//!   bindings/iterations in place.
-//! - The mounted tree is built lazily on the first `apply` and
-//!   reused on every subsequent one. Tearing down (e.g. element
-//!   detach) drops the tree; the next apply rebuilds from scratch.
+//! - **chrome** — bindings outside the per-conclusion repeat element.
+//!   Rendered once against the lead conclusion (e.g. a sheet title
+//!   surrounding a repeated row).
+//! - **repeat** — the element cloned once per conclusion. The renderer
+//!   keys rows by the conclusion's `this`, clones the repeat element
+//!   (or, when no single element encloses the references, the whole
+//!   fragment), renders the repeat body against that conclusion, and
+//!   stamps `with=<this>` on the clone so the repeat boundary is
+//!   inspectable.
 //!
-//! Entity URIs are unique per cardinality-many tuple so they make
-//! excellent keys; DOM order follows BTreeMap's lexicographic
-//! ordering, which gives us deterministic positions across applies
-//! without needing to negotiate "what order did the worker send
-//! them in?"
+//! Inside a repeat row, cardinality-many *subject fields* still iterate
+//! their values via [`MountedNode::Iteration`] — `{this}` chooses the
+//! repeat element, a many-valued `{tags}` repeats a subtree within one
+//! conclusion.
+//!
+//! Three update primitives:
+//!
+//! - **MountedBinding** caches the last rendered string and skips the
+//!   write when the value is unchanged, preserving node identity.
+//! - **MountedIteration** keys rows by the value's string form, cloning
+//!   new keys and detaching vanished ones.
+//! - **MountedRepeat** keys rows by conclusion `this`, the same way, so
+//!   adding/removing a subject touches only its row.
+//!
+//! Rows build **detached** and insert with a single `insertBefore`, so
+//! custom elements inside a row mount exactly once (a move would fire
+//! `disconnected`/`connected` and double-mount nested `<tonk-display>`).
 
 use std::collections::BTreeMap;
 
 use ipld_core::ipld::Ipld;
 use tonk_concept::template::{
-    Binding, BindingKind, BindingPlan, PlanNode, Snapshot, apply_attribute_binding, extract_plan,
-    navigate, render_segments_with_shadow, single_field_value,
+    Binding, BindingKind, BindingPlan, PlanNode, RepeatPlan, Snapshot, apply_attribute_binding,
+    extract_plan, navigate, render_segments_with_shadow, single_field_value,
 };
 use tonk_schema::conclusion::Conclusion;
 use wasm_bindgen::JsCast;
@@ -38,102 +47,93 @@ use web_sys::{Document, DocumentFragment, Element, Node, window};
 
 use crate::events::preprocess::{self, Bindings};
 
-/// Stateful renderer for one entity. Holds the template,
-/// extracted plan, and (after the first apply) the mounted-state
-/// tree mirroring the plan.
+/// Stateful renderer for one `<tonk-view>`. Holds the template, the
+/// split plan, and (after the first apply) the mounted-state tree.
 pub struct Renderer {
     /// Where the rendered fragment lives.
     host: Element,
-    /// Cloneable template fragment captured at construction time.
-    /// Used for the initial mount and for cloning iteration-root
-    /// subtrees on the fly when new iteration values appear.
+    /// Cloneable template fragment captured at construction time. Used
+    /// for the initial mount and for cloning repeat rows / iteration
+    /// subtrees on the fly.
     template: DocumentFragment,
-    /// Binding plan extracted from `template` at construction time.
+    /// Split binding plan extracted from `template` at construction.
     plan: BindingPlan,
     /// Event-handler bindings discovered on the template by the
-    /// preprocess pass. Exposed via [`Renderer::event_bindings`]
-    /// so the host element can resolve concept descriptors and
-    /// install delegation listeners.
+    /// preprocess pass.
     event_bindings: Bindings,
-    /// The currently mounted state. `None` before the first apply;
-    /// `Some` thereafter. Dropping it (e.g. when the element
-    /// detaches) discards every cached value; the next apply will
-    /// rebuild from scratch.
+    /// Mounted state. `None` before the first apply; `Some` after.
+    /// Dropped on detach; the next apply rebuilds from scratch.
     mounted: Option<MountedScope>,
 }
 
-/// The top-level mounted scope — one `Renderer` has exactly one.
-/// Holds the live root cloned from the template plus the mounted
-/// nodes mirroring `plan.nodes`.
+/// Top-level mounted state — one per `Renderer`. Holds the live root
+/// cloned from the template, the chrome nodes (rendered once), and the
+/// per-conclusion repeat.
 struct MountedScope {
-    /// Live root in the DOM. We hold this for navigate() — the
-    /// browser owns it via parent chain once appended.
+    /// Live root in the DOM (the cloned fragment, held for navigate()).
     root: Node,
-    /// Mirror of `plan.nodes`, in lockstep order.
-    nodes: Vec<MountedNode>,
+    /// Mirror of `plan.chrome`, rendered once against the lead
+    /// conclusion.
+    chrome: Vec<MountedNode>,
+    /// The per-conclusion repeat rows.
+    repeat: MountedRepeat,
 }
 
-/// One mounted plan-tree node. Mirrors [`PlanNode`] but carries
-/// only the DOM bookkeeping needed to update in place — path /
-/// kind / segments stay on the plan node, which we walk in
-/// lockstep with the mounted tree during reconciliation.
+/// The per-conclusion repeat: a keyed set of rows, one per subject,
+/// plus the anchor marking their slot in the DOM.
+struct MountedRepeat {
+    /// Comment node marking where rows insert. Rows sit before it; it
+    /// stays put across applies.
+    anchor: Node,
+    /// Rows keyed by the conclusion's `this`. BTreeMap so DOM order is
+    /// deterministic (lexicographic by subject URI).
+    rows: BTreeMap<String, MountedRow>,
+}
+
+/// One mounted plan-tree node. Mirrors [`PlanNode`] but carries only
+/// the DOM bookkeeping needed to update in place — the plan node stays
+/// authoritative for path / kind / segments.
 enum MountedNode {
-    /// A leaf binding with its last-rendered string cached so we
-    /// can skip writes that wouldn't change anything.
+    /// A leaf binding with its last-rendered string cached.
     Binding {
-        /// The most recent rendered string. Compared against the
-        /// freshly rendered value on each apply; equal ⇒ no write.
+        /// Most recent rendered string; equal ⇒ no write.
         last_value: String,
     },
-    /// An iteration over a field's values. Owns its rows and the
-    /// comment-node anchor in the DOM that marks where new rows
-    /// get inserted before. The plan node's `field` and `body`
-    /// stay authoritative during reconciliation; we cache only
-    /// what the DOM needs.
+    /// An iteration over a subject field's values (cardinality-many
+    /// within one conclusion).
     Iteration {
-        /// Path to the iteration root in the template. Used to
-        /// clone fresh rows; the live DOM doesn't have an
-        /// iteration root element anymore (it's been replaced by
-        /// the anchor and the rows).
+        /// Absolute template path to the iteration root, for cloning.
         template_path: Vec<usize>,
-        /// Comment node marking the iteration's slot in the live
-        /// DOM. Rows insert *before* this node; removed rows
-        /// detach. The anchor stays put across applies.
+        /// Comment anchor marking the iteration's slot.
         anchor: Node,
-        /// Mounted rows, keyed by the stringified iteration value.
-        /// BTreeMap so iteration / DOM order is lexicographic by
-        /// key — deterministic regardless of input array order.
+        /// Rows keyed by the stringified iteration value.
         rows: BTreeMap<String, MountedRow>,
     },
 }
 
-/// One row inside a [`MountedNode::Iteration`]. Holds the row's
-/// live DOM root plus the mounted state of the body bindings
-/// inside it.
+/// One row inside a [`MountedRepeat`] or [`MountedNode::Iteration`].
 struct MountedRow {
-    /// The cloned iteration-root element in the live DOM. Removed
-    /// when the row vanishes.
+    /// The cloned row root in the live DOM. Removed when the row
+    /// vanishes.
     root: Node,
-    /// Mounted state for the body bindings, paths relative to the
-    /// row's `root`.
+    /// Mounted state for the body, paths relative to `root`.
     body: Vec<MountedNode>,
 }
 
+/// The conclusion a scope falls back to when the frame is empty.
+fn empty_conclusion() -> Conclusion {
+    Conclusion {
+        this: String::new(),
+        fields: BTreeMap::new(),
+    }
+}
+
 impl Renderer {
-    /// Construct a renderer from a pre-snapshotted template +
-    /// container pair. Used by `<tonk-view>` after it pulls the
-    /// host's children into a `DocumentFragment` at
-    /// `connectedCallback`. `snapshot.container` becomes the
-    /// renderer's append target.
+    /// Construct a renderer from a snapshotted template + container.
     pub fn from_snapshot(snapshot: Snapshot) -> Self {
-        // Preprocess on<event>=<concept> attributes into
-        // data-on<event>=<concept> before plan extraction. The
-        // rewrite is a pure DOM mutation on the template fragment;
-        // iteration rows clone the rewritten subtree so every row
-        // inherits the data-prefixed form. The plan extractor
-        // ignores attributes without `{field}` interpolation, so
-        // the rewritten data-on<event> attributes pass through
-        // untouched — exactly what the delegation listener needs.
+        // Preprocess on<event>=<concept> into data-on<event> before
+        // plan extraction; the rewrite is a pure DOM mutation that
+        // iteration rows inherit via cloning.
         let event_bindings = preprocess::preprocess(&snapshot.fragment);
         let plan = extract_plan(&snapshot.fragment);
         Self {
@@ -145,33 +145,28 @@ impl Renderer {
         }
     }
 
-    /// Event-handler bindings discovered on the template — the
-    /// set of distinct event types and concept names referenced
-    /// by `on<event>=<concept>` attributes. The host element
-    /// uses these to resolve concept descriptors and install
-    /// delegation listeners.
+    /// Event-handler bindings discovered on the template.
     pub fn event_bindings(&self) -> &Bindings {
         &self.event_bindings
     }
 
-    /// Apply an entity conclusion. First call mounts the template;
-    /// subsequent calls reconcile in place — touch only the DOM
-    /// nodes whose rendered value changed and add/remove iteration
-    /// rows whose key set differs from the previous apply.
-    pub fn apply(&mut self, conclusion: &Conclusion) {
+    /// Apply an entity frame. First call mounts; subsequent calls
+    /// reconcile in place — touch only the nodes whose rendered value
+    /// changed and add/remove repeat rows whose subject set differs.
+    pub fn apply(&mut self, frame: &[Conclusion]) {
         let Some(document) = window().and_then(|w| w.document()) else {
             return;
         };
         if self.mounted.is_none() {
-            self.mount_initial(&document, conclusion);
+            self.mount_initial(&document, frame);
         } else {
-            self.update_existing(&document, conclusion);
+            self.update_existing(&document, frame);
         }
     }
 
-    /// First-apply path — clone the template fragment, build the
-    /// mounted tree from scratch, attach the clone to the host.
-    fn mount_initial(&mut self, document: &Document, conclusion: &Conclusion) {
+    /// First-apply path: clone the template, render chrome once, mount
+    /// one repeat row per conclusion, attach to the host.
+    fn mount_initial(&mut self, document: &Document, frame: &[Conclusion]) {
         let Some(fragment) = self
             .template
             .clone_node_with_deep(true)
@@ -181,99 +176,298 @@ impl Renderer {
             return;
         };
         let root: Node = fragment.clone().into();
-        let nodes = build_mounted_nodes(
+        let lead = frame.first().cloned().unwrap_or_else(empty_conclusion);
+
+        // Chrome renders once against the lead conclusion. No shadow.
+        let chrome = build_mounted_nodes(
             document,
-            &self.plan.nodes,
+            &self.plan.chrome,
             &root,
             &self.template,
             &[],
-            conclusion,
+            &lead,
             &BTreeMap::new(),
         );
 
-        // Tag the first top-level element with `data-this` for
-        // CSS / consumer hooks, matching the prior contract.
-        let children = fragment.child_nodes();
-        for i in 0..children.length() {
-            if let Some(n) = children.item(i)
-                && let Some(el) = n.dyn_ref::<Element>()
-            {
-                let _ = el.set_attribute("data-this", &conclusion.this);
-                break;
-            }
-        }
+        let repeat = mount_repeat(document, &self.plan.repeat, &root, &self.template, frame);
 
         let _ = self.host.append_child(&fragment);
-        self.mounted = Some(MountedScope { root, nodes });
+        self.mounted = Some(MountedScope {
+            root,
+            chrome,
+            repeat,
+        });
     }
 
-    /// Incremental-update path — walk the existing mounted tree
-    /// in lockstep with the plan tree and reconcile against the
-    /// new conclusion. No re-clone of the template, no DOM
-    /// destruction of nodes whose content hasn't changed.
-    fn update_existing(&mut self, document: &Document, conclusion: &Conclusion) {
+    /// Incremental-update path: reconcile chrome against the lead
+    /// conclusion and the repeat rows against the new frame.
+    fn update_existing(&mut self, document: &Document, frame: &[Conclusion]) {
         let Some(scope) = self.mounted.as_mut() else {
             return;
         };
+        let lead = frame.first().cloned().unwrap_or_else(empty_conclusion);
+
         update_nodes(
             document,
-            &self.plan.nodes,
-            &mut scope.nodes,
+            &self.plan.chrome,
+            &mut scope.chrome,
             &scope.root,
             &self.template,
-            conclusion,
+            &lead,
             &BTreeMap::new(),
         );
 
-        // `data-this` should still reflect the conclusion. The
-        // entity URI rarely changes on a `Renderer` (one entity
-        // per view) but if it does, keep the attribute current.
-        let children = scope.root.child_nodes();
-        for i in 0..children.length() {
-            if let Some(n) = children.item(i)
-                && let Some(el) = n.dyn_ref::<Element>()
+        update_repeat(
+            document,
+            &self.plan.repeat,
+            &mut scope.repeat,
+            &self.template,
+            frame,
+        );
+    }
+}
+
+/// Build the per-conclusion repeat at mount: replace the repeat element
+/// with an anchor and clone one keyed row per conclusion.
+///
+/// When `plan.path` is `Some`, the repeat element is located and
+/// replaced. When `None`, the whole fragment repeats: the anchor is
+/// appended at the fragment's end and each row clones every top-level
+/// node of the fragment.
+fn mount_repeat(
+    document: &Document,
+    plan: &RepeatPlan,
+    root: &Node,
+    template: &DocumentFragment,
+    frame: &[Conclusion],
+) -> MountedRepeat {
+    let anchor: Node = document.create_comment("tonk-repeat").into();
+    let mut rows: BTreeMap<String, MountedRow> = BTreeMap::new();
+
+    match &plan.path {
+        Some(path) => {
+            // Locate the repeat element, drop it from the live clone,
+            // put the anchor in its slot, and clone rows from the
+            // pristine template element at `path`.
+            if let Some(repeat_el) = navigate(root, path)
+                && let Some(parent) = repeat_el.parent_node()
             {
-                if el.get_attribute("data-this").as_deref() != Some(&conclusion.this) {
-                    let _ = el.set_attribute("data-this", &conclusion.this);
+                let _ = parent.insert_before(&anchor, Some(&repeat_el));
+                let _: Result<Node, _> = parent.remove_child(&repeat_el);
+                for member in frame {
+                    let key = member.this.clone();
+                    if rows.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(row) = build_repeat_row(document, plan, template, member) {
+                        let _ = parent.insert_before(&row.root, Some(&anchor));
+                        rows.insert(key, row);
+                    }
                 }
-                break;
             }
+        }
+        None => {
+            // Whole-fragment repeat — a multi-root fragment with no
+            // single enclosing element (e.g. `<h1>{a}</h1><p>{b}</p>`).
+            // There is no element to clone-per-conclusion or stamp
+            // `with=` on, so the lead conclusion renders once over the
+            // fragment's own nodes (matching the historical
+            // clone-whole-fragment contract). Single-root templates
+            // never reach here: `this_repeat_root` returns the root
+            // element path instead.
+            let lead = frame.first().cloned().unwrap_or_else(empty_conclusion);
+            let body = build_mounted_nodes(
+                document,
+                &plan.body,
+                root,
+                template,
+                &[],
+                &lead,
+                &BTreeMap::new(),
+            );
+            if let Some(first) = frame.first() {
+                rows.insert(
+                    first.this.clone(),
+                    MountedRow {
+                        root: root.clone(),
+                        body,
+                    },
+                );
+            }
+        }
+    }
+
+    MountedRepeat { anchor, rows }
+}
+
+/// Reconcile the repeat rows against a new frame: new subjects clone +
+/// mount, vanished subjects detach, surviving subjects recurse into
+/// their body.
+fn update_repeat(
+    document: &Document,
+    plan: &RepeatPlan,
+    mounted: &mut MountedRepeat,
+    template: &DocumentFragment,
+    frame: &[Conclusion],
+) {
+    let Some(parent) = mounted.anchor.parent_node() else {
+        // No anchor in the DOM — the whole-fragment (`None`) path, which
+        // tracks a single lead row. Reconcile it in place against the
+        // lead conclusion; there is nothing to add/remove.
+        if let (Some((_, row)), Some(lead)) = (mounted.rows.iter_mut().next(), frame.first()) {
+            update_nodes(
+                document,
+                &plan.body,
+                &mut row.body,
+                &row.root,
+                template,
+                lead,
+                &BTreeMap::new(),
+            );
+        }
+        return;
+    };
+
+    // Incoming subjects, keyed and deduped, in frame order.
+    let mut incoming: BTreeMap<String, Conclusion> = BTreeMap::new();
+    for member in frame {
+        incoming
+            .entry(member.this.clone())
+            .or_insert_with(|| member.clone());
+    }
+
+    // Single-row rename: when exactly one row exists whose subject
+    // vanished and a fresh subject appears, reuse the row (preserves
+    // inner custom-element state across a single-entity swap).
+    if mounted.rows.len() == 1 {
+        let old_key = mounted.rows.keys().next().cloned().expect("len == 1");
+        if !incoming.contains_key(&old_key)
+            && let Some(new_key) = incoming
+                .keys()
+                .find(|k| !mounted.rows.contains_key(*k))
+                .cloned()
+            && let Some(row) = mounted.rows.remove(&old_key)
+        {
+            mounted.rows.insert(new_key, row);
+        }
+    }
+
+    // Remove vanished subjects.
+    let stale: Vec<String> = mounted
+        .rows
+        .keys()
+        .filter(|k| !incoming.contains_key(*k))
+        .cloned()
+        .collect();
+    for key in stale {
+        if let Some(row) = mounted.rows.remove(&key) {
+            let _: Result<Node, _> = parent.remove_child(&row.root);
+        }
+    }
+
+    // Walk incoming in sorted-key order: reuse + recurse, or clone +
+    // insert at the sorted position.
+    for (key, member) in incoming {
+        if let Some(row) = mounted.rows.get_mut(&key) {
+            update_nodes(
+                document,
+                &plan.body,
+                &mut row.body,
+                &row.root,
+                template,
+                &member,
+                &BTreeMap::new(),
+            );
+            stamp_with(&row.root, &member.this);
+        } else if let Some(new_row) = build_repeat_row(document, plan, template, &member) {
+            let next_anchor = mounted
+                .rows
+                .range(key.clone()..)
+                .next()
+                .map(|(_, row)| row.root.clone())
+                .unwrap_or_else(|| mounted.anchor.clone());
+            let _ = parent.insert_before(&new_row.root, Some(&next_anchor));
+            mounted.rows.insert(key, new_row);
         }
     }
 }
 
-/// Build a fresh `Vec<MountedNode>` from a plan and write its
-/// initial values into the DOM. Used for both the top-level
-/// mount and each iteration row's body.
+/// Clone one repeat row from the pristine template and render its body
+/// against `member`. The returned row is **detached**; the caller
+/// inserts it with a single `insertBefore`. Stamps `with=<this>` on the
+/// clone.
 ///
-/// **Ordering caveat**: iteration nodes mutate the live DOM by
-/// replacing their iteration-root element with an anchor + rows.
-/// Doing that to an earlier sibling shifts subsequent sibling
-/// indices, which would invalidate the path-based navigation
-/// the *next* plan node performs. To avoid that, we process the
-/// plan in two passes:
+/// `plan.path` selects what to clone: a specific element, or (for a
+/// whole-fragment repeat) the fragment's nodes wrapped so the body
+/// paths still resolve.
+fn build_repeat_row(
+    document: &Document,
+    plan: &RepeatPlan,
+    template: &DocumentFragment,
+    member: &Conclusion,
+) -> Option<MountedRow> {
+    let template_root: Node = template.clone().into();
+
+    let (row_root, body_scope): (Node, Vec<usize>) = match &plan.path {
+        Some(path) => {
+            let template_el = navigate(&template_root, path)?;
+            let clone = template_el.clone_node_with_deep(true).ok()?;
+            (clone, path.clone())
+        }
+        None => {
+            // Whole-fragment repeat: clone the fragment's single root
+            // element. A multi-root fragment isn't a supported repeat
+            // unit (no single element to stamp / key); fall back to the
+            // first element child.
+            let clone = template_root.clone_node_with_deep(true).ok()?;
+            (clone, Vec::new())
+        }
+    };
+
+    let body = build_mounted_nodes(
+        document,
+        &plan.body,
+        &row_root,
+        template,
+        &body_scope,
+        member,
+        &BTreeMap::new(),
+    );
+
+    stamp_with(&row_root, &member.this);
+
+    Some(MountedRow {
+        root: row_root,
+        body,
+    })
+}
+
+/// Stamp `with=<this>` on a repeat row's root element so the repeat
+/// boundary is inspectable. No-op when the root isn't an element (a
+/// whole-fragment clone yielding a fragment).
+fn stamp_with(root: &Node, this: &str) {
+    if let Some(el) = root.dyn_ref::<Element>() {
+        let _ = el.set_attribute("with", this);
+    }
+}
+
+/// Build a `Vec<MountedNode>` from a plan and write its initial values
+/// into the DOM. Used for chrome, repeat bodies, and iteration rows.
 ///
-/// 1. **Reverse pass** — process iteration nodes from last to
-///    first, since each iteration's mutation only affects later
-///    siblings (already processed).
-/// 2. **Build in plan order** — assemble the resulting
-///    `MountedNode` Vec in the original plan order so it stays
-///    in lockstep with the plan tree.
-///
-/// Leaf bindings don't mutate sibling structure, so they're
-/// processed in plan order without complication.
+/// **Ordering caveat**: iteration nodes mutate the live DOM (replace
+/// their root with an anchor + rows), shifting later sibling indices.
+/// Process iterations last-to-first so each mutation only affects
+/// already-processed siblings; assemble the result in plan order to
+/// stay in lockstep with the plan.
 fn build_mounted_nodes(
     document: &Document,
     plan: &[PlanNode],
     scope_root: &Node,
     template: &DocumentFragment,
     template_scope: &[usize],
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) -> Vec<MountedNode> {
-    // Allocate the result vec; fill in reverse so iteration
-    // nodes process their DOM mutations from rightmost to
-    // leftmost. Bindings are order-independent.
     let mut out: Vec<Option<MountedNode>> = (0..plan.len()).map(|_| None).collect();
     for (i, node) in plan.iter().enumerate().rev() {
         out[i] = Some(build_mounted_node(
@@ -282,7 +476,7 @@ fn build_mounted_nodes(
             scope_root,
             template,
             template_scope,
-            conclusion,
+            member,
             shadow,
         ));
     }
@@ -291,51 +485,35 @@ fn build_mounted_nodes(
         .collect()
 }
 
-/// Build one mounted node — leaf or iteration — and perform its
-/// initial DOM writes / clones.
+/// Build one mounted node — leaf or iteration — and perform its initial
+/// DOM writes / clones.
 ///
-/// `template_scope` is the path inside `template` that corresponds
-/// to `scope_root` in the live DOM. Nested iterations use it to
-/// reconstruct the absolute template path of their iteration root
-/// (their `path` is relative to the *parent scope*, not the
-/// template fragment).
+/// `template_scope` is the path inside `template` corresponding to
+/// `scope_root` in the live DOM. Nested iterations use it to
+/// reconstruct the absolute template path of their iteration root.
 fn build_mounted_node(
     document: &Document,
     plan: &PlanNode,
     scope_root: &Node,
     template: &DocumentFragment,
     template_scope: &[usize],
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) -> MountedNode {
     match plan {
         PlanNode::Binding(b) => {
-            let rendered = render_binding(b, conclusion, shadow);
-            write_binding(scope_root, b, &rendered, conclusion, shadow);
+            let rendered = render_binding(b, member, shadow);
+            write_binding(scope_root, b, &rendered, member, shadow);
             MountedNode::Binding {
                 last_value: rendered,
             }
         }
         PlanNode::Iteration { field, path, body } => {
-            // Locate the iteration root in this scope, replace it
-            // with a comment anchor, and clone-then-mount one row
-            // per value. The original element is gone from the
-            // live DOM after this; future clones come from the
-            // pristine `template` fragment.
             let anchor: Node = document
                 .create_comment(&format!("tonk-iter:{field}"))
                 .into();
-
             let mut rows: BTreeMap<String, MountedRow> = BTreeMap::new();
 
-            // Compose the absolute template path for cloning rows.
-            // `path` is relative to the parent scope; pre-pending
-            // `template_scope` (the parent's template-absolute
-            // path) gives us the location of the iteration root in
-            // the original fragment. Nested iterations rely on
-            // this — without composition, an inner iter at path
-            // `[0]` would re-clone the outer wrapper instead of
-            // the inner row template.
             let template_iter_path: Vec<usize> = template_scope
                 .iter()
                 .copied()
@@ -345,34 +523,28 @@ fn build_mounted_node(
             if let Some(iter_root) = navigate(scope_root, path)
                 && let Some(parent) = iter_root.parent_node()
             {
-                // Drop the in-clone template element; the anchor
-                // takes its slot so rows can insert before it.
                 let _ = parent.insert_before(&anchor, Some(&iter_root));
                 let _: Result<Node, _> = parent.remove_child(&iter_root);
 
                 let raw_value = shadow
                     .get(field)
-                    .or_else(|| conclusion.fields.get(field))
+                    .or_else(|| member.fields.get(field))
                     .cloned();
-                let keyed = collect_keyed_values(raw_value, &conclusion.this);
+                let keyed = collect_keyed_values(raw_value, &member.this);
 
                 for (key, value) in keyed {
                     if rows.contains_key(&key) {
-                        continue; // dedupe
+                        continue;
                     }
                     if let Some(row) = build_iteration_row(
                         document,
                         &template_iter_path,
                         template,
                         body,
-                        field,
-                        value,
-                        conclusion,
+                        (field, value),
+                        member,
                         shadow,
                     ) {
-                        // BTreeMap order ⇒ DOM order. Insert each
-                        // row before the anchor so they land in
-                        // sorted-key order naturally.
                         let _ = parent.insert_before(&row.root, Some(&anchor));
                         rows.insert(key, row);
                     }
@@ -395,7 +567,7 @@ fn update_nodes(
     mounted: &mut [MountedNode],
     scope_root: &Node,
     template: &DocumentFragment,
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) {
     for (plan_node, mounted_node) in plan.iter().zip(mounted.iter_mut()) {
@@ -405,7 +577,7 @@ fn update_nodes(
             mounted_node,
             scope_root,
             template,
-            conclusion,
+            member,
             shadow,
         );
     }
@@ -418,20 +590,20 @@ fn update_node(
     mounted: &mut MountedNode,
     scope_root: &Node,
     template: &DocumentFragment,
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) {
     match (plan, mounted) {
         (PlanNode::Binding(b), MountedNode::Binding { last_value }) => {
-            let rendered = render_binding(b, conclusion, shadow);
+            let rendered = render_binding(b, member, shadow);
             if *last_value != rendered {
-                write_binding(scope_root, b, &rendered, conclusion, shadow);
+                write_binding(scope_root, b, &rendered, member, shadow);
                 *last_value = rendered;
             }
         }
         (
             PlanNode::Iteration {
-                field: plan_field,
+                field,
                 path: _,
                 body,
             },
@@ -443,27 +615,26 @@ fn update_node(
         ) => {
             update_iteration(
                 document,
-                plan_field,
+                field,
                 template_path,
                 body,
                 anchor,
                 rows,
                 template,
-                conclusion,
+                member,
                 shadow,
             );
         }
         _ => {
-            // Plan/mounted shapes diverged — should be impossible
-            // since the plan is constant for a Renderer instance.
-            // Bail silently rather than panic in production.
+            // Plan/mounted shapes diverged — impossible for a constant
+            // plan. Bail silently rather than panic.
         }
     }
 }
 
-/// Reconcile one mounted iteration against a new value list.
-/// New keys clone + mount; vanished keys detach + drop; surviving
-/// keys recurse into their body.
+/// Reconcile one mounted subject-field iteration against a new value
+/// list. New keys clone + mount; vanished keys detach; survivors
+/// recurse into their body with `field` shadowed.
 #[allow(clippy::too_many_arguments)]
 fn update_iteration(
     document: &Document,
@@ -473,63 +644,33 @@ fn update_iteration(
     anchor: &Node,
     rows: &mut BTreeMap<String, MountedRow>,
     template: &DocumentFragment,
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) {
     let raw_value = shadow
         .get(field)
-        .or_else(|| conclusion.fields.get(field))
+        .or_else(|| member.fields.get(field))
         .cloned();
-    let keyed = collect_keyed_values(raw_value, &conclusion.this);
-
-    // Index incoming values by key, deduping.
     let mut incoming: BTreeMap<String, Ipld> = BTreeMap::new();
-    for (key, value) in keyed {
+    for (key, value) in collect_keyed_values(raw_value, &member.this) {
         incoming.entry(key).or_insert(value);
     }
 
-    // Find the anchor's parent — every row sits between
-    // siblings of the anchor in the parent.
     let Some(parent) = anchor.parent_node() else {
         return;
     };
 
-    // Single-row rename fallback. When the existing set has
-    // exactly one row whose key vanished from `incoming`, and at
-    // least one of the incoming keys isn't currently present,
-    // reuse the old row under a new key instead of destroying it.
-    //
-    // This preserves DOM identity (and therefore inner custom-
-    // element state, focus, in-flight subscriptions) across the
-    // common cardinality transitions that fold_rows produces:
-    //
-    //   - scalar value edit: `width: 12` → `width: 16`. The same
-    //     row is reused, only its bound attribute is patched.
-    //   - scalar → array growth: `column: "a"` → `column: ["a","b"]`.
-    //     The folded representation flips from a string to an
-    //     array, but the row for "a" should survive — the new "b"
-    //     row is added alongside, the existing column is not
-    //     torn down.
-    //   - array → scalar shrink (cardinality 1 → 1 with a swap):
-    //     `column: ["a"]` → `column: "b"`. The single row is
-    //     reused under the new key.
-    //
-    // For "true" array reconciliation (multiple rows on both
-    // sides) the rename never fires — keys match exactly.
+    // Single-row rename fallback (scalar edit / scalar↔array swaps).
     if rows.len() == 1 {
         let old_key = rows.keys().next().cloned().expect("len == 1");
         if !incoming.contains_key(&old_key)
-            && let Some((new_key, _)) = incoming
-                .iter()
-                .find(|(k, _)| !rows.contains_key(*k))
-                .map(|(k, v)| (k.clone(), v.clone()))
+            && let Some(new_key) = incoming.keys().find(|k| !rows.contains_key(*k)).cloned()
             && let Some(row) = rows.remove(&old_key)
         {
             rows.insert(new_key, row);
         }
     }
 
-    // Remove vanished keys.
     let stale: Vec<String> = rows
         .keys()
         .filter(|k| !incoming.contains_key(*k))
@@ -541,82 +682,50 @@ fn update_iteration(
         }
     }
 
-    // Walk incoming in sorted-key order. For each key:
-    //   - Reuse existing row → recurse into body.
-    //   - Add new row → clone from template, mount, insert at
-    //     the correct sorted position.
     for (key, value) in incoming {
         if let Some(row) = rows.get_mut(&key) {
-            // Existing row: update its body bindings in place
-            // with shadow extended by this iteration's value.
             let mut nested_shadow = shadow.clone();
-            nested_shadow.insert(field.to_owned(), value);
+            nested_shadow.insert(field.to_owned(), value.clone());
             update_nodes(
                 document,
                 plan_body,
                 &mut row.body,
                 &row.root,
                 template,
-                conclusion,
+                member,
                 &nested_shadow,
             );
-        } else {
-            // New row: clone + build (detached), then insert
-            // once at the correct sorted position. Single
-            // insertBefore avoids the move-induced custom-element
-            // lifecycle re-fire (see `build_iteration_row`'s
-            // doc-comment).
-            if let Some(new_row) = build_iteration_row(
-                document,
-                template_path,
-                template,
-                plan_body,
-                field,
-                value,
-                conclusion,
-                shadow,
-            ) {
-                let next_anchor = rows
-                    .range(key.clone()..)
-                    .next()
-                    .map(|(_, row)| row.root.clone())
-                    .unwrap_or_else(|| anchor.clone());
-                let _ = parent.insert_before(&new_row.root, Some(&next_anchor));
-                rows.insert(key, new_row);
-            }
+        } else if let Some(new_row) = build_iteration_row(
+            document,
+            template_path,
+            template,
+            plan_body,
+            (field, value),
+            member,
+            shadow,
+        ) {
+            let next_anchor = rows
+                .range(key.clone()..)
+                .next()
+                .map(|(_, row)| row.root.clone())
+                .unwrap_or_else(|| anchor.clone());
+            let _ = parent.insert_before(&new_row.root, Some(&next_anchor));
+            rows.insert(key, new_row);
         }
     }
 }
 
-/// Clone the iteration root from the pristine template, build
-/// its body's mounted state with all bindings applied. The
-/// returned [`MountedRow`] is **detached** — the caller decides
-/// where to insert it via a single `parent.insertBefore` call.
-///
-/// We deliberately don't insert here. Inserting now and then
-/// again at the sorted position would amount to a *move*, which
-/// the DOM spec implements as detach + reattach; that fires
-/// `disconnected_callback` and `connected_callback` on every
-/// custom element inside the row, causing inner `<tonk-display>`
-/// instances to spin up *twice* and mount two slides.
-///
-/// Bindings are written against the detached clone before any
-/// element is connected to the DOM, so custom-element lifecycle
-/// callbacks don't fire during `build_mounted_nodes`. By the
-/// time the caller inserts, every observed attribute is already
-/// at its final value and `connected_callback` runs exactly
-/// once.
-///
-/// Returns `None` if cloning fails (degenerate template).
+/// Clone a subject-field iteration root from the pristine template and
+/// build its body with `field` shadowed to `value`. Detached; caller
+/// inserts.
 #[allow(clippy::too_many_arguments)]
 fn build_iteration_row(
     document: &Document,
     template_path: &[usize],
     template: &DocumentFragment,
     body_plan: &[PlanNode],
-    field: &str,
-    value: Ipld,
-    conclusion: &Conclusion,
+    shadow_entry: (&str, Ipld),
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) -> Option<MountedRow> {
     let template_root: Node = template.clone().into();
@@ -624,18 +733,16 @@ fn build_iteration_row(
     let row_root = template_iter_root.clone_node_with_deep(true).ok()?;
 
     let mut nested_shadow = shadow.clone();
+    let (field, value) = shadow_entry;
     nested_shadow.insert(field.to_owned(), value);
-    // The row's template scope is `template_path` — anything
-    // nested inside (e.g. a child iteration's `path`) is relative
-    // to it. Threading this lets nested iterations recover the
-    // absolute template path needed for cloning.
+
     let body = build_mounted_nodes(
         document,
         body_plan,
         &row_root,
         template,
         template_path,
-        conclusion,
+        member,
         &nested_shadow,
     );
 
@@ -645,10 +752,7 @@ fn build_iteration_row(
     })
 }
 
-/// Stable string key for an iteration value. Entity URIs (and
-/// any other Ipld string) become themselves; non-strings get
-/// canonicalised via dag-json so two equal values produce equal
-/// keys.
+/// Stable string key for an iteration value.
 fn key_for(value: &Ipld) -> String {
     match value {
         Ipld::String(s) => s.clone(),
@@ -659,29 +763,25 @@ fn key_for(value: &Ipld) -> String {
     }
 }
 
-/// Render a binding's segments against the conclusion + shadow,
-/// returning the substituted string.
+/// Render a binding's segments against the conclusion + shadow.
 fn render_binding(
     binding: &Binding,
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) -> String {
     let segments = match &binding.kind {
         BindingKind::Text { segments } => segments,
         BindingKind::Attribute { segments, .. } => segments,
     };
-    render_segments_with_shadow(segments, &conclusion.this, &conclusion.fields, shadow)
+    render_segments_with_shadow(segments, &member.this, &member.fields, shadow)
 }
 
-/// Write a binding's rendered value to the target DOM node
-/// identified by its path within `scope_root`. Attribute-form
-/// bindings flow through [`apply_attribute_binding`] which decides
-/// between property and attribute assignment per value type.
+/// Write a binding's rendered value to the target DOM node.
 fn write_binding(
     scope_root: &Node,
     binding: &Binding,
     rendered: &str,
-    conclusion: &Conclusion,
+    member: &Conclusion,
     shadow: &BTreeMap<String, Ipld>,
 ) {
     match &binding.kind {
@@ -691,29 +791,19 @@ fn write_binding(
             }
         }
         BindingKind::Attribute { .. } => {
-            let value = single_field_value(binding, &conclusion.this, &conclusion.fields, shadow);
+            let value = single_field_value(binding, &member.this, &member.fields, shadow);
             apply_attribute_binding(scope_root, binding, rendered, value.as_ref());
         }
     }
 }
 
-/// Resolve a JSON value into the list of (row-key, row-value)
-/// pairs the iteration renderer needs.
+/// Resolve a value into the list of (row-key, row-value) pairs the
+/// iteration renderer needs.
 ///
 /// - `Null` / missing → no rows.
-/// - `Array` → one row per element, keyed by `key_for(value)`
-///   so cardinality-many reconciliation matches rows across
-///   applies by element identity.
-/// - Anything else (a scalar) → one row keyed by the enclosing
-///   conclusion's `this` (entity URI). This identifies the row
-///   by the *entity it describes*, not by the placeholder's
-///   current value, so editing a cardinality-one field (e.g. a
-///   column's width) reuses the same row and patches only the
-///   bound attribute. The `entity_key` is supplied by the
-///   caller because it carries the relevant scope's `this` —
-///   for nested iterations that may differ from the outer
-///   conclusion's `this` once `subject=` markers identify an
-///   inner entity.
+/// - `Array` → one row per element, keyed by `key_for`.
+/// - scalar → one row keyed by the conclusion's `this`, so editing a
+///   cardinality-one field reuses the same row.
 fn collect_keyed_values(value: Option<Ipld>, entity_key: &str) -> Vec<(String, Ipld)> {
     match value {
         None | Some(Ipld::Null) => Vec::new(),

--- a/rust/tonk-display/src/resolve.rs
+++ b/rust/tonk-display/src/resolve.rs
@@ -83,6 +83,44 @@ pub fn view_predicate() -> Value {
     })
 }
 
+/// The descriptor of the built-in **directory** view concept
+/// (`tonk:view/directory`). Same `model` field as [`view_predicate`],
+/// but its template lives under `xyz.tonk.view/directory` so a model
+/// can declare a detail view and a directory view independently (both
+/// keyed by `model`). Used as the default view predicate when
+/// `<tonk-display>` has no `entity` (directory mode). The `display`
+/// term name is kept so `view_by_model_query` and the renderer read
+/// the template uniformly regardless of view kind.
+pub fn directory_view_predicate() -> Value {
+    json!({
+        "with": {
+            "model":   { "the": "xyz.tonk.view/model",     "as": "Entity", "cardinality": "one" },
+            "display": { "the": "xyz.tonk.view/directory", "as": "Text",   "cardinality": "one" }
+        }
+    })
+}
+
+/// Build the live **directory** subscription query: like
+/// [`entity_query`] but with `this` left as a variable instead of
+/// pinned, so the query matches *every* instance of the model. The
+/// worker emits one flat row per (instance, many-value) tuple; the
+/// caller groups them by `this`. Used when `<tonk-display>` has no
+/// `entity` (directory mode).
+pub fn instances_query(descriptor_json: &str) -> Result<Query, serde_json::Error> {
+    let predicate: Value = serde_json::from_str(descriptor_json)?;
+    let with = predicate
+        .get("with")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let mut terms: IndexMap<String, Value> = IndexMap::new();
+    terms.insert("this".into(), json!({ "?": { "name": "this" } }));
+    for field in with.keys() {
+        terms.insert(field.clone(), json!({ "?": { "name": field } }));
+    }
+    serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
+}
+
 /// True if `s` looks like an entity URI (contains `:`) rather than
 /// a bookmark name.
 pub fn looks_like_uri(s: &str) -> bool {

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -102,13 +102,22 @@ impl CustomElement for TonkView {
         // how a single prototype method reaches the right
         // instance's state.
         let draw = Closure::wrap(Box::new(move |detail: JsValue| {
-            let conclusion: Conclusion = match serde_wasm_bindgen::from_value(detail) {
-                Ok(c) => c,
-                Err(_) => return,
-            };
+            // `draw` accepts a FRAME (an array of conclusions) — the
+            // renderer renders one row per conclusion. A single
+            // conclusion (`{this, fields}`) is accepted too and treated
+            // as a one-row frame, so callers passing one entity still
+            // work.
+            let frame: Vec<Conclusion> =
+                match serde_wasm_bindgen::from_value::<Vec<Conclusion>>(detail.clone()) {
+                    Ok(frame) => frame,
+                    Err(_) => match serde_wasm_bindgen::from_value::<Conclusion>(detail) {
+                        Ok(c) => vec![c],
+                        Err(_) => return,
+                    },
+                };
             let mut s = state.borrow_mut();
             if let Some(renderer) = s.renderer.as_mut() {
-                renderer.apply(&conclusion);
+                renderer.apply(&frame);
             }
         }) as Box<dyn FnMut(JsValue)>);
         let draw_fn: &Function = draw.as_ref().unchecked_ref();
@@ -1012,6 +1021,127 @@ mod tests {
             items,
             vec!["zA".to_owned(), "zB".to_owned(), "zC".to_owned()],
             "rows should appear in sorted-key order regardless of input array order",
+        );
+    }
+
+    /// Build a serialized FRAME — a JS array of `{ this, fields }`
+    /// conclusions, the shape `<tonk-display>` passes for a directory
+    /// (one conclusion per instance). `draw` fans it out into one repeat
+    /// row per conclusion keyed by `this`.
+    fn frame(members: &[(&str, &[(&str, &str)])]) -> JsValue {
+        let conclusions: Vec<Conclusion> = members
+            .iter()
+            .map(|(this, fields)| {
+                let mut map: BTreeMap<String, Ipld> = BTreeMap::new();
+                for (k, v) in *fields {
+                    map.insert((*k).to_owned(), Ipld::String((*v).to_owned()));
+                }
+                Conclusion {
+                    this: (*this).to_owned(),
+                    fields: map,
+                }
+            })
+            .collect();
+        serde_wasm_bindgen::to_value(&conclusions).expect("serialize frame")
+    }
+
+    // A directory frame with N conclusions must render N repeat rows,
+    // one per subject. Regression: the slide-mount replay used to push
+    // only the lead conclusion (a single-conclusion serialize), so a
+    // directory of [Alice, Bob] rendered Alice alone. The `{this}`
+    // marker on `<wa-carousel-item>` makes it the repeat node; each
+    // conclusion clones it once, stamped with its own `this`.
+    #[dialog_common::test]
+    fn it_renders_one_repeat_row_per_conclusion_in_a_directory_frame() {
+        let host = mount(
+            "<wa-carousel><wa-carousel-item subject={this}>{name}</wa-carousel-item></wa-carousel>",
+        );
+        call_draw(
+            &host,
+            &frame(&[
+                ("did:key:zAlice", &[("name", "Alice")]),
+                ("did:key:zBob", &[("name", "Bob")]),
+            ]),
+        );
+
+        let items = host.query_selector_all("wa-carousel-item").unwrap();
+        assert_eq!(
+            items.length(),
+            2,
+            "a 2-conclusion frame must render 2 rows, got: {}",
+            host.inner_html(),
+        );
+
+        // Each row carries its own `with=<this>` debug attribute and the
+        // per-conclusion `{name}` resolved against that conclusion. Rows
+        // are keyed in sorted-`this` order (zAlice < zBob).
+        let first = items.item(0).unwrap();
+        let first_el = first.dyn_ref::<Element>().expect("element");
+        assert_eq!(
+            first_el.get_attribute("with").as_deref(),
+            Some("did:key:zAlice")
+        );
+        assert_eq!(first_el.text_content().as_deref(), Some("Alice"));
+
+        let second = items.item(1).unwrap();
+        let second_el = second.dyn_ref::<Element>().expect("element");
+        assert_eq!(
+            second_el.get_attribute("with").as_deref(),
+            Some("did:key:zBob")
+        );
+        assert_eq!(second_el.text_content().as_deref(), Some("Bob"));
+    }
+
+    // A single-conclusion frame is just a one-row directory — the same
+    // path, one repeat row. Guards the cardinality-one case the unified
+    // "everything is a list of folds" model collapses into.
+    #[dialog_common::test]
+    fn it_renders_a_single_repeat_row_for_a_one_conclusion_frame() {
+        let host = mount(
+            "<wa-carousel><wa-carousel-item subject={this}>{name}</wa-carousel-item></wa-carousel>",
+        );
+        call_draw(&host, &frame(&[("did:key:zAlice", &[("name", "Alice")])]));
+
+        let items = host.query_selector_all("wa-carousel-item").unwrap();
+        assert_eq!(items.length(), 1, "one conclusion → one row");
+        let only = items.item(0).unwrap();
+        let only_el = only.dyn_ref::<Element>().expect("element");
+        assert_eq!(
+            only_el.get_attribute("with").as_deref(),
+            Some("did:key:zAlice")
+        );
+        assert_eq!(only_el.text_content().as_deref(), Some("Alice"));
+    }
+
+    // Re-applying a frame that grew by one subject adds exactly one row
+    // and preserves the existing row's node identity — the incremental
+    // path the directory carousel relies on when an instance appears.
+    #[dialog_common::test]
+    fn it_appends_a_repeat_row_when_the_frame_grows() {
+        let host = mount(
+            "<wa-carousel><wa-carousel-item subject={this}>{name}</wa-carousel-item></wa-carousel>",
+        );
+        call_draw(&host, &frame(&[("did:key:zAlice", &[("name", "Alice")])]));
+        let alice_before = host
+            .query_selector_all("wa-carousel-item")
+            .unwrap()
+            .item(0)
+            .expect("alice row");
+
+        call_draw(
+            &host,
+            &frame(&[
+                ("did:key:zAlice", &[("name", "Alice")]),
+                ("did:key:zBob", &[("name", "Bob")]),
+            ]),
+        );
+
+        let items = host.query_selector_all("wa-carousel-item").unwrap();
+        assert_eq!(items.length(), 2, "frame grew to 2: {}", host.inner_html());
+        let alice_after = items.item(0).expect("alice row still first");
+        assert!(
+            alice_before.is_same_node(Some(alice_after.unchecked_ref())),
+            "Alice's row must keep its node identity across the grow",
         );
     }
 }

--- a/rust/tonk-ui/assets/hot-swap.js
+++ b/rust/tonk-ui/assets/hot-swap.js
@@ -207,13 +207,20 @@
         animation: spin 0.8s infinite linear;
       }
 
-      /* Build error: danger fill, spinning ring handle, forced visible. */
+      /* Error: danger fill, forced visible, and it keeps pulsing (the
+         update class stays on) to announce the trouble. The handle is
+         hidden — a spinning ring reads as "in progress" and overlaps
+         the message, and a solid dot adds nothing, so the error pill is
+         just the pulsing danger drawer with its text. The dot selectors
+         below are specific enough to win over the update /
+         input-checked spinner. */
       .notification.error .pill { background: var(--hs-danger); color: var(--hs-danger-fg); opacity: 1; }
-      .notification.error .dot {
+      .notification.error .dot,
+      .notification.update.error input:checked + .pill .dot {
         background: transparent;
-        border: 2px solid transparent;
-        border-left-color: var(--hs-danger-fg);
-        animation: spin 0.8s infinite linear;
+        border: none;
+        animation: none;
+        opacity: 0;
       }
 
       /* FOLDED: retract the drawer — width shrinks back to the handle
@@ -460,6 +467,7 @@
   const apply = async (library, glyph = GLYPH_LIBRARY) => {
     const hash = await libraryHash(library)
     await conjure(glyph, hash)
+    view.error = false    // clear any prior failure before retrying
     view.pulse = true     // pulsing = applying
     try {
       await reseed(library)
@@ -474,8 +482,16 @@
         view.folded = false
       }, 600)
     } catch (e) {
+      // Applying the new library failed — it didn't lower (a parse /
+      // analyze error, a dangling anchor) or the evaluate was
+      // rejected. Surface it loudly: red error state, forced visible
+      // and unfolded, still pulsing to announce the trouble, so a bad
+      // edit can't silently leave repos unseeded. The `error` setter
+      // keeps the pulse on; cleared on the next successful apply.
       console.error("[hot-swap]", e)
-      view.pulse = false // stop pulsing but stay visible to signal trouble
+      view.error = true
+      view.folded = false
+      view.setStatus(GLYPH_ERROR, "apply failed")
     }
   }
 

--- a/rust/tonk-ui/assets/hot-swap.js
+++ b/rust/tonk-ui/assets/hot-swap.js
@@ -378,7 +378,11 @@
   const reseed = async (library) => {
     const branches = [...document.querySelectorAll("tonk-branch")]
     if (branches.length === 0) {
-      throw new Error("no <tonk-branch> in the page to evaluate against")
+      // No branch mounted in this view (e.g. the repo landing page) —
+      // there is nothing to re-seed here, which is not a failure. The
+      // fetched library is cached; the next view with a branch picks it
+      // up. Return quietly rather than flagging an error.
+      return
     }
 
     for (const branch of branches) {

--- a/rust/tonk-ui/src/components/display.rs
+++ b/rust/tonk-ui/src/components/display.rs
@@ -4,28 +4,28 @@
 //! containing `/` — e.g. `id:tonk-workspace/itinerary` — are
 //! captured whole instead of being truncated at the first slash.
 //!
-//! Mounts a `<tonk-display>` element after resolving `subject` to
-//! a concrete entity URI. The route accepts either form:
+//! Mounts a `<tonk-display>` element. The `subject` segment encodes
+//! up to three attributes with `@` and `!` delimiters:
+//!
+//! - `{model}` — directory mode: only `model` is set, so the element
+//!   renders every instance of the model (e.g. `display/work:space`).
+//! - `{entity}@{model}` — `entity` + `model` (e.g.
+//!   `display/id:x@trip`).
+//! - `{entity}@{model}!{view}` — all three (e.g.
+//!   `display/id:x@trip!tonk:view`).
+//!
+//! The entity part resolves to a concrete URI before mounting:
 //!
 //! - **Entity URI** — anything containing a `:` (e.g. a `did:key:…`
-//!   or `concept:…` URI). Used verbatim as the element's `entity`
-//!   attribute. No lookup happens.
-//!
+//!   or `id:…` URI). Used verbatim. No lookup happens.
 //! - **Name** — a bare bookmark (e.g. `demo`). The route queries the
-//!   branch for a `Name` row whose `this` equals `id:<subject>` and
-//!   reads its `entity` field. The resolved URI becomes the
-//!   element's `entity` attribute. Missing name ⇒ a 404 section is
-//!   rendered and the element is never mounted.
+//!   branch for a `Name` row whose `this` equals `id:<name>` and
+//!   reads its `entity` field. Missing name ⇒ a 404 section is
+//!   rendered and the element is never mounted. (Directory mode
+//!   supplies no entity, so there is nothing to resolve.)
 //!
-//! Query parameters carry the optional view/model selection:
-//!
-//! - `?view=<name>` — display name, forwarded as the element's
-//!   `view` attribute. If omitted, the element falls back to its
-//!   built-in generic rendering (one `<dl>` row per concept field).
-//! - `?model=<concept>` — concept name or URI, forwarded as the
-//!   element's `model` attribute. If omitted, the element queries
-//!   every attribute on the entity instead of going through a
-//!   concept descriptor.
+//! The model and view parts pass through verbatim as the `model` /
+//! `view` attributes.
 //!
 //! Doing name resolution at the route (rather than inside
 //! `<tonk-display>`) keeps the element decoupled from the routing
@@ -36,7 +36,7 @@
 //! express cleanly.
 
 use leptos::prelude::*;
-use leptos_router::hooks::{use_params, use_query_map};
+use leptos_router::hooks::use_params;
 use leptos_router::params::Params;
 use reqwest::StatusCode;
 use serde_json::json;
@@ -51,15 +51,14 @@ pub struct TonkDisplayParams {
     subject: Option<String>,
 }
 
-/// Single-entity display route. Resolves the path's `:subject`
-/// (either an entity URI or a bookmark name) to an entity URI,
-/// then mounts a `<tonk-display>` element with the resolved URI
-/// plus any `?view=` / `?model=` query parameters as attributes.
+/// Display route. Parses the path's `subject` segment into
+/// `entity`/`model`/`view` (see the module docs), resolves the
+/// optional entity to a URI, and mounts a `<tonk-display>` with those
+/// attributes. With no entity it is directory mode (only `model`).
 #[component]
 #[allow(clippy::unused_unit)]
 pub fn TonkDisplayView() -> impl IntoView {
     let params = use_params::<TonkDisplayParams>();
-    let query_map = use_query_map();
 
     let space_name = Signal::derive_local(move || {
         params
@@ -75,45 +74,53 @@ pub fn TonkDisplayView() -> impl IntoView {
             .and_then(|p| p.branch)
             .filter(|s| !s.is_empty())
     });
-    let subject = Signal::derive_local(move || {
+    // The `:subject` segment encodes up to three attributes:
+    //   `{model}`                 → directory mode: only `model`.
+    //   `{entity}@{model}`        → `entity` + `model`.
+    //   `{entity}@{model}!{view}` → `entity` + `model` + `view`.
+    // `@` separates the (optional) entity from the model; `!`
+    // separates the (optional) view. The entity may be a bookmark
+    // name (resolved below); the model/view pass through verbatim.
+    let segment = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.subject)
             .filter(|s| !s.is_empty())
     });
-    let view_name = Signal::derive_local(move || {
-        query_map
+    let parsed = Signal::derive_local(move || segment.get().map(|s| parse_subject(&s)));
+    let entity_name = Signal::derive_local(move || {
+        parsed
             .get()
-            .get("view")
-            .as_deref()
-            .map(str::to_owned)
+            .and_then(|p| p.entity)
             .filter(|s| !s.is_empty())
     });
-    let model_name = Signal::derive_local(move || {
-        query_map
-            .get()
-            .get("model")
-            .as_deref()
-            .map(str::to_owned)
-            .filter(|s| !s.is_empty())
-    });
+    let model_name =
+        Signal::derive_local(move || parsed.get().map(|p| p.model).filter(|s| !s.is_empty()));
+    let view_name =
+        Signal::derive_local(move || parsed.get().and_then(|p| p.view).filter(|s| !s.is_empty()));
 
-    // Resolve `:subject` → entity URI. URIs pass through; names hit
-    // the worker via a `Name` query. The Suspense below waits on
+    // Resolve the entity part (if present) → entity URI. URIs pass
+    // through; names hit the worker via a `Name` query. In directory
+    // mode (no `@`, so no entity) this resolves to `None` and the
+    // element mounts with only `model`. The Suspense below waits on
     // the resolve before rendering anything substantive.
     let resolved_entity = LocalResource::new(move || {
         let space = space_name.get();
         let branch = branch_name.get();
-        let subject = subject.get();
+        let entity = entity_name.get();
         async move {
-            let (Some(space), Some(branch), Some(subject)) = (space, branch, subject) else {
+            let Some(entity) = entity else {
+                // Directory mode: no entity to resolve.
                 return Ok::<Option<String>, TonkUiError>(None);
             };
-            if looks_like_uri(&subject) {
-                return Ok(Some(subject));
+            let (Some(space), Some(branch)) = (space, branch) else {
+                return Ok(None);
+            };
+            if looks_like_uri(&entity) {
+                return Ok(Some(entity));
             }
-            resolve_name(&space, &branch, &subject).await
+            resolve_name(&space, &branch, &entity).await
         }
     });
 
@@ -134,8 +141,12 @@ pub fn TonkDisplayView() -> impl IntoView {
         };
         let document = leptos::prelude::document();
         slot.set_inner_html("");
+        // An entity name was given in the path but did not resolve →
+        // 404. (Directory mode supplies no entity name, so `None` there
+        // is expected, not a miss.)
+        let unresolved = entity_name.get().is_some() && matches!(result, Ok(None));
         match result {
-            Ok(Some(uri)) => {
+            Ok(uri) if !unresolved => {
                 let host = match document.create_element("tonk-display") {
                     Ok(el) => el,
                     Err(_) => return,
@@ -143,21 +154,27 @@ pub fn TonkDisplayView() -> impl IntoView {
                 // Space and branch come from the surrounding
                 // <tonk-repository> / <tonk-branch> ancestors via
                 // event-annotation; no attributes needed on the
-                // element itself.
-                let _ = host.set_attribute("entity", &uri);
-                if let Some(v) = view_name.get() {
-                    let _ = host.set_attribute("view", &v);
+                // element itself. `entity` is set only when present
+                // (absent in directory mode).
+                if let Some(uri) = uri {
+                    let _ = host.set_attribute("entity", &uri);
                 }
                 if let Some(m) = model_name.get() {
                     let _ = host.set_attribute("model", &m);
                 }
+                if let Some(v) = view_name.get() {
+                    let _ = host.set_attribute("view", &v);
+                }
                 let _ = slot.append_child(&host);
             }
-            Ok(None) => {
+            Ok(_) => {
                 // Unresolved bookmark — render a 404 inline.
                 if let Ok(section) = document.create_element("section") {
                     let _ = section.set_attribute("class", "not-found");
-                    let label = format!("No entity is named {}", subject.get().unwrap_or_default());
+                    let label = format!(
+                        "No entity is named {}",
+                        entity_name.get().unwrap_or_default()
+                    );
                     section.set_text_content(Some(&label));
                     let _ = slot.append_child(&section);
                 }
@@ -184,6 +201,43 @@ pub fn TonkDisplayView() -> impl IntoView {
                 <div class="display-view-slot" node_ref=mount></div>
             </tonk-branch>
         </tonk-repository>
+    }
+}
+
+/// The `<tonk-display>` attributes encoded in a display-route path
+/// segment. `model` is always present; `entity` and `view` are
+/// optional.
+#[derive(Clone)]
+struct Subject {
+    entity: Option<String>,
+    model: String,
+    view: Option<String>,
+}
+
+/// Parse a display-route path segment into its attributes. Grammar:
+///
+/// - `{model}`                 → `entity: None, model, view: None`
+/// - `{entity}@{model}`        → `entity, model, view: None`
+/// - `{entity}@{model}!{view}` → `entity, model, view`
+///
+/// `@` separates an optional entity from the model; `!` separates an
+/// optional view. Entity URIs / model / view names may contain `:`
+/// and `/`, but not `@` or `!`, so the split is unambiguous. The view
+/// is split off first so a `!` after the model is honored even when
+/// there is no `@`.
+fn parse_subject(segment: &str) -> Subject {
+    let (head, view) = match segment.split_once('!') {
+        Some((head, view)) => (head, Some(view.to_owned())),
+        None => (segment, None),
+    };
+    let (entity, model) = match head.split_once('@') {
+        Some((entity, model)) => (Some(entity.to_owned()), model.to_owned()),
+        None => (None, head.to_owned()),
+    };
+    Subject {
+        entity,
+        model,
+        view,
     }
 }
 

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -230,7 +230,15 @@ tonk-notation {
    .display-view-slot > tonk-display > tonk-view > .workspace`, all of
    which default to inline/auto height and would collapse the view to
    its content size — so establish a 100dvh height chain down to the
-   view. `:has()` lets the host opt in only when it wraps this route. */
+   view. `:has()` lets the host opt in only when it wraps this route.
+
+   The chain uses child combinators so it sizes only the route's OWN
+   mount slot (`.display-view-slot > tonk-display > tonk-view`), not
+   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree. A
+   view template that wants its inner wrappers transparent (e.g.
+   board-view flattening the strip's child displays with
+   `display: contents`) must be able to do so without this chain
+   clawing them back to `display: block`. */
 html:has(.display-route),
 body:has(.display-route) {
     height: 100%;
@@ -243,8 +251,8 @@ tonk-host:has(.display-route) {
 .display-route,
 .display-route > tonk-branch,
 .display-route > tonk-branch > .display-view-slot,
-.display-route tonk-display,
-.display-route tonk-view {
+.display-route > tonk-branch > .display-view-slot > tonk-display,
+.display-route > tonk-branch > .display-view-slot > tonk-display > tonk-view {
     display: block;
     height: 100%;
     min-height: 0;
@@ -1560,11 +1568,20 @@ tonk-code:focus-within {
     margin-block-end: var(--wa-space-2xs);
 }
 
-/* ── Board layout ─────────────────────────────────────────────
- * Horizontal strip rendered by `<tonk-board>` and its view
- * templates. See `plan/tonk-board.md`. Tiles fill the column
- * by default; opening another tile splits the column or grows
- * a new column in the strip.
+/* ── Board route height anchor ────────────────────────────────
+ * The board's strip/column/tile layout lives WITH the view, in
+ * the `board-view` / `column-view` `display:` templates (see
+ * core.yaml). Those templates size the strip with
+ * `block-size: 100%`, which only resolves against a host that
+ * establishes a real height — that's the route's job, and the
+ * only board CSS that stays here.
+ *
+ * This route mounts `tonk-board` inside `main.board-view`, so the
+ * height chain runs `main → tonk-repository → tonk-branch →
+ * tonk-board → tonk-display → tonk-view → tonk-strip`. The bare
+ * `/display` route establishes its own chain (see `.display-route`
+ * above); both bottom out at `tonk-strip`, which the view styles
+ * from there down. See `plan/tonk-board.md`.
  */
 .board-view {
     /* Fill the viewport; no padding so the strip's graph-paper
@@ -1576,9 +1593,10 @@ tonk-code:focus-within {
 }
 
 /* Every custom-element layer between <main.board-view> and the
-   leaf content defaults to `display: inline`. Force the whole
-   chain into the layout flow so block-size: 100% propagates from
-   the viewport down to the strip and columns. */
+   strip defaults to `display: inline`. Force the whole chain into
+   the layout flow so block-size: 100% propagates from the
+   viewport down to the strip (the view template takes over from
+   the strip downward). */
 .board-view tonk-repository,
 .board-view tonk-branch,
 .board-view tonk-board,
@@ -1587,128 +1605,4 @@ tonk-code:focus-within {
     display: block;
     block-size: 100%;
     min-block-size: 0;
-}
-
-/* The intermediate <tonk-display>/<tonk-view> layers between the
-   strip and its columns are pure rendering wrappers, not layout
-   boxes. `display: contents` makes them transparent to the
-   strip's flex flow so each <tonk-column> becomes a direct flex
-   item (and its `flex: 0 0 calc(--col-w * --cell)` actually
-   sizes the column instead of the wrapping <tonk-display>). */
-tonk-strip > tonk-display,
-tonk-strip > tonk-display > tonk-view {
-    display: contents;
-}
-
-/* Two-layer engineering-graph-paper background, applied to
-   each tile (the surface the dark canvas occupies). The grid
-   travels with the tile content because the tile is the
-   visible canvas; the strip's lighter seam color shows through
-   every gap (between tiles AND between columns) for a single
-   coherent gutter colour throughout the board.
-
-   `background-attachment: local` ties the grid to the column's
-   scroll position so the dots travel with vertical scroll. */
-tonk-column > .tile {
-    --dot-gap: 16px;
-    --dot-size-dim: 0.5px;
-    --dot-size-bright: 0.5px;
-    --dot-color-dim: color-mix(in oklab, currentColor 16%, transparent);
-    --dot-color-bright: color-mix(in oklab, currentColor 25%, transparent);
-    background-image:
-        radial-gradient(
-            circle,
-            var(--dot-color-bright) var(--dot-size-bright),
-            transparent calc(var(--dot-size-bright) + 0.5px)
-        ),
-        radial-gradient(
-            circle,
-            var(--dot-color-dim) var(--dot-size-dim),
-            transparent calc(var(--dot-size-dim) + 0.5px)
-        );
-    background-size:
-        calc(var(--dot-gap) * 4) calc(var(--dot-gap) * 4),
-        var(--dot-gap) var(--dot-gap);
-    background-position:
-        calc(var(--dot-gap) * -2) calc(var(--dot-gap) * -2),
-        calc(var(--dot-gap) / -2) calc(var(--dot-gap) / -2);
-    background-attachment: local;
-}
-
-tonk-strip {
-    --pitch: 16px;
-    --cell: 64px;
-    /* Narrow gutter between columns — just enough that the
-       contrasting strip fill reads as a seam. */
-    --gap: 4px;
-
-    display: flex;
-    flex-direction: row;
-    align-items: stretch;
-    gap: var(--gap);
-    padding: 0;
-    box-sizing: border-box;
-    block-size: 100%;
-    inline-size: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scroll-snap-type: x proximity;
-    /* The strip's fill is what shows through every seam —
-       between columns AND between tiles within a column (since
-       <tonk-column> is transparent). Uses the theme's
-       `neutral-fill-normal` token so the gutter contrast
-       adapts with dark / light mode. */
-    background-color: var(--wa-color-neutral-fill-normal);
-}
-
-tonk-column {
-    /* Width is driven by `--col-w` set on the element by the
-       column-view template (one --cell unit = 64px). Tiles
-       stack top-to-bottom inside; overflow is handled here at
-       the column level, so the column's dot-grid background
-       scrolls together with the tiles. */
-    flex: 0 0 calc(var(--col-w, 12) * var(--cell));
-    block-size: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap);
-    overflow-y: auto;
-    overflow-x: hidden;
-    scroll-snap-align: start;
-    min-block-size: 0;
-    /* Transparent so the strip's seam fill shows through the
-       column-to-column gaps AND the tile-to-tile gaps inside
-       each column. The column's grid layer still paints (it's a
-       `background-image`, not a fill) and reads against whatever
-       the strip provides underneath. */
-    background-color: transparent;
-}
-
-tonk-column::-webkit-scrollbar {
-    display: none;
-}
-
-/* Tiles size to their content along the column's main axis and
-   stack top-to-bottom. Overflow happens at the COLUMN level
-   (the column is the scroller) — never inside an individual
-   tile — so a tile renders all its content unclipped and the
-   user scrolls the whole column to reach what's below. Tiles
-   paint the dark canvas fill; the gaps between tiles (and the
-   gaps between columns) expose the strip's lighter seam fill
-   underneath, giving a single coherent gutter colour throughout
-   the board. */
-tonk-column > .tile {
-    flex: 0 0 auto;
-    inline-size: 100%;
-    box-sizing: border-box;
-    background-color: var(--wa-color-neutral-fill-quiet);
-}
-
-/* The inner <tonk-display> participates in the column's scroll —
-   it must NOT clip or scroll on its own. */
-tonk-column > .tile > tonk-display,
-tonk-column > .tile > tonk-display > tonk-view {
-    display: block;
-    inline-size: 100%;
-    overflow: visible;
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -271,6 +271,70 @@ wa-carousel-item tonk-notation {
     height: 100%;
 }
 
+/* `wa-carousel.seamless` is an opt-in carousel whose chrome takes no
+   visual space: a slide fills the whole element and the pagination dots
+   float on the right edge as a vertical switcher, so the rendered
+   instance looks exactly as it would without the carousel wrapping it.
+   The directory view uses it to present a model's instances as a stack
+   of full-bleed slides. A plain `<wa-carousel>` keeps Web Awesome's
+   default layout (bottom dots, gap, aspect ratio).
+
+   Web Awesome lays its `part="base"` out as a grid with a row gap that
+   reserves space for the pagination beneath the scroll container. We
+   flatten that to a single full-size cell and lift the dots out of flow
+   with `position: absolute`, so they overlay the slide instead of
+   consuming layout. The scroll container then occupies 100% and the
+   slide fills it; the aspect-ratio constraint is dropped so the content
+   sizes to the available space rather than a 16/9 letterbox. */
+wa-carousel.seamless {
+    --aspect-ratio: auto;
+    display: block;
+    height: 100%;
+    position: relative;
+}
+wa-carousel.seamless::part(base) {
+    display: block;
+    height: 100%;
+    gap: 0;
+    padding: 0;
+}
+/* Stretch slides to fill the scroll container instead of centering them
+   at content height — the default grid `align-items: center` is what
+   letterboxed a full-height view into a short, centered band. */
+wa-carousel.seamless::part(scroll-container) {
+    height: 100%;
+    align-items: stretch;
+}
+/* Each slide, and the nested `<tonk-display>` chain inside it, fills the
+   carousel-item so a directory instance occupies the whole viewport just
+   like a bare single-entity route. The bare route gets a full-height
+   chain from the `.display-route > … > tonk-view` rule above, but a
+   carousel-nested display is not a direct child of that chain, so it
+   would otherwise collapse to its content size (a cramped column). */
+wa-carousel.seamless > wa-carousel-item {
+    height: 100%;
+}
+wa-carousel.seamless > wa-carousel-item > tonk-display,
+wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-view,
+wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-notation {
+    flex: 1 1 auto;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+/* Pagination dots: overlay on the right edge, centered vertically, in a
+   column so they read as a vertical slide switcher. Out of flow so they
+   take no layout space. */
+wa-carousel.seamless::part(pagination) {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: var(--wa-space-s);
+    margin: 0;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
 /* `<tonk-notation>`'s rendered `<pre>` reuses the dialog-yaml
    editor palette so the read-only carousel slide visually
    matches what users see when authoring the same notation in a

--- a/rust/tonk-worker/src/cache.rs
+++ b/rust/tonk-worker/src/cache.rs
@@ -108,7 +108,7 @@ async fn open_cache() -> Result<Cache, JsValue> {
 
 fn caches() -> Result<web_sys::CacheStorage, JsValue> {
     let global: ServiceWorkerGlobalScope = js_sys::global().dyn_into()?;
-    Ok(global.caches()?)
+    global.caches()
 }
 
 async fn cache_match(cache: &Cache, request: &Request) -> Result<Option<Response>, JsValue> {

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -423,13 +423,13 @@ async fn handle_subscribe(
     {
         let bridges = state.read().await.bridges.clone();
         let guard = bridges.read().await;
-        if let Some(session) = guard.get(&client) {
-            if session.subscriptions.contains_key(&id) {
-                log!("bridge: subscribe id '{id}' already active for {client:?}");
-                drop(guard);
-                send_error(&state, &client, "subscribe-error", &id, "id already in use").await;
-                return;
-            }
+        if let Some(session) = guard.get(&client)
+            && session.subscriptions.contains_key(&id)
+        {
+            log!("bridge: subscribe id '{id}' already active for {client:?}");
+            drop(guard);
+            send_error(&state, &client, "subscribe-error", &id, "id already in use").await;
+            return;
         }
     }
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -243,7 +243,7 @@ fn reject_404() -> Result<JsValue, JsValue> {
             Some("view clients cannot reach /api/; use the bridge"),
             &init,
         )?;
-        return Ok(JsValue::from(response));
+        Ok(JsValue::from(response))
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {


### PR DESCRIPTION
## Why

`<tonk-display>` could only render a single pinned entity. There was no way to point it at a *model* and get every instance, and the template engine carried a single-conclusion assumption that made "a collection of folds" impossible to express. Directory views (a model's instances rendered through one template) need both: a display that queries by model, and a renderer where repetition is a first-class, coherent idea rather than a special case bolted onto the single-entity path.

## Approach

**One template, two halves.** A frame is a list of folded conclusions (one per subject); cardinality-one is just a one-element frame. Each template splits into render-once *chrome* and a per-conclusion *repeat* element. The repeat element is chosen by the outermost subject reference: an explicit `{this}` on it pins it, otherwise the fragment root repeats with an inferred `with={this}` stamp (so the boundary is inspectable in the DOM). `{this}` stops being a cardinality-many field; the renderer clones the repeat element per conclusion while subject fields inside still iterate their own values. Incremental updates are preserved by keying rows on `this`.

**Display gains directory mode.** `<tonk-display model=M>` with no `entity` queries every instance of M and renders them through the model's `tonk:view/directory` (falling back to a `_:_` default carousel, or a notation dump when a model has no view). The route segment encodes `{entity}@{model}!{view}` so these are addressable. `{dom.host/*}` threads the outer model into nested displays, since an instance carries no back-pointer to its model.

The directory "only one item" bug this surfaced was not the engine: the async slide-mount replayed only the cached lead conclusion, collapsing a multi-instance frame to one row. The fix caches and replays the whole folded frame.

## Notes

- The repeat-node rule is pinned by five worked examples, captured as native tests in `template.rs`; the multi-conclusion render path is captured as `<tonk-view>` wasm tests in `view.rs`.
- `docs/templates.md` documents the model.
- Verified live: the `person` directory carousel renders both demo instances, and the workspace view renders chrome once around per-stop repeat rows.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the handling of caching, rendering, and directory views in the `tonk` project, enhancing the clarity and efficiency of the codebase.

### Detailed summary
- Simplified return statements in `worker.rs`.
- Adjusted cache handling in `cache.rs`.
- Updated template extraction functions in `element.rs`.
- Improved session subscription checks in `bridge.rs`.
- Enhanced comments and documentation across multiple files.
- Added tests for pinned instance resolution in `analyzer.rs`.
- Updated the rendering logic for directory views in `display.rs`.
- Enhanced CSS for carousel and board layouts in `styles.css`.

> The following files were skipped due to too many changes: `rust/tonk-display/src/element.rs`, `rust/tonk-concept/src/template.rs`, `rust/tonk-display/src/render.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->