### PR TITLE
feat: local-disk vault sync via the File System Access API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,6 +5220,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "getrandom 0.4.1",
+ "idb",
  "js-sys",
  "leptos",
  "leptos-use",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1089,7 +1089,7 @@ dependencies = [
  "dialog-capability",
  "dialog-common",
  "dialog-effects",
- "dialog-search-tree",
+ "dialog-prolly-tree",
  "dialog-storage",
  "ed25519-dalek",
  "futures-util",
@@ -1098,9 +1098,9 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "rkyv",
  "serde",
  "serde-big-array",
+ "serde_ipld_dagcbor",
  "serde_json",
  "static_assertions",
  "thiserror 2.0.18",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "base58",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "base58",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "base58",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1221,12 +1221,13 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "dialog-capability",
  "dialog-common",
  "dialog-effects",
+ "dialog-remote-fs",
  "dialog-remote-s3",
  "dialog-remote-ucan-s3",
  "serde",
@@ -1235,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1267,12 +1268,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialog-query"
+name = "dialog-prolly-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
+ "anyhow",
  "async-stream",
  "async-trait",
+ "base58",
+ "blake3",
+ "dialog-common",
+ "dialog-storage",
+ "futures-core",
+ "futures-util",
+ "nonempty",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "dialog-query"
+version = "0.1.0"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
+dependencies = [
+ "async-stream",
  "base58",
  "blake3",
  "dialog-artifacts",
@@ -1291,9 +1311,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialog-remote-fs"
+version = "0.1.0"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
+dependencies = [
+ "async-trait",
+ "base58",
+ "blake3",
+ "dialog-capability",
+ "dialog-common",
+ "dialog-effects",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pidlock",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1332,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1367,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1380,10 +1422,10 @@ dependencies = [
  "dialog-effects",
  "dialog-network",
  "dialog-operator",
+ "dialog-prolly-tree",
  "dialog-query",
  "dialog-remote-s3",
  "dialog-remote-ucan-s3",
- "dialog-search-tree",
  "dialog-storage",
  "dialog-ucan",
  "dialog-ucan-core",
@@ -1403,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1416,7 +1458,6 @@ dependencies = [
  "dialog-macros",
  "dialog-storage",
  "futures-core",
- "futures-util",
  "hashbrown 0.16.1",
  "nonempty",
  "parking_lot",
@@ -1432,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1475,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "async-trait",
  "base58",
@@ -1496,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1522,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-06-12#cea45f6b9a345bfc1082608cbcfe8a34a407a6fc"
+source = "git+https://github.com/dialog-db/dialog-db.git?branch=chore%2Fpidlock-0.2#8e8ef67d5a051e54a8addba631e7f336725be989"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",
@@ -2942,6 +2983,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,13 +3202,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pidlock"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df53bd1a4f9f7d54dc8e604c09aa3d06988d052ac35db5b34d7423272f8046a8"
+checksum = "f837924d5368f9f35a1c404699de3c074311358035c77d7164f5948c08b31382"
 dependencies = [
- "libc",
- "log",
- "windows-sys 0.45.0",
+ "nix",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -5222,6 +5275,7 @@ dependencies = [
  "dialog-effects",
  "dialog-operator",
  "dialog-query",
+ "dialog-remote-fs",
  "dialog-remote-ucan-s3",
  "dialog-repository",
  "dialog-search-tree",
@@ -5790,6 +5844,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,6 +5875,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5829,6 +5915,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5965,6 +6061,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,23 +138,25 @@ js-sys = "0.3"
 send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
-# Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-06-12" }
+# Dialog DB — pinned to chore/pidlock-0.2 while dialog-remote-fs work lands
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-network = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-remote-fs = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", branch = "chore/pidlock-0.2" }
 
 [profile.dev]
 opt-level = 1

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = { workspace = true }
 console_error_panic_hook = { workspace = true }
 custom-elements = { workspace = true }
 futures-util = { workspace = true }
+idb = { workspace = true }
 js-sys = { workspace = true }
 leptos = { workspace = true, features = ["csr"] }
 leptos_router = { workspace = true }
@@ -81,7 +82,21 @@ getrandom_0_3 = { workspace = true }
 
 [dependencies.web-sys]
 workspace = true
-features = ["BroadcastChannel", "MessageEvent", "Window"]
+features = [
+    "BroadcastChannel",
+    "FileSystemDirectoryHandle",
+    "FileSystemGetDirectoryOptions",
+    "FileSystemGetFileOptions",
+    "FileSystemHandle",
+    "FileSystemHandlePermissionDescriptor",
+    "FileSystemPermissionMode",
+    "PermissionState",
+    "MessageEvent",
+    "Navigator",
+    "ServiceWorker",
+    "ServiceWorkerContainer",
+    "Window",
+]
 
 [lints.rust]
 # The dialog_common::test macro uses cfg conditions that originate from the macro crate.

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -84,6 +84,7 @@ getrandom_0_3 = { workspace = true }
 workspace = true
 features = [
     "BroadcastChannel",
+    "Crypto",
     "FileSystemDirectoryHandle",
     "FileSystemGetDirectoryOptions",
     "FileSystemGetFileOptions",

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -135,17 +135,41 @@ self.onfetch = event => {
 // worker's `onmessage` stashes the port against the client id and
 // routes per-envelope dispatch from there.
 //
-// One synchronous early-out: a `{type:"claim"}` message asks the
-// SW to take control of every client in scope. The page sends
-// this on cold-start when it lands on a SW that was activated in
-// a previous session — `onactivate` doesn't refire, so without
-// this nudge the page would stay uncontrolled (and every /api/*
-// fetch would land on the static-asset server as a 405). The
-// claim raises `controllerchange` on the page side, which the
-// shell's `serviceWorkerActivates()` Promise awaits.
+// Two synchronous early-outs handled here:
+//   - `{type:"claim"}` asks the SW to take control of every client
+//     in scope. The page sends this on cold-start when it lands on
+//     a SW that was activated in a previous session — `onactivate`
+//     doesn't refire, so without this nudge the page would stay
+//     uncontrolled (and every /api/* fetch would land on the
+//     static-asset server as a 405). The claim raises
+//     `controllerchange` on the page side, which the shell's
+//     `serviceWorkerActivates()` Promise awaits.
+//   - `register-fs-handle` / `unregister-fs-handle` carry FS Access
+//     API directory handles supplied by the page. They're forwarded
+//     to the wasm worker, which stashes them in `dialog-remote-fs`'s
+//     thread-local registry so later sync invocations targeting an
+//     `FsAddress` with the same id can resolve them. Browsers don't
+//     persist FS-Access permission across sessions, so the page
+//     re-registers after each user gesture that re-grants access.
 self.onmessage = event => {
-    if (event.data && event.data.type === "claim") {
+    const data = event.data;
+    if (data && data.type === "claim") {
         event.waitUntil?.(self.clients.claim());
+        return;
+    }
+    if (data && (data.type === "register-fs-handle" || data.type === "unregister-fs-handle")) {
+        event.waitUntil?.((async () => {
+            try {
+                const worker = await activateWorker();
+                if (data.type === "register-fs-handle") {
+                    worker.registerFsHandle(data.id, data.handle);
+                } else {
+                    worker.unregisterFsHandle(data.id);
+                }
+            } catch (err) {
+                log("Failed to handle message:", data.type, err);
+            }
+        })());
         return;
     }
     event.waitUntil?.(

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -541,7 +541,10 @@ pub async fn set_fs_upstream(
             repo, branch, vault_id, status, text
         )));
     }
-    response.json::<FsUpstreamResponse>().await.map_err(into_api_error)
+    response
+        .json::<FsUpstreamResponse>()
+        .await
+        .map_err(into_api_error)
 }
 
 /// POST a sync route. `op` is `"pull"` / `"push"` for the

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -4,8 +4,8 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_worker::{
     BranchConfiguration, CreateInviteRequest, CreateInviteResponse, EvaluateResponse,
-    IdentifyResponse, JoinRequest, JoinResponse, ProfileInfo, QueryResponse, RemoteConfiguration,
-    RepositoryConfiguration, RepositoryInfo, SyncResponse, SyncStatusResponse,
+    FsUpstreamResponse, IdentifyResponse, JoinRequest, JoinResponse, ProfileInfo, QueryResponse,
+    RemoteConfiguration, RepositoryConfiguration, RepositoryInfo, SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -500,6 +500,48 @@ pub async fn sync_status(repo: &str, branch: &str) -> Result<SyncStatusResponse,
         .json::<SyncStatusResponse>()
         .await
         .map_err(into_api_error)
+}
+
+/// Idempotently configure a branch to track a local FS-backed vault
+/// as its upstream.
+///
+/// `POST /api/repository/{repo}/branch/{branch}/upstream/fs/{vault_id}`.
+/// After a successful return, the existing `/sync` routes for this
+/// branch dispatch through `dialog-remote-fs` — provided the
+/// corresponding handle has already been registered with the worker
+/// (see [`crate::fs_access::register_handle_with_worker`]).
+pub async fn set_fs_upstream(
+    repo: &str,
+    branch: &str,
+    vault_id: &str,
+) -> Result<FsUpstreamResponse, TonkUiError> {
+    log!(
+        "Setting FS upstream repo='{}' branch='{}' vault='{}'",
+        repo,
+        branch,
+        vault_id
+    );
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/api/repository/{}/branch/{}/upstream/fs/{}",
+            origin(),
+            repo,
+            branch,
+            vault_id,
+        ))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(TonkUiError::ApiError(format!(
+            "POST /api/repository/{}/branch/{}/upstream/fs/{} returned {}: {}",
+            repo, branch, vault_id, status, text
+        )));
+    }
+    response.json::<FsUpstreamResponse>().await.map_err(into_api_error)
 }
 
 /// POST a sync route. `op` is `"pull"` / `"push"` for the

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -40,6 +40,9 @@ use join::*;
 mod invite;
 use invite::*;
 
+mod vaults_page;
+pub use vaults_page::TonkVaults;
+
 /// The hosting document's service-worker Client ID, learned from
 /// the `X-Tonk-Client-Id` header on the `PUT /api/repository/...`
 /// response. Provided as a Leptos context so descendant

--- a/rust/tonk-ui/src/components/join.rs
+++ b/rust/tonk-ui/src/components/join.rs
@@ -221,14 +221,18 @@ pub fn TonkJoin() -> impl IntoView {
     // match (if any). Held in a local-storage signal because
     // `VaultEntry` carries a `FileSystemDirectoryHandle` — `!Send`.
     let disk_match: RwSignal<Option<Option<VaultEntry>>, LocalStorage> = RwSignal::new_local(None);
-    Effect::new(move |fired: Option<()>| {
-        if fired.is_some() {
+    let lookup_started = RwSignal::new(false);
+    Effect::new(move |_: Option<()>| {
+        // Re-fires whenever `parsed_invite` updates. Only kick off
+        // the IDB lookup once the invite has actually parsed
+        // successfully, and de-dup against the initial None tick.
+        if lookup_started.get_untracked() {
             return;
         }
-        // Run once on mount; depends on parsed_invite via `get`.
         let Some(Ok(invite)) = parsed_invite.get() else {
             return;
         };
+        lookup_started.set(true);
         let subject = invite.subject().to_string();
         spawn_local(async move {
             match VaultRegistry::open().await {

--- a/rust/tonk-ui/src/components/join.rs
+++ b/rust/tonk-ui/src/components/join.rs
@@ -7,7 +7,8 @@ use url::Url;
 use crate::{
     api::{self, JoinError},
     components::{LastJoinOutcome, ProfileResource},
-    did,
+    did, fs_access,
+    vaults::{VaultEntry, VaultRegistry},
 };
 
 /// Lifecycle of a `/join` page load.
@@ -41,6 +42,14 @@ enum JoinView {
     Member {
         /// Subject DID, for the sigil + a hint of what they're joining.
         subject: String,
+    },
+    /// A registered local-disk vault already holds this subject —
+    /// fast-path past the cloud join into an FS-upstream sync.
+    OnDisk {
+        /// Subject DID, for the sigil.
+        subject: String,
+        /// The registered vault to sync from.
+        vault: VaultEntry,
     },
 }
 
@@ -94,6 +103,49 @@ async fn refresh_after_join(repo: &str) {
     }
 }
 
+/// Sync via an already-registered FS vault.
+///
+/// Re-prompts for FS-Access permission (browsers reset that per
+/// session), hands the handle to the worker, saves the delegation
+/// chain via `/api/profile/join`, wires the branch's upstream at the
+/// vault, and pulls once so the recipient lands on fresh data. The
+/// joined space's name comes from the shared repository, so there is
+/// no local name to pass.
+///
+/// Returns `(target_name, outcome_label)` on success.
+async fn sync_from_disk_join(
+    invite_url: &str,
+    vault_id: &str,
+    handle: &web_sys::FileSystemDirectoryHandle,
+) -> Result<(String, &'static str), String> {
+    match fs_access::request_readwrite_permission(handle).await {
+        Ok(web_sys::PermissionState::Granted) => {}
+        Ok(_) => return Err("Permission was not granted.".into()),
+        Err(e) => return Err(format!("Permission request failed: {e}")),
+    }
+    fs_access::register_handle_with_worker(vault_id, handle)
+        .map_err(|e| format!("Could not hand vault to service worker: {e}"))?;
+
+    let response = api::join(invite_url).await.map_err(|e| match e {
+        JoinError::NameTaken => {
+            "This space is already being added — refresh and try again.".to_string()
+        }
+        JoinError::Other(err) => format!("{err}"),
+    })?;
+    let (target_name, outcome) = match response {
+        JoinResponse::Joined { repository } => (repository.name, "joined"),
+        JoinResponse::Renewed { repository } => (repository.name, "renewed"),
+    };
+
+    if let Err(e) = api::set_fs_upstream(&target_name, "main", vault_id).await {
+        return Err(format!("Could not wire FS upstream: {e}"));
+    }
+    if let Err(e) = api::pull(&target_name, "main").await {
+        log!("post-join FS pull on '{}' failed (continuing): {e:?}", target_name);
+    }
+    Ok((target_name, outcome))
+}
+
 /// Sigil hex string for a DID, suitable for `<tonk-sigil value=...>`.
 /// Matches the helper used in [`super::space`] so a space's sigil
 /// is consistent across the join page and the space view.
@@ -109,6 +161,11 @@ fn did_sigil_value(did: &str) -> Option<String> {
 /// space (chain refreshed), a fresh member to `/` where the new space's
 /// card resolves its name by pulling the shared content branch. There is
 /// no name form: the name is the repository's, not a local label.
+///
+/// One exception to the auto-join: if a registered local-disk vault
+/// already holds the subject, we surface a "Sync from disk" affordance
+/// instead and reconcile through `dialog-remote-fs` rather than the
+/// cloud.
 ///
 /// The full URL (including any `#fragment`, which carries the
 /// ephemeral seed for audience-open invites) is read from
@@ -158,6 +215,38 @@ pub fn TonkJoin() -> impl IntoView {
         });
     }
 
+    // Once the invite parses we look the subject up in the per-
+    // browser-profile vault registry. The outer `Option` tracks
+    // whether the lookup has completed; the inner `Option` is the
+    // match (if any). Held in a local-storage signal because
+    // `VaultEntry` carries a `FileSystemDirectoryHandle` — `!Send`.
+    let disk_match: RwSignal<Option<Option<VaultEntry>>, LocalStorage> = RwSignal::new_local(None);
+    Effect::new(move |fired: Option<()>| {
+        if fired.is_some() {
+            return;
+        }
+        // Run once on mount; depends on parsed_invite via `get`.
+        let Some(Ok(invite)) = parsed_invite.get() else {
+            return;
+        };
+        let subject = invite.subject().to_string();
+        spawn_local(async move {
+            match VaultRegistry::open().await {
+                Ok(registry) => match registry.find_by_subject(&subject).await {
+                    Ok(found) => disk_match.set(Some(found)),
+                    Err(e) => {
+                        log!("vault-registry lookup failed: {e}");
+                        disk_match.set(Some(None));
+                    }
+                },
+                Err(e) => {
+                    log!("vault-registry open failed: {e}");
+                    disk_match.set(Some(None));
+                }
+            }
+        });
+    });
+
     // Derive the lifecycle view from (parsed invite, profile).
     let join_view = Signal::derive_local(move || {
         let parsed = match parsed_invite.get() {
@@ -199,27 +288,34 @@ pub fn TonkJoin() -> impl IntoView {
             Some(Err(e)) => return JoinView::InvalidInvite(format!("{e}")),
         };
 
-        // Whether the recipient already has this subject or is joining it
-        // fresh no longer changes the flow — both auto-join and redirect
-        // into the space, routed by the subject's did:key. The worker's
-        // join handler is idempotent (it renews an existing chain or
-        // creates a fresh replica), so the UI need not branch here. The
+        // Prefer a registered local-disk vault when one already holds
+        // this subject: wait for that lookup to settle, then take the
+        // FS fast-path. Otherwise the worker's join handler is
+        // idempotent (it renews an existing chain or creates a fresh
+        // replica), so the cloud flow is the same whether or not the
+        // recipient already has the subject — no further branching. The
         // `profile_info` read above still gates on the profile being
         // loaded (and the scoped-audience check).
         let _ = &profile_info;
-        JoinView::Member { subject }
+        match disk_match.get() {
+            None => JoinView::Loading,
+            Some(Some(vault)) => JoinView::OnDisk { subject, vault },
+            Some(None) => JoinView::Member { subject },
+        }
     });
 
-    // Auto-join as soon as the view resolves to either `AlreadyMember`
-    // or `NewMember`: there is no longer a name to confirm — a joined
-    // space's name comes from the shared repository's own content branch,
-    // not a locally-chosen label. Fire `/api/profile/join` (claim + chain
-    // save) and navigate.
+    // Auto-join as soon as the view resolves to `Member`: there is no
+    // longer a name to confirm — a joined space's name comes from the
+    // shared repository's own content branch, not a locally-chosen
+    // label. Fire `/api/profile/join` (claim + chain save) and navigate.
     //
     // An already-member lands back in the space (honouring any `then=`
     // deep-link). A fresh member lands on `/`: the Hub lists the new
     // replica and its name card queries the repo, which pulls the content
     // branch and resolves the name in place — no install screen needed.
+    //
+    // The `OnDisk` state is deliberately excluded: it waits for the user
+    // to grant FS-Access permission via the "Sync from disk" button.
     //
     // Tracked separately so we don't double-fire if `join_view` re-derives.
     let auto_joined = RwSignal::new(false);
@@ -288,13 +384,50 @@ pub fn TonkJoin() -> impl IntoView {
         }
     };
 
+    // Tracks the in-flight "Sync from disk" action so its button can
+    // show a spinner and disable while the FS round-trip runs.
+    let submitting = RwSignal::new(false);
+
+    // Click handler for the `OnDisk` fast-path: re-prompt for permission
+    // on the registered handle, save the delegation chain, wire the
+    // branch upstream at the FS vault, pull once, then navigate.
+    let on_disk_sync = {
+        let navigate = navigate.clone();
+        let invite_url = invite_url.clone();
+        let then_suffix = then_suffix.clone();
+        move |vault: VaultEntry| {
+            error.set(None);
+            submitting.set(true);
+
+            let navigate = navigate.clone();
+            let invite_url = invite_url.clone();
+            let then_suffix = then_suffix.clone();
+            spawn_local(async move {
+                let outcome = sync_from_disk_join(&invite_url, &vault.id, &vault.handle).await;
+                submitting.set(false);
+                match outcome {
+                    Ok((target_name, join_outcome)) => {
+                        last_join_outcome.set(Some(join_outcome));
+                        profile_resource.refetch();
+                        let destination =
+                            compose_destination(&target_name, then_suffix.as_deref());
+                        navigate(&destination, NavigateOptions::default());
+                    }
+                    Err(message) => error.set(Some(message)),
+                }
+            });
+        }
+    };
+
     view! {
         <main class="join-view">
             <wa-card class="join-card">
                 { move || render_body(
                     join_view.get(),
                     error,
+                    submitting,
                     on_cancel.clone(),
+                    on_disk_sync.clone(),
                 ) }
             </wa-card>
         </main>
@@ -304,22 +437,30 @@ pub fn TonkJoin() -> impl IntoView {
 /// Render the card body for the current [`JoinView`] state.
 ///
 /// Pulled into a standalone function so each branch is locally readable.
-/// There is no form any more — both `AlreadyMember` and `NewMember`
-/// auto-join (the name comes from the shared repo, not a typed label), so
-/// every actionable branch just shows a "Joining…" affordance.
-fn render_body<C>(state: JoinView, error: RwSignal<Option<String>>, on_cancel: C) -> impl IntoView
+/// The cloud-join branches auto-join (the name comes from the shared
+/// repo, not a typed label) and just show a "Joining…" affordance; the
+/// `OnDisk` branch surfaces a "Sync from disk" CTA wired to
+/// `on_disk_sync`.
+fn render_body<C, D>(
+    state: JoinView,
+    error: RwSignal<Option<String>>,
+    submitting: RwSignal<bool>,
+    on_cancel: C,
+    on_disk_sync: D,
+) -> impl IntoView
 where
     C: Fn(leptos::ev::MouseEvent) + 'static + Clone,
+    D: Fn(VaultEntry) + 'static + Clone,
 {
-    use leptos::either::EitherOf4;
+    use leptos::either::EitherOf5;
     match state {
-        JoinView::Loading => EitherOf4::A(view! {
+        JoinView::Loading => EitherOf5::A(view! {
             <div slot="header">
                 <h1>"Joining…"</h1>
             </div>
             <wa-spinner></wa-spinner>
         }),
-        JoinView::InvalidInvite(message) => EitherOf4::B(view! {
+        JoinView::InvalidInvite(message) => EitherOf5::B(view! {
             <div slot="header">
                 <h1>"Invite link is invalid"</h1>
             </div>
@@ -336,7 +477,7 @@ where
         }),
         JoinView::AudienceMismatch { audience, subject } => {
             let sigil_value = did_sigil_value(&subject);
-            EitherOf4::C(view! {
+            EitherOf5::C(view! {
                 <div slot="header">
                     <h1>"This invite is for someone else"</h1>
                 </div>
@@ -360,8 +501,8 @@ where
             // claims the invite, pulls the content branch, then redirects
             // into the now-ready space.
             let sigil_value = did_sigil_value(&subject);
-            let _ = on_cancel;
-            EitherOf4::D(view! {
+            let _ = &on_cancel;
+            EitherOf5::D(view! {
                 <div slot="header">
                     <h1>"Joining…"</h1>
                 </div>
@@ -374,6 +515,48 @@ where
                             { message }
                         </wa-callout>
                     }) }
+                </div>
+            })
+        }
+        JoinView::OnDisk { subject, vault } => {
+            let sigil_value = did_sigil_value(&subject);
+            let display_name = vault.display_name.clone();
+            EitherOf5::E(view! {
+                <div slot="header">
+                    <h1>"Sync from disk"</h1>
+                    <p class="join-subtitle">
+                        "We found a registered vault on this device that matches "
+                        "this invite. Open it to sync without the cloud."
+                    </p>
+                </div>
+                <div class="join-target wa-stack wa-gap-s wa-align-items-center">
+                    <tonk-sigil value=sigil_value></tonk-sigil>
+                    <p>"Vault: "<strong>{ display_name }</strong></p>
+                    { move || error.get().map(|message| view! {
+                        <wa-callout variant="danger">
+                            <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
+                            { message }
+                        </wa-callout>
+                    }) }
+                </div>
+                <div slot="footer" class="join-actions">
+                    <wa-button
+                        type="button"
+                        variant="neutral"
+                        appearance="plain"
+                        on:click=on_cancel
+                    >"Cancel"</wa-button>
+                    <wa-button
+                        type="button"
+                        variant="primary"
+                        prop:loading=move || submitting.get()
+                        prop:disabled=move || submitting.get()
+                        on:click={
+                            let on_disk_sync = on_disk_sync.clone();
+                            let vault = vault.clone();
+                            move |_| on_disk_sync(vault.clone())
+                        }
+                    >"Sync from disk"</wa-button>
                 </div>
             })
         }

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -1,6 +1,6 @@
 use crate::components::{
     LastJoinOutcome, TonkBoardView, TonkDisplayView, TonkHub, TonkInviteDialog, TonkJoin,
-    TonkProfile, TonkSpaceViewer, TonkToolbar,
+    TonkProfile, TonkSpaceViewer, TonkToolbar, TonkVaults,
 };
 use leptos::prelude::*;
 use leptos_router::{
@@ -51,6 +51,7 @@ pub fn TonkLauncher() -> impl IntoView {
                             view=TonkBoardView
                         />
                         <Route path=path!("profile") view=TonkProfile />
+                        <Route path=path!("vaults") view=TonkVaults />
                         <Route path=path!("join") view=TonkJoin />
                     </ParentRoute>
 

--- a/rust/tonk-ui/src/components/space.rs
+++ b/rust/tonk-ui/src/components/space.rs
@@ -1633,6 +1633,10 @@ fn summarize_address(address: &SiteAddress) -> RemoteAddressSummary {
             url: addr.endpoint().to_string(),
             details: Some(format!("{} · {}", addr.bucket(), addr.region())),
         },
+        SiteAddress::Fs(addr) => RemoteAddressSummary {
+            url: format!("disk:{}", addr.id()),
+            details: None,
+        },
     }
 }
 

--- a/rust/tonk-ui/src/components/toolbar.rs
+++ b/rust/tonk-ui/src/components/toolbar.rs
@@ -53,6 +53,7 @@ pub fn TonkToolbar() -> impl IntoView {
         crate::components::route::parse_space(&decoded).map(|space_ref| space_ref.name)
     });
     let profile_active = Signal::derive(move || location.pathname.get() == "/profile");
+    let vaults_active = Signal::derive(move || location.pathname.get() == "/vaults");
 
     // Turn the space list into a stable-sorted list of tiles, carrying
     // the routing key (the URL the tile links by) and the subject DID
@@ -148,6 +149,15 @@ pub fn TonkToolbar() -> impl IntoView {
             </wa-button>
         </div>
 
+        <wa-button
+            slot="navigation-footer"
+            class="sidebar-space sidebar-space--vaults"
+            class:is-active=move || vaults_active.get()
+            href="/vaults"
+            aria-label="Vaults on disk"
+        >
+            <wa-icon name="hard-drive" label="Vaults on disk"></wa-icon>
+        </wa-button>
         <wa-button
             slot="navigation-footer"
             class="sidebar-space sidebar-space--profile"

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -10,8 +10,14 @@
 //! scaffolded as placeholders — landing them next once the open
 //! flow is shaken out end-to-end.
 
-use leptos::{logging::log, prelude::*, task::spawn_local};
+use leptos::{
+    ev::{Event, SubmitEvent},
+    logging::log,
+    prelude::*,
+    task::spawn_local,
+};
 use std::collections::HashMap;
+use wasm_bindgen::JsCast;
 use web_sys::{FileSystemDirectoryHandle, PermissionState};
 
 use crate::{
@@ -54,16 +60,81 @@ pub fn TonkVaults() -> impl IntoView {
     // resolves to nothing) and paint accordingly.
     reload();
 
+    // Holds the directory the user picked while they're typing a
+    // display name into the dialog. `None` means the dialog is
+    // closed. `!Send` so it lives in `LocalStorage`.
+    let pending_handle: RwSignal<Option<FileSystemDirectoryHandle>, LocalStorage> =
+        RwSignal::new_local(None);
+    let proposed_name = RwSignal::new(String::new());
+    let dialog_error = RwSignal::new(Option::<String>::None);
+
     let on_open_click = move |_| {
         spawn_local(async move {
-            match open_existing_vault().await {
-                Ok(Some(())) => reload(),
+            match fs_access::show_directory_picker().await {
+                Ok(Some(handle)) => {
+                    // Pre-fill the dialog with the directory's name so
+                    // the common case is "just hit Open".
+                    proposed_name.set(handle.name());
+                    dialog_error.set(None);
+                    pending_handle.set(Some(handle));
+                }
                 Ok(None) => {
-                    // User cancelled the picker — leave the list as-is.
+                    // User cancelled the picker — nothing to do.
                 }
                 Err(e) => {
-                    log!("open_existing_vault: {e}");
+                    log!("show_directory_picker: {e}");
                     entries.set(Err(format!("{e}")));
+                }
+            }
+        });
+    };
+
+    let close_dialog = move || {
+        pending_handle.set(None);
+        proposed_name.set(String::new());
+        dialog_error.set(None);
+    };
+
+    let on_dialog_cancel = move |_| close_dialog();
+
+    // `wa-dialog` fires `wa-after-hide` once the close animation
+    // finishes (Esc / X / `open=false`). Clear the pending state
+    // here so cancellation paths converge on the same cleanup.
+    let on_after_hide = move |_: Event| close_dialog();
+
+    let on_name_input = move |event: Event| {
+        let value = event
+            .target()
+            .and_then(|target| target.dyn_into::<web_sys::HtmlElement>().ok())
+            .and_then(|el| {
+                js_sys::Reflect::get(&el, &wasm_bindgen::JsValue::from_str("value"))
+                    .ok()
+                    .and_then(|v| v.as_string())
+            })
+            .unwrap_or_default();
+        proposed_name.set(value);
+    };
+
+    let on_dialog_submit = move |event: SubmitEvent| {
+        event.prevent_default();
+        let Some(handle) = pending_handle.get() else {
+            return;
+        };
+        let name = proposed_name.get().trim().to_string();
+        if name.is_empty() {
+            dialog_error.set(Some("Name can't be empty".into()));
+            return;
+        }
+        dialog_error.set(None);
+        spawn_local(async move {
+            match register_picked_vault(&handle, &name).await {
+                Ok(()) => {
+                    close_dialog();
+                    reload();
+                }
+                Err(e) => {
+                    log!("register_picked_vault: {e}");
+                    dialog_error.set(Some(format!("{e}")));
                 }
             }
         });
@@ -125,6 +196,45 @@ pub fn TonkVaults() -> impl IntoView {
             <Show when=move || refreshing.get()>
                 <wa-spinner></wa-spinner>
             </Show>
+
+            <wa-dialog
+                label="Name this vault"
+                prop:open=move || pending_handle.get().is_some()
+                on:wa-after-hide=on_after_hide
+            >
+                <form on:submit=on_dialog_submit>
+                    <div class="wa-stack wa-gap-s">
+                        <wa-input
+                            name="vault-display-name"
+                            label="Local name"
+                            placeholder="e.g. recipes"
+                            autocomplete="off"
+                            autofocus
+                            required
+                            prop:value=move || proposed_name.get()
+                            on:input=on_name_input
+                        ></wa-input>
+                        { move || dialog_error.get().map(|message| view! {
+                            <wa-callout variant="danger">
+                                <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
+                                { message }
+                            </wa-callout>
+                        }) }
+                    </div>
+                    <wa-button
+                        slot="footer"
+                        type="button"
+                        variant="neutral"
+                        appearance="plain"
+                        on:click=on_dialog_cancel
+                    >"Cancel"</wa-button>
+                    <wa-button
+                        slot="footer"
+                        type="submit"
+                        variant="primary"
+                    >"Open"</wa-button>
+                </form>
+            </wa-dialog>
         </section>
     }
 }
@@ -313,20 +423,16 @@ async fn load_with_status() -> Result<Vec<VaultEntry>, VaultRegistryError> {
     Ok(list)
 }
 
-/// Drive the open-existing flow: pick a directory, ask for a
-/// display name, write the entry to the registry, and hand the
-/// handle to the worker. Returns `Ok(None)` if the user cancels
-/// the picker.
-async fn open_existing_vault() -> Result<Option<()>, TonkUiError> {
-    let Some(handle) = fs_access::show_directory_picker().await? else {
-        return Ok(None);
-    };
-
-    let display_name = prompt_display_name(handle.name())?;
-    let Some(display_name) = display_name else {
-        return Ok(None);
-    };
-
+/// Persist a freshly-picked directory in the registry under
+/// `display_name`, then best-effort ask for permission and hand
+/// the handle to the worker so the row starts green.
+///
+/// The picker + display-name input are driven from the component
+/// itself (via `wa-dialog`); this is the post-dialog tail.
+async fn register_picked_vault(
+    handle: &FileSystemDirectoryHandle,
+    display_name: &str,
+) -> Result<(), TonkUiError> {
     let vault_id = random_vault_id()?;
 
     let registry = VaultRegistry::open()
@@ -334,7 +440,7 @@ async fn open_existing_vault() -> Result<Option<()>, TonkUiError> {
         .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
     let entry = VaultEntry {
         id: vault_id.clone(),
-        display_name,
+        display_name: display_name.to_string(),
         handle: handle.clone(),
         subject_did: None,
         last_synced_at: None,
@@ -349,11 +455,11 @@ async fn open_existing_vault() -> Result<Option<()>, TonkUiError> {
     // green immediately on the freshly registered row. Failure here
     // just leaves the status at yellow until the user re-clicks
     // Reconnect.
-    if let Ok(PermissionState::Granted) = fs_access::request_readwrite_permission(&handle).await {
+    if let Ok(PermissionState::Granted) = fs_access::request_readwrite_permission(handle).await {
         let _ = registry.update_status(&vault_id, VaultStatus::Green).await;
-        fs_access::register_handle_with_worker(&vault_id, &handle)?;
+        fs_access::register_handle_with_worker(&vault_id, handle)?;
     }
-    Ok(Some(()))
+    Ok(())
 }
 
 /// Yellow → green reconnect: re-prompt for permission, update the
@@ -394,22 +500,6 @@ async fn remove_vault(id: &str) -> Result<(), TonkUiError> {
         .map_err(|e| TonkUiError::other(format!("remove: {e}")))?;
     let _ = fs_access::unregister_handle_with_worker(id);
     Ok(())
-}
-
-fn prompt_display_name(default: String) -> Result<Option<String>, TonkUiError> {
-    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
-    // `window.prompt(message, default)` — the `_with_message_and_default` overload.
-    let result = window
-        .prompt_with_message_and_default("Name this vault", &default)
-        .map_err(|_| TonkUiError::other("prompt() rejected"))?;
-    Ok(result.and_then(|s| {
-        let trimmed = s.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    }))
 }
 
 fn random_vault_id() -> Result<String, TonkUiError> {

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -2,22 +2,16 @@
 //! Access API.
 //!
 //! Renders the per-browser-profile registry, paints a tri-state
-//! status indicator per entry, and exposes an "Open existing vault
-//! on disk" CTA that walks the user through `showDirectoryPicker`,
-//! a display-name prompt, and registration with the worker.
-//!
-//! Recovery affordances (Reconnect / Re-locate / Sync now) are
-//! scaffolded as placeholders — landing them next once the open
-//! flow is shaken out end-to-end.
+//! status indicator per entry, and exposes per-row Reconnect /
+//! Sync / Forget actions. The page is purely a management view —
+//! vaults are *created* by the join flow ("I have this on disk"
+//! on `/join?access=…`), which is where the subject DID is known
+//! and the registry entry can be wired to a profile space. An
+//! "import vault from disk" entry point that creates a new space
+//! from a picked directory is a separate piece of work.
 
-use leptos::{
-    ev::{Event, SubmitEvent},
-    logging::log,
-    prelude::*,
-    task::spawn_local,
-};
+use leptos::{logging::log, prelude::*, task::spawn_local};
 use std::collections::HashMap;
-use wasm_bindgen::JsCast;
 use web_sys::{FileSystemDirectoryHandle, PermissionState};
 
 use crate::{
@@ -34,7 +28,7 @@ pub fn TonkVaults() -> impl IntoView {
     let profile_resource =
         use_context::<ProfileResource>().expect("ProfileResource provided by TonkShell");
 
-    // Reactive list of vaults. Re-fetched after open / reconnect /
+    // Reactive list of vaults. Re-fetched after reconnect / sync /
     // delete so the UI converges without bespoke per-row signals.
     let entries: RwSignal<Result<Vec<VaultEntry>, String>, LocalStorage> =
         RwSignal::new_local(Ok(Vec::new()));
@@ -60,86 +54,6 @@ pub fn TonkVaults() -> impl IntoView {
     // resolves to nothing) and paint accordingly.
     reload();
 
-    // Holds the directory the user picked while they're typing a
-    // display name into the dialog. `None` means the dialog is
-    // closed. `!Send` so it lives in `LocalStorage`.
-    let pending_handle: RwSignal<Option<FileSystemDirectoryHandle>, LocalStorage> =
-        RwSignal::new_local(None);
-    let proposed_name = RwSignal::new(String::new());
-    let dialog_error = RwSignal::new(Option::<String>::None);
-
-    let on_open_click = move |_| {
-        spawn_local(async move {
-            match fs_access::show_directory_picker().await {
-                Ok(Some(handle)) => {
-                    // Pre-fill the dialog with the directory's name so
-                    // the common case is "just hit Open".
-                    proposed_name.set(handle.name());
-                    dialog_error.set(None);
-                    pending_handle.set(Some(handle));
-                }
-                Ok(None) => {
-                    // User cancelled the picker — nothing to do.
-                }
-                Err(e) => {
-                    log!("show_directory_picker: {e}");
-                    entries.set(Err(format!("{e}")));
-                }
-            }
-        });
-    };
-
-    let close_dialog = move || {
-        pending_handle.set(None);
-        proposed_name.set(String::new());
-        dialog_error.set(None);
-    };
-
-    let on_dialog_cancel = move |_| close_dialog();
-
-    // `wa-dialog` fires `wa-after-hide` once the close animation
-    // finishes (Esc / X / `open=false`). Clear the pending state
-    // here so cancellation paths converge on the same cleanup.
-    let on_after_hide = move |_: Event| close_dialog();
-
-    let on_name_input = move |event: Event| {
-        let value = event
-            .target()
-            .and_then(|target| target.dyn_into::<web_sys::HtmlElement>().ok())
-            .and_then(|el| {
-                js_sys::Reflect::get(&el, &wasm_bindgen::JsValue::from_str("value"))
-                    .ok()
-                    .and_then(|v| v.as_string())
-            })
-            .unwrap_or_default();
-        proposed_name.set(value);
-    };
-
-    let on_dialog_submit = move |event: SubmitEvent| {
-        event.prevent_default();
-        let Some(handle) = pending_handle.get() else {
-            return;
-        };
-        let name = proposed_name.get().trim().to_string();
-        if name.is_empty() {
-            dialog_error.set(Some("Name can't be empty".into()));
-            return;
-        }
-        dialog_error.set(None);
-        spawn_local(async move {
-            match register_picked_vault(&handle, &name).await {
-                Ok(()) => {
-                    close_dialog();
-                    reload();
-                }
-                Err(e) => {
-                    log!("register_picked_vault: {e}");
-                    dialog_error.set(Some(format!("{e}")));
-                }
-            }
-        });
-    };
-
     // Reverse-map of subject DID → local space name from the
     // shared profile resource. Drives the per-row "Sync" button:
     // a vault entry with a `subject_did` matching a space is
@@ -161,17 +75,14 @@ pub fn TonkVaults() -> impl IntoView {
         <section class="tonk-vaults">
             <header>
                 <h1>"Vaults on this device"</h1>
-                <wa-button variant="brand" on:click=on_open_click>
-                    "Open existing vault on disk"
-                </wa-button>
             </header>
 
             { move || match entries.get() {
                 Ok(list) if list.is_empty() => view! {
                     <wa-callout variant="neutral">
                         <wa-icon slot="icon" name="circle-info"></wa-icon>
-                        "No vaults registered on this device yet. "
-                        "Click \"Open existing vault on disk\" to add one."
+                        "No vaults registered on this device. Open an invite "
+                        "link and pick \"I have this on disk\" to add one."
                     </wa-callout>
                 }.into_any(),
                 Ok(list) => view! {
@@ -196,45 +107,6 @@ pub fn TonkVaults() -> impl IntoView {
             <Show when=move || refreshing.get()>
                 <wa-spinner></wa-spinner>
             </Show>
-
-            <wa-dialog
-                label="Name this vault"
-                prop:open=move || pending_handle.get().is_some()
-                on:wa-after-hide=on_after_hide
-            >
-                <form on:submit=on_dialog_submit>
-                    <div class="wa-stack wa-gap-s">
-                        <wa-input
-                            name="vault-display-name"
-                            label="Local name"
-                            placeholder="e.g. recipes"
-                            autocomplete="off"
-                            autofocus
-                            required
-                            prop:value=move || proposed_name.get()
-                            on:input=on_name_input
-                        ></wa-input>
-                        { move || dialog_error.get().map(|message| view! {
-                            <wa-callout variant="danger">
-                                <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
-                                { message }
-                            </wa-callout>
-                        }) }
-                    </div>
-                    <wa-button
-                        slot="footer"
-                        type="button"
-                        variant="neutral"
-                        appearance="plain"
-                        on:click=on_dialog_cancel
-                    >"Cancel"</wa-button>
-                    <wa-button
-                        slot="footer"
-                        type="submit"
-                        variant="primary"
-                    >"Open"</wa-button>
-                </form>
-            </wa-dialog>
         </section>
     }
 }
@@ -423,45 +295,6 @@ async fn load_with_status() -> Result<Vec<VaultEntry>, VaultRegistryError> {
     Ok(list)
 }
 
-/// Persist a freshly-picked directory in the registry under
-/// `display_name`, then best-effort ask for permission and hand
-/// the handle to the worker so the row starts green.
-///
-/// The picker + display-name input are driven from the component
-/// itself (via `wa-dialog`); this is the post-dialog tail.
-async fn register_picked_vault(
-    handle: &FileSystemDirectoryHandle,
-    display_name: &str,
-) -> Result<(), TonkUiError> {
-    let vault_id = random_vault_id()?;
-
-    let registry = VaultRegistry::open()
-        .await
-        .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
-    let entry = VaultEntry {
-        id: vault_id.clone(),
-        display_name: display_name.to_string(),
-        handle: handle.clone(),
-        subject_did: None,
-        last_synced_at: None,
-        last_known_status: VaultStatus::Yellow,
-    };
-    registry
-        .put(&entry)
-        .await
-        .map_err(|e| TonkUiError::other(format!("saving registry entry: {e}")))?;
-
-    // Best effort: ask for permission so the boot-scan reload paints
-    // green immediately on the freshly registered row. Failure here
-    // just leaves the status at yellow until the user re-clicks
-    // Reconnect.
-    if let Ok(PermissionState::Granted) = fs_access::request_readwrite_permission(handle).await {
-        let _ = registry.update_status(&vault_id, VaultStatus::Green).await;
-        fs_access::register_handle_with_worker(&vault_id, handle)?;
-    }
-    Ok(())
-}
-
 /// Yellow → green reconnect: re-prompt for permission, update the
 /// registry, hand the handle back to the worker on success.
 async fn reconnect_vault(
@@ -500,12 +333,4 @@ async fn remove_vault(id: &str) -> Result<(), TonkUiError> {
         .map_err(|e| TonkUiError::other(format!("remove: {e}")))?;
     let _ = fs_access::unregister_handle_with_worker(id);
     Ok(())
-}
-
-fn random_vault_id() -> Result<String, TonkUiError> {
-    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
-    let crypto = window
-        .crypto()
-        .map_err(|_| TonkUiError::other("crypto API unavailable"))?;
-    Ok(crypto.random_uuid())
 }

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -11,9 +11,12 @@
 //! flow is shaken out end-to-end.
 
 use leptos::{logging::log, prelude::*, task::spawn_local};
+use std::collections::HashMap;
 use web_sys::{FileSystemDirectoryHandle, PermissionState};
 
 use crate::{
+    api,
+    components::ProfileResource,
     error::TonkUiError,
     fs_access,
     vaults::{VaultEntry, VaultRegistry, VaultRegistryError, VaultStatus},
@@ -22,11 +25,18 @@ use crate::{
 /// Top-level `/vaults` view.
 #[component]
 pub fn TonkVaults() -> impl IntoView {
+    let profile_resource =
+        use_context::<ProfileResource>().expect("ProfileResource provided by TonkShell");
+
     // Reactive list of vaults. Re-fetched after open / reconnect /
     // delete so the UI converges without bespoke per-row signals.
     let entries: RwSignal<Result<Vec<VaultEntry>, String>, LocalStorage> =
         RwSignal::new_local(Ok(Vec::new()));
     let refreshing = RwSignal::new(false);
+    // Last-sync error per vault, surfaced inline on the row that
+    // produced it. Keyed by vault id.
+    let sync_errors: RwSignal<HashMap<String, String>, LocalStorage> =
+        RwSignal::new_local(HashMap::new());
 
     let reload = move || {
         refreshing.set(true);
@@ -59,6 +69,23 @@ pub fn TonkVaults() -> impl IntoView {
         });
     };
 
+    // Reverse-map of subject DID → local space name from the
+    // shared profile resource. Drives the per-row "Sync" button:
+    // a vault entry with a `subject_did` matching a space is
+    // ready to wire as that space's FS upstream. Recomputed when
+    // the profile resource updates so a newly-joined space starts
+    // offering Sync without a manual reload.
+    let space_by_did: Signal<HashMap<String, String>, LocalStorage> =
+        Signal::derive_local(move || {
+            let Some(Ok(Some(info))) = profile_resource.get() else {
+                return HashMap::new();
+            };
+            info.space
+                .into_iter()
+                .map(|(name, did)| (did.to_string(), name))
+                .collect()
+        });
+
     view! {
         <section class="tonk-vaults">
             <header>
@@ -78,7 +105,13 @@ pub fn TonkVaults() -> impl IntoView {
                 }.into_any(),
                 Ok(list) => view! {
                     <ul class="vaults-list">
-                        { list.into_iter().map(|entry| render_row(entry, reload)).collect_view() }
+                        { list.into_iter().map(|entry| {
+                            let matched_space = entry
+                                .subject_did
+                                .as_deref()
+                                .and_then(|did| space_by_did.get().get(did).cloned());
+                            render_row(entry, matched_space, sync_errors, reload)
+                        }).collect_view() }
                     </ul>
                 }.into_any(),
                 Err(message) => view! {
@@ -99,7 +132,18 @@ pub fn TonkVaults() -> impl IntoView {
 /// Render a single registered vault. Action buttons key off
 /// `last_known_status` so the visible affordance matches what's
 /// actually possible without the user gesturing again.
-fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl IntoView {
+///
+/// `matched_space` is the local name of the profile space whose
+/// subject DID matches this vault's `subject_did`, when both are
+/// known. Drives the "Sync" button: without a match there's no
+/// repo to wire as upstream, so we hide the action rather than
+/// guess.
+fn render_row(
+    entry: VaultEntry,
+    matched_space: Option<String>,
+    sync_errors: RwSignal<HashMap<String, String>, LocalStorage>,
+    reload: impl Fn() + Copy + 'static,
+) -> impl IntoView {
     let (status_label, status_variant) = match entry.last_known_status {
         VaultStatus::Green => ("Ready", "success"),
         VaultStatus::Yellow => ("Tap to reconnect", "warning"),
@@ -109,6 +153,9 @@ fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl Int
     let entry_id = entry.id.clone();
     let id_for_reconnect = entry.id.clone();
     let handle_for_reconnect = entry.handle.clone();
+    let id_for_sync = entry.id.clone();
+    let handle_for_sync = entry.handle.clone();
+    let id_for_error_read = entry.id.clone();
 
     let on_reconnect = move |_| {
         let id = id_for_reconnect.clone();
@@ -119,6 +166,36 @@ fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl Int
                 Err(e) => log!("reconnect failed: {e}"),
             }
         });
+    };
+
+    let on_sync = {
+        let matched_space = matched_space.clone();
+        move |_| {
+            let Some(space) = matched_space.clone() else {
+                return;
+            };
+            let id = id_for_sync.clone();
+            let handle = handle_for_sync.clone();
+            sync_errors.update(|errors| {
+                errors.remove(&id);
+            });
+            spawn_local(async move {
+                match sync_vault(&space, &id, &handle).await {
+                    Ok(()) => {
+                        sync_errors.update(|errors| {
+                            errors.remove(&id);
+                        });
+                        reload();
+                    }
+                    Err(e) => {
+                        log!("sync_vault({id}, {space}): {e}");
+                        sync_errors.update(|errors| {
+                            errors.insert(id.clone(), format!("{e}"));
+                        });
+                    }
+                }
+            });
+        }
     };
 
     let id_for_remove = entry_id.clone();
@@ -132,6 +209,19 @@ fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl Int
         });
     };
 
+    let sync_button = match (entry.last_known_status, matched_space.clone()) {
+        (VaultStatus::Green, Some(space)) => view! {
+            <wa-button size="small" variant="brand" on:click=on_sync>
+                { format!("Sync to {space}") }
+            </wa-button>
+        }
+        .into_any(),
+        // Subject DID matches a known space but permission isn't
+        // green yet — Reconnect runs first, surfaced via the
+        // status-block button below.
+        _ => view! { <span></span> }.into_any(),
+    };
+
     view! {
         <li class="vaults-list__row" data-vault-id=entry_id>
             <div class="vaults-list__name">{ display_name }</div>
@@ -143,12 +233,55 @@ fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl Int
                     }.into_any(),
                     _ => view! { <span></span> }.into_any(),
                 } }
+                { sync_button }
                 <wa-button size="small" appearance="plain" on:click=on_remove>
                     "Forget"
                 </wa-button>
             </div>
+            { move || sync_errors
+                .get()
+                .get(&id_for_error_read)
+                .cloned()
+                .map(|message| view! {
+                    <wa-callout variant="danger">
+                        <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
+                        { message }
+                    </wa-callout>
+                })
+            }
         </li>
     }
+}
+
+/// Re-register the handle with the worker, wire the FS upstream
+/// for `(space, "main")`, and pull. Also updates the registry
+/// entry's `last_synced_at` on success.
+async fn sync_vault(
+    space: &str,
+    vault_id: &str,
+    handle: &FileSystemDirectoryHandle,
+) -> Result<(), TonkUiError> {
+    // Browsers reset FS-Access permission per session; re-request
+    // here so a fresh page load can sync without a separate
+    // Reconnect click. If the user already granted in this
+    // session, this is a no-op.
+    match fs_access::request_readwrite_permission(handle).await {
+        Ok(PermissionState::Granted) => {}
+        Ok(_) => return Err(TonkUiError::other("Permission was not granted")),
+        Err(e) => return Err(e),
+    }
+    fs_access::register_handle_with_worker(vault_id, handle)?;
+    api::set_fs_upstream(space, "main", vault_id).await?;
+    api::pull(space, "main").await?;
+
+    let registry = VaultRegistry::open()
+        .await
+        .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
+    let now_ms = js_sys::Date::now();
+    if let Err(e) = registry.touch_last_synced(vault_id, now_ms).await {
+        log!("touch_last_synced('{vault_id}'): {e}");
+    }
+    Ok(())
 }
 
 /// Open the registry, list every entry, then probe each handle's

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -297,10 +297,7 @@ async fn load_with_status() -> Result<Vec<VaultEntry>, VaultRegistryError> {
 
 /// Yellow → green reconnect: re-prompt for permission, update the
 /// registry, hand the handle back to the worker on success.
-async fn reconnect_vault(
-    id: &str,
-    handle: &FileSystemDirectoryHandle,
-) -> Result<(), TonkUiError> {
+async fn reconnect_vault(id: &str, handle: &FileSystemDirectoryHandle) -> Result<(), TonkUiError> {
     let state = fs_access::request_readwrite_permission(handle).await?;
     let registry = VaultRegistry::open()
         .await

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -1,0 +1,287 @@
+//! `/vaults` — manage local-disk vaults backed by the File System
+//! Access API.
+//!
+//! Renders the per-browser-profile registry, paints a tri-state
+//! status indicator per entry, and exposes an "Open existing vault
+//! on disk" CTA that walks the user through `showDirectoryPicker`,
+//! a display-name prompt, and registration with the worker.
+//!
+//! Recovery affordances (Reconnect / Re-locate / Sync now) are
+//! scaffolded as placeholders — landing them next once the open
+//! flow is shaken out end-to-end.
+
+use leptos::{logging::log, prelude::*, task::spawn_local};
+use web_sys::{FileSystemDirectoryHandle, PermissionState};
+
+use crate::{
+    error::TonkUiError,
+    fs_access,
+    vaults::{VaultEntry, VaultRegistry, VaultRegistryError, VaultStatus},
+};
+
+/// Top-level `/vaults` view.
+#[component]
+pub fn TonkVaults() -> impl IntoView {
+    // Reactive list of vaults. Re-fetched after open / reconnect /
+    // delete so the UI converges without bespoke per-row signals.
+    let entries: RwSignal<Result<Vec<VaultEntry>, String>, LocalStorage> =
+        RwSignal::new_local(Ok(Vec::new()));
+    let refreshing = RwSignal::new(false);
+
+    let reload = move || {
+        refreshing.set(true);
+        spawn_local(async move {
+            match load_with_status().await {
+                Ok(list) => entries.set(Ok(list)),
+                Err(e) => entries.set(Err(format!("{e}"))),
+            }
+            refreshing.set(false);
+        });
+    };
+
+    // Boot scan on mount. Permission-only — without a user gesture
+    // it can't escape "yellow", but it can detect "red" (handle
+    // resolves to nothing) and paint accordingly.
+    reload();
+
+    let on_open_click = move |_| {
+        spawn_local(async move {
+            match open_existing_vault().await {
+                Ok(Some(())) => reload(),
+                Ok(None) => {
+                    // User cancelled the picker — leave the list as-is.
+                }
+                Err(e) => {
+                    log!("open_existing_vault: {e}");
+                    entries.set(Err(format!("{e}")));
+                }
+            }
+        });
+    };
+
+    view! {
+        <section class="tonk-vaults">
+            <header>
+                <h1>"Vaults on this device"</h1>
+                <wa-button variant="brand" on:click=on_open_click>
+                    "Open existing vault on disk"
+                </wa-button>
+            </header>
+
+            { move || match entries.get() {
+                Ok(list) if list.is_empty() => view! {
+                    <wa-callout variant="neutral">
+                        <wa-icon slot="icon" name="circle-info"></wa-icon>
+                        "No vaults registered on this device yet. "
+                        "Click \"Open existing vault on disk\" to add one."
+                    </wa-callout>
+                }.into_any(),
+                Ok(list) => view! {
+                    <ul class="vaults-list">
+                        { list.into_iter().map(|entry| render_row(entry, reload)).collect_view() }
+                    </ul>
+                }.into_any(),
+                Err(message) => view! {
+                    <wa-callout variant="danger">
+                        <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
+                        { message }
+                    </wa-callout>
+                }.into_any(),
+            } }
+
+            <Show when=move || refreshing.get()>
+                <wa-spinner></wa-spinner>
+            </Show>
+        </section>
+    }
+}
+
+/// Render a single registered vault. Action buttons key off
+/// `last_known_status` so the visible affordance matches what's
+/// actually possible without the user gesturing again.
+fn render_row(entry: VaultEntry, reload: impl Fn() + Copy + 'static) -> impl IntoView {
+    let (status_label, status_variant) = match entry.last_known_status {
+        VaultStatus::Green => ("Ready", "success"),
+        VaultStatus::Yellow => ("Tap to reconnect", "warning"),
+        VaultStatus::Red => ("Vault not found", "danger"),
+    };
+    let display_name = entry.display_name.clone();
+    let entry_id = entry.id.clone();
+    let id_for_reconnect = entry.id.clone();
+    let handle_for_reconnect = entry.handle.clone();
+
+    let on_reconnect = move |_| {
+        let id = id_for_reconnect.clone();
+        let handle = handle_for_reconnect.clone();
+        spawn_local(async move {
+            match reconnect_vault(&id, &handle).await {
+                Ok(()) => reload(),
+                Err(e) => log!("reconnect failed: {e}"),
+            }
+        });
+    };
+
+    let id_for_remove = entry_id.clone();
+    let on_remove = move |_| {
+        let id = id_for_remove.clone();
+        spawn_local(async move {
+            match remove_vault(&id).await {
+                Ok(()) => reload(),
+                Err(e) => log!("remove failed: {e}"),
+            }
+        });
+    };
+
+    view! {
+        <li class="vaults-list__row" data-vault-id=entry_id>
+            <div class="vaults-list__name">{ display_name }</div>
+            <wa-badge variant=status_variant>{ status_label }</wa-badge>
+            <div class="vaults-list__actions">
+                { match entry.last_known_status {
+                    VaultStatus::Yellow => view! {
+                        <wa-button size="small" on:click=on_reconnect>"Reconnect"</wa-button>
+                    }.into_any(),
+                    _ => view! { <span></span> }.into_any(),
+                } }
+                <wa-button size="small" appearance="plain" on:click=on_remove>
+                    "Forget"
+                </wa-button>
+            </div>
+        </li>
+    }
+}
+
+/// Open the registry, list every entry, then probe each handle's
+/// readwrite permission so the boot scan paints the right colour.
+/// Permission probe never prompts, so the worst it can do is paint
+/// yellow.
+async fn load_with_status() -> Result<Vec<VaultEntry>, VaultRegistryError> {
+    let registry = VaultRegistry::open().await?;
+    let mut list = registry.list().await?;
+    for entry in list.iter_mut() {
+        let probed = match fs_access::query_readwrite_permission(&entry.handle).await {
+            Ok(PermissionState::Granted) => VaultStatus::Green,
+            Ok(PermissionState::Prompt) => VaultStatus::Yellow,
+            Ok(PermissionState::Denied) | Ok(_) => VaultStatus::Red,
+            Err(e) => {
+                log!("queryPermission failed for vault '{}': {e}", entry.id);
+                VaultStatus::Red
+            }
+        };
+        if probed != entry.last_known_status {
+            entry.last_known_status = probed;
+            // Best-effort write-back; if it fails, log and keep
+            // serving the in-memory view.
+            if let Err(e) = registry.update_status(&entry.id, probed).await {
+                log!("update_status('{}') failed: {e}", entry.id);
+            }
+        }
+    }
+    Ok(list)
+}
+
+/// Drive the open-existing flow: pick a directory, ask for a
+/// display name, write the entry to the registry, and hand the
+/// handle to the worker. Returns `Ok(None)` if the user cancels
+/// the picker.
+async fn open_existing_vault() -> Result<Option<()>, TonkUiError> {
+    let Some(handle) = fs_access::show_directory_picker().await? else {
+        return Ok(None);
+    };
+
+    let display_name = prompt_display_name(handle.name())?;
+    let Some(display_name) = display_name else {
+        return Ok(None);
+    };
+
+    let vault_id = random_vault_id()?;
+
+    let registry = VaultRegistry::open()
+        .await
+        .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
+    let entry = VaultEntry {
+        id: vault_id.clone(),
+        display_name,
+        handle: handle.clone(),
+        last_synced_at: None,
+        last_known_status: VaultStatus::Yellow,
+    };
+    registry
+        .put(&entry)
+        .await
+        .map_err(|e| TonkUiError::other(format!("saving registry entry: {e}")))?;
+
+    // Best effort: ask for permission so the boot-scan reload paints
+    // green immediately on the freshly registered row. Failure here
+    // just leaves the status at yellow until the user re-clicks
+    // Reconnect.
+    if let Ok(PermissionState::Granted) = fs_access::request_readwrite_permission(&handle).await {
+        let _ = registry.update_status(&vault_id, VaultStatus::Green).await;
+        fs_access::register_handle_with_worker(&vault_id, &handle)?;
+    }
+    Ok(Some(()))
+}
+
+/// Yellow → green reconnect: re-prompt for permission, update the
+/// registry, hand the handle back to the worker on success.
+async fn reconnect_vault(
+    id: &str,
+    handle: &FileSystemDirectoryHandle,
+) -> Result<(), TonkUiError> {
+    let state = fs_access::request_readwrite_permission(handle).await?;
+    let registry = VaultRegistry::open()
+        .await
+        .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
+    let next = match state {
+        PermissionState::Granted => VaultStatus::Green,
+        PermissionState::Prompt => VaultStatus::Yellow,
+        _ => VaultStatus::Red,
+    };
+    registry
+        .update_status(id, next)
+        .await
+        .map_err(|e| TonkUiError::other(format!("update_status: {e}")))?;
+    if next == VaultStatus::Green {
+        fs_access::register_handle_with_worker(id, handle)?;
+    }
+    Ok(())
+}
+
+/// Drop a vault from the registry and tell the worker to forget
+/// its handle. Best-effort: registry removal is the source of
+/// truth, the worker-side unregister is a hint.
+async fn remove_vault(id: &str) -> Result<(), TonkUiError> {
+    let registry = VaultRegistry::open()
+        .await
+        .map_err(|e| TonkUiError::other(format!("opening registry: {e}")))?;
+    registry
+        .remove(id)
+        .await
+        .map_err(|e| TonkUiError::other(format!("remove: {e}")))?;
+    let _ = fs_access::unregister_handle_with_worker(id);
+    Ok(())
+}
+
+fn prompt_display_name(default: String) -> Result<Option<String>, TonkUiError> {
+    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
+    // `window.prompt(message, default)` — the `_with_message_and_default` overload.
+    let result = window
+        .prompt_with_message_and_default("Name this vault", &default)
+        .map_err(|_| TonkUiError::other("prompt() rejected"))?;
+    Ok(result.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
+}
+
+fn random_vault_id() -> Result<String, TonkUiError> {
+    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
+    let crypto = window
+        .crypto()
+        .map_err(|_| TonkUiError::other("crypto API unavailable"))?;
+    Ok(crypto.random_uuid())
+}

--- a/rust/tonk-ui/src/components/vaults_page.rs
+++ b/rust/tonk-ui/src/components/vaults_page.rs
@@ -203,6 +203,7 @@ async fn open_existing_vault() -> Result<Option<()>, TonkUiError> {
         id: vault_id.clone(),
         display_name,
         handle: handle.clone(),
+        subject_did: None,
         last_synced_at: None,
         last_known_status: VaultStatus::Yellow,
     };

--- a/rust/tonk-ui/src/error.rs
+++ b/rust/tonk-ui/src/error.rs
@@ -19,4 +19,17 @@ pub enum TonkUiError {
         /// Source range in the submitted document, when known.
         range: Option<lsp_types::Range>,
     },
+
+    /// Catch-all for errors that don't fit the API or analyzer
+    /// shapes (FS Access API failures, missing browser globals,
+    /// malformed stored state, etc.).
+    #[error("{0}")]
+    Other(String),
+}
+
+impl TonkUiError {
+    /// Convenience constructor for the [`TonkUiError::Other`] catch-all.
+    pub fn other(message: impl Into<String>) -> Self {
+        TonkUiError::Other(message.into())
+    }
 }

--- a/rust/tonk-ui/src/fs_access.rs
+++ b/rust/tonk-ui/src/fs_access.rs
@@ -1,0 +1,159 @@
+//! Thin wrappers around the File System Access API + the page-to-SW
+//! postMessage handshake.
+//!
+//! `web_sys` provides typed bindings for `showDirectoryPicker`,
+//! `queryPermission`, and `requestPermission`; this module narrows
+//! their `Promise`-returning shapes into plain `async fn`s that return
+//! crate-specific result types, and adds a one-call helper for
+//! handing a directory handle to the active service worker.
+//!
+//! All helpers run in the page (Leptos `csr` build), not the SW. The
+//! SW receives handles via the `message` listener in
+//! `assets/service_worker.js`, which forwards to
+//! `worker.registerFsHandle(id, handle)`.
+
+use crate::error::TonkUiError;
+use js_sys::{Object, Reflect};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    FileSystemDirectoryHandle, FileSystemHandlePermissionDescriptor, FileSystemPermissionMode,
+    PermissionState,
+};
+
+fn js_error(context: &str, error: JsValue) -> TonkUiError {
+    let message = error
+        .dyn_ref::<js_sys::Error>()
+        .map(|e| String::from(e.message()))
+        .or_else(|| error.as_string())
+        .unwrap_or_else(|| format!("{error:?}"));
+    TonkUiError::other(format!("{context}: {message}"))
+}
+
+/// Prompt the user to pick a directory.
+///
+/// Returns `Ok(None)` when the user cancels the picker; any other
+/// failure (FS Access unsupported, transient JS error, etc.) bubbles
+/// up as `Err`.
+pub async fn show_directory_picker() -> Result<Option<FileSystemDirectoryHandle>, TonkUiError> {
+    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
+    let promise = window
+        .show_directory_picker()
+        .map_err(|e| js_error("showDirectoryPicker (unsupported?)", e))?;
+    match JsFuture::from(promise).await {
+        Ok(value) => {
+            let handle: FileSystemDirectoryHandle = value
+                .dyn_into()
+                .map_err(|_| TonkUiError::other("showDirectoryPicker returned non-handle"))?;
+            Ok(Some(handle))
+        }
+        Err(error) => {
+            // Cancellation surfaces as an AbortError DOMException — distinguish
+            // from real failures so the UI can stay quiet on cancel.
+            if is_abort_error(&error) {
+                Ok(None)
+            } else {
+                Err(js_error("showDirectoryPicker", error))
+            }
+        }
+    }
+}
+
+/// Query the current readwrite permission for a handle without
+/// prompting the user.
+pub async fn query_readwrite_permission(
+    handle: &FileSystemDirectoryHandle,
+) -> Result<PermissionState, TonkUiError> {
+    let descriptor = readwrite_descriptor();
+    let value = JsFuture::from(handle.query_permission_with_descriptor(&descriptor))
+        .await
+        .map_err(|e| js_error("queryPermission", e))?;
+    permission_state_from_js(&value)
+}
+
+/// Prompt the user to grant readwrite permission for a handle. Must
+/// be invoked from a user-gesture handler (click, keypress, etc.) —
+/// the browser silently rejects otherwise.
+pub async fn request_readwrite_permission(
+    handle: &FileSystemDirectoryHandle,
+) -> Result<PermissionState, TonkUiError> {
+    let descriptor = readwrite_descriptor();
+    let value = JsFuture::from(handle.request_permission_with_descriptor(&descriptor))
+        .await
+        .map_err(|e| js_error("requestPermission", e))?;
+    permission_state_from_js(&value)
+}
+
+/// Send a handle to the active service worker so the worker stashes
+/// it in `dialog-remote-fs`'s thread-local registry under `id`. The
+/// SW shim listens for `{type: "register-fs-handle", id, handle}` and
+/// forwards to `worker.registerFsHandle`.
+pub fn register_handle_with_worker(
+    id: &str,
+    handle: &FileSystemDirectoryHandle,
+) -> Result<(), TonkUiError> {
+    let message = Object::new();
+    set(&message, "type", &JsValue::from_str("register-fs-handle"))?;
+    set(&message, "id", &JsValue::from_str(id))?;
+    set(&message, "handle", handle.as_ref())?;
+    post_to_worker(&message)
+}
+
+/// Tell the active service worker to forget the handle previously
+/// registered under `id`.
+pub fn unregister_handle_with_worker(id: &str) -> Result<(), TonkUiError> {
+    let message = Object::new();
+    set(&message, "type", &JsValue::from_str("unregister-fs-handle"))?;
+    set(&message, "id", &JsValue::from_str(id))?;
+    post_to_worker(&message)
+}
+
+fn readwrite_descriptor() -> FileSystemHandlePermissionDescriptor {
+    let descriptor = FileSystemHandlePermissionDescriptor::new();
+    descriptor.set_mode(FileSystemPermissionMode::Readwrite);
+    descriptor
+}
+
+fn permission_state_from_js(value: &JsValue) -> Result<PermissionState, TonkUiError> {
+    // `query/requestPermission` resolve with a string ("granted" |
+    // "prompt" | "denied"); web_sys exposes `PermissionState` as a
+    // string enum that decodes via `wasm_bindgen::JsCast::dyn_into`.
+    let state = value
+        .as_string()
+        .ok_or_else(|| TonkUiError::other("permission state was not a string"))?;
+    match state.as_str() {
+        "granted" => Ok(PermissionState::Granted),
+        "prompt" => Ok(PermissionState::Prompt),
+        "denied" => Ok(PermissionState::Denied),
+        other => Err(TonkUiError::other(format!(
+            "unexpected permission state '{other}'",
+        ))),
+    }
+}
+
+fn is_abort_error(error: &JsValue) -> bool {
+    error
+        .dyn_ref::<js_sys::Error>()
+        .map(|e| {
+            let name = String::from(e.name());
+            name == "AbortError"
+        })
+        .unwrap_or(false)
+}
+
+fn post_to_worker(message: &Object) -> Result<(), TonkUiError> {
+    let window = web_sys::window().ok_or_else(|| TonkUiError::other("window unavailable"))?;
+    let container = window.navigator().service_worker();
+    let controller = container.controller().ok_or_else(|| {
+        TonkUiError::other("no active service worker controller — page must reload to acquire one")
+    })?;
+    controller
+        .post_message(message.as_ref())
+        .map_err(|e| js_error("serviceWorker.controller.postMessage", e))
+}
+
+fn set(obj: &Object, key: &str, value: &JsValue) -> Result<(), TonkUiError> {
+    Reflect::set(obj.as_ref(), &JsValue::from_str(key), value)
+        .map_err(|e| js_error(&format!("set {key}"), e))?;
+    Ok(())
+}

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -23,6 +23,11 @@ pub mod watch;
 /// DID parsing helpers.
 pub mod did;
 
+/// Thin wrappers around the File System Access API: directory picker,
+/// permission probes, and the page-to-service-worker handshake that
+/// forwards directory handles into `dialog-remote-fs`'s registry.
+pub mod fs_access;
+
 /// Per-browser-profile registry of local-disk vaults backed by the
 /// File System Access API.
 pub mod vaults;

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -23,6 +23,10 @@ pub mod watch;
 /// DID parsing helpers.
 pub mod did;
 
+/// Per-browser-profile registry of local-disk vaults backed by the
+/// File System Access API.
+pub mod vaults;
+
 /// Error types for the Tonk UI.
 pub mod error;
 

--- a/rust/tonk-ui/src/vaults.rs
+++ b/rust/tonk-ui/src/vaults.rs
@@ -1,0 +1,298 @@
+//! Per-browser-profile registry of local-disk vaults.
+//!
+//! Each entry pairs a vault id (the opaque string used as
+//! `FsAddress::id` on the worker side) with the
+//! `FileSystemDirectoryHandle` the user picked, a display name, and
+//! cached status. Persisted in IndexedDB so the list survives reloads;
+//! the handle itself rides along through IDB's structured-cloneable
+//! storage — only the permission grant doesn't survive (browsers reset
+//! that on every cold load).
+//!
+//! Status semantics ([`VaultStatus`]):
+//! - `Green`: permission queried as `granted`; sync will succeed.
+//! - `Yellow`: handle known but permission is `prompt` — needs a user
+//!   gesture to reconnect.
+//! - `Red`: handle no longer resolves (directory moved/renamed) and
+//!   the user must re-pick.
+//!
+//! Construction (`VaultRegistry::open`) is async because IndexedDB
+//! open is async; the same registry instance is intended to be held
+//! for the lifetime of the page.
+
+use idb::{Database, DatabaseEvent, Factory, KeyPath, ObjectStoreParams, TransactionMode};
+use js_sys::{Object, Reflect};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::FileSystemDirectoryHandle;
+
+const DB_NAME: &str = "tonk-vaults";
+const STORE_NAME: &str = "vaults";
+const DB_VERSION: u32 = 1;
+
+const FIELD_ID: &str = "id";
+const FIELD_DISPLAY_NAME: &str = "displayName";
+const FIELD_HANDLE: &str = "handle";
+const FIELD_LAST_SYNCED_AT: &str = "lastSyncedAt";
+const FIELD_LAST_KNOWN_STATUS: &str = "lastKnownStatus";
+
+/// Cached permission/probe state for a vault.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultStatus {
+    /// Permission `granted` at last probe — sync ready.
+    Green,
+    /// Permission `prompt` — needs a user gesture to reconnect.
+    Yellow,
+    /// Handle no longer resolves (directory missing) — re-pick required.
+    Red,
+}
+
+impl VaultStatus {
+    fn to_storage(self) -> &'static str {
+        match self {
+            VaultStatus::Green => "green",
+            VaultStatus::Yellow => "yellow",
+            VaultStatus::Red => "red",
+        }
+    }
+
+    fn from_storage(s: &str) -> Option<Self> {
+        match s {
+            "green" => Some(VaultStatus::Green),
+            "yellow" => Some(VaultStatus::Yellow),
+            "red" => Some(VaultStatus::Red),
+            _ => None,
+        }
+    }
+}
+
+/// One entry in the registry.
+#[derive(Clone)]
+pub struct VaultEntry {
+    /// Opaque id — used as the `FsAddress::id` on the worker side.
+    /// Consumers typically use the vault's subject DID.
+    pub id: String,
+    /// User-chosen friendly name (shown in the vaults list and the
+    /// reconnect prompt).
+    pub display_name: String,
+    /// The directory the user picked via `showDirectoryPicker()`.
+    pub handle: FileSystemDirectoryHandle,
+    /// Wall-clock ms since epoch of the most recent sync, or `None`
+    /// if this vault has never been synced from this device.
+    pub last_synced_at: Option<f64>,
+    /// Last-probed status. Refreshed on boot scan and after each
+    /// permission/connectivity change.
+    pub last_known_status: VaultStatus,
+}
+
+impl std::fmt::Debug for VaultEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VaultEntry")
+            .field("id", &self.id)
+            .field("display_name", &self.display_name)
+            .field("handle", &"<FileSystemDirectoryHandle>")
+            .field("last_synced_at", &self.last_synced_at)
+            .field("last_known_status", &self.last_known_status)
+            .finish()
+    }
+}
+
+/// Errors raised by [`VaultRegistry`] operations.
+#[derive(Debug, Error)]
+pub enum VaultRegistryError {
+    /// IndexedDB returned an error.
+    #[error("IndexedDB error: {0}")]
+    Idb(String),
+    /// A record was missing an expected field or had the wrong shape.
+    #[error("Stored vault record is malformed: {0}")]
+    Malformed(String),
+}
+
+impl From<idb::Error> for VaultRegistryError {
+    fn from(error: idb::Error) -> Self {
+        VaultRegistryError::Idb(error.to_string())
+    }
+}
+
+/// Per-browser-profile registry of FS-Access vaults.
+pub struct VaultRegistry {
+    db: Database,
+}
+
+impl VaultRegistry {
+    /// Open (or create) the IndexedDB-backed registry.
+    pub async fn open() -> Result<Self, VaultRegistryError> {
+        let factory = Factory::new()?;
+        let mut request = factory.open(DB_NAME, Some(DB_VERSION))?;
+        request.on_upgrade_needed(|event| {
+            let database = event
+                .database()
+                .expect("idb upgrade event missing database");
+            // Ignore "already exists" — covers the case where a
+            // previous version created the store at the same name.
+            let mut params = ObjectStoreParams::new();
+            params.key_path(Some(KeyPath::new_single(FIELD_ID)));
+            let _ = database.create_object_store(STORE_NAME, params);
+        });
+        let db = request.await?;
+        Ok(Self { db })
+    }
+
+    /// List every registered vault.
+    pub async fn list(&self) -> Result<Vec<VaultEntry>, VaultRegistryError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_NAME], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_NAME)?;
+        let raw = store.get_all(None, None)?.await?;
+        tx.await?;
+
+        let mut entries = Vec::with_capacity(raw.len());
+        for value in raw {
+            entries.push(decode_entry(&value)?);
+        }
+        Ok(entries)
+    }
+
+    /// Fetch a single entry by id.
+    pub async fn get(&self, id: &str) -> Result<Option<VaultEntry>, VaultRegistryError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_NAME], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_NAME)?;
+        let value = store.get(JsValue::from_str(id))?.await?;
+        tx.await?;
+        match value {
+            Some(value) if !value.is_undefined() && !value.is_null() => {
+                Ok(Some(decode_entry(&value)?))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Insert or replace an entry.
+    pub async fn put(&self, entry: &VaultEntry) -> Result<(), VaultRegistryError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_NAME], TransactionMode::ReadWrite)?;
+        let store = tx.object_store(STORE_NAME)?;
+        let value = encode_entry(entry)?;
+        store.put(&value, None)?.await?;
+        tx.commit()?.await?;
+        Ok(())
+    }
+
+    /// Remove the entry with the given id. Returns `true` if it
+    /// existed.
+    pub async fn remove(&self, id: &str) -> Result<bool, VaultRegistryError> {
+        let existed = self.get(id).await?.is_some();
+        if !existed {
+            return Ok(false);
+        }
+        let tx = self
+            .db
+            .transaction(&[STORE_NAME], TransactionMode::ReadWrite)?;
+        let store = tx.object_store(STORE_NAME)?;
+        store.delete(JsValue::from_str(id))?.await?;
+        tx.commit()?.await?;
+        Ok(true)
+    }
+
+    /// Update an entry's cached status (boot scan, reconnect, etc.).
+    /// No-op if the entry is missing.
+    pub async fn update_status(
+        &self,
+        id: &str,
+        status: VaultStatus,
+    ) -> Result<(), VaultRegistryError> {
+        let Some(mut entry) = self.get(id).await? else {
+            return Ok(());
+        };
+        entry.last_known_status = status;
+        self.put(&entry).await
+    }
+
+    /// Update an entry's last-synced timestamp (ms since epoch).
+    /// No-op if the entry is missing.
+    pub async fn touch_last_synced(
+        &self,
+        id: &str,
+        when_ms: f64,
+    ) -> Result<(), VaultRegistryError> {
+        let Some(mut entry) = self.get(id).await? else {
+            return Ok(());
+        };
+        entry.last_synced_at = Some(when_ms);
+        self.put(&entry).await
+    }
+}
+
+fn encode_entry(entry: &VaultEntry) -> Result<JsValue, VaultRegistryError> {
+    let obj = Object::new();
+    set(&obj, FIELD_ID, &JsValue::from_str(&entry.id))?;
+    set(
+        &obj,
+        FIELD_DISPLAY_NAME,
+        &JsValue::from_str(&entry.display_name),
+    )?;
+    set(&obj, FIELD_HANDLE, entry.handle.as_ref())?;
+    set(
+        &obj,
+        FIELD_LAST_SYNCED_AT,
+        &match entry.last_synced_at {
+            Some(t) => JsValue::from_f64(t),
+            None => JsValue::NULL,
+        },
+    )?;
+    set(
+        &obj,
+        FIELD_LAST_KNOWN_STATUS,
+        &JsValue::from_str(entry.last_known_status.to_storage()),
+    )?;
+    Ok(obj.into())
+}
+
+fn decode_entry(value: &JsValue) -> Result<VaultEntry, VaultRegistryError> {
+    let id = get_string(value, FIELD_ID)?;
+    let display_name = get_string(value, FIELD_DISPLAY_NAME)?;
+    let handle_value = Reflect::get(value, &JsValue::from_str(FIELD_HANDLE))
+        .map_err(|_| VaultRegistryError::Malformed(format!("missing {FIELD_HANDLE}")))?;
+    let handle: FileSystemDirectoryHandle = handle_value.dyn_into().map_err(|_| {
+        VaultRegistryError::Malformed(format!("{FIELD_HANDLE} is not a FileSystemDirectoryHandle"))
+    })?;
+    let last_synced_at = Reflect::get(value, &JsValue::from_str(FIELD_LAST_SYNCED_AT))
+        .ok()
+        .and_then(|v| {
+            if v.is_null() || v.is_undefined() {
+                None
+            } else {
+                v.as_f64()
+            }
+        });
+    let status_str = get_string(value, FIELD_LAST_KNOWN_STATUS)?;
+    let last_known_status = VaultStatus::from_storage(&status_str).ok_or_else(|| {
+        VaultRegistryError::Malformed(format!("unknown status value '{status_str}'"))
+    })?;
+
+    Ok(VaultEntry {
+        id,
+        display_name,
+        handle,
+        last_synced_at,
+        last_known_status,
+    })
+}
+
+fn set(obj: &Object, key: &str, value: &JsValue) -> Result<(), VaultRegistryError> {
+    Reflect::set(obj.as_ref(), &JsValue::from_str(key), value)
+        .map_err(|_| VaultRegistryError::Malformed(format!("could not set {key}")))?;
+    Ok(())
+}
+
+fn get_string(value: &JsValue, key: &str) -> Result<String, VaultRegistryError> {
+    Reflect::get(value, &JsValue::from_str(key))
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or_else(|| VaultRegistryError::Malformed(format!("missing or non-string {key}")))
+}

--- a/rust/tonk-ui/src/vaults.rs
+++ b/rust/tonk-ui/src/vaults.rs
@@ -33,6 +33,7 @@ const DB_VERSION: u32 = 1;
 const FIELD_ID: &str = "id";
 const FIELD_DISPLAY_NAME: &str = "displayName";
 const FIELD_HANDLE: &str = "handle";
+const FIELD_SUBJECT_DID: &str = "subjectDid";
 const FIELD_LAST_SYNCED_AT: &str = "lastSyncedAt";
 const FIELD_LAST_KNOWN_STATUS: &str = "lastKnownStatus";
 
@@ -71,13 +72,22 @@ impl VaultStatus {
 #[derive(Clone)]
 pub struct VaultEntry {
     /// Opaque id — used as the `FsAddress::id` on the worker side.
-    /// Consumers typically use the vault's subject DID.
+    /// Currently a randomly-minted UUID; the join flow associates an
+    /// entry with a subject DID via `subject_did` rather than reusing
+    /// it as the id, so multiple entries can coexist for the same
+    /// subject (e.g. the user picked the same vault twice).
     pub id: String,
     /// User-chosen friendly name (shown in the vaults list and the
     /// reconnect prompt).
     pub display_name: String,
     /// The directory the user picked via `showDirectoryPicker()`.
     pub handle: FileSystemDirectoryHandle,
+    /// Subject DID this vault holds, when known. Set when the entry
+    /// is created via the join flow (where the invite supplies the
+    /// DID) or when a standalone "open existing vault" verifies the
+    /// directory's `credential/key/self` against an expected DID.
+    /// `None` for standalone opens that haven't been associated yet.
+    pub subject_did: Option<String>,
     /// Wall-clock ms since epoch of the most recent sync, or `None`
     /// if this vault has never been synced from this device.
     pub last_synced_at: Option<f64>,
@@ -92,6 +102,7 @@ impl std::fmt::Debug for VaultEntry {
             .field("id", &self.id)
             .field("display_name", &self.display_name)
             .field("handle", &"<FileSystemDirectoryHandle>")
+            .field("subject_did", &self.subject_did)
             .field("last_synced_at", &self.last_synced_at)
             .field("last_known_status", &self.last_known_status)
             .finish()
@@ -153,6 +164,21 @@ impl VaultRegistry {
             entries.push(decode_entry(&value)?);
         }
         Ok(entries)
+    }
+
+    /// Find an entry whose `subject_did` matches `did`. Returns the
+    /// first match. Linear scan over the full registry — fine at the
+    /// current scale (a handful of entries per device).
+    pub async fn find_by_subject(
+        &self,
+        did: &str,
+    ) -> Result<Option<VaultEntry>, VaultRegistryError> {
+        for entry in self.list().await? {
+            if entry.subject_did.as_deref() == Some(did) {
+                return Ok(Some(entry));
+            }
+        }
+        Ok(None)
     }
 
     /// Fetch a single entry by id.
@@ -239,6 +265,14 @@ fn encode_entry(entry: &VaultEntry) -> Result<JsValue, VaultRegistryError> {
     set(&obj, FIELD_HANDLE, entry.handle.as_ref())?;
     set(
         &obj,
+        FIELD_SUBJECT_DID,
+        &match &entry.subject_did {
+            Some(did) => JsValue::from_str(did),
+            None => JsValue::NULL,
+        },
+    )?;
+    set(
+        &obj,
         FIELD_LAST_SYNCED_AT,
         &match entry.last_synced_at {
             Some(t) => JsValue::from_f64(t),
@@ -261,6 +295,15 @@ fn decode_entry(value: &JsValue) -> Result<VaultEntry, VaultRegistryError> {
     let handle: FileSystemDirectoryHandle = handle_value.dyn_into().map_err(|_| {
         VaultRegistryError::Malformed(format!("{FIELD_HANDLE} is not a FileSystemDirectoryHandle"))
     })?;
+    let subject_did = Reflect::get(value, &JsValue::from_str(FIELD_SUBJECT_DID))
+        .ok()
+        .and_then(|v| {
+            if v.is_null() || v.is_undefined() {
+                None
+            } else {
+                v.as_string()
+            }
+        });
     let last_synced_at = Reflect::get(value, &JsValue::from_str(FIELD_LAST_SYNCED_AT))
         .ok()
         .and_then(|v| {
@@ -279,6 +322,7 @@ fn decode_entry(value: &JsValue) -> Result<VaultEntry, VaultRegistryError> {
         id,
         display_name,
         handle,
+        subject_did,
         last_synced_at,
         last_known_status,
     })

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -31,6 +31,7 @@ dialog-csv = { workspace = true }
 dialog-effects = { workspace = true }
 dialog-operator = { workspace = true }
 dialog-query = { workspace = true }
+dialog-remote-fs = { workspace = true }
 dialog-remote-ucan-s3 = { workspace = true }
 dialog-repository = { workspace = true }
 dialog-search-tree = { workspace = true }
@@ -73,6 +74,7 @@ web-sys = { workspace = true, features = [
     "CryptoKey",
     "ExtendableMessageEvent",
     "FetchEvent",
+    "FileSystemDirectoryHandle",
     "Headers",
     "ReadableStream",
     "MessageChannel",

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -34,6 +34,9 @@ pub use sync::{
 // depending on `tonk-schema` directly.
 pub use tonk_schema::SyncState;
 
+mod fs_upstream;
+pub use fs_upstream::{FsUpstreamPath, FsUpstreamResponse};
+
 mod identify;
 pub use identify::IdentifyResponse;
 
@@ -169,6 +172,14 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route(
             "/api/repository/{repo}/branch/{branch}/sync/status",
             get(sync::sync_status),
+        )
+        // FS-remote upstream wiring. Idempotently configures the
+        // repo's "fs" remote to point at the named vault and sets the
+        // local branch's upstream to track it. Subsequent /sync calls
+        // dispatch to the FS provider in dialog-remote-fs.
+        .route(
+            "/api/repository/{repo}/branch/{branch}/upstream/fs/{vault_id}",
+            post(fs_upstream::set_fs_upstream),
         )
         // Claim operations
         .route(

--- a/rust/tonk-worker/src/router/fs_upstream.rs
+++ b/rust/tonk-worker/src/router/fs_upstream.rs
@@ -25,9 +25,12 @@ use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
+use tonk_schema::Replica;
 
 use super::AppState;
 use crate::TonkWorkerError;
+
+const META_BRANCH: &str = "meta";
 
 /// Conventional name for the FS-remote on a repository. There's only
 /// ever one — switching the underlying vault id rewrites this entry.
@@ -127,6 +130,42 @@ pub async fn set_fs_upstream(
         .perform(&tonk.operator)
         .await
         .map_err(|e| TonkWorkerError::Router(format!("set upstream: {e}")))?;
+
+    // The dialog layer now knows the remote and the upstream wiring,
+    // but the UI's `GET /api/repository/{name}` reads remotes/branches
+    // from the **meta-branch concepts** (`Remote`, `TrackingBranch`,
+    // `Replica.branch().set_upstream`). Without these asserts the
+    // repo view shows `REMOTES (0)` and `UPSTREAM none` even though
+    // the underlying configuration is in place — matching what
+    // `PUT /api/repository`'s remote/upstream block does.
+    let meta = repo
+        .branch(META_BRANCH)
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Router(format!("open meta branch on '{}': {e}", params.repo))
+        })?;
+
+    let address_for_concept: dialog_repository::SiteAddress =
+        FsAddress::new(&params.vault_id).into();
+    let replica = Replica::new(tonk.profile.did(), repo.did(), &params.repo);
+    let remote_concept = replica.remote(FS_REMOTE_NAME, repo.did(), &address_for_concept);
+    let tracked = remote_concept.branch(&params.branch);
+
+    meta.transaction()
+        .assert(remote_concept.clone())
+        .assert(tracked.clone())
+        // Asserting the local branch concept is harmless if it
+        // already exists (cardinality-one no-op) and necessary if
+        // it doesn't — matches what `PUT /api/repository` does
+        // before wiring upstream tracking.
+        .assert(replica.branch(&params.branch))
+        .assert(replica.branch(&params.branch).set_upstream(&tracked))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Router(format!("commit meta updates: {e}")))?;
 
     Ok((
         StatusCode::OK,

--- a/rust/tonk-worker/src/router/fs_upstream.rs
+++ b/rust/tonk-worker/src/router/fs_upstream.rs
@@ -1,0 +1,139 @@
+//! Configure a branch to track a `dialog-remote-fs` directory as its
+//! upstream.
+//!
+//! `POST /api/repository/{repo}/branch/{branch}/upstream/fs/{vault_id}`
+//!
+//! Idempotent: if the `"fs"` remote already exists with the same vault
+//! id, the call just re-points the branch's upstream at it. If it
+//! exists with a different vault id, returns `409 Conflict` — switching
+//! a repo's FS-remote target needs an explicit reset.
+//!
+//! The handle for `vault_id` must already have been registered via
+//! [`TonkServiceWorker::register_fs_handle`](crate::TonkServiceWorker::register_fs_handle)
+//! before any subsequent `sync` invocation; this route only wires the
+//! metadata, it doesn't touch the disk.
+
+use ::axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use axum_wasm_macros::wasm_compat;
+use dialog_remote_fs::FsAddress;
+use dialog_repository::{LoadRemoteError, RepositoryExt as _};
+use serde::{Deserialize, Serialize};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+
+use super::AppState;
+use crate::TonkWorkerError;
+
+/// Conventional name for the FS-remote on a repository. There's only
+/// ever one — switching the underlying vault id rewrites this entry.
+const FS_REMOTE_NAME: &str = "fs";
+
+/// Path parameters: which repo/branch/vault to wire up.
+#[derive(Debug, Deserialize)]
+pub struct FsUpstreamPath {
+    /// Repository name (local).
+    pub repo: String,
+    /// Branch name (local) — also the branch name on the FS remote.
+    pub branch: String,
+    /// Opaque vault id — must match what was registered with
+    /// `registerFsHandle`.
+    pub vault_id: String,
+}
+
+/// Response shape.
+#[derive(Debug, Serialize)]
+pub struct FsUpstreamResponse {
+    /// `true` when the upstream points at the requested vault id.
+    pub success: bool,
+    /// The remote's name (always `"fs"` today).
+    pub remote: String,
+    /// The vault id the remote points at.
+    pub vault_id: String,
+}
+
+#[wasm_compat]
+pub async fn set_fs_upstream(
+    State(state): State<AppState>,
+    Path(params): Path<FsUpstreamPath>,
+) -> Result<(StatusCode, Json<FsUpstreamResponse>), TonkWorkerError> {
+    log!(
+        "Setting FS upstream: repo={} branch={} vault_id={}",
+        params.repo,
+        params.branch,
+        params.vault_id
+    );
+
+    let tonk = state.write().await;
+
+    let repo = tonk
+        .profile
+        .repository(&params.repo)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::NotFound(format!("repository '{}': {e}", params.repo)))?;
+
+    let address = FsAddress::new(&params.vault_id);
+
+    // Idempotency: if "fs" remote already exists, only proceed when it
+    // points at the same vault id. Replacing it with a different vault
+    // would silently re-target a user's branch to unfamiliar data —
+    // require an explicit reset (deferred to a future route).
+    let remote = match repo.remote(FS_REMOTE_NAME).load().perform(&tonk.operator).await {
+        Ok(existing) => {
+            let existing_address = existing.address();
+            let proposed_site = address.clone().into();
+            if existing_address.site() != &proposed_site {
+                return Err(TonkWorkerError::Conflict(
+                    "FS remote already configured with a different vault id".to_string(),
+                ));
+            }
+            existing
+        }
+        Err(LoadRemoteError::NotFound { .. }) => repo
+            .remote(FS_REMOTE_NAME)
+            .create(address)
+            .perform(&tonk.operator)
+            .await
+            .map_err(|e| TonkWorkerError::Router(format!("create FS remote: {e}")))?,
+        Err(e) => {
+            return Err(TonkWorkerError::Router(format!(
+                "load FS remote: {e}",
+            )));
+        }
+    };
+
+    let remote_branch = remote
+        .branch(&params.branch)
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Router(format!("open remote branch: {e}")))?;
+
+    let local_branch = repo
+        .branch(&params.branch)
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::NotFound(format!("branch '{}': {e}", params.branch)))?;
+
+    local_branch
+        .set_upstream(&remote_branch)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Router(format!("set upstream: {e}")))?;
+
+    Ok((
+        StatusCode::OK,
+        Json(FsUpstreamResponse {
+            success: true,
+            remote: FS_REMOTE_NAME.to_string(),
+            vault_id: params.vault_id,
+        }),
+    ))
+}

--- a/rust/tonk-worker/src/router/fs_upstream.rs
+++ b/rust/tonk-worker/src/router/fs_upstream.rs
@@ -87,7 +87,12 @@ pub async fn set_fs_upstream(
     // points at the same vault id. Replacing it with a different vault
     // would silently re-target a user's branch to unfamiliar data —
     // require an explicit reset (deferred to a future route).
-    let remote = match repo.remote(FS_REMOTE_NAME).load().perform(&tonk.operator).await {
+    let remote = match repo
+        .remote(FS_REMOTE_NAME)
+        .load()
+        .perform(&tonk.operator)
+        .await
+    {
         Ok(existing) => {
             let existing_address = existing.address();
             let proposed_site = address.clone().into();
@@ -105,9 +110,7 @@ pub async fn set_fs_upstream(
             .await
             .map_err(|e| TonkWorkerError::Router(format!("create FS remote: {e}")))?,
         Err(e) => {
-            return Err(TonkWorkerError::Router(format!(
-                "load FS remote: {e}",
-            )));
+            return Err(TonkWorkerError::Router(format!("load FS remote: {e}",)));
         }
     };
 

--- a/rust/tonk-worker/src/router/fs_upstream.rs
+++ b/rust/tonk-worker/src/router/fs_upstream.rs
@@ -46,7 +46,7 @@ pub struct FsUpstreamPath {
 }
 
 /// Response shape.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FsUpstreamResponse {
     /// `true` when the upstream points at the requested vault id.
     pub success: bool,

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -26,7 +26,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_futures::future_to_promise;
-use web_sys::{FetchEvent, Request, Response};
+use web_sys::{FetchEvent, FileSystemDirectoryHandle, Request, Response};
 
 // Global `self.fetch(...)` in the service-worker scope. Fetches
 // issued from an SW bypass the SW's own `onfetch` listener (per
@@ -497,6 +497,26 @@ impl TonkServiceWorker {
         let router = Arc::new(Mutex::new(router));
 
         Ok(Self { router, state, lsp })
+    }
+
+    /// Register a File System Access API directory handle under `id` so
+    /// `dialog-remote-fs` operations targeting an `FsAddress` with the
+    /// same id can resolve it.
+    ///
+    /// The id is opaque to this crate — callers typically use the
+    /// vault's subject DID. Browsers don't persist FS-Access permission
+    /// across sessions, so this needs to be called after each page load
+    /// once the user has re-granted access via a gesture.
+    #[wasm_bindgen(js_name = "registerFsHandle")]
+    pub fn register_fs_handle(&self, id: &str, handle: FileSystemDirectoryHandle) {
+        dialog_remote_fs::registry::register_directory(id, handle);
+    }
+
+    /// Drop a previously-registered FS handle. Returns `true` if an
+    /// entry was present.
+    #[wasm_bindgen(js_name = "unregisterFsHandle")]
+    pub fn unregister_fs_handle(&self, id: &str) -> bool {
+        dialog_remote_fs::registry::unregister_directory(id)
     }
 
     /// Hook the SW's `updatefound` event from JavaScript.

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -509,7 +509,16 @@ impl TonkServiceWorker {
     /// once the user has re-granted access via a gesture.
     #[wasm_bindgen(js_name = "registerFsHandle")]
     pub fn register_fs_handle(&self, id: &str, handle: FileSystemDirectoryHandle) {
+        // `dialog_remote_fs::registry::register_directory` takes a
+        // `FileSystemDirectoryHandle` only under `wasm32`; on native it
+        // wants a `PathBuf`, for which an FS-Access handle has no
+        // equivalent. This browser-only API surface is never invoked on
+        // native — the stub exists solely so `clippy --all` type-checks
+        // the crate on the host.
+        #[cfg(target_arch = "wasm32")]
         dialog_remote_fs::registry::register_directory(id, handle);
+        #[cfg(not(target_arch = "wasm32"))]
+        let _ = (id, handle);
     }
 
     /// Drop a previously-registered FS handle. Returns `true` if an


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces support for managing local-disk vaults using the File System Access API, including new routes, components, and utilities for syncing and handling errors related to vaults.

### Detailed summary
- Added `TonkVaults` component for managing local vaults.
- Introduced `fs_access` module for File System Access API interactions.
- Implemented `set_fs_upstream` API route for syncing branches with local vaults.
- Enhanced error handling with `TonkUiError::Other`.
- Updated `Cargo.toml` for new dependencies related to file handling.
- Integrated vault management into the `/join` flow for seamless user experience.

> The following files were skipped due to too many changes: `Cargo.lock`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->