### PR TITLE
feat: backend for member display names

### DIFF
--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -138,6 +138,29 @@ impl Command for PauseSync {
     type Output = ();
 }
 
+/// Request to rename the current profile (set the member display name).
+///
+/// Asserted transiently when the topbar identity chip's `<tonk-editable>`
+/// commits. Carries the new `name` (read from `currentTarget.value`) and
+/// a `marker` (`data-rename`) that distinguishes it from the declarative
+/// `tonk/rename-repository` transient, which shares the `current-target/
+/// value` attribute. The handler persists the override to the profile
+/// meta branch and re-stamps `MemberName` on the origin space.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProfileRename {
+    /// The command entity (a fresh id per commit).
+    pub this: Entity,
+    /// The new display name.
+    pub name: crate::domain::command::rename::Value,
+    /// Per-command marker (`data-rename="tonk:profile"`).
+    pub marker: crate::domain::command::rename::Rename,
+}
+
+impl Command for ProfileRename {
+    type Input = Self;
+    type Output = ();
+}
+
 /// The durable fact a `tonk:invite` handler asserts: the public
 /// delegation chain it minted, **keyed by the membership DID** (`this`).
 ///

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -219,6 +219,22 @@ pub mod command {
     }
 }
 
+/// Attributes on the profile's own identity facts, written to the
+/// profile's meta branch (private, never replicated) and keyed by the
+/// profile DID entity.
+pub mod profile {
+    use super::Attribute;
+
+    /// The member's chosen display name override. Absent until the user
+    /// renames themselves; `tonk-worker` falls back to a deterministic
+    /// `petname` when it is missing. Cardinality-one (last write wins).
+    /// The struct is named `DisplayName` so the derived attribute is
+    /// `xyz.tonk.profile/display-name`.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.profile")]
+    pub struct DisplayName(pub String);
+}
+
 /// Attributes that live on a repository's own `tonk/repository`
 /// concept — the repository's self-describing name, stored on its
 /// content branch and keyed by the subject DID.

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -187,6 +187,33 @@ pub mod command {
         pub struct PauseSync(pub Entity);
     }
 
+    /// Attributes the `profile/rename` command reads from the identity
+    /// chip's `<tonk-editable>` commit event.
+    pub mod rename {
+        use super::super::Entity;
+        use super::Attribute;
+
+        /// The new name, read from `event.currentTarget.value` on commit
+        /// (blur/Enter) — the same read-path the repo-title editable uses.
+        /// The struct is named `Value` so the attribute is
+        /// `dom.event.current-target/value`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target")]
+        pub struct Value(pub String);
+
+        /// Per-command marker read from the editable's `data-rename`
+        /// attribute. Gives `profile/rename` an attribute the declarative
+        /// `tonk/rename-repository` transient does NOT carry, so a
+        /// repo-title edit (which also writes `current-target/value`)
+        /// never also decodes as a `ProfileRename`. An `Entity` because
+        /// the marker value (`tonk:profile`) carries a `:` — see the
+        /// invite marker note. Derived attribute:
+        /// `dom.event.current-target.dataset/rename`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.dataset")]
+        pub struct Rename(pub Entity);
+    }
+
     /// Attributes the `tonk:join` command reads from the `<tonk-page>`
     /// `mount` event's `detail` — a flat, URL-shaped record (fields mirror
     /// the DOM `URL` interface). The service worker can't see the `#hash`,

