### PR TITLE
refactor: commands as dialog_capability providers

### DIFF
--- a/plan/commands.md
+++ b/plan/commands.md
@@ -14,38 +14,43 @@ transient concept asserted in a commit, swept before the durable write.
 ## The shape
 
 A command is an ordinary `#[derive(Concept)]` that is *asserted
-transiently*. The transient channel (see effects.md) makes the trigger
-edge-triggered: the fact exists only for the commit that asserted it, so
-the handler fires exactly once and the command leaves no durable trace.
+transiently* and also implements
+[`dialog_capability::Command`](https://github.com/dialog-db/dialog-db)
+(`Input = Self`, `Output = ()`). The transient channel (see effects.md)
+makes the trigger edge-triggered: the fact exists only for the commit
+that asserted it, so the command fires exactly once and leaves no durable
+trace.
 
-A handler is an `async fn` whose parameters declare what it needs, axum
-style:
+What *runs* a command is a `Provider<C>` — there is no handler function.
+The provider is a tonk-owned env, `CommandEnv`, a cheap handle over
+`AppState`:
 
 ```rust
-// pure — no capability
-async fn record(cmd: SomeCommand, tx: Transaction) -> Transaction { … }
+// the command concept (tonk-schema)
+#[derive(Concept)]
+struct CreateSpace { this: Entity, name: SpaceName }
+impl dialog_capability::Command for CreateSpace {
+    type Input = Self;
+    type Output = ();
+}
 
-// needs IO — declares the capability
-async fn create_space(
-    cmd: CreateSpace,
-    State(state): State<AppState>,   // declared capability
-    tx: Transaction,
-) -> Transaction { … }
+// the provider (tonk-worker) — capability + behaviour in one impl
+#[async_trait(?Send)]
+impl Provider<CreateSpace> for CommandEnv {
+    async fn execute(&self, cmd: CreateSpace) {
+        // re-lock through self.state() to reach the operator/reactor,
+        // do the IO, commit outcomes. Self-contained; returns ().
+    }
+}
 ```
 
-- The first parameter is the decoded command (owned).
-- Any `State<…>` parameters are *declared capabilities* — the
-  dispatcher supplies them; a pure handler declares none.
-- `Transaction` is the outcome buffer (the Bevy `Commands` analog): the
-  handler `assert`/`retract`s into it and returns it. The dispatcher
-  commits it to the branch the command arrived on.
-
-The handler's only fact-write path is the returned `Transaction`, and it
-always lands on the command's own branch — so a handler can't "commit
-whatever wherever". (A privileged handler that declares `State<AppState>`
-can still do multi-branch IO through the reactor, e.g. `create_space`
-creating a repo; that is an acknowledged exception, gated today only by
-holding the capability. See "Future direction".)
+A command is *self-contained*: `execute` does its own IO and commits its
+own outcomes through the env. There is no outcome buffer and no
+dispatcher-side commit. Capability is **structural** — a command can run
+only if `CommandEnv: Provider<C>` is implemented, and registering a
+command requires that bound, so an unsupported command won't even
+register. (The runtime UCAN-style gate — the operator actually *holding*
+the capability — layers on top of this later; see "Future direction".)
 
 ## How a command flows
 
@@ -68,14 +73,15 @@ holding the capability. See "Future direction".)
 
 3. **Dispatch.** After the commit and once the state lock is released,
    `router::command::dispatch` runs. It matches the captured transients
