### PR TITLE
feat(background-sync): route durable sync per-repository and keep paused badges live

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -150,13 +150,15 @@ self.onmessage = event => {
     );
 };
 
-// Background Sync API event handler
+// Background Sync API event handler. The tag carries the repository
+// identity (`tonk-sync:{repo}`); a rejected promise here tells the
+// user agent to retry the sync with backoff.
 self.onsync = event => {
     log("Background sync event:", event.tag);
     event.waitUntil(
         (async () => {
             let worker = await activateWorker();
-            return worker.sync();
+            return worker.sync(event.tag);
         })()
     );
 };

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -144,28 +144,23 @@
                 await controlled;
             };
 
-            // Trigger sync - uses Background Sync API if available, otherwise falls back to /api/sync
-            self.sync = async () => {
-                if ("serviceWorker" in navigator && "SyncManager" in window) {
-                    try {
-                        const registration =
-                            await navigator.serviceWorker.ready;
-                        await registration.sync.register("tonk-sync");
-                        console.log("[Tonk] Background sync registered");
-                        return;
-                    } catch (e) {
-                        console.warn(
-                            "[Tonk] Background sync registration failed, falling back:",
-                            e,
-                        );
-                    }
+            // Register a one-shot background sync under `tag` so a
+            // local commit reaches its upstream even if the tab goes
+            // offline or closes before the next in-page sweep. The
+            // user agent fires the SW `sync` event when connectivity
+            // returns, retrying with backoff. Rejects where the
+            // Background Sync API is absent (Safari, Firefox) or
+            // registration fails, so the Rust controller falls back to
+            // the in-page sweep.
+            self.tonkRegisterSync = async (tag) => {
+                if (
+                    !("serviceWorker" in navigator) ||
+                    !("SyncManager" in window)
+                ) {
+                    throw new Error("Background Sync API unavailable");
                 }
-                // Fallback to direct sync call
-                const response = await fetch("/api/sync", { method: "POST" });
-                if (!response.ok) {
-                    throw new Error(`Sync failed: ${response.status}`);
-                }
-                console.log("[Tonk] Direct sync completed");
+                const registration = await navigator.serviceWorker.ready;
+                await registration.sync.register(tag);
             };
         </script>
         <!-- The following are load-bearing configuration for the Trunk build tool

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -6,7 +6,6 @@
 use leptos::{logging::log, prelude::*};
 use leptos_router::location::{BrowserUrl, LocationProvider};
 use tonk_worker::{Notification, ProfileInfo};
-use wasm_bindgen::prelude::*;
 
 use crate::{api, error::TonkUiError, watch::watch};
 
@@ -47,14 +46,6 @@ use join::*;
 
 mod invite;
 use invite::*;
-
-#[wasm_bindgen]
-extern "C" {
-    /// Triggers a sync operation.
-    /// Uses Background Sync API if available, otherwise falls back to /api/sync.
-    #[wasm_bindgen(js_namespace = window, catch)]
-    pub async fn sync() -> Result<(), JsValue>;
-}
 
 /// The hosting document's service-worker Client ID, learned from
 /// the `X-Tonk-Client-Id` header on the `PUT /api/repository/...`
@@ -346,13 +337,15 @@ mod tests {
         // Check remote branch state before sync
         let _inspect_result = driver.execute(inspect_script, vec![]).await?;
 
-        // Register sync using the Background Sync API
-        // This triggers the service worker's sync event handler
+        // Register sync using the Background Sync API. The tag carries
+        // the repository identity (`tonk-sync:{repo}`) so the worker's
+        // `sync` event handler knows which repo's upstream branches to
+        // sweep.
         driver
             .execute(
                 r#"
                 const registration = await navigator.serviceWorker.ready;
-                await registration.sync.register('tonk-sync');
+                await registration.sync.register('tonk-sync:home');
                 "#,
                 vec![],
             )

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -1,6 +1,7 @@
 use dialog_repository::SiteAddress;
 use leptos::{either::Either, prelude::*, task::spawn_local, web_sys};
 use leptos_router::{hooks::use_params, params::Params};
+use leptos_use::use_event_listener;
 use tonk_worker::{
     BranchConfiguration, EvaluateResponse, Notification, RemoteConfiguration, RepositoryInfo,
     Revision, SyncState as UpstreamState,
@@ -414,6 +415,41 @@ pub(super) fn BranchRow(
                 }
             });
         });
