### PR TITLE
feat(slide): make the agent reference topic-addressable; modernize + trim docs

### DIFF
--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -28,7 +28,8 @@ use slide::{ExitCode, guide, identity, schema, site};
     name = "slide",
     about = "Headless CLI for reading/writing data and views",
     version,
-    propagate_version = true
+    propagate_version = true,
+    after_help = "Start here:\n  slide guide            one-screen index\n  slide schema           every concept + attribute on the branch\n\nExamples:\n  slide eval -c 'person:'\n  slide concepts\n  slide share display alice --view person-card"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -38,6 +39,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Initialize a new repo in the current working directory
+    #[command(after_help = "Examples:\n  slide init\n  slide init my-repo")]
     Init {
         /// Optional label for the repository.
         ///
@@ -49,6 +51,7 @@ enum Command {
 
     /// Show the local profile DID. With `--reset`, deletes the
     /// on-disk profile and creates a fresh identity.
+    #[command(after_help = "Examples:\n  slide identity\n  slide identity --reset")]
     Identity {
         /// Wipe the on-disk profile and create a new one. This removes
         /// access to exisitng repos without re-delegation.
@@ -59,18 +62,29 @@ enum Command {
     /// Evaluate commands in the current repo
     Eval(EvalArgs),
 
-    /// Print the asserted-notation guide. Useful for agent harnesses
-    /// that need to learn the syntax without repo access.
-    Guide,
+    /// Print the agent reference. With no topic, prints a one-screen
+    /// index; `slide guide <topic>` prints one section; `slide guide
+    /// all` prints everything. Useful for agent harnesses that need to
+    /// learn the syntax without repo access.
+    // Topic list here is hand-rolled for help text; keep in sync with `guide::TOPICS`.
+    #[command(after_help = "Topics: notation, views, events, workspace, all\n\nExamples:\n  slide guide\n  slide guide notation\n  slide guide views\n  slide guide all")]
+    Guide {
+        /// One of: notation, views, events, workspace, all. Omit for
+        /// the index.
+        #[arg(value_name = "TOPIC")]
+        topic: Option<String>,
+    },
 
     /// Print the current site's schema (every named attribute and
     /// concept) as a re-submittable notation document.
+    #[command(after_help = "Examples:\n  slide schema\n  slide schema > schema.notation")]
     Schema,
 
     /// List user-defined concepts on the local branch. One row
     /// per concept, tab-separated `name<TAB>description`. Built-in
     /// concepts (`attribute`, `concept`, …) are omitted — they're
     /// resolvable everywhere and would just be noise.
+    #[command(after_help = "Examples:\n  slide concepts")]
     Concepts,
 
     /// List entities that carry a `text/html` claim on the local
@@ -78,11 +92,13 @@ enum Command {
     /// `name<TAB>entity<TAB>bytes`. Claim-driven: surfaces
     /// anything the host route would serve, regardless of how
     /// the claim was asserted.
+    #[command(after_help = "Examples:\n  slide views")]
     Views,
 
     /// Migrate a `.carry/` directory to `.tonk/`. Walks up from
     /// `$PWD` to find the source unless `--from` is supplied; the
     /// destination is always a sibling `.tonk/` of the source.
+    #[command(after_help = "Examples:\n  slide migrate\n  slide migrate --from ../old --move")]
     Migrate {
         /// Explicit source `.carry/` directory. Default: walk up
         /// from `$PWD`.
@@ -96,20 +112,24 @@ enum Command {
     },
 
     /// Push the local main branch to its upstream.
+    #[command(after_help = "Examples:\n  slide push")]
     Push,
 
     /// Pull the local main branch from its upstream.
+    #[command(after_help = "Examples:\n  slide pull")]
     Pull,
 
     /// Print how the local main branch relates to its upstream:
     /// `synced`, `ahead`, `behind`, `diverged`, or `no-upstream`.
     /// Read-only — fetches the upstream head without merging.
+    #[command(after_help = "Examples:\n  slide status")]
     Status,
 
     /// Mint a UCAN delegation chain over the local repo and
     /// print a paste-able invite URL. The default form is
     /// audience-open: anyone holding the URL can claim by
     /// redelegating from the embedded ephemeral key.
+    #[command(after_help = "Examples:\n  slide invite\n  slide invite --remote prod")]
     Invite {
         /// Override the URL prefix the invite is built against.
         #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
@@ -125,6 +145,7 @@ enum Command {
 
     /// Claim an invite URL into a fresh `.tonk/` under the
     /// current directory. Refuses if a site already exists.
+    #[command(after_help = "Examples:\n  slide join 'https://...#invite'")]
     Join {
         /// Invite URL produced by `slide invite` or
         /// tonk-ui's invite flow.
@@ -151,6 +172,7 @@ enum ShareCommand {
     /// Share a named concept. The recipient lands on the
     /// auto-rendered concept view at
     /// `/space/<space-name>/branch/main/concept/<name>`.
+    #[command(after_help = "Examples:\n  slide share concept person\n  slide share concept person --space-name demo")]
     Concept {
         /// Local name of the concept to share.
         #[arg(value_name = "NAME")]
@@ -173,6 +195,7 @@ enum ShareCommand {
     /// Share an HTML view. The recipient lands on the iframe
     /// viewer at `/space/<space-name>/branch/main/view/<entity>`
     /// with the body served from the entity's `text/html` claim.
+    #[command(after_help = "Examples:\n  slide share view my-page")]
     View {
         /// Bookmark name or `did:key:…` entity URI for the view.
         /// `slide views` lists what's available.
@@ -196,6 +219,7 @@ enum ShareCommand {
     /// Use this for declarative views built against the `view`
     /// concept (`{model, display}`), identified by their anchor
     /// name — `share view` is for the iframe viewer.
+    #[command(after_help = "Examples:\n  slide share display alice --view person-card\n  slide share display alice --model person")]
     Display {
         /// Bookmark name or `did:key:…` entity URI for the
         /// entity to render. Names survive entity-URI changes
@@ -234,6 +258,7 @@ enum RemoteCommand {
     /// Register a UCAN-S3 access-service remote on the local
     /// site. Writes the dialog remote handle and the
     /// meta-branch `Remote` concept browsers read.
+    #[command(after_help = "Examples:\n  slide remote add prod https://access.example.com")]
     Add {
         /// Local name for the remote.
         #[arg(value_name = "NAME")]
@@ -249,10 +274,12 @@ enum RemoteCommand {
     },
 
     /// Print every remote registered on the meta branch.
+    #[command(after_help = "Examples:\n  slide remote list")]
     List,
 
     /// Wire the local `main` branch's upstream to
     /// `<remote>/main`.
+    #[command(after_help = "Examples:\n  slide remote set-upstream prod")]
     SetUpstream {
         /// Name of the remote to track.
         #[arg(value_name = "REMOTE")]
@@ -261,6 +288,7 @@ enum RemoteCommand {
 }
 
 #[derive(Args, Debug)]
+#[command(after_help = "Examples:\n  slide eval -c 'person:'\n  slide eval ./doc.notation\n  cat doc.notation | slide eval -\n  slide eval -c 'person:' --format json\n  slide eval ./doc.notation --no-sync")]
 struct EvalArgs {
     /// Inline document. Mutually exclusive with the positional
     /// path / `-`.
@@ -311,7 +339,7 @@ async fn main() {
         Command::Init { label } => init(label).await,
         Command::Identity { reset } => identity(reset).await,
         Command::Eval(args) => eval(args).await,
-        Command::Guide => print_guide(),
+        Command::Guide { topic } => print_guide(topic.as_deref()),
         Command::Schema => print_schema().await,
         Command::Concepts => print_concepts().await,
         Command::Views => print_views().await,
@@ -430,9 +458,13 @@ fn resolve_source(args: &EvalArgs) -> Result<Source, String> {
     }
 }
 
-fn print_guide() -> ExitCode {
+fn print_guide(topic: Option<&str>) -> ExitCode {
+    let text = match guide::resolve(topic) {
+        Ok(text) => text,
+        Err(err) => return print_error(err.to_string()),
+    };
     let mut stdout = std::io::stdout().lock();
-    if let Err(e) = stdout.write_all(guide::GUIDE.as_bytes()) {
+    if let Err(e) = stdout.write_all(text.as_bytes()) {
         return print_error(format!("failed to write stdout: {e}"));
     }
     ExitCode::Success

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -67,7 +67,9 @@ enum Command {
     /// all` prints everything. Useful for agent harnesses that need to
     /// learn the syntax without repo access.
     // Topic list here is hand-rolled for help text; keep in sync with `guide::TOPICS`.
-    #[command(after_help = "Topics: notation, views, events, workspace, all\n\nExamples:\n  slide guide\n  slide guide notation\n  slide guide views\n  slide guide all")]
+    #[command(
+        after_help = "Topics: notation, views, events, workspace, all\n\nExamples:\n  slide guide\n  slide guide notation\n  slide guide views\n  slide guide all"
+    )]
     Guide {
         /// One of: notation, views, events, workspace, all. Omit for
         /// the index.
@@ -172,7 +174,9 @@ enum ShareCommand {
     /// Share a named concept. The recipient lands on the
     /// auto-rendered concept view at
     /// `/space/<space-name>/branch/main/concept/<name>`.
-    #[command(after_help = "Examples:\n  slide share concept person\n  slide share concept person --space-name demo")]
+    #[command(
+        after_help = "Examples:\n  slide share concept person\n  slide share concept person --space-name demo"
+    )]
     Concept {
         /// Local name of the concept to share.
         #[arg(value_name = "NAME")]
@@ -219,7 +223,9 @@ enum ShareCommand {
     /// Use this for declarative views built against the `view`
     /// concept (`{model, display}`), identified by their anchor
     /// name — `share view` is for the iframe viewer.
-    #[command(after_help = "Examples:\n  slide share display alice --view person-card\n  slide share display alice --model person")]
+    #[command(
+        after_help = "Examples:\n  slide share display alice --view person-card\n  slide share display alice --model person"
+    )]
     Display {
         /// Bookmark name or `did:key:…` entity URI for the
         /// entity to render. Names survive entity-URI changes
@@ -288,7 +294,9 @@ enum RemoteCommand {
 }
 
 #[derive(Args, Debug)]
-#[command(after_help = "Examples:\n  slide eval -c 'person:'\n  slide eval ./doc.notation\n  cat doc.notation | slide eval -\n  slide eval -c 'person:' --format json\n  slide eval ./doc.notation --no-sync")]
+#[command(
+    after_help = "Examples:\n  slide eval -c 'person:'\n  slide eval ./doc.notation\n  cat doc.notation | slide eval -\n  slide eval -c 'person:' --format json\n  slide eval ./doc.notation --no-sync"
+)]
 struct EvalArgs {
     /// Inline document. Mutually exclusive with the positional
     /// path / `-`.

--- a/rust/slide/src/guide-events.md
+++ b/rust/slide/src/guide-events.md
@@ -1,4 +1,4 @@
-## Reactive views: events and effects
+# Reactive views: events and effects
 
 Templates with `{field}` interpolation cover the read path: a
 view subscribes to a query and re-renders rows in place when the
@@ -253,7 +253,7 @@ concept!: &complete
   transient: true
   with:
     todo:
-      the: dom.event.target.dataset/todo
+      the: dom.event.current-target.dataset/todo
       as:  entity
 
 rule!:
@@ -286,8 +286,9 @@ slide share display <subject> --view <view-name>
   template). Omit `--view` and the element falls back to
   carousel mode — every view published for the subject's model.
 
-There is no `--model`: the view declares its own `model`, so the
-caller never repeats it. The `view` concept is `{model,
+With `--view`, you don't pass `--model`: the named view declares its
+own `model`, so the caller never repeats it. (`--model` is the carousel
+form — see `slide guide views`.) The `view` concept is `{model,
 display}`; identity lives in the anchor name, not a `name` field.
 
 Concrete example, given the counter setup above:
@@ -317,21 +318,6 @@ Two related verbs to keep apart:
 
 `slide share display` is the verb that pairs with this guide.
 
-### What this replaces
-
-Earlier drafts of this guide pointed at a `globalThis.tonk` API
-(`tonk.query`, `tonk.subscribe`, `tonk.evaluate`) that lived on
-the window inside the served view iframe. That API still backs
-the host elements internally, but it is no longer the agent
-surface: writing views as `<script type="module">` blocks that
-call into it is a stopgap, not a pattern to lean on.
-
-The declarative path is the right one because every piece is
-the same machinery the rest of the system already uses:
-concepts, rules, queries, subscriptions. Adding a new
-interaction means adding a transient concept and a rule, not
-inventing a new request shape on the wire.
-
 ### When the declarative path doesn't fit
 
 Anything that needs to render arbitrary HTML/CSS/JS without
@@ -340,3 +326,8 @@ embeds, complex canvas drawing, a charting library — belongs
 in a sandboxed iframe view rather than in the main view body.
 That sandbox is a separate piece (`<tonk-portal>`) outside the
 scope of this guide.
+
+---
+
+Don't memorize built-ins — run `slide schema` to see the concepts,
+rules, and transient commands already on the branch.

--- a/rust/slide/src/guide-events.md
+++ b/rust/slide/src/guide-events.md
@@ -10,8 +10,11 @@ The model has three pieces:
 
 1. **`on<event>=<concept>`** on a template element names the
    concept a DOM event produces.
-2. A **transient concept** describes the shape of that event-
-   derived fact and where each field reads from.
+2. A **command** (`command!:`) describes the shape of that event-
+   derived fact and where each field reads from. A command is a
+   transient concept — `command!:` is the keyword `slide schema`
+   shows and is equivalent to `concept!:` with `transient: true`;
+   both write a fact that lives one cycle and is never persisted.
 3. A **rule** (`rule!:`) watches for the transient and asserts
    downstream state. The transient is the trigger; its one-cycle
    lifetime makes the rule fire exactly once per event.
@@ -32,10 +35,9 @@ concept!: &counter
   with:
     count: count
 
-# The event-derived concept. `transient: true` is what tells the
-# reactor not to persist it.
-concept!: &increment
-  transient: true
+# The event-derived command — a transient concept the reactor
+# sweeps after one cycle instead of persisting.
+command!: &increment
   with:
     subject:
       the: dom.event.current-target.dataset/subject
@@ -105,6 +107,7 @@ the live JS event. The `the:` identifier names a path:
 | `dom.event.target/value`                      | `event.target.value`                 |
 | `dom.event.current-target.dataset/subject`    | the bound element's `data-subject`   |
 | `dom.event.current-target.dataset/item-id`    | the bound element's `data-item-id`   |
+| `dom.event.detail/sheet`                      | a CustomEvent's `event.detail.sheet` |
 
 Rules of the translation:
 
@@ -112,6 +115,11 @@ Rules of the translation:
   successive property step on the event object.
 - Within a segment, kebab-case becomes camelCase before lookup
   (`shift-key` → `shiftKey`, `item-id` → `itemId`).
+- A leading `detail` segment is `event.detail` — the payload a
+  custom element dispatches with a `CustomEvent` (e.g. a
+  `<tonk-sheet-binder>` emitting `{detail: {sheet}}`). Plain DOM
+  events have no `detail`; this is how you read fields off an
+  event a component raised rather than a raw click.
 - A leading `target` segment is `event.target` — the *deepest*
   node the event fired on. A leading `current-target` segment
   is the **bound element**: the closest ancestor of
@@ -121,9 +129,13 @@ Rules of the translation:
   `data-*` you put on the element with the handler, always use
   `current-target` — `target` may be a child you didn't author
   (e.g. a `<span>` inside the button).
-- The path is evaluated live, at handler-fire time. A missing
-  path (e.g. `event.pressure` on a `MouseEvent`) omits that
-  field from the asserted fact.
+- The path is evaluated live, at handler-fire time. A path that
+  fails to resolve — a missing/`undefined` step (e.g.
+  `event.pressure` on a `MouseEvent`), or a value that won't
+  coerce to `as:` — aborts the *whole* assertion: nothing is
+  posted and the event falls through to the next matching
+  binding. Only a `the:` that doesn't address the event at all
+  is silently dropped.
 - The `as:` type drives coercion: `text` → string, `entity` →
   string parsed as a URI (rejected if it has no `:`),
   `unsigned-integer` / `signed-integer` / `float` → number,
@@ -146,8 +158,7 @@ view!: &todo-row
       <button onclick=complete data-todo={this}>done</button>
     </li>
 
-concept!: &complete
-  transient: true
+command!: &complete
   with:
     todo:
       the: dom.event.current-target.dataset/todo
@@ -182,8 +193,7 @@ runtime sees a `the:` under `dom.event.do` and calls the method
 before the handler returns.
 
 ```yaml
-concept!: &save
-  transient: true
+command!: &save
   with:
     body:
       the: dom.event.current-target.elements.body/value
@@ -204,8 +214,13 @@ view!: &save-form
 
 The submit fires on the `<form>`, so `current-target` is the
 form and `elements.body` is the named `<textarea>` — its
-`value` becomes the `body` field. `preventDefault` fires
-synchronously so the page doesn't reload.
+`value` becomes the `body` field. The lookup is by the control's
+`name` (here `name="body"`), but remember each path segment is
+camelCased first: a multi-word field must be named in camelCase
+(`name="noteBody"`, read as `…elements.noteBody/value`) — a
+kebab `name="note-body"` won't resolve, since the path looks up
+`noteBody`. `preventDefault` fires synchronously so the page
+doesn't reload.
 
 ### `rule!:` — the reactive layer
 
@@ -249,8 +264,7 @@ between bindings.
 To remove a fact in response to a transient, use `retract!:`:
 
 ```yaml
-concept!: &complete
-  transient: true
+command!: &complete
   with:
     todo:
       the: dom.event.current-target.dataset/todo

--- a/rust/slide/src/guide-index.md
+++ b/rust/slide/src/guide-index.md
@@ -1,0 +1,34 @@
+# slide
+
+Headless CLI for reading and writing tonk data and views as
+asserted-notation. You define concepts (schemas), assert facts against
+them, and publish views that render those facts.
+
+## The loop
+
+1. Discover what's already on the branch — don't guess or memorize:
+   - `slide schema`   — every attribute and concept, as re-submittable notation
+   - `slide concepts` — user-defined concepts (name + description)
+   - `slide views`    — entities carrying a renderable claim
+2. Write a notation document with `slide eval`:
+   - `slide eval -c '<doc>'`   — inline
+   - `slide eval <path>`       — from a file
+   - `<doc> | slide eval -`    — from stdin
+   A committing eval auto-syncs (pull-before / push-after) unless `--no-sync`.
+3. Share a live view: `slide share display <entity> --view <name>`.
+
+## Reference topics
+
+Run `slide guide <topic>` — e.g. `slide guide notation`:
+
+- `notation`  — asserted-notation syntax: queries, assertions, names,
+                `this:`, fields, blanks, joins, built-ins.
+- `views`     — display templates, `<tonk-display>` / `<tonk-concept>`,
+                and how a view resolves from a model.
+- `events`    — interactivity: effects, rules, transient concepts, and
+                `on<event>=<concept>` DOM bindings.
+- `workspace` — building sheets for the tonk-ui workspace shell
+                (app-layer; subject to change).
+- `all`       — every topic at once.
+
+Each subcommand also carries examples: `slide <command> --help`.

--- a/rust/slide/src/guide-views.md
+++ b/rust/slide/src/guide-views.md
@@ -1,88 +1,113 @@
-# Slide-specific notation: HTML views
+# Views: rendering data
 
-slide ships two share verbs that turn local data into a URL a human can
-paste into a browser: `slide share concept <name>` and `slide share view
-<name|entity>`. The concept share is automatic — any concept the agent
-has defined is shareable as-is. The view share targets entities that
-carry a `text/html` claim, and that claim has to come from somewhere.
+A **view** is an HTML template bound to a concept. The tonk-ui host
+ships two custom elements that render live branch data into views;
+neither needs a framework or a `<script>`. Author views by asserting
+the `view` concept — there is no separate write path.
 
-slide does not invent a write path for HTML; it goes through `slide eval`
-like everything else. The convention is one attribute and one concept,
-which you assert once per repository:
+## The `view` concept
+
+`view` is `{model, display}`: the concept it renders and the HTML
+template. Assert one per presentation:
+
+```yaml
+view!: &person-card
+  model: person
+  display: !text/html |
+    <article>
+      <h2>{name}</h2>
+      <p>{age}</p>
+    </article>
+```
+
+`{field}` placeholders interpolate the rendered entity's fields, drawn
+from the `model` concept's shape. A view is identified by its **anchor
+name** (`&person-card` publishes `id:person-card`); re-asserting the
+same anchor with a new `display` re-points the name, so edits replace
+in place and never leave duplicate rows.
+
+## `<tonk-display>` — one entity through a view
+
+`<tonk-display entity=<uri> model=<concept> view=<view-concept>>`
+renders a single entity. The resolution that trips people up:
+
+- `model` is the entity's concept; it projects the entity's fields.
+- `view` is a **view concept** (e.g. the built-in `tonk:view`), NOT a
+  specific view instance. `<tonk-display>` resolves the view concept,
+  then runs a **model-constrained query** to find the view instance
+  whose `model` equals the resolved model.
+
+So you author the instance with a `model` (above) and point callers at
+the concept:
+
+```yaml
+# Correct: the sheet/host references the view CONCEPT.
+view: tonk:view
+# Wrong: referencing a view instance (id:person-card) makes the
+# concept-of-concepts lookup miss → "Not found / no concept matched".
+```
+
+Omit `view` to fall back to the built-in detail view for the model. A
+`<tonk-display>` with a `model` but no `entity` renders a **directory
+view** — every instance of the model — using the model's
+`view/directory`, or a default carousel.
+
+Share a display: `slide share display <entity> --view <view-name>`
+(or `--model <concept>` for carousel mode).
+
+## `<tonk-concept>` — many rows, live
+
+`<tonk-concept source="<concept>[?k=v...]">` opens a live subscription
+and clones a row template per match. Rows insert/update/remove as the
+branch changes.
+
+```html
+<tonk-concept source="person">
+  <ul>
+    <template>
+      <li>{name} is {age}</li>
+    </template>
+  </ul>
+</tonk-concept>
+```
+
+- `source` is a concept name (`person`) or an entity URI (anything with
+  `:`), plus optional `?key=value` constant filters
+  (`person?name=Alice`).
+- With a `<template>` child, its parent is the row container and the
+  surrounding chrome (`<ul>`, `<tbody>`, …) survives. Without one, each
+  direct child of `<tonk-concept>` is the row template and rows append
+  to the host.
+- `{field}` substitutes in text and attribute values. A field with no
+  value renders empty; unknown `{` has no escape.
+
+## Escape hatch: raw `text/html` views
+
+For a one-off HTML page (no live binding), assert a `text/html` claim
+and serve it through the iframe viewer:
 
 ```yaml
 attribute!: &html-body
-  description: "HTML body of a slide-authored view"
+  description: "HTML body of a one-off page"
   the:         text/html
   as:          text
   cardinality: many
 
-concept!: &view
-  description: "An HTML view, served via the host route"
-  with:
-    body: html-body
-```
+concept!: &page
+  with: { body: html-body }
 
-The non-obvious bit is `the: text/html`. Attribute URIs (the `the:`
-field on `attribute!`) are validated at the dialog layer, which
-accepts any `<domain>/<name>` shape — including MIME-style strings
-like `text/html`. Once that attribute is declared, `view` is a normal
-concept and you write views the way you write any other concept
-assertion.
-
-## You are writing a body fragment, not a full document
-
-A view body is the **inside of `<body>`**, nothing more. The host
-wraps it at serve time with a fixed shell that provides the
-doctype, a `<meta charset>`, and the `<tonk-concept>` runtime script
-that hydrates live data into your templates. Write content, not
-chrome:
-
-```yaml
-view!: &my-task-list
+page!: &about
   body: |
-    <h1>Tasks</h1>
-    <tonk-concept source="task">
-      <ul>
-        <template>
-          <li>{title} — {status}</li>
-        </template>
-      </ul>
-    </tonk-concept>
+    <h1>About</h1>
 ```
 
-Do **not** write `<!doctype>`, `<html>`, `<head>`, `<body>`, or
-`<title>` tags yourself — the host wraps your body in its own
-shell, so writing chrome doubles it up. If you need page-level
-styling, put a `<style>` tag at the top of the body fragment.
+`slide views` lists every entity carrying a `text/html` claim;
+`slide share view <name>` opens it in the iframe viewer. The viewer
+shell does not register `<tonk-display>`, so events won't fire there —
+use `slide share display` for interactive, data-bound views.
 
-The runtime that activates `<tonk-concept>` is provided by the host
-and ships with every served view. You don't import it, link to it,
-or include it — assume it's there.
+---
 
-For interactive views (forms, buttons, custom write flows), wire
-DOM events declaratively with `on<event>=<concept>` attributes and
-let a rule pick up the resulting transient assertion. See the next
-section.
-
-Git-tag semantics apply: re-asserting the same body is idempotent
-(same content → same content-derived entity), a different body
-produces a new entity and re-points the `my-task-list` name. To
-retract every attribute in the projection, query the entity into a
-variable and use `..: _`:
-
-```yaml
-view:
-  this: ?v
-  body: ?body
-
-view!:
-  this: ?v
-  ..:   _
-```
-
-To list views: `slide views`. To share one: `slide share view my-task-list`.
-The listing is claim-driven — it surfaces every entity holding a
-`text/html` claim regardless of which concept (if any) it was asserted
-through — so a non-`view` schema that happens to assert `text/html` still
-shows up.
+For interactivity (clicks, forms) see `slide guide events`. Don't
+memorize built-ins — run `slide schema` / `slide concepts` /
+`slide views` to see what's on the branch.

--- a/rust/slide/src/guide-workspace.md
+++ b/rust/slide/src/guide-workspace.md
@@ -4,15 +4,20 @@
 > reworked. The concepts below are how it works today. Always confirm
 > against `slide schema` rather than relying on this list.
 
-The tonk-ui shell renders a **workspace** (`tonk/space`) as a strip of
+The tonk-ui shell renders a **workspace** (`workspace`) as a strip of
 **sheets** (tabs). Each sheet displays one entity through a model and a
 view.
+
+> Don't confuse `workspace` with `space`. `workspace` (pinned to
+> `tonk:workspace`) is this tab surface, `{name, sheet (many), active}`.
+> `space` is a separate profile-side record the Hub lists joinable
+> repos from, `{name, subject, kind}` — not what you assert here.
 
 ## Concept catalogue
 
 Run `slide schema` for the authoritative shape. At a glance:
 
-- `tonk/space`      — a workspace: `{name, sheet (many), active}`.
+- `workspace`        — a workspace: `{name, sheet (many), active}`.
 - `workspace/sheet` — a tab: `{title, subtitle, icon, order, entity, model, view}`.
 - `artifact`        — the generic "entity shown as a tab" shape sheets build on.
 - `view`, `view/directory` — display templates (see `slide guide views`).
@@ -20,8 +25,10 @@ Run `slide schema` for the authoritative shape. At a glance:
 - `portal`          — a sandboxed-iframe HTML document.
 - `inspector`       — a built-in space-inspector tile.
 - `workspace/create-sheet`, `workspace/activate-sheet`,
-  `workspace/close-sheet`, `workspace/active-sheet` — transient command
-  concepts the tab strip fires (see `slide guide events`).
+  `workspace/close-sheet` — `command!:` transients the tab strip fires
+  (see `slide guide events`).
+- `workspace/active-sheet` — the durable `{active}` projection a rule
+  writes in response to `activate-sheet`.
 
 ## The sheet recipe
 
@@ -56,17 +63,17 @@ See `slide guide views` for the resolution rule in full.
 
 ## Wiring sheets into a workspace
 
-`tonk/space.sheet` is cardinality-many, and the notation has no list
+`workspace.sheet` is cardinality-many, and the notation has no list
 syntax — add each member with its own `this:`-bound assertion. A fresh
 anchored concept assertion must also set every field (or add `..: _`):
 
 ```yaml
-tonk/space!: &lab
+workspace!: &lab
   name:   "Lab"
   active: sheet-alice
   sheet:  sheet-alice     # first member inline so every field is set
 
-tonk/space!:
+workspace!:
   this:  lab              # this: present, so a partial body is fine
   sheet: sheet-bob
 ```

--- a/rust/slide/src/guide-workspace.md
+++ b/rust/slide/src/guide-workspace.md
@@ -1,0 +1,76 @@
+# Building for the tonk-ui workspace
+
+> App-layer and subject to change: the workspace shell is being
+> reworked. The concepts below are how it works today. Always confirm
+> against `slide schema` rather than relying on this list.
+
+The tonk-ui shell renders a **workspace** (`tonk/space`) as a strip of
+**sheets** (tabs). Each sheet displays one entity through a model and a
+view.
+
+## Concept catalogue
+
+Run `slide schema` for the authoritative shape. At a glance:
+
+- `tonk/space`      — a workspace: `{name, sheet (many), active}`.
+- `workspace/sheet` — a tab: `{title, subtitle, icon, order, entity, model, view}`.
+- `artifact`        — the generic "entity shown as a tab" shape sheets build on.
+- `view`, `view/directory` — display templates (see `slide guide views`).
+- `board`, `column-view`, `tile` — the kanban-style board layout.
+- `portal`          — a sandboxed-iframe HTML document.
+- `inspector`       — a built-in space-inspector tile.
+- `workspace/create-sheet`, `workspace/activate-sheet`,
+  `workspace/close-sheet`, `workspace/active-sheet` — transient command
+  concepts the tab strip fires (see `slide guide events`).
+
+## The sheet recipe
+
+A sheet points at the entity to show, the entity's model concept, and
+the **view concept** to resolve a template through:
+
+```yaml
+workspace/sheet!: &sheet-alice
+  title:    "Alice"
+  subtitle: "person"
+  icon:     "user"
+  order:    "a"
+  entity:   alice        # the entity to display
+  model:    person       # its concept
+  view:     tonk:view    # the VIEW CONCEPT, not a specific view
+```
+
+`view: tonk:view` is the part agents get wrong. The sheet's `view`
+field is the *view concept*; `<tonk-display>` then runs a
+model-constrained query to pick the actual view instance whose `model`
+matches. So author the view instance with a `model`, and let the sheet
+reference the concept:
+
+```yaml
+view!: &person-card        # the instance, selected by its model
+  model: person
+  display: !text/html |
+    <article><h2>{name}</h2><p>{age}</p></article>
+```
+
+See `slide guide views` for the resolution rule in full.
+
+## Wiring sheets into a workspace
+
+`tonk/space.sheet` is cardinality-many, and the notation has no list
+syntax — add each member with its own `this:`-bound assertion. A fresh
+anchored concept assertion must also set every field (or add `..: _`):
+
+```yaml
+tonk/space!: &lab
+  name:   "Lab"
+  active: sheet-alice
+  sheet:  sheet-alice     # first member inline so every field is set
+
+tonk/space!:
+  this:  lab              # this: present, so a partial body is fine
+  sheet: sheet-bob
+```
+
+Open it in the shell: push, then
+`slide share display <workspace-entity>` (carousel of its sheets) or
+`slide share display alice --view person-card` for one sheet.

--- a/rust/slide/src/guide.rs
+++ b/rust/slide/src/guide.rs
@@ -1,40 +1,88 @@
-//! `slide guide` — the agent's one-shot reference, baked into
-//! the binary so a sandbox without repo access can still
-//! discover the syntax by running one command. Three sections
-//! glued together at compile time:
+//! `slide guide` — the agent's reference, baked into the binary so a
+//! sandbox without repo access can still learn the syntax. Served as
+//! discrete topics instead of one dump: `slide guide` prints a short
+//! index, `slide guide <topic>` prints one section, `slide guide all`
+//! prints everything.
 //!
-//! 1. `tonk-notation/guide.md` — the canonical notation
-//!    reference (parsed by the worker too; same syntax slide
-//!    consumes).
-//! 2. `slide/src/guide-views.md` — slide-specific addendum
-//!    covering the view convention that `slide share view`
-//!    relies on. Kept out of the upstream notation guide so the
-//!    notation reference stays a clean syntax doc.
-//! 3. `slide/src/guide-views-dynamic.md` — companion to the views
-//!    addendum that documents the declarative reactivity surface:
-//!    `on<event>=<concept>` template attributes, the `dom.event`
-//!    namespace transient concepts read from, and `rule!:` heads
-//!    that turn those transients into downstream state.
-//! 4. `tonk-concept/SPEC.md` — the `<tonk-concept>` custom
-//!    element reference: source-attribute grammar, template
-//!    detection, `{field}` substitution. Relevant whenever an
-//!    agent authors an HTML view body that embeds a live
-//!    concept; the slide-side write/share machinery doesn't
-//!    care about it, but the agent does.
-//!
-//! `include_str!` resolves at compile time relative to the
-//! source file. Paths follow the workspace layout from
-//! `rust/slide/src/guide.rs`. `concat!` is happy to glue
-//! `include_str!` outputs because both expand to string
-//! literals at compile time.
+//! `tonk-notation/guide.md` is the canonical notation reference (the
+//! worker parses the same syntax) and is shared, not forked. The other
+//! topic files live beside this module. `include_str!` resolves at
+//! compile time relative to `rust/slide/src/guide.rs`.
 
-/// The full bundled guide.
+/// The one-screen index printed by a bare `slide guide`.
+pub const INDEX: &str = include_str!("guide-index.md");
+
+/// Asserted-notation syntax reference (`slide guide notation`).
+pub const NOTATION: &str = include_str!("../../tonk-notation/guide.md");
+
+/// Display templates and view resolution (`slide guide views`).
+pub const VIEWS: &str = include_str!("guide-views.md");
+
+/// Effects, rules, transients, DOM-event reactivity (`slide guide events`).
+pub const EVENTS: &str = include_str!("guide-events.md");
+
+/// tonk-workspace authoring model (`slide guide workspace`; app-layer).
+pub const WORKSPACE: &str = include_str!("guide-workspace.md");
+
+/// Valid topic names for `slide guide <topic>`, in display order.
+pub const TOPICS: &[&str] = &["notation", "views", "events", "workspace"];
+
+/// The full guide: every topic concatenated. Backs `slide guide all`.
+/// `concat!` needs literal `include_str!` calls, so the paths are
+/// repeated here rather than reusing the per-topic constants.
 pub const GUIDE: &str = concat!(
     include_str!("../../tonk-notation/guide.md"),
     "\n",
     include_str!("guide-views.md"),
     "\n",
-    include_str!("guide-views-dynamic.md"),
+    include_str!("guide-events.md"),
     "\n",
-    include_str!("../../tonk-concept/SPEC.md"),
+    include_str!("guide-workspace.md"),
 );
+
+/// The body for a single named topic, or `None` if `name` isn't a
+/// recognized topic.
+pub fn topic(name: &str) -> Option<&'static str> {
+    match name {
+        "notation" => Some(NOTATION),
+        "views" => Some(VIEWS),
+        "events" => Some(EVENTS),
+        "workspace" => Some(WORKSPACE),
+        _ => None,
+    }
+}
+
+/// Resolve a `slide guide [TOPIC]` argument to the text to print.
+///
+/// - `None` → the [`INDEX`].
+/// - `Some("all")` → the full [`GUIDE`].
+/// - `Some(topic)` → that topic's body.
+/// - `Some(unknown)` → `Err` naming the valid topics.
+pub fn resolve(arg: Option<&str>) -> Result<&'static str, GuideError> {
+    match arg {
+        None => Ok(INDEX),
+        Some("all") => Ok(GUIDE),
+        Some(name) => topic(name).ok_or_else(|| GuideError::UnknownTopic(name.to_owned())),
+    }
+}
+
+/// Why [`resolve`] couldn't map a topic argument to guide text.
+#[derive(Debug)]
+pub enum GuideError {
+    /// The argument was neither `all` nor a known topic.
+    UnknownTopic(String),
+}
+
+impl std::fmt::Display for GuideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownTopic(name) => write!(
+                f,
+                "unknown guide topic '{name}'; valid topics: {}, all",
+                TOPICS.join(", "),
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GuideError {}

--- a/rust/slide/tests/notation.rs
+++ b/rust/slide/tests/notation.rs
@@ -302,14 +302,38 @@ mod when_introspecting_the_schema {
     }
 }
 
-mod when_bundling_the_notation_guide {
+mod when_serving_the_guide {
     use slide::guide;
 
     #[dialog_common::test]
-    fn it_bakes_the_guide_into_the_binary() {
-        // `include_str!` resolves at compile time, so the binary
-        // works in sandboxes without source-tree access.
-        assert!(guide::GUIDE.starts_with("# Asserted-notation guide"));
-        assert!(guide::GUIDE.contains("attribute!"));
+    fn it_returns_the_index_for_no_topic() {
+        let text = guide::resolve(None).expect("index resolves");
+        assert!(text.contains("slide guide notation"));
+    }
+
+    #[dialog_common::test]
+    fn it_returns_each_topic_body() {
+        assert!(guide::topic("notation").unwrap().contains("attribute!"));
+        assert!(guide::topic("views").unwrap().contains("tonk:view"));
+        assert!(guide::topic("events").unwrap().contains("rule!"));
+        assert!(
+            guide::topic("workspace")
+                .unwrap()
+                .contains("view: tonk:view")
+        );
+        assert!(guide::topic("bogus").is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_returns_the_full_guide_for_all() {
+        let all = guide::resolve(Some("all")).expect("all resolves");
+        assert!(all.starts_with("# Asserted-notation guide"));
+        assert_eq!(all, guide::GUIDE);
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_an_unknown_topic() {
+        let err = guide::resolve(Some("nope")).expect_err("unknown rejects");
+        assert!(err.to_string().contains("notation"));
     }
 }

--- a/rust/slide/tests/notation.rs
+++ b/rust/slide/tests/notation.rs
@@ -332,8 +332,41 @@ mod when_serving_the_guide {
     }
 
     #[dialog_common::test]
+    fn it_concatenates_the_per_topic_bodies_into_the_full_guide() {
+        // `GUIDE` repeats the `include_str!` paths literally (concat!
+        // needs them), so it can silently drift from the per-topic
+        // consts. Pin it to the concatenation so a renamed/moved topic
+        // file updated in only one place fails here.
+        let expected = format!(
+            "{}\n{}\n{}\n{}",
+            guide::NOTATION,
+            guide::VIEWS,
+            guide::EVENTS,
+            guide::WORKSPACE,
+        );
+        assert_eq!(guide::GUIDE, expected);
+    }
+
+    #[dialog_common::test]
+    fn it_resolves_every_advertised_topic() {
+        // `TOPICS`, the `topic()` match arms, and the unknown-topic
+        // error message are three hand-synced lists. Drive the test
+        // off `TOPICS` so a name advertised there but missing a match
+        // arm (or vice versa) is caught.
+        for name in guide::TOPICS {
+            let body =
+                guide::topic(name).unwrap_or_else(|| panic!("advertised topic {name} has no body"));
+            assert!(!body.is_empty(), "topic {name} is empty");
+            assert_eq!(guide::resolve(Some(name)).expect("topic resolves"), body);
+        }
+    }
+
+    #[dialog_common::test]
     fn it_errors_on_an_unknown_topic() {
         let err = guide::resolve(Some("nope")).expect_err("unknown rejects");
-        assert!(err.to_string().contains("notation"));
+        let message = err.to_string();
+        assert!(message.contains("nope"), "echoes the bad input");
+        assert!(message.contains("notation"), "lists a valid topic");
+        assert!(message.contains("all"), "advertises the `all` pseudo-topic");
     }
 }

--- a/rust/tonk-notation/guide.md
+++ b/rust/tonk-notation/guide.md
@@ -7,9 +7,9 @@ retraction. The worker's `/evaluate` route runs a whole
 document in one transaction, returning matches and a commit
 summary.
 
-This guide builds up examples that you can paste into the
-editor in order — each one runs against the branch the previous
-ones left behind.
+The examples below can be pasted into the editor and evaluated
+against a branch; the worked example near the top runs against an
+empty branch.
 
 ## Two flavours of expression
 
@@ -71,50 +71,9 @@ URIs come in several schemes:
 
 All of these are direct references and require no resolution.
 
-## Worked tutorial
+## A worked example
 
-The shortest path from "empty branch" to "you can read and
-write your own data." Run the snippets in order.
-
-### 1. Define an attribute
-
-`attribute!` is the built-in concept for declaring an attribute.
-The body says where the attribute lives (`the:`), what kind of
-value it carries (`as:`), and how many values per entity
-(`cardinality:`). The `&person-name` anchor publishes the
-resulting attribute entity under the name `person-name`, so
-future revisions can reference it by that bare symbol.
-
-```yaml
-attribute!: &person-name
-  description: "The person's name"
-  the:         xyz.tonk.person/name
-  as:          text
-  cardinality: one
-```
-
-After the commit, the URI `id:person-name` is an entity pointing
-to the new attribute entity. The bare symbol `person-name`,
-when resolves to the attribute entity itself.
-
-### 2. Define more attributes
-
-Each `attribute!` concept produces one attribute entity. You can
-have many in one document; they all commit in one transaction.
-
-```yaml
-attribute!: &person-age
-  description: The person's age in years
-  the:         xyz.tonk.person/age
-  as:          unsigned-integer
-  cardinality: one
-```
-
-### 3. Define a concept
-
-`concept!` composes attributes into a named shape. Its `with:`
-block maps field names to attributes. References are written
-as bare symbols, which resolve through the name table.
+Define attributes, compose a concept, assert an entity, query it:
 
 ```yaml
 attribute!: &person-name
@@ -123,175 +82,24 @@ attribute!: &person-name
   as:          text
   cardinality: one
 
-attribute!: &person-age
-  description: The person's age
-  the:         xyz.tonk.person/age
-  as:          unsigned-integer
-  cardinality: one
-
 concept!: &person
-  description: "A person"
+  description: A person
   with:
     name: person-name
-    age:  person-age
-```
 
-The bare symbols `person-name` and `person-age` in the `with:`
-block resolve against the names published earlier or in the same
-document.
-
-### 4. Add a person
-
-`person!:` is asserts the `person` concept. Use `&maintainer` to name the resulting entity `maintainer`:
-
-```yaml
-person!: &maintainer
-  name: Alice
-  age:  28
-```
-
-The semantics:
-
-- The entity is derived from the asserted payload
-  (`Entity::of(&{name: "Alice", age: 28})`).
-- Derived entity gets associated with `id:alice`.
-- Re-running the same body is a no-op.
-- Re-running with a *different* body produces a different
-  entity and associates `id:alice` to the new one. The previous
-  entity still exists with its claims; but the name
-  no longer resolves to it.
-
-### 5. Read it back
-
-Anonymous query — `person:` matches every entity satisfying
-the `person` concept's schema and surfaces every field:
-
-```yaml
-person:
-```
-
-Constrain the match by giving fields literal values:
-
-```yaml
-person:
-  name: Alice
-```
-
-Bind the matched entity to a variable using `this:`, and captures it under a
-variable so it could be used in other expressions.
-
-```yaml
-person:
-  this: ?p
-  name: Alice
-  age:  ?age
-```
-
-`?p` and `?age` come back in the result frame.
-
-### 6. Update Maintainer
-
-Two distinct operations, syntactically different.
-
-**Re-point the name** to a new entity (same name, different
-target). Reuse the anchor with a different body:
-
-```yaml
-person!: &maintainer
-  name: Bob
-  age:  40
-```
-
-This produces a *new* entity (different body hash). The name
-`id:maintainer` is re-pointed to it.
-
-**Update the same entity**. Use a query to bind the entity to
-a variable, then assert against the variable:
-
-```yaml
-person:
-  this: ?alice
-  name: Alice
-
-person!:
-  this: ?alice
-  age:  29
-```
-
-The query binds `?alice` to every entity currently named
-"Alice" in the `person` concept. The assertion writes
-`age = 30` on each match. Because `xyz.tonk.person/age` is
-`cardinality: one`, the prior age claim is auto-retracted as
-part of the transaction.
-
-### 7. Retract Alice's whole projection
-
-Retraction always happens inside an assertion body, against an
-entity selected via `this:`. The blank value `_` does the work.
-Two shapes cover all cases:
-
-- `field: _` — retract just that one attribute.
-- `..: _` — retract every attribute in the concept's `with:` map
-  that isn't named explicitly elsewhere in the body.
-
-To retract a single field:
-
-```yaml
-person!:
-  this: ?alice
-  age: _
-```
-
-To retract every attribute in the concept (full concept-level
-retraction), combine `..: _` with a query that binds the entity:
-
-```yaml
-person:
-  this: ?alice
+person!: &alice
   name: "Alice"
 
-person!:
-  this: ?alice
-  ..: _
+person:
+  this: ?p
+  name: "Alice"
 ```
 
-The worker queries the branch for every fact whose attribute is
-in the `person` concept's `with:` map and whose subject is the
-matched `?alice` entity, and dissociates each match.
-
-To retract every attribute *except* the ones you specify,
-combine explicit fields with `..: _`:
-
-```yaml
-person!:
-  this: ?alice
-  name: ?name
-  ..: _
-```
-
-This preserves `name` and retracts every other attribute in the
-concept's `with:` map.
-
-You can name the entity directly without a prior query — by URI:
-
-```yaml
-person!:
-  this: did:key:zHjKf…
-  ..: _
-```
-
-Or by name:
-
-```yaml
-person!:
-  this: alice
-  ..: _
-```
-
-Retraction by name follows the name's current redirection. If
-`id:alice` was re-pointed since the data was written, the
-retraction targets the entity it currently points to, not the
-original.
+`&alice` publishes `id:alice`. Re-asserting the same body is a no-op;
+a different body mints a new entity and re-points the name. To update
+the same entity, bind it with a query and assert against the variable
+(`this: ?p`). To retract, assert `field: _` (one attribute) or
+`..: _` (every attribute in the concept's `with:` map).
 
 ## Symbols and strings
 
@@ -798,14 +606,3 @@ name:
 In practice you rarely write `name!` directly; the `&`
 anchor sugar covers most uses.
 
-## Why the parser is permissive
-
-The parser produces diagnostics as it goes and continues past
-recoverable errors so the editor can show every problem in
-one pass. A document with three malformed expressions
-surfaces three diagnostics, not one.
-
-This means `parse(code).syntax` can be `Some(..)` *with* a
-non-empty `diagnostics` list — partial trees are
-intentional, and the analyzer in `tonk-schema` will refuse to
-build an `Analysis` from a tree that has any errors.


### PR DESCRIPTION
## Summary

Reworks slide's agent-facing documentation around agent-CLI ergonomics. The headline change: slide guide no longer dumps the entire ~1450-line reference in one shot — a bare invocation now prints a 34-line index, and agents pull individual topics on demand. Also adds --help examples across the CLI, removes obsolete guidance, fixes a documented-but-wrong view-resolution rule, and trims the notation reference.

Motivated by treating slide as a tool agents drive: discover what you need, don't pay context for what you don't.

## What changed

Topic-addressable slide guide (guide.rs, bin/slide.rs)
- slide guide → one-screen index (what slide is, the read→write loop, the schema/concepts/views discovery commands, the topic list).
- slide guide <notation|views|events|workspace> → one section.
- slide guide all → the full concatenation (back-compat).
- Unknown topic fails fast: error naming the valid topics, exit code 4.
- New guide::resolve/topic/TOPICS/INDEX; tonk-notation/guide.md stays the shared notation source (not forked).

--help examples everywhere (bin/slide.rs)
- Every subcommand (and the top-level) gains a clap after_help Examples: block — the thing agents pattern-match off. None were present before.

### Docs corrected and modernized
- views topic rewritten around the current <tonk-display> model, including the resolution rule that's easy to get wrong: a sheet/host's view: is a view concept (tonk:view), and the actual view instance is selected by a model-constrained query.
- events topic: dropped the obsolete globalThis.tonk/<script>-bridge history; fixed a --model/--view contradiction and a dom.event.target → current-target footgun in the retract example.
- workspace topic (new, light): the sheet recipe and the cardinality-many / partial-assert pitfalls, flagged app-layer and subject to change.
- notation topic trimmed 811→608 lines (replaced the seven-step worked tutorial with one compact example; dropped the parser-internals aside) with no change to syntax semantics.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `slide` CLI documentation and functionality by adding detailed guides on various topics, updating tests, and restructuring code related to guide retrieval and error handling.

### Detailed summary
- Added a new section on `guide-index.md` explaining the `slide` CLI and its commands.
- Renamed the test module from `when_bundling_the_notation_guide` to `when_serving_the_guide`.
- Updated tests to cover guide resolution and topic retrieval.
- Improved error handling for unknown topics in `guide.rs`.
- Revised content in `guide-workspace.md` and `guide-views.md` for clarity and completeness.
- Introduced a new command structure in the `slide` CLI for better help text and examples.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->