### PR TITLE
feat(share): restore the share/invite flow via <tonk-share>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,8 +5244,10 @@ name = "tonk-workspace"
 version = "0.1.0"
 dependencies = [
  "custom-elements",
+ "dialog-common",
  "js-sys",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -312,6 +312,31 @@ view!: &workspace/view
           flex: none;
         }
 
+        /* The share control (`<tonk-share>` renders this button). An
+           icon-only ghost button sized to match the placeholder icons,
+           brightening on hover so it reads as the live action among
+           the chrome. */
+        .workspace__share {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 28px; height: 28px;
+          padding: 0;
+          flex: none;
+          color: inherit;
+          background: transparent;
+          border: none;
+          border-radius: var(--wa-border-radius-s);
+          cursor: pointer;
+        }
+        .workspace__share:hover {
+          color: var(--wa-color-text-normal);
+          background: var(--wa-color-neutral-fill-quiet);
+        }
+        .workspace__share-glyph {
+          width: 18px; height: 18px;
+        }
+
         /* The binder fills the space below the top bar: the active sheet
            panel fills the rest, the projected tab strip pins to the
            bottom. */
@@ -473,7 +498,7 @@ view!: &workspace/view
         <span class="workspace__sync">synced</span>
         <span class="workspace__spacer"></span>
         <span class="workspace__actions">
-          <span class="workspace__icon"></span>
+          <tonk-share></tonk-share>
           <span class="workspace__icon"></span>
           <span class="workspace__icon"></span>
         </span>

--- a/rust/tonk-ui/assets/hot-swap.js
+++ b/rust/tonk-ui/assets/hot-swap.js
@@ -76,7 +76,11 @@
         position: fixed;
         display: inline-block;
         z-index: 2147483647;
-        top: 0px;
+        /* Bottom-right corner: the top-right is the workspace top bar's
+           real controls (share + sync toggle), and this dev pill's
+           invisible hover-zone (.hide::after below) would otherwise
+           intercept clicks on them. */
+        bottom: 0px;
         right: 0px;
         border: none;
         margin: 10px;
