### PR TITLE
feat(workspace,worker): sync remote on new spaces + reconcile cached branch

### DIFF
--- a/docs/space-sync-remotes-and-launchpad.md
+++ b/docs/space-sync-remotes-and-launchpad.md
@@ -1,0 +1,183 @@
+# Space sync remotes, the empty-space launchpad, and the persistent topbar
+
+A session writeup. The goal we started with: **let users choose a sync remote when creating a space, and attach one after the fact.** Getting there surfaced a chain of architectural realities and bugs in the declarative space-creation flow. This documents what we built, every bug we hit, and why the final design looks the way it does.
+
+The work spans `tonk-schema`, `tonk-worker`, `tonk-core` (notation), `tonk-workspace`, and `tonk-ui`, stacked on commit `53d3b28a4`.
+
+---
+
+## 1. The starting point: space creation is a declarative effect
+
+The worker side was already done in an earlier commit (`4495`): `PUT /api/repository/{name}` wires remotes at creation, and `POST /api/repository/{repo}/remote` (`attach_remote` → `ensure_remote_config`) attaches one later. So the remaining work looked like front-end plumbing.
+
+It wasn't, because a rebase mid-session had replaced the old Leptos `create_space()` dialog with a **declarative effects model** (Hub PR #489):
+
+- `profile.yaml`'s Hub renders `<tonk-display model="space">`; its "New space" form is `<form onsubmit=space/create>`.
+- Submitting asserts a **transient `CreateSpace` concept** (`tonk-schema/src/command.rs`) whose fields are `dom.event.*` read-paths (`tonk-schema/src/domain.rs::command`). The notation event layer (`tonk-display/src/events/`) reads the form fields and POSTs a transient claim to `/api/profile/branch/meta/transact`.
+- After commit, the worker's `dispatch()` matches the transient against registered command **handlers** and runs them.
+
+So both "create with a remote" and "attach later" had to become **declarative commands**, not Leptos dialogs.
+
+### Key facts about command matching (these drive everything below)
+
+- A command **matches by decoding its concept from the committed transient's facts**. `match_transients` groups transient artifacts by entity, looks up candidate handlers by the *attributes* the entity touches, and keeps those whose concept decodes.
+- **Every declared concept field is required.** `Option<T>` is unsupported — the `Concept` derive does `<Field as Attribute>::Type`, and `Option<RemoteUrl>` isn't an `Attribute`.
+- The **profile meta branch is seeded once per profile and not re-seeded across versions** (`bootstrap_profile_meta` → `seed_profile_library`, fetching the served `/library/profile.yaml`). So a profile's `space/create` *descriptor* is frozen at the version that created the profile.
+- A `Provider<C>` only receives the **decoded command**, never the raw facts. `CommandHandler::run` receives the `EntityFacts`.
+
+---
+
+## 2. What shipped (final design)
+
+### Create-time and enable-later are one handler
+
+There is **no `EnableSync` concept**. A single custom `CreateSpaceHandler` (`tonk-worker/src/router/repository.rs`, registered via `registry.register(Box::new(...))`, not `.command::<>()`) serves **both** forms:
+
+- `CreateSpace` stays `{ this, name }` — name-only, so it keeps decoding against an older frozen descriptor.
+- The handler is keyed on the shared `…elements.name/value` attribute, so it matches both the Hub "New space" transient and the topbar "Enable sync" transient.
+- It reads the optional remote URL **straight from the facts** via `remote_from_facts` (see §3.5 for why), then:
+  1. **Creates-or-reuses** the repo (`create_space_inner` no-ops an existing one), so the space always appears regardless of the remote.
+  2. **Best-effort attaches** the remote via `enable_sync_inner` → `ensure_remote_config` (idempotent). A remote/auth failure leaves a working local space, retryable from the topbar.
+
+So new-space (new repo, maybe a remote) and enable-sync (existing repo, a remote) are the same code path.
+
+### The UI surface
+
+- **Hub "New space" dialog** (`profile.yaml`): a `Sync server (optional)` `<wa-input name="remote">` and a `<tonk-default-remote>` button that fills it with this server (`origin + /ucan/`). Blank → local-only.
+- **Topbar** (`core.yaml` workspace directory view): brand, a `‹ all repos` crumb, the space title (a new `<tonk-repo-name>` element), the live `<tonk-sync-state>` chip, `<tonk-sync-toggle>`, `<tonk-share>`. On a no-upstream space `<tonk-sync-state>` shows an **Enable sync** trigger that opens a notation `<wa-dialog>` (same remote-URL field + default-service button), bound to `onsubmit=space/enable-sync`.
+- **Empty-space launchpad**: `<tonk-fallback>` chrome ("This space is empty"), revealed when the directory `<tonk-display>` is `data-state="empty"`.
+
+New custom elements added to `tonk-workspace`: `<tonk-default-remote>` (fills a form input with `origin + /ucan/`) and `<tonk-repo-name>` (renders the repo name from the `<tonk-repository>` route ancestor).
+
+---
+
+## 3. The bugs, in the order we hit them
+
+### 3.1 Required field broke all space creation (frozen descriptor)
+
+**First attempt:** add a required `remote` field to `CreateSpace`.
+
+**Symptom:** creating a space with a sync server did nothing — no card, can't navigate. The worker logged `transact profile branch=meta` (the transient committed) but **no `command CreateSpace`** afterward — `dispatch` ran no handler.
+
+**Root cause:** the profile's `space/create` descriptor is frozen (profiles aren't re-seeded across versions). A required `remote` field meant the worker's `CreateSpace{name, remote}` could only match a transient that carried a `remote` fact; against the older name-only descriptor it never matched. `dispatch` committed the transient and silently ran nothing (the dialog still closes via `data-dialog`, so it *looks* successful). This would break creation for **every existing user**, not just locally.
+
+**Fix:** `CreateSpace` stays name-only. Regression guard: `it_decodes_create_space_from_name_only_facts`.
+
+### 3.2 Clicking a new space showed a blank page
+
+**Symptom:** once creation worked (local-only), the new space listed in the Hub but opened to a blank page; `home` rendered fine.
+
+**Root cause:** `home` gets the showcase demo (which seeds a `workspace` instance); a `CreateSpace`'d space gets only the scaffold (`core.yaml`), so it has **zero workspace instances** — genuinely empty. The bare `/space/{name}` route renders the `workspace` *directory* view, which goes to `data-state="empty"`. A `<tonk-fallback>` launchpad element existed and was registered (commit `dc98568a`) but had **never been placed in any view template**, so empty rendered nothing.
+
+**Fix:** wire `<tonk-fallback>` into the `view/directory!: id:tonk-workspace/directory` template as chrome (it carries no `{this}`, so the renderer keeps it mounted regardless of instance count).
+
+### 3.3 The topbar only showed on `home`
+
+**Symptom:** the topbar (brand, sync controls, share) appeared on `home` but not on fresh spaces.
+
+**Root cause:** the topbar was part of the per-instance workspace *entity* view, which only renders when a `workspace` instance exists. `home` has one; a fresh space doesn't.
+
+**Fix:** hoist the topbar (and the enable-sync dialog) up to the always-rendered workspace *directory* view. Its CSS moved to the global `tonk-ui/styles.css` (the directory view always renders; the entity view's `<style>` doesn't). The title can't use the per-instance `{name}` at the directory level — and the workspace `{name}` is a display label, not the repo name anyway — so a new `<tonk-repo-name>` element reads the real repo name from the `<tonk-repository>` route ancestor. Bonus: this makes the **Enable sync** trigger reachable on empty spaces.
+
+### 3.4 The launchpad title was invisible in dark mode
+
+**Root cause:** the global `h1..h6` rule in `styles.css` bakes in a "headline-cover" (`background: var(--wa-color-text-normal); color: var(--wa-color-neutral-fill-quiet)`) that isn't theme-aware — in dark mode it's light text on a light fill.
+
+**Fix:** opt the launchpad title out (`background: none; display: block`), exactly like `.hub-title` does.
+
+### 3.5 The remote was still `None` — a URL deserializes as an `Entity`
+
+**Symptom:** with everything else working, creating a space with the sync field filled logged `command CreateSpace name=test remote=None`. The captured request payload proved the form posted `parameters: {name: "test", remote: "http://127.0.0.1:8080/ucan/"}` correctly — so the bug was worker-side.
+
+**Root cause:** the worker's untagged `Value` deserialization tries `Entity` first for **any string containing a `:`**. A URL has colons, so `http://127.0.0.1:8080/ucan/` deserializes as `Value::Entity`, not `Value::String`. A `String`-typed concept field (the original `EnableSync.remote: RemoteUrl(String)`, which the create handler decoded to read the remote) **can't decode an `Entity`**, so the decode returned `None`. The name (`test`, no colon) deserializes as `String` and decoded fine — which is exactly why only the remote broke.
+
+Confirmed with a one-line probe:
+
+```rust
+serde_json::from_str::<Value>("\"http://127.0.0.1:8080/ucan/\"") // => Entity(http://127.0.0.1:8080/ucan/)
+serde_json::from_str::<Value>("\"test\"")                        // => String("test")
+```
+
+**Fix:** read the remote **directly from the artifact**, tolerating both representations:
+
+```rust
+fn remote_from_facts(facts: &EntityFacts) -> Option<String> {
+    facts.iter()
+        .find(|a| a.the.to_string() == REMOTE_ATTR)
+        .and_then(|a| match &a.is {
+            Value::String(url) => Some(url.clone()),     // colon-less / relative path
+            Value::Entity(uri) => Some(uri.to_string()), // a URL
+            _ => None,
+        })
+        .map(|u| u.trim().to_string())
+        .filter(|u| !u.is_empty())
+}
+```
+
+This is what let us **drop the `EnableSync` concept entirely** (it was only there to decode `{name, remote}`) and collapse to one handler. It also fixed the identical bug on the enable-later path, which previously decoded `EnableSync` via `Provider<EnableSync>` and would have failed on any real URL.
+
+Tests: `it_reads_an_entity_remote` (reproduces the exact `Value::Entity` URL case), `it_reads_a_string_remote`, plus the none/blank cases.
+
+---
+
+## 4. Why a custom `CommandHandler` instead of a `Provider`
+
+The optional remote can't be a concept field (§3.1 frozen-descriptor matching, §3.5 URL-as-Entity), so it has to be read from the transient's raw facts. A `Provider<C>` only ever gets the decoded command — never the facts. The dispatch machinery (`tonk-worker/src/reactor/command.rs`) *does* pass `EntityFacts` to `CommandHandler::run`, so a hand-written handler is the hook. `CreateSpaceHandler` implements `CommandHandler` directly: `matches` decodes `CreateSpace` (name) for candidacy, and `run` reads the name from the decode and the remote from `remote_from_facts`.
+
+This required exporting `RunFuture` from `crate::reactor` alongside the already-public `CommandHandler`, `EntityFacts`, `Env`, and `Decode`.
+
+---
+
+## 5. Attribute-keyed dispatch and the benign overlap
+
+Commands match by **attribute**, not predicate identity. `space/create` and `space/enable-sync` both carry the `…elements.name/value` attribute, so both transients match the single `CreateSpaceHandler`. That's intentional now (one handler), but it's worth remembering: if you ever want two genuinely different behaviors for two forms, give them **distinct field names/attributes**, or one handler will catch both. `enable_sync_inner` soft-skips a missing repo (no-op + log, not an error) and `ensure_remote_config` is idempotent, so the overlap is harmless either way.
+
+---
+
+## 6. Notation/form gotchas worth remembering
+
+- **kebab→camel per path segment** (`tonk-display/src/events/path.rs`): `the: dom.event.current-target.elements.remote-url/value` resolves `elements.remoteUrl`. Use single-word field names (`remote`, not `remote-url`) so the input `name` matches the read-path.
+- **empty input ≠ unresolved**: `build_transact_body` (`events/extract.rs`) aborts the whole transient if a `dom.event*` field resolves to `undefined`/`null`, but an empty text input coerces to `""`. So a blank field still posts a value; absence of a value means the field wasn't in the descriptor.
+- **`data-dialog="open <id>"` is Web Awesome-native** (a global delegated listener), so a button injected by a custom element (e.g. `<tonk-sync-state>`'s Enable-sync trigger) can open a notation `<wa-dialog>`.
+- **The workspace `{name}` is a display label, not the repo's local name** (`xyz.tonk.workspace/name`). The repo name lives only on the `<tonk-repository name>` route ancestor; a declarative form can't read it — hence `<tonk-repo-name>` and the `<tonk-sync-state>` stamp-into-hidden-input pattern.
+- **`profile.yaml` and `core.yaml` are validated natively** by `tonk-worker/tests/standard_library.rs` (parse→analyze→lower). Run it after any library edit.
+
+---
+
+## 7. Files changed
+
+| Area | File | What |
+|------|------|------|
+| Schema | `tonk-schema/src/command.rs` | `CreateSpace { this, name }` only; `EnableSync` removed |
+| Schema | `tonk-schema/src/domain.rs` | `command::remote::Value` attribute (now only documents the form path) |
+| Worker | `tonk-worker/src/router/repository.rs` | `CreateSpaceHandler` (matches name, reads `remote_from_facts`, create-or-reuse + best-effort attach); `enable_sync_inner`; `space_config` |
+| Worker | `tonk-worker/src/router/command.rs` | register the one handler |
+| Worker | `tonk-worker/src/reactor.rs` / `reactor/command.rs` | export `RunFuture` |
+| Notation | `tonk-core/assets/library/core.yaml` | topbar hoisted to the workspace directory view; `<tonk-fallback>` launchpad; `space/enable-sync` command + dialog |
+| Notation | `tonk-core/assets/library/profile.yaml` | optional `remote` field + input + `<tonk-default-remote>` in the create form |
+| UI | `tonk-ui/styles.css` | topbar CSS (global) + `.workspace__default-remote` |
+| Workspace | `tonk-workspace/src/default_remote.rs`, `repo_name.rs`, `sync.rs`, `lib.rs` | new `<tonk-default-remote>` and `<tonk-repo-name>` elements; `<tonk-sync-state>` Enable-sync trigger |
+
+---
+
+## 8. Testing
+
+Verified without a browser (native + compile):
+
+- `it_decodes_create_space_from_name_only_facts` — `CreateSpace` matches a frozen, name-only descriptor.
+- `remote_from_facts_tests` — reads a `Value::String` remote, a `Value::Entity` (URL) remote, none, and blank.
+- `space_config_tests` — local-only vs `origin`/`origin-main` shape.
+- `tonk-worker/tests/standard_library.rs` — `core.yaml`/`profile.yaml`/`demo.yaml` lower cleanly.
+- Worker wasm build + `tonk-workspace` wasm build/tests compile; clippy clean on touched crates (native and wasm).
+
+Still browser-only (needs a running app): the create→sync round-trip end to end, the `data-dialog` open, `<wa-input>` value round-trip, and the visual layout of the topbar/launchpad. Local wasm integration tests need Safari/Chrome automation.
+
+---
+
+## 9. Lessons
+
+- **Don't add a required field to a command concept that older profiles already seeded.** Frozen descriptors + all-fields-required = silent no-match. Read optional inputs from the facts in a custom handler instead.
+- **Don't model URL/colon-bearing text as a typed `String` concept field.** It round-trips through JSON as `Value::Entity`. Read the artifact directly.
+- **Wire new chrome elements into a view.** `<tonk-fallback>` existed and was registered but rendered nothing because no template used it.
+- **Space-level chrome belongs at the directory level**, not the per-instance view, so it renders on empty spaces too — and its CSS belongs in the global stylesheet, since the per-instance view's `<style>` doesn't render when empty.
+- **Capture the actual request payload early.** The `transact` POST body immediately split "front-end posted it wrong" from "worker decoded it wrong" and pointed straight at the `Value::Entity` deserialization.

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -232,6 +232,33 @@ rule!:
     - assert: workspace
       where: { this: ?this, sheet: ?active }
 
+# The Enable-sync command. Submitting the topbar's "Enable sync" form
+# asserts this transient command; the worker's `CreateSpaceHandler`
+# (which serves both this and `space/create`, keyed on the shared `name`
+# attribute) idempotently attaches the remote to the named space — the
+# repo already exists, so the create step no-ops and only the attach
+# runs. `remote` is the URL typed (or the `<tonk-default-remote>` button
+# populated); `name` is the space's local repository name. The workspace
+# concept's `{name}` is a display label, NOT the repo name, so the
+# `<tonk-sync-state>` element (which resolves the repo from its
+# `<tonk-repository>` ancestor) stamps the real name into the form's
+# hidden `name` input on click — the one identifier notation can't read
+# from the event. `prevent-default` stops the page reloading.
+command!: &space/enable-sync
+  description: A request to attach a sync remote to the current space.
+  with:
+    name:
+      description: The space's local repository name, stamped into the hidden `name` input
+      the: dom.event.current-target.elements.name/value
+      as: text
+    remote:
+      description: The sync URL, read from the form's `remote` input on submit
+      the: dom.event.current-target.elements.remote/value
+      as: text
+    prevent-default:
+      description: Stop the form submission from reloading the page
+      the: dom.event.do/prevent-default
+
 # The workspace view: a top bar over a `<tonk-sheet-binder>`, matching
 # the wireframe's Layout F. The binder takes the workspace's `{sheet}`
 # members (each mounted through its sheet-mount view as a
@@ -607,7 +634,80 @@ view/directory!:
           flex: 1 1 auto;
           min-height: 0;
         }
