### PR TITLE
perf: dialog node-cache fix (tonk-2026-06-16) + worker request concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "base58",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "base58",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "base58",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "async-trait",
  "base58",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-15#66b77e2620c3bd2e229aec0b0e4b1a51beb3b0d3"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-16#fffb9f9e0eebb7881937a9892d6859e5646e1e38"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",
@@ -1706,7 +1706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3387,7 +3387,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3790,7 +3790,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3848,7 +3848,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4573,7 +4573,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5786,7 +5786,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,22 +139,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-16" }
 
 [profile.dev]
 opt-level = 1
@@ -173,4 +173,5 @@ opt-level = "s"
 debug = 0
 inherits = "release"
 strip = "debuginfo"
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,22 +139,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-15" }
 
 [profile.dev]
 opt-level = 1

--- a/rust/tonk-worker/src/reactor.rs
+++ b/rust/tonk-worker/src/reactor.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dialog_operator::Profile;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 mod branch;
 mod command;
@@ -63,12 +63,12 @@ pub use transaction::{Commit, TransactionBuilder};
 /// The worker's reactive layer. Owned by `TonkState`.
 pub struct TonkReactor {
     profile: Profile,
-    repos: Mutex<HashMap<String, Arc<RepositoryState>>>,
+    repos: RwLock<HashMap<String, Arc<RepositoryState>>>,
     /// Cached `RepositoryState` for the profile-as-repository.
     /// Lazily populated on first `profile_repository().acquire()`
     /// call; lives outside `repos` because the profile is a
     /// singleton with no name in the routing namespace.
-    profile_repo: Mutex<Option<Arc<RepositoryState>>>,
+    profile_repo: RwLock<Option<Arc<RepositoryState>>>,
 }
 
 impl TonkReactor {
@@ -78,8 +78,8 @@ impl TonkReactor {
     pub fn new(profile: Profile) -> Self {
         Self {
             profile,
-            repos: Mutex::new(HashMap::new()),
-            profile_repo: Mutex::new(None),
+            repos: RwLock::new(HashMap::new()),
+            profile_repo: RwLock::new(None),
         }
     }
 
@@ -98,7 +98,7 @@ impl TonkReactor {
     /// holds the state.
     pub fn shutdown(&self) {
         let repos = {
-            let mut map = self.repos.lock();
+            let mut map = self.repos.write();
             std::mem::take(&mut *map)
         };
         // The profile-as-repository lives in its own slot, not in
@@ -106,10 +106,10 @@ impl TonkReactor {
         // (`/api/profile/branch/meta/query` SSE), so it must be drained
         // too — otherwise that one stream stays open and pins the
         // outgoing worker in `waiting` on every update.
-        let profile = self.profile_repo.lock().take();
+        let profile = self.profile_repo.write().take();
         for repo in repos.into_values().chain(profile) {
             let branches = {
-                let mut map = repo.branches().lock();
+                let mut map = repo.branches().write();
                 std::mem::take(&mut *map)
             };
             for (_, branch) in branches {
@@ -145,12 +145,12 @@ impl TonkReactor {
         Env: BranchOpenProvider,
     {
         // Only a cached repository can hold a stale cached branch.
-        let Some(repo_state) = self.repos.lock().get(repo).map(Arc::clone) else {
+        let Some(repo_state) = self.repos.read().get(repo).map(Arc::clone) else {
             return Ok(());
         };
         // An uncached branch opens fresh on next acquire — already
         // current, nothing to reconcile.
-        if !repo_state.branches().lock().contains_key(branch) {
+        if !repo_state.branches().read().contains_key(branch) {
             return Ok(());
         }
 
@@ -172,7 +172,7 @@ impl TonkReactor {
 
         // Swap under the branches lock so a concurrent subscribe can't
         // land on the discarded state between the adopt and the insert.
-        let mut branches = repo_state.branches().lock();
+        let mut branches = repo_state.branches().write();
         if let Some(old) = branches.get(branch) {
             fresh.adopt_subscriptions_from(old);
         }
@@ -200,7 +200,7 @@ impl TonkReactor {
     /// (`RepositoryReference::acquire`, `BranchReference::acquire`)
     /// can run their lookup-and-open logic directly without
     /// indirecting through helper methods.
-    pub fn repos(&self) -> &Mutex<HashMap<String, Arc<RepositoryState>>> {
+    pub fn repos(&self) -> &RwLock<HashMap<String, Arc<RepositoryState>>> {
         &self.repos
     }
 
@@ -208,14 +208,14 @@ impl TonkReactor {
     /// Used by `RepositoryReference::Profile::acquire` for the
     /// fast-path branch.
     pub fn profile_repo_state(&self) -> Option<Arc<RepositoryState>> {
-        self.profile_repo.lock().clone()
+        self.profile_repo.read().clone()
     }
 
     /// Install the profile-as-repository state into the cache.
     /// Returns the resident value — if another caller raced and
     /// installed first, theirs wins (state is fungible).
     pub fn set_profile_repo_state(&self, state: Arc<RepositoryState>) -> Arc<RepositoryState> {
-        let mut slot = self.profile_repo.lock();
+        let mut slot = self.profile_repo.write();
         if let Some(existing) = slot.clone() {
             existing
         } else {

--- a/rust/tonk-worker/src/reactor/branch/reference.rs
+++ b/rust/tonk-worker/src/reactor/branch/reference.rs
@@ -48,7 +48,7 @@ impl<'a> BranchReference<'a> {
         let repository = self.repository.acquire(env).await?;
 
         // Fast path: branch already cached.
-        if let Some(state) = repository.branches().lock().get(name) {
+        if let Some(state) = repository.branches().read().get(name) {
             return Ok(BranchSession {
                 state: Arc::clone(state),
             });
@@ -68,7 +68,7 @@ impl<'a> BranchReference<'a> {
                 reason: e.to_string(),
             })?;
 
-        let mut branches = repository.branches().lock();
+        let mut branches = repository.branches().write();
         let entry = branches
             .entry(name.to_owned())
             .or_insert_with(|| Arc::new(BranchState::new(branch)));

--- a/rust/tonk-worker/src/reactor/formula.rs
+++ b/rust/tonk-worker/src/reactor/formula.rs
@@ -23,7 +23,8 @@ use dialog_repository::{
     Branch, LocalIndex, NetworkedIndex, RepositoryArchiveExt, RepositoryMemoryExt, Upstream,
 };
 use dialog_search_tree::{
-    ArchivedNodeBody, Buffer, DialogSearchTreeError, Distribution, Geometric, Node, into_owned,
+    ArchivedNodeBody, Buffer, DialogSearchTreeError, Distribution, Geometric, PersistentNode,
+    into_owned,
 };
 use dialog_storage::{Blake3Hash, StorageBackend};
 use ipld_core::ipld::Ipld;
@@ -32,7 +33,7 @@ use thiserror::Error;
 use crate::reactor::{Conclusion, Query, SelectProvider};
 
 /// A decoded tree node, instantiated for the artifact key/value types.
-type TreeNode = Node<KeyBytes, State<Datum>>;
+type TreeNode = PersistentNode<KeyBytes, State<Datum>>;
 
 /// Failure modes for [`resolve_formula`].
 #[derive(Debug, Error)]

--- a/rust/tonk-worker/src/reactor/repository/reference.rs
+++ b/rust/tonk-worker/src/reactor/repository/reference.rs
@@ -77,7 +77,7 @@ impl<'a> RepositoryReference<'a> {
         match self {
             Self::Named { name, .. } => {
                 // Fast path: cached.
-                if let Some(entry) = reactor.repos().lock().get(*name) {
+                if let Some(entry) = reactor.repos().read().get(*name) {
                     return Ok(Arc::clone(entry));
                 }
 
@@ -95,7 +95,7 @@ impl<'a> RepositoryReference<'a> {
 
                 // Insert under the lock — another caller may have
                 // raced; their entry wins.
-                let mut repos = reactor.repos().lock();
+                let mut repos = reactor.repos().write();
                 let entry = repos
                     .entry((*name).to_owned())
                     .or_insert_with(|| Arc::new(RepositoryState::new(Arc::new(repository))));

--- a/rust/tonk-worker/src/reactor/repository/state.rs
+++ b/rust/tonk-worker/src/reactor/repository/state.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dialog_repository::Repository;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use crate::reactor::BranchState;
 
@@ -17,7 +17,7 @@ pub struct RepositoryState {
     /// to skip the repository load when opening another branch
     /// under the same repo.
     repository: Arc<Repository>,
-    branches: Mutex<HashMap<String, Arc<BranchState>>>,
+    branches: RwLock<HashMap<String, Arc<BranchState>>>,
 }
 
 impl RepositoryState {
@@ -25,7 +25,7 @@ impl RepositoryState {
     pub fn new(repository: Arc<Repository>) -> Self {
         Self {
             repository,
-            branches: Mutex::new(HashMap::new()),
+            branches: RwLock::new(HashMap::new()),
         }
     }
 
@@ -37,7 +37,7 @@ impl RepositoryState {
     /// Borrow the branch cache so the chain's
     /// `BranchReference::acquire` can run lookup-and-open
     /// directly.
-    pub fn branches(&self) -> &Mutex<HashMap<String, Arc<BranchState>>> {
+    pub fn branches(&self) -> &RwLock<HashMap<String, Arc<BranchState>>> {
         &self.branches
     }
 }

--- a/rust/tonk-worker/src/reactor/transaction.rs
+++ b/rust/tonk-worker/src/reactor/transaction.rs
@@ -161,6 +161,7 @@ impl Commit<'_> {
         let cached = self.branch.acquire(env).await?;
         let branch = cached.handle();
 
+        let t_induce = web_time::Instant::now();
         let txn = branch
             .transaction()
             .integrate(self.changes)
@@ -168,9 +169,19 @@ impl Commit<'_> {
             .induce(self.transients)
             .perform(env)
             .await?;
+        let induce_ms = t_induce.elapsed().as_millis();
 
+        let t_commit = web_time::Instant::now();
         let revision = txn.commit().perform(env).await?;
+        let commit_ms = t_commit.elapsed().as_millis();
+
+        let t_poll = web_time::Instant::now();
         cached.poll(env).await;
+        let poll_ms = t_poll.elapsed().as_millis();
+
+        tonk_common::log!(
+            "reactor commit timing: induce {induce_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
+        );
         Ok(revision)
     }
 }

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -219,10 +219,12 @@ async fn evaluate_on_branch<'a>(
     // decision: the txn's overlay already reflects every mutation
     // and induce-pass derivation, so this is the same answer a
     // post-commit branch query would give.
+    let t_matches = web_time::Instant::now();
     let matches_after = evaluated
         .matches_after(&tonk_state.operator)
         .await
         .map_err(map_evaluate_error)?;
+    let matches_ms = t_matches.elapsed().as_millis();
 
     // A document commits when it writes anything. `rule!:` is a
     // mutation (the `!` says so) and the analyzer lifts it into a
@@ -237,8 +239,14 @@ async fn evaluate_on_branch<'a>(
             .await
             .map_err(|e| map_evaluate_error(EvaluateError::Query(format!("commit: {e}"))))?;
         let commit_ms = t_commit.elapsed().as_millis();
+        // Re-poll subscriptions so SSE clients see the new state.
+        // The chain commits via dialog directly; the reactor's
+        // subscription registry is the worker's responsibility.
+        let t_poll = web_time::Instant::now();
+        session.poll(&tonk_state.operator).await;
+        let poll_ms = t_poll.elapsed().as_millis();
         let timing = format!(
-            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | commit {commit_ms}ms"
+            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | matches {matches_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
         );
         log!("{timing}");
         // Tee timing onto a BroadcastChannel so a page (or DevTools
@@ -249,10 +257,6 @@ async fn evaluate_on_branch<'a>(
         if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
             let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
         }
-        // Re-poll subscriptions so SSE clients see the new state.
-        // The chain commits via dialog directly; the reactor's
-        // subscription registry is the worker's responsibility.
-        session.poll(&tonk_state.operator).await;
         EvaluateResponse {
             revision_before,
             revision_after: Some(revision_after),

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -296,7 +296,10 @@ pub async fn sync_status(
     State(state): State<AppState>,
     Path(params): Path<SyncPath>,
 ) -> Result<Json<SyncStatusResponse>, TonkWorkerError> {
-    let tonk_state = state.write().await;
+    // Read-only: status acquires a branch and does a remote fetch but never
+    // mutates `TonkState`. A read lock lets concurrent queries proceed instead
+    // of blocking on the (network-bound) status request.
+    let tonk_state = state.read().await;
 
     let session = tonk_state
         .reactor

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -177,9 +177,14 @@ async fn handle_via_router(
         request.extensions_mut().insert(ClientId(client_id.clone()));
     }
 
+    // Clone the router out of the lock and release the guard before
+    // dispatching: `Router` is cheap to clone (its routes are `Arc`-shared)
+    // and `Service::call` runs on the owned clone, so concurrent requests
+    // aren't serialized behind one global lock. Holding the lock across
+    // `.call().await` would queue every request behind the slowest one (e.g. a
+    // network-bound `sync/status`).
+    let mut router = router.lock().await.clone();
     let mut response = router
-        .lock()
-        .await
         .call(request)
         .await
         .expect_throw("Failed to handle API request");


### PR DESCRIPTION
Keeps the tree inspector building against the current dialog release. The `tonk-2026-06-15` tag splits `dialog_search_tree::Node` into `Persistent`/`Transient` variants, so the buffer-decoding role (`new`/`body`/`buffer`) now lives on `PersistentNode`.

The inspector only ever decodes serialized node bytes from the archive, so pointing its `TreeNode` alias at `PersistentNode` is the whole adaptation; the method surface is identical.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving concurrency in the `tonk-worker` codebase by replacing `Mutex` with `RwLock` for shared data structures, allowing multiple readers while still supporting write access. Additionally, it optimizes the handling of state and timing for various operations.

### Detailed summary
- Changed `state.write().await` to `state.read().await` in `sync.rs` for read-only access.
- Updated branch access from `lock()` to `read()` in `reference.rs`.
- Switched branch repository from `Mutex` to `RwLock` in `state.rs`, `reactor.rs`, and `worker.rs`.
- Improved timing logging in `transaction.rs` and `evaluate.rs` with precise measurements.
- Updated Cargo dependencies to a new tag `tonk-2026-06-16`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->