### PR TITLE
Forward full relayed requests; carry path via Referer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,6 +4874,7 @@ dependencies = [
  "serde_json",
  "tonk-common",
  "tonk-schema",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/rust/tonk-host/Cargo.toml
+++ b/rust/tonk-host/Cargo.toml
@@ -21,6 +21,7 @@ serde_ipld_dagjson = { workspace = true }
 serde_json = { workspace = true }
 tonk-common = { workspace = true }
 tonk-schema = { workspace = true }
+uuid = { version = "1", features = ["v4", "js"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-streams = { workspace = true }

--- a/rust/tonk-host/src/bridge.rs
+++ b/rust/tonk-host/src/bridge.rs
@@ -9,6 +9,7 @@ use crate::error::{ErrorDetail, ErrorKind};
 use crate::ready;
 use ipld_core::ipld::Ipld;
 use js_sys::{Function, Promise, Reflect};
+use uuid::Uuid;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -65,6 +66,48 @@ pub fn context_origin() -> Option<String> {
         .origin()
         .ok()
         .filter(|o| !o.is_empty() && o != "null")
+}
+
+thread_local! {
+    /// A stable id for this document instance (top page, or one sealed guest
+    /// iframe). Each document runs its own wasm instance, so a per-instance
+    /// cell gives a distinct id per tab/iframe. The SW keys the session entity
+    /// (route + context facts) by this id. Minted lazily on first use.
+    static SESSION_ID: std::cell::OnceCell<String> = const { std::cell::OnceCell::new() };
+}
+
+/// This document's session id, minted once per instance. A random v4 UUID,
+/// distinct per live document.
+pub fn session_id() -> String {
+    SESSION_ID.with(|cell| {
+        cell.get_or_init(|| format!("host:{}", Uuid::new_v4()))
+            .clone()
+    })
+}
+
+/// The request-context headers every host-relative `/api` request carries, so
+/// the SW can tie the request to its originating document and route/contain it:
+/// `X-Tonk-Hash`, `X-Tonk-Session`. The host does not interpret these; the SW
+/// decides how to use them.
+///
+/// The document path is not stamped: it rides `Referer`, which the browser sets
+/// to the host document's same-origin URL (and the host URL mirrors the guest
+/// route by design). The fragment never rides `Referer`, so the hash is stamped
+/// explicitly, and only when there is one.
+///
+/// The hash comes from the bridge context in a sealed guest (its
+/// `window.location` is `about:srcdoc`, useless) and from `window.location` in
+/// the top document — the same source split as [`context_origin`].
+pub fn context_headers() -> Vec<(&'static str, String)> {
+    let hash = context_field("hash")
+        .or_else(|| window().and_then(|w| w.location().hash().ok()))
+        .filter(|hash| !hash.is_empty());
+
+    let mut headers = vec![("x-tonk-session", session_id())];
+    if let Some(hash) = hash {
+        headers.push(("x-tonk-hash", hash));
+    }
+    headers
 }
 
 /// GET a host-relative path and return its body text. When the bridge is

--- a/rust/tonk-host/src/http.rs
+++ b/rust/tonk-host/src/http.rs
@@ -22,6 +22,15 @@ fn window_handle() -> Result<Window, ErrorDetail> {
     window().ok_or_else(|| ErrorDetail::new(ErrorKind::Network, "no `window` available"))
 }
 
+/// Append the request-context headers (`X-Tonk-Hash`/`X-Tonk-Session`) so the
+/// SW can tie the request to its originating document. The path itself rides
+/// `Referer`. Best-effort: a failed append never blocks the request.
+fn append_context_headers(headers: &Headers) {
+    for (name, value) in crate::bridge::context_headers() {
+        let _ = headers.append(name, &value);
+    }
+}
+
 /// POST JSON `body` to `url` with `accept: application/json`,
 /// return the response body text. Errors out on non-2xx with a
 /// `Network` kind error carrying the status code.
@@ -41,6 +50,7 @@ pub(crate) async fn post_json(url: &str, body: &str) -> Result<String, ErrorDeta
     headers
         .append("accept", "application/json")
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
+    append_context_headers(&headers);
     init.set_headers(&headers);
     init.set_body(&JsValue::from_str(body));
 
@@ -108,6 +118,7 @@ pub(crate) async fn frame_stream(
     headers
         .append("content-type", "application/json")
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("content-type: {e:?}")))?;
+    append_context_headers(&headers);
     init.set_headers(&headers);
     init.set_body(&JsValue::from_str(body));
     init.set_signal(Some(&abort.signal()));
@@ -250,6 +261,7 @@ pub(crate) async fn post_text(
     headers
         .append("accept", "application/json")
         .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("accept: {e:?}")))?;
+    append_context_headers(&headers);
     init.set_headers(&headers);
     init.set_body(&JsValue::from_str(body));
 

--- a/rust/tonk-portal/Cargo.toml
+++ b/rust/tonk-portal/Cargo.toml
@@ -38,6 +38,7 @@ web-sys = { workspace = true, features = [
     "Headers",
     "ReadableStream",
     "ReadableStreamDefaultReader",
+    "Request",
     "RequestInit",
     "RequestCache",
     "Response",

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -115,6 +115,22 @@ const BOOTSTRAP_JS: &str = r#"(function(){
   var resolveReady; var ready=new Promise(function(r){resolveReady=r;});
   var ch=new MessageChannel(), port=ch.port1;
   function mint(){return "r"+(++nextId);}
+  // A stable id for this guest iframe instance; the SW keys the session entity
+  // (route + context facts) by it. Distinct per iframe (each runs this once).
+  var SESSION="guest:"+Date.now().toString(36)+"-"+Math.floor(Math.random()*1e9).toString(36);
+  // The request-context headers every relayed /api fetch carries, so the SW can
+  // tie the request to this guest and route/contain it. The path is not stamped:
+  // the host issues the real fetch, so Referer carries the host's URL, which
+  // mirrors the guest route by design. The fragment never rides Referer, so the
+  // hash is stamped explicitly, and only when there is one. The hash comes from
+  // the injected context (the guest's own location is about:srcdoc). Returns
+  // [[name,value]] pairs prepended to any per-request headers.
+  function contextHeaders(){
+    var c=(window.tonk&&window.tonk.context)||{};
+    var headers=[["x-tonk-session",SESSION]];
+    if(c.hash){ headers.push(["x-tonk-hash",c.hash]); }
+    return headers;
+  }
   function call(type,extra){
     return ready.then(function(){
       return new Promise(function(resolve,reject){
@@ -134,16 +150,19 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     navigate:function(href){
       ready.then(function(){port.postMessage({v:1,type:"navigate",href:href});});
     },
-    // Same-origin fetch performed by the HOST: the opaque guest can't reach a
-    // same-origin, SW-routed `/api/...` endpoint itself. The host fetches the
-    // path on its real origin and TRANSFERS the response stream back; we
-    // rebuild a real `Response`. See the `window.fetch` override below — this
-    // is its transport, and host-relative URLs route through here.
-    fetch:function(path){
+    // Same-origin request performed by the HOST: the opaque guest can't reach a
+    // same-origin, SW-routed `/api/...` endpoint itself. The host issues the
+    // request on its real origin and streams the response back; we rebuild a
+    // real `Response`. The full request (method, headers, body) is forwarded so
+    // POST query/subscribe/transact route through here, not just GET. See the
+    // `window.fetch` override below.
+    fetch:function(path,req){
+      req=req||{};
       return ready.then(function(){
         return new Promise(function(resolve,reject){
           var id=mint(); pending.set(id,{resolve:resolve,reject:reject});
-          port.postMessage({v:1,type:"fetch",id:id,path:path});
+          port.postMessage({v:1,type:"fetch",id:id,path:path,
+            method:req.method||"GET",headers:req.headers||[],body:req.body});
         });
       });
     },
@@ -239,10 +258,31 @@ const BOOTSTRAP_JS: &str = r#"(function(){
   // to the native fetch — notably the runtime bootstrap's own blob-URL module
   // imports, which must never be intercepted.
   var nativeFetch=window.fetch.bind(window);
+  // Normalize a fetch(input, init) call into {method, headers:[[k,v]], body}
+  // the relay can postMessage. `input` may be a string or a Request; `init`
+  // overrides Request fields. Body is read to text (our /api bodies are JSON
+  // strings); a Request body is consumed via .text() so we return a Promise.
+  function relayRequest(url,input,init){
+    var method="GET", headers=contextHeaders(), bodyP=Promise.resolve(undefined);
+    var reqLike=(typeof input==="object"&&input)?input:null;
+    if(reqLike){ method=reqLike.method||method; }
+    if(init&&init.method){ method=init.method; }
+    var hsrc=(init&&init.headers)||(reqLike&&reqLike.headers);
+    if(hsrc){
+      if(typeof hsrc.forEach==="function"){ hsrc.forEach(function(v,k){headers.push([k,v]);}); }
+      else if(Array.isArray(hsrc)){ headers=headers.concat(hsrc); }
+      else { for(var k in hsrc){ if(Object.prototype.hasOwnProperty.call(hsrc,k)){headers.push([k,hsrc[k]]);} } }
+    }
+    if(init&&"body"in init){ bodyP=Promise.resolve(init.body); }
+    else if(reqLike&&!reqLike.bodyUsed&&reqLike.body){ bodyP=reqLike.clone().text(); }
+    return bodyP.then(function(body){
+      return tonk.fetch(url,{method:method,headers:headers,body:body});
+    });
+  }
   window.fetch=function(input,init){
     var url=(typeof input==="string")?input:(input&&input.url)||"";
     if(url.charAt(0)==="/"&&url.charAt(1)!=="/"){
-      return tonk.fetch(url);
+      return relayRequest(url,input,init);
     }
     return nativeFetch(input,init);
   };
@@ -928,13 +968,67 @@ fn handle_host_fetch(port: &MessagePort, data: &JsValue) {
     if !path.starts_with('/') || path.starts_with("//") {
         return post_error(port, "fetch-error", &id, "path must be host-relative");
     };
+    // The guest forwards the full request so POST query/subscribe/transact work,
+    // not just GET. Build a `Request` carrying its method, headers, and body.
+    let request = match build_relayed_request(&path, data) {
+        Ok(request) => request,
+        Err(e) => return post_error(port, "fetch-error", &id, &e),
+    };
     let port = port.clone();
     spawn_local(async move {
-        match fetch(&path).await {
+        match fetch_request(&request).await {
             Ok(resp) => post_fetch_response(&port, &id, &resp).await,
             Err(e) => post_error(&port, "fetch-error", &id, &e),
         }
     });
+}
+
+/// Build a `Request` for a relayed guest fetch from the envelope's
+/// `method`/`headers`/`body`. `headers` is an array of `[name, value]` pairs;
+/// `body` is a string (our `/api` bodies are JSON) or absent.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn build_relayed_request(path: &str, data: &JsValue) -> Result<web_sys::Request, String> {
+    let init = web_sys::RequestInit::new();
+    let method = get_str(data, "method").unwrap_or_else(|| "GET".to_owned());
+    init.set_method(&method);
+
+    let headers = web_sys::Headers::new().map_err(|e| format!("Headers: {e:?}"))?;
+    if let Ok(pairs) = Reflect::get(data, &"headers".into())
+        && let Ok(pairs) = pairs.dyn_into::<js_sys::Array>()
+    {
+        for pair in pairs.iter() {
+            let pair: js_sys::Array = match pair.dyn_into() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if let (Some(name), Some(value)) = (pair.get(0).as_string(), pair.get(1).as_string()) {
+                let _ = headers.append(&name, &value);
+            }
+        }
+    }
+    init.set_headers(&headers);
+
+    // Body — only for methods that carry one. A bodyless GET/HEAD with a body
+    // set throws, so only attach when present and non-null.
+    let body = Reflect::get(data, &"body".into()).unwrap_or(JsValue::UNDEFINED);
+    if !body.is_undefined() && !body.is_null() {
+        init.set_body(&body);
+    }
+
+    web_sys::Request::new_with_str_and_init(path, &init)
+        .map_err(|e| format!("Request {path}: {e:?}"))
+}
+
+/// Perform a host-side `fetch(Request)` and return the `Response`.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn fetch_request(request: &web_sys::Request) -> Result<web_sys::Response, String> {
+    let win = window().ok_or("no window")?;
+    let resp_value = wasm_bindgen_futures::JsFuture::from(win.fetch_with_request(request))
+        .await
+        .map_err(|e| format!("fetch: {e:?}"))?;
+    resp_value
+        .dyn_into::<web_sys::Response>()
+        .map_err(|_| "fetch: not a Response".to_string())
 }
 
 /// Post a `fetch-result` envelope carrying the response status + headers and
@@ -1254,8 +1348,23 @@ fn build_context(host: &Element) -> Object {
     let context = Object::new();
     let this = host.get_attribute("entity").unwrap_or_default();
     let model = host.get_attribute("model").unwrap_or_default();
-    let origin = window()
-        .and_then(|w| w.location().origin().ok())
+    let location = window().map(|w| w.location());
+    let origin = location
+        .as_ref()
+        .and_then(|l| l.origin().ok())
+        .unwrap_or_default();
+    // The guest's own `window.location` is `about:srcdoc`; its REAL location is
+    // the parent's. Pass the parent's path + hash so the guest stamps them on
+    // its requests (the SW reads them to route/contain). `hash` especially:
+    // browsers strip the fragment from network requests, so the SW never sees
+    // it otherwise.
+    let path = location
+        .as_ref()
+        .and_then(|l| l.pathname().ok())
+        .unwrap_or_default();
+    let hash = location
+        .as_ref()
+        .and_then(|l| l.hash().ok())
         .unwrap_or_default();
     let repo = host
         .closest("tonk-repository")
@@ -1272,6 +1381,8 @@ fn build_context(host: &Element) -> Object {
     let _ = Reflect::set(&context, &"this".into(), &JsValue::from_str(&this));
     let _ = Reflect::set(&context, &"model".into(), &JsValue::from_str(&model));
     let _ = Reflect::set(&context, &"origin".into(), &JsValue::from_str(&origin));
+    let _ = Reflect::set(&context, &"path".into(), &JsValue::from_str(&path));
+    let _ = Reflect::set(&context, &"hash".into(), &JsValue::from_str(&hash));
     let _ = Reflect::set(&context, &"repo".into(), &JsValue::from_str(&repo));
     let _ = Reflect::set(&context, &"branch".into(), &JsValue::from_str(&branch));
     context
@@ -2293,5 +2404,48 @@ mod tests {
             "sigil-bytes",
             "the drained bytes must reassemble to the body",
         );
+    }
+
+    /// The relay forwards the FULL request (method, headers, body), not just a
+    /// GET path, so POST query/subscribe/transact route through it. This
+    /// verifies `build_relayed_request` reconstructs each from the envelope.
+    #[dialog_common::test]
+    async fn it_builds_a_relayed_request_with_method_headers_body() {
+        // Envelope shaped like what the guest posts: method + [[name,value]]
+        // header pairs + a string body.
+        let data = Object::new();
+        let _ = Reflect::set(&data, &"method".into(), &"POST".into());
+        let headers = Array::new();
+        let pair = Array::new();
+        pair.push(&"content-type".into());
+        pair.push(&"application/json".into());
+        headers.push(&pair);
+        let _ = Reflect::set(&data, &"headers".into(), &headers);
+        let _ = Reflect::set(&data, &"body".into(), &"{\"q\":1}".into());
+
+        let request =
+            build_relayed_request("/api/repository/x/branch/main/query", &data).expect("request");
+
+        assert_eq!(request.method(), "POST");
+        assert!(
+            request
+                .url()
+                .ends_with("/api/repository/x/branch/main/query"),
+            "url: {}",
+            request.url(),
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("content-type")
+                .ok()
+                .flatten()
+                .as_deref(),
+            Some("application/json"),
+        );
+        let body = JsFuture::from(request.text().expect("text()"))
+            .await
+            .expect("await body");
+        assert_eq!(body.as_string().as_deref(), Some("{\"q\":1}"));
     }
 }

--- a/rust/tonk-worker/src/router/query.rs
+++ b/rust/tonk-worker/src/router/query.rs
@@ -27,6 +27,31 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::reactor::{Conclusion, Query, ReactorError};
 use crate::{TonkWorkerError, router::AppState};
 
+/// Read and log the per-request session context the host stamps: the document
+/// path rides `Referer` (the host's same-origin URL mirrors the guest route),
+/// the fragment rides `X-Tonk-Hash` (when present, since `Referer` drops it),
+/// and `X-Tonk-Session` ties the request to its originating document. Stage 1
+/// of the SW-router rollout: every request now carries which document it came
+/// from; nothing depends on it yet (this just proves the headers arrive). Later
+/// stages key the session entity (route + context facts) by the session id.
+fn log_session_context(route: &str, headers: &HeaderMap) {
+    let get = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+    };
+    let session = get("x-tonk-session");
+    if session.is_empty() {
+        return;
+    }
+    tonk_common::log!(
+        "{route}: session={session} referer={} hash={}",
+        get("referer"),
+        get("x-tonk-hash"),
+    );
+}
+
 /// Path parameters for `/query`.
 #[derive(Debug, Deserialize)]
 pub struct QueryPath {
@@ -87,6 +112,7 @@ async fn query_on_branch<'a>(
     headers: HeaderMap,
     request: Request,
 ) -> Result<Response, TonkWorkerError> {
+    log_session_context("query", &headers);
     let bytes = request
         .into_body()
         .collect()


### PR DESCRIPTION
The sealed guest can only reach same-origin `/api` endpoints by relaying through the host. Until now the relay only forwarded the path, so it was GET-only and stamped the document path as a custom `x-tonk-path` header. Two things follow from how the relay actually works.

The host issues the real fetch on its own origin, so the browser already sets `Referer` to the host URL. Since the host URL is intended to mirror the guest route, `Referer` is the document path and the custom header was redundant. The fragment is the one part `Referer` drops, so `x-tonk-hash` stays, now sent only when there is one.

The relay also forwards method, headers, and body now, so POST query/subscribe/transact route through the host instead of just GET.

The per-document session id moves to a v4 UUID.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces session management for requests in a web application, enhancing the ability to track and log session context. It adds a new `uuid` dependency, implements session ID generation, and modifies request handling to include context headers for better routing and tracking.

### Detailed summary
- Added `uuid` dependency for generating session IDs.
- Introduced `log_session_context` function to log session context from headers.
- Implemented `append_context_headers` to add session-related headers to requests.
- Created a `session_id` function to generate a unique session ID per document instance.
- Modified request handling to forward method, headers, and body.
- Added tests for building relayed requests with method, headers, and body.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->