### PR TITLE
feat(tonk): profile identity in the topbar

### DIFF
--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -667,6 +667,67 @@ view/directory!:
       <tonk-sigil class="workspace__roster-avatar" subject={this} did={member} title={name}></tonk-sigil>
     </div>
 
+# ============================================================
+# SELF-IDENTITY CHIP
+# ============================================================
+
+# The signed-in member's own identity for this space. Resolves against
+# the `state:self` overlay the worker stamps on this space branch
+# (mirroring the sync chip's `state:here`), so self-identity reaches
+# the sealed iframe with no profile-branch access. `did` feeds the
+# sigil; `name` is the editable display name.
+concept!: &tonk/identity
+  this: tonk:identity
+  description: The signed-in member's own identity for this space.
+  with:
+    did:
+      description: The self profile DID (feeds the sigil glyph).
+      the: xyz.tonk.identity/did
+      cardinality: one
+      as: entity
+    name:
+      description: The self display name shown (and edited) in the chip.
+      the: xyz.tonk.identity/name
+      cardinality: one
+      as: text
+
+# The chip view: sigil + an inline-editable name. Editing commits on
+# blur/Enter exactly like the repository-title banner, dispatching the
+# worker-backed `profile/rename` command. `data-rename` carries the
+# marker that distinguishes this transient from `tonk/rename-repository`.
+view!:
+  this: id:tonk:identity/chip
+  model: tonk:identity
+  display: |
+    <span class="workspace__identity">
+      <tonk-sigil class="workspace__identity-avatar" did={did}></tonk-sigil>
+      <tonk-editable
+        class="workspace__identity-name"
+        value={name}
+        data-rename="tonk:profile"
+        onchange=profile/rename
+        aria-label="Your name"
+      ></tonk-editable>
+    </span>
+
+# Rename the signed-in member (set their display name). The editable
+# chip input dispatches this on commit (blur/Enter); `name` reads the
+# input's value and `marker` reads the `data-rename` attribute so the
+# worker handler matches this transient distinctly from
+# `tonk/rename-repository`. No rule: a typed-Rust handler in
+# tonk-worker reacts (it must reach the profile meta branch).
+command!: &profile/rename
+  description: Rename the signed-in member (set their display name).
+  with:
+    name:
+      description: The new name, read from the editable's value on commit.
+      the: dom.event.current-target/value
+      as: text
+    marker:
+      description: Per-command marker (data-rename) distinguishing this from repo rename.
+      the: dom.event.current-target.dataset/rename
+      as: entity
+
 # A read-only label view kind. Its `display` template lives under a
 # distinct attribute (`xyz.tonk.view/label`) so a model can carry both
 # the editable `tonk:view` banner above AND a plain-text label view
@@ -1593,6 +1654,13 @@ view/directory!:
         </tonk-display>
         <span class="workspace__spacer"></span>
         <span class="workspace__actions">
+          <!-- Identity chip: shows the signed-in member's sigil + their
+               editable display name. Resolves against the `state:self`
+               overlay the worker stamps on load (see task-5/6). Editing
+               the name commits via the worker-backed `profile/rename`
+               command (no declarative rule — the Rust handler writes to
+               the profile meta branch). -->
+          <tonk-display entity=state:self model=tonk:identity></tonk-display>
           <!-- One click both opens the share dialog (`data-dialog`) and
                submits the dialog's share form (`form=share-form`, the HTML
                external-submit attribute) — so the invite mints on open with

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -1659,8 +1659,13 @@ view/directory!:
                overlay the worker stamps on load (see task-5/6). Editing
                the name commits via the worker-backed `profile/rename`
                command (no declarative rule — the Rust handler writes to
-               the profile meta branch). -->
-          <tonk-display entity=state:self model=tonk:identity></tonk-display>
+               the profile meta branch). The empty `no-entity` slot renders
+               nothing while `state:self` is briefly absent (e.g. just after
+               an overlay clear) — without it `<tonk-display>` would dump the
+               missing-instance notation as text, mirroring the sync chip. -->
+          <tonk-display entity=state:self model=tonk:identity>
+            <span slot="no-entity" class="workspace__identity" aria-hidden="true"></span>
+          </tonk-display>
           <!-- One click both opens the share dialog (`data-dialog`) and
                submits the dialog's share form (`form=share-form`, the HTML
                external-submit attribute) — so the invite mints on open with

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -620,54 +620,6 @@ view!:
     ></tonk-editable>
 
 # ============================================================