-   against the registry, runs each matched handler, and commits each
-   outcome to the command's branch — **concurrently and independently**
-   (one handler's IO or failure doesn't block another).
+   against the registry and calls each matched command's
+   `Provider::execute` on a clone of the `CommandEnv` —
+   **concurrently and independently** (one command's IO or failure
+   doesn't block another).
 
-4. **Outcome.** The handler's `Transaction` commits durably, so UIs
-   react over their subscriptions like any other state change. Errors
-   are facts too: a handler asserts a `Failed`/`status` outcome rather
-   than returning an error.
+4. **Outcome.** The provider commits its own outcomes through the env, so
+   UIs react over their subscriptions like any other state change. Errors
+   are facts too: a provider asserts a `Failed`/`status` outcome rather
+   than surfacing an error.
 
 ## The decode bridge (dynamic → static)
 
@@ -101,15 +107,16 @@ subscription-like, no tiebreak.
    (see [event-handling.md](./event-handling.md) and the kebab-case note
    below).
 
-2. **Write the handler** (`tonk-worker/src/router/…`), an
-   `async fn(C, [State<…>,] Transaction) -> Transaction`. Use the
-   reactor's `State` (`crate::reactor::State`), NOT axum's — both are in
-   scope in router modules, and only the reactor one is a command
-   capability.
+2. **Impl `Command`** for the concept (`Input = Self`, `Output = ()`),
+   and **impl `Provider<C>` for `CommandEnv`** (`tonk-worker`). The
+   `execute` body re-locks through `self.state()` to reach the
+   operator/reactor, does the IO, and commits its outcomes. Use
+   `#[cfg_attr(not(wasm32), async_trait)] #[cfg_attr(wasm32,
+   async_trait(?Send))]` (or plain `?Send` for a wasm-only provider).
 
-3. **Register it** in `router::command_registry()`:
-   `CommandRegistry::new().command(create_space)`. The builder infers
-   the command type and capabilities from the fn signature.
+3. **Register the type** in `router::command_registry()`:
+   `CommandRegistry::new().command::<CreateSpace>()`. This compiles only
+   if `CommandEnv: Provider<CreateSpace>` — the capability gate.
 
 4. **Define the trigger.** For a form/click, add the `command!` to the
    library (the concept must be present on the branch so the view's
@@ -135,22 +142,24 @@ subscription-like, no tiebreak.
 
 ## Transactional caveat (TODO)
 
-Handlers have no read-set isolation. A handler reads durable state via
-`State<…>`, decides an outcome, and that outcome commits later without
-checking that what it read still holds; concurrent handlers can both
-read and write the same state. The goal (marked `TODO(stm)` on
-`dispatch`/`commit_outcome`/`State`) is STM-like optimistic concurrency:
-track the observed revision/read-set and commit-or-conflict, re-running a
-handler whose reads went stale rather than committing on them.
+Commands have no read-set isolation. A provider reads durable state
+through the env, decides, and commits — without checking that what it
+read still holds; concurrent commands in one batch can both read and
+write the same state. The goal (marked `TODO(stm)` on
+`reactor::command::TypedCommand::run` and `dispatch`) is STM-like
+optimistic concurrency: track the observed revision/read-set and
+commit-or-conflict, re-running a command whose reads went stale rather
+than committing on them.
 
-## Future direction — capability-based commands
+## Future direction — runtime capability gating
 
-The handler layer is bespoke today. The intended end state is to express
-commands as `dialog_capability::Command` (or `Effect`) and replace
-handlers with `impl Provider<CreateSpace> for <env>`: the operator's (or
-a tonk command env's) capability set decides whether a command may run,
-which is UCAN-shaped — a command attempted without the capability simply
-isn't provided. The router would then register command *types* and look
-up the provider, rather than registering handler functions. The decode
-bridge and the transient-trigger dispatch above stay; only the "what
-runs" layer changes.
+Commands are already `dialog_capability::Command`s run by a
+`Provider<C>`, so the *compile-time* capability gate is in place: a
+command can't be registered unless the env provides it. The next step is
+the *runtime* UCAN gate — `execute` succeeding only if the operator
+actually **holds** the capability for each action it attempts (create a
+repo, commit to a branch), rather than the env unconditionally doing the
+work. Moving providers from `CommandEnv` toward the operator's own
+capability chain (where orphan rules allow) is the path there. The decode
+bridge and the transient-trigger dispatch stay; only the authorization
+inside `execute` changes.

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -17,6 +17,7 @@
 //! `dialog.concept/transient` marker), not of the type.
 
 use dialog_artifacts::Entity;
+use dialog_capability::Command;
 use dialog_query::Concept;
 
 use crate::domain::command::Value as SpaceName;
@@ -41,4 +42,13 @@ pub struct CreateSpace {
     pub this: Entity,
     /// Local name for the new space, read from the form's `name` input.
     pub name: SpaceName,
+}
+
+/// `CreateSpace` is a [`dialog_capability::Command`]: a `Provider<CreateSpace>`
+/// (a tonk command env wrapping `AppState`) executes it. The input is the
+/// decoded command itself; the provider is self-contained (it does its own
+/// IO and commits), so the output is `()`.
+impl Command for CreateSpace {
+    type Input = Self;
+    type Output = ();
 }

--- a/rust/tonk-worker/src/reactor.rs
+++ b/rust/tonk-worker/src/reactor.rs
@@ -34,10 +34,7 @@ mod subscription;
 mod transaction;
 
 pub use branch::{BranchReference, BranchSession, BranchState};
-pub use command::{
-    Command, CommandFn, CommandHandler, CommandRegistry, EntityFacts, FromContext, Source, State,
-    Transaction as CommandTx, TypedHandler,
-};
+pub use command::{CommandHandler, CommandRegistry, Decode, EntityFacts, Env, TypedCommand};
 pub use env::{
     BranchOpenProvider, CommitProvider, LoadProvider, PullProvider, PushProvider, SelectProvider,
 };

--- a/rust/tonk-worker/src/reactor/command.rs
+++ b/rust/tonk-worker/src/reactor/command.rs
@@ -23,7 +23,8 @@
 use std::collections::HashMap;
 
 use dialog_artifacts::{Artifact, Changes, Entity, Instruction};
-use dialog_common::{ConditionalSend, ConditionalSync};
+use dialog_capability::{Command, Provider};
+use dialog_common::ConditionalSync;
 use dialog_query::concept::Concept;
 use dialog_query::{Application, ConceptDescriptor, Conclusion, Match, Term};
 
@@ -81,14 +82,18 @@ where
     query.realize(source).ok()
 }
 
-/// A transient trigger concept — the `&C` member of a command
-/// handler's query. Supplies the reverse-index keys (its field
-/// attribute names) and a decode from a transient entity's facts.
+/// A transient trigger concept: the command type a [`Provider`] runs.
+/// Supplies the reverse-index keys (its field attribute names) and a
+/// decode from a transient entity's facts.
 ///
 /// Blanket-implemented for any decodable [`Concept`]; the bounds are
 /// exactly what [`decode_concept`] needs, so a plain
-/// `#[derive(Concept)]` is a `Command` with no extra code.
-pub trait Command: Sized {
+/// `#[derive(Concept)]` is `Decode` with no extra code. (Named `Decode`
+/// rather than `Command` to leave that name to
+/// [`dialog_capability::Command`], which a command type also implements.)
+///
+/// [`Provider`]: dialog_capability::Provider
+pub trait Decode: Sized {
     /// Fully-qualified attribute URIs (`domain/name`) of this
     /// trigger's fields. An entity in the transient set is a
     /// candidate when it carries any of these.
@@ -99,7 +104,7 @@ pub trait Command: Sized {
     fn decode(this: Entity, facts: &EntityFacts) -> Option<Self>;
 }
 
-impl<C> Command for C
+impl<C> Decode for C
 where
     C: Concept<Conclusion = C> + Conclusion,
     C::Application: Default + Application<Conclusion = C>,
@@ -118,167 +123,29 @@ where
     }
 }
 
-/// The write side of a command handler — the Bevy `Commands` analog.
-/// A deferred buffer: the handler calls [`Self::assert`] /
-/// [`Self::retract`] as it runs, and the reactor commits the
-/// accumulated [`Changes`] as one durable transaction after the
-/// handler future resolves (step 4). The handler does NOT commit and
-/// can't read back its own writes mid-run.
+/// The environment a command runs against — the [`Provider`] the
+/// dispatcher calls `execute` on. Supplied at dispatch time (the
+/// registry can't bake it in: it lives *inside* the state, an `Arc`
+/// cycle). In practice the worker's `CommandEnv` wrapping `AppState`;
+/// the alias keeps this module from naming the worker type directly.
 ///
-/// Outcomes are durable (so UIs react over their subscriptions); the
-/// transient trigger self-retracts at the originating commit, so a
-/// handler never retracts its own command.
-#[derive(Default)]
-pub struct Transaction {
-    changes: Changes,
-}
+/// [`Provider`]: dialog_capability::Provider
+pub type Env = crate::router::CommandEnv;
 
-impl Transaction {
-    /// An empty outcome buffer.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Buffer an assertion. Accepts anything assertable — typically a
-    /// `#[derive(Concept)]` outcome (`StatusChange`, `Failed`, …),
-    /// which implements [`Statement`](dialog_artifacts::Statement).
-    pub fn assert<S: dialog_artifacts::Statement>(&mut self, claim: S) -> &mut Self {
-        self.changes.assert(claim);
-        self
-    }
-
-    /// Buffer a retraction.
-    pub fn retract<S: dialog_artifacts::Statement>(&mut self, claim: S) -> &mut Self {
-        self.changes.retract(claim);
-        self
-    }
-
-    /// Consume the buffer, yielding the accumulated [`Changes`] for
-    /// the reactor to commit.
-    pub fn into_changes(self) -> Changes {
-        self.changes
-    }
-}
-
-/// A `'static` boxed future yielding the outcome `Changes` (or `None`
-/// if the trigger didn't decode), `Send` only off wasm. `'static` so
-/// the dispatcher can collect these, release the state lock, then await
-/// them — handler IO never runs while a lock is held.
-#[cfg(not(target_arch = "wasm32"))]
-pub type RunFuture =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Option<Changes>> + Send + 'static>>;
-#[cfg(target_arch = "wasm32")]
-pub type RunFuture =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Option<Changes>> + 'static>>;
-
-/// A `'static` future yielding the populated outcome buffer, `Send`
-/// only off wasm — matches the reactor's
+/// A `'static` boxed future for one command's execution, `Send` only
+/// off wasm — matches the reactor's
 /// [`ConditionalSync`](dialog_common::ConditionalSync) convention so a
-/// handler runs on the single-threaded SW executor.
+/// command runs on the single-threaded SW executor. `'static` so the
+/// dispatcher can build it, release the state lock, then await it —
+/// command IO never runs while a lock is held.
 #[cfg(not(target_arch = "wasm32"))]
-pub type HandlerFuture =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Transaction> + Send + 'static>>;
+pub type RunFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
 #[cfg(target_arch = "wasm32")]
-pub type HandlerFuture =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Transaction> + 'static>>;
+pub type RunFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>>;
 
-/// The source extractors pull their context from — the shared state,
-/// supplied to a handler at dispatch time. Mirrors axum's per-request
-/// state injection: the registry doesn't bake state in (the registry
-/// lives *inside* the state, so it can't hold an `Arc` to itself), so
-/// the dispatcher passes the source when it runs a handler.
-///
-/// `Source` is the worker's [`AppState`](crate::router::AppState) in
-/// practice; the trait keeps this module from depending on it directly.
-pub type Source = crate::router::AppState;
-
-/// Extract `Self` from the shared [`Source`] — the command analog of
-/// axum's `FromRef`/`FromRequestParts`. A handler parameter that is
-/// `FromContext` is a *declared capability*: the handler names what it
-/// needs (`State<AppState>`, …) and the dispatcher provides it from the
-/// source. Pure handlers declare none.
-pub trait FromContext: Sized {
-    /// Pull this value from the source. Cheap — typically an `Arc`
-    /// clone — so the resulting handler future stays `'static`.
-    fn from_context(source: &Source) -> Self;
-}
-
-/// Capability extractor: a cheap handle onto the shared state, named by
-/// `T` (axum's `State<T>`). For now `T = Source`; `FromRef`-style
-/// sub-handle extraction can layer on later without changing handler
-/// signatures. The handler reaches the operator/reactor by re-locking
-/// through this handle when it needs them — declared in the signature,
-/// not handed wholesale.
-///
-/// TODO(stm): reads through `State<T>` are not tracked, so the
-/// dispatcher's outcome commit can't tell whether what the handler read
-/// still holds. The transactional goal is a read-tracking extractor
-/// (e.g. a `Snapshot<C>`/`Current<C>` that records the revision or
-/// datoms it observed) so dispatch can commit-or-conflict against the
-/// handler's read set. See the `TODO(stm)` notes on
-/// `router::command::dispatch`/`commit_outcome`.
-pub struct State<T>(pub T);
-
-impl FromContext for State<Source> {
-    fn from_context(source: &Source) -> Self {
-        State(source.clone())
-    }
-}
-
-/// A typed command handler function: an `async fn` taking the decoded
-/// trigger (owned), zero or more declared-capability extractors, and an
-/// outcome [`Transaction`] to fill (returned).
-///
-/// One blanket impl per extractor arity (axum/bevy style). A handler
-/// with no extractor is a pure transform — no capability — and can only
-/// decide outcomes. A handler that needs IO declares it as a
-/// `FromContext` parameter (e.g. `State<AppState>`); the dispatcher
-/// supplies it from the source. Outcome facts always flow only through
-/// the returned `Transaction`, committed by the dispatcher to the
-/// command's branch — declaring a capability grants IO, never commit
-/// authority.
-///
-/// All values are owned so the future is `'static` and can run detached
-/// past the triggering commit.
-pub trait CommandFn<C, Args>: 'static {
-    /// Run the handler against the dispatch `source`: extract the
-    /// declared capabilities, then invoke the handler with the trigger
-    /// and outcome buffer.
-    fn run(&self, command: C, tx: Transaction, source: &Source) -> HandlerFuture;
-}
-
-// Arity 0: pure transform `async fn(C, Transaction) -> Transaction`.
-impl<C, F, Fut> CommandFn<C, ()> for F
-where
-    F: Fn(C, Transaction) -> Fut + 'static,
-    Fut: std::future::Future<Output = Transaction> + ConditionalSend + 'static,
-    C: 'static,
-{
-    fn run(&self, command: C, tx: Transaction, _source: &Source) -> HandlerFuture {
-        Box::pin(self(command, tx))
-    }
-}
-
-// Arity 1: one declared capability `async fn(C, E1, Transaction) ->
-// Transaction`. The extractor sits between the trigger and the
-// transaction, matching the read-context-then-write shape.
-impl<C, F, Fut, E1> CommandFn<C, (E1,)> for F
-where
-    F: Fn(C, E1, Transaction) -> Fut + 'static,
-    Fut: std::future::Future<Output = Transaction> + ConditionalSend + 'static,
-    C: 'static,
-    E1: FromContext,
-{
-    fn run(&self, command: C, tx: Transaction, source: &Source) -> HandlerFuture {
-        let e1 = E1::from_context(source);
-        Box::pin(self(command, e1, tx))
-    }
-}
-
-/// Dyn-safe handler stored in the [`CommandRegistry`]. One per
-/// registered command. The concrete handler fn and its trigger
-/// concept `C` are erased behind this object; the registry interacts
-/// only through the methods here.
+/// Dyn-safe entry stored in the [`CommandRegistry`]. One per registered
+/// command *type*. The concrete command `C` is erased behind this
+/// object; the registry interacts only through the methods here.
 ///
 /// `ConditionalSync` (Send + Sync off wasm, nothing on wasm) keeps a
 /// `Box<dyn CommandHandler>` — and therefore [`TonkState`] /
