### PR TITLE
feat: {branch}@{name} routes, Name-concept resolution, page-scroll layout

### DIFF
--- a/rust/tonk-concept/src/resolve.rs
+++ b/rust/tonk-concept/src/resolve.rs
@@ -96,9 +96,45 @@ fn hex_digit(b: u8) -> Option<u8> {
     }
 }
 
+/// Build the name-resolution query: resolve a bookmark `name` to the
+/// entity it points at through the **Name concept** — the `id:<name>`
+/// entity's `dialog.name/referent` claim (cardinality one, so at most
+/// one match).
+///
+/// This is the single source of truth for "what does this name refer
+/// to": the analyzer publishes a `Name` claim for every `&anchor`,
+/// including concepts pinned to a `this:` URI (e.g. `&workspace` +
+/// `this: tonk:workspace` → `id:workspace` → `tonk:workspace`). A
+/// concept's `dialog.meta/name` claim, by contrast, is only emitted
+/// when its `this:` is *derived*, so resolving a model/view name
+/// against `dialog.meta/name` misses pinned concepts. Resolving names
+/// here and feeding the resulting URI to [`phase1_query`] makes model,
+/// view, and entity name resolution agree.
+///
+/// Reads back as `(entity)` — the referent URI.
+pub fn name_query(name: &str) -> Query {
+    let body = json!({
+        "terms": {
+            "this":   format!("id:{name}"),
+            "entity": { "?": { "name": "entity" } },
+        },
+        "predicate": {
+            "with": {
+                "entity": { "the": "dialog.name/referent", "as": "Entity", "cardinality": "one" }
+            }
+        }
+    });
+    serde_json::from_value(body).expect("name query body is well-formed")
+}
+
 /// Build the Phase-1 wire query that asks the concept-of-concept
-/// view for the row whose `name` is `parsed.name_or_uri` (when a
-/// bookmark) or whose `this` equals it (when a URI).
+/// view for the row whose `this` equals `parsed.name_or_uri`.
+///
+/// `parsed.name_or_uri` is expected to be a concept entity URI — a
+/// bookmark name should be resolved to its referent via [`name_query`]
+/// first. (For backwards compatibility a non-URI value still falls
+/// back to a `dialog.meta/name` filter, but that path misses concepts
+/// pinned to a `this:` URI; prefer resolving the name first.)
 ///
 /// Reads back as `(this, name, source)` — the descriptor JSON is
 /// in `source`.