+
+        /* Launchpad shown while the space has no workspace instance
+           (a freshly created space gets only the scaffold, so its
+           workspace collection is empty). `<tonk-fallback>` reveals
+           itself when the enclosing directory `<tonk-display>` is
+           `data-state="empty"` and hides the moment content lands. */
+        .workspace-launchpad {
+          flex: 1 1 auto;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 0;
+          padding: var(--wa-space-2xl);
+        }
+        .workspace-launchpad[hidden] { display: none; }
+        .workspace-launchpad__inner {
+          max-width: 28rem;
+          text-align: center;
+        }
+        /* Opt out of the global heading highlight-cover (the dark
+           filled box from styles.css `h1..h6`): it isn't theme-aware,
+           so its inverted text vanishes in dark mode. A plain heading
+           in the normal text colour reads correctly in both. Mirrors
+           `.hub-title`. */
+        .workspace-launchpad__title {
+          display: block;
+          margin: 0 0 var(--wa-space-s);
+          padding: 0;
+          background: none;
+          font-family: var(--wa-font-family-heading);
+          font-size: var(--wa-font-size-2xl);
+          font-weight: var(--wa-font-weight-bold);
+          letter-spacing: normal;
+          color: var(--wa-color-text-normal);
+        }
+        .workspace-launchpad__hint {
+          margin: 0;
+          color: var(--wa-color-text-quiet);
+        }
       </style>
+      <div class="workspace__topbar">
+        <span class="workspace__brand">tonk</span>
+        <a class="workspace__crumb" href="/">&lsaquo; all repos</a>
+        <span class="workspace__title"><tonk-repo-name></tonk-repo-name></span>
+        <tonk-sync-state></tonk-sync-state>
+        <span class="workspace__spacer"></span>
+        <span class="workspace__actions">
+          <tonk-share></tonk-share>
+        </span>
+      </div>
+
+      <!-- Enable-sync dialog: shown via the `<tonk-sync-state>` enable
+           trigger on a no-upstream space. That element stamps the
+           resolved repo name into the hidden `name` input on click; the
+           `remote` input + `<tonk-default-remote>` button collect the
+           URL; submit asserts the transient `space/enable-sync` command.
+           Lives in this always-rendered directory view (with the topbar)
+           so sync can be enabled on any space, including an empty one. -->
+      <wa-dialog id="enable-sync" label="Enable sync" class="workspace__sync-dialog">
+        <form id="enable-sync-form" class="workspace__sync-form" onsubmit=space/enable-sync>
+          <input type="hidden" name="name">
+          <wa-input name="remote" label="Sync server" placeholder="https://…" autocomplete="off" autofocus required></wa-input>
+          <tonk-default-remote field="remote">Use this server</tonk-default-remote>
+        </form>
+        <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
+        <wa-button slot="footer" variant="primary" type="submit" form="enable-sync-form" data-dialog="close">Enable</wa-button>
+      </wa-dialog>
+
+      <tonk-fallback class="workspace-launchpad" hidden>
+        <div class="workspace-launchpad__inner">
+          <h1 class="workspace-launchpad__title">This space is empty</h1>
+          <p class="workspace-launchpad__hint">Nothing has been added here yet.</p>
+        </div>
+      </tonk-fallback>
       <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
     </div>
 

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -64,6 +64,19 @@ command!: &space/create
       description: The space name, read from the form's `name` input on submit
       the: dom.event.current-target.elements.name/value
       as: text
