### PR TITLE
feat(workspace): merge sync status and pause/resume into one pill

### DIFF
--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -283,43 +283,86 @@ view!: &workspace/view
           font-family: var(--wa-font-family-code);
           font-size: var(--wa-font-size-s);
         }
-        .workspace__title { font-weight: var(--wa-font-weight-semibold); }
-        /* The live sync chip (`<tonk-sync-state>` renders this span with
-           one `is-*` state modifier). Layout lives on the base class;
-           colour lives on the modifier. The chip only shows once a state
-           is known because `<tonk-sync-state>` emits the span only then
-           — with no state it emits no span at all, so the element takes
-           no space (there is no CSS rule hiding a modifier-less span). */
+        .workspace__title {
+          font-size: var(--wa-font-size-l);
+          font-weight: var(--wa-font-weight-semibold);
+        }
+        /* The sync pill (`<tonk-sync-state>`): the status indicator *and*
+           the pause/resume button in one. It renders a single
+           `<button class="workspace__sync is-*">` carrying one of four
+           states — `synced`, `syncing`, `paused`, `offline`. Layout and
+           the button reset live on the base class; colour lives on the
+           modifier (text, border, and dot all read `currentColor`). The
+           dot is filled for the running states and a hollow ring for
+           `paused` / `offline`. The whole pill is the button, so a click
+           anywhere toggles auto-sync. */
         .workspace__sync {
           display: inline-flex;
           align-items: center;
-          gap: var(--wa-space-xs);
-          padding: var(--wa-space-3xs) var(--wa-space-s);
-          font-size: var(--wa-font-size-s);
+          box-sizing: border-box;
+          /* The whole pill is a fixed 21px tall (border included),
+             matching the mock — a fixed height rather than letting the
+             text's line-box drive it. With 11px text that leaves ~4px
+             above/below, the couple px of breathing room. A little inline
+             padding so the dot/label don't touch the border. */
+          height: 21px;
+          gap: var(--wa-space-2xs);
+          padding: 0 5px;
+          font-family: inherit;
+          font-size: var(--wa-font-size-2xs);
+          line-height: 1;
+          color: var(--wa-color-text-quiet);
+          background: transparent;
+          border: var(--wa-border-width-s) solid currentColor;
           border-radius: var(--wa-border-radius-s);
+          cursor: pointer;
         }
+        /* A faint state-tinted wash on hover so the pill reads as the
+           live control it is. */
+        .workspace__sync:hover {
+          background: color-mix(in oklab, currentColor 8%, transparent);
+        }
+        .workspace__sync:focus-visible {
+          outline: var(--wa-border-width-m) solid currentColor;
+          outline-offset: 2px;
+        }
+        /* The status dot: filled by default (the running states); the
+           hollow variants below swap the fill for a ring. */
         .workspace__sync::before {
           content: "";
-          width: 7px; height: 7px; border-radius: 50%;
-          background: currentColor; flex: none;
+          width: 7px; height: 7px;
+          border-radius: 50%;
+          border: var(--wa-border-width-s) solid currentColor;
+          background: currentColor;
+          box-sizing: border-box;
+          flex: none;
         }
