### PR TITLE
fix: Tonk on Firefox — recover SW-intercepted request bodies

### DIFF
--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -61,6 +61,7 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-streams = { workspace = true }
 web-sys = { workspace = true, features = [
+    "Blob",
     "BroadcastChannel",
     "Cache",
     "CacheStorage",
@@ -70,6 +71,7 @@ web-sys = { workspace = true, features = [
     "ExtendableMessageEvent",
     "FetchEvent",
     "Headers",
+    "ReadableStream",
     "MessageChannel",
     "MessageEvent",
     "MessagePort",

--- a/rust/tonk-worker/src/axum.rs
+++ b/rust/tonk-worker/src/axum.rs
@@ -14,8 +14,9 @@ use axum::{
 use futures_util::TryStreamExt;
 use js_sys::{Array, Object, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsError, JsValue, UnwrapThrowExt};
+use wasm_bindgen_futures::JsFuture;
 use wasm_streams::ReadableStream;
-use web_sys::{Request as BrowserRequest, Response as BrowserResponse, ResponseInit};
+use web_sys::{Blob, Request as BrowserRequest, Response as BrowserResponse, ResponseInit};
 
 use tonk_common::ExclusiveStream;
 
@@ -34,11 +35,18 @@ impl From<RequestConversion> for BrowserRequest {
     }
 }
 
-impl TryFrom<RequestConversion> for AxumRequest<Body> {
-    type Error = JsError;
-
-    fn try_from(request: RequestConversion) -> Result<Self, Self::Error> {
-        let request: BrowserRequest = request.into();
+impl RequestConversion {
+    /// Convert the browser request into an Axum request.
+    ///
+    /// Firefox does not expose the body of a service-worker-intercepted
+    /// request as a `ReadableStream`: [`BrowserRequest::body`] is `undefined`
+    /// (mapped to `None`) even when bytes are present. Reading the body via
+    /// `blob()` works in every browser, so when `body()` yields nothing we
+    /// fall back to streaming the blob. A genuinely bodyless request (e.g.
+    /// `GET`) yields an empty blob, hence an empty stream, matching the
+    /// previous `Body::empty()` behaviour.
+    pub async fn into_axum_request(self) -> Result<AxumRequest<Body>, JsError> {
+        let request: BrowserRequest = self.into();
         let method = Method::from_str(&request.method())?;
         let uri = Uri::try_from(&request.url())?;
 
@@ -60,25 +68,36 @@ impl TryFrom<RequestConversion> for AxumRequest<Body> {
             request_builder = request_builder.header(header_name, header_value);
         }
 
-        let request = match request.body() {
-            Some(stream) => {
-                request_builder.body(Body::from_stream(Box::pin(ExclusiveStream::new(
-                    wasm_streams::ReadableStream::from_raw(stream)
-                        .into_stream()
-                        .map_ok(|bytes| {
-                            bytes
-                                .dyn_into::<Uint8Array>()
-                                .expect_throw("Could not convert readable stream bytes")
-                                .to_vec()
-                        })
-                        .map_err(|error| format!("{:?}", error)),
-                ))))
+        let stream = match request.body() {
+            Some(stream) => stream,
+            None => {
+                let promise = request
+                    .blob()
+                    .map_err(|value| JsError::new(&format!("request.blob() failed: {value:?}")))?;
+                let blob: Blob = JsFuture::from(promise)
+                    .await
+                    .map_err(|value| JsError::new(&format!("reading request blob: {value:?}")))?
+                    .dyn_into()
+                    .map_err(|value| {
+                        JsError::new(&format!("request.blob() was not a Blob: {value:?}"))
+                    })?;
+                blob.stream()
             }
-            None => request_builder.body(Body::empty()),
-        }
-        .expect_throw("Could not set request body");
+        };
 
-        Ok(request)
+        request_builder
+            .body(Body::from_stream(Box::pin(ExclusiveStream::new(
+                ReadableStream::from_raw(stream)
+                    .into_stream()
+                    .map_ok(|bytes| {
+                        bytes
+                            .dyn_into::<Uint8Array>()
+                            .expect_throw("Could not convert readable stream bytes")
+                            .to_vec()
+                    })
+                    .map_err(|error| format!("{:?}", error)),
+            ))))
+            .map_err(|error| JsError::new(&format!("Could not set request body: {error}")))
     }
 }
 
@@ -155,8 +174,9 @@ mod tests {
         let request = BrowserRequest::new_with_str_and_init("https://example.com/api/test", &init)
             .expect("Failed to create request");
 
-        let axum_request: AxumRequest<Body> = RequestConversion::from(request)
-            .try_into()
+        let axum_request = RequestConversion::from(request)
+            .into_axum_request()
+            .await
             .expect("Failed to convert request");
 
         assert_eq!(axum_request.method(), Method::GET);
@@ -181,8 +201,9 @@ mod tests {
             BrowserRequest::new_with_str_and_init("https://example.com/api/authorize", &init)
                 .expect("Failed to create request");
 
-        let axum_request: AxumRequest<Body> = RequestConversion::from(request)
-            .try_into()
+        let axum_request = RequestConversion::from(request)
+            .into_axum_request()
+            .await
             .expect("Failed to convert request");
 
         assert_eq!(axum_request.method(), Method::POST);
@@ -208,8 +229,9 @@ mod tests {
             let request = BrowserRequest::new_with_str_and_init("https://example.com/api", &init)
                 .expect("Failed to create request");
 
-            let axum_request: AxumRequest<Body> = RequestConversion::from(request)
-                .try_into()
+            let axum_request = RequestConversion::from(request)
+                .into_axum_request()
+                .await
                 .expect("Failed to convert request");
 
             assert_eq!(axum_request.method().as_str(), *method);

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -165,7 +165,8 @@ async fn handle_via_router(
     rewritten_path: Option<String>,
 ) -> Result<JsValue, JsValue> {
     let mut request: axum::http::Request<Body> = RequestConversion::from(browser_request)
-        .try_into()
+        .into_axum_request()
+        .await
         .map_err(JsValue::from)?;
 
     if let Some(new_path) = rewritten_path {


### PR DESCRIPTION
Demoing Tonk on Firefox surfaced that nothing worked: every data request came back as `HTTP 400: invalid ConceptQuery body: EOF while parsing a value at line 1 column 0`.

The cause is a long-standing Firefox limitation ([bug 1387483](https://bugzilla.mozilla.org/show_bug.cgi?id=1387483)): a service worker cannot read an intercepted request's body as a stream. `Request.body` is `undefined` there (Chrome gives a live `ReadableStream`), which web-sys maps to `None`, so our browser→axum conversion fell into the `None => Body::empty()` arm and the in-page router decoded an empty body for every POST.

The body bytes are present and reachable via `request.blob()` in every browser, so the conversion now falls back to `blob().stream()` when `body()` yields nothing, feeding the same `Body::from_stream` path. A genuinely bodyless request (GET) yields an empty blob and thus an empty stream, preserving the previous behaviour without a method or size guard. Reading the blob is async, so the conversion became an async `into_axum_request`.

Verified in Firefox 151: the profile and repository `/query` POSTs that returned 400 now return 200.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the conversion of `BrowserRequest` to `AxumRequest` by implementing an asynchronous method that handles requests with potentially absent bodies. It improves compatibility across browsers by utilizing `Blob` for reading request bodies.

### Detailed summary
- Added `into_axum_request` method to `RequestConversion` for async conversion of requests.
- Improved body handling by falling back to `Blob` if `body()` is `None`.
- Updated `Cargo.toml` to include new features like `Blob` and `ReadableStream`.
- Modified tests to use the new async conversion method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->