-# MEMBERSHIP / ROSTER
-# ============================================================
-
-# The `tonk:membership` concept. The worker writes a Membership fact
-# (member + subject) and a MemberName fact (the member's self-asserted
-# display `name`) onto the repository's content branch `main` on create
-# and on invite-claim, both keyed to the same membership entity. This
-# concept projects them together so a directory view can render the
-# roster. Pinned to `tonk:membership` so `<tonk-display>` can resolve
-# its view. A name is always written alongside the membership, so the
-# cardinality-one `name` field is present for every member.
-concept!: &tonk/membership
-  this: tonk:membership
-  description: A member of a repository, with their published display name.
-  with:
-    subject:
-      description: The repository the membership belongs to.
-      the: xyz.tonk.membership/subject
-      cardinality: one
-      as: entity
-    member:
-      description: The member profile's did:key.
-      the: xyz.tonk.membership/member
-      cardinality: one
-      as: entity
-    name:
-      description: The member's self-asserted display name.
-      the: xyz.tonk.membership/name
-      cardinality: one
-      as: text
-
-# The roster: a directory view over `tonk:membership`. `<tonk-display
-# model=tonk:membership>` (no entity) resolves this. Each membership on
-# the branch becomes one `<tonk-sigil>`; the bare `subject={this}`
-# marker makes the sigil the per-member repeat node, so the wrapping
-# `<div>` renders once as chrome. `did={member}` feeds the shared
-# DID->sigil derivation (matching the other surfaces) and `{name}` is
-# the hover label. Each repo's `main` holds only its own members, so the
-# unfiltered query is already this repo's roster.
-view/directory!:
-  this: id:tonk:membership/roster
-  model: tonk:membership
-  display: |
-    <div class="workspace__roster">
-      <tonk-sigil class="workspace__roster-avatar" subject={this} did={member} title={name}></tonk-sigil>
-    </div>
-
-# ============================================================
 # SELF-IDENTITY CHIP
 # ============================================================
 

--- a/rust/tonk-host/src/navigate.rs
+++ b/rust/tonk-host/src/navigate.rs
@@ -15,7 +15,7 @@
 
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{MessageEvent, window};
+use web_sys::{CustomEvent, CustomEventInit, MessageEvent, window};
 
 /// A handle owning the installed `message` listener. Dropping it (or calling
 /// [`remove`](NavigateListener::remove)) detaches the listener.
@@ -35,14 +35,22 @@ impl NavigateListener {
     }
 }
 
-/// Install a `navigator.serviceWorker` `message` listener that performs a
-/// navigation on `{ type: "navigate", href }`. Returns `None` when there is
-/// no service-worker container (e.g. a non-secure context or a test stub).
+/// Install a `navigator.serviceWorker` `message` listener that handles
+/// worker→page messages:
+/// - `{ type: "navigate", href }` — assigns `window.location`.
+/// - `{ type: "sync" }` — dispatches `tonk:committed` on `window` so the
+///   sync controller pushes immediately instead of waiting for the heartbeat.
+///
+/// Returns `None` when there is no service-worker container (e.g. a
+/// non-secure context or a test stub).
 pub(crate) fn install() -> Option<NavigateListener> {
     let container = service_worker_container()?;
     let closure = Closure::wrap(Box::new(move |event: MessageEvent| {
-        if let Some(href) = navigate_href(&event.data()) {
+        let data = event.data();
+        if let Some(href) = navigate_href(&data) {
             navigate_to(&href);
+        } else if is_sync_message(&data) {
+            dispatch_committed();
         }
     }) as Box<dyn FnMut(MessageEvent)>);
     container
@@ -67,6 +75,28 @@ fn navigate_href(data: &JsValue) -> Option<String> {
         return None;
     }
     Some(href)
+}
+
+/// Return `true` for a `{ type: "sync" }` message.
+fn is_sync_message(data: &JsValue) -> bool {
+    js_sys::Reflect::get(data, &JsValue::from_str("type"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .map(|kind| kind == "sync")
+        .unwrap_or(false)
+}
+
+/// Dispatch `tonk:committed` on `window` so the sync controller treats it
+/// like a local commit and pushes promptly. Keeps tonk-host decoupled from
+/// tonk-ui — no cross-crate dependency needed.
+fn dispatch_committed() {
+    let Some(win) = window() else { return };
+    let init = CustomEventInit::new();
+    init.set_bubbles(false);
+    init.set_cancelable(false);
+    if let Ok(event) = CustomEvent::new_with_event_init_dict("tonk:committed", &init) {
+        let _ = win.dispatch_event(&event);
+    }
 }
 
 /// Assign `window.location` to `href`, redirecting the page.
@@ -103,6 +133,16 @@ mod tests {
         object.into()
     }
 
+    fn sync_message() -> JsValue {
+        let object = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &object,
+            &JsValue::from_str("type"),
+            &JsValue::from_str("sync"),
+        );
+        object.into()
+    }
+
     /// `navigate_href` accepts only a `{ type: "navigate", href }` shape with
     /// a non-empty href; everything else yields `None` (so an unrelated SW
     /// message never navigates). We assert the parse, not the navigation —
@@ -128,6 +168,28 @@ mod tests {
             navigate_href(&JsValue::from_str("not an object")),
             None,
             "a non-object payload should yield None"
+        );
+    }
+
+    /// `is_sync_message` accepts only `{ type: "sync" }`; navigate and
+    /// unrelated messages yield `false`.
+    #[dialog_common::test]
+    async fn it_recognises_only_a_sync_message() {
+        assert!(
+            is_sync_message(&sync_message()),
+            "a sync message should be recognised"
+        );
+        assert!(
+            !is_sync_message(&message("navigate", "/space/abc")),
+            "a navigate message must not be treated as sync"
+        );
+        assert!(
+            !is_sync_message(&message("other", "")),
+            "an unrelated message must not be treated as sync"
+        );
+        assert!(
+            !is_sync_message(&JsValue::from_str("not an object")),
+            "a non-object payload should not be recognised as sync"
         );
     }
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -246,6 +246,24 @@ pub mod command {
     }
 }
 
