### PR TITLE
fix(tonk-ui): iframe fills sheet, pin sheet tabs to viewport bottom

### DIFF
--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -299,6 +299,14 @@ tonk-repository.display-route,
     min-height: 100dvh;
 }
 
+.display-route > tonk-branch > .display-view-slot:has(.workspace) {
+    height: 100dvh;
+}
+.display-route .workspace {
+    height: 100dvh;
+    min-height: 0;
+}
+
 /* Tonk Hub page (`/`). A centered column: a header row with the
    "New repo" button and the "Repositories" title, then the space
    cards (the `space` directory view). The hub here owns its own


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the CSS styles for elements within the `.display-route` and `.workspace` classes to enhance layout responsiveness.

### Detailed summary
- Added a style for `.display-route > tonk-branch > .display-view-slot:has(.workspace)` to set `height` to `100dvh`.
- Set `height` to `100dvh` and `min-height` to `0` for `.display-route .workspace`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->