@@ -287,29 +154,22 @@ where
 /// [`TonkState`]: crate::worker::TonkState
 /// [`AppState`]: crate::router::AppState
 pub trait CommandHandler: ConditionalSync {
-    /// Attribute names whose presence on a transient entity makes
-    /// this handler a candidate. Drives the reverse index.
+    /// Attribute names whose presence on a transient entity makes this
+    /// command a candidate. Drives the reverse index.
     fn trigger_attributes(&self) -> &[String];
 
     /// Whether `facts` (the asserted artifacts for a single transient
-    /// entity) satisfy this handler's trigger concept — i.e. the `&C`
-    /// member decodes.
+    /// entity) decode as this command.
     fn matches(&self, facts: &EntityFacts) -> bool;
 
-    /// Decode the trigger from `facts`, run the handler against
-    /// `source` (the dispatch-time capability source), and return the
-    /// outcome [`Changes`] for the dispatcher to commit. `None` if the
-    /// facts don't decode (treated as "didn't fire").
-    ///
-    /// The returned future owns the decoded trigger, the outcome
-    /// buffer, and any extracted capabilities, so it is `'static` and
-    /// can run detached past the triggering commit. Crucially this lets
-    /// the dispatcher release the state lock before awaiting it, so
-    /// handler IO never runs under a held lock. The dispatcher drains
-    /// the returned `Changes` into a durable commit on the command's
-    /// branch. Boxed so the trait stays dyn-safe for
-    /// `Box<dyn CommandHandler>` storage.
-    fn run(&self, facts: &EntityFacts, source: &Source) -> RunFuture;
+    /// Decode the command from `facts` and execute it via the
+    /// [`Provider`](dialog_capability::Provider) impl on a clone of
+    /// `env`. The returned future owns the decoded command and the env
+    /// clone, so it is `'static` and can run detached past the
+    /// triggering commit — the dispatcher releases the state lock
+    /// before awaiting it. A no-op future when the facts don't decode.
+    /// Boxed so the trait stays dyn-safe for `Box<dyn CommandHandler>`.
+    fn run(&self, facts: &EntityFacts, env: &Env) -> RunFuture;
 }
 
 /// The `of` (entity) shared by a transient entity's facts. Every
@@ -319,39 +179,51 @@ fn facts_entity(facts: &EntityFacts) -> Option<Entity> {
     facts.first().map(|artifact| artifact.of.clone())
 }
 
