### PR TITLE
feat(workspace): replica binder model for sheet selection

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -3809,6 +3809,71 @@ person!:
         );
     }
 
+    /// A field a rule premise omits — or writes as a blank (`_`) —
+    /// lifts to a true `Term::blank()` wildcard, not a named
+    /// anonymous variable. This matters for `unless:` premises:
+    /// negations never bind variables, so the planner treats a named
+    /// variable in a negation as a required-but-unbound binding and
+    /// rejects the rule with `RequiredBindings`. A blank is skipped
+    /// as a wildcard, so the rule compiles.
+    ///
+    /// Regression: a `unless: tonk/binder { this: ?this }` premise
+    /// against a `tonk/binder` concept with an extra `active` field
+    /// (left unmentioned) failed to compile because the omitted
+    /// `active` became `__N`.
+    #[dialog_common::test]
+    async fn it_compiles_a_negation_premise_omitting_a_concept_field() {
+        let specs = [
+            fixed_concept_typed("replica", &[("subject", "dialog.origin/subject", "Entity")]),
+            fixed_concept_typed("binder", &[("active", "xyz.tonk.binder/active", "Entity")]),
+        ];
+
+        // The head `binder`'s `this` is bound by the positive
+        // `replica` premise, `active` by the `==`. The `unless`
+        // negation reads only `this`; its omitted `active` field must
+        // lift to a blank wildcard, not a `__N` variable the planner
+        // would demand be bound.
+        let omitted = must_parse(
+            r#"
+rule!:
+  assert!: binder
+  when:
+    - assert: replica
+      where: { this: ?this }
+    - assert: ==
+      where: { this: ?active, is: about:blank }
+  unless:
+    - assert: binder
+      where: { this: ?this }
+"#,
+        );
+        assert!(
+            analyze_with_concepts(&omitted, &specs).await.is_ok(),
+            "a negation premise omitting a concept field should compile",
+        );
+
+        // Same rule, but `unless` writes `active` as an explicit
+        // blank (`_`) rather than omitting it.
+        let blanked = must_parse(
+            r#"
+rule!:
+  assert!: binder
+  when:
+    - assert: replica
+      where: { this: ?this }
+    - assert: ==
+      where: { this: ?active, is: about:blank }
+  unless:
+    - assert: binder
+      where: { this: ?this, active: _ }
+"#,
+        );
+        assert!(
+            analyze_with_concepts(&blanked, &specs).await.is_ok(),
+            "a negation premise with an explicit `_` field should compile",
+        );
+    }
+
     /// `transient_entities()` returns exactly the concept
     /// entities asserted against a `transient:` concept — the
     /// durable concept's entity is absent.

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -580,15 +580,23 @@ fn lift_premise(
         terms.insert("this".into(), Term::<dialog_query::Any>::unique());
     }
 