+    remote:
+      description: >
+        Optional sync URL, read from the form's `remote` input. The
+        worker's `CreateSpaceHandler` matches on `name` alone (so this
+        command keeps decoding against an older profile descriptor that
+        lacks this field), and reads `remote` opportunistically: blank
+        creates a local-only space, a URL is attached after creation as
+        the `origin` remote with `main` tracking `origin/main`. The
+        `<tonk-default-remote>` button fills it with this server. Single
+        word `remote` (not `remote-url`) because read-path segments are
+        kebab→camel-cased.
+      the: dom.event.current-target.elements.remote/value
+      as: text
     prevent-default:
       description: Stop the form submission from reloading the page
       the: dom.event.do/prevent-default
@@ -102,6 +115,8 @@ view/directory!:
       <wa-dialog id="space-create" label="New space" class="hub-dialog">
         <form id="space-create-form" class="hub-form" onsubmit=space/create>
           <wa-input name="name" label="Space name" placeholder="e.g. pictures" autocomplete="off" autofocus required></wa-input>
+          <wa-input name="remote" label="Sync server (optional)" placeholder="leave blank for a local-only space"></wa-input>
+          <tonk-default-remote field="remote">Use this server</tonk-default-remote>
         </form>
         <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
         <wa-button slot="footer" variant="primary" type="submit" form="space-create-form" data-dialog="close">Create</wa-button>

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -35,6 +35,24 @@ use crate::domain::command::Value as SpaceName;
 /// `name`'s attribute is a `dom.event.*` read-path so the same concept
 /// the form asserts is the one the worker handler decodes — see
 /// [`crate::domain::command::Value`].
+///
+/// Deliberately a single matched field. A command concept must keep
+/// decoding against the descriptor an *older* version seeded — a profile
+/// branch is seeded once and not re-seeded across versions, so its
+/// `space/create` descriptor is frozen at the version that created it.
+/// Adding a required field here would make the command silently fail to
+/// match every such profile (the transient commits, no provider runs),
+/// breaking all space creation.
+///
+/// The optional sync remote is therefore *not* a field here: the worker's
+/// `CreateSpaceHandler` matches on `name` and reads the remote URL
+/// directly from the transient's facts. It can't be a `String`-typed
+/// concept field anyway — a URL round-trips through JSON and the worker's
+/// untagged `Value` deserialization picks `Entity` for any string with a
+/// `:`, so a `remote: String` field would never decode a URL. Reading the
+/// artifact directly tolerates both `String` and `Entity`. The same
+/// handler also serves the topbar's "Enable sync" form (which posts the
+/// same `name`+`remote` shape against an existing space).
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CreateSpace {
     /// The command entity (a fresh id per invocation, derived by the
@@ -44,10 +62,10 @@ pub struct CreateSpace {
     pub name: SpaceName,
 }
 
-/// `CreateSpace` is a [`dialog_capability::Command`]: a `Provider<CreateSpace>`
-/// (a tonk command env wrapping `AppState`) executes it. The input is the
-/// decoded command itself; the provider is self-contained (it does its own
-/// IO and commits), so the output is `()`.
+/// `CreateSpace` is a [`dialog_capability::Command`]. Note the worker
+/// registers a custom `CreateSpaceHandler` (not a plain `Provider`) so it
+/// can read the optional remote from the facts; the `Command` impl is
+/// kept for the decode/`Decode` machinery.
 impl Command for CreateSpace {
     type Input = Self;
     type Output = ();

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -73,6 +73,26 @@ pub mod command {
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("dom.event.current-target.elements.name")]
     pub struct Value(pub String);
+
+    /// The remote URL read from a space form's submit event:
+    /// `event.currentTarget.elements.remote.value` (the `<wa-input
+    /// name="remote">` inside the create / enable-sync forms).
+    ///
+    /// Single word `remote` (not `remote-url`) deliberately: every
+    /// path segment is kebab→camel-cased at read time, so a hyphen
+    /// would force the input's `name` to be `remoteUrl`. Keeping it one
+    /// word lets the form field and the read-path agree on `remote`.
+    ///
+    /// Optional in practice: an empty input coerces to `""` (the input
+    /// element still resolves, so the field is never *unresolved*), and
+    /// the handler reads `""` as "no remote — local-only".
+    pub mod remote {
+        use super::Attribute;
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.elements.remote")]
+        pub struct Value(pub String);
+    }
 }
 
 /// Attributes that live on [`Branch`] entities (and

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -328,6 +328,159 @@ tonk-repository.display-route,
     flex-direction: column;
     gap: var(--wa-space-s);
 }
+/* The default-service button (`<tonk-default-remote>` renders this) in
+   the workspace topbar's enable-sync form — fills the URL field with
+   this server. In the global stylesheet so it is theme-consistent
+   wherever the element is used. A quiet inline button. */
+.workspace__default-remote {
+    align-self: flex-start;
+    padding: var(--wa-space-2xs) var(--wa-space-s);
+    font: inherit;
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-text-quiet);
+    background: transparent;
+    border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-s);
+    cursor: pointer;
+}
+.workspace__default-remote:hover {
+    color: var(--wa-color-text-normal);
+    background: var(--wa-color-neutral-fill-quiet);
+}
+
+/* Space topbar chrome. Hoisted out of the per-instance workspace view so
+   it renders on every space — including empty ones with no workspace
+   instance — at the space (directory) level. The `<tonk-repo-name>`,
+   `<tonk-sync-state>`, `<tonk-sync-toggle>`, and `<tonk-share>` elements
+   render into these classes and resolve their repo from the
+   `<tonk-repository>` route ancestor, so the bar works wherever it sits.
+   In the global stylesheet because the directory view that hosts the bar
+   always renders, while the per-instance view's <style> does not. */
+.workspace__topbar {
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-m);
+    flex: none;
+    height: 52px;
+    padding: 0 var(--wa-space-l);
+    background: var(--wa-color-surface-raised);
+    border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    font-size: var(--wa-font-size-m);
+}
+.workspace__brand {
+    font-weight: var(--wa-font-weight-bold);
+}
+.workspace__crumb {
+    color: var(--wa-color-text-quiet);
+    font-family: var(--wa-font-family-code);
+    font-size: var(--wa-font-size-s);
+}
+.workspace__title {
+    font-weight: var(--wa-font-weight-semibold);
+}
+/* The live sync chip (`<tonk-sync-state>` renders this span with one
+   `is-*` modifier). Layout on the base class, colour on the modifier. */
+.workspace__sync {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+    padding: var(--wa-space-3xs) var(--wa-space-s);
+    font-size: var(--wa-font-size-s);
+    border-radius: var(--wa-border-radius-s);
+}
+.workspace__sync::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    flex: none;
+}
+.workspace__sync.is-synced {
+    color: var(--wa-color-success-on-quiet);
+    background: var(--wa-color-success-fill-quiet);
+}
+.workspace__sync.is-synced::before {
+    background: var(--wa-color-success-fill-loud);
+}
+.workspace__sync.is-ahead,
+.workspace__sync.is-behind {
+    color: var(--wa-color-warning-on-quiet);
+    background: var(--wa-color-warning-fill-quiet);
+}
+.workspace__sync.is-ahead::before,
+.workspace__sync.is-behind::before {
+    background: var(--wa-color-warning-fill-loud);
+}
+.workspace__sync.is-diverged {
+    color: var(--wa-color-danger-on-quiet);
+    background: var(--wa-color-danger-fill-quiet);
+}
+.workspace__sync.is-diverged::before {
+    background: var(--wa-color-danger-fill-loud);
+}
+.workspace__spacer {
+    flex: 1;
+}
+.workspace__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-m);
+    color: var(--wa-color-text-quiet);
+}
+/* The share (`<tonk-share>`) and pause/resume (`<tonk-sync-toggle>`)
+   controls: icon-only ghost buttons that brighten on hover. */
+.workspace__share,
+.workspace__sync-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    flex: none;
+    color: inherit;
+    background: transparent;
+    border: none;
+    border-radius: var(--wa-border-radius-s);
+    cursor: pointer;
+}
+.workspace__share:hover,
+.workspace__sync-toggle:hover {
+    color: var(--wa-color-text-normal);
+    background: var(--wa-color-neutral-fill-quiet);
+}
+.workspace__share-glyph,
+.workspace__sync-toggle-glyph {
+    width: 18px;
+    height: 18px;
+}
+/* The enable-sync trigger (`<tonk-sync-state>` renders this in place of
+   the chip when the branch has no upstream). A small "turn sync on" pill
+   sitting where the status chip otherwise would. */
+.workspace__enable-sync {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-xs);
+    padding: var(--wa-space-3xs) var(--wa-space-s);
+    font: inherit;
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-brand-on-quiet);
+    background: var(--wa-color-brand-fill-quiet);
+    border: none;
+    border-radius: var(--wa-border-radius-s);
+    cursor: pointer;
+}
+.workspace__enable-sync:hover {
+    background: var(--wa-color-brand-fill-normal);
+}
+/* The enable-sync dialog's form: a vertical stack of the URL field and
+   the default-service button. */
+.workspace__sync-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wa-space-s);
+}
 /* Opt out of the global heading highlight-cover (the dark filled box):
    the Hub title is a plain heading like the mock. */
 .hub-title {

--- a/rust/tonk-worker/src/reactor.rs
+++ b/rust/tonk-worker/src/reactor.rs
@@ -34,7 +34,9 @@ mod subscription;
 mod transaction;
 
 pub use branch::{BranchReference, BranchSession, BranchState};
-pub use command::{CommandHandler, CommandRegistry, Decode, EntityFacts, Env, TypedCommand};
+pub use command::{
+    CommandHandler, CommandRegistry, Decode, EntityFacts, Env, RunFuture, TypedCommand,
+};
 pub use env::{
     BranchOpenProvider, CommitProvider, LoadProvider, PullProvider, PushProvider, SelectProvider,
 };
@@ -108,6 +110,68 @@ impl TonkReactor {
                 branch.clear_subscribers();
             }
         }