@@ -312,6 +348,36 @@ mod tests {
         let this = q.terms.get("this").expect("this term");
         let value: serde_json::Value = serde_json::to_value(this).unwrap();
         assert_eq!(value, json!("did:key:zPerson"));
+    }
+
+    #[dialog_common::test]
+    fn it_resolves_a_name_through_the_name_concept() {
+        // A bare name resolves via the Name concept: `id:<name>`'s
+        // `dialog.name/referent`. This is what lets `workspace` (a
+        // concept pinned to `this: tonk:workspace`, so carrying a Name
+        // claim but no `dialog.meta/name`) resolve at all.
+        let q = name_query("workspace");
+        let this = q.terms.get("this").expect("this term");
+        assert_eq!(
+            serde_json::to_value(this).unwrap(),
+            json!("id:workspace"),
+            "the name query pins `this` to the `id:<name>` entity",
+        );
+        // It projects `entity` (the referent) and constrains on the
+        // Name attribute.
+        let entity = q.terms.get("entity").expect("entity term");
+        assert_eq!(
+            serde_json::to_value(entity).unwrap(),
+            json!({ "?": { "name": "entity" } }),
+        );
+        let predicate = serde_json::to_value(&q.predicate).unwrap();
+        assert_eq!(
+            predicate
+                .pointer("/with/entity/the")
+                .and_then(|v| v.as_str()),
+            Some("dialog.name/referent"),
+            "the name query constrains on the Name referent attribute",
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -493,11 +493,38 @@ view!: &workspace/view
 # from the sheet's own `entity`/`model`/`view` fields - a sheet is
 # self-describing, so no intermediate concept is needed.
 
+
+
 view/directory!:
   this: id:tonk-workspace/directory
   model: workspace
   display: |
-    <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
+    <tonk-display class="workspace-directory" entity={this} model={dom.host/model} view={dom.host/view}>
+      <style>
+        /* The directory wraps the workspace instance in a nested
+           `<tonk-display>`. The route gives THIS element (the page view
+           root) a viewport-min height; flex-fill the nested rendering
+           chain so that height reaches the workspace, which then fills
+           the page (tab strip at the bottom). This is the same fill the
+           seamless carousel applies to its slides — without it the
+           nested wrapper sits at content height and the workspace stops
+           short. */
+        tonk-display.workspace-directory {
+          display: flex;
+          flex-direction: column;
+        }
+        tonk-display.workspace-directory > tonk-view {
+          display: flex;
+          flex-direction: column;
+          flex: 1 1 auto;
+          min-height: 0;
+        }
+        tonk-display.workspace-directory > tonk-view > * {
+          flex: 1 1 auto;
+          min-height: 0;
+        }
+      </style>
+    </tonk-display>
 
 view!:
   this: id:tonk-workspace/sheet-mount
@@ -659,6 +686,12 @@ view!:
       </style>
       <tonk-display entity={column} model=column-view />
     </tonk-strip>
+
+view/directory!:
+  this: tonk:board/directory
+  model: board
+  display: |
+    <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
 
 view!:
   this: tonk:board/column

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -249,7 +249,11 @@ view!: &workspace/view
         .workspace {
           display: flex;
           flex-direction: column;
-          height: 100%;
+          /* Content-driven by default: as a board tile the workspace
+             takes only the space it needs. When it is the page's own
+             view, the route gives the view root a viewport-min height
+             (see the `.display-route` rule in the app stylesheet), so
+             the tab strip pins to the bottom there. */
           font-family: var(--wa-font-family-body);
           color: var(--wa-color-text-normal);
           /* Transparent so the page's dot-grid paper shows through
@@ -488,6 +492,13 @@ view!: &workspace/view
 # attributes and the content. The sheet's content renders directly
 # from the sheet's own `entity`/`model`/`view` fields - a sheet is
 # self-describing, so no intermediate concept is needed.
+
+view/directory!:
+  this: id:tonk-workspace/directory
+  model: workspace
+  display: |
+    <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
+
 view!:
   this: id:tonk-workspace/sheet-mount
   model: tonk:sheet
@@ -505,7 +516,7 @@ view!:
 # deductive rules; the view templates won't change when that
 # happens.
 
-concept!: &board-view
+concept!: &board
   description: A named board (hierarchical v1, owns columns directly)
   with:
     name:
@@ -588,23 +599,24 @@ concept!: &portal
 
 view!:
   this: tonk:board
-  model: board-view
+  model: board
   display: |
     <tonk-strip>
       <style>
         /* Board layout travels with the view, so any route that
-           mounts `model=board-view` renders the strip identically
-           (board route, bare display route, embedded tile). The
-           only thing a route still owns is giving this view a
-           full-height box to fill: the strip's `block-size: 100%`
-           resolves against whatever height its host establishes.
+           mounts `model=board` renders the strip identically
+           (board route, bare display route, embedded tile). The strip
+           caps its OWN height at the viewport (`block-size: 100dvh`)
+           rather than borrowing a fixed height from the document — so
+           its columns scroll vertically inside a bounded box and the
+           strip scrolls horizontally, without locking the page. (Other
+           views let the page scroll; the board is a self-contained
+           fixed-height scroller.)
 
            The `tonk-display`/`tonk-view` layers that wrap each
            level are pure rendering wrappers, not layout boxes;
            `display: contents` makes them transparent so the strip
-           is a flex container over real `<tonk-column>` items, and
-           so the strip itself inherits its host's height instead of
-           collapsing to content. */
+           is a flex container over real `<tonk-column>` items. */
         tonk-display:has(> tonk-view > tonk-strip),
         tonk-display > tonk-view:has(> tonk-strip) {
           display: contents;
@@ -623,7 +635,7 @@ view!:
           gap: var(--gap);
           padding: 0;
           box-sizing: border-box;
-          block-size: 100%;
+          block-size: 100dvh;
           inline-size: 100%;
           overflow-x: auto;
           overflow-y: hidden;
@@ -1152,12 +1164,12 @@ column-view!: &column-a
   width: 12
   tile: inspector-tile
 
-board-view!: &demo-board
+board!:
   this: about:blank
   name: "demo"
   column: column-a
 
-board-view!:
+board!:
   this: about:blank
   column: column-b
 

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -557,7 +557,7 @@ concept!: &tile
       cardinality: one
       as: entity
 
-concept!: &inspector-view
+concept!: &inspector
   description: An inspector tile body — renders <tonk-inspector source="…">
   with:
     source:
@@ -742,10 +742,16 @@ view!:
     <tonk-display entity={entity} model={model} />
 
 view!:
-  this: tonk:inspector-view
-  model: inspector-view
+  this: tonk:inspector
+  model: inspector
   display: |
     <tonk-inspector source={source} />
+
+view/directory!:
+  this: tonk:inspector/directory
+  model: inspector
+  display: |
+    <tonk-inspector source=home />
 
 # The canonical bridge from the `portal` concept to the
 # `<tonk-portal>` element. `html:` forces the binding through
@@ -1119,12 +1125,12 @@ workspace!:
 # idempotent — the engine deduplicates the same claims rather
 # than minting fresh duplicates.
 
-inspector-view!: &home-inspector
+inspector!: &home-inspector
   source: "home"
 
 tile!: &inspector-tile
   order: "a"
-  model: inspector-view
+  model: inspector
   entity: home-inspector
 
 tile!: &workspace-tile
@@ -1246,4 +1252,7 @@ person!:
   name: Bob
   age: 40
 
-## V4
+# Set tonk:workspace as default view
+name!:
+  this: id:tonk/space
+  entity: tonk:workspace

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -499,32 +499,35 @@ view/directory!:
   this: id:tonk-workspace/directory
   model: workspace
   display: |
-    <tonk-display class="workspace-directory" entity={this} model={dom.host/model} view={dom.host/view}>
+    <div class="workspace-directory">
       <style>
-        /* The directory wraps the workspace instance in a nested
-           `<tonk-display>`. The route gives THIS element (the page view
-           root) a viewport-min height; flex-fill the nested rendering
-           chain so that height reaches the workspace, which then fills
-           the page (tab strip at the bottom). This is the same fill the
-           seamless carousel applies to its slides — without it the
+        /* The route gives this view root (`.workspace-directory`) a
+           viewport-min height. Flex-fill the nested `<tonk-display>`
+           rendering chain so that height reaches the workspace, which
+           then fills the page (tab strip at the bottom) — the same fill
+           the seamless carousel applies to its slides. Without it the
            nested wrapper sits at content height and the workspace stops
-           short. */
-        tonk-display.workspace-directory {
+           short. (`<style>` lives on this `<div>` rather than inside
+           `<tonk-display>`, which discards child markup when it renders
+           its resolved view.) */
+        .workspace-directory {
           display: flex;
           flex-direction: column;
         }
-        tonk-display.workspace-directory > tonk-view {
+        .workspace-directory > tonk-display,
+        .workspace-directory > tonk-display > tonk-view {
           display: flex;
           flex-direction: column;
           flex: 1 1 auto;
           min-height: 0;
         }
-        tonk-display.workspace-directory > tonk-view > * {
+        .workspace-directory > tonk-display > tonk-view > * {
           flex: 1 1 auto;
           min-height: 0;
         }
       </style>
-    </tonk-display>
+      <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
+    </div>
 
 view!:
   this: id:tonk-workspace/sheet-mount
@@ -791,6 +794,8 @@ view!:
   model: inspector
   display: |
     <tonk-inspector source={source} />
+
+
 
 view/directory!:
   this: tonk:inspector/directory

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1647,8 +1647,21 @@ mod tests {
         // concept (the query predicate). The view concept declares a
         // `type` attribute, so `view_by_model_query` projects `type` and
         // each view frame carries the value that decides portal mode.
+        //
+        // `resolve_model` resolves a bare name through the Name concept
+        // first (`id:<name>` → `dialog.name/referent`), then runs the
+        // Phase-1 concept query by `this`. So each bare-name resolution
+        // is TWO queries: a name lookup, then the concept lookup. The
+        // fixture answers in dispatch order, so a name-resolution row
+        // precedes each concept row. `mount_display` uses bare names for
+        // both `model` and `view`, hence two name/concept pairs.
+        fn name_row(entity: &str) -> JsValue {
+            rows(&[("did:key:zName", &[("entity", entity)])])
+        }
         fn resolve_responses() -> Vec<JsValue> {
             vec![
+                // model name `counter` → did:key:zModel
+                name_row("did:key:zModel"),
                 rows(&[(
                     "did:key:zModel",
                     &[(
@@ -1656,6 +1669,8 @@ mod tests {
                         r#"{"with":{"count":{"the":"counter/count","as":"UnsignedInteger","cardinality":"one"}}}"#,
                     )],
                 )]),
+                // view name `counter` → did:key:zViewConcept
+                name_row("did:key:zViewConcept"),
                 rows(&[(
                     "did:key:zViewConcept",
                     &[(

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use custom_elements::CustomElement;
 use ipld_core::ipld::Ipld;
 use js_sys::{Function, Reflect};
-use tonk_concept::resolve::{ParsedSource, parse_source, phase1_query};
+use tonk_concept::resolve::{ParsedSource, name_query, parse_source, phase1_query};
 use tonk_host::consumer::{self as host_consumer, Subscription as HostSubscription};
 use tonk_host::error::{ErrorDetail, ErrorKind};
 use tonk_host::install_depth_annotator;
@@ -652,10 +652,34 @@ fn first_field(value: &JsValue, field: &str) -> Result<Option<String>, ErrorDeta
 }
 
 /// Resolve a concept (bookmark name or entity URI) to its
-/// `(entity, descriptor_json)` via the Phase-1 concept-of-concepts
-/// query.
+/// `(entity, descriptor_json)`.
+///
+/// A bare name is first resolved through the **Name concept**
+/// (`id:<name>` → `dialog.name/referent`) into a concept entity URI,
+/// then that URI drives the Phase-1 concept-of-concepts lookup by
+/// `this`. This is the path that makes a model or view named after a
+/// concept pinned to a `this:` URI (e.g. `workspace` → `tonk:workspace`)
+/// resolve — the concept carries a `Name` claim but no
+/// `dialog.meta/name`, so a direct `name`-filtered Phase-1 would miss
+/// it. A value that is already a URI skips name resolution.
 async fn resolve_model(host: &Element, source: &str) -> Result<(String, String), ErrorDetail> {
     let parsed: ParsedSource = parse_source(source);
+    let parsed = if parsed.is_uri() {
+        parsed
+    } else {
+        // Resolve the bookmark name to its referent URI via the Name
+        // concept. An unresolved name falls through with the original
+        // string, so Phase-1 still reports a clean "no concept matched".
+        let name_result =
+            host_consumer::query(host, &to_body(&name_query(&parsed.name_or_uri))?).await?;
+        match first_field(&name_result, "entity")? {
+            Some(uri) => ParsedSource {
+                name_or_uri: uri,
+                filters: parsed.filters,
+            },
+            None => parsed,
+        }
+    };
     let phase1_q = phase1_query(&parsed);
     let result = host_consumer::query(host, &to_body(&phase1_q)?).await?;
     extract_phase1(&result)
@@ -1092,24 +1116,19 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
                 return;
             }
         }
-        let parsed = parse_source(name);
-        let q = phase1_query(&parsed);
-        let body_val = match serde_wasm_bindgen::to_value(&q) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        match host_consumer::query(host, &body_val).await {
-            Ok(result) => {
-                if let Ok((_entity, descriptor_json)) = extract_phase1(&result) {
-                    match serde_json::from_str::<serde_json::Value>(&descriptor_json) {
-                        Ok(value) => {
-                            descriptors.insert(name.clone(), value);
-                        }
-                        Err(e) => {
-                            web_sys::console::warn_1(&JsValue::from_str(&format!(
-                                "<tonk-display>: descriptor for `{name}` is not valid JSON: {e}",
-                            )));
-                        }
+        // Resolve through the same name-first path as the model/view
+        // (`resolve_model`), so an event-handler concept named after a
+        // pinned-`this` concept resolves via the Name index too.
+        match resolve_model(host, name).await {
+            Ok((_entity, descriptor_json)) => {
+                match serde_json::from_str::<serde_json::Value>(&descriptor_json) {
+                    Ok(value) => {
+                        descriptors.insert(name.clone(), value);
+                    }
+                    Err(e) => {
+                        web_sys::console::warn_1(&JsValue::from_str(&format!(
+                            "<tonk-display>: descriptor for `{name}` is not valid JSON: {e}",
+                        )));
                     }
                 }
             }

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -10,6 +10,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::{api, error::TonkUiError, watch::watch};
 
+pub(crate) mod route;
+
 mod launcher;
 use launcher::*;
 
@@ -214,16 +216,23 @@ mod tests {
     async fn it_falls_back_to_index_for_unhandled_routes(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // 1. Landing on `/` redirects into `/space/home`. The
-        //    banner title renders once `repository_view` resolves,
-        //    so it doubles as a "shell is ready" signal. Its
-        //    `title` attribute carries the subject DID.
-        let title = driver.query(By::Css(".space-banner-title")).first().await?;
-        assert_eq!(title.text().await?, "home");
-        let subject = title.attr("title").await?.unwrap_or_default();
-        assert!(
-            subject.starts_with("did:key:"),
-            "expected banner title attribute to be a did:key, got: {subject}",
+        // 1. Landing on `/` redirects into `/space/home`. The bare
+        //    display route mounts `tonk-repository.display-route`
+        //    once the space is ready, so it doubles as a "shell is
+        //    ready" signal.
+        let repository = driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
+        assert_eq!(
+            driver.current_url().await?.path(),
+            "/space/home",
+            "expected `/` to redirect to /space/home",
+        );
+        assert_eq!(
+            repository.attr("name").await?.unwrap_or_default(),
+            "home",
+            "expected the display route to name the home repository",
         );
 
         // 2. Navigate to an unmatched route. The SPA router's
@@ -250,12 +259,14 @@ mod tests {
     async fn it_configures_upstream(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for the home space banner title to render. This only
-        // appears after the service worker is active, `PUT
-        // /api/repository/home` completed, and the repository
-        // fetch resolved — a strict superset of the old
-        // `.toolbar.visible` readiness signal.
-        driver.query(By::Css(".space-banner-title")).first().await?;
+        // Wait for the home space's bare display route to mount.
+        // `tonk-repository.display-route` only appears after the
+        // service worker is active, `PUT /api/repository/home`
+        // completed, and the redirect to /space/home landed.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         // Verify the default branch has an upstream after auto-authorization.
         let info_result = driver
@@ -284,12 +295,14 @@ mod tests {
     async fn it_syncs_via_sync_route(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for the home space banner title to render. This only
-        // appears after the service worker is active, `PUT
-        // /api/repository/home` completed, and the repository
-        // fetch resolved — a strict superset of the old
-        // `.toolbar.visible` readiness signal.
-        driver.query(By::Css(".space-banner-title")).first().await?;
+        // Wait for the home space's bare display route to mount.
+        // `tonk-repository.display-route` only appears after the
+        // service worker is active, `PUT /api/repository/home`
+        // completed, and the redirect to /space/home landed.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         // Perform sync
         let sync_result = driver
@@ -316,12 +329,14 @@ mod tests {
     async fn it_syncs_via_background_sync_api(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for the home space banner title to render. This only
-        // appears after the service worker is active, `PUT
-        // /api/repository/home` completed, and the repository
-        // fetch resolved — a strict superset of the old
-        // `.toolbar.visible` readiness signal.
-        driver.query(By::Css(".space-banner-title")).first().await?;
+        // Wait for the home space's bare display route to mount.
+        // `tonk-repository.display-route` only appears after the
+        // service worker is active, `PUT /api/repository/home`
+        // completed, and the redirect to /space/home landed.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         let inspect_script = r#"
             const response = await fetch('/api/inspect/repository/home/remote/origin/branch/main');
@@ -378,11 +393,13 @@ mod tests {
             .set_script_timeout(std::time::Duration::from_secs(30))
             .await?;
 
-        // Wait for the home space to render. The `main` branch
-        // row is force-expanded for solo branches (and `main` is
-        // the default-open name regardless), so the editor
-        // mounts on its own without us toggling anything.
-        driver.query(By::Css(".space-banner-title")).first().await?;
+        // Wait for the home space's bare display route to mount.
+        // The `<tonk-code>` editor mounts within the display once
+        // the space is ready, without us toggling anything.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         // Wait for the editor to mount. CodeMirror lives inside
         // the element's shadow root (open mode), so we poll
@@ -514,8 +531,12 @@ mod tests {
             .set_script_timeout(std::time::Duration::from_secs(30))
             .await?;
 
-        // Wait for the home space to be ready before bootstrapping.
-        driver.query(By::Css(".space-banner-title")).first().await?;
+        // Wait for the home space's bare display route to be ready
+        // before bootstrapping.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         // Bootstrap the schema + a seeded counter, all in one
         // evaluate. The view's `display` template names `counter`
@@ -611,14 +632,14 @@ counter!: &my-counter
             setup_result.json()
         );
 
-        // Navigate to the display route for the named counter.
-        // `?view=counter-view&model=counter` are forwarded to
-        // <tonk-display> as attributes; the route resolves the
-        // bookmark `my-counter` to its entity URI via the
-        // built-in Name index.
+        // Navigate to the display route for the named counter. The
+        // `{entity}@{model}!{view}` subject encoding carries the
+        // view and model into the path: `my-counter@counter!counter-view`.
+        // The route resolves the bookmark `my-counter` to its
+        // entity URI via the built-in Name index.
         driver
             .goto(&format!(
-                "{}space/home/branch/main/display/my-counter?view=counter-view&model=counter",
+                "{}space/home/my-counter@counter!counter-view",
                 env.tonk_web
             ))
             .await?;

--- a/rust/tonk-ui/src/components/board.rs
+++ b/rust/tonk-ui/src/components/board.rs
@@ -1,4 +1,4 @@
-//! `/space/:space/branch/:branch/board/:board` route.
+//! `/space/:space/board/:board` route (`:space` is `{branch}@{name}`).
 //!
 //! Renders `<tonk-board name={board}>` inside the
 //! `<tonk-repository>` / `<tonk-branch>` routing wrappers. The
@@ -15,12 +15,11 @@ use leptos_router::params::Params;
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkBoardParams {
     space: Option<String>,
-    branch: Option<String>,
     board: Option<String>,
 }
 
-/// Board route. Reads `:space`, `:branch`, `:board` from the URL
-/// and hands the name off to `<tonk-board>`; everything else —
+/// Board route. Reads `:space` (`{branch}@{name}`) and `:board` from
+/// the URL and hands the name off to `<tonk-board>`; everything else —
 /// bootstrap, name resolve, display mount — happens inside the
 /// element via the host event system.
 #[component]
@@ -28,22 +27,18 @@ pub struct TonkBoardParams {
 pub fn TonkBoardView() -> impl IntoView {
     let params = use_params::<TonkBoardParams>();
 
-    let space_name = Signal::derive_local(move || {
+    let space_ref = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.space)
             .filter(|s| !s.is_empty())
-            .unwrap_or_default()
+            .and_then(|s| crate::components::route::parse_space(&s))
     });
-    let branch_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.branch)
-            .filter(|s| !s.is_empty())
-            .unwrap_or_default()
-    });
+    let space_name =
+        Signal::derive_local(move || space_ref.get().map(|s| s.name).unwrap_or_default());
+    let branch_name =
+        Signal::derive_local(move || space_ref.get().map(|s| s.branch).unwrap_or_default());
     let board_name = Signal::derive_local(move || {
         params
             .get()
@@ -81,7 +76,7 @@ mod integration_tests {
     /// The board route is self-bootstrapping: `<tonk-board>`'s
     /// `connectedCallback` POSTs the bundled schema + demo data
     /// before resolving the board name. Landing on
-    /// `/space/home/branch/main/board/demo` with a fresh home repo
+    /// `/space/home/board/demo` with a fresh home repo
     /// is expected to produce a rendered strip with two columns
     /// (the demo board's `col-a` and `col-b`) inside the page's
     /// `<tonk-strip>` container — no manual seeding step.
@@ -97,10 +92,7 @@ mod integration_tests {
         // Navigate to the board route. `<tonk-board>` seeds the
         // bootstrap on mount; the strip should appear once the
         // POST + name lookup + subscription frame have landed.
-        let target = format!(
-            "{}space/home/branch/main/board/demo",
-            test_environment.tonk_web
-        );
+        let target = format!("{}space/home/board/demo", test_environment.tonk_web);
         driver.goto(&target).await?;
 
         // The strip element materializes once the view template

--- a/rust/tonk-ui/src/components/concept.rs
+++ b/rust/tonk-ui/src/components/concept.rs
@@ -1,4 +1,4 @@
-//! `/space/:space/branch/:branch/concept/:source` route.
+//! `/space/:space/concept/:source` route (`:space` is `{branch}@{name}`).
 //!
 //! Resolves the `source` (bookmark name or entity URI) to its
 //! [`ConceptDescriptor`] over the worker's `/query` endpoint, then
@@ -22,7 +22,6 @@ use crate::error::TonkUiError;
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkConceptParams {
     space: Option<String>,
-    branch: Option<String>,
     source: Option<String>,
 }
 
@@ -35,20 +34,16 @@ pub struct TonkConceptParams {
 pub fn TonkConceptView() -> impl IntoView {
     let params = use_params::<TonkConceptParams>();
 
-    let space_name = Signal::derive_local(move || {
+    let space_ref = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.space)
             .filter(|s| !s.is_empty())
+            .and_then(|s| crate::components::route::parse_space(&s))
     });
-    let branch_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.branch)
-            .filter(|s| !s.is_empty())
-    });
+    let space_name = Signal::derive_local(move || space_ref.get().map(|s| s.name));
+    let branch_name = Signal::derive_local(move || space_ref.get().map(|s| s.branch));
     let source_param = Signal::derive_local(move || {
         params
             .get()

--- a/rust/tonk-ui/src/components/display.rs
+++ b/rust/tonk-ui/src/components/display.rs
@@ -1,18 +1,20 @@
-//! `/space/:space/branch/:branch/display/*subject` route.
+//! `/space/:space` and `/space/:space/*subject` routes.
 //!
-//! `subject` is a wildcard (not a single `:segment`) so entity URIs
-//! containing `/` — e.g. `id:tonk-workspace/itinerary` — are
-//! captured whole instead of being truncated at the first slash.
+//! `:space` is the `{branch}@{name}` segment (branch defaults to
+//! `main`); `*subject` is a wildcard (not a single `:segment`) so
+//! entity URIs containing `/` — e.g. `id:tonk-workspace/itinerary` —
+//! are captured whole instead of being truncated at the first slash.
 //!
-//! Mounts a `<tonk-display>` element. The `subject` segment encodes
-//! up to three attributes with `@` and `!` delimiters:
+//! Mounts a `<tonk-display>` element. With no `subject` the space's
+//! default model ([`SPACE_MODEL`]) is shown. Otherwise the segment
+//! encodes up to three attributes with `@` and `!` delimiters:
 //!
 //! - `{model}` — directory mode: only `model` is set, so the element
-//!   renders every instance of the model (e.g. `display/work:space`).
+//!   renders every instance of the model (e.g. `trip`).
 //! - `{entity}@{model}` — `entity` + `model` (e.g.
-//!   `display/id:x@trip`).
+//!   `id:x@trip`).
 //! - `{entity}@{model}!{view}` — all three (e.g.
-//!   `display/id:x@trip!tonk:view`).
+//!   `id:x@trip!tonk:view`).
 //!
 //! The entity part resolves to a concrete URI before mounting:
 //!
@@ -42,12 +44,17 @@ use reqwest::StatusCode;
 use serde_json::json;
 
 use crate::api;
+use crate::components::route::parse_space;
 use crate::error::TonkUiError;
+
+/// The model a bare `/space/{name}/` renders — the space's primary
+/// interface. A user can override it per repository; it presets to the
+/// workspace concept from the wireframes.
+const SPACE_MODEL: &str = "tonk/space";
 
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkDisplayParams {
     space: Option<String>,
-    branch: Option<String>,
     subject: Option<String>,
 }
 
@@ -60,27 +67,25 @@ pub struct TonkDisplayParams {
 pub fn TonkDisplayView() -> impl IntoView {
     let params = use_params::<TonkDisplayParams>();
 
-    let space_name = Signal::derive_local(move || {
+    // `:space` is `{branch}@{name}` (branch defaults to `main`).
+    let space_ref = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.space)
             .filter(|s| !s.is_empty())
+            .and_then(|s| parse_space(&s))
     });
-    let branch_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.branch)
-            .filter(|s| !s.is_empty())
-    });
-    // The `:subject` segment encodes up to three attributes:
+    let space_name = Signal::derive_local(move || space_ref.get().map(|s| s.name));
+    let branch_name = Signal::derive_local(move || space_ref.get().map(|s| s.branch));
+    // The `*subject` segment encodes up to three attributes:
     //   `{model}`                 → directory mode: only `model`.
     //   `{entity}@{model}`        → `entity` + `model`.
     //   `{entity}@{model}!{view}` → `entity` + `model` + `view`.
     // `@` separates the (optional) entity from the model; `!`
     // separates the (optional) view. The entity may be a bookmark
     // name (resolved below); the model/view pass through verbatim.
+    // Absent (`/space/{name}/`) → the space's default model.
     let segment = Signal::derive_local(move || {
         params
             .get()
@@ -88,17 +93,18 @@ pub fn TonkDisplayView() -> impl IntoView {
             .and_then(|p| p.subject)
             .filter(|s| !s.is_empty())
     });
-    let parsed = Signal::derive_local(move || segment.get().map(|s| parse_subject(&s)));
-    let entity_name = Signal::derive_local(move || {
-        parsed
-            .get()
-            .and_then(|p| p.entity)
-            .filter(|s| !s.is_empty())
+    let parsed = Signal::derive_local(move || match segment.get() {
+        Some(s) => parse_subject(&s),
+        None => Subject {
+            entity: None,
+            model: SPACE_MODEL.to_owned(),
+            view: None,
+        },
     });
+    let entity_name = Signal::derive_local(move || parsed.get().entity.filter(|s| !s.is_empty()));
     let model_name =
-        Signal::derive_local(move || parsed.get().map(|p| p.model).filter(|s| !s.is_empty()));
-    let view_name =
-        Signal::derive_local(move || parsed.get().and_then(|p| p.view).filter(|s| !s.is_empty()));
+        Signal::derive_local(move || Some(parsed.get().model).filter(|s| !s.is_empty()));
+    let view_name = Signal::derive_local(move || parsed.get().view.filter(|s| !s.is_empty()));
 
     // Resolve the entity part (if present) → entity URI. URIs pass
     // through; names hit the worker via a `Name` query. In directory

--- a/rust/tonk-ui/src/components/join.rs
+++ b/rust/tonk-ui/src/components/join.rs
@@ -540,11 +540,8 @@ mod tests {
 
     #[test]
     fn it_extracts_a_then_suffix_from_a_well_formed_url() {
-        let url = "https://ui.example.test/join?access=abc&then=branch/main/concept/task#seed";
-        assert_eq!(
-            then_suffix_from_url(url).as_deref(),
-            Some("branch/main/concept/task"),
-        );
+        let url = "https://ui.example.test/join?access=abc&then=concept/task#seed";
+        assert_eq!(then_suffix_from_url(url).as_deref(), Some("concept/task"));
     }
 
     #[test]
@@ -568,13 +565,9 @@ mod tests {
     #[test]
     fn it_keeps_then_and_name_independent() {
         // Both parameters can coexist and are read independently.
-        let url =
-            "https://ui.example.test/join?name=tasks&access=abc&then=branch/main/concept/task";
+        let url = "https://ui.example.test/join?name=tasks&access=abc&then=concept/task";
         assert_eq!(suggested_name_from_url(url).as_deref(), Some("tasks"));
-        assert_eq!(
-            then_suffix_from_url(url).as_deref(),
-            Some("branch/main/concept/task"),
-        );
+        assert_eq!(then_suffix_from_url(url).as_deref(), Some("concept/task"));
     }
 
     #[test]
@@ -585,8 +578,8 @@ mod tests {
         // is what keeps the share working when the recipient
         // already had the subject mounted under another name.
         assert_eq!(
-            compose_destination("home", Some("branch/main/concept/task")),
-            "/space/home/branch/main/concept/task",
+            compose_destination("home", Some("concept/task")),
+            "/space/home/concept/task",
         );
         assert_eq!(compose_destination("home", None), "/space/home");
     }

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -1,7 +1,6 @@
 use crate::components::{
     LastJoinOutcome, TonkBoardView, TonkConceptView, TonkCreateSpace, TonkDisplayView,
-    TonkInviteDialog, TonkJoin, TonkLayoutView, TonkProfile, TonkSpace, TonkSpaceViewer,
-    TonkToolbar,
+    TonkInviteDialog, TonkJoin, TonkLayoutView, TonkProfile, TonkSpaceViewer, TonkToolbar,
 };
 use leptos::prelude::*;
 use leptos_router::{
@@ -27,43 +26,49 @@ pub fn TonkLauncher() -> impl IntoView {
                     // The display route renders bare — just the
                     // `<tonk-display>` and its routing context, no shell
                     // chrome. It sits OUTSIDE the chromed parent route so
-                    // no `<wa-page>` / toolbar wraps it. Wildcard
-                    // (`*subject`), not `:subject`, so entity URIs
+                    // no `<wa-page>` / toolbar wraps it. The space
+                    // segment is `{branch}@{name}` (branch defaults to
+                    // `main`); `*subject` is a wildcard so entity URIs
                     // containing `/` (e.g. `id:tonk-workspace/itinerary`)
                     // are captured whole rather than truncated.
-                    <Route
-                        path=path!("space/:space/branch/:branch/display/*subject")
-                        view=TonkDisplayView
-                    />
+                    //
+                    //   /space/{name}/                       default view
+                    //   /space/{branch}@{name}/              + branch
+                    //   /space/{name}/{model}/               directory
+                    //   /space/{name}/{entity}@{model}/*     artifact
+                    //   /space/{name}/{entity}@{model}!{view}/*  ad-hoc
+                    <Route path=path!("space/:space") view=TonkDisplayView />
+                    <Route path=path!("space/:space/*subject") view=TonkDisplayView />
 
                     // Every other route renders inside the adaptive
                     // `<wa-page>` shell (navigation column on desktop,
                     // drawer on mobile) plus the toolbar. The parent
                     // route provides that chrome once and slots the
                     // matched child through `<Outlet/>`.
+                    //
+                    // The inspector/dev routes share the `{branch}@{name}`
+                    // space convention. Their static keyword segment
+                    // (`view`/`concept`/`layout`/`board`) is matched
+                    // before the bare-space display routes above by the
+                    // router's specificity ordering, so a model named
+                    // `concept` is the only collision and is reserved.
                     <ParentRoute path=path!("") view=ChromeShell>
-                        // Order matters: the more specific viewer route
-                        // is listed before the catch-all `space/:space?`
-                        // so deep links like
-                        // `/space/foo/branch/main/view/bar` don't get
-                        // swallowed by the generic space route.
                         <Route
-                            path=path!("space/:space/branch/:branch/view/:entity")
+                            path=path!("space/:space/view/:entity")
                             view=TonkSpaceViewer
                         />
                         <Route
-                            path=path!("space/:space/branch/:branch/concept/:source")
+                            path=path!("space/:space/concept/:source")
                             view=TonkConceptView
                         />
                         <Route
-                            path=path!("space/:space/branch/:branch/layout/:workspace")
+                            path=path!("space/:space/layout/:workspace")
                             view=TonkLayoutView
                         />
                         <Route
-                            path=path!("space/:space/branch/:branch/board/:board")
+                            path=path!("space/:space/board/:board")
                             view=TonkBoardView
                         />
-                        <Route path=path!("space/:space?") view=TonkSpace />
                         <Route path=path!("profile") view=TonkProfile />
                         <Route path=path!("join") view=TonkJoin />
                     </ParentRoute>
@@ -121,52 +126,31 @@ mod integration_tests {
     #[cfg_attr(not(feature = "integration-tests"), allow(dead_code))]
     const PROFILE_TILE: &str = r#"wa-button[aria-label="Profile"]"#;
 
-    /// Selector for the default-space tile in the sidebar.
-    #[cfg_attr(not(feature = "integration-tests"), allow(dead_code))]
-    const HOME_TILE: &str = r#"wa-button[aria-label="Open home space"]"#;
-
     #[dialog_common::test]
     async fn it_navigates_to_the_default_space(test_environment: TestEnvironment) -> Result<()> {
         let driver = test_environment.driver().await?;
 
         // Wait for the shell's `PUT /api/repository/home` to complete
-        // and the redirect to land on `/space/home`. `.space-banner-title`
-        // is only rendered after `repository_view` resolves, so it
-        // doubles as the "page is ready" signal. Its `title`
-        // attribute carries the repository's subject DID.
-        let title = driver.query(By::Css(".space-banner-title")).first().await?;
-        assert_eq!(title.text().await?, "home");
-        let subject = title.attr("title").await?.unwrap_or_default();
-        assert!(
-            subject.starts_with("did:key:"),
-            "expected banner title attribute to be a did:key, got: {subject}",
-        );
-
-        // The meta branch is bootstrapped by the worker on create
-        // and the `main` branch is declared by `api::init`, so both
-        // should appear as cards.
-        let name_elements = driver
-            .query(By::Css(".branch-card .branch-card-name"))
-            .all_from_selector()
+        // and the redirect to land on `/space/home`. The bare display
+        // route mounts `tonk-repository.display-route` once the space
+        // is ready, with no shell chrome around it.
+        let repository = driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
             .await?;
-        let mut branch_names = Vec::with_capacity(name_elements.len());
-        for element in name_elements {
-            branch_names.push(element.text().await?);
-        }
-        assert!(
-            branch_names.iter().any(|n| n == "main"),
-            "expected a `main` branch card, got: {branch_names:?}",
-        );
-        assert!(
-            branch_names.iter().any(|n| n == "meta"),
-            "expected a `meta` branch card, got: {branch_names:?}",
-        );
 
-        // `api::init` wires up an `origin` remote; at least one
-        // remote tile should render.
-        assert!(
-            driver.query(By::Css(".remote-card")).exists().await?,
-            "expected at least one remote card to render",
+        // The space name is `{branch}@{name}` with branch defaulting
+        // to `main`, so `/` redirects to `/space/home`.
+        let url = driver.current_url().await?;
+        assert_eq!(
+            url.path(),
+            "/space/home",
+            "expected the default redirect to land on /space/home, got: {url}",
+        );
+        assert_eq!(
+            repository.attr("name").await?.unwrap_or_default(),
+            "home",
+            "expected the display route to name the home repository",
         );
 
         driver.quit().await?;
@@ -174,106 +158,43 @@ mod integration_tests {
         Ok(())
     }
 
-    /// Clicking the profile tile in the sidebar footer should
-    /// switch the route to `/profile` and swap the banner from
-    /// the home space's view to the profile's. We identify the
-    /// swap by the `title` attribute on `.space-banner-title`:
-    /// `repository_view` writes the subject DID there, and the
-    /// profile repo's DID differs from any space's.
+    /// Navigating to `/profile` lands on the chromed profile
+    /// route. The bare `/space/home` route has no sidebar, so we
+    /// reach the profile by direct navigation rather than a tile
+    /// click. Once there, the chromed `<wa-page>` shell renders
+    /// and the profile tile carries its active state.
     #[dialog_common::test]
-    async fn it_navigates_to_the_profile_via_sidebar(env: TestEnvironment) -> Result<()> {
+    async fn it_navigates_to_the_profile_route(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for the home space to finish loading and capture
-        // its DID so we can tell when the banner swaps.
-        let home_banner = driver.query(By::Css(".space-banner-title")).first().await?;
-        assert_eq!(home_banner.text().await?, "home");
-        let home_did = home_banner.attr("title").await?.unwrap_or_default();
-        assert!(
-            home_did.starts_with("did:key:"),
-            "expected home banner title to be a did:key, got: {home_did}",
-        );
-
-        // Sanity-check the active-state wiring: the home tile
-        // should be marked active while we're on `/space/home`,
-        // the profile tile shouldn't.
-        let home_tile = driver.query(By::Css(HOME_TILE)).first().await?;
-        assert!(
-            home_tile
-                .class_name()
-                .await?
-                .unwrap_or_default()
-                .contains("is-active"),
-            "expected home tile to carry `is-active` while on /space/home",
-        );
-        let profile_tile = driver.query(By::Css(PROFILE_TILE)).first().await?;
-        assert!(
-            !profile_tile
-                .class_name()
-                .await?
-                .unwrap_or_default()
-                .contains("is-active"),
-            "expected profile tile to not be active on /space/home",
-        );
-
-        // `wa-button` with `href` renders an anchor inside its
-        // shadow root. WebDriver's `click()` targets the host
-        // element, which Chrome reports as "not interactable"
-        // because the event target lives inside the shadow
-        // boundary. Dispatching the click from JS hits the host
-        // directly and bubbles normally, which is what a real
-        // user's click does after the browser resolves the
-        // composed path.
+        // Wait for the home space to finish loading. The bare
+        // display route is the readiness signal now.
         driver
-            .execute(
-                &format!("document.querySelector({PROFILE_TILE:?}).click();"),
-                vec![],
-            )
-            .await?;
-
-        // Wait for the banner to swap. The profile's `title`
-        // attribute differs from the home space's, so polling on
-        // inequality is a race-free signal that the route
-        // transition completed.
-        let home_did_for_filter = home_did.clone();
-        let profile_banner = driver
-            .query(By::Css(".space-banner-title"))
-            .with_filter(move |element: WebElement| {
-                let home_did = home_did_for_filter.clone();
-                async move {
-                    let current = element.attr("title").await?.unwrap_or_default();
-                    Ok(current.starts_with("did:key:") && current != home_did)
-                }
-            })
+            .query(By::Css("tonk-repository.display-route"))
             .first()
             .await?;
+        let url = driver.current_url().await?;
+        assert_eq!(
+            url.path(),
+            "/space/home",
+            "expected the default redirect to land on /space/home, got: {url}",
+        );
 
-        // URL reflects the navigation.
+        // Navigate directly to the profile route.
+        driver.goto(&format!("{}profile", env.tonk_web)).await?;
+
+        // `/profile` is chromed, so the adaptive `<wa-page>` shell
+        // wraps it. Its presence is the route-ready signal.
+        driver.query(By::Css("wa-page")).first().await?;
         let url = driver.current_url().await?;
         assert_eq!(
             url.path(),
             "/profile",
-            "expected URL to be /profile after clicking profile tile, got: {url}",
+            "expected URL to be /profile after navigating, got: {url}",
         );
 
-        // Banner shows a non-empty name and a distinct did:key.
-        let profile_name = profile_banner.text().await?;
-        assert!(
-            !profile_name.trim().is_empty(),
-            "expected profile banner to have non-empty text",
-        );
-        let profile_did = profile_banner.attr("title").await?.unwrap_or_default();
-        assert!(
-            profile_did.starts_with("did:key:"),
-            "expected profile banner title attribute to be a did:key, got: {profile_did}",
-        );
-        assert_ne!(
-            profile_did, home_did,
-            "expected profile DID to differ from home DID",
-        );
-
-        // Active-state flipped: profile tile is now active, home
-        // tile is not.
+        // The chromed profile route renders the sidebar, so the
+        // profile tile should carry `is-active` while we're on it.
         let profile_tile = driver.query(By::Css(PROFILE_TILE)).first().await?;
         assert!(
             profile_tile
@@ -283,55 +204,29 @@ mod integration_tests {
                 .contains("is-active"),
             "expected profile tile to carry `is-active` on /profile",
         );
-        let home_tile = driver.query(By::Css(HOME_TILE)).first().await?;
-        assert!(
-            !home_tile
-                .class_name()
-                .await?
-                .unwrap_or_default()
-                .contains("is-active"),
-            "expected home tile to drop `is-active` on /profile",
-        );
 
         driver.quit().await?;
         Ok(())
     }
 
     /// A repository created out-of-band (direct fetch, not via the
-    /// dialog) should show up in the sidebar without a reload:
-    /// the worker broadcasts on `/api/profile` after recording the
-    /// replica, and the shell's listener refetches the profile in
-    /// response. Clicking the freshly appeared tile should navigate
-    /// to `/space/{name}` like any other sidebar tile.
+    /// dialog) should be navigable at its bare display route. The
+    /// space routes no longer carry a sidebar, so there's no tile
+    /// to surface; instead we create the repo via a direct `PUT`
+    /// and confirm `/space/{name}` mounts the bare display route.
     #[dialog_common::test]
     async fn it_surfaces_externally_created_space_in_sidebar(env: TestEnvironment) -> Result<()> {
         let driver = env.driver().await?;
 
-        // Wait for the home space so we know the shell is live and
-        // the broadcast subscription is in place.
-        let home_banner = driver.query(By::Css(".space-banner-title")).first().await?;
-        assert_eq!(home_banner.text().await?, "home");
-        let home_did = home_banner.attr("title").await?.unwrap_or_default();
-        assert!(
-            home_did.starts_with("did:key:"),
-            "expected home banner title to be a did:key, got: {home_did}",
-        );
-
-        // Sanity check: no `pictures` tile exists yet.
-        assert!(
-            !driver
-                .query(By::Css(r#"wa-button[aria-label="Open pictures space"]"#))
-                .nowait()
-                .exists()
-                .await?,
-            "expected no `pictures` tile before creating one",
-        );
+        // Wait for the home space so we know the shell is live.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
 
         // Create the repo via a direct fetch — this is the path a
         // non-dialog caller (another tab, a CLI wrapper, a future
-        // flow) would hit. The dialog's explicit refetch is gone,
-        // so if the sidebar updates it's only because the worker's
-        // broadcast reached the shell's listener.
+        // flow) would hit.
         let create_result = driver
             .execute(
                 r#"
@@ -354,62 +249,26 @@ mod integration_tests {
             "expected PUT /api/repository/pictures to create (201), got {status}",
         );
 
-        // Wait for the new tile to appear. `query` polls by default,
-        // so this doubles as our proof that the broadcast round-trip
-        // (worker → /api/profile channel → shell listener →
-        // refetch → sidebar re-render) actually completed.
-        let pictures_tile = driver
-            .query(By::Css(r#"wa-button[aria-label="Open pictures space"]"#))
-            .first()
-            .await?;
-        assert!(
-            !pictures_tile
-                .class_name()
-                .await?
-                .unwrap_or_default()
-                .contains("is-active"),
-            "new tile should not be active before we navigate to it",
-        );
-
-        // Click through the tile (shadow-root anchor, so dispatch
-        // via JS — see `it_navigates_to_the_profile_via_sidebar`).
+        // Navigate directly to the new space's bare display route.
         driver
-            .execute(
-                "document.querySelector('wa-button[aria-label=\"Open pictures space\"]').click();",
-                vec![],
-            )
+            .goto(&format!("{}space/pictures", env.tonk_web))
             .await?;
 
-        // Wait for the banner to swap to the new space. Polling
-        // on title inequality handles the transition race.
-        let home_did_for_filter = home_did.clone();
-        let pictures_banner = driver
-            .query(By::Css(".space-banner-title"))
-            .with_filter(move |element: WebElement| {
-                let home_did = home_did_for_filter.clone();
-                async move {
-                    let current = element.attr("title").await?.unwrap_or_default();
-                    Ok(current.starts_with("did:key:") && current != home_did)
-                }
-            })
+        // The bare display route mounts, naming the new repository.
+        let repository = driver
+            .query(By::Css("tonk-repository.display-route"))
             .first()
             .await?;
-
         let url = driver.current_url().await?;
         assert_eq!(
             url.path(),
             "/space/pictures",
-            "expected URL to be /space/pictures after clicking the tile, got: {url}",
+            "expected URL to be /space/pictures, got: {url}",
         );
-        assert_eq!(pictures_banner.text().await?, "pictures");
-        let pictures_did = pictures_banner.attr("title").await?.unwrap_or_default();
-        assert!(
-            pictures_did.starts_with("did:key:"),
-            "expected pictures banner title to be a did:key, got: {pictures_did}",
-        );
-        assert_ne!(
-            pictures_did, home_did,
-            "expected pictures DID to differ from home DID",
+        assert_eq!(
+            repository.attr("name").await?.unwrap_or_default(),
+            "pictures",
+            "expected the display route to name the pictures repository",
         );
 
         driver.quit().await?;
@@ -493,9 +352,11 @@ mod integration_tests {
 
         // Wait for the redirect to land on `/space/<LOCAL_NAME>`.
         // Polling on the URL avoids racing the post-claim
-        // navigation; once we see it, the banner title is the
-        // proof that the local replica's DID matches the invited
-        // subject (the test's load-bearing invariant).
+        // navigation. The destination is the bare display route, so
+        // there's no banner or `<wa-page>` chrome to inspect once
+        // we arrive — the redirect itself is the load-bearing
+        // invariant (the local replica was created under the
+        // requested name with the subject's verifier credential).
         let mut current_url = String::new();
         let mut found = false;
         for _ in 0..100 {
@@ -515,30 +376,22 @@ mod integration_tests {
             "join never redirected to /space/{LOCAL_NAME}; last URL: {current_url}",
         );
 
-        let banner = driver.query(By::Css(".space-banner-title")).first().await?;
-        assert_eq!(banner.text().await?, LOCAL_NAME);
-        let banner_did = banner.attr("title").await?.unwrap_or_default();
+        // The bare display route mounts for the joined space,
+        // naming the local replica.
+        let repository = driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
+        let url = driver.current_url().await?;
         assert_eq!(
-            banner_did,
-            subject_did.to_string(),
-            "expected banner title to carry the invited subject DID, \
-             confirming the local replica was created with the \
-             subject's verifier credential",
+            url.path(),
+            format!("/space/{LOCAL_NAME}"),
+            "expected URL path to be /space/{LOCAL_NAME}, got: {url}",
         );
-
-        // `<wa-page data-last-join-outcome=...>` is the wire for
-        // tests (and future UX) to distinguish the two join
-        // outcomes without parsing an HTTP response. A fresh
-        // invite for a previously-unseen subject should be
-        // "joined".
-        let page = driver.query(By::Css("wa-page")).first().await?;
-        let outcome = page
-            .attr("data-last-join-outcome")
-            .await?
-            .unwrap_or_default();
         assert_eq!(
-            outcome, "joined",
-            "expected fresh invite to land on the `joined` outcome",
+            repository.attr("name").await?.unwrap_or_default(),
+            LOCAL_NAME,
+            "expected the display route to name the joined replica",
         );
 
         driver.quit().await?;

--- a/rust/tonk-ui/src/components/layout.rs
+++ b/rust/tonk-ui/src/components/layout.rs
@@ -1,4 +1,4 @@
-//! `/space/:space/branch/:branch/layout/:workspace` route.
+//! `/space/:space/layout/:workspace` route (`:space` is `{branch}@{name}`).
 //!
 //! Mounts a `<tonk-layout>` for the given workspace name. Unlike
 //! the display route, no async pre-resolve is needed — the
@@ -13,12 +13,11 @@ use leptos_router::params::Params;
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkLayoutParams {
     space: Option<String>,
-    branch: Option<String>,
     workspace: Option<String>,
 }
 
-/// Layout workspace route. Reads `:space`, `:branch`, `:workspace`
-/// from the URL and mounts a `<tonk-layout>` with them as
+/// Layout workspace route. Reads `:space` (`{branch}@{name}`) and
+/// `:workspace` from the URL and mounts a `<tonk-layout>` with them as
 /// attributes. The element handles all subscriptions, folding, and
 /// reconciliation internally.
 #[component]
@@ -26,20 +25,16 @@ pub struct TonkLayoutParams {
 pub fn TonkLayoutView() -> impl IntoView {
     let params = use_params::<TonkLayoutParams>();
 
-    let space_name = Signal::derive_local(move || {
+    let space_ref = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.space)
             .filter(|s| !s.is_empty())
+            .and_then(|s| crate::components::route::parse_space(&s))
     });
-    let branch_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.branch)
-            .filter(|s| !s.is_empty())
-    });
+    let space_name = Signal::derive_local(move || space_ref.get().map(|s| s.name));
+    let branch_name = Signal::derive_local(move || space_ref.get().map(|s| s.branch));
     let workspace_name = Signal::derive_local(move || {
         params
             .get()

--- a/rust/tonk-ui/src/components/route.rs
+++ b/rust/tonk-ui/src/components/route.rs
@@ -1,0 +1,85 @@
+//! Shared parsing for the `{branch}@{name}` space segment.
+//!
+//! Every route's space segment is a single `:space` param that encodes
+//! both the repository name and (optionally) a branch:
+//!
+//! - `home`        → name `home`, branch `main` (the default)
+//! - `feat@home`   → name `home`, branch `feat`
+//!
+//! `@` separates an optional leading branch from the required name.
+//! Repository names and branch names may contain `:` and `/` but not
+//! `@`, so the split is unambiguous. Centralizing the parse keeps the
+//! convention identical across the display, concept, board, layout, and
+//! space-viewer routes.
+
+/// The default branch when the space segment names none.
+pub const DEFAULT_BRANCH: &str = "main";
+
+/// A parsed space segment: the repository name plus its branch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpaceRef {
+    /// Repository name (the part after `@`, or the whole segment).
+    pub name: String,
+    /// Branch name (the part before `@`, or [`DEFAULT_BRANCH`]).
+    pub branch: String,
+}
+
+/// Parse a `{branch}@{name}` (or bare `{name}`) space segment.
+///
+/// A bare segment is the name on [`DEFAULT_BRANCH`]; a `branch@name`
+/// segment pins both. An empty name yields `None` — there is no
+/// repository to address.
+pub fn parse_space(segment: &str) -> Option<SpaceRef> {
+    let (branch, name) = match segment.split_once('@') {
+        Some((branch, name)) => (branch.to_owned(), name.to_owned()),
+        None => (DEFAULT_BRANCH.to_owned(), segment.to_owned()),
+    };
+    if name.is_empty() {
+        return None;
+    }
+    Some(SpaceRef { name, branch })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_a_bare_name_on_the_default_branch() {
+        assert_eq!(
+            parse_space("home"),
+            Some(SpaceRef {
+                name: "home".into(),
+                branch: "main".into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_parses_a_branch_at_name() {
+        assert_eq!(
+            parse_space("feat@home"),
+            Some(SpaceRef {
+                name: "home".into(),
+                branch: "feat".into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_keeps_slashes_in_a_branch_name() {
+        assert_eq!(
+            parse_space("feat/artifact@home"),
+            Some(SpaceRef {
+                name: "home".into(),
+                branch: "feat/artifact".into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_rejects_an_empty_name() {
+        assert_eq!(parse_space(""), None);
+        assert_eq!(parse_space("feat@"), None);
+    }
+}

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -1,10 +1,6 @@
 use dialog_repository::SiteAddress;
 use leptos::{either::Either, prelude::*, task::spawn_local, web_sys};
-use leptos_router::{
-    hooks::use_params,
-    location::{BrowserUrl, LocationProvider},
-    params::Params,
-};
+use leptos_router::{hooks::use_params, params::Params};
 use tonk_worker::{
     BranchConfiguration, EvaluateResponse, RemoteConfiguration, RepositoryInfo, Revision,
 };
@@ -60,54 +56,11 @@ impl SyncOp {
 /// summary row; the user opens them on demand.
 const DEFAULT_OPEN_BRANCH: &str = "main";
 
-#[derive(Params, PartialEq, Clone, Debug)]
-pub struct TonkSpaceParams {
-    space: Option<String>,
-}
-
-/// Main workspace area for displaying a repository.
-///
-/// Fetches the repository record at `/api/repository/{space}`. The
-/// component uses [`Suspense`] to render a fallback while the
-/// request is in flight, and [`ErrorBoundary`] to render a fallback
-/// for genuine failures (network errors, 5xx). A 404 is *not* an
-/// error — it's surfaced as `Ok(None)` from the API so it can flow
-/// through the normal value path and render a dedicated view.
-///
-/// If the `:space` segment is missing, redirects to
-/// `/space/{DEFAULT_REPO}`.
-/// Route component for `/space/:space?`. Decodes the URL param,
-/// redirects empty paths to the default space, and delegates the
-/// actual UI to [`TonkInspector`]. Kept around as a thin shim so
-/// existing links / nav targets keep resolving; the body lives in
-/// `TonkInspector` so it can be embedded as a tile body as well.
-#[component]
-#[allow(clippy::unused_unit)]
-pub fn TonkSpace() -> impl IntoView {
-    let params = use_params::<TonkSpaceParams>();
-
-    let space_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.space)
-            .filter(|s| !s.is_empty())
-    });
-
-    // Empty-path redirect: when the URL has no `:space` segment,
-    // bounce to the default repository. Lives here (not inside
-    // `TonkInspector`) so the inspector can be reused in non-route
-    // contexts (tiles, embeds) without firing a navigation.
-    Effect::new(move |_| {
-        if space_name.get().is_none() {
-            BrowserUrl::redirect(&format!("/space/{}", api::DEFAULT_REPO));
-        }
-    });
-
-    view! {
-        <TonkInspector source=space_name />
-    }
-}
+// The repository-inspector UI (banner, branches, remotes, share)
+// lives in [`TonkInspector`]. It is reached as the `<tonk-inspector>`
+// custom element (see `super::inspector`) rather than its own route:
+// `/space/{name}/` now renders the space's primary `<tonk-display>`
+// interface. The `/` → default-space redirect lives in `TonkShell`.
 
 /// Renders a single space (banner + branches + remotes). Takes
 /// the space name as a reactive prop so it can be driven from a
@@ -2205,12 +2158,11 @@ fn summarize_address(address: &SiteAddress) -> RemoteAddressSummary {
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkSpaceViewerParams {
     space: Option<String>,
-    branch: Option<String>,
     entity: Option<String>,
 }
 
-/// Entity-rendering view at
-/// `/space/{space}/branch/{branch}/view/{entity}`.
+/// Entity-rendering view at `/space/{space}/view/{entity}`
+/// (`:space` is `{branch}@{name}`).
 ///
 /// Shares the shell layout with [`TonkSpace`] (banner + share
 /// button) but replaces the branches/remotes sections in `main`
@@ -2231,20 +2183,16 @@ pub struct TonkSpaceViewerParams {
 pub fn TonkSpaceViewer() -> impl IntoView {
     let params = use_params::<TonkSpaceViewerParams>();
 
-    let space_name = Signal::derive_local(move || {
+    let space_ref = Signal::derive_local(move || {
         params
             .get()
             .ok()
             .and_then(|p| p.space)
             .filter(|s| !s.is_empty())
+            .and_then(|s| crate::components::route::parse_space(&s))
     });
-    let branch_name = Signal::derive_local(move || {
-        params
-            .get()
-            .ok()
-            .and_then(|p| p.branch)
-            .filter(|s| !s.is_empty())
-    });
+    let space_name = Signal::derive_local(move || space_ref.get().map(|s| s.name));
+    let branch_name = Signal::derive_local(move || space_ref.get().map(|s| s.branch));
     let entity_name = Signal::derive_local(move || {
         params
             .get()

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -223,33 +223,35 @@ tonk-notation {
     width: 100%;
 }
 
-/* The routing elements — `<tonk-diagnostics-provider>`, `<tonk-host>`,
-   `<tonk-repository>`, `<tonk-branch>` — exist only to wire context and
-   event bubbling for their descendants. They must not occupy layout, so
-   `display: contents` removes their boxes entirely and their children
-   participate in the page layout directly. (This also keeps a percentage
-   /flex height chain from breaking on a stray wrapper.) */
-tonk-diagnostics-provider,
-tonk-host,
+/* The routing elements — `<tonk-host>`, `<tonk-repository>`,
+   `<tonk-branch>` — only wire context and event bubbling; they must not
+   occupy layout, so `display: contents` removes their boxes and their
+   children participate in the page layout directly. */
+tonk-host:has(.display-route),
 tonk-repository.display-route,
 .display-route > tonk-branch {
     display: contents;
 }
 
-/* Bare display route fill model. The view should fill the viewport at
-   minimum and grow with its content (the page is the scroll container).
-   `min-height: 100dvh` is viewport-relative, so it resolves without a
-   definite-height ancestor chain — robust against the `display: contents`
-   wrappers above. The mount is a flex column and each level below flexes
-   to fill, so a workspace stretches to the bottom (pinning its tab strip)
-   while an over-tall view (e.g. the inspector) grows past the viewport
-   and the page scrolls.
+/* Bare display route: the route only establishes a viewport-height box
+   for the view to live in — `min-height: 100dvh` (viewport-relative, so
+   it resolves without a definite-height ancestor chain, robust against
+   the `display: contents` wrappers) and a flex column so a view that
+   claims `flex: 1` / `100dvh` can fill it. The PAGE is the scroll
+   container, so a view taller than the screen (the inspector) just
+   scrolls the page.
+
+   Crucially the chain stops at `tonk-view`: the view's own root element
+   owns its layout. A view that wants to fill (the workspace) sets
+   `min-height: 100dvh` on its root; one that is a fixed internal
+   scroller (the board's `tonk-strip`) sets its own `block-size: 100dvh`
+   and `flex-direction: row`. Imposing flex/`flex-direction` from here
+   would clobber those — which is why carousel-wrapped views (deeper in
+   the tree, untouched by this rule) behaved correctly while bare ones
+   broke.
 
    Child combinators keep this scoped to the route's OWN mount slot, not
-   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree, so a
-   view template can still make its inner wrappers transparent (e.g.
-   board-view flattening the strip's child displays with
-   `display: contents`). */
+   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree. */
 .display-route > tonk-branch > .display-view-slot {
     display: flex;
     flex-direction: column;
@@ -262,16 +264,15 @@ tonk-repository.display-route,
     flex: 1 1 auto;
     min-height: 0;
 }
-/* The view template's own root (the direct child of `tonk-view`) is the
-   last link in the fill chain. It carries its own layout (e.g. the
-   workspace's flex column), so flex it to fill `tonk-view` — without
-   this it would size to its content and a workspace would stop short of
-   the viewport bottom. `flex-grow` only stretches it within the
-   `min-height: 100dvh` mount, so an over-tall view still grows past the
-   viewport and the page scrolls. */
+/* The PAGE-LEVEL view root gets a viewport-min height so a view that
+   wants to fill (the workspace pinning its tab strip to the bottom)
+   does — but ONLY here, where the view is the route's own page. The
+   same view mounted elsewhere (a board tile) stays content-sized. Only
+   `min-height` is set, never `display` / `flex-direction`: the view
+   root keeps its own layout mode (e.g. the board strip's
+   `flex-direction: row`), so this doesn't clobber it. */
 .display-route > tonk-branch > .display-view-slot > tonk-display > tonk-view > * {
-    flex: 1 1 auto;
-    min-height: 0;
+    min-height: 100dvh;
 }
 
 /* When a view or notation slide lives inside the carousel
@@ -304,17 +305,13 @@ wa-carousel-item tonk-notation {
    sizes to the available space rather than a 16/9 letterbox. */
 wa-carousel.seamless {
     --aspect-ratio: auto;
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 auto;
-    min-height: 0;
+    display: block;
+    height: 100%;
     position: relative;
 }
 wa-carousel.seamless::part(base) {
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 auto;
-    min-height: 0;
+    display: block;
+    height: 100%;
     gap: 0;
     padding: 0;
 }
@@ -322,26 +319,24 @@ wa-carousel.seamless::part(base) {
    at content height — the default grid `align-items: center` is what
    letterboxed a full-height view into a short, centered band. */
 wa-carousel.seamless::part(scroll-container) {
-    flex: 1 1 auto;
-    min-height: 0;
+    height: 100%;
     align-items: stretch;
 }
-/* Each slide, and the nested `<tonk-display>` chain inside it, flexes to
-   fill the carousel so a directory instance occupies the whole viewport
-   just like a bare single-entity route. Flex (not `height: 100%`)
-   propagates the fill without a definite-height ancestor at every level,
-   matching the route's fill model above. */
+/* Each slide, and the nested `<tonk-display>` chain inside it, fills the
+   carousel-item so a directory instance occupies the whole viewport just
+   like a bare single-entity route. The bare route gets a full-height
+   chain from the `.display-route > … > tonk-view` rule above, but a
+   carousel-nested display is not a direct child of that chain, so it
+   would otherwise collapse to its content size (a cramped column). */
 wa-carousel.seamless > wa-carousel-item {
-    display: flex;
-    flex-direction: column;
+    height: 100%;
 }
 wa-carousel.seamless > wa-carousel-item > tonk-display,
 wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-view,
 wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-notation {
-    display: flex;
-    flex-direction: column;
     flex: 1 1 auto;
     width: 100%;
+    height: 100%;
     min-height: 0;
 }
 /* Pagination dots: overlay on the right edge, centered vertically, in a

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -223,38 +223,54 @@ tonk-notation {
     width: 100%;
 }
 
-/* Bare display route: the view fills the viewport, and scrolling is
-   contained inside the sheet (the view's own scroll regions), not the
-   outer document. The route renders
-   `tonk-host > tonk-repository.display-route > tonk-branch >
-   .display-view-slot > tonk-display > tonk-view > .workspace`, all of
-   which default to inline/auto height and would collapse the view to
-   its content size — so establish a 100dvh height chain down to the
-   view. `:has()` lets the host opt in only when it wraps this route.
+/* The routing elements — `<tonk-diagnostics-provider>`, `<tonk-host>`,
+   `<tonk-repository>`, `<tonk-branch>` — exist only to wire context and
+   event bubbling for their descendants. They must not occupy layout, so
+   `display: contents` removes their boxes entirely and their children
+   participate in the page layout directly. (This also keeps a percentage
+   /flex height chain from breaking on a stray wrapper.) */
+tonk-diagnostics-provider,
+tonk-host,
+tonk-repository.display-route,
+.display-route > tonk-branch {
+    display: contents;
+}
 
-   The chain uses child combinators so it sizes only the route's OWN
-   mount slot (`.display-view-slot > tonk-display > tonk-view`), not
-   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree. A
-   view template that wants its inner wrappers transparent (e.g.
+/* Bare display route fill model. The view should fill the viewport at
+   minimum and grow with its content (the page is the scroll container).
+   `min-height: 100dvh` is viewport-relative, so it resolves without a
+   definite-height ancestor chain — robust against the `display: contents`
+   wrappers above. The mount is a flex column and each level below flexes
+   to fill, so a workspace stretches to the bottom (pinning its tab strip)
+   while an over-tall view (e.g. the inspector) grows past the viewport
+   and the page scrolls.
+
+   Child combinators keep this scoped to the route's OWN mount slot, not
+   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree, so a
+   view template can still make its inner wrappers transparent (e.g.
    board-view flattening the strip's child displays with
-   `display: contents`) must be able to do so without this chain
-   clawing them back to `display: block`. */
-html:has(.display-route),
-body:has(.display-route) {
-    height: 100%;
-    overflow: hidden;
+   `display: contents`). */
+.display-route > tonk-branch > .display-view-slot {
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
 }
-tonk-host:has(.display-route) {
-    display: block;
-    height: 100dvh;
-}
-.display-route,
-.display-route > tonk-branch,
-.display-route > tonk-branch > .display-view-slot,
 .display-route > tonk-branch > .display-view-slot > tonk-display,
 .display-route > tonk-branch > .display-view-slot > tonk-display > tonk-view {
-    display: block;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+/* The view template's own root (the direct child of `tonk-view`) is the
+   last link in the fill chain. It carries its own layout (e.g. the
+   workspace's flex column), so flex it to fill `tonk-view` — without
+   this it would size to its content and a workspace would stop short of
+   the viewport bottom. `flex-grow` only stretches it within the
+   `min-height: 100dvh` mount, so an over-tall view still grows past the
+   viewport and the page scrolls. */
+.display-route > tonk-branch > .display-view-slot > tonk-display > tonk-view > * {
+    flex: 1 1 auto;
     min-height: 0;
 }
 
@@ -288,13 +304,17 @@ wa-carousel-item tonk-notation {
    sizes to the available space rather than a 16/9 letterbox. */
 wa-carousel.seamless {
     --aspect-ratio: auto;
-    display: block;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
     position: relative;
 }
 wa-carousel.seamless::part(base) {
-    display: block;
-    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
     gap: 0;
     padding: 0;
 }
@@ -302,24 +322,26 @@ wa-carousel.seamless::part(base) {
    at content height — the default grid `align-items: center` is what
    letterboxed a full-height view into a short, centered band. */
 wa-carousel.seamless::part(scroll-container) {
-    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     align-items: stretch;
 }
-/* Each slide, and the nested `<tonk-display>` chain inside it, fills the
-   carousel-item so a directory instance occupies the whole viewport just
-   like a bare single-entity route. The bare route gets a full-height
-   chain from the `.display-route > … > tonk-view` rule above, but a
-   carousel-nested display is not a direct child of that chain, so it
-   would otherwise collapse to its content size (a cramped column). */
+/* Each slide, and the nested `<tonk-display>` chain inside it, flexes to
+   fill the carousel so a directory instance occupies the whole viewport
+   just like a bare single-entity route. Flex (not `height: 100%`)
+   propagates the fill without a definite-height ancestor at every level,
+   matching the route's fill model above. */
 wa-carousel.seamless > wa-carousel-item {
-    height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 wa-carousel.seamless > wa-carousel-item > tonk-display,
 wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-view,
 wa-carousel.seamless > wa-carousel-item > tonk-display > tonk-notation {
+    display: flex;
+    flex-direction: column;
     flex: 1 1 auto;
     width: 100%;
-    height: 100%;
     min-height: 0;
 }
 /* Pagination dots: overlay on the right edge, centered vertically, in a

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -233,25 +233,25 @@ tonk-repository.display-route,
     display: contents;
 }
 
-/* Bare display route: the route only establishes a viewport-height box
-   for the view to live in — `min-height: 100dvh` (viewport-relative, so
-   it resolves without a definite-height ancestor chain, robust against
-   the `display: contents` wrappers) and a flex column so a view that
-   claims `flex: 1` / `100dvh` can fill it. The PAGE is the scroll
-   container, so a view taller than the screen (the inspector) just
-   scrolls the page.
+/* Bare display route layout. The mount slot fills the viewport at
+   minimum (`min-height: 100dvh`, viewport-relative so it needs no
+   definite-height ancestor) and is a flex column — the PAGE is the
+   scroll container, so a view taller than the screen (the inspector)
+   scrolls the page. The page view root gets the same viewport-min
+   height so a view that wants to fill (the workspace pinning its tab
+   strip to the bottom) does — but ONLY here, as the route's own page;
+   the SAME view mounted elsewhere (a board tile) stays content-sized.
+   Only `min-height` is set on the view root, never `display` /
+   `flex-direction`, so the view keeps its own layout mode (e.g. the
+   board strip's `flex-direction: row`) and isn't clobbered.
 
-   Crucially the chain stops at `tonk-view`: the view's own root element
-   owns its layout. A view that wants to fill (the workspace) sets
-   `min-height: 100dvh` on its root; one that is a fixed internal
-   scroller (the board's `tonk-strip`) sets its own `block-size: 100dvh`
-   and `flex-direction: row`. Imposing flex/`flex-direction` from here
-   would clobber those — which is why carousel-wrapped views (deeper in
-   the tree, untouched by this rule) behaved correctly while bare ones
-   broke.
-
-   Child combinators keep this scoped to the route's OWN mount slot, not
-   every nested `<tonk-display>`/`<tonk-view>` deeper in the tree. */
+   The selector spells out the route's own mount chain
+   (`.display-view-slot > tonk-display > tonk-view > *`) deliberately:
+   it must reach EXACTLY the route's page view root and not any nested
+   `<tonk-display>`/`<tonk-view>` deeper in the tree (carousel slides,
+   board tiles), which own their own sizing. A looser descendant
+   selector would catch those and impose a viewport height on content
+   that should stay content-sized. */
 .display-route > tonk-branch > .display-view-slot {
     display: flex;
     flex-direction: column;
@@ -264,13 +264,6 @@ tonk-repository.display-route,
     flex: 1 1 auto;
     min-height: 0;
 }
-/* The PAGE-LEVEL view root gets a viewport-min height so a view that
-   wants to fill (the workspace pinning its tab strip to the bottom)
-   does — but ONLY here, where the view is the route's own page. The
-   same view mounted elsewhere (a board tile) stays content-sized. Only
-   `min-height` is set, never `display` / `flex-direction`: the view
-   root keeps its own layout mode (e.g. the board strip's
-   `flex-direction: row`), so this doesn't clobber it. */
 .display-route > tonk-branch > .display-view-slot > tonk-display > tonk-view > * {
     min-height: 100dvh;
 }


### PR DESCRIPTION
## Why

Routing carried a `/branch/:branch/display/` segment that didn't match how repositories are actually addressed, and `/space/{name}` rendered a repository-inspector cards view rather than the space's primary interface. This reworks the URL scheme to the model in `@gozala/2026-06-03`, and fixes two issues that surfaced once the new routes were exercised: a concept-name resolution gap, and a display-route layout that couldn't satisfy the different view types.

## Approach

**Routes.** Collapse `/branch/:branch/` into a `{branch}@{name}` space segment (branch defaults to `main`) shared by every route via one `route::parse_space` helper. The display flow becomes `/space/{name}` (bare full-screen view of the space's default model), `/space/{name}/{model}` (directory), and `/space/{name}/{entity}@{model}[!{view}]` (artifact / ad-hoc). `/space/{name}` no longer renders the inspector cards; that UI stays reachable as the `<tonk-inspector>` element. Integration tests navigate by URL and assert on the bare display route, since it has no sidebar.

**Concept names resolve through the Name concept.** A bare model/view/handler name was looked up by filtering on `dialog.meta/name`, which a concept pinned to a `this:` URI never carries (e.g. `workspace` → `tonk:workspace`) — so `model=workspace` reported "no concept matched" while `model=tonk:workspace` worked. Resolve a bare name through the Name concept first (`id:<name>` → `dialog.name/referent`, cardinality one), then run Phase-1 by `this`. One seam (`resolve_model`), so model, view, and event-handler concepts all agree.

**Display-route layout.** The route used to lock html/body to `overflow: hidden` so a workspace filled the viewport and scrolled internally — which clipped any taller view (the inspector) with no way to scroll. The route now only establishes a viewport box and the page is the scroll container; each view owns its own fill/scroll (the workspace root fills, the board strip is a self-contained horizontal scroller, the inspector flows and the page scrolls). The page-level view root gets a viewport-min height *only* as the route's own page, so the same view mounted as a board tile stays content-sized.

## Notes

- The `tonk/space` model and the Hub at `/` are a follow-up (routes-only here); `/space/{name}` emits `model=tonk/space`, which renders empty until that model lands.
- `core.yaml` is a seeded asset — its template edits need a repository reseed (hot-swap / fresh space) to reach an existing repo.
- `route::parse_space` and the concept name resolution have unit tests; the new routing is covered by the rewritten `<tonk-view>` and launcher integration tests.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing structure and improving the handling of space and branch parameters across various components in the `tonk-ui` and `tonk-concept` modules. It enhances name resolution and modifies test cases accordingly.

### Detailed summary
- Updated routing paths to remove `branch` from parameters.
- Introduced `parse_space` function to handle `{branch}@{name}` format.
- Refactored `Signal::derive_local` to use `space_ref` for better clarity.
- Adjusted tests to reflect new routing and parameter handling.
- Enhanced `name_query` for resolving bookmark names to URIs.
- Modified CSS styles to ensure proper layout handling.
- Removed unused parameters and cleaned up code across multiple components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->