+    }
+
+    // While auto-sync is paused, the worker posts nothing on the branch
+    // channel — no pull/push moves the head — so the broadcast above
+    // can't keep the badge current. The background controller instead
+    // dispatches `tonk:status-refresh` on each tick; we re-read the
+    // read-only sync status (which fetches the upstream head) so a
+    // paused branch still shows when it has fallen behind or diverged.
+    if has_upstream
+        && let BranchOwner::Repository(space_name) = &owner
+        && let Some(repo) = space_name.get_untracked()
+    {
+        let branch = branch_name.clone();
+        let _ = use_event_listener(
+            window(),
+            leptos::ev::Custom::<web_sys::CustomEvent>::new(
+                crate::sync_controller::STATUS_REFRESH_EVENT,
+            ),
+            move |event| {
+                // The event carries the active repository as a plain
+                // string in `detail`; ignore refreshes for other repos.
+                if event.detail().as_string().as_deref() != Some(repo.as_str()) {
+                    return;
+                }
+                let repo = repo.clone();
+                let branch = branch.clone();
+                spawn_local(async move {
+                    if let Ok(status) = api::sync_status(&repo, &branch).await
+                        && upstream_state.get_untracked() != Some(status.state)
+                    {
+                        upstream_state.set(Some(status.state));
+                    }
+                });
+            },
+        );
     }
 
     let trigger_sync = {

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -15,17 +15,18 @@
 //!   of edits collapses into a single sync.
 //!
 //! On by default for every repository; an explicit per-repository
-//! `off` preference pauses it (see [`is_enabled`] / [`set_enabled`]),
-//! leaving only the manual Pull/Push buttons.
-
-use std::collections::HashMap;
+//! `off` preference pauses it (see [`is_enabled`] / [`set_enabled`]).
+//! Pausing stops pull/push — but the background triggers still fetch
+//! the upstream head read-only on each tick, so the sync-state badges
+//! keep showing where local sits relative to remote. A frozen badge
+//! would make the pause indicator useless.
 
 use leptos::ev;
 use leptos::logging::log;
 use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos_use::{use_debounce_fn, use_event_listener, use_interval_fn};
-use tonk_worker::BranchConfiguration;
+use wasm_bindgen::prelude::*;
 
 use crate::api;
 
@@ -40,6 +41,15 @@ const COMMIT_DEBOUNCE_MS: f64 = 1_000.0;
 /// DOM event a successful local commit dispatches on `window`. The
 /// controller listens for it to sync shortly after a write.
 pub const COMMITTED_EVENT: &str = "tonk:committed";
+
+/// DOM event the controller dispatches on `window` to ask the active
+/// repository's branch rows to re-read their read-only sync status.
+/// Fired on each background trigger while auto-sync is paused, so the
+/// sync-state badges keep tracking remote drift even though nothing is
+/// being pulled or pushed. The active repository name rides in the
+/// event's `detail` as a plain string so a row can ignore events for
+/// other repositories.
+pub const STATUS_REFRESH_EVENT: &str = "tonk:status-refresh";
 
 /// Per-repository `localStorage` key holding the auto-sync pause
 /// preference. Absent means on (the default).
@@ -82,17 +92,95 @@ pub fn set_enabled(repo: &str, enabled: bool) -> bool {
     storage.set_item(&pref_key(repo), value).is_ok()
 }
 
-/// Branch names in `branches` that have an upstream, sorted for a
-/// stable sweep order. Branches without an upstream have nowhere to
-/// sync to, so they're skipped.
-pub fn branches_to_sync(branches: &HashMap<String, BranchConfiguration>) -> Vec<String> {
-    let mut names: Vec<String> = branches
-        .iter()
-        .filter(|(_, config)| config.upstream.is_some())
-        .map(|(name, _)| name.clone())
-        .collect();
-    names.sort();
-    names
+#[wasm_bindgen]
+extern "C" {
+    /// Register a one-shot background sync under `tag` via the page's
+    /// `self.tonkRegisterSync` (defined in `index.html`). Resolves once
+    /// the user agent has accepted the registration; rejects where the
+    /// Background Sync API is unavailable (Safari, Firefox) or
+    /// registration fails, which routes the caller to the in-page
+    /// sweep.
+    #[wasm_bindgen(js_namespace = window, catch)]
+    async fn tonkRegisterSync(tag: &str) -> Result<JsValue, JsValue>;
+}
+
+/// The background-sync tag for `repo`. The worker parses the repo back
+/// out of it ([`tonk_worker::repo_from_sync_tag`]); the identity has
+/// to ride in the tag because a `sync` event delivers only a string.
+fn sync_tag(repo: &str) -> String {
+    format!("tonk-sync:{repo}")
+}
+
+/// Whether this browser offers one-shot Background Sync. Chromium
+/// does; Safari and Firefox don't, and there the commit path uses the
+/// in-page sweep instead. A seam so [`commit_action`] is unit-testable
+/// without a browser.
+fn sync_manager_available() -> bool {
+    js_sys::Reflect::has(&window(), &JsValue::from_str("SyncManager")).unwrap_or(false)
+}
+
+/// What the debounced post-commit trigger should do, given whether
+/// auto-sync is enabled for the repo and whether the Background Sync
+/// API is available.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommitAction {
+    /// Auto-sync is paused — do nothing.
+    Skip,
+    /// Register a durable one-shot background sync; the user agent
+    /// owns the retry from there, even after the tab is gone.
+    Register,
+    /// Run the in-page sweep now — the polyfill where the Background
+    /// Sync API is absent.
+    Sweep,
+}
+
+/// Decide the post-commit action. Pure so the enabled/disabled and
+/// available/absent branches are testable without a browser.
+fn commit_action(enabled: bool, sync_manager_available: bool) -> CommitAction {
+    if !enabled {
+        CommitAction::Skip
+    } else if sync_manager_available {
+        CommitAction::Register
+    } else {
+        CommitAction::Sweep
+    }
+}
+
+/// What a background trigger (interval, `online`, `visibilitychange`)
+/// should do, given whether auto-sync is enabled for the repo.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SweepAction {
+    /// Auto-sync is on — pull then push every upstream branch.
+    Sync,
+    /// Auto-sync is paused — don't touch local or remote state, but
+    /// still fetch the upstream head read-only so the sync-state badges
+    /// keep reflecting where local sits relative to remote.
+    RefreshStatus,
+}
+
+/// Decide what a background trigger should do. Pure so the
+/// enabled/paused branches are testable without a browser.
+fn sweep_action(enabled: bool) -> SweepAction {
+    if enabled {
+        SweepAction::Sync
+    } else {
+        SweepAction::RefreshStatus
+    }
+}
+
+/// Ask the active repository's branch rows to re-read their read-only
+/// sync status, by dispatching [`STATUS_REFRESH_EVENT`] on `window`
+/// with `repo` in the event detail. The rows perform the actual
+/// upstream fetch (via the read-only `sync/status` route), so a paused
+/// repository still learns when remote moves out from under it.
+fn request_status_refresh(repo: &str) {
+    let init = web_sys::CustomEventInit::new();
+    init.set_detail(&JsValue::from_str(repo));
+    let Ok(event) = web_sys::CustomEvent::new_with_event_init_dict(STATUS_REFRESH_EVENT, &init)
+    else {
+        return;
+    };
+    let _ = window().dispatch_event(&event);
 }
 
 /// Notify the background controller that a local commit just landed,