+    }
+
+    /// Reconcile the cached handle for `repo`/`branch` with durable
+    /// storage after its upstream/remote wiring changed on a *separate*
+    /// repository handle.
+    ///
+    /// A [`Branch`](dialog_repository::Branch) captures its `upstream`
+    /// cell when first opened — e.g. during the standard-library seed,
+    /// before any remote is attached. A later `set_upstream` on a
+    /// freshly loaded handle publishes to durable storage but never
+    /// touches that cached cell, so sync — which reads through this
+    /// cache — sees no upstream and fails with `BranchHasNoUpstream`.
+    /// Re-opening re-resolves the upstream from durable storage, so the
+    /// fresh handle reflects the change; we swap it into the cache and
+    /// carry the existing subscriptions over so live SSE streams keep
+    /// updating.
+    ///
+    /// No-op when the repo or branch isn't cached: the next `acquire`
+    /// opens a fresh handle that already reflects durable state.
+    pub async fn refresh_branch<Env>(
+        &self,
+        repo: &str,
+        branch: &str,
+        env: &Env,
+    ) -> Result<(), ReactorError>
+    where
+        Env: BranchOpenProvider,
+    {
+        // Only a cached repository can hold a stale cached branch.
+        let Some(repo_state) = self.repos.lock().get(repo).map(Arc::clone) else {
+            return Ok(());
+        };
+        // An uncached branch opens fresh on next acquire — already
+        // current, nothing to reconcile.
+        if !repo_state.branches().lock().contains_key(branch) {
+            return Ok(());
+        }
+
+        // Re-open outside the lock (open is async). This re-resolves the
+        // branch's upstream cell from durable storage, so the fresh
+        // handle reflects a `set_upstream` performed elsewhere.
+        let handle = repo_state
+            .repository()
+            .branch(branch)
+            .open()
+            .perform(env)
+            .await
+            .map_err(|e| ReactorError::BranchNotFound {
+                repo: repo.to_owned(),
+                branch: branch.to_owned(),
+                reason: e.to_string(),
+            })?;
+        let fresh = Arc::new(BranchState::new(handle));
+
+        // Swap under the branches lock so a concurrent subscribe can't
+        // land on the discarded state between the adopt and the insert.
+        let mut branches = repo_state.branches().lock();
+        if let Some(old) = branches.get(branch) {
+            fresh.adopt_subscriptions_from(old);
+        }
+        branches.insert(branch.to_owned(), fresh);
+        Ok(())
     }
 
     /// Begin a chain scoped to the named repository.

--- a/rust/tonk-worker/src/reactor/branch/state.rs
+++ b/rust/tonk-worker/src/reactor/branch/state.rs
@@ -58,6 +58,22 @@ impl BranchState {
         self.subscriptions.lock().clear();
     }
 
+    /// Move every subscription registered on `other` into this state,
+    /// leaving `other` empty.
+    ///
+    /// Used when the reactor replaces a cached branch handle (e.g. to
+    /// pick up an upstream wired on a separate handle): the fresh
+    /// [`BranchState`] adopts the live subscribers so their SSE streams
+    /// keep updating instead of silently freezing on the discarded
+    /// handle. Each `SubscriberSession` carries its `mpsc::Sender`, so
+    /// re-polls through the new state reach the same receivers; the
+    /// subscriptions keep their `last_hash`, so the next poll only
+    /// re-emits on a genuine change.
+    pub fn adopt_subscriptions_from(&self, other: &BranchState) {
+        let moved = std::mem::take(&mut *other.subscriptions.lock());
+        *self.subscriptions.lock() = moved;
+    }
+
     /// Register a fresh subscriber for `query`. Returns a
     /// [`Subscriber`] carrying the subscription's hash and the
     /// receiver to read broadcast bytes from. The caller is

--- a/rust/tonk-worker/src/reactor/command.rs
+++ b/rust/tonk-worker/src/reactor/command.rs
@@ -140,6 +140,9 @@ pub type Env = crate::router::CommandEnv;
 /// command IO never runs while a lock is held.
 #[cfg(not(target_arch = "wasm32"))]
 pub type RunFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
+/// A `'static` boxed future for one command's execution (the wasm
+/// single-threaded variant — no `Send` bound). See the native variant
+/// above for the rationale.
 #[cfg(target_arch = "wasm32")]
 pub type RunFuture = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>>;
 
@@ -463,6 +466,31 @@ mod tests {
         let decoded = Share::decode(this, &facts).expect("two-field concept decodes");
         assert_eq!(decoded.name.0, "pics");
         assert_eq!(decoded.owner.0, owner);
+    }
+
+    /// Regression: the real [`CreateSpace`] command must decode from
+    /// facts that carry only `name`. A profile branch seeded by an older
+    /// version has the name-only `space/create` descriptor, so its form
+    /// asserts a name-only transient. A `CreateSpace` that required an
+    /// extra field (e.g. a remote URL) would silently fail to match
+    /// there — `dispatch` commits the transient and runs nothing — and
+    /// break *all* space creation for existing profiles. Keep create-time
+    /// fields off the matched concept.
+    #[dialog_common::test]
+    fn it_decodes_create_space_from_name_only_facts() {
+        use tonk_schema::command::CreateSpace;
+
+        let this = entity("did:key:zCreateSpace");
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.elements.name/value")
+            .of(this.clone())
+            .is("pictures".to_string())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+
+        let decoded = CreateSpace::decode(this, &facts)
+            .expect("CreateSpace must decode from name-only facts (older descriptor / blank form)");
+        assert_eq!(decoded.name.0, "pictures");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -51,13 +51,25 @@ impl CommandEnv {
 /// Build the registry of supported command *types*. Registration is just
 /// the type — the behaviour is the `Provider<C>` impl on [`CommandEnv`].
 ///
-/// `CreateSpace` is gated to wasm because its provider seeds from a
-/// served asset that only exists in the service-worker scope. Native
-/// builds get an empty registry (tests register their own).
+/// Gated to wasm because the handler does service-worker-scoped IO
+/// (seeding from a served asset, opening a remote branch over the
+/// network). Native builds get an empty registry (tests register their
+/// own).
+///
+/// One custom [`CreateSpaceHandler`] serves both the Hub "New space"
+/// (`space/create`) and topbar "Enable sync" (`space/enable-sync`) forms:
+/// both post the same `name`(+`remote`) shape, the handler keys on the
+/// shared `name` attribute, and it reads the optional remote from the
+/// transient's facts — which a typed `Provider`, receiving only the
+/// decoded command, can't do.
+///
+/// [`CreateSpaceHandler`]: super::repository::CreateSpaceHandler
 pub fn command_registry() -> CommandRegistry {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
-        CommandRegistry::new().command::<tonk_schema::command::CreateSpace>()
+        let mut registry = CommandRegistry::new();
+        registry.register(Box::new(super::repository::CreateSpaceHandler::new()));
+        registry
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -248,47 +248,184 @@ pub async fn put_repository(
     Ok((StatusCode::CREATED, Json(info)))
 }
 
-/// `CommandEnv` provides [`CreateSpace`] — the asserted-command path that
-/// replaces a direct `PUT /api/repository/{name}`. The "New space" form
-/// asserts a transient `CreateSpace`; the dispatcher calls this.
+/// The form-event attribute carrying the optional sync URL — the
+/// `remote` input on the `space/create` and `space/enable-sync` forms.
+/// Kept in sync with those notation commands' `remote` field `the:`.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const REMOTE_ATTR: &str = "dom.event.current-target.elements.remote/value";
+
+/// Read the optional remote URL from a transient's facts, tolerating
+/// both `Value::String` and `Value::Entity`.
 ///
-/// It does the same work as [`put_repository`]: record the replica
-/// (`status: blank`) so the Hub shows it installing, create the
-/// repository, seed the standard library, then flip the status to
-/// `initialized`. An existing name is a no-op (logged) rather than an
-/// error — there's no HTTP caller to receive a 409/412.
+/// A URL like `http://host/ucan/` round-trips through JSON, and the
+/// worker's untagged `Value` deserialization picks `Entity` for any
+/// string containing a `:` — so a `String`-typed concept field never
+/// decodes a URL (that's the bug a `remote: String` field hit). Reading
+/// the artifact directly sidesteps the concept decode and accepts either
+/// representation. Empty/whitespace → `None` (a local-only space).
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn remote_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
+    use dialog_artifacts::Value;
+
+    facts
+        .iter()
+        .find(|artifact| artifact.the.to_string() == REMOTE_ATTR)
+        .and_then(|artifact| match &artifact.is {
+            Value::String(url) => Some(url.clone()),
+            Value::Entity(uri) => Some(uri.to_string()),
+            _ => None,
+        })
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
+}
+
+/// Command handler for the "New space" form (`space/create`) and the
+/// topbar's "Enable sync" form (`space/enable-sync`).
 ///
-/// The provider re-locks the state through the env to do its (genuinely
-/// multi-branch) IO and commits its own outcomes. `Output = ()`.
+/// `CreateSpace` is matched **name-only** so it keeps decoding against an
+/// older, frozen profile descriptor (see [`CreateSpace`]). The optional
+/// sync URL is read straight from the transient's facts by
+/// [`remote_from_facts`] — not as a concept field, both because a
+/// required field would break the frozen-descriptor match and because a
+/// URL deserializes as `Value::Entity`, which a `String` field can't
+/// decode.
 ///
-/// TODO(ucan): gate this by capability rather than by the mere existence
-/// of this `Provider` impl. Long-term a command is a UCAN-like
-/// invocation: the provider attempts the work and the operator's
-/// capabilities decide whether each action is permitted.
+/// The repository is **created-or-reused** (`create_space_inner` no-ops
+/// an existing one), then, if a remote was given, attached best-effort
+/// via [`enable_sync_inner`]. So the same handler serves both forms: the
+/// Hub "New space" form (new repo) and the topbar "Enable sync" form
+/// (existing repo) — both post the same `name`(+`remote`) shape, and the
+/// handler keys on the shared `name` attribute. A remote/auth failure
+/// leaves a working local space, retryable from the topbar.
 ///
-/// TODO(stm): the existence check and the create are not atomic against
-/// concurrent commands — two `CreateSpace` for the same name could both
-/// pass the check. The transactional goal (read-set tracking + commit-
-/// or-conflict) would close this.
+/// A custom handler (not a plain `Provider<CreateSpace>`) is required
+/// because the provider only receives the decoded command, never the
+/// facts the remote must be read from.
+///
+/// [`CreateSpace`]: tonk_schema::command::CreateSpace
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-#[async_trait::async_trait(?Send)]
-impl dialog_capability::Provider<tonk_schema::command::CreateSpace> for super::CommandEnv {
-    async fn execute(&self, command: tonk_schema::command::CreateSpace) {
-        let name = command.name.0.clone();
-        log!("command CreateSpace name={}", name);
-        if let Err(error) = create_space_inner(self.state(), &name).await {
-            log!("CreateSpace '{}' failed: {}", name, error);
+pub(crate) struct CreateSpaceHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl CreateSpaceHandler {
+    /// Cache `CreateSpace`'s trigger attributes (its `name` field) so the
+    /// registry indexes this handler under them.
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::CreateSpace::trigger_attributes(),
         }
     }
 }
 
-/// The body of the [`CreateSpace`](tonk_schema::command::CreateSpace)
-/// provider, split out so its `?` errors are logged once at the boundary.
-/// Mirrors [`put_repository`] minus the HTTP shell.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler for CreateSpaceHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::CreateSpace::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::reactor::Env,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+
+        // Decode synchronously (the caller still holds the lock), then
+        // hand owned values + an env clone to the `'static` future.
+        let name = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::CreateSpace::decode(entity, facts))
+            .map(|command| command.name.0);
+        // The optional remote is read from the facts directly (tolerating
+        // the URL's `Value::Entity` representation), not via a concept.
+        let remote = remote_from_facts(facts);
+        let env = env.clone();
+
+        Box::pin(async move {
+            let Some(name) = name else {
+                return;
+            };
+            log!("command CreateSpace name={} remote={:?}", name, remote);
+
+            // 1. Always create local-only first, so the space appears
+            //    whether or not a remote was given (and never vanishes on
+            //    a remote failure).
+            if let Err(error) = create_space_inner(env.state(), &name).await {
+                log!("CreateSpace '{}' failed: {}", name, error);
+                return;
+            }
+
+            // 2. If the form carried a remote, attach it best-effort. The
+            //    space already exists, so a failure here just leaves it
+            //    local-only — retryable from the topbar's Enable sync.
+            //    (`remote_from_facts` already dropped empty/blank URLs.)
+            if let Some(remote) = remote
+                && let Err(error) = enable_sync_inner(env.state(), &name, &remote).await
+            {
+                log!("CreateSpace '{}': remote attach failed: {}", name, error);
+            }
+        })
+    }
+}
+
+/// Build the [`RepositoryConfiguration`] for a space with a single
+/// `main` branch, optionally synced to `remote`.
+///
+/// An empty (or whitespace-only) `remote` yields a local-only space —
+/// the historical [`CreateSpace`](tonk_schema::command::CreateSpace)
+/// behaviour. A non-empty `remote` is wired as the `origin` remote with
+/// `main` tracking `origin/main`, so the space syncs from creation —
+/// the same shape `init()` builds for `home`.
+///
+/// The URL is interpreted as a UCAN access-service endpoint (the only
+/// remote scheme the UI offers): the topbar's default-service button
+/// fills it with the worker origin + `/ucan/`, and a user may type any
+/// other UCAN endpoint.
+///
+/// Shared by [`enable_sync_inner`] (called for both the create and
+/// enable-sync forms) so they produce an identical remote shape.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn space_config(remote: &str) -> RepositoryConfiguration {
+    use dialog_remote_ucan_s3::UcanAddress;
+
+    let remote = remote.trim();
+    if remote.is_empty() {
+        return RepositoryConfiguration::default().branch("main", BranchConfiguration::default());
+    }
+    let address = SiteAddress::from(UcanAddress::new(remote));
+    RepositoryConfiguration::default()
+        .remote("origin", RemoteConfiguration::new(address))
+        .branch(
+            "main",
+            BranchConfiguration::default().upstream("origin", "main"),
+        )
+}
+
+/// Create a space local-only, split out so its `?` errors are logged
+/// once at the boundary. Mirrors [`put_repository`] minus the HTTP shell.
+/// An existing name is a no-op (logged), so the create handler can call
+/// this unconditionally for both the "New space" and "Enable sync" forms.
+///
+/// A sync remote is never wired here — it would make a remote/auth
+/// failure abort the whole create, so the space never appears.
+/// [`CreateSpaceHandler`] attaches the remote separately, after this.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn create_space_inner(state: &AppState, name: &str) -> Result<(), RepositoryError> {
-    // The button asks for a `main`-branch space (the same config the old
-    // `create_space` fetch sent).
+    // A local-only `main`-branch space (the same config the button asks
+    // for); a remote is attached afterwards by the handler.
     let configuration =
         RepositoryConfiguration::default().branch("main", BranchConfiguration::default());
 