-/// A handler whose trigger is the typed command concept `C`, running
-/// the captured `async fn` `F` whose declared capabilities are `Args`.
-/// Erases all three behind [`CommandHandler`]: `matches` is the derived
-/// decode of `C`, `trigger_attributes` comes off `C`'s descriptor, and
-/// `run` decodes, extracts the capabilities from the source, then
-/// invokes `F`.
-pub struct TypedHandler<C, Args, F> {
+/// A registry entry for the command type `C`. Holds no handler — the
+/// behaviour is the [`Provider<C>`](dialog_capability::Provider) impl on
+/// [`Env`]. Erases `C` behind [`CommandHandler`]: `matches` is the
+/// derived decode of `C`, `trigger_attributes` comes off `C`'s
+/// descriptor, and `run` decodes then calls `Env::execute`.
+///
+/// A command is registrable iff `Env: Provider<C>` — i.e. the env has
+/// the capability to run it. That bound on [`Self::new`] is the
+/// (compile-time) capability gate; the UCAN-style runtime gate layers on
+/// top of it later.
+pub struct TypedCommand<C> {
     attributes: Vec<String>,
-    handler: F,
-    _command: std::marker::PhantomData<fn() -> (C, Args)>,
+    _command: std::marker::PhantomData<fn() -> C>,
 }
 
-impl<C, Args, F> TypedHandler<C, Args, F>
+impl<C> TypedCommand<C>
 where
-    C: Command,
-    F: CommandFn<C, Args>,
+    C: Decode + Command<Input = C> + 'static,
+    Env: Provider<C>,
 {
-    /// Build a handler for command `C` from the `async fn` to run.
-    /// Caches `C`'s trigger attribute names.
-    pub fn new(handler: F) -> Self {
+    /// Register command `C`, caching its trigger attribute names. The
+    /// `Env: Provider<C>` bound means a command can only be registered
+    /// if the env can execute it.
+    pub fn new() -> Self {
         Self {
             attributes: C::trigger_attributes(),
-            handler,
             _command: std::marker::PhantomData,
         }
     }
 }
 
-impl<C, Args, F> CommandHandler for TypedHandler<C, Args, F>
+impl<C> Default for TypedCommand<C>
 where
-    C: Command,
-    Args: 'static,
-    F: CommandFn<C, Args> + ConditionalSync,
+    C: Decode + Command<Input = C> + 'static,
+    Env: Provider<C>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<C> CommandHandler for TypedCommand<C>
+where
+    C: Decode + Command<Input = C, Output = ()> + ConditionalSync + 'static,
+    Env: Provider<C> + Clone + ConditionalSync + 'static,
 {
     fn trigger_attributes(&self) -> &[String] {
         &self.attributes
@@ -364,21 +236,15 @@ where
         C::decode(this, facts).is_some()
     }
 
-    fn run(&self, facts: &EntityFacts, source: &Source) -> RunFuture {
-        // Decode the trigger and extract capabilities from the source
-        // synchronously, here, while the caller still holds the lock.
-        // `self.handler.run(...)` returns a `'static` `HandlerFuture`
-        // (it owns the trigger, buffer, and capability clones), so the
-        // future below borrows neither `self` nor `source` — the
-        // dispatcher can drop the lock before awaiting it. `None`
-        // (didn't decode) yields no outcome.
+    fn run(&self, facts: &EntityFacts, env: &Env) -> RunFuture {
+        // Decode synchronously here (the caller still holds the lock),
+        // then hand the owned command + an env clone to a `'static`
+        // future so the dispatcher can drop the lock before awaiting.
         let decoded = facts_entity(facts).and_then(|this| C::decode(this, facts));
-        let handler_future =
-            decoded.map(|command| self.handler.run(command, Transaction::new(), source));
+        let env = env.clone();
         Box::pin(async move {
-            match handler_future {
-                Some(future) => Some(future.await.into_changes()),
-                None => None,
+            if let Some(command) = decoded {
+                env.execute(command).await;
             }
         })
     }
@@ -404,22 +270,23 @@ impl CommandRegistry {
         Self::default()
     }
 
-    /// Register a typed handler for command `C`, axum `.route`-style.
-    /// `C` is inferred from the handler's first parameter; declared
-    /// capabilities (`State<…>`) are inferred as `Args`. Chainable.
+    /// Register the command type `C`. Lighter than passing a handler:
+    /// the behaviour is the [`Provider<C>`](dialog_capability::Provider)
+    /// impl on [`Env`], so registration is just the type. The
+    /// `Env: Provider<C>` bound means a command can only be registered if
+    /// the env has the capability to run it. Chainable.
     ///
     /// ```ignore
     /// let registry = CommandRegistry::new()
-    ///     .command(create_repo)   // async fn(CreateRepo, State<AppState>, Transaction) -> Transaction
-    ///     .command(rename_space);
+    ///     .command::<CreateSpace>()   // Env: Provider<CreateSpace>
+    ///     .command::<RenameSpace>();
     /// ```
-    pub fn command<C, Args, F>(mut self, handler: F) -> Self
+    pub fn command<C>(mut self) -> Self
     where
-        C: Command + 'static,
-        Args: 'static,
-        F: CommandFn<C, Args> + ConditionalSync,
+        C: Decode + Command<Input = C, Output = ()> + ConditionalSync + 'static,
+        Env: Provider<C> + Clone + ConditionalSync + 'static,
     {
-        self.register(Box::new(TypedHandler::<C, Args, F>::new(handler)));
+        self.register(Box::new(TypedCommand::<C>::new()));
         self
     }
 
@@ -512,9 +379,8 @@ mod tests {
     use dialog_artifacts::Statement;
     use dialog_query::{Attribute, Concept, the};
 
-    // A real command concept: the typed trigger a handler reads
-    // through `&CreateRepo`. Plain derives — no marker trait — so the
-    // blanket `Command` impl (and `TypedHandler`) apply for free.
+    // A command concept whose `Provider` lives at the router layer; here
+    // we test only the decode + match machinery, which needs no env.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.command")]
     pub struct RepoName(pub String);
@@ -525,17 +391,12 @@ mod tests {
         pub name: RepoName,
     }
 
-    /// The attribute `CreateRepo`'s `name` field stores under — the
-    /// `RepoName` attribute's name (snake-cased from its struct name),
-    /// which is what the trigger reverse-index keys on.
-    fn create_repo_name_attr() -> dialog_query::attribute::The {
-        the!("xyz.tonk.command/repo-name")
-    }
-
-    /// A one-fact transient `CreateRepo{this: of, name}` batch.
+    /// A one-fact transient `CreateRepo{this: of, name}` batch. The
+    /// attribute is `RepoName`'s name (snake-cased from its struct name),
+    /// which is what the reverse index keys on.
     fn create_repo_transient(of: &str, name: &str) -> Changes {
         let mut changes = Changes::new();
-        create_repo_name_attr()
+        the!("xyz.tonk.command/repo-name")
             .of(of.parse::<Entity>().expect("entity URI"))
             .is(name.to_string())
             .assert(&mut changes);
@@ -571,113 +432,16 @@ mod tests {
         );
     }
 
-    // An outcome concept the test handler asserts: `Created{this}`.
-    // Stands in for a real `StatusChange`/`Failed` outcome.
-    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[domain("xyz.tonk.command")]
-    pub struct CreatedName(pub String);
-
-    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct Created {
-        pub this: Entity,
-        pub name: CreatedName,
-    }
-
-    /// A test handler: on a `CreateRepo`, assert a `Created` outcome
-    /// echoing the requested name. A pure transform — no IO — proving
-    /// the decode → run → outcome path.
-    async fn record_created(command: CreateRepo, mut tx: Transaction) -> Transaction {
-        tx.assert(Created {
-            this: command.this.clone(),
-            name: CreatedName(command.name.0.clone()),
-        });
-        tx
-    }
-
-    /// Build a `TypedHandler` over [`record_created`] (arity-0 `Args`
-    /// — a pure transform, no declared capability).
-    fn created_handler() -> Box<dyn CommandHandler> {
-        Box::new(TypedHandler::<CreateRepo, (), _>::new(record_created))
-    }
-
     #[dialog_common::test]
-    fn it_matches_a_handler_by_its_trigger_concept() {
-        let mut registry = CommandRegistry::new();
-        registry.register(created_handler());
-
-        let changes = create_repo_transient("did:key:zCmd", "pictures");
-        assert_eq!(
-            registry.match_transients(&changes).len(),
-            1,
-            "the CreateRepo trigger should fire once"
-        );
-    }
-
-    #[dialog_common::test]
-    fn it_ignores_a_transient_no_handler_triggers_on() {
-        let mut registry = CommandRegistry::new();
-        registry.register(created_handler());
-
-        let mut changes = Changes::new();
+    fn it_groups_transients_by_entity() {
+        // Two facts on one entity group together; an unrelated entity is
+        // its own group.
+        let mut changes = create_repo_transient("did:key:zA", "alpha");
         the!("xyz.tonk.unrelated/noise")
-            .of("did:key:zNoise".parse::<Entity>().expect("entity URI"))
+            .of("did:key:zB".parse::<Entity>().expect("entity URI"))
             .is("x".to_string())
             .assert(&mut changes);
-        assert!(
-            registry.match_transients(&changes).is_empty(),
-            "an unrelated transient should not fire"
-        );
-    }
-
-    #[dialog_common::test]
-    fn it_fires_every_matching_handler_subscription_style() {
-        // Two handlers on the same command: both fire (commands are
-        // subscription-like, no tiebreak).
-        let mut registry = CommandRegistry::new();
-        registry.register(created_handler());
-        registry.register(created_handler());
-
-        let changes = create_repo_transient("did:key:zCmd", "pictures");
-        assert_eq!(
-            registry.match_transients(&changes).len(),
-            2,
-            "both handlers on the command fire"
-        );
-    }
-
-    #[dialog_common::test]
-    fn it_reports_empty_until_a_handler_is_registered() {
-        let registry = CommandRegistry::new();
-        assert!(registry.is_empty(), "a fresh registry has no handlers");
-    }
-
-    #[dialog_common::test]
-    async fn it_runs_a_pure_handler_and_returns_the_outcome_changes() {
-        // A pure handler (arity-0) ignores the source, so we can run it
-        // directly by invoking the captured fn — the `CommandHandler::run`
-        // path that takes a `Source` is exercised end-to-end at the
-        // router layer where a real `AppState` exists.
-        let by_entity = group_by_entity(create_repo_transient("did:key:zCmd", "pictures"));
-        let (entity, facts) = by_entity.into_iter().next().expect("one entity");
-        let command = CreateRepo::decode(entity, &facts).expect("decodes");
-
-        let tx = record_created(command, Transaction::new()).await;
-        let names: Vec<String> = tx
-            .into_changes()
-            .into_instructions()
-            .into_iter()
-            .filter_map(|inst| match inst {
-                Instruction::Assert(a) | Instruction::Replace(a) => match a.is {
-                    dialog_artifacts::Value::String(s) => Some(s),
-                    _ => None,
-                },
-                Instruction::Retract(_) => None,
-            })
-            .collect();
-        assert_eq!(
-            names,
-            vec!["pictures".to_string()],
-            "handler should have asserted a Created outcome echoing the name"
-        );
+        let by_entity = group_by_entity(changes);
+        assert_eq!(by_entity.len(), 2, "two distinct entities → two groups");
     }
 }

--- a/rust/tonk-worker/src/reactor/command.rs
+++ b/rust/tonk-worker/src/reactor/command.rs
@@ -376,11 +376,13 @@ mod tests {
     #![allow(missing_docs)]
 
     use super::*;
-    use dialog_artifacts::Statement;
+    use dialog_artifacts::{Statement, Value};
     use dialog_query::{Attribute, Concept, the};
 
-    // A command concept whose `Provider` lives at the router layer; here
-    // we test only the decode + match machinery, which needs no env.
+    // --- Test command concepts ------------------------------------------
+    // Their `Provider`s live at the router layer; here we test the decode,
+    // grouping, and registry/matching machinery, which needs no env.
+
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.command")]
     pub struct RepoName(pub String);
@@ -391,41 +393,83 @@ mod tests {
         pub name: RepoName,
     }
 
+    // A two-field command: `name` (text) + `owner` (entity), to cover
+    // multi-field decode and a typed (entity) field.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.command")]
+    pub struct Owner(pub Entity);
+
+    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Share {
+        pub this: Entity,
+        pub name: RepoName,
+        pub owner: Owner,
+    }
+
+    fn entity(uri: &str) -> Entity {
+        uri.parse().expect("entity URI")
+    }
+
     /// A one-fact transient `CreateRepo{this: of, name}` batch. The
     /// attribute is `RepoName`'s name (snake-cased from its struct name),
     /// which is what the reverse index keys on.
     fn create_repo_transient(of: &str, name: &str) -> Changes {
         let mut changes = Changes::new();
         the!("xyz.tonk.command/repo-name")
-            .of(of.parse::<Entity>().expect("entity URI"))
+            .of(entity(of))
             .is(name.to_string())
             .assert(&mut changes);
         changes
     }
 
+    fn noise_fact(changes: &mut Changes, of: &str) {
+        the!("xyz.tonk.unrelated/noise")
+            .of(entity(of))
+            .is("x".to_string())
+            .assert(changes);
+    }
+
+    fn facts_for(changes: Changes) -> (Entity, EntityFacts) {
+        group_by_entity(changes)
+            .into_iter()
+            .next()
+            .expect("one entity")
+    }
+
+    // --- decode ---------------------------------------------------------
+
     #[dialog_common::test]
     fn it_decodes_a_command_from_its_transient_facts() {
-        let changes = create_repo_transient("did:key:zCmd", "pictures");
-        let by_entity = group_by_entity(changes);
-        let (entity, facts) = by_entity.into_iter().next().expect("one entity");
-
+        let (entity, facts) = facts_for(create_repo_transient("did:key:zCmd", "pictures"));
         let decoded = CreateRepo::decode(entity.clone(), &facts).expect("decodes");
         assert_eq!(decoded.this, entity);
         assert_eq!(decoded.name.0, "pictures");
     }
 
     #[dialog_common::test]
-    fn it_does_not_decode_when_a_required_field_is_absent() {
-        // An entity carrying an unrelated attribute (not `name`)
-        // shouldn't decode as a CreateRepo.
+    fn it_decodes_a_multi_field_command() {
+        let owner = entity("did:key:zOwner");
         let mut changes = Changes::new();
-        the!("xyz.tonk.unrelated/noise")
-            .of("did:key:zNoise".parse::<Entity>().expect("entity URI"))
-            .is("x".to_string())
+        the!("xyz.tonk.command/repo-name")
+            .of(entity("did:key:zShare"))
+            .is("pics".to_string())
             .assert(&mut changes);
-        let by_entity = group_by_entity(changes);
-        let (entity, facts) = by_entity.into_iter().next().expect("one entity");
+        the!("xyz.tonk.command/owner")
+            .of(entity("did:key:zShare"))
+            .is(owner.clone())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
 
+        let decoded = Share::decode(this, &facts).expect("two-field concept decodes");
+        assert_eq!(decoded.name.0, "pics");
+        assert_eq!(decoded.owner.0, owner);
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_decode_when_a_required_field_is_absent() {
+        let mut changes = Changes::new();
+        noise_fact(&mut changes, "did:key:zNoise");
+        let (entity, facts) = facts_for(changes);
         assert!(
             CreateRepo::decode(entity, &facts).is_none(),
             "missing required `name` field should fail to decode"
@@ -433,15 +477,229 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_groups_transients_by_entity() {
-        // Two facts on one entity group together; an unrelated entity is
-        // its own group.
-        let mut changes = create_repo_transient("did:key:zA", "alpha");
-        the!("xyz.tonk.unrelated/noise")
-            .of("did:key:zB".parse::<Entity>().expect("entity URI"))
-            .is("x".to_string())
+    fn it_does_not_decode_a_partial_multi_field_command() {
+        // `Share` needs name AND owner; only `name` present → no decode.
+        let (this, facts) = facts_for(create_repo_transient("did:key:zShare", "pics"));
+        assert!(
+            Share::decode(this, &facts).is_none(),
+            "a multi-field command missing one field must not decode"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_decode_on_a_type_mismatch() {
+        // `Share.owner` is an entity field; give it a string. The
+        // `try_into` in the derived realize fails → no decode.
+        let mut changes = Changes::new();
+        the!("xyz.tonk.command/repo-name")
+            .of(entity("did:key:zBad"))
+            .is("pics".to_string())
             .assert(&mut changes);
+        the!("xyz.tonk.command/owner")
+            .of(entity("did:key:zBad"))
+            .is("not-an-entity".to_string()) // wrong type for `Owner(Entity)`
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+        assert!(
+            Share::decode(this, &facts).is_none(),
+            "an entity field given a string must fail to decode"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_unrelated_attributes_when_decoding() {
+        // The command's own fields decode even though the entity carries
+        // an extra, unrelated attribute.
+        let mut changes = create_repo_transient("did:key:zExtra", "pictures");
+        noise_fact(&mut changes, "did:key:zExtra");
+        let (this, facts) = facts_for(changes);
+        let decoded = CreateRepo::decode(this, &facts).expect("decodes despite extra attr");
+        assert_eq!(decoded.name.0, "pictures");
+    }
+
+    #[dialog_common::test]
+    fn it_reports_a_commands_trigger_attributes() {
+        let attrs = CreateRepo::trigger_attributes();
+        assert_eq!(attrs, vec!["xyz.tonk.command/repo-name".to_string()]);
+
+        let mut share = Share::trigger_attributes();
+        share.sort();
+        assert_eq!(
+            share,
+            vec![
+                "xyz.tonk.command/owner".to_string(),
+                "xyz.tonk.command/repo-name".to_string(),
+            ]
+        );
+    }
+
+    // --- group_by_entity ------------------------------------------------
+
+    #[dialog_common::test]
+    fn it_groups_facts_of_one_entity_together() {
+        let mut changes = create_repo_transient("did:key:zA", "alpha");
+        noise_fact(&mut changes, "did:key:zA"); // same entity, 2nd fact
         let by_entity = group_by_entity(changes);
-        assert_eq!(by_entity.len(), 2, "two distinct entities → two groups");
+        assert_eq!(by_entity.len(), 1, "one entity → one group");
+        assert_eq!(
+            by_entity.values().next().unwrap().len(),
+            2,
+            "both facts land in the group"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_groups_distinct_entities_separately() {
+        let mut changes = create_repo_transient("did:key:zA", "alpha");
+        noise_fact(&mut changes, "did:key:zB");
+        assert_eq!(
+            group_by_entity(changes).len(),
+            2,
+            "two distinct entities → two groups"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_groups_an_empty_batch_to_nothing() {
+        assert!(group_by_entity(Changes::new()).is_empty());
+    }
+
+    // --- registry + matching (via a stub handler) -----------------------
+    // A stub `CommandHandler` lets us exercise the reverse-index match and
+    // the "all matches fire" / "candidate but doesn't decode" edges
+    // without a real `Provider` env (which lives at the router layer).
+
+    struct StubHandler {
+        attributes: Vec<String>,
+        // Decode succeeds only when the entity carries this attribute.
+        decode_on: String,
+    }
+
+    impl StubHandler {
+        fn boxed(attribute: &str) -> Box<dyn CommandHandler> {
+            Box::new(StubHandler {
+                attributes: vec![attribute.to_string()],
+                decode_on: attribute.to_string(),
+            })
+        }
+    }
+
+    impl CommandHandler for StubHandler {
+        fn trigger_attributes(&self) -> &[String] {
+            &self.attributes
+        }
+        fn matches(&self, facts: &EntityFacts) -> bool {
+            facts.iter().any(|a| a.the.to_string() == self.decode_on)
+        }
+        fn run(&self, _facts: &EntityFacts, _env: &Env) -> RunFuture {
+            Box::pin(async {})
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_reports_empty_until_a_command_is_registered() {
+        let mut registry = CommandRegistry::new();
+        assert!(registry.is_empty());
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        assert!(!registry.is_empty());
+    }
+
+    #[dialog_common::test]
+    fn it_matches_a_registered_command_on_its_trigger() {
+        let mut registry = CommandRegistry::new();
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        let fired = registry.match_transients(&create_repo_transient("did:key:zCmd", "pics"));
+        assert_eq!(fired.len(), 1);
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_match_an_unrelated_transient() {
+        let mut registry = CommandRegistry::new();
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        let mut changes = Changes::new();
+        noise_fact(&mut changes, "did:key:zNoise");
+        assert!(registry.match_transients(&changes).is_empty());
+    }
+
+    #[dialog_common::test]
+    fn it_fires_all_matching_commands_subscription_style() {
+        // Two commands registered on the same trigger attribute: BOTH
+        // fire (commands are subscription-like, no tiebreak).
+        let mut registry = CommandRegistry::new();
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        let fired = registry.match_transients(&create_repo_transient("did:key:zCmd", "pics"));
+        assert_eq!(fired.len(), 2, "both commands on the attribute fire");
+    }
+
+    #[dialog_common::test]
+    fn it_drops_a_candidate_whose_trigger_does_not_decode() {
+        // A command keyed on an attribute the entity has, but whose
+        // `matches` (decode) returns false, is a candidate but does NOT
+        // fire. We register a stub keyed on `repo-name` but that only
+        // decodes on `owner`, then submit a `repo-name`-only entity.
+        let mut registry = CommandRegistry::new();
+        registry.register(Box::new(StubHandler {
+            attributes: vec!["xyz.tonk.command/repo-name".to_string()],
+            decode_on: "xyz.tonk.command/owner".to_string(),
+        }));
+        let fired = registry.match_transients(&create_repo_transient("did:key:zCmd", "pics"));
+        assert!(
+            fired.is_empty(),
+            "a candidate that fails to decode must not fire"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_considers_a_command_once_when_two_of_its_attributes_match() {
+        // A command keyed on two attributes, both present on the entity,
+        // is still considered once (candidate dedup).
+        let mut registry = CommandRegistry::new();
+        registry.register(Box::new(StubHandler {
+            attributes: vec![
+                "xyz.tonk.command/repo-name".to_string(),
+                "xyz.tonk.command/owner".to_string(),
+            ],
+            decode_on: "xyz.tonk.command/repo-name".to_string(),
+        }));
+        let mut changes = create_repo_transient("did:key:zCmd", "pics");
+        the!("xyz.tonk.command/owner")
+            .of(entity("did:key:zCmd"))
+            .is(entity("did:key:zOwner"))
+            .assert(&mut changes);
+        let fired = registry.match_transients(&changes);
+        assert_eq!(fired.len(), 1, "the command fires once, not per-attribute");
+    }
+
+    #[dialog_common::test]
+    fn it_matches_each_command_entity_in_a_batch() {
+        // Two distinct command entities in one batch each match.
+        let mut registry = CommandRegistry::new();
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        let mut changes = create_repo_transient("did:key:zA", "alpha");
+        the!("xyz.tonk.command/repo-name")
+            .of(entity("did:key:zB"))
+            .is("beta".to_string())
+            .assert(&mut changes);
+        let fired = registry.match_transients(&changes);
+        assert_eq!(fired.len(), 2, "each command entity fires once");
+    }
+
+    #[dialog_common::test]
+    fn it_hands_each_match_the_full_entity_facts() {
+        // The facts handed to a matched handler are that entity's facts
+        // (so the handler can decode every field).
+        let mut registry = CommandRegistry::new();
+        registry.register(StubHandler::boxed("xyz.tonk.command/repo-name"));
+        let fired = registry.match_transients(&create_repo_transient("did:key:zCmd", "pics"));
+        let (_, facts) = &fired[0];
+        let name = facts
+            .iter()
+            .find(|a| a.the.to_string() == "xyz.tonk.command/repo-name")
+            .and_then(|a| match &a.is {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            });
+        assert_eq!(name.as_deref(), Some("pics"));
     }
 }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -63,7 +63,7 @@ pub use host::{ClientId, ViewBinding, ViewBindings};
 mod migration;
 
 mod command;
-pub use command::{RepoTarget, command_registry, dispatch};
+pub use command::{CommandEnv, command_registry, dispatch};
 
 /// Shared application state containing profile and operator.
 pub type AppState = Arc<RwLock<TonkState>>;

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -120,10 +120,13 @@ mod tests {
     use super::*;
     use dialog_artifacts::Statement;
     use dialog_query::{Attribute, Concept, Entity, the};
+    use std::sync::Mutex;
 
-    // A test command + its `Provider` impl on `CommandEnv`, proving the
-    // capability-based registration: `command::<Ping>()` only compiles
-    // because `CommandEnv: Provider<Ping>` is implemented below.
+    // A test command whose provider RECORDS each invocation's tag, so a
+    // test can observe whether (and with what) `execute` ran. The
+    // provider does no IO, so `run`-level tests don't need a real
+    // service-worker scope — only `dispatch` (which builds a real
+    // `CommandEnv` from `AppState`) is browser-gated.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.command")]
     pub struct PingTag(pub String);
@@ -139,12 +142,22 @@ mod tests {
         type Output = ();
     }
 
+    /// Tags passed to `Ping`'s provider, in invocation order. The `run`
+    /// tests `drain` it; serialized within the single-threaded test run.
+    static PING_LOG: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    /// Take and clear the recorded tags. Only the wasm-gated `run` tests
+    /// read it; the provider writes it on every target.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    fn drain_ping_log() -> Vec<String> {
+        std::mem::take(&mut *PING_LOG.lock().unwrap())
+    }
+
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     impl dialog_capability::Provider<Ping> for CommandEnv {
-        async fn execute(&self, _command: Ping) {
-            // A real provider would use `self.state()` to do IO; this
-            // test only needs the impl to exist so `Ping` is registrable.
+        async fn execute(&self, command: Ping) {
+            PING_LOG.lock().unwrap().push(command.tag.0);
         }
     }
 
@@ -170,5 +183,128 @@ mod tests {
             1,
             "the registered Ping command should match its trigger"
         );
+    }
+
+    // The `run` and `dispatch` tests build a real `CommandEnv` from an
+    // `AppState`, which needs the service-worker scope (`test_state`).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    mod run {
+        use super::*;
+        use crate::reactor::{CommandRegistry, EntityFacts};
+        use crate::router::AppState;
+        use crate::router::tests::test_state;
+        use std::sync::Arc;
+        use tokio::sync::RwLock;
+
+        async fn env() -> (AppState, CommandEnv) {
+            let state: AppState = Arc::new(RwLock::new(test_state().await));
+            let env = CommandEnv::new(state.clone());
+            (state, env)
+        }
+
+        fn one_match<'a>(
+            registry: &'a CommandRegistry,
+            changes: &Changes,
+        ) -> (&'a dyn crate::reactor::CommandHandler, EntityFacts) {
+            let mut fired = registry.match_transients(changes);
+            assert_eq!(fired.len(), 1, "expected exactly one matched command");
+            fired.pop().unwrap()
+        }
+
+        #[dialog_common::test]
+        async fn it_runs_the_provider_with_the_decoded_command() {
+            let _ = drain_ping_log();
+            let (_state, env) = env().await;
+            let registry = CommandRegistry::new().command::<Ping>();
+            let changes = ping_transient("did:key:zPing", "hello");
+
+            let (handler, facts) = one_match(&registry, &changes);
+            handler.run(&facts, &env).await;
+
+            assert_eq!(
+                drain_ping_log(),
+                vec!["hello".to_string()],
+                "the provider should run once with the decoded tag"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn it_runs_the_provider_for_a_non_decoding_entity_as_a_noop() {
+            // `TypedCommand::run`'s own decode guard: handed an entity's
+            // facts that don't decode as `Ping`, `run` is a no-op (the
+            // provider is never called). We get a handler from a real
+            // match, then run it against unrelated facts directly.
+            let _ = drain_ping_log();
+            let (_state, env) = env().await;
+            let registry = CommandRegistry::new().command::<Ping>();
+            let matched = registry.match_transients(&ping_transient("did:key:zP", "t"));
+            let handler = matched[0].0;
+
+            let unrelated: EntityFacts = {
+                let mut changes = Changes::new();
+                the!("xyz.tonk.unrelated/noise")
+                    .of("did:key:zNoise".parse::<Entity>().unwrap())
+                    .is("x".to_string())
+                    .assert(&mut changes);
+                // One entity → its facts.
+                match changes.into_instructions().into_iter().next().unwrap() {
+                    dialog_artifacts::Instruction::Assert(a)
+                    | dialog_artifacts::Instruction::Replace(a)
+                    | dialog_artifacts::Instruction::Retract(a) => vec![a],
+                }
+            };
+            handler.run(&unrelated, &env).await;
+
+            assert!(
+                drain_ping_log().is_empty(),
+                "a non-decoding entity must not run the provider"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn it_dispatches_every_matched_command_in_a_batch() {
+            let _ = drain_ping_log();
+            let (state, _env) = env().await;
+            // Install the registry on the state so `dispatch` sees it.
+            {
+                let mut tonk = state.write().await;
+                tonk.commands = CommandRegistry::new().command::<Ping>();
+            }
+
+            // Two distinct Ping entities in one batch → two invocations.
+            let mut changes = ping_transient("did:key:zA", "alpha");
+            the!("xyz.tonk.command/ping-tag")
+                .of("did:key:zB".parse::<Entity>().unwrap())
+                .is("beta".to_string())
+                .assert(&mut changes);
+
+            dispatch(&state, changes).await;
+
+            let mut tags = drain_ping_log();
+            tags.sort();
+            assert_eq!(
+                tags,
+                vec!["alpha".to_string(), "beta".to_string()],
+                "dispatch runs each matched command's provider"
+            );
+        }
+
+        #[dialog_common::test]
+        async fn it_dispatches_nothing_when_no_command_matches() {
+            let _ = drain_ping_log();
+            let (state, _env) = env().await;
+            {
+                let mut tonk = state.write().await;
+                tonk.commands = CommandRegistry::new().command::<Ping>();
+            }
+            let mut changes = Changes::new();
+            the!("xyz.tonk.unrelated/noise")
+                .of("did:key:zNoise".parse::<Entity>().unwrap())
+                .is("x".to_string())
+                .assert(&mut changes);
+
+            dispatch(&state, changes).await;
+            assert!(drain_ping_log().is_empty());
+        }
     }
 }

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -1,18 +1,15 @@
 //! Command registration and post-commit dispatch.
 //!
-//! [`command_registry`] builds the registry of typed-Rust command
-//! handlers the worker carries on [`TonkState`]. [`dispatch`] runs the
-//! handlers a freshly-committed transient batch triggers, committing
-//! each handler's outcome back to the branch the command arrived on.
+//! [`command_registry`] builds the registry of supported command *types*
+//! the worker carries on [`TonkState`]. [`dispatch`] runs the commands a
+//! freshly-committed transient batch triggers.
 //!
-//! The split honours the sandbox: a handler declares its capability in
-//! its signature (axum-style `State<…>`), so a pure handler
-//! (`async fn(C, Transaction) -> Transaction`) gets nothing, while one
-//! that needs IO names `State<AppState>` and the dispatcher supplies it.
-//! Either way the handler's only fact-write path is the returned
-//! [`Transaction`](crate::reactor::CommandTx); the privileged commit
-//! lives here, in the worker layer, and always targets the command's
-//! own branch — so a handler can never "commit whatever whenever".
+//! A command is a [`dialog_capability::Command`] run by a
+//! [`Provider<C>`](dialog_capability::Provider) — there is no handler
+//! function. The provider is [`CommandEnv`], a cheap handle over
+//! [`AppState`]; registering a command requires `CommandEnv: Provider<C>`,
+//! so capability is a compile-time gate. A command is self-contained: its
+//! `execute` does its own IO and commits its own outcomes through the env.
 //!
 //! [`TonkState`]: crate::worker::TonkState
 

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -21,18 +21,46 @@ use dialog_artifacts::Changes;
 use super::AppState;
 use crate::reactor::CommandRegistry;
 
-/// Build the registry of command handlers the worker installs at
-/// startup. Real handlers register here via the chainable
-/// [`command`](CommandRegistry::command) builder.
+/// The environment commands run against — a cheap handle (clone of
+/// [`AppState`]) that implements
+/// [`Provider<C>`](dialog_capability::Provider) for each command `C` the
+/// worker supports. The dispatcher hands a clone to the matched command;
+/// `execute` does the work, reaching the operator/reactor by re-locking
+/// through the `AppState`.
 ///
-/// `create_space` is the SW-scoped repository-creation handler; it's
-/// gated to wasm because seeding fetches a served asset that only
-/// exists in the service-worker scope. Native builds get an empty
-/// registry (tests that exercise dispatch register their own).
+/// Capability is structural: a command runs iff `CommandEnv: Provider<C>`
+/// is implemented. Registering a command requires that bound, so an
+/// unsupported command won't even register. (The runtime UCAN-style gate
+/// — the operator actually *holding* the capability — layers on top of
+/// this later.)
+#[derive(Clone)]
+pub struct CommandEnv {
+    state: AppState,
+}
+
+impl CommandEnv {
+    /// Build the env over a clone of the shared state.
+    pub fn new(state: AppState) -> Self {
+        Self { state }
+    }
+
+    /// Borrow the underlying state — `Provider` impls re-lock through
+    /// this to reach the operator and reactor.
+    pub fn state(&self) -> &AppState {
+        &self.state
+    }
+}
+
+/// Build the registry of supported command *types*. Registration is just
+/// the type — the behaviour is the `Provider<C>` impl on [`CommandEnv`].
+///
+/// `CreateSpace` is gated to wasm because its provider seeds from a
+/// served asset that only exists in the service-worker scope. Native
+/// builds get an empty registry (tests register their own).
 pub fn command_registry() -> CommandRegistry {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
-        CommandRegistry::new().command(super::repository::create_space)
+        CommandRegistry::new().command::<tonk_schema::command::CreateSpace>()
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
@@ -40,104 +68,49 @@ pub fn command_registry() -> CommandRegistry {
     }
 }
 
-/// Run every command handler the just-committed `transients` triggered,
-/// committing each handler's outcome to the same `(repo, branch)` the
-/// command arrived on.
+/// Run every command the just-committed `transients` triggered.
 ///
 /// Called by a mutation path (e.g. `/transact`) after its commit, with
-/// `AppState` and the branch identity in hand. The transients have
-/// already been swept from durable storage by the commit; we matched
-/// them from the pre-commit buffer, so the trigger fired exactly once.
+/// `AppState` in hand. The transients have already been swept from
+/// durable storage by the commit; we matched them from the pre-commit
+/// buffer, so the trigger fired exactly once.
 ///
-/// Each handler runs and its outcome commits independently and
-/// *concurrently* — handlers don't block one another, and a slow or
-/// failing one doesn't hold up the rest. (Concurrent, not parallel:
-/// they share the single SW task, interleaving at await points.)
+/// Each command's `Provider::execute` runs *concurrently and
+/// independently* — they don't block one another, and a slow or failing
+/// one doesn't hold up the rest. (Concurrent, not parallel: they share
+/// the single SW task, interleaving at await points.) A command is
+/// self-contained: it does its own IO and commits through the
+/// [`CommandEnv`], so there's no outcome buffer to commit here.
 ///
-/// TODO(stm): handlers have no transactional isolation. A handler reads
-/// durable state (via `State<AppState>`), decides an outcome, then the
-/// outcome commits later — but between the read and the commit, another
-/// commit may have changed what it read. The goal is STM-like
-/// optimistic concurrency: record the revision (or the read set) a
-/// handler observed, and on outcome commit verify nothing it read has
-/// changed since; on conflict, re-run the handler against fresh state
-/// (or fail it) rather than committing a decision based on stale reads.
-/// Concurrency (above) makes this sharper: two handlers in the same
-/// batch can read the same state and both commit, with neither seeing
-/// the other's write. Introducing real read-set tracking + compare-and-
-/// commit is a sizeable change; until then, handlers must assume their
-/// reads may be stale at commit time.
-pub async fn dispatch(state: &AppState, repo: RepoTarget, branch: String, transients: Changes) {
-    // Match handlers and build their `'static` run-futures while
-    // holding the read lock — the futures own everything (decoded
-    // trigger, extracted capabilities), so we can drop the lock before
-    // awaiting them. That keeps handler IO from ever running under a
-    // held lock (a handler that extracts `State<AppState>` may re-lock).
+/// TODO(stm): commands have no transactional isolation. A command reads
+/// durable state through the env, decides, and commits — but between the
+/// read and the commit another commit may have changed what it read, and
+/// concurrent commands in the same batch can both read and write the same
+/// state. The goal is STM-like optimistic concurrency: track the observed
+/// revision/read-set and commit-or-conflict, re-running on conflict. See
+/// the `TODO(stm)` notes on `reactor::command::TypedCommand::run`.
+pub async fn dispatch(state: &AppState, transients: Changes) {
+    // Match commands and build their `'static` run-futures while holding
+    // the read lock — each future owns its decoded command and an env
+    // clone, so we can drop the lock before awaiting them. That keeps
+    // command IO from ever running under a held lock (a command re-locks
+    // through its env).
     let run_futures = {
         let tonk = state.read().await;
         if tonk.commands.is_empty() {
             return;
         }
+        let env = CommandEnv::new(state.clone());
         tonk.commands
             .match_transients(&transients)
             .into_iter()
-            .map(|(handler, facts)| handler.run(&facts, state))
+            .map(|(handler, facts)| handler.run(&facts, &env))
             .collect::<Vec<_>>()
     };
 
-    // Drive every (run → commit) chain concurrently. Each chain awaits
-    // its handler, then commits its outcome to the command's branch;
-    // `join_all` interleaves them so independent effects make progress
-    // together rather than strictly in sequence.
-    let chains = run_futures.into_iter().map(|run| async {
-        if let Some(changes) = run.await {
-            commit_outcome(state, &repo, &branch, changes).await;
-        }
-    });
-    futures_util::future::join_all(chains).await;
-}
-
-/// Which repository a command's branch belongs to — the profile
-/// repository, or a named one. Mirrors the reactor's repository
-/// addressing so the outcome commit re-acquires the right branch.
-#[derive(Clone, Debug)]
-pub enum RepoTarget {
-    /// The profile-as-repository (the Hub's meta branch lives here).
-    Profile,
-    /// A named repository.
-    Named(String),
-}
-
-/// Commit one handler's outcome `Changes` to `(repo, branch)` through
-/// the reactor, so the write fans out to subscribers like any other.
-/// Logs and swallows errors: an outcome that fails to commit must not
-/// take down the dispatch loop (the command already succeeded).
-async fn commit_outcome(state: &AppState, repo: &RepoTarget, branch: &str, changes: Changes) {
-    let tonk = state.read().await;
-    let repository = match repo {
-        RepoTarget::Profile => tonk.reactor.profile_repository(),
-        RepoTarget::Named(name) => tonk.reactor.repository(name),
-    };
-
-    // TODO(stm): commit unconditionally — no check that the state the
-    // handler read still holds. The transactional goal is to thread the
-    // handler's observed revision/read-set here and commit conditionally
-    // (compare-and-swap on the branch revision, or per-read conflict
-    // detection), so an outcome derived from stale reads is rejected and
-    // the handler re-runs rather than overwriting a concurrent change.
-    // `Changes` implements `Statement`, so the whole outcome batch
-    // asserts in one call.
-    let result = repository
-        .branch(branch)
-        .transaction()
-        .assert(changes)
-        .commit()
-        .perform(&tonk.operator)
-        .await;
-
-    if let Err(error) = result {
-        tonk_common::log!("[command] outcome commit failed on branch '{branch}': {error}");
-    }
+    // Drive every command concurrently. `join_all` interleaves them so
+    // independent effects make progress together rather than in sequence.
+    futures_util::future::join_all(run_futures).await;
 }
 
 #[cfg(test)]
@@ -145,15 +118,12 @@ mod tests {
     #![allow(missing_docs)]
 
     use super::*;
-    use crate::reactor::{CommandTx, State};
-    use dialog_artifacts::{Changes, Statement};
+    use dialog_artifacts::Statement;
     use dialog_query::{Attribute, Concept, Entity, the};
 
-    // A command that declares a capability: it reads `State<AppState>`,
-    // proving a non-pure handler registers and triggers. The handler
-    // body doesn't touch the state here (a real one would re-lock to
-    // reach the operator/reactor) — the point is that declaring the
-    // capability compiles and the dispatcher supplies it.
+    // A test command + its `Provider` impl on `CommandEnv`, proving the
+    // capability-based registration: `command::<Ping>()` only compiles
+    // because `CommandEnv: Provider<Ping>` is implemented below.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.command")]
     pub struct PingTag(pub String);
@@ -164,10 +134,18 @@ mod tests {
         pub tag: PingTag,
     }
 
-    async fn handle_ping(ping: Ping, _state: State<AppState>, mut tx: CommandTx) -> CommandTx {
-        // A real handler would use `_state` to do IO; here we just echo.
-        tx.assert(ping);
-        tx
+    impl dialog_capability::Command for Ping {
+        type Input = Self;
+        type Output = ();
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl dialog_capability::Provider<Ping> for CommandEnv {
+        async fn execute(&self, _command: Ping) {
+            // A real provider would use `self.state()` to do IO; this
+            // test only needs the impl to exist so `Ping` is registrable.
+        }
     }
 
     fn ping_transient(of: &str, tag: &str) -> Changes {
@@ -181,15 +159,16 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_registers_a_capability_declaring_handler() {
-        // `handle_ping` declares `State<AppState>`; the chainable
-        // builder infers `C = Ping` and `Args = (State<AppState>,)`.
-        let registry = command_registry().command(handle_ping);
+    fn it_registers_a_command_type_by_its_provider() {
+        // `command::<Ping>()` compiles only because `CommandEnv:
+        // Provider<Ping>` — the capability gate. The registered type
+        // matches its trigger.
+        let registry = command_registry().command::<Ping>();
         let changes = ping_transient("did:key:zPing", "hi");
         assert_eq!(
             registry.match_transients(&changes).len(),
             1,
-            "the capability-declaring Ping handler should match its trigger"
+            "the registered Ping command should match its trigger"
         );
     }
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -246,9 +246,9 @@ pub async fn put_repository(
     Ok((StatusCode::CREATED, Json(info)))
 }
 
-/// Command handler for [`CreateSpace`] — the asserted-command path that
-/// replaces a direct `PUT /api/repository/{name}`. The "New space"
-/// button asserts a transient `CreateSpace`; the dispatcher runs this.
+/// `CommandEnv` provides [`CreateSpace`] — the asserted-command path that
+/// replaces a direct `PUT /api/repository/{name}`. The "New space" form
+/// asserts a transient `CreateSpace`; the dispatcher calls this.
 ///
 /// It does the same work as [`put_repository`]: record the replica
 /// (`status: blank`) so the Hub shows it installing, create the
@@ -256,43 +256,33 @@ pub async fn put_repository(
 /// `initialized`. An existing name is a no-op (logged) rather than an
 /// error — there's no HTTP caller to receive a 409/412.
 ///
-/// Capability is declared as `State<AppState>`: this handler does
-/// genuine multi-branch IO (creates a repo, commits to the profile and
-/// content branches), so it is a privileged handler. The returned
-/// [`CommandTx`] is unused — outcomes are written through the create
-/// path itself, not the deferred buffer.
+/// The provider re-locks the state through the env to do its (genuinely
+/// multi-branch) IO and commits its own outcomes. `Output = ()`.
 ///
-/// TODO(ucan): gate this by capability rather than by simply holding
-/// `State<AppState>`. Long-term a command is a UCAN-like invocation:
-/// the handler attempts the work and the operator's capabilities decide
-/// whether each action (create repo, commit to branch) is permitted.
-/// See `project_effect_command_design`.
+/// TODO(ucan): gate this by capability rather than by the mere existence
+/// of this `Provider` impl. Long-term a command is a UCAN-like
+/// invocation: the provider attempts the work and the operator's
+/// capabilities decide whether each action is permitted.
 ///
 /// TODO(stm): the existence check and the create are not atomic against
 /// concurrent commands — two `CreateSpace` for the same name could both
 /// pass the check. The transactional goal (read-set tracking + commit-
 /// or-conflict) would close this.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub async fn create_space(
-    command: tonk_schema::command::CreateSpace,
-    // Our command `State`, not axum's (which this module also imports):
-    // it's the capability extractor pulling `AppState` from the dispatch
-    // source.
-    crate::reactor::State(state): crate::reactor::State<AppState>,
-    tx: crate::reactor::CommandTx,
-) -> crate::reactor::CommandTx {
-    let name = command.name.0.clone();
-    log!("command CreateSpace name={}", name);
-
-    if let Err(error) = create_space_inner(&state, &name).await {
-        log!("CreateSpace '{}' failed: {}", name, error);
+#[async_trait::async_trait(?Send)]
+impl dialog_capability::Provider<tonk_schema::command::CreateSpace> for super::CommandEnv {
+    async fn execute(&self, command: tonk_schema::command::CreateSpace) {
+        let name = command.name.0.clone();
+        log!("command CreateSpace name={}", name);
+        if let Err(error) = create_space_inner(self.state(), &name).await {
+            log!("CreateSpace '{}' failed: {}", name, error);
+        }
     }
-    tx
 }
 
-/// The body of [`create_space`], split out so its `?` errors are logged
-/// once at the handler boundary. Mirrors [`put_repository`] minus the
-/// HTTP shell.
+/// The body of the [`CreateSpace`](tonk_schema::command::CreateSpace)
+/// provider, split out so its `?` errors are logged once at the boundary.
+/// Mirrors [`put_repository`] minus the HTTP shell.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn create_space_inner(state: &AppState, name: &str) -> Result<(), RepositoryError> {
     // The button asks for a `main`-branch space (the same config the old

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -69,26 +69,19 @@ pub async fn transact(
     body: Bytes,
 ) -> Result<Json<TransactResponse>, TonkWorkerError> {
     log!("transact repo={}, branch={}", path.repo, path.branch);
-    let (response, dispatch) = {
+    let (response, transients) = {
         let tonk_state = state.write().await;
         let tonk_branch = tonk_state
             .reactor
             .repository(&path.repo)
             .branch(&path.branch);
-        transact_on_branch(
-            &tonk_state,
-            tonk_branch,
-            super::RepoTarget::Named(path.repo.clone()),
-            path.branch.clone(),
-            body,
-        )
-        .await?
+        transact_on_branch(&tonk_state, tonk_branch, body).await?
     };
     // The transient commands (if any) were captured before commit;
     // dispatch them now that the state lock is released, so each
-    // handler's outcome commit can re-acquire it.
-    if let Some(work) = dispatch {
-        super::dispatch(&state, work.repo, work.branch, work.transients).await;
+    // command's `execute` can re-acquire it.
+    if let Some(transients) = transients {
+        super::dispatch(&state, transients).await;
     }
     Ok(response)
 }
@@ -102,39 +95,22 @@ pub async fn transact_profile(
     body: Bytes,
 ) -> Result<Json<TransactResponse>, TonkWorkerError> {
     log!("transact profile branch={}", path.branch);
-    let (response, dispatch) = {
+    let (response, transients) = {
         let tonk_state = state.write().await;
         let tonk_branch = tonk_state.reactor.profile_repository().branch(&path.branch);
-        transact_on_branch(
-            &tonk_state,
-            tonk_branch,
-            super::RepoTarget::Profile,
-            path.branch.clone(),
-            body,
-        )
-        .await?
+        transact_on_branch(&tonk_state, tonk_branch, body).await?
     };
-    if let Some(work) = dispatch {
-        super::dispatch(&state, work.repo, work.branch, work.transients).await;
+    if let Some(transients) = transients {
+        super::dispatch(&state, transients).await;
     }
     Ok(response)
-}
-
-/// Captured inputs for post-commit command dispatch: the transient
-/// batch that was committed, and the branch it landed on.
-struct DispatchWork {
-    repo: super::RepoTarget,
-    branch: String,
-    transients: dialog_artifacts::Changes,
 }
 
 async fn transact_on_branch<'a>(
     tonk_state: &'a crate::worker::TonkState,
     tonk_branch: BranchReference<'a>,
-    repo: super::RepoTarget,
-    branch: String,
     body: Bytes,
-) -> Result<(Json<TransactResponse>, Option<DispatchWork>), TonkWorkerError> {
+) -> Result<(Json<TransactResponse>, Option<dialog_artifacts::Changes>), TonkWorkerError> {
     let request: TransactRequest = serde_json::from_slice(&body)
         .map_err(|e| TonkWorkerError::Router(format!("invalid TransactRequest body: {e}")))?;
 
@@ -169,15 +145,7 @@ async fn transact_on_branch<'a>(
     // is the only post-commit view of which commands arrived. Empty →
     // no command dispatch.
     let transients = builder.transients.clone();
-    let dispatch = if transients.is_empty() {
-        None
-    } else {
-        Some(DispatchWork {
-            repo,
-            branch,
-            transients,
-        })
-    };
+    let to_dispatch = (!transients.is_empty()).then_some(transients);
 
     let revision_after = builder
         .commit()
@@ -194,7 +162,7 @@ async fn transact_on_branch<'a>(
                 entities: Default::default(),
             },
         }),
-        dispatch,
+        to_dispatch,
     ))
 }
 


### PR DESCRIPTION
Follow-up to #493. Replaces the bespoke axum-style command handler layer with `dialog_capability`, the model we'd flagged as the intended end state.

## What changes

- A command now implements `dialog_capability::Command` (`Input = Self`, `Output = ()`).
- A tonk-owned `CommandEnv` (a handle over `AppState`) implements `Provider<C>` in place of a handler function. Its `execute` does its own IO and commits its own outcomes through the env — self-contained, no outcome buffer.
- Registration is type-only: `command::<CreateSpace>()`. It compiles **only** when `CommandEnv: Provider<C>`, so capability is a compile-time gate — a command can't be registered unless the env can run it.
- Dispatch sheds the outcome-buffer / branch-commit machinery and just runs matched providers concurrently.

The decode bridge and transient-trigger dispatch are unchanged; only the "what runs" layer moved. `CreateSpace`'s behaviour is identical (same `create_space_inner` body). The runtime UCAN gate (the operator actually *holding* the capability) is the next step, noted in `plan/commands.md`.

## Tests

Command coverage goes from a handful of smoke tests to the full surface:
- **decode**: single/multi-field, missing field, partial multi-field, type mismatch, unrelated-attribute tolerance, trigger-attribute reporting.
- **grouping**: facts of one entity together, distinct entities apart, empty batch.
- **registry/matching**: empty-until-registered, match/no-match, all-matching-commands-fire (subscription semantics), candidate-that-fails-to-decode dropped, two-attribute candidate considered once, per-entity batch matching, full-facts handoff.
- **provider run/dispatch** (browser-gated, recording provider): run invokes the provider with the decoded command, a non-decoding entity is a no-op, dispatch runs every matched command, dispatches nothing when none match.

All `#[dialog_common::test]` (native + wasm). fmt, clippy `-D warnings`, native tests, and wasm test-compile green locally.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the command handling architecture in the `tonk` project to utilize a new `Provider` pattern, enhancing the command execution model and improving the separation of concerns between command definitions and their execution.

### Detailed summary
- Replaced `RepoTarget` with `CommandEnv` in `router.rs`.
- Updated command imports in `reactor.rs`.
- Introduced `Command` trait implementation for `CreateSpace`.
- Refactored transaction handling to use `transients` instead of `dispatch`.
- Improved command dispatching logic in `dispatch` function.
- Simplified command registration to use command types directly.
- Enhanced tests for command decoding and execution flow.

> The following files were skipped due to too many changes: `rust/tonk-worker/src/reactor/command.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->