--- a/rust/tonk-schema/src/identity.rs
+++ b/rust/tonk-schema/src/identity.rs
@@ -1,0 +1,45 @@
+//! Profile identity concepts: the durable display-name override stored on
+//! the profile meta branch. (The transient self overlay used by the
+//! topbar chip is added with the chip UI.)
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+
+use crate::domain::profile::DisplayName;
+
+/// The profile's chosen display name, stored on the profile meta branch
+/// keyed by the profile DID entity. Cardinality-one: a rename overwrites
+/// in place. Absent until the user renames — `tonk-worker` resolves the
+/// effective name as "this override, else `petname(did)`".
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProfileName {
+    /// The profile DID entity the name attaches to.
+    pub this: Entity,
+    /// The chosen display name.
+    pub name: DisplayName,
+}
+
+impl ProfileName {
+    /// A display-name override for the given profile entity.
+    pub fn new(profile: Entity, name: String) -> Self {
+        Self {
+            this: profile,
+            name: DisplayName(name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProfileName;
+    use crate::prelude::EntityExt;
+    use dialog_artifacts::Entity;
+
+    #[test]
+    fn it_attaches_the_name_to_the_profile_entity() {
+        let entity = Entity::of(&"profile-x");
+        let pn = ProfileName::new(entity.clone(), "fancy-otter".into());
+        assert_eq!(pn.this, entity);
+        assert_eq!(pn.name.0, "fancy-otter");
+    }
+}

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -86,5 +86,8 @@ pub use remote::*;
 pub mod tracking_branch;
 pub use tracking_branch::*;
 
+mod identity;
+pub use identity::ProfileName;
+
 mod petname;
 pub use petname::petname;

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -85,3 +85,6 @@ pub use remote::*;
 
 pub mod tracking_branch;
 pub use tracking_branch::*;
+
+mod petname;
+pub use petname::petname;

--- a/rust/tonk-schema/src/petname.rs
+++ b/rust/tonk-schema/src/petname.rs
@@ -8,17 +8,17 @@
 use dialog_varsig::Did;
 
 const ADJECTIVES: &[&str] = &[
-    "fancy", "brave", "calm", "clever", "eager", "gentle", "jolly", "keen",
-    "lively", "mellow", "nimble", "plucky", "quiet", "rapid", "sunny", "witty",
-    "bold", "bright", "cosy", "deft", "fond", "glad", "honest", "lucky",
-    "merry", "noble", "proud", "quirky", "spry", "tidy", "vivid", "warm",
+    "fancy", "brave", "calm", "clever", "eager", "gentle", "jolly", "keen", "lively", "mellow",
+    "nimble", "plucky", "quiet", "rapid", "sunny", "witty", "bold", "bright", "cosy", "deft",
+    "fond", "glad", "honest", "lucky", "merry", "noble", "proud", "quirky", "spry", "tidy",
+    "vivid", "warm",
 ];
 
 const ANIMALS: &[&str] = &[
-    "otter", "lynx", "heron", "marten", "badger", "vole", "finch", "newt",
-    "stoat", "ibis", "tapir", "gecko", "raven", "quokka", "dingo", "okapi",
-    "panda", "robin", "shrew", "toad", "wren", "yak", "zebra", "puffin",
-    "mole", "hare", "swift", "crane", "loris", "civet", "fossa", "genet",
+    "otter", "lynx", "heron", "marten", "badger", "vole", "finch", "newt", "stoat", "ibis",
+    "tapir", "gecko", "raven", "quokka", "dingo", "okapi", "panda", "robin", "shrew", "toad",
+    "wren", "yak", "zebra", "puffin", "mole", "hare", "swift", "crane", "loris", "civet", "fossa",
+    "genet",
 ];
 
 /// A stable `adjective-animal` name derived from a profile DID.
@@ -63,7 +63,11 @@ mod tests {
         let name = petname(&did("z6MkProfileA"));
         let parts: Vec<&str> = name.split('-').collect();
         assert_eq!(parts.len(), 2, "expected adjective-animal, got {name}");
-        assert!(parts.iter().all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_lowercase())));
+        assert!(
+            parts
+                .iter()
+                .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_lowercase()))
+        );
     }
 
     #[test]

