### PR TITLE
feat: CSV import/export of branch artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-csv"
+version = "0.1.0"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+dependencies = [
+ "async-trait",
+ "base58",
+ "csv-async",
+ "dialog-artifacts",
+ "futures-util",
+ "getrandom 0.2.17",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "dialog-effects"
 version = "0.1.0"
 source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
@@ -4337,6 +4352,7 @@ dependencies = [
  "dialog-capability",
  "dialog-common",
  "dialog-credentials",
+ "dialog-csv",
  "dialog-effects",
  "dialog-operator",
  "dialog-query",
@@ -5188,6 +5204,7 @@ dependencies = [
  "dialog-capability",
  "dialog-common",
  "dialog-credentials",
+ "dialog-csv",
  "dialog-effects",
  "dialog-operator",
  "dialog-query",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1083,7 +1089,7 @@ dependencies = [
  "dialog-capability",
  "dialog-common",
  "dialog-effects",
- "dialog-prolly-tree",
+ "dialog-search-tree",
  "dialog-storage",
  "ed25519-dalek",
  "futures-util",
@@ -1092,9 +1098,9 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "rkyv",
  "serde",
  "serde-big-array",
- "serde_ipld_dagcbor",
  "serde_json",
  "static_assertions",
  "thiserror 2.0.18",
@@ -1107,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1124,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1152,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-trait",
  "base58",
@@ -1173,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-trait",
  "base58",
@@ -1188,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1200,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1214,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1246,29 +1252,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialog-prolly-tree"
-version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "base58",
- "blake3",
- "dialog-common",
- "dialog-storage",
- "futures-core",
- "futures-util",
- "nonempty",
- "rand 0.8.5",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1292,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1331,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1366,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1379,10 +1365,10 @@ dependencies = [
  "dialog-effects",
  "dialog-network",
  "dialog-operator",
- "dialog-prolly-tree",
  "dialog-query",
  "dialog-remote-s3",
  "dialog-remote-ucan-s3",
+ "dialog-search-tree",
  "dialog-storage",
  "dialog-ucan",
  "dialog-ucan-core",
@@ -1400,9 +1386,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-search-tree"
+version = "0.1.0"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base58",
+ "blake3",
+ "bytes",
+ "dashmap",
+ "dialog-common",
+ "dialog-macros",
+ "dialog-storage",
+ "futures-core",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "nonempty",
+ "parking_lot",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "sieve-cache",
+ "stable_deref_trait",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1445,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "async-trait",
  "base58",
@@ -1466,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1492,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-10#187b36ac5f88519a4572f45e71ebbe0eca904d28"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",
@@ -1750,6 +1765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,7 +2020,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2007,6 +2028,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "base58",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "base58",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "base58",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "async-trait",
  "base58",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Fswitch-to-search-tree#1bf3f48cbcc0139f24289f6f581c77cf8ebf6375"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,21 +137,21 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch 
 dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,20 +137,20 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-10" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/switch-to-search-tree" }
 
 [profile.dev]
 opt-level = 1

--- a/rust/slide/Cargo.toml
+++ b/rust/slide/Cargo.toml
@@ -29,6 +29,10 @@ path = "tests/notation.rs"
 name = "sync"
 path = "tests/sync.rs"
 
+[[test]]
+name = "transfer"
+path = "tests/transfer.rs"
+
 [features]
 integration-tests = []
 
@@ -46,6 +50,7 @@ clap = { workspace = true }
 dialog-artifacts = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-credentials = { workspace = true }
+dialog-csv = { workspace = true }
 dialog-effects = { workspace = true }
 dialog-operator = { workspace = true }
 dialog-query = { workspace = true }

--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -20,6 +20,7 @@ use slide::output::Format;
 use slide::remote::{self, AddOutcome, RemoteRecord, UpstreamOutcome};
 use slide::share::{self, ShareDisplayOutcome, ShareOptions, ShareOutcome, ShareViewOutcome};
 use slide::sync::{self, SyncOutcome};
+use slide::transfer;
 use slide::views::{self, ViewSummary};
 use slide::{ExitCode, guide, identity, schema, site};
 
@@ -111,6 +112,24 @@ enum Command {
         /// filesystem; copy + delete fallback otherwise.
         #[arg(long = "move")]
         do_move: bool,
+    },
+
+    /// Export the local main branch's artifacts as CSV. Writes to
+    /// stdout unless `--out <file>` is given.
+    #[command(after_help = "Examples:\n  slide export\n  slide export --out data.csv")]
+    Export {
+        /// Write the CSV to this file instead of stdout.
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+    },
+
+    /// Import artifacts from a CSV file, committing each row as an
+    /// assertion on the local main branch.
+    #[command(after_help = "Examples:\n  slide import data.csv")]
+    Import {
+        /// The CSV file to read (`the,of,as,is,cause` columns).
+        #[arg(value_name = "PATH")]
+        file: PathBuf,
     },
 
     /// Push the local main branch to its upstream.
@@ -352,6 +371,8 @@ async fn main() {
         Command::Concepts => print_concepts().await,
         Command::Views => print_views().await,
         Command::Migrate { from, do_move } => migrate(from, do_move).await,
+        Command::Export { out } => export_op(out).await,
+        Command::Import { file } => import_op(file).await,
         Command::Push => sync_op(SyncOp::Push).await,
         Command::Pull => sync_op(SyncOp::Pull).await,
         Command::Status => status_op().await,
@@ -506,6 +527,65 @@ async fn sync_op(op: SyncOp) -> ExitCode {
     match result {
         Ok(outcome) => {
             print_sync_outcome(op, &outcome);
+            ExitCode::Success
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            err.exit_code()
+        }
+    }
+}
+
+async fn export_op(out: Option<PathBuf>) -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+    };
+    let site = match site::SlideSite::discover_and_open(&cwd).await {
+        Ok(s) => s,
+        Err(err) => return print_error(err.to_string()),
+    };
+
+    let destination = match &out {
+        Some(path) => transfer::Destination::File(path.clone()),
+        None => transfer::Destination::Stdout,
+    };
+
+    match transfer::export(&site, destination).await {
+        Ok(bytes) => {
+            // The CSV may be on stdout, so status goes to stderr.
+            if let Some(path) = out {
+                eprintln!("exported {bytes} bytes to {}", path.display());
+            } else {
+                eprintln!("exported {bytes} bytes");
+            }
+            ExitCode::Success
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            err.exit_code()
+        }
+    }
+}
+
+async fn import_op(file: PathBuf) -> ExitCode {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+    };
+    let site = match site::SlideSite::discover_and_open(&cwd).await {
+        Ok(s) => s,
+        Err(err) => return print_error(err.to_string()),
+    };
+
+    match transfer::import(&site, &file).await {
+        Ok(revision) => {
+            println!(
+                "imported {} -> revision {}.{}",
+                file.display(),
+                revision.period,
+                revision.moment,
+            );
             ExitCode::Success
         }
         Err(err) => {

--- a/rust/slide/src/lib.rs
+++ b/rust/slide/src/lib.rs
@@ -30,6 +30,7 @@ pub mod schema;
 pub mod share;
 pub mod site;
 pub mod sync;
+pub mod transfer;
 pub mod views;
 
 /// CLI exit codes.

--- a/rust/slide/src/transfer.rs
+++ b/rust/slide/src/transfer.rs
@@ -1,0 +1,92 @@
+//! `slide export` / `slide import` — CSV round-trip of a branch's
+//! artifacts.
+//!
+//! Wraps dialog's `Branch::export()` / `Branch::import()` with
+//! `dialog_csv`'s CSV exporter / importer. Like [`crate::sync`],
+//! this talks to dialog directly — slide has no SSE clients, so it
+//! skips the reactor wrapper the worker uses.
+
+use std::path::PathBuf;
+
+use dialog_csv::{CsvExporter, CsvImporter};
+use dialog_repository::Revision;
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+
+use crate::ExitCode;
+use crate::site::SlideSite;
+
+/// Failure modes for [`export`] / [`import`].
+#[derive(Debug, Error)]
+pub enum TransferError {
+    /// An I/O error reading or writing a file / stdout.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The dialog export stream failed.
+    #[error("export failed: {0}")]
+    Export(dialog_artifacts::DialogArtifactsError),
+
+    /// The dialog import / commit failed.
+    #[error("import failed: {0}")]
+    Import(dialog_repository::CommitError),
+}
+
+impl TransferError {
+    /// Map to a process exit code.
+    pub fn exit_code(&self) -> ExitCode {
+        match self {
+            TransferError::Io(_) => ExitCode::IoError,
+            TransferError::Export(_) | TransferError::Import(_) => ExitCode::CommitError,
+        }
+    }
+}
+
+/// Where an [`export`] writes its CSV.
+pub enum Destination {
+    /// Write to the given file path.
+    File(PathBuf),
+    /// Write to stdout.
+    Stdout,
+}
+
+/// Export every artifact on the site's `main` branch as CSV to
+/// `destination`. Returns the number of bytes written.
+pub async fn export(site: &SlideSite, destination: Destination) -> Result<usize, TransferError> {
+    // Buffer in memory: the dialog exporter wants an `AsyncWrite`,
+    // and we want a byte count + a single flush to the real sink.
+    let mut buf: Vec<u8> = Vec::new();
+    site.branch
+        .export(CsvExporter::from(&mut buf))
+        .perform(&site.operator)
+        .await
+        .map_err(TransferError::Export)?;
+
+    let len = buf.len();
+    match destination {
+        Destination::File(path) => {
+            let mut file = tokio::fs::File::create(&path).await?;
+            file.write_all(&buf).await?;
+            file.flush().await?;
+        }
+        Destination::Stdout => {
+            let mut out = tokio::io::stdout();
+            out.write_all(&buf).await?;
+            out.flush().await?;
+        }
+    }
+    Ok(len)
+}
+
+/// Import artifacts from a CSV file at `path`, committing each row
+/// as an assertion on the site's `main` branch in one transaction.
+/// Returns the post-commit revision.
+pub async fn import(site: &SlideSite, path: &PathBuf) -> Result<Revision, TransferError> {
+    let file = tokio::fs::File::open(path).await?;
+    let importer = CsvImporter::from(file);
+    site.branch
+        .import(importer)
+        .perform(&site.operator)
+        .await
+        .map_err(TransferError::Import)
+}

--- a/rust/slide/tests/transfer.rs
+++ b/rust/slide/tests/transfer.rs
@@ -1,0 +1,80 @@
+//! `slide export` / `slide import` — CSV round-trip of a branch's
+//! artifacts.
+
+mod common;
+
+use anyhow::Result;
+use slide::transfer::{self, Destination};
+
+use crate::common::{ATTRIBUTE_DECL, TestSite};
+
+/// Read a site's CSV export back as a String via a temp file.
+async fn export_to_string(test: &TestSite) -> Result<String> {
+    let path = test.parent.join("export.csv");
+    transfer::export(&test.site, Destination::File(path.clone())).await?;
+    Ok(tokio::fs::read_to_string(&path).await?)
+}
+
+#[tokio::test]
+async fn it_exports_seeded_artifacts_as_csv() -> Result<()> {
+    let test = TestSite::new().await?;
+    test.eval_inline(ATTRIBUTE_DECL).await?;
+
+    let csv = export_to_string(&test).await?;
+    assert!(
+        csv.starts_with("the,of,as,is,cause"),
+        "export missing CSV header: {csv}",
+    );
+    assert!(
+        csv.lines().count() > 1,
+        "export should have at least one data row: {csv}",
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_round_trips_export_then_import() -> Result<()> {
+    // Seed one site, export it to a file.
+    let source = TestSite::new().await?;
+    source.eval_inline(ATTRIBUTE_DECL).await?;
+    let source_csv = export_to_string(&source).await?;
+    let csv_path = source.parent.join("export.csv");
+
+    // Import that file into a fresh, empty site.
+    let dest = TestSite::new().await?;
+    let _revision = transfer::import(&dest.site, &csv_path).await?;
+
+    // The destination's export now matches the source's, row-for-row.
+    let dest_csv = export_to_string(&dest).await?;
+    let mut source_rows: Vec<&str> = source_csv.lines().skip(1).collect();
+    let mut dest_rows: Vec<&str> = dest_csv.lines().skip(1).collect();
+    source_rows.sort_unstable();
+    dest_rows.sort_unstable();
+    assert_eq!(
+        dest_rows, source_rows,
+        "round-tripped rows differ\nsource:\n{source_csv}\ndest:\n{dest_csv}",
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_imports_an_empty_csv_without_error() -> Result<()> {
+    let test = TestSite::new().await?;
+    let path = test.parent.join("empty.csv");
+    tokio::fs::write(&path, "the,of,as,is,cause\n").await?;
+
+    // An empty import succeeds; it just commits nothing meaningful.
+    let _ = transfer::import(&test.site, &path).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_exports_to_stdout_destination() -> Result<()> {
+    // Smoke-test the stdout path: export should report a non-zero
+    // byte count for a seeded branch even when writing to stdout.
+    let test = TestSite::new().await?;
+    test.eval_inline(ATTRIBUTE_DECL).await?;
+    let bytes = transfer::export(&test.site, Destination::Stdout).await?;
+    assert!(bytes > 0, "stdout export wrote nothing");
+    Ok(())
+}

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -732,12 +732,16 @@ mod tests {
     /// covers the commit path the test fixtures use to assert
     /// concept facts onto the branch.
     trait FixtureEnv:
-        tonk_schema::concept::QueryEnv + dialog_query::Provider<dialog_effects::memory::Publish>
+        tonk_schema::concept::QueryEnv
+        + dialog_query::Provider<dialog_effects::memory::Publish>
+        + dialog_query::Provider<dialog_effects::archive::Import>
     {
     }
 
     impl<T> FixtureEnv for T where
-        T: tonk_schema::concept::QueryEnv + dialog_query::Provider<dialog_effects::memory::Publish>
+        T: tonk_schema::concept::QueryEnv
+            + dialog_query::Provider<dialog_effects::memory::Publish>
+            + dialog_query::Provider<dialog_effects::archive::Import>
     {
     }
 

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -822,12 +822,16 @@ mod tests {
     /// covers the commit path the test fixtures use to assert
     /// concept facts onto the branch.
     trait FixtureEnv:
-        tonk_schema::concept::QueryEnv + dialog_query::Provider<dialog_effects::memory::Publish>
+        tonk_schema::concept::QueryEnv
+        + dialog_query::Provider<dialog_effects::memory::Publish>
+        + dialog_query::Provider<dialog_effects::archive::Import>
     {
     }
 
     impl<T> FixtureEnv for T where
-        T: tonk_schema::concept::QueryEnv + dialog_query::Provider<dialog_effects::memory::Publish>
+        T: tonk_schema::concept::QueryEnv
+            + dialog_query::Provider<dialog_effects::memory::Publish>
+            + dialog_query::Provider<dialog_effects::archive::Import>
     {
     }
 

--- a/rust/tonk-schema/src/resolution.rs
+++ b/rust/tonk-schema/src/resolution.rs
@@ -383,7 +383,9 @@ mod tests {
         transient: bool,
     ) -> anyhow::Result<Entity>
     where
-        Env: QueryEnv + dialog_capability::Provider<dialog_effects::memory::Publish>,
+        Env: QueryEnv
+            + dialog_capability::Provider<dialog_effects::memory::Publish>
+            + dialog_capability::Provider<dialog_effects::archive::Import>,
     {
         let txn = branch.transaction();
         let mut txn = txn;

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -27,6 +27,7 @@ dialog-capability = { workspace = true }
 dialog-common = { workspace = true }
 dialog-artifacts = { workspace = true }
 dialog-credentials = { workspace = true }
+dialog-csv = { workspace = true }
 dialog-effects = { workspace = true }
 dialog-operator = { workspace = true }
 dialog-query = { workspace = true }

--- a/rust/tonk-worker/src/reactor.rs
+++ b/rust/tonk-worker/src/reactor.rs
@@ -26,6 +26,8 @@ mod branch;
 mod command;
 mod env;
 mod error;
+mod export;
+mod import;
 mod pull;
 mod push;
 mod repository;
@@ -41,6 +43,8 @@ pub use env::{
     BranchOpenProvider, CommitProvider, LoadProvider, PullProvider, PushProvider, SelectProvider,
 };
 pub use error::ReactorError;
+pub use export::{Export, ExportError};
+pub use import::{Import, ImportError};
 pub use pull::Pull;
 pub use push::Push;
 pub use repository::{RepositoryReference, RepositoryState};

--- a/rust/tonk-worker/src/reactor/branch/reference.rs
+++ b/rust/tonk-worker/src/reactor/branch/reference.rs
@@ -9,8 +9,14 @@ use std::sync::Arc;
 
 use dialog_query::ConceptQuery;
 
+use dialog_artifacts::Exporter;
+use dialog_common::ConditionalSend;
+use dialog_repository::Importer;
+
 use crate::reactor::env::{BranchOpenProvider, LoadProvider};
 use crate::reactor::error::ReactorError;
+use crate::reactor::export::Export;
+use crate::reactor::import::Import;
 use crate::reactor::pull::Pull;
 use crate::reactor::push::Push;
 use crate::reactor::subscribe::Subscribe;
@@ -94,5 +100,19 @@ impl<'a> BranchReference<'a> {
     /// branch state.
     pub fn push(self) -> Push<'a> {
         Push::new(self)
+    }
+
+    /// Stream every artifact on the branch into `exporter`. Chain
+    /// `.perform(&op)`. Read-only — no re-poll.
+    pub fn export<E: Exporter>(self, exporter: E) -> Export<'a, E> {
+        Export::new(self, exporter)
+    }
+
+    /// Commit every artifact `importer` yields as an assertion, in
+    /// one transaction. Chain `.perform(&op)`. Re-polls every
+    /// subscription on the branch so changed results fan out, the
+    /// same way a transaction commit does.
+    pub fn import<I: Importer + Unpin + ConditionalSend>(self, importer: I) -> Import<'a, I> {
+        Import::new(self, importer)
     }
 }

--- a/rust/tonk-worker/src/reactor/env.rs
+++ b/rust/tonk-worker/src/reactor/env.rs
@@ -12,7 +12,7 @@
 
 use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;
-use dialog_effects::archive::{Get, Put};
+use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::Identify;
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_effects::space::Load;
@@ -54,6 +54,7 @@ impl<T> SelectProvider for T where
 pub trait CommitProvider:
     Provider<Get>
     + Provider<Put>
+    + Provider<Import>
     + Provider<Resolve>
     + Provider<Publish>
     + Provider<Identify>
@@ -66,6 +67,7 @@ pub trait CommitProvider:
 impl<T> CommitProvider for T where
     T: Provider<Get>
         + Provider<Put>
+        + Provider<Import>
         + Provider<Resolve>
         + Provider<Publish>
         + Provider<Identify>
@@ -80,6 +82,7 @@ impl<T> CommitProvider for T where
 pub trait PullProvider:
     Provider<Get>
     + Provider<Put>
+    + Provider<Import>
     + Provider<Resolve>
     + Provider<Publish>
     + Provider<Identify>
@@ -92,6 +95,7 @@ pub trait PullProvider:
 impl<T> PullProvider for T where
     T: Provider<Get>
         + Provider<Put>
+        + Provider<Import>
         + Provider<Resolve>
         + Provider<Publish>
         + Provider<Identify>

--- a/rust/tonk-worker/src/reactor/export.rs
+++ b/rust/tonk-worker/src/reactor/export.rs
@@ -1,0 +1,72 @@
+//! [`Export`] — wrap [`dialog_repository::Branch::export`] so a
+//! route or CLI can stream a branch's artifacts into any
+//! [`Exporter`] (e.g. `dialog_csv::CsvExporter`) without reaching
+//! for dialog handles directly.
+//!
+//! Read-only: export never mutates the branch, so unlike
+//! [`super::Pull`] / [`super::transaction::Commit`] it does not
+//! re-poll subscriptions.
+
+use dialog_artifacts::{DialogArtifactsError, Exporter};
+
+use super::BranchReference;
+use super::env::{BranchOpenProvider, LoadProvider, SelectProvider};
+use super::error::ReactorError;
+
+/// Export-all-artifacts effect. Generic over the [`Exporter`] sink
+/// so the format (CSV, …) is the caller's concern.
+pub struct Export<'a, E> {
+    /// The branch to export from.
+    pub branch: BranchReference<'a>,
+    /// The sink the artifacts stream into.
+    pub exporter: E,
+}
+
+impl<'a, E: Exporter> Export<'a, E> {
+    /// Build a new `Export` effect.
+    pub fn new(branch: BranchReference<'a>, exporter: E) -> Self {
+        Self { branch, exporter }
+    }
+
+    /// Execute the export, writing every artifact on the branch
+    /// into the exporter. Returns once the exporter is closed.
+    pub async fn perform<Env>(self, env: &Env) -> Result<(), ExportError>
+    where
+        Env: LoadProvider + BranchOpenProvider + SelectProvider,
+    {
+        let cached = self.branch.acquire(env).await?;
+        cached
+            .handle()
+            .export(self.exporter)
+            .perform(env)
+            .await
+            .map_err(ExportError::Export)?;
+        Ok(())
+    }
+}
+
+/// Failure modes of an [`Export`].
+#[derive(Debug)]
+pub enum ExportError {
+    /// The branch could not be resolved / opened.
+    Reactor(ReactorError),
+    /// The dialog export stream failed.
+    Export(DialogArtifactsError),
+}
+
+impl From<ReactorError> for ExportError {
+    fn from(error: ReactorError) -> Self {
+        ExportError::Reactor(error)
+    }
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportError::Reactor(e) => write!(f, "{e}"),
+            ExportError::Export(e) => write!(f, "export failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ExportError {}

--- a/rust/tonk-worker/src/reactor/import.rs
+++ b/rust/tonk-worker/src/reactor/import.rs
@@ -1,0 +1,73 @@
+//! [`Import`] — wrap [`dialog_repository::Branch::import`] so the
+//! imported artifacts commit as assertions and every subscription
+//! on the branch re-polls, the same notify-on-commit discipline
+//! [`super::Pull`] and [`super::transaction::Commit`] follow. The
+//! caller supplies any [`Importer`] (e.g. `dialog_csv::CsvImporter`).
+
+use dialog_common::ConditionalSend;
+use dialog_repository::{CommitError, Importer, Revision};
+
+use super::BranchReference;
+use super::env::{BranchOpenProvider, CommitProvider, LoadProvider, SelectProvider};
+use super::error::ReactorError;
+
+/// Import-artifacts effect. Generic over the [`Importer`] source so
+/// the format (CSV, …) is the caller's concern.
+pub struct Import<'a, I> {
+    /// The branch to import into.
+    pub branch: BranchReference<'a>,
+    /// The artifact source.
+    pub importer: I,
+}
+
+impl<'a, I: Importer + Unpin + ConditionalSend> Import<'a, I> {
+    /// Build a new `Import` effect.
+    pub fn new(branch: BranchReference<'a>, importer: I) -> Self {
+        Self { branch, importer }
+    }
+
+    /// Execute the import: every artifact is committed as an
+    /// assertion in one transaction, then subscriptions re-poll so
+    /// SSE clients see the new state. Returns the post-commit
+    /// revision.
+    pub async fn perform<Env>(self, env: &Env) -> Result<Revision, ImportError>
+    where
+        Env: LoadProvider + BranchOpenProvider + CommitProvider + SelectProvider,
+    {
+        let cached = self.branch.acquire(env).await?;
+        let revision = cached
+            .handle()
+            .import(self.importer)
+            .perform(env)
+            .await
+            .map_err(ImportError::Commit)?;
+        cached.poll(env).await;
+        Ok(revision)
+    }
+}
+
+/// Failure modes of an [`Import`].
+#[derive(Debug)]
+pub enum ImportError {
+    /// The branch could not be resolved / opened.
+    Reactor(ReactorError),
+    /// The dialog import / commit failed.
+    Commit(CommitError),
+}
+
+impl From<ReactorError> for ImportError {
+    fn from(error: ReactorError) -> Self {
+        ImportError::Reactor(error)
+    }
+}
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImportError::Reactor(e) => write!(f, "{e}"),
+            ImportError::Commit(e) => write!(f, "import failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -54,6 +54,9 @@ pub use query::QueryPath;
 mod transact;
 pub use transact::{ProfileTransactPath, TransactPath, TransactResponse};
 
+mod transfer;
+pub use transfer::ImportResponse;
+
 pub mod bridge;
 pub use bridge::BridgeRegistry;
 
@@ -187,6 +190,17 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route(
             "/api/repository/{repo}/branch/{branch}/evaluate",
             post(evaluate::evaluate),
+        )
+        // CSV export / import — stream the branch's artifacts out as
+        // `text/csv`, or commit a CSV body's rows as assertions. See
+        // `router/transfer.rs`.
+        .route(
+            "/api/repository/{repo}/branch/{branch}/export",
+            get(transfer::export),
+        )
+        .route(
+            "/api/repository/{repo}/branch/{branch}/import",
+            post(transfer::import),
         )
         // Structured-mutation route — see `plan/transact-endpoint.md`.
         // Bypasses tonk-notation: accepts a typed

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -192,13 +192,10 @@ async fn evaluate_on_branch<'a>(
     let text = std::str::from_utf8(&body)
         .map_err(|e| TonkWorkerError::Router(format!("body is not valid UTF-8: {e}")))?;
 
-    let t_parse = web_time::Instant::now();
     let parsed = parse(text);
     let syntax = surface_parse_diagnostics(parsed)?;
-    let parse_ms = t_parse.elapsed().as_millis();
 
-    let exprs = syntax.expressions.len();
-    log!("Evaluating {exprs} expression(s)");
+    log!("Evaluating {} expression(s)", syntax.expressions.len());
 
     let session = tonk_branch
         .acquire(&tonk_state.operator)
@@ -207,13 +204,11 @@ async fn evaluate_on_branch<'a>(
     let branch = session.handle();
     let revision_before = branch.revision();
 
-    let t_eval = web_time::Instant::now();
     let evaluated = syntax
         .evaluate(branch.transaction())
         .perform(&tonk_state.operator)
         .await
         .map_err(map_evaluate_error)?;
-    let eval_ms = t_eval.elapsed().as_millis();
 
     // Compute the post-evaluation matches before any commit
     // decision: the txn's overlay already reflects every mutation
@@ -229,26 +224,12 @@ async fn evaluate_on_branch<'a>(
     // `Statement::InstallEffect`, so a document with any planned
     // statement is the single commit signal.
     let response = if query.transact && evaluated.analysis.analysis.has_statements() {
-        let t_commit = web_time::Instant::now();
         let revision_after = evaluated
             .txn
             .commit()
             .perform(&tonk_state.operator)
             .await
             .map_err(|e| map_evaluate_error(EvaluateError::Query(format!("commit: {e}"))))?;
-        let commit_ms = t_commit.elapsed().as_millis();
-        let timing = format!(
-            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | commit {commit_ms}ms"
-        );
-        log!("{timing}");
-        // Tee timing onto a BroadcastChannel so a page (or DevTools
-        // listener) can read seed numbers without the SW console — the
-        // seed runs background in the SW, so its logs never reach the
-        // page console.
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-        if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
-            let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
-        }
         // Re-poll subscriptions so SSE clients see the new state.
         // The chain commits via dialog directly; the reactor's
         // subscription registry is the worker's responsibility.

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -192,10 +192,13 @@ async fn evaluate_on_branch<'a>(
     let text = std::str::from_utf8(&body)
         .map_err(|e| TonkWorkerError::Router(format!("body is not valid UTF-8: {e}")))?;
 
+    let t_parse = web_time::Instant::now();
     let parsed = parse(text);
     let syntax = surface_parse_diagnostics(parsed)?;
+    let parse_ms = t_parse.elapsed().as_millis();
 
-    log!("Evaluating {} expression(s)", syntax.expressions.len());
+    let exprs = syntax.expressions.len();
+    log!("Evaluating {exprs} expression(s)");
 
     let session = tonk_branch
         .acquire(&tonk_state.operator)
@@ -204,11 +207,13 @@ async fn evaluate_on_branch<'a>(
     let branch = session.handle();
     let revision_before = branch.revision();
 
+    let t_eval = web_time::Instant::now();
     let evaluated = syntax
         .evaluate(branch.transaction())
         .perform(&tonk_state.operator)
         .await
         .map_err(map_evaluate_error)?;
+    let eval_ms = t_eval.elapsed().as_millis();
 
     // Compute the post-evaluation matches before any commit
     // decision: the txn's overlay already reflects every mutation
@@ -224,12 +229,26 @@ async fn evaluate_on_branch<'a>(
     // `Statement::InstallEffect`, so a document with any planned
     // statement is the single commit signal.
     let response = if query.transact && evaluated.analysis.analysis.has_statements() {
+        let t_commit = web_time::Instant::now();
         let revision_after = evaluated
             .txn
             .commit()
             .perform(&tonk_state.operator)
             .await
             .map_err(|e| map_evaluate_error(EvaluateError::Query(format!("commit: {e}"))))?;
+        let commit_ms = t_commit.elapsed().as_millis();
+        let timing = format!(
+            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | commit {commit_ms}ms"
+        );
+        log!("{timing}");
+        // Tee timing onto a BroadcastChannel so a page (or DevTools
+        // listener) can read seed numbers without the SW console — the
+        // seed runs background in the SW, so its logs never reach the
+        // page console.
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
+            let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
+        }
         // Re-poll subscriptions so SSE clients see the new state.
         // The chain commits via dialog directly; the reactor's
         // subscription registry is the worker's responsibility.

--- a/rust/tonk-worker/src/router/transfer.rs
+++ b/rust/tonk-worker/src/router/transfer.rs
@@ -1,0 +1,285 @@
+//! CSV export / import routes.
+//!
+//! - `GET  /api/repository/{repo}/branch/{branch}/export` streams
+//!   every artifact on the branch out as `text/csv`.
+//! - `POST /api/repository/{repo}/branch/{branch}/import` reads a
+//!   `text/csv` body and commits each row as an assertion.
+//!
+//! Both go through the reactor's [`BranchReference::export`] /
+//! [`BranchReference::import`] wrappers, so import re-polls
+//! subscriptions automatically (the route then broadcasts the new
+//! revision so revision/sync badges refresh, the same as
+//! `evaluate`). The CSV format lives here; the reactor stays
+//! format-agnostic.
+
+use ::axum::{
+    body::{Body, Bytes},
+    extract::{Path, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use axum_wasm_macros::wasm_compat;
+use dialog_csv::{CsvExporter, CsvImporter};
+use serde::{Deserialize, Serialize};
+use std::io::Cursor;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use super::AppState;
+use super::evaluate::EvaluatePath;
+use crate::TonkWorkerError;
+use crate::broadcast::{Notification, broadcast};
+
+/// `GET /api/repository/{repo}/branch/{branch}/export`
+///
+/// Streams every artifact on the branch as a CSV document
+/// (`the,of,as,is,cause` columns). Read-only.
+#[wasm_compat]
+pub async fn export(
+    State(state): State<AppState>,
+    Path(path): Path<EvaluatePath>,
+) -> Result<Response, TonkWorkerError> {
+    log!("export repo={}, branch={}", path.repo, path.branch);
+    let tonk_state = state.write().await;
+    let tonk_branch = tonk_state
+        .reactor
+        .repository(&path.repo)
+        .branch(&path.branch);
+
+    let mut buf: Vec<u8> = Vec::new();
+    tonk_branch
+        .export(CsvExporter::from(&mut buf))
+        .perform(&tonk_state.operator)
+        .await
+        .map_err(|e| TonkWorkerError::NotFound(e.to_string()))?;
+
+    let filename = format!("{}-{}.csv", path.repo, path.branch);
+    let mut response = (StatusCode::OK, Body::from(buf)).into_response();
+    let headers = response.headers_mut();
+    headers.insert(header::CONTENT_TYPE, "text/csv".parse().unwrap());
+    if let Ok(value) = format!("attachment; filename=\"{filename}\"").parse::<header::HeaderValue>()
+    {
+        headers.insert(header::CONTENT_DISPOSITION, value);
+    }
+    Ok(response)
+}
+
+/// Wire-shape returned by `/import` — the post-commit revision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportResponse {
+    /// Revision of the branch after the import committed.
+    pub revision: dialog_repository::Revision,
+}
+
+/// `POST /api/repository/{repo}/branch/{branch}/import`
+///
+/// Reads a `text/csv` body (`the,of,as,is,cause` columns) and
+/// commits each row as an assertion in one transaction. Returns the
+/// post-commit revision and broadcasts it so subscribers refresh.
+#[wasm_compat]
+pub async fn import(
+    State(state): State<AppState>,
+    Path(path): Path<EvaluatePath>,
+    body: Bytes,
+) -> Result<axum::Json<ImportResponse>, TonkWorkerError> {
+    log!(
+        "import repo={}, branch={} ({} bytes)",
+        path.repo,
+        path.branch,
+        body.len()
+    );
+    let tonk_state = state.write().await;
+    let tonk_branch = tonk_state
+        .reactor
+        .repository(&path.repo)
+        .branch(&path.branch);
+
+    let importer = CsvImporter::from(Cursor::new(body.to_vec()));
+    let revision = tonk_branch
+        .import(importer)
+        .perform(&tonk_state.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Router(e.to_string()))?;
+
+    // Announce the moved head on the branch channel so subscribed
+    // UIs refresh their revision/sync badges, the same as
+    // `evaluate`. The reactor already re-polled SSE subscriptions.
+    broadcast(
+        &format!("/api/repository/{}/branch/{}", path.repo, path.branch),
+        &Notification {
+            branch: path.branch.clone(),
+            revision: revision.clone(),
+        },
+    );
+
+    Ok(axum::Json(ImportResponse { revision }))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use ::axum::body::Body;
+    use ::axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::router::{
+        AppState, ImportResponse, RepositoryInfo, api_router_from_state, api_router_with_state,
+        tests::test_state,
+    };
+
+    /// Create a repo via `PUT /api/repository/{label}` and return the
+    /// shared state plus the repo's routing key.
+    async fn fresh_repo(label: &str) -> (AppState, String) {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{label}"))
+                    .method("PUT")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = ::axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let info: RepositoryInfo = serde_json::from_slice(&body).unwrap();
+        (state, info.name)
+    }
+
+    /// Seed two `attribute!:` facts on `main` so the branch has
+    /// artifacts to export. Uses the evaluate route so the path is
+    /// the real one a client takes.
+    async fn seed(state: &AppState, repo: &str) {
+        let (app, _lsp) = api_router_from_state(state.clone());
+        let doc = "attribute!: &probe-name\n  description: A name\n  the: xyz.tonk.probe/name\n  as: text\n  cardinality: one\n";
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/evaluate"))
+                    .method("POST")
+                    .header("content-type", "application/yaml")
+                    .body(Body::from(doc))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "seed evaluate failed");
+    }
+
+    async fn get_export(state: &AppState, repo: &str) -> (StatusCode, String, String) {
+        let (app, _lsp) = api_router_from_state(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/export"))
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        let bytes = ::axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            content_type,
+            String::from_utf8(bytes.to_vec()).unwrap(),
+        )
+    }
+
+    async fn post_import(state: &AppState, repo: &str, csv: &str) -> (StatusCode, Vec<u8>) {
+        let (app, _lsp) = api_router_from_state(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/import"))
+                    .method("POST")
+                    .header("content-type", "text/csv")
+                    .body(Body::from(csv.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = ::axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, bytes.to_vec())
+    }
+
+    /// Export returns a CSV document with the dialog header and at
+    /// least one data row for a seeded branch.
+    #[dialog_common::test]
+    async fn it_exports_branch_artifacts_as_csv() {
+        let (state, repo) = fresh_repo("export-test").await;
+        seed(&state, &repo).await;
+
+        let (status, content_type, csv) = get_export(&state, &repo).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            content_type.starts_with("text/csv"),
+            "content-type was {content_type:?}",
+        );
+        assert!(
+            csv.starts_with("the,of,as,is,cause"),
+            "export missing CSV header: {csv}",
+        );
+        assert!(
+            csv.lines().count() > 1,
+            "export should have at least one data row: {csv}",
+        );
+    }
+
+    /// Export from one repo, import into a fresh repo, and confirm
+    /// the second repo's export matches — the CSV round-trips through
+    /// the HTTP routes.
+    #[dialog_common::test]
+    async fn it_roundtrips_export_then_import() {
+        let (state, source) = fresh_repo("rt-source").await;
+        seed(&state, &source).await;
+        let (_, _, source_csv) = get_export(&state, &source).await;
+
+        let (_, dest) = fresh_repo("rt-dest").await;
+        let (status, body) = post_import(&state, &dest, &source_csv).await;
+        assert_eq!(status, StatusCode::OK, "import failed: {body:?}");
+        let resp: ImportResponse = serde_json::from_slice(&body).unwrap();
+        // The import committed a real revision (non-default head).
+        let _ = resp.revision;
+
+        // The destination now exports the same artifact rows the
+        // source did (header + data, set-equal).
+        let (_, _, dest_csv) = get_export(&state, &dest).await;
+        let mut source_rows: Vec<&str> = source_csv.lines().skip(1).collect();
+        let mut dest_rows: Vec<&str> = dest_csv.lines().skip(1).collect();
+        source_rows.sort_unstable();
+        dest_rows.sort_unstable();
+        assert_eq!(
+            dest_rows, source_rows,
+            "round-tripped rows differ\nsource:\n{source_csv}\ndest:\n{dest_csv}",
+        );
+    }
+
+    /// An empty CSV (header only) imports without error and commits
+    /// nothing meaningful.
+    #[dialog_common::test]
+    async fn it_imports_an_empty_csv() {
+        let (state, repo) = fresh_repo("empty-import").await;
+        let (status, _) = post_import(&state, &repo, "the,of,as,is,cause\n").await;
+        assert_eq!(status, StatusCode::OK);
+    }
+}


### PR DESCRIPTION
To investigate performance profiles with real data, branches need a way to get artifacts in and out in bulk. This adds a CSV round-trip that reuses dialog's `Branch::export`/`import` together with `dialog-csv`, exposed both over HTTP from the worker and as `slide` commands so the same data can be loaded from the CLI or the web.

Import goes through the reactor rather than calling dialog directly: that way it re-polls subscriptions after committing and the route broadcasts a revision notification, so SSE clients and the sync badge stay current without the route re-implementing that plumbing. The reactor `Export`/`Import` wrappers are kept format-agnostic — generic over dialog's `Exporter`/`Importer` — so the CSV specifics live only at the route and CLI edges. Slide talks to dialog directly (no reactor) since it has no SSE clients, mirroring how `slide sync` already works.

The feature requires `dialog-csv`, which only ships on dialog-db's `feat/switch-to-search-tree` branch, so the first commit moves every dialog dependency from the `tonk-2026-06-10` tag onto that branch. A second commit adds per-phase evaluate timing (parse / analyze+eval / commit) teed onto a `tonk-timing` BroadcastChannel, since the seed runs in the service worker where console logs never reach the page.

Commits are kept separate so they can be reviewed (and reverted) independently:
1. `chore(deps)` — track the dialog-db search-tree branch
2. `feat(worker)` — evaluate phase timing
3. `feat(worker,slide)` — the CSV import/export feature

Covered by wasm route tests (export, round-trip, empty input) and native slide tests (export, round-trip with row-for-row equality, empty CSV, stdout).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces CSV export and import functionality for the `slide` project, enhancing data handling capabilities. It adds new modules for transferring data and updates various components to support these features, including tests for functionality.

### Detailed summary
- Added `pub mod transfer;` in `rust/slide/src/lib.rs`.
- Introduced `export` and `import` modules in `rust/tonk-worker/src/reactor`.
- Updated `rust/tonk-worker/src/router.rs` to include new routes for CSV export and import.
- Created `rust/slide/src/transfer.rs` for handling CSV export and import logic.
- Implemented tests in `rust/slide/tests/transfer.rs` for verifying CSV functionality.
- Updated `Cargo.toml` to include `dialog-csv` dependency.
- Modified various traits and implementations to integrate new CSV functionalities.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->