@@ -130,16 +218,19 @@ pub fn mount(source: Signal<Option<String>, LocalStorage>) {
             return;
         };
         // Honor the per-repository pause preference, read fresh so a
-        // toggle takes effect on the very next trigger. Paused means
-        // only the manual Pull/Push buttons act.
-        if !is_enabled(&repo) {
-            return;
+        // toggle takes effect on the very next trigger. Paused stops
+        // pull/push, but we still refresh the read-only sync status so
+        // the badges keep tracking remote drift.
+        match sweep_action(is_enabled(&repo)) {
+            SweepAction::RefreshStatus => request_status_refresh(&repo),
+            SweepAction::Sync => {
+                syncing.set(true);
+                spawn_local(async move {
+                    sweep_repository(&repo).await;
+                    syncing.set(false);
+                });
+            }
         }
-        syncing.set(true);
-        spawn_local(async move {
-            sweep_repository(&repo).await;
-            syncing.set(false);
-        });
     };
 
     // Steady interval.
@@ -155,8 +246,34 @@ pub fn mount(source: Signal<Option<String>, LocalStorage>) {
         }
     });
 
-    // Local commit — debounced so a burst of edits syncs once.
-    let debounced = use_debounce_fn(sweep, COMMIT_DEBOUNCE_MS);
+    // Local commit — debounced so a burst of edits collapses into one
+    // action. Where the Background Sync API is present we register a
+    // durable one-shot sync so the push survives the tab closing or
+    // going offline; otherwise we run the in-page sweep as the
+    // polyfill. The interval, `online`, and `visibilitychange` triggers
+    // above are untouched and keep running the in-page sweep regardless
+    // of `SyncManager` support — they cover pull and double as a push
+    // safety net.
+    let on_commit = move || {
+        let Some(repo) = source.get_untracked() else {
+            return;
+        };
+        match commit_action(is_enabled(&repo), sync_manager_available()) {
+            CommitAction::Skip => {}
+            CommitAction::Sweep => sweep(),
+            CommitAction::Register => {
+                spawn_local(async move {
+                    if tonkRegisterSync(&sync_tag(&repo)).await.is_err() {
+                        // Unsupported or registration rejected — fall
+                        // back to the in-page sweep so the commit still
+                        // reconciles before the next tick.
+                        sweep();
+                    }
+                });
+            }
+        }
+    };
+    let debounced = use_debounce_fn(on_commit, COMMIT_DEBOUNCE_MS);
     let _ = use_event_listener(
         window(),
         ev::Custom::<web_sys::Event>::new(COMMITTED_EVENT),
@@ -178,7 +295,7 @@ async fn sweep_repository(repo: &str) {
             return;
         }
     };