@@ -319,6 +456,53 @@ async fn create_space_inner(state: &AppState, name: &str) -> Result<(), Reposito
     // Seed + flip to initialized once the lock is released (seeding is
     // the slow part; holding the lock would stall the page).
     seed_and_initialize(state, name, &subject, &branches).await
+}
+
+/// Attach a sync remote to a space, idempotently, via
+/// [`ensure_remote_config`] — the same helper [`attach_remote`] uses, so
+/// the in-app path and the HTTP route converge on one implementation.
+///
+/// Called by [`CreateSpaceHandler`] after the repository exists (created
+/// or pre-existing), for both the Hub "New space" and topbar "Enable
+/// sync" forms. A missing repository or empty URL is a no-op (logged),
+/// not an error.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn enable_sync_inner(
+    state: &AppState,
+    name: &str,
+    remote: &str,
+) -> Result<(), RepositoryError> {
+    if remote.trim().is_empty() {
+        // Submitted with no URL — nothing to attach.
+        log!("enable sync '{}': empty remote, nothing to attach", name);
+        return Ok(());
+    }
+    let configuration = space_config(remote);
+
+    let tonk = state.write().await;
+    // A missing repository is a no-op, not an error — defensive against a
+    // stale name (e.g. an enable-sync form whose hidden repo field didn't
+    // populate). The create path always runs `create_space_inner` first,
+    // so the repo is present by the time this is reached on that path.
+    let repository = match tonk
+        .profile
+        .repository(name)
+        .load()
+        .perform(&tonk.operator)
+        .await
+    {
+        Ok(repository) => repository,
+        Err(error) => {
+            log!(
+                "enable sync '{}': repository not present, skipping ({})",
+                name,
+                error
+            );
+            return Ok(());
+        }
+    };
+
+    ensure_remote_config(&tonk, &repository, name, &configuration).await
 }
 
 /// Spawn the background seed + status flip for a freshly created
@@ -1433,6 +1617,27 @@ where
         },
     );
 
+    // The upstream was just published on *this* loaded handle, but the
+    // reactor caches a separate branch handle (opened earlier, e.g. when
+    // the standard library was seeded) whose `upstream` cell predates it.
+    // Sync reads through that cached handle, so without reconciling it the
+    // pull would fail with `BranchHasNoUpstream` even though the upstream
+    // is durable. Refresh each branch we wired so the cached handle
+    // reflects it.
+    for (branch_name, settings) in &configuration.branch {
+        if settings.upstream.is_some() {
+            tonk.reactor
+                .refresh_branch(name, branch_name, &tonk.operator)
+                .await
+                .map_err(|e| {
+                    RepositoryError::Internal(format!(
+                        "Failed to refresh cached branch '{}' after wiring upstream: {}",
+                        branch_name, e
+                    ))
+                })?;
+        }
+    }
+
     Ok(())
 }
 
