### PR TITLE
feat(slide): render slide-authored views in tonk-ui

### DIFF
--- a/rust/slide/src/guide-views.md
+++ b/rust/slide/src/guide-views.md
@@ -80,6 +80,44 @@ prepend the `window.tonk` bridge bootstrap, which can't function
 headlessly (no service worker, no message channel), so a portal's own
 data queries don't run under SSR.
 
+## Rendering a reference by name (cross-concept join)
+
+When one concept points at another (an entity reference), a `{field}`
+placeholder interpolates the field's **raw value** — the target's URI
+(`did:key:…`), not a name. To show the referenced entity's name you must
+**nest a `<tonk-display>`** over the reference field; interpolating the
+field alone never resolves it.
+
+Render the reference through a small **label view** — a `view/label`
+instance. It lives under the built-in `tonk:view/label` concept, so it
+doesn't collide with the model's default `tonk:view`:
+
+```yaml
+# A comment points at its author (a person).
+view!: &comment-card
+  model: comment
+  display: !text/html |
+    <article>
+      <strong><tonk-display entity={author} model=person view=tonk:view/label></tonk-display></strong>
+      <p>{body}</p>
+    </article>
+
+# The label view the line above resolves: just the person's name.
+view/label!: &person-label
+  model: person
+  display: !text/html |
+    {name}
+```
+
+`<tonk-display entity={author} …>` follows the `author` reference to the
+person entity and renders it through the `tonk:view/label` view
+constrained to `model: person`, so the card shows the name, not
+`did:key:…`. Writing `{author}` directly would print the URI. The same
+nesting renders any reference: `entity` is the reference field, `model`
+the referenced concept, and `view` the view concept you want
+(`tonk:view/label` for just a name, `tonk:view` for the full detail
+card).
+
 ## Escape hatch: raw `text/html` views
 
 For a one-off HTML page (no live binding), assert a `text/html` claim

--- a/rust/slide/tests/notation.rs
+++ b/rust/slide/tests/notation.rs
@@ -31,6 +31,28 @@ mod when_evaluating_a_document {
     }
 
     #[dialog_common::test]
+    async fn it_seeds_the_standard_library_view_concept_on_init() -> Result<()> {
+        // A freshly initialised site carries the tonk standard
+        // library — the same `core.yaml` the tonk-ui service worker
+        // seeds at repository creation — so the renderer's `tonk:view`
+        // concept is present without the user defining it.
+        // `<tonk-display>` queries `tonk:view` by `model`, so views
+        // authored through slide resolve and render instead of
+        // showing "View not found".
+        let test = common::TestSite::new().await?;
+        let query = test
+            .eval_inline("concept:\n  this: ?c\n  name: \"view\"\n")
+            .await?;
+        assert!(
+            !query.response.matches_after.is_empty()
+                && !query.response.matches_after[0].results.is_empty(),
+            "expected a freshly-initialised site to seed the `view` concept, got: {:#?}",
+            query.response.matches_after,
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_round_trips_a_concept_declaration() -> Result<()> {
         let test = common::TestSite::new().await?;
         test.eval_inline(ATTRIBUTE_DECL).await?;


### PR DESCRIPTION
Seed the tonk standard library at slide init and document the cross-concept join pattern, so a slide-created repo renders in tonk-ui out of the box.

## Why

A slide init repo was created bare — no standard library — so the tonk-ui renderer found no tonk:view concept (it queries tonk:view / xyz.tonk.view/*). Views rendered "View not found" and slide eval rejected view!: with "unknown concept view". tonk-ui never hits this because its service worker seeds tonk-core/assets/library/core.yaml into a repository at creation; a slide-created repo went through slide's own init path and never got it.

## What

- feat(slide): init now embeds core.yaml (include_str!) and evaluates it into a freshly created repo via the existing eval pipeline — only on first creation; reopening an existing site is untouched.
- docs(slide): a "Rendering a reference by name (cross-concept join)" section in guide-views — interpolating {ref} yields the target's did:key: URI; render a reference by nesting <tonk-display entity={ref} model=<concept> view=tonk:view/label>.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new test for verifying the seeding of the `view` concept in a freshly initialized site and adds documentation on rendering references by name using the `tonk-display` component.

### Detailed summary
- Added a new asynchronous test function `it_seeds_the_standard_library_view_concept_on_init` to verify the presence of the `view` concept.
- Enhanced documentation in `guide-views.md` on rendering references by name using `tonk-display` and provided examples of YAML configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->