+/// Attributes on the transient self-identity overlay the topbar chip
+/// reads (`state:self`). Overlay-only — never persisted, never replicated.
+pub mod identity {
+    use super::{Attribute, Entity};
+
+    /// The self profile DID (feeds `<tonk-sigil did=>`). Derived
+    /// attribute: `xyz.tonk.identity/did`.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.identity")]
+    pub struct Did(pub Entity);
+
+    /// The self display name (the editable chip label). Derived
+    /// attribute: `xyz.tonk.identity/name`.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.identity")]
+    pub struct Name(pub String);
+}
+
 /// Attributes on the profile's own identity facts, written to the
 /// profile's meta branch (private, never replicated) and keyed by the
 /// profile DID entity.

--- a/rust/tonk-schema/src/identity.rs
+++ b/rust/tonk-schema/src/identity.rs
@@ -1,10 +1,11 @@
 //! Profile identity concepts: the durable display-name override stored on
-//! the profile meta branch. (The transient self overlay used by the
-//! topbar chip is added with the chip UI.)
+//! the profile meta branch and the transient self overlay used by the
+//! topbar chip.
 
 use dialog_artifacts::Entity;
 use dialog_query::Concept;
 
+use crate::domain::identity::{Did as IdentityDid, Name as IdentityName};
 use crate::domain::profile::DisplayName;
 
 /// The profile's chosen display name, stored on the profile meta branch
@@ -25,6 +26,30 @@ impl ProfileName {
         Self {
             this: profile,
             name: DisplayName(name),
+        }
+    }
+}
+
+/// The self-identity overlay the topbar chip resolves against
+/// `state:self`. Transient: stamped on space load and on rename, never
+/// committed. Carries the self DID (for the sigil) and the current name.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProfileIdentity {
+    /// The well-known `state:self` entity.
+    pub this: Entity,
+    /// The self profile DID.
+    pub did: IdentityDid,
+    /// The current display name.
+    pub name: IdentityName,
+}
+
+impl ProfileIdentity {
+    /// A self-identity stamp for the `state:self` entity.
+    pub fn new(state_self: Entity, did: Entity, name: String) -> Self {
+        Self {
+            this: state_self,
+            did: IdentityDid(did),
+            name: IdentityName(name),
         }
     }
 }

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -87,7 +87,7 @@ pub mod tracking_branch;
 pub use tracking_branch::*;
 
 mod identity;
-pub use identity::ProfileName;
+pub use identity::{ProfileIdentity, ProfileName};
 
 mod petname;
 pub use petname::petname;