@@ -241,7 +245,7 @@
       .notification.hide::after {
         content: "";
         position: absolute;
-        top: 0; right: 0;
+        bottom: 0; right: 0;
         width: 8em; height: 3em;
         pointer-events: all;
         z-index: 0;

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -74,7 +74,9 @@ pub type CreateSpaceOpen = RwSignal<bool>;
 
 /// Shared open-state for the invite dialog. `Some(name)` opens
 /// the dialog and triggers a fresh invite mint for that space;
-/// `None` closes it. Set by the `Invite` button in [`TonkSpace`].
+/// `None` closes it. Set by the workspace's `<tonk-share>` control
+/// (via the `tonk:share` window bridge in [`TonkShell`]) and by the
+/// space viewer's share button.
 pub type InviteSpace = RwSignal<Option<String>>;
 
 /// Outcome of the most recent invite redemption, if any. Written
@@ -165,11 +167,35 @@ pub fn TonkShell() -> impl IntoView {
     let create_space_open: CreateSpaceOpen = RwSignal::new(false);
     provide_context(create_space_open);
 
-    // Shared open-state for the invite dialog. The space view's
-    // "Invite" button writes a `Some(name)` here; the dialog
-    // resets it back to `None` on close.
+    // Shared open-state for the invite dialog. The workspace top
+    // bar's `<tonk-share>` control writes a `Some(name)` here (via
+    // the `tonk:share` bridge below); the dialog resets it back to
+    // `None` on close.
     let invite_space: InviteSpace = RwSignal::new(None);
     provide_context(invite_space);
+
+    // Bridge `<tonk-share>` to the invite dialog. The workspace
+    // element can't call into the shell directly — view templates
+    // bind DOM events to data-model commands only, and sharing isn't
+    // a data mutation (it mints a UCAN invite over HTTP and opens a
+    // modal). So the element dispatches a bubbling, composed
+    // `tonk:share` CustomEvent carrying `{ repo }`, and the shell
+    // listens on the window. This mirrors how the sync controller
+    // bridges `tonk:committed` / `tonk:status-refresh`.
+    let _ = leptos_use::use_event_listener(
+        window(),
+        leptos::ev::Custom::<web_sys::CustomEvent>::new("tonk:share"),
+        move |event| {
+            // Prefer the repo the element resolved from its
+            // `<tonk-repository>` ancestor; fall back to the active
+            // repo parsed from the route for any host that fires the
+            // event without a detail.
+            let repo = share_repo_from_event(&event).or_else(active_repo_from_route);
+            if let Some(repo) = repo {
+                invite_space.set(Some(repo));
+            }
+        },
+    );
 
     // The last join outcome lives in a shared signal so the view
     // tree (specifically `TonkLauncher`) can render it as a
@@ -192,6 +218,24 @@ pub fn TonkShell() -> impl IntoView {
             <TonkLauncher></TonkLauncher>
         </tonk-diagnostics-provider>
     }
+}
+
+/// Read the `repo` from a `tonk:share` event's `detail`, if present
+/// and non-empty.
+fn share_repo_from_event(event: &web_sys::CustomEvent) -> Option<String> {
+    js_sys::Reflect::get(&event.detail(), &wasm_bindgen::JsValue::from_str("repo"))
+        .ok()
+        .and_then(|value| value.as_string())
+        .filter(|repo| !repo.is_empty())
+}
+
+/// Fall back to the active repository parsed from the current route
+/// (`/space/{branch}@{name}/…`) when a `tonk:share` event carries no
+/// repo of its own. Mirrors the toolbar's active-space derivation.
+fn active_repo_from_route() -> Option<String> {
+    let pathname = window().location().pathname().ok()?;
+    let segment = pathname.strip_prefix("/space/")?.split('/').next()?;
+    route::parse_space(segment).map(|space| space.name)
 }
 
 #[cfg(test)]

--- a/rust/tonk-ui/src/components/inspector.rs
+++ b/rust/tonk-ui/src/components/inspector.rs
@@ -7,18 +7,17 @@
 //! building a Leptos sub-tree.
 //!
 //! Mount strategy: the element creates a fresh Leptos root via
-//! `leptos::mount::mount_to` on its own host node. The only
-//! page-level signal the inspector still consults is
-//! `InviteSpace` (driven by the share button); a no-op stub is
-//! provided locally so click is silently swallowed when the
-//! element runs outside the launcher shell. A follow-up should
-//! replace this with a bubbling CustomEvent so any host can
-//! react.
+//! `leptos::mount::mount_to` on its own host node. The inspector
+//! consults no page-level signal, so it renders standalone in any
+//! host (board tile, demo, embed) without provided context. (The
+//! share affordance now lives in the workspace top bar as
+//! `<tonk-share>`, which bridges to the shell via a `tonk:share`
+//! window event — see `super::invite` / `TonkShell`.)
 
 use std::any::Any;
 use std::cell::RefCell;
 
-use crate::components::{InviteSpace, TonkInspector};
+use crate::components::TonkInspector;
 use custom_elements::CustomElement;
 use leptos::prelude::*;
 use web_sys::{HtmlElement, window};
@@ -57,14 +56,6 @@ impl CustomElement for TonkInspectorElement {
 
         let source = self.source;
         let handle = leptos::mount::mount_to(this.clone(), move || {
-            // Local no-op invite-space stub so the share button
-            // doesn't panic when the inspector runs outside the
-            // launcher (e.g. inside a board tile). The shell's
-            // invite dialog won't open from here until we bridge
-            // it via a CustomEvent.
-            let invite_space: InviteSpace = RwSignal::new(None);
-            provide_context(invite_space);
-
             view! {
                 <TonkInspector source=source />
             }

--- a/rust/tonk-ui/src/components/invite.rs
+++ b/rust/tonk-ui/src/components/invite.rs
@@ -18,9 +18,10 @@ fn sigil_value_for_did(did: &str) -> Option<String> {
 /// Modal dialog showing a freshly minted invite URL.
 ///
 /// Mounted once at the launcher level. Visibility is driven by the
-/// shared [`InviteSpace`] signal: a space-view button writes
-/// `Some(name)` to open the dialog and trigger the mint; the
-/// dialog clears the signal back to `None` on close.
+/// shared [`InviteSpace`] signal: the workspace top bar's
+/// `<tonk-share>` control writes `Some(name)` (via the shell's
+/// `tonk:share` window bridge) to open the dialog and trigger the
+/// mint; the dialog clears the signal back to `None` on close.
 ///
 /// Consumes [`api::create_invite`]'s tagged response — for now
 /// only the URL is rendered, but the same component can branch
@@ -126,7 +127,7 @@ pub fn TonkInviteDialog() -> impl IntoView {
 
     view! {
         <wa-dialog
-            label="Invite to space"
+            label="Share this repo."
             prop:open=move || invite_space.get().is_some()
             on:wa-after-hide=on_after_hide
         >
@@ -136,9 +137,7 @@ pub fn TonkInviteDialog() -> impl IntoView {
                     value=move || subject.get().and_then(|s| sigil_value_for_did(&s))
                 ></tonk-sigil>
                 <div class="invite-body-stack wa-stack wa-gap-s">
-                    { move || invite_space.get().map(|name| view! {
-                        <p>"Share this link with someone you want to join " <strong>{ name.clone() }</strong> "."</p>
-                    }) }
+                    <p class="invite-body-caption">"anyone with this link can join & edit"</p>
                     { move || if loading.get() {
                         Some(view! { <wa-spinner></wa-spinner> }.into_any())
                     } else if let Some(value) = url.get() {

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -275,6 +275,62 @@ mod integration_tests {
         Ok(())
     }
 
+    /// The shell bridges the workspace's `<tonk-share>` control to
+    /// the invite dialog via a `tonk:share` window event. Firing it
+    /// for the home repo opens the dialog and, once the mint lands,
+    /// surfaces the invite-link input — the same path a real share
+    /// click drives, minus the DOM click on the element (covered by
+    /// `tonk-workspace`'s own dispatch test).
+    #[dialog_common::test]
+    async fn it_opens_the_invite_dialog_on_a_tonk_share_event(env: TestEnvironment) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // Wait for the home space's bare display route — the shell is
+        // live, so the `tonk:share` listener is mounted.
+        driver
+            .query(By::Css("tonk-repository.display-route"))
+            .first()
+            .await?;
+
+        // Fire the bridge event the workspace's `<tonk-share>`
+        // dispatches on click.
+        driver
+            .execute(
+                r#"window.dispatchEvent(new CustomEvent('tonk:share', {
+                    detail: { repo: 'home' },
+                }));"#,
+                vec![],
+            )
+            .await?;
+
+        // The invite-link input renders only after the dialog opened
+        // and the mint resolved, so its presence proves the bridge
+        // opened the dialog and `create_invite` ran.
+        let input = driver.query(By::Css("#tonk-invite-url")).first().await?;
+        assert_eq!(
+            input.tag_name().await?.to_lowercase(),
+            "wa-input",
+            "expected the minted invite link to render in a wa-input",
+        );
+
+        // The dialog itself is open (its `open` property is set by the
+        // shared `invite_space` signal the bridge wrote).
+        let is_open = driver
+            .execute(
+                r#"return document.querySelector('wa-dialog')?.open === true;"#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(
+            is_open.json().as_bool(),
+            Some(true),
+            "expected the invite <wa-dialog> to be open after tonk:share",
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     /// Land on `/join?...&name=<chosen>#<seed>` carrying an
     /// audience-open invite, click Join, and verify the
     /// recipient lands on `/space/<chosen>` with a banner whose

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -97,16 +97,6 @@ pub fn TonkInspector(
     // component's owner, so it tears down when the inspector unmounts.
     crate::sync_controller::mount(source);
 
-    // Open the shared invite dialog when the user clicks the
-    // share affordance. Dialog itself drives the mint and renders
-    // the URL.
-    let invite_space = use_context::<InviteSpace>().expect("InviteSpace provided by TonkShell");
-    let on_share = move |_| {
-        if let Some(name) = source.get() {
-            invite_space.set(Some(name));
-        }
-    };
-
     view! {
         <Suspense fallback=|| view! {
             <wa-spinner></wa-spinner>
@@ -121,7 +111,6 @@ pub fn TonkInspector(
                     Some(info) => Either::Left(render_space_view(
                         info,
                         source,
-                        on_share,
                     )),
                     None => Either::Right(view! {
                         <wa-callout variant="neutral">
@@ -138,18 +127,14 @@ pub fn TonkInspector(
     }
 }
 
-/// Top-level layout for a loaded [`RepositoryInfo`]: banner with
-/// share button, branches section (each as a `<wa-details>`
+/// Top-level layout for a loaded [`RepositoryInfo`]: banner with the
+/// auto-sync toggle, branches section (each as a `<wa-details>`
 /// rendered by [`BranchRow`]), remotes section (compact
 /// [`RemoteCard`] tiles).
-fn render_space_view<F>(
+fn render_space_view(
     info: RepositoryInfo,
     space_name: Signal<Option<String>, LocalStorage>,
-    on_share: F,
-) -> impl IntoView
-where
-    F: Fn(leptos::ev::MouseEvent) + 'static + Clone,
-{
+) -> impl IntoView {
     let local_subject = info.subject.to_string();
     let space_title = info.name.clone();
 
@@ -243,18 +228,6 @@ where
                         name=move || if auto_sync_on.get() { "arrows-rotate" } else { "pause" }
                         variant="solid"
                         label="Toggle auto-sync"
-                    ></wa-icon>
-                </wa-button>
-                <wa-button
-                    variant="neutral"
-                    appearance="accent"
-                    size="small"
-                    on:click=on_share
-                >
-                    <wa-icon
-                        name="share-nodes"
-                        variant="solid"
-                        label="Invite someone to this space"
                     ></wa-icon>
                 </wa-button>
             </div>

--- a/rust/tonk-workspace/Cargo.toml
+++ b/rust/tonk-workspace/Cargo.toml
@@ -33,6 +33,10 @@ web-sys = { workspace = true, features = [
   "Window",
 ] }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+wasm-bindgen-test = { workspace = true }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(dialog_test_native_integration)",

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -14,13 +14,16 @@
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod binder;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod share;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod sheet;
 
-/// Register the workspace custom elements (`<tonk-sheet>` and
-/// `<tonk-sheet-binder>`) with the page. Idempotent — calling more
-/// than once is harmless.
+/// Register the workspace custom elements (`<tonk-sheet>`,
+/// `<tonk-sheet-binder>`, and `<tonk-share>`) with the page.
+/// Idempotent — calling more than once is harmless.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub fn register() {
     sheet::register();
     binder::register();
+    share::register();
 }

--- a/rust/tonk-workspace/src/share.rs
+++ b/rust/tonk-workspace/src/share.rs
@@ -1,0 +1,243 @@
+//! `<tonk-share>` — a share-this-repo control for the workspace top
+//! bar.
+//!
+//! Deliberately dumb: it renders a single icon button and, on click,
+//! emits *intent*. It walks up to the nearest `<tonk-repository
+//! name="…">` ancestor (the display route wraps the whole view in one,
+//! see `tonk-ui`'s `display.rs`), reads its `name`, and dispatches a
+//! bubbling, composed `tonk:share` `CustomEvent` carrying `{ repo }`.
+//!
+//! It knows nothing about invites, UCANs, or the dialog — the app
+//! shell owns that policy and listens for `tonk:share` on the window.
+//! This mirrors the `<tonk-sheet-binder>` → `activate` pattern (see
+//! [`super::binder`]): the element dispatches an event, the consumer
+//! decides what it means.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use web_sys::{CustomEvent, CustomEventInit, Element, Event, HtmlElement, window};
+
+/// A retained click-listener closure, kept alive for the element's
+/// lifetime so the listener stays valid.
+type ClickClosure = Rc<RefCell<Option<Closure<dyn FnMut(Event)>>>>;
+
+/// The event name the shell listens for to open the invite dialog.
+/// The first `tonk:`-prefixed window bridge from a workspace element.
+const SHARE_EVENT: &str = "tonk:share";
+
+/// Per-element state. Holds the click closure so it lives as long as
+/// the element and drops on disconnect.
+#[derive(Default)]
+pub(crate) struct TonkShare {
+    click: ClickClosure,
+}
+
+impl CustomElement for TonkShare {
+    fn shadow() -> bool {
+        // Light DOM: the consuming workspace view styles the button
+        // (`.workspace__share`) and the element must see its
+        // `<tonk-repository>` ancestor via `closest`.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &[]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        ensure_button(this);
+        install_click(this, &self.click);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        self.click.borrow_mut().take();
+    }
+}
+
+/// CSS class the consuming workspace view styles.
+const BUTTON: &str = "workspace__share";
+
+/// Inline share-nodes glyph (three connected nodes), drawn with
+/// `currentColor` so it follows the button's text colour.
+const GLYPH: &str = r#"<svg class="workspace__share-glyph" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="12" r="3"></circle><circle cx="18" cy="5" r="3"></circle><circle cx="18" cy="19" r="3"></circle><line x1="8.6" y1="10.6" x2="15.4" y2="6.4"></line><line x1="8.6" y1="13.4" x2="15.4" y2="17.6"></line></svg>"#;
+
+/// Find or create the share button as the element's only child.
+/// Idempotent — a reconnect reuses the existing button.
+fn ensure_button(this: &HtmlElement) -> Option<Element> {
+    let document = window().and_then(|w| w.document())?;
+    if let Ok(Some(existing)) = this.query_selector(&format!(":scope > .{BUTTON}")) {
+        return Some(existing);
+    }
+    let button = document.create_element("button").ok()?;
+    let _ = button.set_attribute("class", BUTTON);
+    let _ = button.set_attribute("type", "button");
+    let _ = button.set_attribute("part", "button");
+    let _ = button.set_attribute("aria-label", "Share this repo");
+    let _ = button.set_attribute("title", "Share this repo");
+    button.set_inner_html(GLYPH);
+    let _ = this.append_child(&button);
+    Some(button)
+}
+
+/// Install the click listener: resolve the repo from the nearest
+/// `<tonk-repository>` ancestor and dispatch `tonk:share`.
+fn install_click(this: &HtmlElement, slot: &ClickClosure) {
+    let host = this.clone();
+    let listener = Closure::wrap(Box::new(move |_event: Event| {
+        let repo = repo_from_ancestor(&host).unwrap_or_default();
+        dispatch_share(&host, &repo);
+    }) as Box<dyn FnMut(Event)>);
+
+    let _ = this.add_event_listener_with_callback("click", listener.as_ref().unchecked_ref());
+    *slot.borrow_mut() = Some(listener);
+}
+
+/// Read the `name` of the nearest `<tonk-repository>` ancestor. The
+/// display route wraps the whole view in `<tonk-repository name=…>`,
+/// so a share control rendered inside any view can recover the repo
+/// it belongs to.
+fn repo_from_ancestor(this: &HtmlElement) -> Option<String> {
+    this.closest("tonk-repository")
+        .ok()
+        .flatten()
+        .and_then(|repo| repo.get_attribute("name"))
+        .filter(|name| !name.is_empty())
+}
+
+/// Dispatch `tonk:share` with `detail = { repo }`, bubbling + composed
+/// so it crosses any light-DOM boundary up to the window, where the
+/// shell listens.
+fn dispatch_share(host: &HtmlElement, repo: &str) {
+    let detail = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(
+        &detail,
+        &JsValue::from_str("repo"),
+        &JsValue::from_str(repo),
+    );
+    let init = CustomEventInit::new();
+    init.set_detail(&detail);
+    init.set_bubbles(true);
+    init.set_composed(true);
+    if let Ok(event) = CustomEvent::new_with_event_init_dict(SHARE_EVENT, &init) {
+        let _ = host.dispatch_event(&event);
+    }
+}
+
+/// Register `<tonk-share>`. Idempotent.
+pub(crate) fn register() {
+    if already_registered() {
+        return;
+    }
+    TonkShare::define("tonk-share");
+}
+
+fn already_registered() -> bool {
+    let Some(win) = window() else {
+        return false;
+    };
+    !win.custom_elements().get("tonk-share").is_undefined()
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use web_sys::CustomEvent;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    async fn it_dispatches_tonk_share_with_the_ancestor_repo() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        // <tonk-repository name="pictures"><tonk-share></tonk-share></tonk-repository>
+        // mirrors the display route, which wraps the view in a named
+        // `<tonk-repository>`.
+        let repo = document.create_element("tonk-repository").unwrap();
+        repo.set_attribute("name", "pictures").unwrap();
+        let share = document.create_element("tonk-share").unwrap();
+        repo.append_child(&share).unwrap();
+        // Appending an already-defined custom element runs its
+        // connectedCallback synchronously, so the button is injected by
+        // the time `append_child` returns.
+        body.append_child(&repo).unwrap();
+
+        // Capture the next `tonk:share` event's `detail.repo` off the
+        // window — the bubbling + composed event must reach it.
+        let captured: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let sink = captured.clone();
+        let listener = Closure::wrap(Box::new(move |event: Event| {
+            let event = event.dyn_into::<CustomEvent>().unwrap();
+            let repo = js_sys::Reflect::get(&event.detail(), &JsValue::from_str("repo"))
+                .ok()
+                .and_then(|value| value.as_string());
+            *sink.borrow_mut() = repo;
+        }) as Box<dyn FnMut(Event)>);
+        window()
+            .unwrap()
+            .add_event_listener_with_callback("tonk:share", listener.as_ref().unchecked_ref())
+            .unwrap();
+
+        let button = share
+            .query_selector(".workspace__share")
+            .unwrap()
+            .expect("share button injected on connect");
+        button.dyn_ref::<HtmlElement>().unwrap().click();
+
+        assert_eq!(captured.borrow().as_deref(), Some("pictures"));
+
+        window()
+            .unwrap()
+            .remove_event_listener_with_callback("tonk:share", listener.as_ref().unchecked_ref())
+            .unwrap();
+        repo.remove();
+    }
+
+    #[dialog_common::test]
+    async fn it_dispatches_an_empty_repo_with_no_repository_ancestor() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        // No `<tonk-repository>` ancestor — the element falls back to an
+        // empty repo, leaving the shell to resolve it from the route.
+        let share = document.create_element("tonk-share").unwrap();
+        body.append_child(&share).unwrap();
+
+        let captured: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let sink = captured.clone();
+        let listener = Closure::wrap(Box::new(move |event: Event| {
+            let event = event.dyn_into::<CustomEvent>().unwrap();
+            let repo = js_sys::Reflect::get(&event.detail(), &JsValue::from_str("repo"))
+                .ok()
+                .and_then(|value| value.as_string());
+            *sink.borrow_mut() = repo;
+        }) as Box<dyn FnMut(Event)>);
+        window()
+            .unwrap()
+            .add_event_listener_with_callback("tonk:share", listener.as_ref().unchecked_ref())
+            .unwrap();
+
+        let button = share
+            .query_selector(".workspace__share")
+            .unwrap()
+            .expect("share button injected on connect");
+        button.dyn_ref::<HtmlElement>().unwrap().click();
+
+        assert_eq!(captured.borrow().as_deref(), Some(""));
+
+        window()
+            .unwrap()
+            .remove_event_listener_with_callback("tonk:share", listener.as_ref().unchecked_ref())
+            .unwrap();
+        share.remove();
+    }
+}


### PR DESCRIPTION
The layout rewrite (#488) made the bare <tonk-display> workspace the primary repo surface, leaving the old share affordance reachable only through <tonk-inspector> — where it was wired to a no-op stub. There was no way to share a repo from the normal workspace view.

Restore it with a <tonk-share> custom element in the workspace top bar. It resolves the repo from its <tonk-repository> ancestor and dispatches a bubbling, composed tonk:share CustomEvent; TonkShell listens on the window and opens the existing TonkInviteDialog (which mints via the unchanged create_invite API). This is the first tonk: window bridge, the escape hatch for a non-command UI action a view template can't express.

- new <tonk-share> element in tonk-workspace (+ dispatch test)
- core.yaml workspace view: swap a placeholder icon for <tonk-share>
- TonkShell: tonk:share -> invite_space bridge (+ integration test)
- dialog copy aligned to the wireframe ("Share this repo.")
- remove the dead inspector share button and no-op InviteSpace stub
- move the dev hot-swap pill to the bottom-right so its hover-zone no longer intercepts clicks on the top-bar controls

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `<tonk-share>` component for sharing repositories in the workspace, enhances the invite dialog functionality, and updates related styles and logic to support this feature.

### Detailed summary
- Added `dialog-common` and `wasm-bindgen-test` dependencies.
- Created the `<tonk-share>` component for sharing functionality.
- Updated `register()` to include `share::register()`.
- Modified the invite dialog to use `<tonk-share>`.
- Enhanced styles for the share button.
- Updated event handling for sharing logic.
- Adjusted comments and documentation for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->