-    for branch in branches_to_sync(&info.branch) {
+    for branch in tonk_worker::branches_to_sync(&info.branch) {
         // The `/sync` route reports pull/push failures as a 200 with
         // `success: false` (a non-fast-forward push after divergence,
         // a fetch failure), so a transport-level `Ok` is not proof the
@@ -200,55 +317,41 @@ async fn sweep_repository(repo: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tonk_worker::UpstreamConfiguration;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    fn with_upstream() -> BranchConfiguration {
-        BranchConfiguration {
-            upstream: Some(UpstreamConfiguration {
-                remote: "origin".to_string(),
-                branch: "main".to_string(),
-            }),
-            revision: None,
-        }
-    }
-
-    fn without_upstream() -> BranchConfiguration {
-        BranchConfiguration {
-            upstream: None,
-            revision: None,
-        }
+    #[dialog_common::test]
+    fn it_skips_the_commit_action_when_auto_sync_is_paused() {
+        assert_eq!(commit_action(false, true), CommitAction::Skip);
+        assert_eq!(commit_action(false, false), CommitAction::Skip);
     }
 
     #[dialog_common::test]
-    fn it_selects_only_branches_with_an_upstream() {
-        let branches = HashMap::from([
-            ("main".to_string(), with_upstream()),
-            ("scratch".to_string(), without_upstream()),
-        ]);
-        assert_eq!(branches_to_sync(&branches), vec!["main".to_string()]);
+    fn it_registers_a_background_sync_when_enabled_and_supported() {
+        assert_eq!(commit_action(true, true), CommitAction::Register);
     }
 
     #[dialog_common::test]
-    fn it_returns_branches_sorted_for_a_stable_sweep_order() {
-        let branches = HashMap::from([
-            ("zeta".to_string(), with_upstream()),
-            ("alpha".to_string(), with_upstream()),
-        ]);
-        assert_eq!(
-            branches_to_sync(&branches),
-            vec!["alpha".to_string(), "zeta".to_string()]
-        );
+    fn it_falls_back_to_the_in_page_sweep_when_supported_api_is_absent() {
+        assert_eq!(commit_action(true, false), CommitAction::Sweep);
     }
 
     #[dialog_common::test]
-    fn it_returns_empty_when_no_branch_has_an_upstream() {
-        let branches = HashMap::from([("main".to_string(), without_upstream())]);
-        assert!(branches_to_sync(&branches).is_empty());
+    fn it_syncs_on_a_background_trigger_when_enabled() {
+        assert_eq!(sweep_action(true), SweepAction::Sync);
+    }
+
+    #[dialog_common::test]
+    fn it_refreshes_status_only_on_a_background_trigger_when_paused() {
+        assert_eq!(sweep_action(false), SweepAction::RefreshStatus);
+    }
+
+    #[dialog_common::test]
+    fn it_builds_a_sync_tag_the_worker_can_parse() {
+        assert_eq!(sync_tag("home"), "tonk-sync:home");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -27,7 +27,9 @@ pub use repository::{
 
 mod sync;
 pub use dialog_repository::Revision;
-pub use sync::{SyncResponse, SyncStatusResponse};
+pub use sync::{
+    SyncResponse, SyncStatusResponse, branches_to_sync, repo_from_sync_tag, sync_repository,
+};
 // Re-exported so API consumers (the UI) can name the state without
 // depending on `tonk-schema` directly.
 pub use tonk_schema::SyncState;
@@ -742,6 +744,41 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[dialog_common::test]
+    async fn it_sweeps_a_tagged_repo_with_no_upstream_branches_as_a_no_op() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let tonk = test_state().await;
+        let app_state: crate::router::AppState = Arc::new(RwLock::new(tonk));
+        let (app, _lsp) = crate::api_router_from_state(app_state.clone());
+        let repo = "test-bgsync-noupstream";
+
+        put_repo(&app, repo).await;
+
+        // No branch has an upstream, so the worker-side sweep selects
+        // nothing and runs the `/sync` route zero times — a clean
+        // resolve, not a rejection.
+        super::sync_repository(&app_state, repo)
+            .await
+            .expect("a no-upstream repo should sweep cleanly");
+    }
+
+    #[dialog_common::test]
+    async fn it_treats_a_tag_for_an_unknown_repo_as_a_no_op() {
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        let tonk = test_state().await;
+        let app_state: crate::router::AppState = Arc::new(RwLock::new(tonk));
+
+        // Nothing to retry for a repo that does not exist, so the
+        // sweep resolves rather than rejecting.
+        super::sync_repository(&app_state, "no-such-repo")
+            .await
+            .expect("an unknown repo should resolve as a no-op");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -8,6 +8,8 @@
 //! re-polls every subscription on the branch (push doesn't change
 //! local state, so it doesn't re-poll).
 
+use std::collections::HashMap;
+
 use ::axum::{Json, extract::Path, extract::State};
 use axum_wasm_macros::wasm_compat;
 use dialog_repository::Revision;
@@ -17,7 +19,7 @@ use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_schema::{SyncState, classify};
 
-use super::AppState;
+use super::{AppState, BranchConfiguration};
 use crate::TonkWorkerError;
 use crate::broadcast::{Notification, broadcast};
 
@@ -40,6 +42,93 @@ fn announce_head(repo: &str, branch: &str, revision: Option<Revision>) {
                 revision,
             },
         );
+    }
+}
+
+/// Tag prefix every durable background sync carries; the repository
+/// name follows the colon. A `sync` event delivers only this string
+/// and the worker has no notion of an "active repository", so the
+/// repo identity has to ride along in the tag.
+const SYNC_TAG_PREFIX: &str = "tonk-sync:";
+
+/// Parse the repository name out of a background-sync tag.
+///
+/// Tags are `tonk-sync:{repo}`. Anything not matching that shape — a
+/// bare or differently-prefixed tag, an empty repo — yields `None`,
+/// so a malformed tag becomes a no-op rather than an error.
+pub fn repo_from_sync_tag(tag: &str) -> Option<&str> {
+    tag.strip_prefix(SYNC_TAG_PREFIX)
+        .filter(|repo| !repo.is_empty())
+}
+
+/// Branch names in `branches` that have an upstream, sorted for a
+/// stable sweep order. Branches without an upstream have nowhere to
+/// sync to, so they're skipped. Shared with the in-page sweep so the
+/// background `sync` event and the in-page polyfill pick exactly the
+/// same branches.
+pub fn branches_to_sync(branches: &HashMap<String, BranchConfiguration>) -> Vec<String> {
+    let mut names: Vec<String> = branches
+        .iter()
+        .filter(|(_, config)| config.upstream.is_some())
+        .map(|(name, _)| name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Sweep every upstream branch of `repo`, reusing the per-branch
+/// [`sync`] route. This is what a durable background `sync` event runs
+/// once it has parsed the repo out of its tag; it makes the same
+/// branch selection ([`branches_to_sync`]) as the in-page sweep.
+///
+/// `Ok(())` means every selected branch reconciled, or there was
+/// nothing to do. `Err` means at least one branch did not land — the
+/// caller surfaces that as a rejected `sync` so the user agent retries
+/// with backoff. An unknown repo is not an error: there is nothing to
+/// retry, so it resolves as a no-op.
+pub async fn sync_repository(state: &AppState, repo: &str) -> Result<(), String> {
+    let info = match super::repository::get_repository(State(state.clone()), Path(repo.to_string()))
+        .await
+    {
+        Ok(Json(info)) => info,
+        Err(e) => {
+            log!("background sync: could not load '{repo}': {e}");
+            return Ok(());
+        }
+    };
+
+    let mut failed = false;
+    for branch in branches_to_sync(&info.branch) {
+        let params = SyncPath {
+            repo: repo.to_string(),
+            branch: branch.clone(),
+        };
+        // The `/sync` route reports pull/push failures as a 200 with
+        // `success: false` (a non-fast-forward push after divergence,
+        // a fetch failure), so a returned `Ok` is not proof the sync
+        // landed — inspect `success` too.
+        match sync(State(state.clone()), Path(params)).await {
+            Ok(Json(response)) if !response.success => {
+                let detail = response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string());
+                log!("background sync of {repo}/{branch} did not complete: {detail}");
+                failed = true;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                log!("background sync of {repo}/{branch} failed: {e}");
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        Err(format!(
+            "background sync of '{repo}' did not fully reconcile"
+        ))
+    } else {
+        Ok(())
     }
 }
 
@@ -317,5 +406,76 @@ pub async fn sync(
                 error: Some(format!("Push failed: {e}")),
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::UpstreamConfiguration;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn with_upstream() -> BranchConfiguration {
+        BranchConfiguration {
+            upstream: Some(UpstreamConfiguration {
+                remote: "origin".to_string(),
+                branch: "main".to_string(),
+            }),
+            revision: None,
+        }
+    }
+
+    fn without_upstream() -> BranchConfiguration {
+        BranchConfiguration {
+            upstream: None,
+            revision: None,
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_parses_the_repo_from_a_well_formed_tag() {
+        assert_eq!(repo_from_sync_tag("tonk-sync:home"), Some("home"));
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_a_tag_without_the_sync_prefix() {
+        assert_eq!(repo_from_sync_tag("home"), None);
+        assert_eq!(repo_from_sync_tag("other-tag"), None);
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_a_prefix_only_tag_with_an_empty_repo() {
+        assert_eq!(repo_from_sync_tag("tonk-sync:"), None);
+    }
+
+    #[dialog_common::test]
+    fn it_selects_only_branches_with_an_upstream() {
+        let branches = HashMap::from([
+            ("main".to_string(), with_upstream()),
+            ("scratch".to_string(), without_upstream()),
+        ]);
+        assert_eq!(branches_to_sync(&branches), vec!["main".to_string()]);
+    }
+
+    #[dialog_common::test]
+    fn it_returns_branches_sorted_for_a_stable_sweep_order() {
+        let branches = HashMap::from([
+            ("zeta".to_string(), with_upstream()),
+            ("alpha".to_string(), with_upstream()),
+        ]);
+        assert_eq!(
+            branches_to_sync(&branches),
+            vec!["alpha".to_string(), "zeta".to_string()]
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_returns_empty_when_no_branch_has_an_upstream() {
+        let branches = HashMap::from([("main".to_string(), without_upstream())]);
+        assert!(branches_to_sync(&branches).is_empty());
     }
 }

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -643,42 +643,33 @@ impl TonkServiceWorker {
         })
     }
 
-    /// Performs a full sync operation (pull then push) with the upstream remote.
+    /// Runs a durable background sync for the repository named in
+    /// `tag`, invoked from the Background Sync API `onsync` event.
     ///
-    /// This method dispatches to the `/api/repository/home/branch/main/sync`
-    /// route internally, so the sync logic is not duplicated. It is intended to
-    /// be called from the Background Sync API event or as a polyfill.
+    /// The event carries only a tag string, so the repo identity
+    /// travels in it as `tonk-sync:{repo}`. The worker enumerates that
+    /// repo's upstream branches and reconciles each through the
+    /// `/sync` route — the same selection the in-page sweep makes.
     ///
     /// # Returns
     ///
-    /// A JavaScript `Promise` that resolves to `undefined` on success, or
-    /// rejects with an error if the sync failed.
-    pub fn sync(&self) -> Promise {
-        log!("Background sync triggered, dispatching to /api/repository/home/branch/main/sync");
-
-        let router = self.router.clone();
+    /// A JavaScript `Promise` that resolves to `undefined` once every
+    /// upstream branch has reconciled. A malformed or unrecognized tag
+    /// resolves as a no-op. If a branch fails to land, the promise
+    /// rejects so the user agent retries the sync with backoff.
+    pub fn sync(&self, tag: String) -> Promise {
+        let state = self.state.clone();
 
         future_to_promise(async move {
-            let request = axum::http::Request::builder()
-                .method("POST")
-                .uri("/api/repository/home/branch/main/sync")
-                .body(Body::empty())
-                .expect_throw("Failed to build sync request");
+            let Some(repo) = crate::router::repo_from_sync_tag(&tag) else {
+                log!("Background sync: ignoring unrecognized tag {tag:?}");
+                return Ok(JsValue::UNDEFINED);
+            };
+            log!("Background sync triggered for repo '{repo}'");
 
-            let response = router
-                .lock()
-                .await
-                .call(request)
-                .await
-                .expect_throw("Failed to handle sync request");
-
-            if response.status().is_success() {
-                Ok(JsValue::UNDEFINED)
-            } else {
-                Err(JsValue::from_str(&format!(
-                    "Sync failed with status: {}",
-                    response.status()
-                )))
+            match crate::router::sync_repository(&state, repo).await {
+                Ok(()) => Ok(JsValue::UNDEFINED),
+                Err(e) => Err(JsValue::from_str(&e)),
             }
         })
     }


### PR DESCRIPTION
Carry the repository identity in the Background Sync tag (`tonk-sync:{repo}`) instead of hardcoding `home`/`main`. The worker parses the repo back out (`repo_from_sync_tag`) and sweeps every upstream branch through the `/sync` route via a new shared `sync_repository`, rejecting the `onsync` promise when a branch fails to land so the user agent retries with backoff.

On commit, register a durable one-shot background sync where the API exists so the push survives the tab closing or going offline; fall back to the in-page sweep on Safari/Firefox. The post-commit and background-trigger decisions are factored into pure `commit_action`/`sweep_action` functions so they're unit- testable without a browser.

While auto-sync is paused, background triggers no longer go fully idle: they dispatch `tonk:status-refresh` so branch rows re-read the read-only sync status, keeping the sync-state badges tracking remote drift instead of freezing.

Move `branches_to_sync` into tonk-worker so the background sync event and the in-page polyfill select exactly the same branches.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the Background Sync functionality in the `tonk` application, improving how synchronization is managed between local and remote repositories. It introduces better handling of sync tags and ensures appropriate actions are taken based on the availability of the Background Sync API.

### Detailed summary
- Updated `self.onsync` to use `event.tag` for synchronization.
- Removed obsolete `sync` function from the `wasm_bindgen` export.
- Enhanced sync registration with specific repository tags.
- Improved handling of sync events and repository identification.
- Added tests for repo tag parsing and branch selection logic.
- Refactored sync logic to manage upstream branches more efficiently.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->