--- a/rust/tonk-schema/src/petname.rs
+++ b/rust/tonk-schema/src/petname.rs
@@ -23,13 +23,14 @@ const ANIMALS: &[&str] = &[
 
 /// A stable `adjective-animal` name derived from a profile DID.
 pub fn petname(did: &Did) -> String {
-    // Two independent FNV-1a folds over the DID string give two indices.
-    // FNV is stable across platforms and runs (unlike `DefaultHasher`,
-    // which is randomized), preserving the determinism contract.
+    // Two FNV-1a folds over the DID string with distinct initial seeds produce
+    // decorrelated indices for adjective and animal. FNV is stable across
+    // platforms and runs (unlike `DefaultHasher`, which is randomized),
+    // preserving the determinism contract.
     let bytes = did.as_str().as_bytes();
 
     let adj = fnv1a(bytes, 0xcbf29ce484222325) as usize % ADJECTIVES.len();
-    let animal = fnv1a(bytes, 0x100000001b3) as usize % ANIMALS.len();
+    let animal = fnv1a(bytes, 0xdeadbeefcafe1234) as usize % ANIMALS.len();
     format!("{}-{}", ADJECTIVES[adj], ANIMALS[animal])
 }
 
@@ -54,7 +55,7 @@ mod tests {
     #[test]
     fn it_is_deterministic_for_the_same_did() {
         let d = did("z6MkProfileA");
-        assert_eq!(petname(&d), petname(&d));
+        assert_eq!(petname(&d), "deft-shrew");
     }
 
     #[test]

--- a/rust/tonk-schema/src/petname.rs
+++ b/rust/tonk-schema/src/petname.rs
@@ -1,0 +1,73 @@
+//! Deterministic friendly names for members.
+//!
+//! `petname` maps a profile DID to a stable `adjective-animal` pair. It is
+//! the default display name a member gets before they pick one. Pure and
+//! deterministic: the same DID always yields the same name (no RNG), so a
+//! member reads the same on every device without storing the default.
+
+use dialog_varsig::Did;
+
+const ADJECTIVES: &[&str] = &[
+    "fancy", "brave", "calm", "clever", "eager", "gentle", "jolly", "keen",
+    "lively", "mellow", "nimble", "plucky", "quiet", "rapid", "sunny", "witty",
+    "bold", "bright", "cosy", "deft", "fond", "glad", "honest", "lucky",
+    "merry", "noble", "proud", "quirky", "spry", "tidy", "vivid", "warm",
+];
+
+const ANIMALS: &[&str] = &[
+    "otter", "lynx", "heron", "marten", "badger", "vole", "finch", "newt",
+    "stoat", "ibis", "tapir", "gecko", "raven", "quokka", "dingo", "okapi",
+    "panda", "robin", "shrew", "toad", "wren", "yak", "zebra", "puffin",
+    "mole", "hare", "swift", "crane", "loris", "civet", "fossa", "genet",
+];
+
+/// A stable `adjective-animal` name derived from a profile DID.
+pub fn petname(did: &Did) -> String {
+    // Two independent FNV-1a folds over the DID string give two indices.
+    // FNV is stable across platforms and runs (unlike `DefaultHasher`,
+    // which is randomized), preserving the determinism contract.
+    let bytes = did.as_str().as_bytes();
+
+    let adj = fnv1a(bytes, 0xcbf29ce484222325) as usize % ADJECTIVES.len();
+    let animal = fnv1a(bytes, 0x100000001b3) as usize % ANIMALS.len();
+    format!("{}-{}", ADJECTIVES[adj], ANIMALS[animal])
+}
+
+fn fnv1a(bytes: &[u8], seed: u64) -> u64 {
+    let mut hash = seed;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::petname;
+    use dialog_varsig::Did;
+
+    fn did(seed: &str) -> Did {
+        format!("did:key:{seed}").parse().unwrap()
+    }
+
+    #[test]
+    fn it_is_deterministic_for_the_same_did() {
+        let d = did("z6MkProfileA");
+        assert_eq!(petname(&d), petname(&d));
+    }
+
+    #[test]
+    fn it_produces_an_adjective_animal_pair() {
+        let name = petname(&did("z6MkProfileA"));
+        let parts: Vec<&str> = name.split('-').collect();
+        assert_eq!(parts.len(), 2, "expected adjective-animal, got {name}");
+        assert!(parts.iter().all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_lowercase())));
+    }
+
+    #[test]
+    fn it_differs_for_different_dids() {
+        // Not a hard guarantee, but the two chosen seeds must not collide.
+        assert_ne!(petname(&did("z6MkProfileA")), petname(&did("z6MkProfileB")));
+    }
+}

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -45,6 +45,8 @@ mod lsp_env;
 mod profile;
 pub use profile::{ProfileInfo, SpaceEntry};
 