--- a/rust/tonk-schema/src/replica.rs
+++ b/rust/tonk-schema/src/replica.rs
@@ -294,6 +294,12 @@ impl Replica {
     /// question.
     pub const SYNC_STATE_HERE: &'static str = "state:here";
 
+    /// The fixed entity the self-identity overlay is keyed on — a
+    /// well-known singleton so the topbar chip can subscribe without
+    /// resolving this device's membership entity. One space per page, so
+    /// a singleton suffices (same rationale as `SYNC_STATE_HERE`).
+    pub const SELF_STATE_HERE: &'static str = "state:self";
+
     /// `tonk/sync` `status` URI: up to date, nothing to do.
     pub const IDLE: &'static str = "sync:idle";
 

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -536,6 +536,48 @@ tonk-roster {
     gap: var(--wa-space-m);
     color: var(--wa-color-text-quiet);
 }
+/* Self-identity chip: the signed-in member's sigil + their editable
+   display name, in the topbar actions row. The name reads as plain text
+   until hovered/focused, mirroring the repository-title banner
+   (`.workspace__title-input`); the avatar reuses the roster sigil's
+   black-ringed circle (`.workspace__roster-avatar`). */
+.workspace__identity {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    color: var(--wa-color-text-normal, inherit);
+}
+.workspace__identity-avatar {
+    width: 1.5rem;
+    height: 1.5rem;
+    box-sizing: border-box;
+    overflow: hidden;
+    border-radius: 50%;
+    border: 1.5px solid #1c1c1c;
+    background: #fff;
+    color: #1c1c1c;
+    flex: none;
+}
+.workspace__identity-name {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--wa-border-radius-s);
+    padding: var(--wa-space-3xs) var(--wa-space-2xs);
+    margin: calc(-1 * var(--wa-space-3xs)) calc(-1 * var(--wa-space-2xs));
+    min-width: 6ch;
+    white-space: nowrap;
+    cursor: text;
+}
+.workspace__identity-name:hover {
+    border-color: var(--wa-color-surface-border, rgba(127, 127, 127, 0.2));
+}
+.workspace__identity-name:focus {
+    outline: none;
+    border-color: var(--wa-color-brand-fill-loud, #0070f3);
+    background: var(--wa-color-surface-default, #fff);
+}
 /* The share (`<tonk-share>`) and pause/resume (`<tonk-sync-toggle>`)
    controls: icon-only ghost buttons that brighten on hover. */
 .workspace__share,

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -479,50 +479,11 @@ tonk-repository.display-route,
 .workspace__sync.is-diverged::before {
     background: var(--wa-color-danger-fill-loud);
 }
-/* The member roster (`<tonk-roster>` renders this cluster): one
-   `<tonk-sigil>` avatar per repo member, each cropped into a
-   black-ringed circle and overlapped into a left-to-right stack.
-   Later siblings paint over earlier ones; the drop shadow on each
-   avatar's leading edge gives the overlap its depth. */
-/* `<tonk-roster>` is a bare custom element (display:inline by
-   default), so the cluster rode the text baseline and sat high.
-   Make it a centred flex item so it aligns with the share button
-   through the topbar's vertical centre. */
-tonk-roster {
-    display: inline-flex;
-    align-items: center;
-}
-.workspace__roster {
-    display: inline-flex;
-    align-items: center;
-    line-height: 0;
-    padding-inline-end: 0.4rem;
-}
-.workspace__roster-avatar {
-    width: 1.5rem;
-    height: 1.5rem;
-    box-sizing: border-box;
-    /* The sigil child is absolutely positioned, so `border-radius`
-       alone won't clip it — `overflow: hidden` crops the square
-       identicon into the circle. The white disc occludes the avatar
-       beneath where they overlap; the leftward shadow reads as the
-       upper avatar lifting off the one below. */
-    overflow: hidden;
-    border-radius: 50%;
-    border: 1.5px solid #1c1c1c;
-    background: #fff;
-    color: #1c1c1c;
-    box-shadow: -2px 0 3px -1px rgba(0, 0, 0, 0.3);
-    margin-inline-end: -0.5rem;
-}
-.workspace__roster-avatar:last-child {
-    margin-inline-end: 0;
-}
-/* The roster renders through a `<tonk-display>` → `<tonk-view>` pair
-   whose line boxes would otherwise sit the avatar cluster above the
+/* The topbar chips (identity, sync) render through a `<tonk-display>` →
+   `<tonk-view>` pair whose line boxes would otherwise sit them above the
    topbar's centerline. Collapse the wrappers (as `.workspace__title`
-   does) so `.workspace__roster` is laid out — and vertically centered —
-   directly by the `.workspace__actions` flex row. */
+   does) so each chip is laid out — and vertically centered — directly by
+   the `.workspace__actions` flex row. */
 .workspace__actions tonk-display,
 .workspace__actions tonk-view {
     display: contents;
@@ -539,8 +500,8 @@ tonk-roster {
 /* Self-identity chip: the signed-in member's sigil + their editable
    display name, in the topbar actions row. The name reads as plain text
    until hovered/focused, mirroring the repository-title banner
-   (`.workspace__title-input`); the avatar reuses the roster sigil's
-   black-ringed circle (`.workspace__roster-avatar`). */
+   (`.workspace__title-input`); the avatar is a black-ringed circle
+   cropping the square sigil. */
 .workspace__identity {
     display: inline-flex;
     align-items: center;

--- a/rust/tonk-worker/src/router/host.rs
+++ b/rust/tonk-worker/src/router/host.rs
@@ -226,6 +226,12 @@ pub async fn guest(
 
     let tonk = state.read().await;
 
+    // Stamp the self-identity overlay so the topbar chip can render the
+    // member's sigil + name immediately on space open, before the first
+    // sync-status sweep arrives.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    crate::router::sync::publish_self_identity(&tonk, &params.repo, &params.branch).await;
+
     let repo = tonk
         .profile
         .repository(&params.repo)

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -745,6 +745,61 @@ fn notify_navigate(client: Option<&crate::router::ClientId>, href: &str) {
     });
 }
 
+/// Post a `{ type: "sync" }` message to the originating client so it
+/// dispatches a `tonk:committed` window event, prompting the sync
+/// controller to push immediately instead of waiting for the heartbeat.
+///
+/// Mirrors [`notify_navigate`] exactly — fire-and-forget on a spawned
+/// task, no `TonkState` access, so the caller's held read lock is
+/// irrelevant.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn notify_sync(client: Option<&crate::router::ClientId>) {
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_futures::{JsFuture, spawn_local};
+
+    let Some(client) = client else {
+        log!("notify_sync: no originating client; skipping prompt sync");
+        return;
+    };
+    let client_id = client.0.clone();
+
+    let global: web_sys::ServiceWorkerGlobalScope = match js_sys::global().dyn_into() {
+        Ok(g) => g,
+        Err(_) => {
+            log!("notify_sync: not in a service worker scope; skipping prompt sync");
+            return;
+        }
+    };
+
+    spawn_local(async move {
+        let client_value = match JsFuture::from(global.clients().get(&client_id)).await {
+            Ok(value) if !value.is_undefined() && !value.is_null() => value,
+            Ok(_) => {
+                log!("notify_sync: originating client {client_id} is gone; skipping");
+                return;
+            }
+            Err(e) => {
+                log!("notify_sync: clients.get failed: {e:?}");
+                return;
+            }
+        };
+        let Ok(client) = client_value.dyn_into::<web_sys::Client>() else {
+            log!("notify_sync: clients.get did not yield a Client; skipping");
+            return;
+        };
+
+        let message = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &message,
+            &JsValue::from_str("type"),
+            &JsValue::from_str("sync"),
+        );
+        if let Err(e) = client.post_message(&message) {
+            log!("notify_sync: post_message(sync) failed: {e:?}");
+        }
+    });
+}
+
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -926,7 +926,6 @@ async fn run_pause_sync(
     // sweep settles it to the real state (idle / local / offline).
     if now_enabled {
         super::sync::publish_sync_status_attr(&tonk, repo, branch, Replica::pending_status()).await;
-        super::sync::publish_self_identity(&tonk, repo, branch).await;
     } else {
         super::sync::publish_paused_status(&tonk, repo, branch).await;
     }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -3345,9 +3345,8 @@ mod tests {
             .await
             .expect("acquire main");
 
-        let entity: dialog_artifacts::Entity = tonk_schema::Replica::SELF_STATE_HERE
-            .parse()
-            .unwrap();
+        let entity: dialog_artifacts::Entity =
+            tonk_schema::Replica::SELF_STATE_HERE.parse().unwrap();
         let rows: Vec<tonk_schema::ProfileIdentity> = session
             .handle()
             .query()

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -601,6 +601,9 @@ async fn run_invite(
         this: subject_entity,
         seed: Seed(seed),
     });
+    // Re-stamp state:self after clear_overlay wiped it — without this the
+    // topbar identity chip loses its data until the next sync_status poll.
+    crate::router::sync::publish_self_identity(&tonk, repo_name, CONTENT_BRANCH).await;
     tonk.reactor
         .schedule_poll(std::sync::Arc::clone(&session.state));
 
@@ -858,6 +861,12 @@ async fn run_profile_rename(
     // 3. Re-stamp the self-identity overlay so the topbar chip reflects the
     //    new name instantly without waiting for the next sync cycle.
     crate::router::sync::publish_self_identity(&tonk, key, CONTENT_BRANCH).await;
+
+    // 4. Prompt an immediate push so peers see the new name without waiting
+    //    for the 20s heartbeat. Fire-and-forget: the held read lock is
+    //    released before the spawned task runs.
+    drop(tonk);
+    crate::router::join::notify_sync(env.client());
 
     Ok(())
 }
@@ -3270,5 +3279,93 @@ mod tests {
         assert_eq!(names.len(), 1, "exactly the founder's name");
         assert_eq!(names[0].this, memberships[0].this);
         assert!(!names[0].name.0.is_empty(), "a non-empty display name");
+    }
+
+    /// Build a one-entity transient `Invite{this, time, marker}` batch —
+    /// the facts the share form's submit event asserts. Carries both the
+    /// `time-stamp` (`dom.event/time-stamp`) and the `marker`
+    /// (`dom.event.current-target.dataset/invite`) so it decodes as an
+    /// `Invite` command and not a `PauseSync` (identical `{this, time}`
+    /// shape otherwise).
+    fn invite_transient(of: &str) -> dialog_artifacts::Changes {
+        use dialog_artifacts::{Entity, Statement};
+        use dialog_query::the;
+
+        let entity: Entity = of.parse().expect("entity URI");
+        let mut changes = dialog_artifacts::Changes::new();
+        the!("dom.event/time-stamp")
+            .of(entity.clone())
+            .is(1.0_f64)
+            .assert(&mut changes);
+        the!("dom.event.current-target.dataset/invite")
+            .of(entity)
+            .is("tonk:invite".parse::<Entity>().expect("marker URI"))
+            .assert(&mut changes);
+        changes
+    }
+
+    /// Dispatching a `tonk:invite` command clears the overlay (to rotate
+    /// the credential) but MUST re-stamp `state:self` so the topbar chip
+    /// retains the member's identity data. Without the re-stamp the chip
+    /// goes blank until the next sync_status poll (~20 s).
+    #[dialog_common::test]
+    async fn it_restamps_state_self_after_invite_clears_the_overlay() {
+        use dialog_query::{Output as _, Query, Term};
+
+        let (_app, state, key) = fresh_repo("test-invite-restamps-self").await;
+
+        // Prime state:self so we have something to lose.
+        {
+            let tonk = state.read().await;
+            crate::router::sync::publish_self_identity(&tonk, &key, "main").await;
+        }
+
+        // Drive the invite command through the real dispatcher — same path
+        // the share modal takes.
+        let changes = invite_transient("did:key:zInviteCmd");
+        crate::router::dispatch(
+            &state,
+            crate::router::CommandOrigin {
+                repo: key.clone(),
+                branch: "main".to_string(),
+                client: None,
+            },
+            changes,
+        )
+        .await;
+
+        // state:self must still be present on the overlay after run_invite's
+        // clear_overlay + re-stamp sequence.
+        let tonk = state.read().await;
+        let session = tonk
+            .reactor
+            .repository(&key)
+            .branch("main")
+            .acquire(&tonk.operator)
+            .await
+            .expect("acquire main");
+
+        let entity: dialog_artifacts::Entity = tonk_schema::Replica::SELF_STATE_HERE
+            .parse()
+            .unwrap();
+        let rows: Vec<tonk_schema::ProfileIdentity> = session
+            .handle()
+            .query()
+            .with(session.overlay())
+            .select(Query::<tonk_schema::ProfileIdentity> {
+                this: Term::from(entity),
+                did: Term::var("did"),
+                name: Term::var("name"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "state:self must be re-stamped after invite clears the overlay",
+        );
     }
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -855,6 +855,10 @@ async fn run_profile_rename(
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("failed to restamp member name: {e}")))?;
 
+    // 3. Re-stamp the self-identity overlay so the topbar chip reflects the
+    //    new name instantly without waiting for the next sync cycle.
+    crate::router::sync::publish_self_identity(&tonk, key, CONTENT_BRANCH).await;
+
     Ok(())
 }
 
@@ -922,6 +926,7 @@ async fn run_pause_sync(
     // sweep settles it to the real state (idle / local / offline).
     if now_enabled {
         super::sync::publish_sync_status_attr(&tonk, repo, branch, Replica::pending_status()).await;
+        super::sync::publish_self_identity(&tonk, repo, branch).await;
     } else {
         super::sync::publish_paused_status(&tonk, repo, branch).await;
     }

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -824,7 +824,7 @@ mod overlay_tests {
     use dialog_query::{Output as _, Query, Term};
     use tonk_schema::{petname, prelude::DidExt as _};
 
-    use crate::router::{api_router_with_state, tests::test_state, tests::put_repo};
+    use crate::router::{api_router_with_state, tests::put_repo, tests::test_state};
 
     #[dialog_common::test]
     async fn it_stamps_the_self_identity_overlay_on_load() {
@@ -841,9 +841,8 @@ mod overlay_tests {
             .await
             .unwrap();
 
-        let entity: dialog_artifacts::Entity = tonk_schema::Replica::SELF_STATE_HERE
-            .parse()
-            .unwrap();
+        let entity: dialog_artifacts::Entity =
+            tonk_schema::Replica::SELF_STATE_HERE.parse().unwrap();
         let rows: Vec<tonk_schema::ProfileIdentity> = session
             .handle()
             .query()

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -495,6 +495,13 @@ pub async fn sync_status(
     // of blocking on the (network-bound) status request.
     let tonk_state = state.read().await;
 
+    // A status check fires whenever a space is opened, so this is the load-time
+    // hook for the topbar identity chip: re-stamp the `state:self` overlay here,
+    // before any sync-state branch returns, so a freshly opened space (even a
+    // paused or upstream-less one) always carries the member's identity.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    publish_self_identity(&tonk_state, &params.repo, &params.branch).await;
+
     // A paused replica reports `paused` and skips the upstream fetch — so a
     // status sweep can't clobber the chip's `paused` with a fresh `synced`/
     // `ahead` reading, and we don't hit the network while paused.
@@ -815,7 +822,7 @@ mod overlay_tests {
     wasm_bindgen_test_configure!(run_in_service_worker);
 
     use dialog_query::{Output as _, Query, Term};
-    use tonk_schema::petname;
+    use tonk_schema::{petname, prelude::DidExt as _};
 
     use crate::router::{api_router_with_state, tests::test_state, tests::put_repo};
 
@@ -856,6 +863,11 @@ mod overlay_tests {
             rows[0].name.0,
             petname(&tonk.profile.did()),
             "name must be the petname when no override is set",
+        );
+        assert_eq!(
+            rows[0].did.0,
+            tonk.profile.did().this(),
+            "did must match the profile DID for the sigil",
         );
     }
 }

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -122,6 +122,39 @@ pub async fn publish_paused_status(tonk: &crate::worker::TonkState, repo: &str, 
     publish_sync_status_attr(tonk, repo, branch, tonk_schema::Replica::paused_status()).await;
 }
 
+/// Stamp the self-identity overlay (`state:self`) on a space branch so
+/// the topbar chip can render the member's sigil + name without seeing
+/// the profile branch. Overlay-only — never committed, never replicated.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn publish_self_identity(tonk: &crate::worker::TonkState, repo: &str, branch: &str) {
+    use tonk_schema::{ProfileIdentity, Replica, prelude::DidExt as _};
+
+    let Ok(entity) = Replica::SELF_STATE_HERE.parse() else {
+        return;
+    };
+    let did = tonk.profile.did().this();
+    let name = crate::router::profile_name::resolve_display_name(tonk).await;
+    let stamp = ProfileIdentity::new(entity, did, name);
+
+    let session = match tonk
+        .reactor
+        .repository(repo)
+        .branch(branch)
+        .acquire(&tonk.operator)
+        .await
+    {
+        Ok(session) => session,
+        Err(e) => {
+            log!("publish_self_identity: failed to acquire {repo}/{branch}: {e}");
+            return;
+        }
+    };
+    session.state.assert_overlay(stamp);
+    tonk.reactor
+        .schedule_poll(std::sync::Arc::clone(&session.state));
+    tonk.reactor.run_scheduled_polls(&tonk.operator).await;
+}
+
 /// Whether auto-sync is enabled for `repo`'s content branch: reads the durable
 /// boolean [`ReplicaSyncEnabled`](tonk_schema::ReplicaSyncEnabled) preference
 /// keyed on this device's replica entity, on the space content branch. An
@@ -771,5 +804,58 @@ mod tests {
     fn it_returns_empty_when_no_branch_has_an_upstream() {
         let branches = HashMap::from([("main".to_string(), without_upstream())]);
         assert!(branches_to_sync(&branches).is_empty());
+    }
+}
+
+/// Overlay tests — wasm-only (needs IndexedDB / branch IO via the service-worker
+/// host).
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod overlay_tests {
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_schema::petname;
+
+    use crate::router::{api_router_with_state, tests::test_state, tests::put_repo};
+
+    #[dialog_common::test]
+    async fn it_stamps_the_self_identity_overlay_on_load() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "chip-space").await;
+        let tonk = state.read().await;
+        super::publish_self_identity(&tonk, &key, "main").await;
+
+        let session = tonk
+            .reactor
+            .repository(&key)
+            .branch("main")
+            .acquire(&tonk.operator)
+            .await
+            .unwrap();
+
+        let entity: dialog_artifacts::Entity = tonk_schema::Replica::SELF_STATE_HERE
+            .parse()
+            .unwrap();
+        let rows: Vec<tonk_schema::ProfileIdentity> = session
+            .handle()
+            .query()
+            .with(session.overlay())
+            .select(Query::<tonk_schema::ProfileIdentity> {
+                this: Term::from(entity),
+                did: Term::var("did"),
+                name: Term::var("name"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 1, "expected one state:self row");
+        assert_eq!(
+            rows[0].name.0,
+            petname(&tonk.profile.did()),
+            "name must be the petname when no override is set",
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a profile identity chip to the space topbar: every member gets a friendly auto-generated name (e.g. `fancy-otter`) and a sigil, and can rename themselves inline — like editing the repo title. Names sync to everyone in the space and are visible in the share-modal roster.

Before this, every member was literally named "tonk" (a hardcoded constant) with no way to set a name.

<img width="404" height="126" alt="CleanShot 2026-06-24 at 10 47 42@2x" src="https://github.com/user-attachments/assets/bb9afd36-d565-4f51-ba68-407607c59344" />

## How it works — the member name, end to end

**1. The name's home: a synced `MemberName` fact.**
Each member's display name lives in a `MemberName` fact on the space's **content branch** (`main`), keyed to that member's membership entity. Because it's on the synced branch, every member converges on the same value — it's not a per-viewer alias. This fact already existed; the gap was that nothing meaningful was ever written to it.

**2. The default: deterministic from the profile DID.**
A new `petname(&Did)` generator (`tonk-schema`) hashes the profile DID into an `adjective-animal` pair via two FNV-1a folds. It's pure and deterministic — the same DID always yields the same name, with no stored state — so a member reads the same default on every device and across spaces, for free.

**3. The override: a local fact on the profile meta branch.**
When a member renames themselves, the chosen name is stored as a `ProfileName` fact on their **profile meta branch** (local-only, never synced — it's the device's source of truth). The effective name is resolved by `resolve_display_name`: the stored override if present, else `petname(did)`.

**4. Propagation: meta → content.**
The override never syncs directly (meta branches don't). Instead, `resolve_display_name` feeds every `MemberName` write — at space create, at invite-claim, and on rename — so the name propagates outward through the per-space `MemberName` fact on the synced branch. That's what other members actually see.

**5. The chip: a `state:self` overlay read declaratively.**
The topbar renders inside a sealed iframe that can't see the profile branch, so the worker stamps a transient `state:self` overlay (a `ProfileIdentity` carrying the self DID + resolved name) onto the space branch — mirroring the existing `state:here` sync-chip overlay. A declarative `tonk:identity` concept + view (`core.yaml`) reads it: `<tonk-sigil did={did}>` + an inline-editable name. The overlay is re-stamped on the space-load status check and on rename.

**6. Rename: a worker-backed command, then a prompt push.**
The editable's `onchange=profile/rename` dispatches a transient `ProfileRename` command. A `data-rename` marker keeps it from colliding with the repo-rename transient (they share the `currentTarget.value` read-path). The worker handler: persists the `ProfileName` override → re-stamps `MemberName` on the current space → re-stamps the `state:self` overlay (instant chip update) → posts a `{type:"sync"}` message to the page, which triggers an immediate sync push so other members see the rename in ~1s rather than on the 20s heartbeat.

## Bug fixes (found in two-browser testing, folded in)

- **Prompt propagation:** rename now pushes immediately via a worker→page `{type:"sync"}` message (reusing the `tonk:join` navigate channel), instead of waiting up to 20s for the sync heartbeat. An in-handler push would deadlock (handler holds a read lock; push takes a write lock), so the fire-and-forget message channel is the safe path.
- **Chip never leaks raw notation:** added a `no-entity` fallback slot so the chip renders nothing during any brief data gap instead of dumping `tonk:identity: this: state:self` as text.
- **Chip survives the share modal:** minting an invite calls `clear_overlay()`, which wiped `state:self`; the invite handler now re-stamps it immediately.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily enhances the self-identity management in the `tonk` application, particularly for the UI and data handling related to user profiles and their display names.

### Detailed summary
- Updated `pub use` in `rust/tonk-schema/src/lib.rs` to include `ProfileIdentity`.
- Introduced `SELF_STATE_HERE` constant in `rust/tonk-schema/src/replica.rs`.
- Added `identity` module in `rust/tonk-schema/src/domain.rs` with `Did` and `Name` structs.
- Enhanced the `ProfileIdentity` struct in `rust/tonk-schema/src/identity.rs` to manage user identity.
- Implemented `publish_self_identity` function in `rust/tonk-worker/src/router/sync.rs` to manage identity overlay.
- Added immediate identity updates in `rust/tonk-worker/src/router/join.rs` and `repository.rs` after profile changes.
- Updated CSS styles in `rust/tonk-ui/styles.css` for improved UI of identity display.
- Modified YAML schema in `rust/tonk-core/assets/library/core.yaml` to reflect new identity concepts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->