@@ -1506,6 +1711,134 @@ pub async fn attach_remote(
 /// (unavailable in the wasm test scope, which is why
 /// [`fetch_standard_library`] is bypassed here).
 ///
+/// The pure remote-shape builder shared by the create and attach paths.
+/// Native — no browser/service-worker scope needed.
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+mod space_config_tests {
+    use super::space_config;
+
+    #[test]
+    fn it_builds_a_local_only_config_for_an_empty_remote() {
+        let config = space_config("");
+        assert!(
+            config.remote.is_empty(),
+            "an empty remote must leave the space local-only"
+        );
+        let main = config.branch.get("main").expect("main branch present");
+        assert!(
+            main.upstream.is_none(),
+            "a local-only space's main branch must have no upstream"
+        );
+    }
+
+    #[test]
+    fn it_treats_a_whitespace_remote_as_local_only() {
+        let config = space_config("   ");
+        assert!(config.remote.is_empty());
+        assert!(config.branch.get("main").unwrap().upstream.is_none());
+    }
+
+    #[test]
+    fn it_wires_origin_and_tracks_main_for_a_remote_url() {
+        let config = space_config("https://example.test/ucan/");
+        assert!(
+            config.remote.contains_key("origin"),
+            "a remote URL must register the origin remote"
+        );
+        let upstream = config
+            .branch
+            .get("main")
+            .and_then(|b| b.upstream.as_ref())
+            .expect("main must track an upstream when a remote is given");
+        assert_eq!(upstream.remote, "origin");
+        assert_eq!(upstream.branch, "main");
+    }
+}
+
+/// The optional-remote reader the create/enable handler uses. Native.
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+mod remote_from_facts_tests {
+    use super::remote_from_facts;
+    use dialog_artifacts::{Artifact, Changes, Entity, Instruction, Statement, Value};
+    use dialog_query::the;
+
+    const URL: &str = "http://127.0.0.1:8080/ucan/";
+
+    fn artifacts(changes: Changes) -> Vec<Artifact> {
+        changes
+            .into_instructions()
+            .into_iter()
+            .map(|instruction| match instruction {
+                Instruction::Assert(artifact)
+                | Instruction::Replace(artifact)
+                | Instruction::Retract(artifact) => artifact,
+            })
+            .collect()
+    }
+
+    /// Seed the always-present `name` fact (the create form's required field).
+    fn name_fact(changes: &mut Changes, of: &Entity) {
+        the!("dom.event.current-target.elements.name/value")
+            .of(of.clone())
+            .is("test".to_string())
+            .assert(changes);
+    }
+
+    #[test]
+    fn it_reads_a_string_remote() {
+        let of: Entity = "did:key:zCreate".parse().expect("entity");
+        let mut changes = Changes::new();
+        name_fact(&mut changes, &of);
+        // `.is(String)` produces a `Value::String` — the relative-path case.
+        the!("dom.event.current-target.elements.remote/value")
+            .of(of)
+            .is(URL.to_string())
+            .assert(&mut changes);
+        assert_eq!(remote_from_facts(&artifacts(changes)).as_deref(), Some(URL));
+    }
+
+    #[test]
+    fn it_reads_an_entity_remote() {
+        // A URL deserializes as `Value::Entity` (any string with a `:`) —
+        // exactly the case a `String`-typed concept field couldn't decode,
+        // which is why the handler reads the artifact directly.
+        let url_value: Value = serde_json::from_str(&format!("\"{URL}\"")).unwrap();
+        let url = match url_value {
+            Value::Entity(entity) => entity,
+            other => panic!("URL should deserialize as Entity, got {other:?}"),
+        };
+        let of: Entity = "did:key:zCreate".parse().expect("entity");
+        let mut changes = Changes::new();
+        name_fact(&mut changes, &of);
+        // `.is(Entity)` produces a `Value::Entity` — the URL case.
+        the!("dom.event.current-target.elements.remote/value")
+            .of(of)
+            .is(url)
+            .assert(&mut changes);
+        assert_eq!(remote_from_facts(&artifacts(changes)).as_deref(), Some(URL));
+    }
+
+    #[test]
+    fn it_returns_none_without_a_remote_fact() {
+        let of: Entity = "did:key:zLocal".parse().expect("entity");
+        let mut changes = Changes::new();
+        name_fact(&mut changes, &of);
+        assert!(remote_from_facts(&artifacts(changes)).is_none());
+    }
+
+    #[test]
+    fn it_treats_a_blank_remote_as_none() {
+        let of: Entity = "did:key:zBlank".parse().expect("entity");
+        let mut changes = Changes::new();
+        name_fact(&mut changes, &of);
+        the!("dom.event.current-target.elements.remote/value")
+            .of(of)
+            .is("   ".to_string())
+            .assert(&mut changes);
+        assert!(remote_from_facts(&artifacts(changes)).is_none());
+    }
+}
+
 /// wasm32-only — `evaluate_body` and the worker test `TonkState` are
 /// built from the service-worker harness.
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
@@ -1748,5 +2081,103 @@ mod tests {
             "invite minted after attach must embed a remote= param; url was {}",
             invite.url(),
         );
+    }
+
+    /// Regression: the reactor caches a branch handle the first time it's
+    /// touched — e.g. when the standard library is seeded — capturing its
+    /// `upstream` cell *before* any remote is attached. Attaching a remote
+    /// later sets the upstream on a freshly loaded handle; the cached
+    /// handle must be reconciled, or sync (which reads through the cache)
+    /// fails with `BranchHasNoUpstream` even though the upstream is durable.
+    #[dialog_common::test]
+    async fn it_reconciles_the_cached_branch_handle_after_attach() {
+        use dialog_repository::Upstream;
+
+        let repo = "test-attach-refreshes-cache";
+        let (app, state) = fresh_repo(repo).await;
+
+        // Seed through the reactor so `main` is cached with no upstream —
+        // the state real space creation leaves behind before sync is on.
+        seed(&state, repo, CORE).await;
+
+        attach(&app, repo, &origin_config("https://example.test/ucan/")).await;
+
+        // The cached handle that sync reads must now report the upstream.
+        let guard = state.read().await;
+        let session = guard
+            .reactor
+            .repository(repo)
+            .branch("main")
+            .acquire(&guard.operator)
+            .await
+            .expect("acquire cached main");
+        let upstream = session
+            .handle()
+            .upstream()
+            .expect("cached main must report the upstream after attach");
+        assert!(
+            matches!(
+                upstream,
+                Upstream::Remote { ref remote, ref branch, .. }
+                    if remote == "origin" && branch == "main"
+            ),
+            "cached main must track origin/main, got {upstream:?}",
+        );
+    }
+
+    /// Reconciling the cached handle swaps in a fresh `BranchState`, but it
+    /// must carry the live subscriptions across so in-flight SSE streams
+    /// don't silently freeze on the discarded handle.
+    #[dialog_common::test]
+    async fn it_keeps_live_subscriptions_when_refreshing_a_branch() {
+        use std::sync::Arc;
+
+        use dialog_query::{ConceptQuery, Query};
+        use tonk_schema::meta::Name;
+
+        let repo = "test-attach-keeps-subscriptions";
+        let (app, state) = fresh_repo(repo).await;
+        seed(&state, repo, CORE).await;
+
+        // Register a subscription on the cached `main` and note which
+        // `BranchState` it landed on. Hold the subscriber so its receiver
+        // (and the paired sender in the state) stays connected.
+        let subscriber;
+        let before_ptr;
+        {
+            let guard = state.read().await;
+            let session = guard
+                .reactor
+                .repository(repo)
+                .branch("main")
+                .acquire(&guard.operator)
+                .await
+                .expect("acquire cached main");
+            subscriber = session
+                .subscribe(ConceptQuery::from(Query::<Name>::default()))
+                .expect("subscribe");
+            before_ptr = Arc::as_ptr(&session.state);
+        }
+
+        attach(&app, repo, &origin_config("https://example.test/ucan/")).await;
+
+        let guard = state.read().await;
+        let session = guard
+            .reactor
+            .repository(repo)
+            .branch("main")
+            .acquire(&guard.operator)
+            .await
+            .expect("re-acquire main");
+        assert!(
+            !std::ptr::eq(before_ptr, Arc::as_ptr(&session.state)),
+            "refresh must swap in a fresh BranchState",
+        );
+        assert_eq!(
+            session.state.subscriptions().lock().len(),
+            1,
+            "the live subscription must survive the refresh",
+        );
+        drop(subscriber);
     }
 }

--- a/rust/tonk-workspace/src/default_remote.rs
+++ b/rust/tonk-workspace/src/default_remote.rs
@@ -1,0 +1,226 @@
+//! `<tonk-default-remote>` — a button that fills a sibling form input
+//! with this server's UCAN access-service URL.
+//!
+//! The create / enable-sync forms collect a remote URL the user can
+//! type. Most of the time they want *this* server, but notation has no
+//! `window.origin` and no inline JS, so a static template can't encode
+//! `origin + /ucan/`. This dumb element bridges that gap: it renders a
+//! button and, on click, writes `location.origin + "/ucan/"` into the
+//! form control named by its `field` attribute (default `remote`),
+//! resolved within the closest `<form>`.
+//!
+//! Like [`super::share`], it holds no app policy — just the
+//! origin-resolution a static template can't do. The button's label is
+//! the element's own text content (defaulting to "Use this server").
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use web_sys::{Element, Event, HtmlElement, window};
+
+/// A retained click-listener closure, kept alive for the element's
+/// lifetime so the listener stays valid.
+type ClickClosure = Rc<RefCell<Option<Closure<dyn FnMut(Event)>>>>;
+
+/// CSS class the consuming view styles.
+const BUTTON: &str = "workspace__default-remote";
+
+/// Path of the UCAN access service, resolved against the page origin —
+/// the same path `tonk-ui`'s `init()` wires for the `home` space.
+const ACCESS_SERVICE_PATH: &str = "/ucan/";
+
+/// The form-control `name` filled when the element sets no `field`.
+const DEFAULT_FIELD: &str = "remote";
+
+/// Fallback button label when the element carries no text.
+const DEFAULT_LABEL: &str = "Use this server";
+
+/// Per-element state. Holds the click closure so it lives as long as
+/// the element and drops on disconnect.
+#[derive(Default)]
+pub(crate) struct TonkDefaultRemote {
+    click: ClickClosure,
+}
+
+impl CustomElement for TonkDefaultRemote {
+    fn shadow() -> bool {
+        // Light DOM: the consuming view styles the button and the
+        // element must see its `<form>` ancestor via `closest`.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &[]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        ensure_button(this);
+        install_click(this, &self.click);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        self.click.borrow_mut().take();
+    }
+}
+
+/// The default-service URL for this page: `origin + /ucan/`.
+fn default_remote_url() -> Option<String> {
+    let origin = window()?.location().origin().ok()?;
+    Some(format!("{origin}{ACCESS_SERVICE_PATH}"))
+}
+
+/// Find or create the button as the element's only child. The label is
+/// the element's own text content (moved onto the button so the host
+/// carries no stray text node), defaulting to [`DEFAULT_LABEL`].
+/// Idempotent — a reconnect reuses the existing button.
+fn ensure_button(this: &HtmlElement) -> Option<Element> {
+    let document = window().and_then(|w| w.document())?;
+    if let Ok(Some(existing)) = this.query_selector(&format!(":scope > .{BUTTON}")) {
+        return Some(existing);
+    }
+    let label = this
+        .text_content()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| DEFAULT_LABEL.to_string());
+    this.set_text_content(None);
+
+    let button = document.create_element("button").ok()?;
+    let _ = button.set_attribute("class", BUTTON);
+    let _ = button.set_attribute("type", "button");
+    let _ = button.set_attribute("part", "button");
+    button.set_text_content(Some(&label));
+    let _ = this.append_child(&button);
+    Some(button)
+}
+
+/// Install the click listener: resolve `origin + /ucan/` and write it
+/// into the form control named by the element's `field` attribute.
+fn install_click(this: &HtmlElement, slot: &ClickClosure) {
+    let host = this.clone();
+    let listener = Closure::wrap(Box::new(move |_event: Event| {
+        if let Some(url) = default_remote_url() {
+            fill_target(&host, &url);
+        }
+    }) as Box<dyn FnMut(Event)>);
+
+    let _ = this.add_event_listener_with_callback("click", listener.as_ref().unchecked_ref());
+    *slot.borrow_mut() = Some(listener);
+}
+
+/// Set the `value` of the form control named by `this`'s `field`
+/// attribute (default `remote`) within the closest `<form>`. The target
+/// is a `<wa-input>` (a form-associated custom element), so we set its
+/// `value` *property* via reflection rather than the `value` attribute
+/// — that's the slot the event layer reads on submit
+/// (`elements.<field>.value`).
+fn fill_target(this: &HtmlElement, url: &str) {
+    let field = this
+        .get_attribute("field")
+        .unwrap_or_else(|| DEFAULT_FIELD.to_string());
+    let Ok(Some(form)) = this.closest("form") else {
+        return;
+    };
+    let Ok(Some(input)) = form.query_selector(&format!("[name=\"{field}\"]")) else {
+        return;
+    };
+    let input_js: &JsValue = input.as_ref();
+    let _ = js_sys::Reflect::set(
+        input_js,
+        &JsValue::from_str("value"),
+        &JsValue::from_str(url),
+    );
+}
+
+/// Register `<tonk-default-remote>`. Idempotent.
+pub(crate) fn register() {
+    let Some(elements) = window().map(|w| w.custom_elements()) else {
+        return;
+    };
+    if elements.get("tonk-default-remote").is_undefined() {
+        TonkDefaultRemote::define("tonk-default-remote");
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Clicking the button writes `origin + /ucan/` into the form input
+    /// named by `field`. Uses a native `<input>` as the target so the
+    /// test can read `.value` back without a `<wa-input>` upgrade.
+    #[dialog_common::test]
+    async fn it_fills_the_named_input_with_the_default_service() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        // <form><tonk-default-remote field="remote"/><input name="remote"></form>
+        let form = document.create_element("form").unwrap();
+        let element = document.create_element("tonk-default-remote").unwrap();
+        element.set_attribute("field", "remote").unwrap();
+        let input = document.create_element("input").unwrap();
+        input.set_attribute("name", "remote").unwrap();
+        form.append_child(&element).unwrap();
+        form.append_child(&input).unwrap();
+        // Appending a defined element runs connectedCallback synchronously,
+        // so the button is present by the time `append_child` returns.
+        body.append_child(&form).unwrap();
+
+        let button = element
+            .query_selector(".workspace__default-remote")
+            .unwrap()
+            .expect("button injected on connect");
+        button.dyn_ref::<HtmlElement>().unwrap().click();
+
+        let value = js_sys::Reflect::get(input.as_ref(), &JsValue::from_str("value"))
+            .ok()
+            .and_then(|v| v.as_string())
+            .unwrap_or_default();
+        let origin = window().unwrap().location().origin().unwrap();
+        assert_eq!(
+            value,
+            format!("{origin}/ucan/"),
+            "click should fill the named input with origin + /ucan/"
+        );
+
+        form.remove();
+    }
+
+    /// The element's text content becomes the button label; an empty
+    /// element falls back to the default.
+    #[dialog_common::test]
+    async fn it_uses_its_text_as_the_button_label() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let labeled = document.create_element("tonk-default-remote").unwrap();
+        labeled.set_text_content(Some("Use this server"));
+        body.append_child(&labeled).unwrap();
+        let button = labeled
+            .query_selector(".workspace__default-remote")
+            .unwrap()
+            .expect("button injected");
+        assert_eq!(button.text_content().as_deref(), Some("Use this server"));
+
+        let bare = document.create_element("tonk-default-remote").unwrap();
+        body.append_child(&bare).unwrap();
+        let bare_button = bare
+            .query_selector(".workspace__default-remote")
+            .unwrap()
+            .expect("button injected");
+        assert_eq!(bare_button.text_content().as_deref(), Some(DEFAULT_LABEL));
+
+        labeled.remove();
+        bare.remove();
+    }
+}

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -16,6 +16,10 @@ mod ancestors;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod binder;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod default_remote;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod repo_name;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod share;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod sheet;
@@ -24,8 +28,9 @@ mod sheet;
 mod sync;
 
 /// Register the workspace custom elements (`<tonk-sheet>`,