+mod profile_name;
+
 mod evaluate;
 pub use evaluate::{CommitSummary, EvaluatePath, EvaluateResponse, QueryMatchBlock, QueryResult};
 

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -115,6 +115,7 @@ pub fn command_registry() -> CommandRegistry<CommandEnv> {
         registry.register(Box::new(super::repository::CreateSpaceHandler::new()));
         registry.register(Box::new(super::repository::InviteHandler::new()));
         registry.register(Box::new(super::repository::PauseSyncHandler::new()));
+        registry.register(Box::new(super::repository::ProfileRenameHandler::new()));
         registry.register(Box::new(super::join::JoinHandler::new()));
         registry
     }

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -384,7 +384,8 @@ where
     // A member claiming their own invite is not provenance.
     let self_invite = invitation.inviter.0 == tonk.profile.did().this();
 
-    let member_name = MemberName::new(membership.this().clone(), tonk.profile_name.clone());
+    let display_name = crate::router::profile_name::resolve_display_name(tonk).await;
+    let member_name = MemberName::new(membership.this().clone(), display_name);
     let mut transaction = tonk
         .reactor
         .repository(key)

--- a/rust/tonk-worker/src/router/profile.rs
+++ b/rust/tonk-worker/src/router/profile.rs
@@ -58,6 +58,9 @@ pub struct ProfileInfo {
     /// own self-replica.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub space: Vec<SpaceEntry>,
+    /// The member's effective display name (override, else petname).
+    /// Lets the shell read identity without going through a space branch.
+    pub display_name: String,
 }
 
 /// Handler for `GET /api/profile`.
@@ -156,5 +159,51 @@ pub async fn get_profile(
         });
     }
 
-    Ok(Json(ProfileInfo { profile, space }))
+    let display_name = crate::router::profile_name::resolve_display_name(&tonk).await;
+
+    Ok(Json(ProfileInfo {
+        profile,
+        space,
+        display_name,
+    }))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt as _;
+
+    use crate::api_router;
+    use crate::router::tests::test_state;
+
+    #[dialog_common::test]
+    async fn it_reports_a_display_name_on_the_profile() {
+        let state = test_state().await;
+        let expected = tonk_schema::petname(&state.profile.did());
+        let (app, _lsp) = api_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/profile")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let name = json["display_name"].as_str().expect("display_name is a string");
+        assert_eq!(name, expected);
+    }
 }