-        .workspace__sync.is-synced {
-          color: var(--wa-color-success-on-quiet);
-          background: var(--wa-color-success-fill-quiet);
+        .workspace__sync.is-synced { color: var(--wa-color-success-on-quiet); }
+        .workspace__sync.is-syncing { color: var(--wa-color-warning-on-quiet); }
+        /* Paused: a mid grey. Offline: a lighter grey, so "no remote"
+           reads as more recessed than a deliberate pause. */
+        .workspace__sync.is-paused { color: var(--wa-color-text-quiet); }
+        .workspace__sync.is-offline {
+          color: color-mix(in oklab, var(--wa-color-text-quiet) 60%, transparent);
+          /* Offline isn't actionable — nothing to pause — so it reads as
+             inert: no pointer, no hover wash. */
+          cursor: default;
         }
-        .workspace__sync.is-synced::before { background: var(--wa-color-success-fill-loud); }
-        .workspace__sync.is-ahead,
-        .workspace__sync.is-behind {
-          color: var(--wa-color-warning-on-quiet);
-          background: var(--wa-color-warning-fill-quiet);
+        .workspace__sync.is-offline:hover { background: transparent; }
+        /* Hollow dot for the two settled states. */
+        .workspace__sync.is-paused::before,
+        .workspace__sync.is-offline::before { background: transparent; }
+        /* Syncing pulses to read as in-progress. */
+        .workspace__sync.is-syncing::before {
+          animation: workspace__sync-pulse 1.2s ease-in-out infinite;
         }
-        .workspace__sync.is-ahead::before,
-        .workspace__sync.is-behind::before { background: var(--wa-color-warning-fill-loud); }
-        .workspace__sync.is-diverged {
-          color: var(--wa-color-danger-on-quiet);
-          background: var(--wa-color-danger-fill-quiet);
+        @keyframes workspace__sync-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
         }
-        .workspace__sync.is-diverged::before { background: var(--wa-color-danger-fill-loud); }
+        @media (prefers-reduced-motion: reduce) {
+          .workspace__sync.is-syncing::before { animation: none; }
+        }
         .workspace__spacer { flex: 1; }
         .workspace__actions {
           display: inline-flex;
@@ -350,30 +393,6 @@ view!: &workspace/view
           background: var(--wa-color-neutral-fill-quiet);
         }
         .workspace__share-glyph {
-          width: 18px; height: 18px;
-        }
-
-        /* The pause/resume control (`<tonk-sync-toggle>` renders this
-           button). Sized and styled like `.workspace__share` — an
-           icon-only ghost button that brightens on hover. */
-        .workspace__sync-toggle {
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          width: 28px; height: 28px;
-          padding: 0;
-          flex: none;
-          color: inherit;
-          background: transparent;
-          border: none;
-          border-radius: var(--wa-border-radius-s);
-          cursor: pointer;
-        }
-        .workspace__sync-toggle:hover {
-          color: var(--wa-color-text-normal);
-          background: var(--wa-color-neutral-fill-quiet);
-        }
-        .workspace__sync-toggle-glyph {
           width: 18px; height: 18px;
         }
 
@@ -538,7 +557,6 @@ view!: &workspace/view
         <tonk-sync-state></tonk-sync-state>
         <span class="workspace__spacer"></span>
         <span class="workspace__actions">
-          <tonk-sync-toggle></tonk-sync-toggle>
           <tonk-share></tonk-share>
         </span>
       </div>

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -24,9 +24,9 @@ mod sheet;
 mod sync;
 
 /// Register the workspace custom elements (`<tonk-sheet>`,
-/// `<tonk-sheet-binder>`, `<tonk-share>`, `<tonk-sync-toggle>`, and
-/// `<tonk-sync-state>`) with the page. Idempotent — calling more than
-/// once is harmless.
+/// `<tonk-sheet-binder>`, `<tonk-share>`, and `<tonk-sync-state>` — the
+/// status pill that doubles as the pause/resume button) with the page.
+/// Idempotent — calling more than once is harmless.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub fn register() {
     sheet::register();

--- a/rust/tonk-workspace/src/sync.rs
+++ b/rust/tonk-workspace/src/sync.rs
@@ -14,6 +14,7 @@
 //!       into this one: if sync is running, those deltas are being
 //!       reconciled right now.
 //!     - `paused`  — auto-sync off. Overrides any real drift.
+//!
 //!   It re-reads the read-only `sync/status` route whenever the
 //!   controller dispatches `tonk:status-refresh` or a commit lands, and
 //!   clicking the pill flips the per-repository `tonk:auto-sync:{repo}`
@@ -58,8 +59,8 @@ mod logic {
     /// preference (not a `SyncState`); `offline` covers both `NoUpstream`
     /// (no remote configured) and a failed status fetch (remote
     /// unavailable), which read identically to the user.
-    pub(crate) const PAUSED_CHIP: (&'static str, &'static str) = ("paused", "is-paused");
-    pub(crate) const OFFLINE_CHIP: (&'static str, &'static str) = ("offline", "is-offline");
+    pub(crate) const PAUSED_CHIP: (&str, &str) = ("paused", "is-paused");
+    pub(crate) const OFFLINE_CHIP: (&str, &str) = ("offline", "is-offline");
 
     /// Label and modifier class for a live sync state.
     ///
@@ -481,10 +482,7 @@ mod dom {
             // labelled for the resume action.
             assert_eq!(button.text_content().as_deref(), Some("paused"));
             assert_eq!(button.class_name(), "workspace__sync is-paused");
-            assert_eq!(
-                button.get_attribute("title").as_deref(),
-                Some(PAUSED_LABEL)
-            );
+            assert_eq!(button.get_attribute("title").as_deref(), Some(PAUSED_LABEL));
 
             // Click → running: the preference flips to "on". (The running
             // pill awaits a status fetch that can't resolve here, so we

--- a/rust/tonk-workspace/src/sync.rs
+++ b/rust/tonk-workspace/src/sync.rs
@@ -1,19 +1,26 @@
 //! Background-sync chrome for the workspace top bar.
 //!
-//! Two dumb light-DOM custom elements, cut from the same cloth as
-//! [`super::share`]: they resolve their repo/branch from the nearest
-//! `<tonk-repository>` / `<tonk-branch>` ancestors and otherwise hold
+//! One dumb light-DOM custom element, cut from the same cloth as
+//! [`super::share`]: it resolves its repo/branch from the nearest
+//! `<tonk-repository>` / `<tonk-branch>` ancestors and otherwise holds
 //! no app policy.
 //!
-//! - `<tonk-sync-toggle>` pauses/resumes background sync by flipping
-//!   the per-repository `tonk:auto-sync:{repo}` `localStorage`
-//!   preference — the exact key the Leptos `sync_controller` reads.
-//! - `<tonk-sync-state>` paints a live `synced` / `ahead` / `behind` /
-//!   `diverged` chip for the branch in scope relative to its remote,
-//!   re-reading the read-only `sync/status` route whenever the
-//!   controller dispatches `tonk:status-refresh` or a commit lands.
+//! - `<tonk-sync-state>` is the status indicator *and* the pause/resume
+//!   button in one. It shows exactly three states for the branch in
+//!   scope:
+//!     - `synced`  — auto-sync on and up to date with the remote.
+//!     - `syncing` — auto-sync on and mid-reconcile (pushing/pulling).
+//!       The remote's `ahead` / `behind` / `diverged` states all fold
+//!       into this one: if sync is running, those deltas are being
+//!       reconciled right now.
+//!     - `paused`  — auto-sync off. Overrides any real drift.
+//!   It re-reads the read-only `sync/status` route whenever the
+//!   controller dispatches `tonk:status-refresh` or a commit lands, and
+//!   clicking the pill flips the per-repository `tonk:auto-sync:{repo}`
+//!   `localStorage` preference — the exact key the Leptos
+//!   `sync_controller` reads.
 //!
-//! The two coordinate with the controller only through that shared
+//! It coordinates with the controller only through that shared
 //! `localStorage` key and the `tonk:status-refresh` / `tonk:committed`
 //! window events — no direct coupling to `tonk-ui`.
 
@@ -46,17 +53,29 @@ mod logic {
             .unwrap_or_else(|| "main".to_string())
     }
 
-    /// Label and modifier class for a sync state, or `None` for states
-    /// with nothing to show (`NoUpstream`). A pure mirror of
-    /// `tonk-ui`'s `upstream_state_chip`, with the workspace's own
-    /// `is-*` modifier classes in place of the `<wa-badge>` variants.
-    pub(crate) fn state_chip(state: SyncState) -> Option<(&'static str, &'static str)> {
+    /// The pill's `(label, modifier-class)` for the paused preference
+    /// and for an absent / unreachable remote. `paused` comes from the
+    /// preference (not a `SyncState`); `offline` covers both `NoUpstream`
+    /// (no remote configured) and a failed status fetch (remote
+    /// unavailable), which read identically to the user.
+    pub(crate) const PAUSED_CHIP: (&'static str, &'static str) = ("paused", "is-paused");
+    pub(crate) const OFFLINE_CHIP: (&'static str, &'static str) = ("offline", "is-offline");
+
+    /// Label and modifier class for a live sync state.
+    ///
+    /// The pill shows only three *running* labels: `synced` when up to
+    /// date, `syncing…` for any drift (`Ahead` / `Behind` / `Diverged`
+    /// all mean auto-sync is mid-reconcile, so they collapse into one),
+    /// and `offline` when there is no upstream to sync against. (`paused`
+    /// is not a `SyncState`; it comes from the preference and is painted
+    /// by the element directly.)
+    pub(crate) fn state_chip(state: SyncState) -> (&'static str, &'static str) {
         match state {
-            SyncState::Synced => Some(("synced", "is-synced")),
-            SyncState::Ahead => Some(("ahead", "is-ahead")),
-            SyncState::Behind => Some(("behind", "is-behind")),
-            SyncState::Diverged => Some(("diverged", "is-diverged")),
-            SyncState::NoUpstream => None,
+            SyncState::Synced => ("synced", "is-synced"),
+            SyncState::Ahead | SyncState::Behind | SyncState::Diverged => {
+                ("syncing…", "is-syncing")
+            }
+            SyncState::NoUpstream => OFFLINE_CHIP,
         }
     }
 }
@@ -81,7 +100,9 @@ mod dom {
 
     use tonk_schema::SyncState;
 
-    use super::logic::{branch_or_default, pref_is_enabled, pref_key, state_chip};
+    use super::logic::{
+        OFFLINE_CHIP, PAUSED_CHIP, branch_or_default, pref_is_enabled, pref_key, state_chip,
+    };
     use crate::ancestors::repo_from_ancestor;
 
     /// Window event the controller dispatches to ask the chip to
@@ -185,7 +206,7 @@ mod dom {
     }
 
     /// Dispatch [`STATUS_REFRESH_EVENT`] on `window` with `repo` in the
-    /// detail, so the chip re-reads status immediately after a toggle.
+    /// detail, so the pill re-reads status immediately after a toggle.
     fn request_status_refresh(repo: &str) {
         let init = CustomEventInit::new();
         init.set_detail(&JsValue::from_str(repo));
@@ -197,114 +218,66 @@ mod dom {
         }
     }
 
-    // ---- `<tonk-sync-toggle>` -------------------------------------
+    // ---- `<tonk-sync-state>` --------------------------------------
 
-    /// CSS class the consuming workspace view styles for the toggle.
-    const TOGGLE_BUTTON: &str = "workspace__sync-toggle";
+    /// CSS class for the pill button (with an `is-*` state modifier).
+    const STATE_CHIP: &str = "workspace__sync";
 
-    /// Title/`aria-label` while auto-sync is running. Mirrors tonk-ui.
+    /// Title/`aria-label` on the pill while auto-sync is running and
+    /// reachable — the `synced` / `syncing…` states, where a click pauses.
     const RUNNING_LABEL: &str = "Auto-sync on — click to pause";
-    /// Title/`aria-label` while auto-sync is paused. Mirrors tonk-ui.
+    /// Title/`aria-label` on the pill while paused (and reachable), where
+    /// a click resumes.
     const PAUSED_LABEL: &str = "Auto-sync paused — click to resume";
+    /// Title/`aria-label` on the offline pill — no upstream or an
+    /// unreachable remote. Not a toggle hint: the pill isn't clickable.
+    const OFFLINE_LABEL: &str = "Offline — no remote to sync";
 
-    /// Inline rotating-arrows glyph (running) — the icon *reflects the
-    /// active mode*, mirroring tonk-ui's inspector toggle
-    /// (`arrows-rotate`). Drawn with `currentColor`.
-    const SYNC_GLYPH: &str = r#"<svg class="workspace__sync-toggle-glyph" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>"#;
-    /// Inline pause glyph (paused). Drawn with `currentColor`.
-    const PAUSE_GLYPH: &str = r#"<svg class="workspace__sync-toggle-glyph" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><rect x="6" y="5" width="4" height="14"></rect><rect x="14" y="5" width="4" height="14"></rect></svg>"#;
-
-    /// Per-element state for `<tonk-sync-toggle>`.
-    #[derive(Default)]
-    pub(crate) struct TonkSyncToggle {
-        click: Listener,
-    }
-
-    impl CustomElement for TonkSyncToggle {
-        fn shadow() -> bool {
-            false
-        }
-
-        fn observed_attributes() -> &'static [&'static str] {
-            &[]
-        }
-
-        fn inject_children(&mut self, _this: &HtmlElement) {}
-
-        fn connected_callback(&mut self, this: &HtmlElement) {
-            if let Some(button) = ensure_toggle_button(this) {
-                let repo = repo_from_ancestor(this).unwrap_or_default();
-                paint_toggle(&button, is_enabled(&repo));
-            }
-            install_toggle_click(this, &self.click);
-        }
-
-        fn disconnected_callback(&mut self, _this: &HtmlElement) {
-            self.click.borrow_mut().take();
-        }
-    }
-
-    /// Find or create the toggle button as the element's only child.
-    fn ensure_toggle_button(this: &HtmlElement) -> Option<Element> {
-        if let Ok(Some(existing)) = this.query_selector(&format!(":scope > .{TOGGLE_BUTTON}")) {
-            return Some(existing);
-        }
-        let document = window()?.document()?;
-        let button = document.create_element("button").ok()?;
-        let _ = button.set_attribute("class", TOGGLE_BUTTON);
-        let _ = button.set_attribute("type", "button");
-        let _ = button.set_attribute("part", "button");
-        let _ = this.append_child(&button);
-        Some(button)
-    }
-
-    /// Paint the toggle button's glyph + title/`aria-label` for the
-    /// current state. The glyph reflects the active mode: rotating
-    /// sync-arrows + "click to pause" when running; pause bars +
-    /// "click to resume" when paused.
-    fn paint_toggle(button: &Element, enabled: bool) {
-        let (glyph, label) = if enabled {
-            (SYNC_GLYPH, RUNNING_LABEL)
-        } else {
-            (PAUSE_GLYPH, PAUSED_LABEL)
-        };
-        button.set_inner_html(glyph);
-        let _ = button.set_attribute("title", label);
-        let _ = button.set_attribute("aria-label", label);
-    }
-
-    /// Install the toggle's click listener: flip the preference and, if
-    /// the write lands, repaint and ask the chip to refresh. A rejected
-    /// write leaves the icon as-is — the controller still reads the old
-    /// preference, so UI and behaviour stay consistent.
+    /// Install the pill's click listener on the host: flip the
+    /// preference and ask for a status refresh. The refresh dispatches
+    /// `tonk:status-refresh`, which this element's own listener catches
+    /// and repaints from — the same route the controller's sweep uses,
+    /// so the pill has a single refresh path. A rejected write leaves
+    /// the pill as-is. The click bubbles up from the inner button, so a
+    /// click anywhere on the pill toggles.
+    ///
+    /// `offline` is the exception: with no upstream (or an unreachable
+    /// one) there is nothing to pause, so a click on the offline pill is
+    /// a no-op — the user can't toggle into `paused` from there.
     fn install_toggle_click(this: &HtmlElement, slot: &Listener) {
         let host = this.clone();
         let listener = Closure::wrap(Box::new(move |_event: Event| {
-            let repo = repo_from_ancestor(&host).unwrap_or_default();
+            if is_offline(&host) {
+                return;
+            }
+            let Some(repo) = repo_from_ancestor(&host) else {
+                return;
+            };
             let next = !is_enabled(&repo);
             if set_enabled(&repo, next) {
-                if let Ok(Some(button)) = host.query_selector(&format!(":scope > .{TOGGLE_BUTTON}"))
-                {
-                    paint_toggle(&button, next);
-                }
                 request_status_refresh(&repo);
             }
         }) as Box<dyn FnMut(Event)>);
-
         let _ = this.add_event_listener_with_callback("click", listener.as_ref().unchecked_ref());
         *slot.borrow_mut() = Some(listener);
     }
 
-    // ---- `<tonk-sync-state>` --------------------------------------
-
-    /// CSS class for the chip span (with an `is-*` state modifier).
-    const STATE_CHIP: &str = "workspace__sync";
+    /// Whether the pill is currently showing the (non-actionable)
+    /// `offline` state, read from the painted button's modifier class.
+    fn is_offline(host: &HtmlElement) -> bool {
+        let (_, offline_class) = OFFLINE_CHIP;
+        host.query_selector(&format!(":scope > .{STATE_CHIP}"))
+            .ok()
+            .flatten()
+            .is_some_and(|button| button.class_list().contains(offline_class))
+    }
 
     /// Per-element state for `<tonk-sync-state>`.
     #[derive(Default)]
     pub(crate) struct TonkSyncState {
         refresh: Listener,
         committed: Listener,
+        click: Listener,
     }
 
     impl CustomElement for TonkSyncState {
@@ -321,6 +294,7 @@ mod dom {
         fn connected_callback(&mut self, this: &HtmlElement) {
             refresh_state(this);
             install_state_listeners(this, &self.refresh, &self.committed);
+            install_toggle_click(this, &self.click);
         }
 
         fn disconnected_callback(&mut self, _this: &HtmlElement) {
@@ -340,55 +314,85 @@ mod dom {
             }
             self.refresh.borrow_mut().take();
             self.committed.borrow_mut().take();
+            self.click.borrow_mut().take();
         }
     }
 
-    /// Resolve repo+branch and refresh the chip. With no repository
-    /// ancestor there is nothing to show, so the chip is hidden. With a
-    /// repo, fetch the status and paint; a fetch failure leaves the chip
-    /// as-is rather than flashing error chrome — holding the last good
-    /// value in steady state, or staying empty on a first-load failure
-    /// until the next refresh event (the controller's ≤20s sweep fires
-    /// one, so a blank chip self-heals).
+    /// Resolve repo+branch and repaint the pill. With no repository
+    /// ancestor there is nothing to show, so the host is cleared.
+    ///
+    /// State priority, highest first:
+    ///   1. `offline` — no upstream, or an unreachable remote (a `None`
+    ///      fetch). Nothing to sync *or* pause, so it overrides the
+    ///      preference entirely (and the pill goes inert).
+    ///   2. `paused`  — preference off and the remote reachable. Overrides
+    ///      the real drift (`ahead` / `behind` / `diverged`).
+    ///   3. `synced` / `syncing…` — running and reachable.
+    ///
+    /// The status is fetched on every refresh — even while paused —
+    /// because only the fetch can tell `offline` from `paused`. The
+    /// paused pill is painted optimistically first so it appears at once;
+    /// the fetch then confirms it or overrides it with `offline`. A
+    /// repaint never clears first, so a refresh holds the last good pill
+    /// until the new one is ready.
     fn refresh_state(this: &HtmlElement) {
         let Some(repo) = repo_from_ancestor(this) else {
-            paint_chip(this, None);
+            this.set_inner_html("");
             return;
         };
+        // Optimistic: show `paused` immediately so the pill is present
+        // without waiting on the network. The fetch below may override
+        // it with `offline`.
+        if !is_enabled(&repo) {
+            paint(this, PAUSED_CHIP, PAUSED_LABEL);
+        }
         let branch = branch_from_ancestor(this);
         let host = this.clone();
         spawn_local(async move {
-            if let Some(state) = fetch_sync_status(&repo, &branch).await {
-                paint_chip(&host, state_chip(state));
+            match fetch_sync_status(&repo, &branch).await {
+                // Offline wins over the preference: no reachable remote.
+                None | Some(SyncState::NoUpstream) => {
+                    paint(&host, OFFLINE_CHIP, OFFLINE_LABEL);
+                }
+                // Reachable + running: the live state.
+                Some(state) if is_enabled(&repo) => {
+                    paint(&host, state_chip(state), RUNNING_LABEL);
+                }
+                // Reachable + paused: the preference overrides real drift.
+                Some(_) => paint(&host, PAUSED_CHIP, PAUSED_LABEL),
             }
         });
     }
 
-    /// Paint (or hide) the chip. `None` — no repo or `NoUpstream` —
-    /// clears the host so it takes no space; `Some((label, class))`
-    /// renders a single `<span class="workspace__sync {class}">label</span>`.
-    fn paint_chip(host: &HtmlElement, chip: Option<(&'static str, &'static str)>) {
-        match chip {
-            None => host.set_inner_html(""),
-            Some((label, class)) => {
-                if let Some(span) = ensure_chip_span(host) {
-                    let _ = span.set_attribute("class", &format!("{STATE_CHIP} {class}"));
-                    span.set_text_content(Some(label));
-                }
-            }
+    /// Paint the pill button: set its `is-*` modifier + label and the
+    /// `title`/`aria-label`. The title is supplied by the caller — a
+    /// toggle hint for the actionable states (`RUNNING_LABEL` /
+    /// `PAUSED_LABEL`) or a plain status note for the inert `offline`
+    /// pill (`OFFLINE_LABEL`).
+    fn paint(host: &HtmlElement, chip: (&'static str, &'static str), title: &str) {
+        let (label, class) = chip;
+        if let Some(button) = ensure_pill_button(host) {
+            let _ = button.set_attribute("class", &format!("{STATE_CHIP} {class}"));
+            button.set_text_content(Some(label));
+            let _ = button.set_attribute("title", title);
+            let _ = button.set_attribute("aria-label", title);
         }
     }
 
-    /// Find or create the chip span as the element's only child.
-    fn ensure_chip_span(host: &HtmlElement) -> Option<Element> {
+    /// Find or create the pill `<button>` as the element's only child.
+    /// A real button so the whole pill is focusable and click-to-toggle;
+    /// the host's click listener catches the bubble.
+    fn ensure_pill_button(host: &HtmlElement) -> Option<Element> {
         if let Ok(Some(existing)) = host.query_selector(&format!(":scope > .{STATE_CHIP}")) {
             return Some(existing);
         }
         let document = window()?.document()?;
-        let span = document.create_element("span").ok()?;
-        let _ = span.set_attribute("class", STATE_CHIP);
-        let _ = host.append_child(&span);
-        Some(span)
+        let button = document.create_element("button").ok()?;
+        let _ = button.set_attribute("class", STATE_CHIP);
+        let _ = button.set_attribute("type", "button");
+        let _ = button.set_attribute("part", "button");
+        let _ = host.append_child(&button);
+        Some(button)
     }
 
     /// Install the chip's window listeners: `tonk:status-refresh`
@@ -431,14 +435,11 @@ mod dom {
         *committed_slot.borrow_mut() = Some(committed_listener);
     }
 
-    /// Register both elements. Idempotent.
+    /// Register the element. Idempotent.
     pub(crate) fn register() {
         let Some(elements) = window().map(|w| w.custom_elements()) else {
             return;
         };
-        if elements.get("tonk-sync-toggle").is_undefined() {
-            TonkSyncToggle::define("tonk-sync-toggle");
-        }
         if elements.get("tonk-sync-state").is_undefined() {
             TonkSyncState::define("tonk-sync-state");
         }
@@ -452,79 +453,117 @@ mod dom {
         wasm_bindgen_test_configure!(run_in_browser);
 
         #[dialog_common::test]
-        async fn it_toggles_the_preference_and_swaps_the_icon() {
+        async fn it_shows_paused_on_connect_and_toggles_the_preference_on_click() {
             register();
             let document = window().unwrap().document().unwrap();
             let body = document.body().unwrap();
             let storage = window().unwrap().local_storage().unwrap().unwrap();
             let key = "tonk:auto-sync:toggletest";
-            let _ = storage.remove_item(key);
+            // Start paused so the pill paints synchronously on connect —
+            // the running branch would await a status fetch that never
+            // resolves in this DOM-only test (no service worker).
+            storage.set_item(key, "off").unwrap();
 
             let repo = document.create_element("tonk-repository").unwrap();
             repo.set_attribute("name", "toggletest").unwrap();
-            let toggle = document.create_element("tonk-sync-toggle").unwrap();
-            repo.append_child(&toggle).unwrap();
+            let state = document.create_element("tonk-sync-state").unwrap();
+            repo.append_child(&state).unwrap();
             // Defined element → connectedCallback runs synchronously on
-            // append, so the button is present by the time it returns.
+            // append, so the pill is present by the time it returns.
             body.append_child(&repo).unwrap();
 
-            let button = toggle
-                .query_selector(".workspace__sync-toggle")
+            let button = state
+                .query_selector(".workspace__sync")
                 .unwrap()
-                .expect("toggle button injected on connect");
+                .expect("pill injected on connect");
 
-            // Default on: running label + the sync-arrows glyph
-            // (distinguished by its `polyline` arrowheads).
+            // Paused: the neutral `is-paused` pill reading "paused",
+            // labelled for the resume action.
+            assert_eq!(button.text_content().as_deref(), Some("paused"));
+            assert_eq!(button.class_name(), "workspace__sync is-paused");
             assert_eq!(
                 button.get_attribute("title").as_deref(),
-                Some(RUNNING_LABEL)
+                Some(PAUSED_LABEL)
             );
-            assert!(button.inner_html().contains("polyline"));
 
-            // Click → paused: preference flips to off, label + glyph swap
-            // to the pause bars (`rect`s).
-            button.dyn_ref::<HtmlElement>().unwrap().click();
-            assert_eq!(storage.get_item(key).unwrap().as_deref(), Some("off"));
-            assert_eq!(button.get_attribute("title").as_deref(), Some(PAUSED_LABEL));
-            assert!(button.inner_html().contains("rect"));
-
-            // Click again → running.
+            // Click → running: the preference flips to "on". (The running
+            // pill awaits a status fetch that can't resolve here, so we
+            // assert on the persisted preference — the load-bearing side
+            // effect — rather than the repainted label.)
             button.dyn_ref::<HtmlElement>().unwrap().click();
             assert_eq!(storage.get_item(key).unwrap().as_deref(), Some("on"));
-            assert_eq!(
-                button.get_attribute("title").as_deref(),
-                Some(RUNNING_LABEL)
-            );
+
+            // Click again → paused: flips back and repaints synchronously.
+            button.dyn_ref::<HtmlElement>().unwrap().click();
+            assert_eq!(storage.get_item(key).unwrap().as_deref(), Some("off"));
+            assert_eq!(button.text_content().as_deref(), Some("paused"));
 
             repo.remove();
             let _ = storage.remove_item(key);
         }
 
         #[dialog_common::test]
-        async fn it_paints_the_chip_for_a_state_and_hides_on_no_upstream() {
+        async fn it_ignores_clicks_while_offline() {
+            register();
+            let document = window().unwrap().document().unwrap();
+            let body = document.body().unwrap();
+            let storage = window().unwrap().local_storage().unwrap().unwrap();
+            let key = "tonk:auto-sync:offlinetest";
+            // Running (on) — `offline` is a *running* sub-state.
+            storage.set_item(key, "on").unwrap();
+
+            let repo = document.create_element("tonk-repository").unwrap();
+            repo.set_attribute("name", "offlinetest").unwrap();
+            let state = document.create_element("tonk-sync-state").unwrap();
+            repo.append_child(&state).unwrap();
+            body.append_child(&repo).unwrap();
+
+            // Force the offline pill (the connect-time fetch can't resolve
+            // in this DOM-only test, so paint it directly).
+            let host_el = state.dyn_ref::<HtmlElement>().unwrap();
+            paint(host_el, OFFLINE_CHIP, OFFLINE_LABEL);
+            let button = state
+                .query_selector(".workspace__sync")
+                .unwrap()
+                .expect("offline pill present");
+            assert_eq!(button.class_name(), "workspace__sync is-offline");
+
+            // Click → no-op: there's nothing to pause, so the preference
+            // stays "on" and the pill stays offline.
+            button.dyn_ref::<HtmlElement>().unwrap().click();
+            assert_eq!(storage.get_item(key).unwrap().as_deref(), Some("on"));
+            assert_eq!(button.class_name(), "workspace__sync is-offline");
+
+            repo.remove();
+            let _ = storage.remove_item(key);
+        }
+
+        #[dialog_common::test]
+        async fn it_paints_each_running_state_on_the_pill() {
             let document = window().unwrap().document().unwrap();
             let body = document.body().unwrap();
             let host = document.create_element("tonk-sync-state").unwrap();
             body.append_child(&host).unwrap();
             let host_el = host.dyn_ref::<HtmlElement>().unwrap();
 
-            // A concrete state renders the label + single modifier class.
-            paint_chip(host_el, state_chip(SyncState::Ahead));
-            let span = host
+            // Synced → green "synced" pill, filled dot (via the class).
+            paint(host_el, state_chip(SyncState::Synced), RUNNING_LABEL);
+            let button = host
                 .query_selector(".workspace__sync")
                 .unwrap()
-                .expect("chip painted for a concrete state");
-            assert_eq!(span.text_content().as_deref(), Some("ahead"));
-            assert_eq!(span.class_name(), "workspace__sync is-ahead");
+                .expect("pill painted for a concrete state");
+            assert_eq!(button.text_content().as_deref(), Some("synced"));
+            assert_eq!(button.class_name(), "workspace__sync is-synced");
 
-            // NoUpstream → nothing to show → host cleared.
-            paint_chip(host_el, state_chip(SyncState::NoUpstream));
-            assert!(host.query_selector(".workspace__sync").unwrap().is_none());
+            // Any drift collapses to the single "syncing…" state.
+            paint(host_el, state_chip(SyncState::Behind), RUNNING_LABEL);
+            assert_eq!(button.text_content().as_deref(), Some("syncing…"));
+            assert_eq!(button.class_name(), "workspace__sync is-syncing");
 
-            // No repo (None) hides the same way.
-            paint_chip(host_el, state_chip(SyncState::Behind));
-            paint_chip(host_el, None);
-            assert!(host.query_selector(".workspace__sync").unwrap().is_none());
+            // NoUpstream → "offline" (same pill as an unreachable remote).
+            paint(host_el, state_chip(SyncState::NoUpstream), OFFLINE_LABEL);
+            assert_eq!(button.text_content().as_deref(), Some("offline"));
+            assert_eq!(button.class_name(), "workspace__sync is-offline");
 
             host.remove();
         }
@@ -546,30 +585,33 @@ mod tests {
 
     #[dialog_common::test]
     fn it_maps_synced_to_the_synced_chip() {
-        assert_eq!(state_chip(SyncState::Synced), Some(("synced", "is-synced")));
+        assert_eq!(state_chip(SyncState::Synced), ("synced", "is-synced"));
     }
 
     #[dialog_common::test]
-    fn it_maps_ahead_to_the_ahead_chip() {
-        assert_eq!(state_chip(SyncState::Ahead), Some(("ahead", "is-ahead")));
+    fn it_collapses_ahead_to_the_syncing_chip() {
+        assert_eq!(state_chip(SyncState::Ahead), ("syncing…", "is-syncing"));
     }
 
     #[dialog_common::test]
-    fn it_maps_behind_to_the_behind_chip() {
-        assert_eq!(state_chip(SyncState::Behind), Some(("behind", "is-behind")));
+    fn it_collapses_behind_to_the_syncing_chip() {
+        assert_eq!(state_chip(SyncState::Behind), ("syncing…", "is-syncing"));
     }
 
     #[dialog_common::test]
-    fn it_maps_diverged_to_the_diverged_chip() {
-        assert_eq!(
-            state_chip(SyncState::Diverged),
-            Some(("diverged", "is-diverged"))
-        );
+    fn it_collapses_diverged_to_the_syncing_chip() {
+        assert_eq!(state_chip(SyncState::Diverged), ("syncing…", "is-syncing"));
     }
 
     #[dialog_common::test]
-    fn it_hides_the_chip_for_no_upstream() {
-        assert_eq!(state_chip(SyncState::NoUpstream), None);
+    fn it_maps_no_upstream_to_the_offline_chip() {
+        assert_eq!(state_chip(SyncState::NoUpstream), OFFLINE_CHIP);
+        assert_eq!(OFFLINE_CHIP, ("offline", "is-offline"));
+    }
+
+    #[dialog_common::test]
+    fn it_labels_the_paused_chip() {
+        assert_eq!(PAUSED_CHIP, ("paused", "is-paused"));
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## What

Merges the two separate workspace-topbar elements — the `<tonk-sync-toggle>` button and the `<tonk-sync-state>` chip — into a **single clickable `<tonk-sync-state>` pill** that is both the status indicator and the pause/resume control.

## States

The pill shows exactly four states for the branch in scope:

| State | Look | When |
|---|---|---|
| `synced` | green, filled dot | running, up to date |
| `syncing…` | amber, **pulsing** dot | running, reconciling (old `ahead`/`behind`/`diverged` all collapse here) |
| `paused` | grey, hollow dot | auto-sync off, remote reachable |
| `offline` | light-grey, hollow dot | no upstream, or remote unreachable |

Clicking the pill toggles auto-sync (synced/syncing → pause, paused → resume).

## Behaviour notes

- **Offline overrides the preference** and is non-interactive — there's nothing to pause, so a click on the offline pill is a no-op (and it renders with `cursor: default`, no hover).
- Status is **fetched on every refresh, even while paused**, because only the fetch can distinguish `offline` from `paused`. The paused pill paints optimistically first, then the fetch confirms it or overrides with `offline`.
- A repo paused *before* going offline returns to `paused` once the remote is reachable again (the preference is preserved).

## UI

- Pill: fixed **21px** height, **11px** text, 5px inline padding, 7px dot.
- Repo title bumped to **20px**.
- Pulse animation respects `prefers-reduced-motion`.
- Removes the standalone `<tonk-sync-toggle>` element, its CSS, and its tag in the `core.yaml` topbar view.

## Notes

- The topbar markup + styles live in the seeded `core.yaml` view template, so existing browser repos need a re-seed (clear site data / hot-swap pill) to pick up the change.
- Tests: native logic tests + wasm DOM tests updated (state mapping, click-toggles-preference, offline-click-is-no-op, per-state paint). `cargo check` passes for native and `wasm32-unknown-unknown`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `tonk-sync-state` element to enhance its functionality and styling, consolidating the pause/resume button with the sync status indicator. It also refines the CSS and modifies the associated logic for better user experience.

### Detailed summary
- Updated documentation for `register` function.
- Revised CSS for `.workspace__title` and `.workspace__sync`, enhancing styling.
- Merged functionality of `<tonk-sync-toggle>` into `<tonk-sync-state>`.
- Adjusted state handling for sync states, including `paused` and `offline`.
- Improved click handling logic for the sync state pill.
- Enhanced tests for state transitions and UI behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->