-/// `<tonk-sheet-binder>`, `<tonk-share>`, and `<tonk-sync-state>` — the
-/// status pill that doubles as the pause/resume button) with the page.
+/// `<tonk-sheet-binder>`, `<tonk-share>`, `<tonk-sync-state>` — the
+/// status pill that doubles as the pause/resume button —
+/// `<tonk-default-remote>`, and `<tonk-repo-name>`) with the page.
 /// Idempotent — calling more than once is harmless.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub fn register() {
@@ -33,4 +38,6 @@ pub fn register() {
     binder::register();
     share::register();
     sync::register();
+    default_remote::register();
+    repo_name::register();
 }

--- a/rust/tonk-workspace/src/repo_name.rs
+++ b/rust/tonk-workspace/src/repo_name.rs
@@ -1,0 +1,103 @@
+//! `<tonk-repo-name>` — renders the local name of the enclosing space.
+//!
+//! The topbar lives at the space (directory) level so it shows on every
+//! space, including empty ones with no workspace instance. Its title is
+//! the repository's local name (the `/space/{name}` segment), which
+//! lives on the `<tonk-repository name=…>` route ancestor — not in any
+//! view's data model (the workspace concept's own `name` is a display
+//! label, and absent at the directory level). Like [`super::share`] this
+//! dumb element resolves that ancestor and writes the name as its text
+//! content.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use custom_elements::CustomElement;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use web_sys::{HtmlElement, window};
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use crate::ancestors::repo_from_ancestor;
+
+/// Per-element state. The element holds nothing — it renders once on
+/// connect and carries no listeners.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Default)]
+pub(crate) struct TonkRepoName;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl CustomElement for TonkRepoName {
+    fn shadow() -> bool {
+        // Light DOM: the consuming view styles the title text and the
+        // element must see its `<tonk-repository>` ancestor via `closest`.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &[]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        let name = repo_from_ancestor(this).unwrap_or_default();
+        this.set_text_content(Some(&name));
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {}
+}
+
+/// Register `<tonk-repo-name>`. Idempotent.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn register() {
+    let Some(elements) = window().map(|w| w.custom_elements()) else {
+        return;
+    };
+    if elements.get("tonk-repo-name").is_undefined() {
+        TonkRepoName::define("tonk-repo-name");
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// The element writes the nearest `<tonk-repository>` ancestor's
+    /// `name` as its text content.
+    #[dialog_common::test]
+    async fn it_renders_the_ancestor_repo_name() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let repo = document.create_element("tonk-repository").unwrap();
+        repo.set_attribute("name", "pictures").unwrap();
+        let name = document.create_element("tonk-repo-name").unwrap();
+        repo.append_child(&name).unwrap();
+        // A defined element runs connectedCallback synchronously on append.
+        body.append_child(&repo).unwrap();
+
+        assert_eq!(name.text_content().as_deref(), Some("pictures"));
+        let _ = name.dyn_ref::<HtmlElement>();
+
+        repo.remove();
+    }
+
+    /// With no `<tonk-repository>` ancestor it renders empty rather than
+    /// erroring.
+    #[dialog_common::test]
+    async fn it_renders_empty_without_a_repository_ancestor() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let name = document.create_element("tonk-repo-name").unwrap();
+        body.append_child(&name).unwrap();
+
+        assert_eq!(name.text_content().as_deref(), Some(""));
+
+        name.remove();
+    }
+}

--- a/rust/tonk-workspace/src/sync.rs
+++ b/rust/tonk-workspace/src/sync.rs
@@ -19,7 +19,12 @@
 //!   controller dispatches `tonk:status-refresh` or a commit lands, and
 //!   clicking the pill flips the per-repository `tonk:auto-sync:{repo}`
 //!   `localStorage` preference — the exact key the Leptos
-//!   `sync_controller` reads.
+//!   `sync_controller` reads. For a branch with no upstream it instead
+//!   reveals an "Enable sync" trigger that opens the notation
+//!   `#enable-sync` dialog, stamping the repo it resolved from its
+//!   ancestor into the dialog's hidden `name` input (the workspace
+//!   `{name}` is a display label, not the repo name, so the form can't
+//!   read it declaratively).
 //!
 //! It coordinates with the controller only through that shared
 //! `localStorage` key and the `tonk:status-refresh` / `tonk:committed`