--- a/rust/tonk-worker/src/router/profile.rs
+++ b/rust/tonk-worker/src/router/profile.rs
@@ -203,7 +203,9 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let name = json["display_name"].as_str().expect("display_name is a string");
+        let name = json["display_name"]
+            .as_str()
+            .expect("display_name is a string");
         assert_eq!(name, expected);
     }
 }

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -1,0 +1,154 @@
+//! Resolving and stamping a member's display name.
+//!
+//! The effective display name is the durable `ProfileName` override on
+//! the profile meta branch, or a deterministic `petname(profile_did)`
+//! when no override exists. This is what every `MemberName` write uses.
+
+use dialog_query::{Output as _, Query, Term};
+use tonk_common::log;
+use tonk_schema::prelude::DidExt as _;
+use tonk_schema::{MemberName, Membership, ProfileName, petname};
+
+use crate::RepositoryError;
+use crate::worker::TonkState;
+
+// The meta and content branch name constants, as used throughout router code.
+const META_BRANCH: &str = "meta";
+const CONTENT_BRANCH: &str = "main";
+
+/// The member's effective display name: stored override, else the
+/// deterministic default derived from the profile DID.
+pub(crate) async fn resolve_display_name(tonk: &TonkState) -> String {
+    let profile_entity = tonk.profile.did().this();
+
+    let session = match tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            log!("resolve_display_name: meta acquire failed: {e}");
+            return petname(&tonk.profile.did());
+        }
+    };
+
+    let rows: Vec<ProfileName> = session
+        .handle()
+        .query()
+        .select(Query::<ProfileName> {
+            this: Term::from(profile_entity),
+            name: Term::var("name"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .unwrap_or_default();
+
+    rows.into_iter()
+        .next()
+        .map(|pn| pn.name.0)
+        .unwrap_or_else(|| petname(&tonk.profile.did()))
+}
+
+/// Re-stamp the self member's `MemberName` on a space's content branch.
+/// Used by the rename handler so the current space's roster updates.
+pub(crate) async fn restamp_member_name(
+    tonk: &TonkState,
+    key: &str,
+    name: &str,
+) -> Result<(), RepositoryError> {
+    // The repo (subject) DID identifies the membership entity. Read it
+    // from the acquired content-branch handle (`of()` is the subject),
+    // matching how sync.rs derives the replica subject.
+    let session = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("acquire content branch '{key}': {e}")))?;
+    let repo_did = session.handle().of().clone();
+    let membership = Membership::new(tonk.profile.did(), repo_did);
+
+    tonk.reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .transaction()
+        .assert(MemberName::new(membership.this().clone(), name.to_string()))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            RepositoryError::Internal(format!("restamp member name for '{key}': {e}"))
+        })?;
+    Ok(())
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use crate::worker::{DefaultSpace, TonkState};
+    use dialog_capability::Subject;
+    use dialog_operator::Profile;
+    use dialog_storage::provider::storage::Storage;
+    use tonk_schema::petname;
+
+    /// Build an isolated `TonkState` backed by a unique IDB namespace.
+    /// Tests that write to the profile meta branch must not share storage
+    /// with each other — `Profile::open(name)` keys the IDB by `name`.
+    async fn isolated_state(name: &str) -> TonkState {
+        crate::patch_idb_versionchange();
+        let storage = Storage::<DefaultSpace>::default();
+        let profile = Profile::open(name)
+            .perform(&storage)
+            .await
+            .expect("profile opens");
+        let operator = profile
+            .derive(b"test-worker")
+            .allow(Subject::any())
+            .build(storage)
+            .await
+            .expect("operator builds");
+        let reactor = crate::Reactor::new(profile.clone());
+        TonkState {
+            profile,
+            operator,
+            profile_name: name.to_string(),
+            reactor,
+            view_bindings: Default::default(),
+            bridges: Default::default(),
+            commands: crate::router::command_registry(),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_defaults_to_the_petname_when_no_override() {
+        let tonk = isolated_state("profile-name-test-default").await;
+        let expected = petname(&tonk.profile.did());
+        assert_eq!(resolve_display_name(&tonk).await, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_the_stored_override() {
+        let tonk = isolated_state("profile-name-test-override").await;
+        let profile_entity = tonk.profile.did().this();
+        tonk.reactor
+            .profile_repository()
+            .branch(META_BRANCH)
+            .transaction()
+            .assert(ProfileName::new(profile_entity, "brave-lynx".into()))
+            .commit()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        assert_eq!(resolve_display_name(&tonk).await, "brave-lynx");
+    }
+}

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -7,13 +7,21 @@
 use dialog_query::{Output as _, Query, Term};
 use tonk_common::log;
 use tonk_schema::prelude::DidExt as _;
-use tonk_schema::{MemberName, Membership, ProfileName, petname};
+use tonk_schema::{ProfileName, petname};
 
+// Used only by the wasm-gated `restamp_member_name`.
+#[cfg(target_arch = "wasm32")]
 use crate::RepositoryError;
 use crate::worker::TonkState;
+#[cfg(target_arch = "wasm32")]
+use tonk_schema::{MemberName, Membership};
 
 // The meta and content branch name constants, as used throughout router code.
 const META_BRANCH: &str = "meta";
+// Only the wasm-gated rename handler re-stamps member names, so this and
+// `restamp_member_name` exist only on the wasm target (the worker's real
+// runtime). Gating them keeps the native `clippy -D warnings` build clean.
+#[cfg(target_arch = "wasm32")]
 const CONTENT_BRANCH: &str = "main";
 
 /// The member's effective display name: stored override, else the
@@ -55,6 +63,7 @@ pub(crate) async fn resolve_display_name(tonk: &TonkState) -> String {
 
 /// Re-stamp the self member's `MemberName` on a space's content branch.
 /// Used by the rename handler so the current space's roster updates.
+#[cfg(target_arch = "wasm32")]
 pub(crate) async fn restamp_member_name(
     tonk: &TonkState,
     key: &str,

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -14,7 +14,6 @@ use crate::worker::TonkState;
 
 // The meta and content branch name constants, as used throughout router code.
 const META_BRANCH: &str = "meta";
-#[allow(dead_code)]
 const CONTENT_BRANCH: &str = "main";
 
 /// The member's effective display name: stored override, else the
@@ -56,7 +55,6 @@ pub(crate) async fn resolve_display_name(tonk: &TonkState) -> String {
 
 /// Re-stamp the self member's `MemberName` on a space's content branch.
 /// Used by the rename handler so the current space's roster updates.
-#[allow(dead_code)]
 pub(crate) async fn restamp_member_name(
     tonk: &TonkState,
     key: &str,
@@ -83,9 +81,7 @@ pub(crate) async fn restamp_member_name(
         .commit()
         .perform(&tonk.operator)
         .await
-        .map_err(|e| {
-            RepositoryError::Internal(format!("restamp member name for '{key}': {e}"))
-        })?;
+        .map_err(|e| RepositoryError::Internal(format!("restamp member name for '{key}': {e}")))?;
     Ok(())
 }
 

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -14,6 +14,7 @@ use crate::worker::TonkState;
 
 // The meta and content branch name constants, as used throughout router code.
 const META_BRANCH: &str = "meta";
+#[allow(dead_code)]
 const CONTENT_BRANCH: &str = "main";
 
 /// The member's effective display name: stored override, else the
@@ -55,6 +56,7 @@ pub(crate) async fn resolve_display_name(tonk: &TonkState) -> String {
 
 /// Re-stamp the self member's `MemberName` on a space's content branch.
 /// Used by the rename handler so the current space's roster updates.
+#[allow(dead_code)]
 pub(crate) async fn restamp_member_name(
     tonk: &TonkState,
     key: &str,

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1488,7 +1488,8 @@ where
     } else {
         MemberRole::member(membership.this().clone())
     };
-    let member_name = MemberName::new(membership.this().clone(), tonk.profile_name.clone());
+    let display_name = crate::router::profile_name::resolve_display_name(tonk).await;
+    let member_name = MemberName::new(membership.this().clone(), display_name);
 
     // Write through the *reactor's* cached content-branch handle, not a
     // fresh `repository.branch().open()`. Background sync pulls/publishes

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -730,6 +730,133 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PauseSyncHand
     }
 }
 
+/// Post-commit handler for the [`ProfileRename`] command.
+///
+/// Fired when the topbar identity chip's `<tonk-editable>` commits a
+/// transient [`ProfileRename`]. It persists the new display name as a
+/// durable [`ProfileName`] override on the profile's meta branch, then
+/// re-stamps the self member's [`MemberName`] on the *origin* space's
+/// content branch so the current space's roster updates at once.
+///
+/// The new name is the only payload (read from `currentTarget.value`);
+/// the space to re-stamp is read from
+/// [`CommandEnv::origin`](crate::router::CommandEnv::origin), not a
+/// command field. An empty/whitespace name is a no-op — a member can't
+/// blank their own name out.
+///
+/// A custom handler (not a plain `Provider<ProfileRename>`) because it
+/// writes durable branch state the decoded command doesn't carry and
+/// targets the repo from the origin rather than a command field — like
+/// [`InviteHandler`]/[`PauseSyncHandler`].
+///
+/// [`ProfileRename`]: tonk_schema::command::ProfileRename
+/// [`ProfileName`]: tonk_schema::ProfileName
+/// [`MemberName`]: tonk_schema::MemberName
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct ProfileRenameHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl ProfileRenameHandler {
+    /// Cache `ProfileRename`'s trigger attributes (its `name` field) so
+    /// the registry indexes this handler under them.
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::ProfileRename::trigger_attributes(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler<crate::router::CommandEnv> for ProfileRenameHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::ProfileRename::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::router::CommandEnv,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+
+        // Decode synchronously (the caller still holds the lock), then
+        // hand the owned new name + an env clone to the `'static` future.
+        let name = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::ProfileRename::decode(entity, facts))
+            .map(|command| command.name.0);
+        let key = env.origin().repo.clone();
+        let env = env.clone();
+
+        Box::pin(async move {
+            let Some(name) = name else {
+                return;
+            };
+            let name = name.trim();
+            // Don't let a member blank their own name out.
+            if name.is_empty() {
+                return;
+            }
+            log!("command ProfileRename repo={} name={}", key, name);
+
+            if let Err(error) = run_profile_rename(&env, &key, name).await {
+                log!("ProfileRename for repo '{}' failed: {}", key, error);
+            }
+        })
+    }
+}
+
+/// Persist the display-name override on the profile meta branch and
+/// re-stamp `MemberName` on the origin space's content branch.
+///
+/// Split out from [`ProfileRenameHandler::run`] so the `?` early-return
+/// funnels into the single `log!` there — the command future itself
+/// returns `()`.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn run_profile_rename(
+    env: &crate::router::CommandEnv,
+    key: &str,
+    name: &str,
+) -> Result<(), TonkWorkerError> {
+    let tonk = env.state().read().await;
+    let profile_entity = tonk.profile.did().this();
+
+    // 1. Persist the override on the profile meta branch.
+    tonk.reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .transaction()
+        .assert(tonk_schema::ProfileName::new(profile_entity, name.to_string()))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("failed to persist profile name override: {e}"))
+        })?;
+
+    // 2. Re-stamp MemberName on the current space.
+    crate::router::profile_name::restamp_member_name(&tonk, key, name)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("failed to restamp member name: {e}"))
+        })?;
+
+    Ok(())
+}
+
 /// Toggle the durable `enabled` preference on the replica and publish the
 /// matching live status to the chip's overlay.
 ///