-    // Per-field bindings declared by the user. Fields not
-    // mentioned default to anonymous variables (consistent with
-    // how `Query` bodies project unmentioned fields).
+    // Per-field bindings declared by the user. A field the user
+    // omits, or writes as a blank (`_`), becomes a true
+    // `Term::blank()` wildcard: a premise has no result block to
+    // project a value into, so the query-side `_`-renders-back
+    // substitution (which mints a named `__N` variable) does not
+    // apply here. A named variable in a negation premise would be
+    // treated as a required-but-unbound binding by the planner and
+    // fail to compile; a blank is skipped as a wildcard.
     for (field_name, attr) in descriptor.with().iter() {
         if field_name == "this" {
             continue;
         }
         let user_binding = premise.bindings.iter().find(|f| f.name == *field_name);
         let term = match user_binding {
+            Some(field) if matches!(field.value, FieldValue::Blank) => {
+                Term::<dialog_query::Any>::blank()
+            }
             Some(field) => field_value_to_term(
                 field_name,
                 &field.value,
@@ -597,7 +605,7 @@ fn lift_premise(
                 analysis,
                 attr.content_type(),
             )?,
-            None => Term::<dialog_query::Any>::unique(),
+            None => Term::<dialog_query::Any>::blank(),
         };
         terms.insert(field_name.to_string(), term);
     }

--- a/rust/tonk-concept/src/template.rs
+++ b/rust/tonk-concept/src/template.rs
@@ -228,6 +228,16 @@ pub fn longest_common_path_prefix(paths: &[Vec<usize>]) -> Vec<usize> {
 /// binds `{this}` becomes the per-conclusion *repeat root* (so
 /// surrounding chrome renders once); that is discovered separately.
 /// See `tonk-core/docs/templates.md`.
+///
+/// `{dom.host/*}` references are excluded too: they copy a scalar
+/// attribute off the *outer* host element (e.g.
+/// `active={dom.host/data-active}`), they are not subject fields with
+/// a cardinality. Without this exclusion a host-attribute reference
+/// would make its element an iteration root, so an absent host
+/// attribute (zero values) would clone the element zero times and
+/// drop it entirely — `<tonk-sheet-binder active={dom.host/data-active}>`
+/// vanished when the host carried no `data-active`. The same exclusion
+/// already governs repeat-node resolution (see [`refers_subject`]).
 pub fn binding_fields(binding: &Binding) -> Vec<String> {
     let segments = match &binding.kind {
         BindingKind::Text { segments } => segments,
@@ -237,6 +247,7 @@ pub fn binding_fields(binding: &Binding) -> Vec<String> {
     for seg in segments {
         if let Segment::Field(name) = seg
             && name != "this"
+            && !is_dom_host_field(name)
             && !out.contains(name)
         {
             out.push(name.clone());
@@ -1048,6 +1059,7 @@ mod dom {
         let BindingKind::Attribute {
             attr_name,
             force_attribute,
+            segments,
             ..
         } = &binding.kind
         else {
@@ -1060,8 +1072,27 @@ mod dom {
             return;
         };
 
+        // A lone `{field}` binding (not `this`) whose field is absent
+        // resolves to no value: omit the attribute entirely rather than
+        // setting it to the empty string. `active={dom.host/data-active}`
+        // with no `data-active` on the host must leave `<tonk-sheet-binder>`
+        // with no `active` attribute at all, not `active=""` — the latter
+        // is a real "" selection, not "unset". A present-but-empty value
+        // still writes `""`; only a missing field clears the attribute.
+        let absent_single_field = single_field_value.is_none()
+            && matches!(segments.as_slice(), [Segment::Field(name)] if name != "this");
+
         if *force_attribute {
-            write_forced_attribute(el, attr_name, rendered, single_field_value);
+            if absent_single_field {
+                let _ = el.remove_attribute(attr_name);
+            } else {
+                write_forced_attribute(el, attr_name, rendered, single_field_value);
+            }
+            return;
+        }
+
+        if absent_single_field {
+            let _ = el.remove_attribute(attr_name);
             return;
         }
 
@@ -1420,6 +1451,22 @@ mod tests {
                 }
             }
             other => panic!("expected single Iteration, got {other:?}"),
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_make_a_dom_host_attribute_an_iteration_root() {
+        // `<tonk-sheet-binder active={dom.host/data-active}>` — an
+        // attribute that copies a scalar off the outer host, not a
+        // subject field. It must stay a flat `Binding`, never an
+        // `Iteration`: otherwise an absent `data-active` (zero values)
+        // would clone the element zero times and drop it entirely.
+        let nodes = build_plan_nodes(vec![attr_binding(&[0], "active", "dom.host/data-active")]);
+        match &nodes[..] {
+            [PlanNode::Binding(b)] => {
+                assert_eq!(b.path, vec![0]);
+            }
+            other => panic!("expected a single flat Binding, got {other:?}"),
         }
     }
 

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -132,32 +132,6 @@ concept!: &empty-artifact
       cardinality: one
       as: text
 
-# The `workspace` concept: the UI surface below the header. It owns
-# its sheets (cardinality-many). Pinned to `tonk:workspace` so the
-# shell can query a workspace by a stable concept entity.
-concept!: &workspace
-  this: tonk:workspace
-  description: A workspace surface - a named set of sheets shown as tabs.
-  with:
-    name:
-      description: Workspace name, shown in the header
-      the: xyz.tonk.workspace/name
-      cardinality: one
-      as: text
-    sheet:
-      description: The sheets (tabs) in this workspace
-      the: xyz.tonk.workspace/sheet
-      cardinality: many
-      as: entity
-    active:
-      description: |
-        The currently selected sheet, shown in the canvas. Cardinality
-        one, so re-asserting it replaces the previous selection - a
-        single moving pointer driven by the `activate-sheet` command.
-      the: xyz.tonk.workspace/active
-      cardinality: one
-      as: entity
-
 # The `sheet` concept: one tab in a workspace. A sheet is an
 # artifact (same title/icon/entity/model/view fields, same attribute
 # URIs) plus an `order` lexicographic key that positions the tab. So
@@ -204,49 +178,18 @@ concept!: &workspace/sheet
       as: text
 
 # Tab selection. Clicking a tab fires the transient `activate-sheet`
-# command, reading which sheet was clicked from the bound element's
-# `data-sheet`. The inductive rule below finds the workspace that owns
-# that sheet and points its cardinality-one `active` field at the
-# clicked sheet (replacing the prior selection). The command itself is
-# swept after the cycle - only the `active` pointer persists.
+# command, reading which sheet was clicked from the binder's `activate`
+# event detail. The inductive rule below points the binder's
+# cardinality-one `active` field at the clicked sheet (replacing the
+# prior selection). The command itself is swept after the cycle - only
+# the `active` pointer persists.
 command!: &workspace/activate-sheet
-  description: A request to make `sheet` the active sheet of its workspace.
+  description: A request to make `sheet` the active sheet of the binder.
   with:
     sheet:
       description: The sheet to activate, from the binder's `activate` event detail
       the: dom.event.detail/sheet
       as: entity
-
-# A minimal projection of the workspace's `active` pointer: the
-# workspace entity (`this`) and its `active` sheet, on the same
-# `xyz.tonk.workspace/active` attribute the `workspace` concept reads.
-# The rule asserts THIS (binding only `this` + `active`), rather than
-# re-asserting the whole `workspace` concept (which would force
-# binding every field). Writing `active` here updates the same triple
-# the workspace view sees.
-concept!: &workspace/active-sheet
-  description: The active-sheet pointer of a workspace, as a standalone fact.
-  with:
-    active:
-      description: The selected sheet
-      the: xyz.tonk.workspace/active
-      cardinality: one
-      as: entity
-
-# The inductive rule: when an `activate-sheet` command fires, find the
-# workspace that owns the clicked sheet and point its `active` field at
-# that sheet. Binding `?this` through the `workspace` membership means
-# the command needs only the sheet - no workspace id plumbed through
-# the DOM. The command is transient (satisfies the install-time
-# trigger gate, swept after commit); only the `active` pointer
-# persists.
-rule!:
-  assert!: workspace/active-sheet
-  when:
-    - assert: workspace/activate-sheet
-      where: { sheet: ?active }
-    - assert: workspace
-      where: { this: ?this, sheet: ?active }
 
 # The Enable-sync command. Submitting the topbar's "Enable sync" form
 # asserts this transient command; the worker's `CreateSpaceHandler`
@@ -279,10 +222,11 @@ command!: &space/enable-sync
 # `close-sheet` command. `sheet` is the closed sheet; `next` is the
 # neighbour the binder picked (by tab order) to fall back to when the
 # closed sheet was the active one. The two rules below (a) retract the
-# workspace -> sheet membership so the tab disappears, and (b) move the
-# `active` pointer to `next` if the closed sheet was active.
+# sheet's `order` so it no longer matches the sheet directory (the tab
+# disappears; the underlying artifact survives), and (b) move the
+# binder's `active` to `next` if the closed sheet was active.
 command!: &workspace/close-sheet
-  description: A request to remove `sheet` from its workspace.
+  description: A request to close `sheet`, demoting it back to a plain artifact.
   with:
     sheet:
       description: |
@@ -299,337 +243,49 @@ command!: &workspace/close-sheet
       the: dom.event.detail/next
       as: entity
 
-# A minimal projection of one workspace -> sheet membership triple:
-# the workspace (`this`) and one of its `sheet` members, on the same
-# `xyz.tonk.workspace/sheet` attribute the `workspace` concept reads.
-# A `retract!:` rule over this dissociates exactly that one membership
-# (binding only `this` + `sheet`), rather than re-asserting the whole
-# `workspace` concept.
-concept!: &workspace/sheet-member
-  description: One workspace -> sheet membership, as a standalone fact.
+# A minimal projection of a sheet's `order` key - the one field a
+# `tonk:sheet` carries over a plain `artifact`. A `retract!:` rule over
+# this dissociates exactly the `order` triple, rather than re-asserting
+# the whole `tonk:sheet` (which would force binding every field).
+concept!: &workspace/sheet-order
+  description: A sheet's order key, as a standalone fact.
   with:
-    sheet:
-      description: A sheet that is a member of this workspace
-      the: xyz.tonk.workspace/sheet
-      cardinality: many
-      as: entity
+    order:
+      description: Lexicographic order key positioning the tab
+      the: xyz.tonk.sheet/order
+      cardinality: one
+      as: text
 
-# Retract the membership: when `close-sheet` fires, find the workspace
-# owning the closed sheet and dissociate that one `sheet` triple. The
-# sheet's own facts (title/entity/...) persist - only its workspace
-# membership is removed, so it could be re-added later.
+# Retract the order: when `close-sheet` fires, drop the closed sheet's
+# `order` triple. The sheet's artifact facts (title/entity/model/...)
+# persist - only the `order` that made it a `tonk:sheet` is removed, so
+# the directory query (which requires `order`) no longer matches it and
+# the tab disappears. The artifact could be re-promoted to a sheet
+# later by re-asserting an `order`.
 rule!:
-  description: Removes a sheet from its workspace when closed
-  retract!: workspace/sheet-member
+  description: Demotes a closed sheet back to a plain artifact
+  retract!: workspace/sheet-order
   when:
     - assert: workspace/close-sheet
-      where: { sheet: ?sheet }
-    - assert: workspace
-      where: { this: ?this, sheet: ?sheet }
+      where: { sheet: ?this }
+    - assert: workspace/sheet-order
+      where: { this: ?this, order: ?order }
 
-# Reassign active: when the closed sheet was the workspace's active
-# one, point `active` at the neighbour the binder supplied. Both the
-# closed sheet (`active: ?sheet`) and the neighbour (`sheet: ?active`)
-# are joined through the workspace's own membership, mirroring the
-# `activate-sheet` rule above - the new `active` is a sheet the
-# workspace actually owns, not just a value carried on the command.
-# The `active: ?sheet` join gates this to the active-sheet case;
-# closing a non-active sheet leaves `active` untouched (no match).
+# Reassign active: when the closed sheet was the binder's active one,
+# point `active` at the neighbour the binder supplied. The binder is
+# the replica's (bound through `tonk/replica`); the `active: ?sheet`
+# join gates this to the active-sheet case, so closing a non-active
+# sheet leaves `active` untouched (no match).
 rule!:
-  description: Moves the active pointer to the neighbour when the active sheet closes
-  assert!: workspace/active-sheet
+  description: Moves the binder's active pointer to the neighbour when the active sheet closes
+  assert!: tonk/binder
   when:
     - assert: workspace/close-sheet
       where: { sheet: ?sheet, next: ?active }
-    - assert: workspace
-      where: { this: ?this, active: ?sheet, sheet: ?active }
-
-# The workspace view: a top bar over a `<tonk-sheet-binder>`, matching
-# the wireframe's Layout F. The binder takes the workspace's `{sheet}`
-# members (each mounted through its sheet-mount view as a
-# `<tonk-sheet>`), projects the bottom tab strip from them, and shows
-# the `active` sheet's panel. Clicking a tab fires `activate-sheet`,
-# which re-points `active`.
-view!: &workspace/view
-  this: id:tonk-workspace/workspace-view
-  model: workspace
-  display: |
-    <div class="workspace">
-      <style>
-        /* Styling uses the app's Web Awesome design tokens (--wa-*)
-           rather than hardcoded colours, so the viewer follows the
-           active theme and light/dark automatically. */
-        .workspace {
-          display: flex;
-          flex-direction: column;
-          /* Content-driven by default: as a board tile the workspace
-             takes only the space it needs. When it is the page's own
-             view, the route gives the view root a viewport-min height
-             (see the `.display-route` rule in the app stylesheet), so
-             the tab strip pins to the bottom there. */
-          font-family: var(--wa-font-family-body);
-          color: var(--wa-color-text-normal);
-          /* Transparent so the page's dot-grid paper shows through
-             (matching the wireframe). */
-          background: transparent;
-        }
-        /* The binder fills the space below the top bar: the active sheet
-           panel fills the rest, the projected tab strip pins to the
-           bottom. */
-        .workspace__binder {
-          display: flex;
-          flex-direction: column;
-          flex: 1;
-          min-height: 0;
-        }
-
-        /* The view mounts each sheet through a `<tonk-display>` wrapper;
-           those wrappers are the binder's flex children (the panels).
-           The active panel FILLS the available height; the rest
-           collapse (their inner <tonk-sheet> is `hidden`). Scrolling
-           happens inside the sheet's card. */
-        .workspace__binder > tonk-display {
-          flex: 1;
-          min-height: 0;
-          padding: var(--wa-space-l);
-          box-sizing: border-box;
-          order: 1;
-        }
-        .workspace__binder > tonk-display:not(:has(tonk-sheet:not([hidden]))) {
-          display: none;
-        }
-        .workspace__binder > tonk-display > tonk-view {
-          display: block;
-          height: 100%;
-          min-height: 0;
-        }
-
-        /* The sheet card: a header strip the sheet projects from its
-           attributes, over the sheet's content. Transparent body so the
-           page's dot-grid shows through; bordered frame. */
-        .workspace__binder tonk-sheet {
-          display: flex;
-          flex-direction: column;
-          height: 100%;
-          min-height: 0;
-          color: inherit;
-          font-family: inherit;
-          border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-          background: transparent;
-          overflow: hidden;
-        }
-        /* The card body: everything after the projected header. The
-           sheet's content <tonk-display> is the last child; it scrolls. */
-        .workspace__binder tonk-sheet > tonk-display {
-          flex: 1;
-          min-height: 0;
-          overflow: auto;
-        }
-        .workspace__binder tonk-sheet > tonk-display > tonk-view {
-          display: block;
-          min-height: 100%;
-        }
-        /* A portal sheet: `<tonk-portal>`'s iframe has no intrinsic
-           content height, so a plain block would collapse it to the
-           iframe's default 150px. Make the portal's `tonk-view` a flex
-           column and let the portal flex to fill the scroll box — its
-           `height: 100%` has no definite containing block to resolve
-           against here, but `flex: 1` does. */
-        .workspace__binder tonk-sheet > tonk-display > tonk-view:has(> tonk-portal) {
-          display: flex;
-          flex-direction: column;
-        }
-        .workspace__binder tonk-sheet > tonk-display > tonk-view > tonk-portal {
-          display: block;
-          flex: 1;
-          min-height: 0;
-        }
-
-        /* The card header the sheet projects (status dot + name +
-           subtitle). A surface fill so it reads as chrome over the
-           transparent body. */
-        .tonk-sheet__head {
-          display: flex;
-          align-items: center;
-          gap: var(--wa-space-s);
-          flex: none;
-          padding: var(--wa-space-s) var(--wa-space-m);
-          background: var(--wa-color-surface-raised);
-          border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        }
-        .tonk-sheet__dot {
-          width: 7px; height: 7px; border-radius: 50%;
-          background: currentColor; flex: none;
-        }
-        .tonk-sheet__name { font-size: var(--wa-font-size-s); font-weight: var(--wa-font-weight-semibold); }
-        .tonk-sheet__meta { font-size: var(--wa-font-size-s); color: var(--wa-color-text-quiet); }
-
-        /* The bottom tab strip the binder projects. Equal-width bullet
-           segments separated by rules; the active tab gets a brand
-           accent top bar. The binder sets the CSS `order` per tab. */
-        .tonk-sheet-binder__tabs {
-          display: flex;
-          align-items: stretch;
-          flex: none;
-          height: 48px;
-          order: 2;
-          /* Left inset so the first tab aligns with the sheet card's
-             left edge (the panel padding above). */
-          padding-left: var(--wa-space-l);
-          /* A surface fill matching the top bar (not the darker lowered
-             surface). */
-          background: var(--wa-color-surface-raised);
-          border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-        }
-        /* Tabs are content-width (short), left-aligned, separated by
-           rules — not stretched to fill the strip (the wireframe). */
-        .tonk-sheet-binder__tab {
-          flex: none;
-          display: inline-flex;
-          align-items: center;
-          gap: var(--wa-space-s);
-          padding: 0 var(--wa-space-l);
-          font: inherit;
-          font-size: var(--wa-font-size-s);
-          color: var(--wa-color-text-quiet);
-          background: transparent;
-          border: none;
-          border-right: var(--wa-border-width-s) solid var(--wa-color-surface-border);
-          border-top: 2px solid transparent;
-          cursor: pointer;
-          white-space: nowrap;
-        }
-        /* The leading status bullet (hollow when inactive). */
-        .tonk-sheet-binder__tab::before {
-          content: "";
-          width: 7px; height: 7px;
-          border-radius: 50%;
-          border: var(--wa-border-width-s) solid currentColor;
-          background: transparent;
-          flex: none;
-        }
-        .tonk-sheet-binder__tab:hover {
-          color: var(--wa-color-text-normal);
-          background: var(--wa-color-neutral-fill-quiet);
-        }
-
-        /* Active tab: brand-accent top bar, raised surface, filled
-           bullet, normal-weight bright text — the selected sheet. */
-        .tonk-sheet-binder__tab.is-active {
-          color: var(--wa-color-text-normal);
-          font-weight: var(--wa-font-weight-semibold);
-          background: var(--wa-color-surface-default);
-          border-top-color: var(--wa-color-brand-fill-loud);
-        }
-        .tonk-sheet-binder__tab.is-active::before {
-          background: var(--wa-color-brand-fill-loud);
-          border-color: var(--wa-color-brand-fill-loud);
-        }
-
-        /* The close button the binder appends to each tab. A small
-           `×` glyph after the title, hidden until the tab is hovered
-           (the wireframe's editor-tab behaviour). It brightens to the
-           danger colour on its own hover. */
-        .tonk-sheet-binder__close {
-          width: 16px; height: 16px;
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          flex: none;
-          font-size: var(--wa-font-size-m);
-          line-height: 1;
-          color: var(--wa-color-text-quiet);
-          border-radius: var(--wa-border-radius-s);
-          visibility: hidden;
-          cursor: pointer;
-        }
-        .tonk-sheet-binder__tab:hover .tonk-sheet-binder__close,
-        .tonk-sheet-binder__tab.is-active .tonk-sheet-binder__close {
-          visibility: visible;
-        }
-        .tonk-sheet-binder__close:hover {
-          color: var(--wa-color-danger-on-quiet);
-          background: var(--wa-color-danger-fill-quiet);
-        }
-
-        /* The "+" add-sheet button the binder appends after the tabs. A
-           dashed-border square that solidifies and brightens on hover,
-           matching the wireframe's `tab-strip__add`. */
-        .tonk-sheet-binder__add {
-          align-self: center;
-          flex: none;
-          margin-left: var(--wa-space-s);
-          width: 28px; height: 28px;
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          font-size: var(--wa-font-size-l);
-          line-height: 1;
-          color: var(--wa-color-text-quiet);
-          background: transparent;
-          border: var(--wa-border-width-s) dashed var(--wa-color-surface-border);
-          border-radius: var(--wa-border-radius-s);
-          cursor: pointer;
-        }
-        .tonk-sheet-binder__add:hover {
-          color: var(--wa-color-text-normal);
-          border-style: solid;
-          border-color: var(--wa-color-text-normal);
-        }
-
-        /* The inline create form the binder swaps in for the "+" button
-           while naming a new sheet: an underlined name input plus
-           create / esc controls, with a brand-accent top bar like an
-           active tab. */
-        .tonk-sheet-binder__create {
-          align-self: stretch;
-          display: inline-flex;
-          align-items: center;
-          gap: var(--wa-space-s);
-          margin-left: var(--wa-space-s);
-          padding: 0 var(--wa-space-m);
-          border-top: 2px solid var(--wa-color-brand-fill-loud);
-          background: var(--wa-color-surface-default);
-        }
-        .tonk-sheet-binder__create-input {
-          min-width: 160px;
-          padding: var(--wa-space-2xs) 0;
-          font: inherit;
-          font-size: var(--wa-font-size-s);
-          color: var(--wa-color-text-normal);
-          background: transparent;
-          border: none;
-          border-bottom: var(--wa-border-width-s) solid var(--wa-color-text-normal);
-          outline: none;
-        }
-        .tonk-sheet-binder__create-input::placeholder { color: var(--wa-color-text-quiet); }
-        .tonk-sheet-binder__create-commit,
-        .tonk-sheet-binder__create-cancel {
-          flex: none;
-          font: inherit;
-          cursor: pointer;
-          border: none;
-          border-radius: var(--wa-border-radius-s);
-          padding: var(--wa-space-2xs) var(--wa-space-s);
-        }
-        .tonk-sheet-binder__create-commit {
-          font-size: var(--wa-font-size-s);
-          color: var(--wa-color-brand-on-loud);
-          background: var(--wa-color-brand-fill-loud);
-        }
-        .tonk-sheet-binder__create-cancel {
-          font-family: var(--wa-font-family-code);
-          font-size: var(--wa-font-size-xs);
-          color: var(--wa-color-text-quiet);
-          background: transparent;
-        }
-        .tonk-sheet-binder__create-cancel:hover { color: var(--wa-color-text-normal); }
-      </style>
-
-      <tonk-sheet-binder class="workspace__binder" active={active} onactivate=workspace/activate-sheet onclose=workspace/close-sheet oncreate=workspace/create-sheet>
-        <tonk-display entity={sheet} model=tonk:sheet />
-      </tonk-sheet-binder>
-    </div>
+    - assert: tonk/replica
+      where: { this: ?this }
+    - assert: tonk/binder
+      where: { this: ?this, active: ?sheet }
 
 # The sheet-mount view (default view for `workspace/sheet`): wraps the
 # sheet's content in a `<tonk-sheet>` carrying its metadata as
@@ -641,113 +297,6 @@ view!: &workspace/view
 # self-describing, so no intermediate concept is needed.
 
 
-
-view/directory!:
-  this: id:tonk-workspace/directory
-  model: workspace
-  display: |
-    <div class="workspace-directory">
-      <style>
-        /* The route gives this view root (`.workspace-directory`) a
-           viewport-min height. Flex-fill the nested `<tonk-display>`
-           rendering chain so that height reaches the workspace, which
-           then fills the page (tab strip at the bottom) — the same fill
-           the seamless carousel applies to its slides. Without it the
-           nested wrapper sits at content height and the workspace stops
-           short. (`<style>` lives on this `<div>` rather than inside
-           `<tonk-display>`, which discards child markup when it renders
-           its resolved view.) */
-        .workspace-directory {
-          display: flex;
-          flex-direction: column;
-        }
-        .workspace-directory > tonk-display,
-        .workspace-directory > tonk-display > tonk-view {
-          display: flex;
-          flex-direction: column;
-          flex: 1 1 auto;
-          min-height: 0;
-        }
-        .workspace-directory > tonk-display > tonk-view > * {
-          flex: 1 1 auto;
-          min-height: 0;
-        }
-
-        /* Launchpad shown while the space has no workspace instance
-           (a freshly created space gets only the scaffold, so its
-           workspace collection is empty). `<tonk-fallback>` reveals
-           itself when the enclosing directory `<tonk-display>` is
-           `data-state="empty"` and hides the moment content lands. */
-        .workspace-launchpad {
-          flex: 1 1 auto;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-height: 0;
-          padding: var(--wa-space-2xl);
-        }
-        .workspace-launchpad[hidden] { display: none; }
-        .workspace-launchpad__inner {
-          max-width: 28rem;
-          text-align: center;
-        }
-        /* Opt out of the global heading highlight-cover (the dark
-           filled box from styles.css `h1..h6`): it isn't theme-aware,
-           so its inverted text vanishes in dark mode. A plain heading
-           in the normal text colour reads correctly in both. Mirrors
-           `.hub-title`. */
-        .workspace-launchpad__title {
-          display: block;
-          margin: 0 0 var(--wa-space-s);
-          padding: 0;
-          background: none;
-          font-family: var(--wa-font-family-heading);
-          font-size: var(--wa-font-size-2xl);
-          font-weight: var(--wa-font-weight-bold);
-          letter-spacing: normal;
-          color: var(--wa-color-text-normal);
-        }
-        .workspace-launchpad__hint {
-          margin: 0;
-          color: var(--wa-color-text-quiet);
-        }
-      </style>
-      <div class="workspace__topbar">
-        <span class="workspace__brand">tonk</span>
-        <a class="workspace__crumb" href="/">&lsaquo; all repos</a>
-        <span class="workspace__title"><tonk-repo-name></tonk-repo-name></span>
-        <tonk-sync-state></tonk-sync-state>
-        <span class="workspace__spacer"></span>
-        <span class="workspace__actions">
-          <tonk-share></tonk-share>
-        </span>
-      </div>
-
-      <!-- Enable-sync dialog: shown via the `<tonk-sync-state>` enable
-           trigger on a no-upstream space. That element stamps the
-           resolved repo name into the hidden `name` input on click; the
-           `remote` input + `<tonk-default-remote>` button collect the
-           URL; submit asserts the transient `space/enable-sync` command.
-           Lives in this always-rendered directory view (with the topbar)
-           so sync can be enabled on any space, including an empty one. -->
-      <wa-dialog id="enable-sync" label="Enable sync" class="workspace__sync-dialog">
-        <form id="enable-sync-form" class="workspace__sync-form" onsubmit=space/enable-sync>
-          <input type="hidden" name="name">
-          <wa-input name="remote" label="Sync server" placeholder="https://…" autocomplete="off" autofocus required></wa-input>
-          <tonk-default-remote field="remote">Use this server</tonk-default-remote>
-        </form>
-        <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
-        <wa-button slot="footer" variant="primary" type="submit" form="enable-sync-form" data-dialog="close">Enable</wa-button>
-      </wa-dialog>
-
-      <tonk-fallback class="workspace-launchpad" hidden>
-        <div class="workspace-launchpad__inner">
-          <h1 class="workspace-launchpad__title">This space is empty</h1>
-          <p class="workspace-launchpad__hint">Nothing has been added here yet.</p>
-        </div>
-      </tonk-fallback>
-      <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
-    </div>
 
 view!:
   this: id:tonk-workspace/sheet-mount
@@ -1259,10 +808,13 @@ concept!: &space
       as: entity
 
 
-# Set tonk:workspace as default view
+# Set the binder shell as the space's default view. The display route
+# mounts `<tonk-display model="tonk/space">`; this alias resolves it to
+# `tonk:binder`, so directory mode renders the `tonk:shell` view (the
+# topbar over the sheet binder) for the device's replica binder.
 name!:
   this: id:tonk/space
-  entity: tonk:workspace
+  entity: tonk:binder
 
 command!: &workspace/create-sheet
   description: Create a new sheet in the workspace
@@ -1340,26 +892,482 @@ rule!:
         order: ?order
 
 rule!:
-  description: Adds new sheet to the workspace and activates it
-  assert!: workspace
+  description: Activates the freshly created sheet on the binder
+  assert!: tonk/binder
   when:
     - assert: workspace/create-sheet
       where:
-        this: ?sheet
+        this: ?active
         name: ?title
         order: ?order
-    - assert: workspace
+    # The binder is the replica's (bound through `tonk/replica`); point
+    # its `active` at the new sheet so creating lands the user on the
+    # new empty artifact (the head's `active` field unifies with the
+    # created sheet `?active`).
+    - assert: tonk/replica
       where:
         this: ?this
-        name: ?name
-    - assert: ==
+
+
+
+concept!: &tonk/replica
+  this: tonk:replica
+  description: |
+      Replica of the shared repositiory on this device. It is unique per device
+      and can be used to associate device specific metadata about the repository.
+
+  with:
+    subject:
+      description: |
+          The repository subject (as did:key) representing it's unique identifier
+      the: dialog.origin/subject
+      as: entity
+    profile:
+      description: |
+          Profile entity (as did:key) representing persistent identity on this device
+      the: dialog.origin/profile
+      as: entity
+
+# what's up
+view/directory!:
+  this: tonk:shell
+  model: tonk:binder
+  display: |
+    <div class="workspace-directory">
+      <style>
+        /* The route gives this view root (`.workspace-directory`) a
+           viewport-min height. Flex-fill the nested `<tonk-display>`
+           rendering chain so that height reaches the workspace, which
+           then fills the page (tab strip at the bottom) — the same fill
+           the seamless carousel applies to its slides. Without it the
+           nested wrapper sits at content height and the workspace stops
+           short. (`<style>` lives on this `<div>` rather than inside
+           `<tonk-display>`, which discards child markup when it renders
+           its resolved view.) */
+        .workspace-directory {
+          display: flex;
+          flex-direction: column;
+        }
+        .workspace-directory > tonk-display,
+        .workspace-directory > tonk-display > tonk-view {
+          display: flex;
+          flex-direction: column;
+          flex: 1 1 auto;
+          min-height: 0;
+        }
+        .workspace-directory > tonk-display > tonk-view > * {
+          flex: 1 1 auto;
+          min-height: 0;
+        }
+
+        /* Launchpad shown while the space has no workspace instance
+           (a freshly created space gets only the scaffold, so its
+           workspace collection is empty). `<tonk-fallback>` reveals
+           itself when the enclosing directory `<tonk-display>` is
+           `data-state="empty"` and hides the moment content lands. */
+        .workspace-launchpad {
+          flex: 1 1 auto;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 0;
+          padding: var(--wa-space-2xl);
+        }
+        .workspace-launchpad[hidden] { display: none; }
+        .workspace-launchpad__inner {
+          max-width: 28rem;
+          text-align: center;
+        }
+        /* Opt out of the global heading highlight-cover (the dark
+           filled box from styles.css `h1..h6`): it isn't theme-aware,
+           so its inverted text vanishes in dark mode. A plain heading
+           in the normal text colour reads correctly in both. Mirrors
+           `.hub-title`. */
+        .workspace-launchpad__title {
+          display: block;
+          margin: 0 0 var(--wa-space-s);
+          padding: 0;
+          background: none;
+          font-family: var(--wa-font-family-heading);
+          font-size: var(--wa-font-size-2xl);
+          font-weight: var(--wa-font-weight-bold);
+          letter-spacing: normal;
+          color: var(--wa-color-text-normal);
+        }
+        .workspace-launchpad__hint {
+          margin: 0;
+          color: var(--wa-color-text-quiet);
+        }
+      </style>
+      <div class="workspace__topbar">
+        <span class="workspace__brand">tonk</span>
+        <a class="workspace__crumb" href="/">&lsaquo; all repos</a>
+        <span class="workspace__title"><tonk-repo-name></tonk-repo-name></span>
+        <tonk-sync-state></tonk-sync-state>
+        <span class="workspace__spacer"></span>
+        <span class="workspace__actions">
+          <tonk-share></tonk-share>
+        </span>
+      </div>
+
+      <!-- Enable-sync dialog: shown via the `<tonk-sync-state>` enable
+           trigger on a no-upstream space. That element stamps the
+           resolved repo name into the hidden `name` input on click; the
+           `remote` input + `<tonk-default-remote>` button collect the
+           URL; submit asserts the transient `space/enable-sync` command.
+           Lives in this always-rendered directory view (with the topbar)
+           so sync can be enabled on any space, including an empty one. -->
+      <wa-dialog id="enable-sync" label="Enable sync" class="workspace__sync-dialog">
+        <form id="enable-sync-form" class="workspace__sync-form" onsubmit=space/enable-sync>
+          <input type="hidden" name="name">
+          <wa-input name="remote" label="Sync server" placeholder="https://…" autocomplete="off" autofocus required></wa-input>
+          <tonk-default-remote field="remote">Use this server</tonk-default-remote>
+        </form>
+        <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
+        <wa-button slot="footer" variant="primary" type="submit" form="enable-sync-form" data-dialog="close">Enable</wa-button>
+      </wa-dialog>
+
+      <tonk-fallback class="workspace-launchpad" hidden>
+        <div class="workspace-launchpad__inner">
+          <h1 class="workspace-launchpad__title">This space is empty</h1>
+          <p class="workspace-launchpad__hint">Nothing has been added here yet.</p>
+        </div>
+      </tonk-fallback>
+      <tonk-display model=workspace/sheet data-active={active} />
+    </div>
+
+
+view/directory!:
+  this: tonk:sheet-binder
+  model: tonk:sheet
+  display: |
+    <div class="workspace">
+      <style>
+        /* Styling uses the app's Web Awesome design tokens (--wa-*)
+           rather than hardcoded colours, so the viewer follows the
+           active theme and light/dark automatically. */
+        .workspace {
+          display: flex;
+          flex-direction: column;
+          /* Content-driven by default: as a board tile the workspace
+             takes only the space it needs. When it is the page's own
+             view, the route gives the view root a viewport-min height
+             (see the `.display-route` rule in the app stylesheet), so
+             the tab strip pins to the bottom there. */
+          font-family: var(--wa-font-family-body);
+          color: var(--wa-color-text-normal);
+          /* Transparent so the page's dot-grid paper shows through
+             (matching the wireframe). */
+          background: transparent;
+        }
+        /* The binder fills the space below the top bar: the active sheet
+           panel fills the rest, the projected tab strip pins to the
+           bottom. */
+        .workspace__binder {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          min-height: 0;
+        }
+
+        /* The view mounts each sheet through a `<tonk-display>` wrapper;
+           those wrappers are the binder's flex children (the panels).
+           The active panel FILLS the available height; the rest
+           collapse (their inner <tonk-sheet> is `hidden`). Scrolling
+           happens inside the sheet's card. */
+        .workspace__binder > tonk-display {
+          flex: 1;
+          min-height: 0;
+          padding: var(--wa-space-l);
+          box-sizing: border-box;
+          order: 1;
+        }
+        .workspace__binder > tonk-display:not(:has(tonk-sheet:not([hidden]))) {
+          display: none;
+        }
+        .workspace__binder > tonk-display > tonk-view {
+          display: block;
+          height: 100%;
+          min-height: 0;
+        }
+
+        /* The sheet card: a header strip the sheet projects from its
+           attributes, over the sheet's content. Transparent body so the
+           page's dot-grid shows through; bordered frame. */
+        .workspace__binder tonk-sheet {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          min-height: 0;
+          color: inherit;
+          font-family: inherit;
+          border: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+          background: transparent;
+          overflow: hidden;
+        }
+        /* The card body: everything after the projected header. The
+           sheet's content <tonk-display> is the last child; it scrolls. */
+        .workspace__binder tonk-sheet > tonk-display {
+          flex: 1;
+          min-height: 0;
+          overflow: auto;
+        }
+        .workspace__binder tonk-sheet > tonk-display > tonk-view {
+          display: block;
+          min-height: 100%;
+        }
+        /* A portal sheet: `<tonk-portal>`'s iframe has no intrinsic
+           content height, so a plain block would collapse it to the
+           iframe's default 150px. Make the portal's `tonk-view` a flex
+           column and let the portal flex to fill the scroll box — its
+           `height: 100%` has no definite containing block to resolve
+           against here, but `flex: 1` does. */
+        .workspace__binder tonk-sheet > tonk-display > tonk-view:has(> tonk-portal) {
+          display: flex;
+          flex-direction: column;
+        }
+        .workspace__binder tonk-sheet > tonk-display > tonk-view > tonk-portal {
+          display: block;
+          flex: 1;
+          min-height: 0;
+        }
+
+        /* The card header the sheet projects (status dot + name +
+           subtitle). A surface fill so it reads as chrome over the
+           transparent body. */
+        .tonk-sheet__head {
+          display: flex;
+          align-items: center;
+          gap: var(--wa-space-s);
+          flex: none;
+          padding: var(--wa-space-s) var(--wa-space-m);
+          background: var(--wa-color-surface-raised);
+          border-bottom: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        }
+        .tonk-sheet__dot {
+          width: 7px; height: 7px; border-radius: 50%;
+          background: currentColor; flex: none;
+        }
+        .tonk-sheet__name { font-size: var(--wa-font-size-s); font-weight: var(--wa-font-weight-semibold); }
+        .tonk-sheet__meta { font-size: var(--wa-font-size-s); color: var(--wa-color-text-quiet); }
+
+        /* The bottom tab strip the binder projects. Equal-width bullet
+           segments separated by rules; the active tab gets a brand
+           accent top bar. The binder sets the CSS `order` per tab. */
+        .tonk-sheet-binder__tabs {
+          display: flex;
+          align-items: stretch;
+          flex: none;
+          height: 48px;
+          order: 2;
+          /* Left inset so the first tab aligns with the sheet card's
+             left edge (the panel padding above). */
+          padding-left: var(--wa-space-l);
+          /* A surface fill matching the top bar (not the darker lowered
+             surface). */
+          background: var(--wa-color-surface-raised);
+          border-top: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+        }
+        /* Tabs are content-width (short), left-aligned, separated by
+           rules — not stretched to fill the strip (the wireframe). */
+        .tonk-sheet-binder__tab {
+          flex: none;
+          display: inline-flex;
+          align-items: center;
+          gap: var(--wa-space-s);
+          padding: 0 var(--wa-space-l);
+          font: inherit;
+          font-size: var(--wa-font-size-s);
+          color: var(--wa-color-text-quiet);
+          background: transparent;
+          border: none;
+          border-right: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+          border-top: 2px solid transparent;
+          cursor: pointer;
+          white-space: nowrap;
+        }
+        /* The leading status bullet (hollow when inactive). */
+        .tonk-sheet-binder__tab::before {
+          content: "";
+          width: 7px; height: 7px;
+          border-radius: 50%;
+          border: var(--wa-border-width-s) solid currentColor;
+          background: transparent;
+          flex: none;
+        }
+        .tonk-sheet-binder__tab:hover {
+          color: var(--wa-color-text-normal);
+          background: var(--wa-color-neutral-fill-quiet);
+        }
+
+        /* Active tab: brand-accent top bar, raised surface, filled
+           bullet, normal-weight bright text — the selected sheet. */
+        .tonk-sheet-binder__tab.is-active {
+          color: var(--wa-color-text-normal);
+          font-weight: var(--wa-font-weight-semibold);
+          background: var(--wa-color-surface-default);
+          border-top-color: var(--wa-color-brand-fill-loud);
+        }
+        .tonk-sheet-binder__tab.is-active::before {
+          background: var(--wa-color-brand-fill-loud);
+          border-color: var(--wa-color-brand-fill-loud);
+        }
+
+        /* The close button the binder appends to each tab. A small
+           `×` glyph after the title, hidden until the tab is hovered
+           (the wireframe's editor-tab behaviour). It brightens to the
+           danger colour on its own hover. */
+        .tonk-sheet-binder__close {
+          width: 16px; height: 16px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          flex: none;
+          font-size: var(--wa-font-size-m);
+          line-height: 1;
+          color: var(--wa-color-text-quiet);
+          border-radius: var(--wa-border-radius-s);
+          visibility: hidden;
+          cursor: pointer;
+        }
+        .tonk-sheet-binder__tab:hover .tonk-sheet-binder__close,
+        .tonk-sheet-binder__tab.is-active .tonk-sheet-binder__close {
+          visibility: visible;
+        }
+        .tonk-sheet-binder__close:hover {
+          color: var(--wa-color-danger-on-quiet);
+          background: var(--wa-color-danger-fill-quiet);
+        }
+
+        /* The "+" add-sheet button the binder appends after the tabs. A
+           dashed-border square that solidifies and brightens on hover,
+           matching the wireframe's `tab-strip__add`. */
+        .tonk-sheet-binder__add {
+          align-self: center;
+          flex: none;
+          margin-left: var(--wa-space-s);
+          width: 28px; height: 28px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          font-size: var(--wa-font-size-l);
+          line-height: 1;
+          color: var(--wa-color-text-quiet);
+          background: transparent;
+          border: var(--wa-border-width-s) dashed var(--wa-color-surface-border);
+          border-radius: var(--wa-border-radius-s);
+          cursor: pointer;
+        }
+        .tonk-sheet-binder__add:hover {
+          color: var(--wa-color-text-normal);
+          border-style: solid;
+          border-color: var(--wa-color-text-normal);
+        }
+
+        /* The inline create form the binder swaps in for the "+" button
+           while naming a new sheet: an underlined name input plus
+           create / esc controls, with a brand-accent top bar like an
+           active tab. */
+        .tonk-sheet-binder__create {
+          align-self: stretch;
+          display: inline-flex;
+          align-items: center;
+          gap: var(--wa-space-s);
+          margin-left: var(--wa-space-s);
+          padding: 0 var(--wa-space-m);
+          border-top: 2px solid var(--wa-color-brand-fill-loud);
+          background: var(--wa-color-surface-default);
+        }
+        .tonk-sheet-binder__create-input {
+          min-width: 160px;
+          padding: var(--wa-space-2xs) 0;
+          font: inherit;
+          font-size: var(--wa-font-size-s);
+          color: var(--wa-color-text-normal);
+          background: transparent;
+          border: none;
+          border-bottom: var(--wa-border-width-s) solid var(--wa-color-text-normal);
+          outline: none;
+        }
+        .tonk-sheet-binder__create-input::placeholder { color: var(--wa-color-text-quiet); }
+        .tonk-sheet-binder__create-commit,
+        .tonk-sheet-binder__create-cancel {
+          flex: none;
+          font: inherit;
+          cursor: pointer;
+          border: none;
+          border-radius: var(--wa-border-radius-s);
+          padding: var(--wa-space-2xs) var(--wa-space-s);
+        }
+        .tonk-sheet-binder__create-commit {
+          font-size: var(--wa-font-size-s);
+          color: var(--wa-color-brand-on-loud);
+          background: var(--wa-color-brand-fill-loud);
+        }
+        .tonk-sheet-binder__create-cancel {
+          font-family: var(--wa-font-family-code);
+          font-size: var(--wa-font-size-xs);
+          color: var(--wa-color-text-quiet);
+          background: transparent;
+        }
+        .tonk-sheet-binder__create-cancel:hover { color: var(--wa-color-text-normal); }
+      </style>
+
+      <tonk-sheet-binder active={dom.host/data-active} class="workspace__binder" onactivate=workspace/activate-sheet onclose=workspace/close-sheet oncreate=workspace/create-sheet>
+        <tonk-display entity={this} model=tonk:sheet />
+      </tonk-sheet-binder>
+    </div>
+
+command!: &tonk/binder-init
+  description: Initialize a binder for the replica
+  with:
+    reason:
+       description: Reason to initialize the binder
+       as: text
+       the: xyz.tonk.init/reason
+
+concept!: &tonk/binder
+  this: tonk:binder
+  description: A binder view of the the tonk replica
+  with:
+    active:
+      description: Currently active sheet
+      the: xyz.tonk.binder/active
+      as: entity
+
+# Tab selection: when an `activate-sheet` command fires, point the
+# binder's `active` at the clicked sheet (replacing the prior
+# selection). The binder is the replica's (one per device, bound
+# through `tonk/replica`), so the command needs only the sheet - no
+# binder id plumbed through the DOM. Mirrors the close/create rules.
+rule!:
+  assert!: tonk/binder
+  when:
+    - assert: workspace/activate-sheet
+      where: { sheet: ?active }
+    - assert: tonk/replica
+      where: { this: ?this }
+
+# Sets active sheet of the binder to about:blank unless
+# it already has an active sheet. This ensures that every
+# replica also matches a binder model.
+rule!:
+  assert!: tonk/binder
+  when:
+    - assert: tonk/binder-init
       where:
-        this: ?this
-        is: about:blank
-    # Auto-activate the freshly created sheet - creating lands the user
-    # on the new empty artifact (the head's `active` field unifies with
-    # `?sheet`).
+         this: ?init
+    - assert: tonk/replica
+      where:
+         this: ?this
     - assert: ==
       where:
         this: ?active
-        is: ?sheet
+        is: about:blank
+  unless:
+    - assert: tonk/binder
+      where:
+        this: ?this
+
+tonk/binder-init!:
+   reason: Initialize a new tonk repository

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -960,44 +960,6 @@ view/directory!:
           min-height: 0;
         }
 
-        /* Launchpad shown while the space has no workspace instance
-           (a freshly created space gets only the scaffold, so its
-           workspace collection is empty). `<tonk-fallback>` reveals
-           itself when the enclosing directory `<tonk-display>` is
-           `data-state="empty"` and hides the moment content lands. */
-        .workspace-launchpad {
-          flex: 1 1 auto;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-height: 0;
-          padding: var(--wa-space-2xl);
-        }
-        .workspace-launchpad[hidden] { display: none; }
-        .workspace-launchpad__inner {
-          max-width: 28rem;
-          text-align: center;
-        }
-        /* Opt out of the global heading highlight-cover (the dark
-           filled box from styles.css `h1..h6`): it isn't theme-aware,
-           so its inverted text vanishes in dark mode. A plain heading
-           in the normal text colour reads correctly in both. Mirrors
-           `.hub-title`. */
-        .workspace-launchpad__title {
-          display: block;
-          margin: 0 0 var(--wa-space-s);
-          padding: 0;
-          background: none;
-          font-family: var(--wa-font-family-heading);
-          font-size: var(--wa-font-size-2xl);
-          font-weight: var(--wa-font-weight-bold);
-          letter-spacing: normal;
-          color: var(--wa-color-text-normal);
-        }
-        .workspace-launchpad__hint {
-          margin: 0;
-          color: var(--wa-color-text-quiet);
-        }
       </style>
       <div class="workspace__topbar">
         <span class="workspace__brand">tonk</span>
@@ -1027,12 +989,6 @@ view/directory!:
         <wa-button slot="footer" variant="primary" type="submit" form="enable-sync-form" data-dialog="close">Enable</wa-button>
       </wa-dialog>
 
-      <tonk-fallback class="workspace-launchpad" hidden>
-        <div class="workspace-launchpad__inner">
-          <h1 class="workspace-launchpad__title">This space is empty</h1>
-          <p class="workspace-launchpad__hint">Nothing has been added here yet.</p>
-        </div>
-      </tonk-fallback>
       <tonk-display model=workspace/sheet data-active={active} />
     </div>
 
@@ -1311,9 +1267,81 @@ view/directory!:
           background: transparent;
         }
         .tonk-sheet-binder__create-cancel:hover { color: var(--wa-color-text-normal); }
+
+
+        /* Empty state. The binder reveals `[slot="empty"]` and flags
+           itself `data-empty` when it has no sheets. The launchpad fills
+           the canvas area above the (add-only) tab strip, centered over
+           the dot-grid paper - matching the wireframe's "empty repo"
+           frame. The binder hides it (`hidden`) whenever a sheet exists. */
+        .workspace-launchpad {
+          flex: 1 1 auto;
+          order: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 0;
+          padding: var(--wa-space-2xl);
+        }
+        .workspace-launchpad[hidden] { display: none; }
+        .workspace-launchpad__inner {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: var(--wa-space-m);
+          max-width: 28rem;
+          text-align: center;
+        }
+        /* Opt out of the global heading highlight-cover (the dark filled
+           box from styles.css `h1..h6`): a plain heading in the normal
+           text colour reads correctly in both light and dark. */
+        .workspace-launchpad__title {
+          display: block;
+          margin: 0;
+          padding: 0;
+          background: none;
+          font-family: var(--wa-font-family-code);
+          font-size: var(--wa-font-size-2xl);
+          font-weight: var(--wa-font-weight-bold);
+          letter-spacing: normal;
+          color: var(--wa-color-text-normal);
+        }
+        .workspace-launchpad__hint {
+          margin: 0;
+          color: var(--wa-color-text-quiet);
+          font-family: var(--wa-font-family-code);
+          font-size: var(--wa-font-size-s);
+        }
+        /* The prominent "add artifact" button: a hatched/dashed frame
+           that solidifies on hover, echoing the strip's "+" add control
+           and the wireframe's center call to action. */
+        .workspace-launchpad__add {
+          margin-top: var(--wa-space-s);
+          padding: var(--wa-space-s) var(--wa-space-l);
+          font-family: var(--wa-font-family-code);
+          font-size: var(--wa-font-size-m);
+          font-weight: var(--wa-font-weight-semibold);
+          color: var(--wa-color-text-normal);
+          background: transparent;
+          border: var(--wa-border-width-s) dashed var(--wa-color-surface-border);
+          border-radius: var(--wa-border-radius-s);
+          cursor: pointer;
+        }
+        .workspace-launchpad__add:hover {
+          border-style: solid;
+          border-color: var(--wa-color-text-normal);
+          background: var(--wa-color-neutral-fill-quiet);
+        }
       </style>
 
       <tonk-sheet-binder active={dom.host/data-active} class="workspace__binder" onactivate=workspace/activate-sheet onclose=workspace/close-sheet oncreate=workspace/create-sheet>
+        <div slot="empty" class="workspace-launchpad" hidden>
+          <div class="workspace-launchpad__inner">
+            <h1 class="workspace-launchpad__title">nothing here yet.</h1>
+            <p class="workspace-launchpad__hint">start by creating an artifact &mdash; the agent will fill it.</p>
+            <button type="button" class="workspace-launchpad__add" data-create>+ add artifact</button>
+          </div>
+        </div>
         <tonk-display entity={this} model=tonk:sheet />
       </tonk-sheet-binder>
     </div>
@@ -1371,3 +1399,5 @@ rule!:
 
 tonk/binder-init!:
    reason: Initialize a new tonk repository
+
+# test

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -1032,6 +1032,8 @@ view/directory!:
            collapse (their inner <tonk-sheet> is `hidden`). Scrolling
            happens inside the sheet's card. */
         .workspace__binder > tonk-display {
+          display: flex;
+          flex-direction: column;
           flex: 1;
           min-height: 0;
           padding: var(--wa-space-l);
@@ -1042,8 +1044,9 @@ view/directory!:
           display: none;
         }
         .workspace__binder > tonk-display > tonk-view {
-          display: block;
-          height: 100%;
+          display: flex;
+          flex-direction: column;
+          flex: 1;
           min-height: 0;
         }
 
@@ -1053,7 +1056,7 @@ view/directory!:
         .workspace__binder tonk-sheet {
           display: flex;
           flex-direction: column;
-          height: 100%;
+          flex: 1;
           min-height: 0;
           color: inherit;
           font-family: inherit;

--- a/rust/tonk-core/assets/library/demo.yaml
+++ b/rust/tonk-core/assets/library/demo.yaml
@@ -354,22 +354,11 @@ workspace/sheet!:
   view: tonk:view
   order: "c"
 
-# The demo workspace owns the three sheets, with the itinerary
-# selected as the initial active sheet (a click on a tab re-points
-# `active` via the activate-sheet command + rule).
-workspace!:
-  this: about:blank
-  name: "Trip planning"
-  active: id:tonk-workspace/sheet/itinerary
-  sheet: id:tonk-workspace/sheet/itinerary
-
-workspace!:
-  this: about:blank
-  sheet: id:tonk-workspace/sheet/lodging
-
-workspace!:
-  this: about:blank
-  sheet: id:tonk-workspace/sheet/sketch
+# The three sheets above are top-level `tonk:sheet` instances; the
+# binder enumerates every sheet directly (no workspace membership). The
+# binder's `active` is seeded to `about:blank` at repository creation,
+# so the binder falls back to showing the first sheet by order until a
+# tab is clicked (the activate-sheet command re-points `active`).
 
 # ============================================================
 # DEMO BOARD
@@ -388,17 +377,6 @@ tile!: &inspector-tile
   model: inspector
   entity: home-inspector
 
-tile!: &workspace-tile
-  order: "b"
-  model: workspace
-  entity: about:blank
-
-column-view!: &column-b
-  this: c:b
-  order: "aq"
-  width: 15
-  tile: workspace-tile
-
 column-view!: &column-a
   this: c:a
   order: "a"
@@ -409,10 +387,6 @@ board!:
   this: about:blank
   name: "demo"
   column: column-a
-
-board!:
-  this: about:blank
-  column: column-b
 
 # ============================================================
 # DEMO PEOPLE

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -212,7 +212,14 @@ impl CustomElement for TonkDisplay {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["entity", "model", "view"]
+        // `entity`/`model`/`view` are the subject inputs: a change to any
+        // restarts the resolve/subscribe flow. `data-active` is a
+        // host-context attribute a parent view threads in (read by a
+        // template as `{dom.host/data-active}`); a change to it does not
+        // alter what this display resolves, only the value projected into
+        // the already-mounted view, so it is propagated in place rather
+        // than restarting. See `attribute_changed_callback`.
+        &["entity", "model", "view", "data-active"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -244,14 +251,33 @@ impl CustomElement for TonkDisplay {
     fn attribute_changed_callback(
         &mut self,
         this: &HtmlElement,
-        _name: String,
-        _old: Option<String>,
-        _new: Option<String>,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
     ) {
+        if old == new {
+            return;
+        }
         let host: Element = this.clone().into();
         let Some(state) = self.inner.borrow().clone() else {
             return;
         };
+
+        // Only a subject input — `entity`/`model`/`view` — changes what
+        // this display resolves (a different entity, model, or view
+        // template), so only those tear down and restart the
+        // resolve/subscribe flow. Every other observed attribute is
+        // host-context (e.g. `data-active`, threaded in for a template to
+        // read as `{dom.host/<attr>}`): it leaves the resolved template
+        // unchanged and only alters a value projected into the mounted
+        // view, so it is propagated in place — re-augment the cached
+        // frame and replay it through the existing slides, which the
+        // `<tonk-view>` renderer diffs into the DOM without a teardown.
+        if !resolves_template(&name) {
+            replay_host_attributes(&host, &state);
+            return;
+        }
+
         {
             let mut s = state.borrow_mut();
             s.abort_all();
@@ -1379,6 +1405,44 @@ fn with_host_attributes(host: &Element, conclusion: &Conclusion) -> Conclusion {
     augmented
 }
 
+/// Whether a change to `name` resolves a different view template —
+/// `entity`/`model`/`view` are the subject inputs that decide what this
+/// display resolves, so a change to any tears down and restarts the
+/// flow. Every other observed attribute is host-context (threaded in
+/// for a template to read as `{dom.host/<name>}`) and updates in place.
+///
+/// Conservative for now: a `model` change tears down even when the
+/// resolved view template is unchanged (a model only re-projects the
+/// field set). The ideal is to tear down solely on a view *template*
+/// change and otherwise re-resolve the projection in place; that needs
+/// the in-place path to re-run the query without rebuilding the DOM,
+/// which is a larger change left for later.
+fn resolves_template(name: &str) -> bool {
+    matches!(name, "entity" | "model" | "view")
+}
+
+/// Re-project the host's current attributes into the mounted view(s)
+/// without restarting. Re-augments the cached frame with
+/// `with_host_attributes` (picking up the changed `data-*` value) and
+/// replays it through each slide's `<tonk-view>` renderer, which diffs
+/// the new values into the existing DOM in place. A no-op before
+/// anything is mounted (no frame, no slides).
+fn replay_host_attributes(host: &Element, state: &Rc<RefCell<Inner>>) {
+    let s = state.borrow();
+    if s.last_frame.is_empty() || s.slides.is_empty() {
+        return;
+    }
+    let augmented: Vec<Conclusion> = s
+        .last_frame
+        .iter()
+        .map(|c| with_host_attributes(host, c))
+        .collect();
+    let detail = serialize_conclusions(&augmented);
+    for slide in s.slides.values() {
+        call_render(&slide.view_el, &detail);
+    }
+}
+
 fn dispatch_error(host: &Element, err: ErrorDetail) {
     dispatch_event(host, "tonk-display:error", Some(event_detail(&err)));
 }
@@ -1414,6 +1478,23 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Only the subject inputs (`entity`/`model`/`view`) re-resolve what
+    /// the display renders, so only those force a teardown. A host-context
+    /// attribute like `data-active` (threaded in for a template to read
+    /// as `{dom.host/data-active}`) leaves the resolved view unchanged and
+    /// must update in place — a teardown there would re-resolve and reload
+    /// the whole subtree on every selection change.
+    #[dialog_common::test]
+    fn it_tears_down_only_on_subject_input_changes() {
+        assert!(resolves_template("entity"));
+        assert!(resolves_template("model"));
+        assert!(resolves_template("view"));
+        assert!(
+            !resolves_template("data-active"),
+            "a host-context attribute must update in place, not tear down",
+        );
+    }
 
     /// Outbound `tonk-display:result` / `:error` details must be plain
     /// JS objects so consumers can read `event.detail.<field>`.
@@ -1890,6 +1971,118 @@ mod tests {
                 .await
                 .expect("the fallback chrome should render on an empty collection at mount");
             assert_eq!(fallback.text_content().as_deref(), Some("Nothing yet"));
+        }
+
+        // A chrome element binding a host-context attribute
+        // (`{dom.host/data-active}`) must receive the host's `data-active`
+        // value, even when `data-active` is set on the host before any
+        // frame arrives. The binder relies on this to learn which sheet is
+        // active: `<tonk-sheet-binder active={dom.host/data-active}>`.
+        #[dialog_common::test]
+        async fn it_projects_a_host_attribute_set_before_the_frame_into_chrome() {
+            let host = FakeHost::install(directory_resolve_responses());
+            let display = mount_directory(&host, "item");
+            // The host carries `data-active` from the start, mirroring the
+            // shell threading it in before the directory view resolves.
+            display
+                .set_attribute("data-active", "id:active-one")
+                .unwrap();
+
+            for _ in 0..200 {
+                if host.subscribe_tags().len() >= 2 {
+                    break;
+                }
+                sleep(5).await;
+            }
+
+            // Chrome `<span data-x={dom.host/data-active}>` (no subject
+            // ref, so it renders once) plus a per-instance row.
+            host.push_frame(
+                "view",
+                &rows(&[(
+                    "did:key:zView",
+                    &[(
+                        "display",
+                        "<div><span class=\"probe\" data-x={dom.host/data-active}></span><ul><li data-id={this}>{title}</li></ul></div>",
+                    )],
+                )]),
+            );
+            host.push_frame(
+                "entity",
+                &rows(&[("did:key:zItem1", &[("title", "Hello")])]),
+            );
+
+            let probe = await_selector(&display, "span.probe")
+                .await
+                .expect("the chrome probe should render");
+            assert_eq!(
+                probe.get_attribute("data-x").as_deref(),
+                Some("id:active-one"),
+                "chrome must project the host's data-active via {{dom.host/data-active}}",
+            );
+        }
+
+        // Changing `data-active` after mount reprojects it into the chrome
+        // in place (no teardown), so a tab switch's persisted active is
+        // reflected without a reload.
+        #[dialog_common::test]
+        async fn it_reprojects_a_host_attribute_change_into_chrome_in_place() {
+            let host = FakeHost::install(directory_resolve_responses());
+            let display = mount_directory(&host, "item");
+
+            for _ in 0..200 {
+                if host.subscribe_tags().len() >= 2 {
+                    break;
+                }
+                sleep(5).await;
+            }
+
+            host.push_frame(
+                "view",
+                &rows(&[(
+                    "did:key:zView",
+                    &[(
+                        "display",
+                        "<div><span class=\"probe\" data-x={dom.host/data-active}></span><ul><li data-id={this}>{title}</li></ul></div>",
+                    )],
+                )]),
+            );
+            host.push_frame(
+                "entity",
+                &rows(&[("did:key:zItem1", &[("title", "Hello")])]),
+            );
+
+            let probe = await_selector(&display, "span.probe")
+                .await
+                .expect("the chrome probe should render");
+
+            // The instance content rendered: capture it so we can assert it
+            // is NOT torn down by the host-attribute change.
+            let row = await_selector(&display, "li[data-id]")
+                .await
+                .expect("the instance row should render");
+
+            display
+                .set_attribute("data-active", "id:active-two")
+                .unwrap();
+
+            // The change reprojects into the same chrome node in place.
+            for _ in 0..200 {
+                if probe.get_attribute("data-x").as_deref() == Some("id:active-two") {
+                    break;
+                }
+                sleep(5).await;
+            }
+            assert_eq!(
+                probe.get_attribute("data-x").as_deref(),
+                Some("id:active-two"),
+                "a data-active change must reproject into chrome",
+            );
+            // Same node — an in-place update, not a teardown/remount.
+            assert!(
+                row.is_connected(),
+                "the mounted instance must survive a host-attribute change (no teardown)",
+            );
         }
     }
 }

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1973,6 +1973,94 @@ mod tests {
             assert_eq!(fallback.text_content().as_deref(), Some("Nothing yet"));
         }
 
+        // A static element that is a direct *sibling* of the repeat root
+        // (the `{this}` element) must survive rendering — it is chrome,
+        // not part of the repeat. Regression for the binder's
+        // `[slot="empty"]` launchpad: `<tonk-sheet-binder>` holds the
+        // repeat `<tonk-display entity={this}>` and a static `<div
+        // slot="empty">` as direct siblings; the launchpad was dropped
+        // when it sat *after* the repeat element. (A static node BEFORE
+        // the repeat element survived, which is what made the bug
+        // position-dependent.)
+        #[dialog_common::test]
+        async fn it_keeps_a_static_sibling_after_the_repeat_element() {
+            let host = FakeHost::install(directory_resolve_responses());
+            let display = mount_directory(&host, "item");
+
+            for _ in 0..200 {
+                if host.subscribe_tags().len() >= 2 {
+                    break;
+                }
+                sleep(5).await;
+            }
+
+            // The repeat root is the `<span data-id={this}>` element; the
+            // `<p class="after">` is its direct following sibling (chrome).
+            host.push_frame(
+                "view",
+                &rows(&[(
+                    "did:key:zView",
+                    &[(
+                        "display",
+                        "<div><span data-id={this}>{title}</span><p class=\"after\">keep me</p></div>",
+                    )],
+                )]),
+            );
+            host.push_frame(
+                "entity",
+                &rows(&[("did:key:zItem1", &[("title", "Hello")])]),
+            );
+
+            let row = await_selector(&display, "span[data-id]")
+                .await
+                .expect("the repeat row should render");
+            assert_eq!(row.text_content().as_deref(), Some("Hello"));
+
+            let after = await_selector(&display, "p.after")
+                .await
+                .expect("a static sibling after the repeat element must survive");
+            assert_eq!(after.text_content().as_deref(), Some("keep me"));
+        }
+
+        // The static sibling must also survive when the repeat element
+        // is a *custom element* (the binder's real shape): the renderer
+        // must not let the element's own connectedCallback / mutation
+        // churn drop chrome that follows it.
+        #[dialog_common::test]
+        async fn it_keeps_a_static_sibling_after_a_repeat_custom_element() {
+            let host = FakeHost::install(directory_resolve_responses());
+            let display = mount_directory(&host, "item");
+
+            for _ in 0..200 {
+                if host.subscribe_tags().len() >= 2 {
+                    break;
+                }
+                sleep(5).await;
+            }
+
+            // Repeat root is a nested `<tonk-display entity={this}>` (a
+            // custom element); the `<p class="after">` follows it.
+            host.push_frame(
+                "view",
+                &rows(&[(
+                    "did:key:zView",
+                    &[(
+                        "display",
+                        "<div><tonk-display entity={this} model=item data-id={this}></tonk-display><p class=\"after\">keep me</p></div>",
+                    )],
+                )]),
+            );
+            host.push_frame(
+                "entity",
+                &rows(&[("did:key:zItem1", &[("title", "Hello")])]),
+            );
+
+            let after = await_selector(&display, "p.after")
+                .await
+                .expect("a static sibling after a custom-element repeat root must survive");
+            assert_eq!(after.text_content().as_deref(), Some("keep me"));
+        }
+
         // A chrome element binding a host-context attribute
         // (`{dom.host/data-active}`) must receive the host's `data-active`
         // value, even when `data-active` is set on the host before any

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -192,8 +192,19 @@ impl Renderer {
         let repeat = mount_repeat(document, &self.plan.repeat, &root, &self.template, frame);
 
         let _ = self.host.append_child(&fragment);
+        // After `append_child` the fragment is emptied — its children now
+        // live under `host`. `navigate()` on a later update must walk the
+        // live tree, so the stored navigation root is the host, not the
+        // now-empty fragment. The fragment's top-level children appended
+        // in order onto an empty host, so a path relative to the fragment
+        // root is equally valid relative to the host. (Initial chrome /
+        // repeat above ran against the still-populated fragment, which is
+        // why they mount correctly; only the update path read the emptied
+        // fragment and silently found no node — dropping every chrome
+        // update, e.g. `<tonk-sheet-binder active={dom.host/data-active}>`
+        // never reflecting a host-attribute change.)
         self.mounted = Some(MountedScope {
-            root,
+            root: self.host.clone().into(),
             chrome,
             repeat,
         });

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -552,8 +552,8 @@ async fn seed_and_initialize(
         // in the default `home` repository, on top of the scaffold. It
         // resolves its bare concept references against the scaffold just
         // committed above. Every other repo gets the scaffold alone, so
-        // its directory render has zero `workspace` instances and reads
-        // as genuinely empty — the precondition for the launchpad view.
+        // its directory render has zero sheet instances and reads as
+        // genuinely empty — the precondition for the launchpad view.
         if name == DEFAULT_REPOSITORY_NAME {
             let demo = fetch_standard_library(DEMO_LIBRARY_URL)
                 .await
@@ -591,7 +591,7 @@ const STANDARD_LIBRARY_URL: &str = "/library/core.yaml";
 /// URL of the served showcase-demo notation asset (`demo.yaml`),
 /// copied into the dist alongside `core.yaml`. Seeded on top of the
 /// scaffold, but only into the default `home` repository, so every
-/// other repo starts with zero workspace instances. Only referenced
+/// other repo starts with zero sheet instances. Only referenced
 /// from the SW-scoped background seed path.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const DEMO_LIBRARY_URL: &str = "/library/demo.yaml";
@@ -1914,10 +1914,9 @@ mod tests {
             .unwrap_or(0)
     }
 
-    /// The scaffold alone defines the `workspace` concept — so the
-    /// directory route can resolve it — but seeds zero `workspace`
-    /// instances. That empty render is the precondition for the
-    /// launchpad.
+    /// The scaffold alone defines the `workspace/sheet` concept — so the
+    /// directory route can resolve it — but seeds zero sheet instances.
+    /// That empty render is the precondition for the launchpad.
     #[dialog_common::test]
     async fn it_seeds_scaffold_without_showcase_instances() {
         let repo = "test-seed-scaffold-only";
@@ -1925,14 +1924,14 @@ mod tests {
         seed(&state, repo, CORE).await;
 
         assert_eq!(
-            count(&state, repo, "workspace:\n").await,
+            count(&state, repo, "workspace/sheet:\n").await,
             0,
-            "scaffold-only repo must have zero workspace instances",
+            "scaffold-only repo must have zero sheet instances",
         );
     }
 
     /// The showcase, seeded on top of the scaffold, resolves its bare
-    /// concept references (`workspace`, `person`, …) against the
+    /// concept references (`workspace/sheet`, `person`, …) against the
     /// committed scaffold and lands the demo instances — what the
     /// default `home` repo gets. Guards the cross-document resolution
     /// the split depends on.
@@ -1944,8 +1943,8 @@ mod tests {
         seed(&state, repo, DEMO).await;
 
         assert!(
-            count(&state, repo, "workspace:\n").await >= 1,
-            "showcase must seed at least one workspace instance",
+            count(&state, repo, "workspace/sheet:\n").await >= 1,
+            "showcase must seed at least one sheet instance",
         );
         assert_eq!(
             count(&state, repo, "person:\n").await,

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -159,9 +159,12 @@ fn project(this: &HtmlElement) {
 
     // Reconcile tab buttons against the sheets: build one tab per
     // sheet (reuse by `data-sheet`), drop tabs whose sheet vanished.
-    // The tab highlight follows the real `active`, not the display
-    // fallback — a fallback panel shouldn't light up a tab as selected.
-    reconcile_tabs(&document, &strip, &sheets, &active);
+    // The highlighted tab follows `shown` — the sheet whose panel is
+    // visible — so the tab strip and the canvas always agree. When
+    // `active` names a present sheet that is the same as `shown`; when
+    // `active` is unset / `about:blank` / dangling, `shown` falls back
+    // to the first sheet and its tab lights up to match the panel.
+    reconcile_tabs(&document, &strip, &sheets, &shown);
 
     // Order + show/hide the sheet panels: show the `shown` sheet (the
     // active one, or the fallback), hide the rest.
@@ -870,9 +873,10 @@ mod tests {
     async fn it_shows_the_first_sheet_when_active_is_dangling() {
         // `active` names a sheet that isn't present (a stale persisted
         // pointer). The binder must still show a panel — the first sheet
-        // by order — rather than collapse the layout. It does NOT rewrite
-        // `active` (display-only fallback), so it can't steal focus
-        // during a transient reconcile gap.
+        // by order — rather than collapse the layout, and the tab strip
+        // follows the shown panel. It does NOT rewrite `active`
+        // (display-only fallback), so it can't steal focus during a
+        // transient reconcile gap.
         let binder = mount_binder("id:gone", &[("b", "b", "Second"), ("a", "a", "First")]);
 
         let first_panel = binder
@@ -897,6 +901,33 @@ mod tests {
             binder.get_attribute("active").as_deref(),
             Some("id:gone"),
             "the binder must not rewrite a dangling active",
+        );
+        binder.remove();
+    }
+
+    #[dialog_common::test]
+    async fn it_highlights_the_first_tab_when_active_is_unset() {
+        // No selection yet (the binder's `active` is `about:blank` until
+        // a tab is clicked). The panel falls back to the first sheet by
+        // order, and the tab strip must agree: the first tab lights up so
+        // the strip and the canvas show the same sheet.
+        let binder = mount_binder("about:blank", &[("b", "b", "Second"), ("a", "a", "First")]);
+
+        let first_tab = binder
+            .query_selector(&format!(".{TAB}[data-sheet=\"a\"]"))
+            .unwrap()
+            .expect("first tab present");
+        assert!(
+            first_tab.class_list().contains(ACTIVE),
+            "the first tab must be highlighted to match the shown panel",
+        );
+        let second_tab = binder
+            .query_selector(&format!(".{TAB}[data-sheet=\"b\"]"))
+            .unwrap()
+            .expect("second tab present");
+        assert!(
+            !second_tab.class_list().contains(ACTIVE),
+            "only the shown (first) tab is highlighted",
         );
         binder.remove();
     }

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -122,6 +122,10 @@ const CREATE_CANCEL: &str = "tonk-sheet-binder__create-cancel";
 /// button or the inline form; it lives on the DOM so the stateless
 /// `project()` can see it across re-renders.
 const CREATING: &str = "data-creating";
+/// Host attribute flag: present (any value) while the binder has no
+/// sheets. `project()` sets it so the consuming view can style the
+/// empty binder; it pairs with revealing the `[slot="empty"]` region.
+const EMPTY: &str = "data-empty";
 
 /// Build/refresh the tab strip from the `<tonk-sheet>` children, then
 /// apply ordering + the active state. Idempotent.
@@ -179,9 +183,40 @@ fn project(this: &HtmlElement) {
         }
     }
 
+    // Empty state: with no sheets, reveal the view-supplied
+    // `[slot="empty"]` launchpad and flag the host `data-empty` so the
+    // view can style the empty binder (e.g. hide the tab strip's panel
+    // area). With sheets present the launchpad is hidden and the host
+    // flag cleared. The strip's add control stays in both states, so
+    // creating the first sheet is always one click.
+    project_empty(this, sheets.is_empty());
+
     // The add control sits after the tabs: the "+" button (idle) or the
     // inline create form (while naming a new sheet).
     ensure_add_control(this, &strip, &document);
+}
+
+/// Toggle the view-supplied empty-state region. The consuming view
+/// places a `[slot="empty"]` child (e.g. a launchpad) inside the binder
+/// alongside the `<tonk-sheet>` children; it is shown only when the
+/// binder has zero sheets. The host carries a `data-empty` flag in the
+/// same condition so the view's stylesheet can react (light DOM, so no
+/// real `<slot>` — the binder toggles `hidden` directly).
+fn project_empty(this: &HtmlElement, empty: bool) {
+    if empty {
+        let _ = this.set_attribute(EMPTY, "");
+    } else {
+        let _ = this.remove_attribute(EMPTY);
+    }
+    if let Ok(nodes) = this.query_selector_all(":scope > [slot=\"empty\"]") {
+        for i in 0..nodes.length() {
+            if let Some(node) = nodes.item(i)
+                && let Some(el) = node.dyn_ref::<HtmlElement>()
+            {
+                el.set_hidden(!empty);
+            }
+        }
+    }
 }
 
 /// Render the strip's trailing add control: the "+" button when idle,
@@ -406,8 +441,13 @@ fn install_click(this: &HtmlElement, slot: &ClickClosure) {
             return;
         };
 
-        // The "+" add button: open the inline create input.
-        if node.closest(&format!(".{ADD}")).ok().flatten().is_some() {
+        // The "+" add button, or any `[data-create]` trigger the view
+        // places in its empty-state launchpad: open the inline create
+        // input. Routing the launchpad's "add artifact" button here
+        // reuses the strip's create flow (a single create path).
+        if node.closest(&format!(".{ADD}")).ok().flatten().is_some()
+            || node.closest("[data-create]").ok().flatten().is_some()
+        {
             let _ = host.set_attribute(CREATING, "");
             project(&host);
             return;
@@ -458,12 +498,12 @@ fn install_click(this: &HtmlElement, slot: &ClickClosure) {
             // is gone the panel CSS (`:has(tonk-sheet:not([hidden]))`)
             // finds no visible panel and collapses the layout. Pointing
             // `active` at the surviving neighbour now keeps a panel
-            // shown throughout. The command (fired below) persists the
-            // same `active` via the reassign rule, idempotently.
-            if host.get_attribute("active").as_deref() == Some(sheet.as_str())
-                && let Some(next) = next.as_deref()
-            {
-                let _ = host.set_attribute("active", next);
+            // shown throughout. With no neighbour (the last sheet),
+            // `active` moves to `about:blank` so the binder reads as
+            // empty and reveals the launchpad. The command (fired below)
+            // persists the same `active` via the reassign rule.
+            if host.get_attribute("active").as_deref() == Some(sheet.as_str()) {
+                let _ = host.set_attribute("active", next.as_deref().unwrap_or(NO_NEIGHBOUR));
             }
 
             dispatch_close(&host, &sheet, next.as_deref());
@@ -550,8 +590,14 @@ fn neighbour(this: &HtmlElement, sheet: &str) -> Option<String> {
 /// the `activate` event uses `sheet`, and the workspace's
 /// `activate-sheet` command reads `dom.event.detail/sheet`, so a close
 /// carrying `sheet` would also match that command and select the
-/// closed tab. `next` is the neighbour to activate after the close, or
-/// absent when the closed sheet was the only one.
+/// closed tab. `next` is the neighbour to activate after the close; when
+/// the closed sheet was the only one it falls back to `about:blank` (the
+/// "no selection" sentinel) so the command always has a value to bind —
+/// the `close-sheet` command's `next` field is required, and an absent
+/// event field would fail the whole command build, leaving the last tab
+/// unclosable. Reassigning active to `about:blank` renders as empty, so
+/// closing the last sheet reveals the launchpad.
+const NO_NEIGHBOUR: &str = "about:blank";
 fn dispatch_close(host: &HtmlElement, closed: &str, next: Option<&str>) {
     let detail = js_sys::Object::new();
     let _ = js_sys::Reflect::set(
@@ -559,13 +605,11 @@ fn dispatch_close(host: &HtmlElement, closed: &str, next: Option<&str>) {
         &JsValue::from_str("closed"),
         &JsValue::from_str(closed),
     );
-    if let Some(next) = next {
-        let _ = js_sys::Reflect::set(
-            &detail,
-            &JsValue::from_str("next"),
-            &JsValue::from_str(next),
-        );
-    }
+    let _ = js_sys::Reflect::set(
+        &detail,
+        &JsValue::from_str("next"),
+        &JsValue::from_str(next.unwrap_or(NO_NEIGHBOUR)),
+    );
     let init = CustomEventInit::new();
     init.set_detail(&detail);
     init.set_bubbles(true);
@@ -812,7 +856,11 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_omits_next_when_closing_the_only_sheet() {
+    async fn it_falls_back_to_about_blank_next_when_closing_the_only_sheet() {
+        // Closing the last sheet has no neighbour, so `next` falls back to
+        // `about:blank` rather than being omitted: the `close-sheet`
+        // command's `next` field is required, and an absent event field
+        // would fail the whole command build, leaving the tab unclosable.
         let binder = mount_binder("a", &[("a", "a", "Only")]);
         let (closed, _closed_l) = capture_detail("close", "closed");
         let (next, _next_l) = capture_detail("close", "next");
@@ -826,8 +874,8 @@ mod tests {
         assert_eq!(closed.borrow().as_deref(), Some("a"));
         assert_eq!(
             next.borrow().as_deref(),
-            None,
-            "no neighbour to fall back to"
+            Some("about:blank"),
+            "the only sheet has no neighbour, so next falls back to about:blank",
         );
         binder.remove();
     }
@@ -865,6 +913,80 @@ mod tests {
             binder.get_attribute("active").as_deref(),
             Some("a"),
             "closing a non-active sheet must not move active",
+        );
+        binder.remove();
+    }
+
+    /// Append a `[slot="empty"]` launchpad child to a binder and
+    /// return it. Used by the empty-state tests.
+    fn add_empty_slot(binder: &Element) -> Element {
+        let document = window().unwrap().document().unwrap();
+        let slot = document.create_element("div").unwrap();
+        slot.set_attribute("slot", "empty").unwrap();
+        slot.set_inner_html("<button data-create>add</button>");
+        binder.append_child(&slot).unwrap();
+        slot
+    }
+
+    #[dialog_common::test]
+    async fn it_reveals_the_empty_slot_when_there_are_no_sheets() {
+        // No sheets: the binder flags itself `data-empty` and reveals the
+        // view-supplied `[slot="empty"]` launchpad.
+        let binder = mount_binder("about:blank", &[]);
+        let slot = add_empty_slot(&binder);
+        // Re-project now that the slot exists (it was appended after the
+        // connectedCallback projection); a mutation re-projects in the
+        // app, but drive it directly here.
+        project(binder.dyn_ref::<HtmlElement>().unwrap());
+
+        assert!(
+            binder.has_attribute(EMPTY),
+            "the binder flags itself data-empty with no sheets",
+        );
+        assert!(
+            !slot.dyn_ref::<HtmlElement>().unwrap().hidden(),
+            "the empty slot is revealed when there are no sheets",
+        );
+        binder.remove();
+    }
+
+    #[dialog_common::test]
+    async fn it_hides_the_empty_slot_when_a_sheet_is_present() {
+        let binder = mount_binder("a", &[("a", "a", "First")]);
+        let slot = add_empty_slot(&binder);
+        project(binder.dyn_ref::<HtmlElement>().unwrap());
+
+        assert!(
+            !binder.has_attribute(EMPTY),
+            "the binder clears data-empty when a sheet exists",
+        );
+        assert!(
+            slot.dyn_ref::<HtmlElement>().unwrap().hidden(),
+            "the empty slot is hidden when a sheet is present",
+        );
+        binder.remove();
+    }
+
+    #[dialog_common::test]
+    async fn it_opens_the_create_input_from_an_empty_slot_data_create_button() {
+        // The launchpad's `[data-create]` button routes to the binder's
+        // inline create flow, the same path as the strip's "+".
+        let binder = mount_binder("about:blank", &[]);
+        let slot = add_empty_slot(&binder);
+        project(binder.dyn_ref::<HtmlElement>().unwrap());
+
+        let button = slot
+            .query_selector("[data-create]")
+            .unwrap()
+            .expect("data-create button in the empty slot");
+        button.dyn_ref::<HtmlElement>().unwrap().click();
+
+        assert!(
+            binder
+                .query_selector(&format!(".{CREATE_INPUT}"))
+                .unwrap()
+                .is_some(),
+            "clicking the launchpad add button opens the create input",
         );
         binder.remove();
     }


### PR DESCRIPTION
The workspace surface no longer has a standalone `workspace` concept. It is now a view of the device's **replica binder**: `tonk:binder.active` (one per replica, origin-derived) holds the selected sheet, and sheets are top-level `tonk:sheet` instances enumerated directly rather than via workspace membership. This makes selection per-device and removes the container entity that was carrying two roles (shell + sheet collection) and rendering its chrome twice.

Selection now flows through the binder. `activate`/`close`/`create` target it via a `tonk/replica` join; closing a sheet retracts only the `order` it carries over a plain artifact, so the tab disappears but the artifact survives. The binder is seeded to `about:blank` at repository creation so every replica matches a binder, and closing the last sheet falls back to `about:blank` (the `close-sheet` command's `next` is required, so an absent value would otherwise fail the build and leave the last tab unclosable).

Getting the selection to actually reach the binder surfaced two renderer bugs, fixed here:

- `<tonk-display>` stored the `DocumentFragment` as its navigation root, but `append_child` empties it — so in-place chrome updates navigated against an empty fragment and silently dropped the write. The binder's `active={dom.host/data-active}` never reflected the persisted selection (switching a tab worked; a reload fell back to the first sheet). The host is now the navigation root.
- A `{dom.host/*}` reference (a scalar copied off the outer host) was treated as an iteration candidate, so an absent host attribute cloned its element zero times and dropped it. Excluded from iteration candidacy, matching the repeat-node resolution that already ignores `dom.host/*`.

The empty space now shows a launchpad (the wireframe's "empty repo" frame) via a binder empty slot instead of the old `<tonk-fallback>`, which watched the wrong display's emptiness and never showed.

Also fixes an analyzer bug uncovered along the way: omitted/`_` rule premise fields lifted to a named anonymous variable, which a negation premise requires to be bound — failing the binder-init rule's `unless`. They now lift to a blank wildcard.

Verified live in the browser (tab switch persists across reload; close works down to the last tab); standard library lowers; native + wasm tests compile; fmt/clippy clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of sheet and binder functionalities within the `tonk` application, improving attribute management, and refining the behavior of navigation and rendering in various components.

### Detailed summary
- Added comments to clarify the behavior of `append_child` and fragment handling in `render.rs`.
- Improved handling of blank fields and term projections in `rule.rs`.
- Updated YAML configurations for better clarity on workspace and sheet relationships.
- Enhanced tests to ensure correct behavior for empty states and attribute management in the binder.
- Improved attribute handling in `router/repository.rs` for sheets.
- Refined CSS styles for better layout and visibility of components in the UI.

> The following files were skipped due to too many changes: `rust/tonk-core/assets/library/core.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->