@@ -242,13 +247,15 @@ mod dom {
     /// the pill as-is. The click bubbles up from the inner button, so a
     /// click anywhere on the pill toggles.
     ///
-    /// `offline` is the exception: with no upstream (or an unreachable
-    /// one) there is nothing to pause, so a click on the offline pill is
-    /// a no-op — the user can't toggle into `paused` from there.
+    /// Only the actionable pill toggles: an `offline` pill (no upstream
+    /// or unreachable) and the "Enable sync" trigger (shown in place of
+    /// the pill for a no-upstream branch) have nothing to pause, so a
+    /// click on them is a no-op — and the trigger's own listener still
+    /// runs to open the enable-sync dialog.
     fn install_toggle_click(this: &HtmlElement, slot: &Listener) {
         let host = this.clone();
         let listener = Closure::wrap(Box::new(move |_event: Event| {
-            if is_offline(&host) {
+            if !is_togglable(&host) {
                 return;
             }
             let Some(repo) = repo_from_ancestor(&host) else {
@@ -263,22 +270,41 @@ mod dom {
         *slot.borrow_mut() = Some(listener);
     }
 
-    /// Whether the pill is currently showing the (non-actionable)
-    /// `offline` state, read from the painted button's modifier class.
-    fn is_offline(host: &HtmlElement) -> bool {
+    /// Whether the host is currently showing an actionable pill — a
+    /// `synced` / `syncing…` / `paused` state the user can pause or
+    /// resume. False for the inert `offline` pill and when the
+    /// enable-sync trigger is showing instead of a pill (no pill child).
+    fn is_togglable(host: &HtmlElement) -> bool {
         let (_, offline_class) = OFFLINE_CHIP;
         host.query_selector(&format!(":scope > .{STATE_CHIP}"))
             .ok()
             .flatten()
-            .is_some_and(|button| button.class_list().contains(offline_class))
+            .is_some_and(|button| !button.class_list().contains(offline_class))
     }
+
+    /// CSS class for the "Enable sync" trigger button rendered in place
+    /// of the chip when the branch has no upstream.
+    const ENABLE_BUTTON: &str = "workspace__enable-sync";
+
+    /// Label for the enable-sync trigger.
+    const ENABLE_LABEL: &str = "Enable sync";
+
+    /// `id` of the notation enable-sync form (`core.yaml`) whose hidden
+    /// `name` input this element stamps with the resolved repo on click.
+    const ENABLE_SYNC_FORM_ID: &str = "enable-sync-form";
 
     /// Per-element state for `<tonk-sync-state>`.
     #[derive(Default)]
     pub(crate) struct TonkSyncState {
         refresh: Listener,
         committed: Listener,
+        /// Pause/resume toggle on the pill (the synced/syncing/paused
+        /// states); a no-op while the enable-sync trigger or an offline
+        /// pill is showing.
         click: Listener,
+        /// Enable-sync trigger: stamps the resolved repo into the
+        /// notation enable-sync form before its dialog opens.
+        trigger: Listener,
     }
 
     impl CustomElement for TonkSyncState {
@@ -296,6 +322,7 @@ mod dom {
             refresh_state(this);
             install_state_listeners(this, &self.refresh, &self.committed);
             install_toggle_click(this, &self.click);
+            install_trigger_click(this, &self.trigger);
         }
 
         fn disconnected_callback(&mut self, _this: &HtmlElement) {
@@ -315,7 +342,11 @@ mod dom {
             }
             self.refresh.borrow_mut().take();
             self.committed.borrow_mut().take();
+            // The click and trigger listeners are element-local (on
+            // `this`), so removal drops with the element; just free the
+            // closures.
             self.click.borrow_mut().take();
+            self.trigger.borrow_mut().take();
         }
     }
 
@@ -351,11 +382,14 @@ mod dom {
         let host = this.clone();
         spawn_local(async move {
             match fetch_sync_status(&repo, &branch).await {
-                // Offline wins over the preference: no reachable remote.
-                None | Some(SyncState::NoUpstream) => {
-                    paint(&host, OFFLINE_CHIP, OFFLINE_LABEL);
-                }
-                // Reachable + running: the live state.
+                // No upstream: offer the "Enable sync" trigger instead of
+                // a pill — a local-only branch can't sync until it has a
+                // remote, so the actionable affordance is to add one.
+                Some(SyncState::NoUpstream) => paint_enable_sync(&host),
+                // Unreachable remote (a `None` fetch): there *is* an
+                // upstream, but we can't reach it — the inert offline pill.
+                None => paint(&host, OFFLINE_CHIP, OFFLINE_LABEL),
+                // Reachable + running: the live state, click pauses.
                 Some(state) if is_enabled(&repo) => {
                     paint(&host, state_chip(state), RUNNING_LABEL);
                 }
@@ -369,14 +403,33 @@ mod dom {
     /// `title`/`aria-label`. The title is supplied by the caller — a
     /// toggle hint for the actionable states (`RUNNING_LABEL` /
     /// `PAUSED_LABEL`) or a plain status note for the inert `offline`
-    /// pill (`OFFLINE_LABEL`).
+    /// pill (`OFFLINE_LABEL`). Clears any stale enable-sync trigger, so a
+    /// branch that just gained an upstream swaps the trigger for the pill.
     fn paint(host: &HtmlElement, chip: (&'static str, &'static str), title: &str) {
         let (label, class) = chip;
+        remove_child(host, ENABLE_BUTTON);
         if let Some(button) = ensure_pill_button(host) {
             let _ = button.set_attribute("class", &format!("{STATE_CHIP} {class}"));
             button.set_text_content(Some(label));
             let _ = button.set_attribute("title", title);
             let _ = button.set_attribute("aria-label", title);
+        }
+    }
+
+    /// Reveal the "Enable sync" trigger for a no-upstream branch,
+    /// replacing any stale pill. The button opens the notation
+    /// `#enable-sync` dialog through Web Awesome's `data-dialog`
+    /// handler; the repo it attaches to is stamped into the dialog's
+    /// hidden `name` input by [`install_trigger_click`] on click.
+    fn paint_enable_sync(host: &HtmlElement) {
+        remove_child(host, STATE_CHIP);
+        let _ = ensure_enable_button(host);
+    }
+
+    /// Remove the element's only child matching `class`, if present.
+    fn remove_child(host: &HtmlElement, class: &str) {
+        if let Ok(Some(child)) = host.query_selector(&format!(":scope > .{class}")) {
+            child.remove();
         }
     }
 
@@ -394,6 +447,64 @@ mod dom {
         let _ = button.set_attribute("part", "button");
         let _ = host.append_child(&button);
         Some(button)
+    }
+
+    /// Find or create the enable-sync trigger button as the element's
+    /// only child. Carries `data-dialog="open enable-sync"` so a click
+    /// opens the notation dialog (Web Awesome's global handler).
+    fn ensure_enable_button(host: &HtmlElement) -> Option<Element> {
+        if let Ok(Some(existing)) = host.query_selector(&format!(":scope > .{ENABLE_BUTTON}")) {
+            return Some(existing);
+        }
+        let document = window()?.document()?;
+        let button = document.create_element("button").ok()?;
+        let _ = button.set_attribute("class", ENABLE_BUTTON);
+        let _ = button.set_attribute("type", "button");
+        let _ = button.set_attribute("part", "button");
+        let _ = button.set_attribute("data-dialog", "open enable-sync");
+        button.set_text_content(Some(ENABLE_LABEL));
+        let _ = host.append_child(&button);
+        Some(button)
+    }
+
+    /// Install the trigger's click listener on the host: stamp the repo
+    /// resolved from the `<tonk-repository>` ancestor into the notation
+    /// enable-sync form's hidden `name` input, so the asserted command
+    /// targets the right repository. Harmless when the element is
+    /// showing a chip (the chip carries no `data-dialog`, so no dialog
+    /// opens — the stamp is just unused).
+    fn install_trigger_click(this: &HtmlElement, slot: &Listener) {
+        let host = this.clone();
+        let listener = Closure::wrap(Box::new(move |_event: Event| {
+            if let Some(repo) = repo_from_ancestor(&host) {
+                stamp_enable_sync_repo(&repo);
+            }
+        }) as Box<dyn FnMut(Event)>);
+
+        let _ = this.add_event_listener_with_callback("click", listener.as_ref().unchecked_ref());
+        *slot.borrow_mut() = Some(listener);
+    }
+
+    /// Write `repo` into the notation enable-sync form's hidden `name`
+    /// input. The input is a native `<input>`, but we set the `value`
+    /// *property* (via reflection) since that's the slot the event
+    /// layer reads on submit (`elements.name.value`).
+    fn stamp_enable_sync_repo(repo: &str) {
+        let Some(document) = window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(form) = document.get_element_by_id(ENABLE_SYNC_FORM_ID) else {
+            return;
+        };
+        let Ok(Some(input)) = form.query_selector("[name=\"name\"]") else {
+            return;
+        };
+        let input_js: &JsValue = input.as_ref();
+        let _ = js_sys::Reflect::set(
+            input_js,
+            &JsValue::from_str("value"),
+            &JsValue::from_str(repo),
+        );
     }
 
     /// Install the chip's window listeners: `tonk:status-refresh`
@@ -564,6 +675,81 @@ mod dom {
             assert_eq!(button.class_name(), "workspace__sync is-offline");
 
             host.remove();
+        }
+
+        #[dialog_common::test]
+        async fn it_reveals_the_enable_sync_trigger_and_swaps_with_the_pill() {
+            let document = window().unwrap().document().unwrap();
+            let body = document.body().unwrap();
+            let host = document.create_element("tonk-sync-state").unwrap();
+            body.append_child(&host).unwrap();
+            let host_el = host.dyn_ref::<HtmlElement>().unwrap();
+
+            // No upstream → an "Enable sync" trigger that opens the
+            // notation dialog (`data-dialog`), not a pill.
+            paint_enable_sync(host_el);
+            let button = host
+                .query_selector(".workspace__enable-sync")
+                .unwrap()
+                .expect("enable-sync trigger painted for no-upstream");
+            assert_eq!(button.text_content().as_deref(), Some("Enable sync"));
+            assert_eq!(
+                button.get_attribute("data-dialog").as_deref(),
+                Some("open enable-sync"),
+            );
+
+            // A concrete state replaces the trigger with the pill — no
+            // stale button left behind.
+            paint(host_el, state_chip(SyncState::Synced), RUNNING_LABEL);
+            assert!(
+                host.query_selector(".workspace__enable-sync")
+                    .unwrap()
+                    .is_none(),
+                "painting the pill must remove the enable-sync trigger",
+            );
+            assert!(host.query_selector(".workspace__sync").unwrap().is_some());
+
+            host.remove();
+        }
+
+        #[dialog_common::test]
+        async fn it_stamps_the_resolved_repo_into_the_enable_sync_form_on_click() {
+            register();
+            let document = window().unwrap().document().unwrap();
+            let body = document.body().unwrap();
+
+            // The notation form the element stamps: a hidden `name`
+            // input inside `#enable-sync-form`.
+            let form = document.create_element("form").unwrap();
+            form.set_id("enable-sync-form");
+            let hidden = document.create_element("input").unwrap();
+            hidden.set_attribute("type", "hidden").unwrap();
+            hidden.set_attribute("name", "name").unwrap();
+            form.append_child(&hidden).unwrap();
+            body.append_child(&form).unwrap();
+
+            // <tonk-repository name="pictures"><tonk-sync-state/></tonk-repository>
+            let repo = document.create_element("tonk-repository").unwrap();
+            repo.set_attribute("name", "pictures").unwrap();
+            let state = document.create_element("tonk-sync-state").unwrap();
+            repo.append_child(&state).unwrap();
+            body.append_child(&repo).unwrap();
+
+            // Clicking the element resolves the ancestor repo and stamps
+            // it into the form's hidden `name` input.
+            state.dyn_ref::<HtmlElement>().unwrap().click();
+
+            let value = js_sys::Reflect::get(hidden.as_ref(), &JsValue::from_str("value"))
+                .ok()
+                .and_then(|v| v.as_string())
+                .unwrap_or_default();
+            assert_eq!(
+                value, "pictures",
+                "click should stamp the ancestor repo into the enable-sync form"
+            );
+
+            form.remove();
+            repo.remove();
         }
     }
 }


### PR DESCRIPTION
Wire an optional sync remote into space creation and make it actually sync. The create / enable-sync forms post a `remote` URL; the worker attaches it as `origin`, tracks `origin/main`, and the topbar `<tonk-sync-state>` pill reveals an "Enable sync" trigger for a local-only branch (opening the notation `#enable-sync` dialog). Adds the `<tonk-default-remote>` and `<tonk-repo-name>` workspace elements and the `space/enable-sync` command.

Reconcile the reactor's cached branch handle after attaching a remote. The reactor caches one `Branch` handle per repo/branch, and a `Branch` captures its `upstream` cell when first opened — e.g. while seeding the standard library, before any remote exists. A later `set_upstream` on a freshly loaded handle publishes to durable storage but never touches the cached cell, so background sync — which reads through the cache — failed with `BranchHasNoUpstream` even though the upstream was durable. `TonkReactor::refresh_branch` re-opens the branch (re-resolving the upstream from durable storage) and swaps a fresh `BranchState` into the cache, carrying live subscriptions across so in-flight SSE streams don't freeze. Called from `ensure_remote_config`, covering both the create→enable-sync path and the `attach_remote` route.

Resolve the rebase over staging's unified sync pill (#494): fold the branch's "Enable sync" trigger into the merged status/pause-resume pill (`<tonk-sync-state>`), drop the superseded `<tonk-sync-toggle>`, and take staging's pill CSS.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the space creation and synchronization features in the `tonk` application. It consolidates the handling of space creation and enabling sync into a single command, improving the user experience and fixing related bugs.

### Detailed summary
- Added `adopt_subscriptions_from` method in `BranchState` to transfer subscriptions.
- Introduced `remote` module in `tonk-schema` for handling sync URLs.
- Registered new elements: `<tonk-default-remote>` and `<tonk-repo-name>`.
- Updated `CreateSpace` to read optional remote directly from facts.
- Reworked `CreateSpaceHandler` to handle both space creation and sync enabling.
- Enhanced UI components for better synchronization handling.
- Improved CSS for workspace elements and topbar.
- Documented changes and bugs encountered during development.

> The following files were skipped due to too many changes: `rust/tonk-worker/src/router/repository.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->