@@ -2701,6 +2828,117 @@ mod tests {
         assert!(founder.is_self, "founder is the active profile");
         assert!(founder.invited_by.is_none(), "founder has no inviter");
         assert!(founder.name.is_some(), "founder is named");
+    }
+
+    /// Build a one-entity transient `ProfileRename{this, name, marker}`
+    /// batch — the facts the identity chip's `<tonk-editable>` commit
+    /// asserts. Mirrors how `command::tests::ping_transient` hand-builds a
+    /// command transient via `the!`, carrying both the `name`
+    /// (`current-target/value`) and the `marker`
+    /// (`current-target.dataset/rename`) so it decodes as a `ProfileRename`.
+    fn profile_rename_transient(of: &str, name: &str) -> dialog_artifacts::Changes {
+        use dialog_artifacts::{Entity, Statement};
+        use dialog_query::the;
+
+        let entity: Entity = of.parse().expect("entity URI");
+        let mut changes = dialog_artifacts::Changes::new();
+        the!("dom.event.current-target/value")
+            .of(entity.clone())
+            .is(name.to_string())
+            .assert(&mut changes);
+        the!("dom.event.current-target.dataset/rename")
+            .of(entity)
+            .is("tonk:profile".parse::<Entity>().expect("marker URI"))
+            .assert(&mut changes);
+        changes
+    }
+
+    /// Read the self member's stamped name off the space's content
+    /// branch.
+    async fn self_member_name(state: &AppState, key: &str) -> Option<String> {
+        let tonk = state.read().await;
+        use dialog_repository::RepositoryExt as _;
+        let repository: dialog_repository::Repository = tonk
+            .profile
+            .repository(key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .expect("repo loads");
+        let info = super::build_repository_info(&tonk, key, &repository).await;
+        info.members
+            .into_iter()
+            .find(|m| m.is_self)
+            .and_then(|m| m.name)
+    }
+
+    /// A `profile/rename` command persists the display-name override AND
+    /// re-stamps the self member's `MemberName` on the current space.
+    #[dialog_common::test]
+    async fn it_persists_the_override_and_restamps_the_current_space() {
+        let (_app, state, key) = fresh_repo("test-profile-rename").await;
+
+        // Drive the transient command through the real dispatcher, scoped
+        // to the space's content branch — mirrors
+        // `command::tests::it_dispatches_every_matched_command_in_a_batch`.
+        let changes = profile_rename_transient("did:key:zRenameCmd", "brave-lynx");
+        crate::router::dispatch(
+            &state,
+            crate::router::CommandOrigin {
+                repo: key.clone(),
+                branch: "main".to_string(),
+                client: None,
+            },
+            changes,
+        )
+        .await;
+
+        // Override is on the profile meta branch.
+        {
+            let tonk = state.read().await;
+            assert_eq!(
+                crate::router::profile_name::resolve_display_name(&tonk).await,
+                "brave-lynx",
+                "the override is persisted on the profile meta branch",
+            );
+        }
+
+        // The current space's roster now reads the re-stamped name.
+        assert_eq!(
+            self_member_name(&state, &key).await.as_deref(),
+            Some("brave-lynx"),
+            "the self member's MemberName is re-stamped on the space",
+        );
+    }
+
+    /// An empty/whitespace name is a no-op: the prior name stands (a
+    /// member can't blank their own name out).
+    #[dialog_common::test]
+    async fn it_ignores_a_whitespace_only_rename() {
+        let (_app, state, key) = fresh_repo("test-profile-rename-empty").await;
+
+        // The founder is already named at create time; capture it.
+        let before = self_member_name(&state, &key)
+            .await
+            .expect("founder is named");
+
+        let changes = profile_rename_transient("did:key:zRenameEmpty", "   ");
+        crate::router::dispatch(
+            &state,
+            crate::router::CommandOrigin {
+                repo: key.clone(),
+                branch: "main".to_string(),
+                client: None,
+            },
+            changes,
+        )
+        .await;
+
+        assert_eq!(
+            self_member_name(&state, &key).await,
+            Some(before),
+            "a whitespace-only rename leaves the name unchanged",
+        );
     }
 
     /// Seed a notation document into the repo's `main` branch.

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -839,7 +839,10 @@ async fn run_profile_rename(
         .profile_repository()
         .branch(META_BRANCH)
         .transaction()
-        .assert(tonk_schema::ProfileName::new(profile_entity, name.to_string()))
+        .assert(tonk_schema::ProfileName::new(
+            profile_entity,
+            name.to_string(),
+        ))
         .commit()
         .perform(&tonk.operator)
         .await
@@ -850,9 +853,7 @@ async fn run_profile_rename(
     // 2. Re-stamp MemberName on the current space.
     crate::router::profile_name::restamp_member_name(&tonk, key, name)
         .await
-        .map_err(|e| {
-            TonkWorkerError::Internal(format!("failed to restamp member name: {e}"))
-        })?;
+        .map_err(|e| TonkWorkerError::Internal(format!("failed to restamp member name: {e}")))?;
 
     Ok(())
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new profile renaming feature, allowing users to change their display names. It includes new data structures and logic to manage profile names, and updates existing components to utilize the new naming system.

### Detailed summary
- Added `ProfileName` struct for managing display names.
- Introduced `ProfileRename` command to handle renaming.
- Updated `resolve_display_name` function to return the effective display name.
- Modified `get_profile` to include the display name in the response.
- Implemented `ProfileRenameHandler` to persist name changes.
- Added tests for the new profile renaming functionality.
- Included a `petname` function to generate default display names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->