### PR TITLE
fix(notation): resolve slash-namespaced attribute references

### DIFF
--- a/rust/slide/SHARE.md
+++ b/rust/slide/SHARE.md
@@ -41,7 +41,7 @@ the `text/html` attribute. The seed schema:
 ```yaml
 attribute! html-body:
   description: "HTML body of a slide-authored view"
-  the:         text/html
+  the:         "text/html"
   as:          Text
   cardinality: many
 

--- a/rust/slide/src/guide-views.md
+++ b/rust/slide/src/guide-views.md
@@ -126,7 +126,7 @@ and serve it through the iframe viewer:
 ```yaml
 attribute!: &html-body
   description: "HTML body of a one-off page"
-  the:         text/html
+  the:         "text/html"
   as:          text
   cardinality: many
 

--- a/rust/slide/tests/common.rs
+++ b/rust/slide/tests/common.rs
@@ -97,7 +97,7 @@ concept!: &task
 pub const VIEW_DECL: &str = r#"
 attribute!: &html-body
   description: "HTML body of a slide-authored view"
-  the:         text/html
+  the:         "text/html"
   as:          text
   cardinality: many
 

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -1225,6 +1225,33 @@ concept!: &person
         assert_eq!(analysis.mutate.statements.len(), 3);
     }
 
+    /// A `concept!`'s `with:` field can reference a `/`-namespaced
+    /// anchor (`issue/title`) the same way it references a bare one.
+    /// The slash-bearing token is a qualified symbol — a name lookup
+    /// against the in-doc anchor table — not a string literal, so it
+    /// resolves instead of erroring `E_UNSUPPORTED_FIELD_VALUE`.
+    #[dialog_common::test]
+    async fn it_resolves_namespaced_attribute_referenced_by_a_concept() {
+        let syntax = must_parse(
+            r#"
+attribute!: &issue/title
+  the:         io.gozala.issue/title
+  as:          Text
+  cardinality: one
+  description: "Issue title"
+concept!: &issue
+  description: "Work item"
+  with:
+    title: issue/title
+"#,
+        );
+        let analysis = flat(analyze_empty(&syntax).await.unwrap());
+        assert!(analysis.declarations.contains_key("issue/title"));
+        assert!(analysis.declarations.contains_key("issue"));
+        // 2 statements — 1 attribute + 1 concept.
+        assert_eq!(analysis.mutate.statements.len(), 2);
+    }
+
     /// `concept!` `with:` accepts inline attribute definitions
     /// alongside bare-symbol references. Each inline definition
     /// becomes its own `Statement::Assert` so the attribute

--- a/rust/tonk-notation/src/parse.rs
+++ b/rust/tonk-notation/src/parse.rs
@@ -943,15 +943,17 @@ fn walk_field_value(
 ///
 /// - `_` → [`FieldValue::Blank`]
 /// - `?name` → [`FieldValue::Variable`]
-/// - URI shapes (contains `:` or `/`) → [`FieldValue::Uri`]
-/// - bare lowercase identifier → [`FieldValue::Symbol`]
-/// - everything else (uppercase, mixed case, dotted) → string
-///   literal
+/// - URI shapes (`<scheme>:…` or `<dotted-domain>/name`) →
+///   [`FieldValue::Uri`]
+/// - bare lowercase identifier (`title`) or a `/`-qualified one
+///   (`issue/title`, `space/route/view`) → [`FieldValue::Symbol`]
+/// - everything else (uppercase, mixed case) → string literal
 ///
 /// References require an explicit shape (no leading sigil for
 /// symbols — bare lowercase is itself the marker). Quotes
 /// distinguish string literals that would otherwise look like
-/// symbols.
+/// symbols — `text/html` reads as a qualified symbol, so the MIME
+/// literal must be written `"text/html"`.
 fn classify_plain_value(text: &str) -> FieldValue {
     if text == "_" {
         return FieldValue::Blank;
@@ -969,7 +971,7 @@ fn classify_plain_value(text: &str) -> FieldValue {
     if let Some(scalar) = parse_typed_scalar(text) {
         return FieldValue::Literal(scalar);
     }
-    if is_symbol(text) {
+    if is_symbol(text) || is_qualified_symbol(text) {
         return FieldValue::Symbol(text.to_owned());
     }
     FieldValue::Literal(Scalar::String(text.to_owned()))
@@ -1081,6 +1083,24 @@ fn is_symbol(text: &str) -> bool {
         return false;
     }
     chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '+'))
+}
+
+/// Qualified symbol: one or more `/`-joined [`is_symbol`] segments
+/// (`issue/title`, `space/route/view`). A name lookup against the
+/// anchor table, same as a bare symbol — the slash is a namespace
+/// separator, not a URI marker. Mirrors the anchor charset
+/// ([`is_anchor_char`] allows `/`) so any anchor name can be
+/// referenced back.
+///
+/// A `/` whose left side contains a `.` (`io.gozala.issue/title`)
+/// is a URI, not a qualified symbol — [`looks_like_uri`] claims
+/// those first, matching the head-name convention in
+/// [`is_attribute_identifier`].
+fn is_qualified_symbol(text: &str) -> bool {
+    match text.split_once('/') {
+        Some((first, rest)) => is_symbol(first) && rest.split('/').all(is_symbol),
+        None => false,
+    }
 }
 
 fn is_blank_scalar(value: &MarkedYaml<'_>) -> bool {
@@ -2295,16 +2315,58 @@ page!:
         }
     }
 
-    /// MIME-type-shaped plain scalars (`text/html`,
-    /// `application/json`) classify as string literals, not
-    /// URIs. The reverse-dotted-domain rule requires at least
-    /// one `.` before the `/`; `text/` doesn't have one.
+    /// A `/`-joined bare identifier (`issue/title`,
+    /// `space/route/view`) classifies as a qualified
+    /// [`FieldValue::Symbol`] — a name lookup against the anchor
+    /// table, symmetric with the slash-bearing anchor charset.
     #[dialog_common::test]
-    fn it_parses_mime_type_as_string_literal() {
+    fn it_parses_namespaced_reference_as_symbol() {
+        let syntax = parse_clean(
+            r#"
+concept!:
+  with:
+    title: issue/title
+    body:  space/route/view
+"#,
+        );
+        let Expression::Claim(Effectful {
+            anchor: _anchor,
+            inner: a,
+        }) = &syntax.expressions[0]
+        else {
+            panic!("expected Assertion");
+        };
+        let with = a
+            .fields
+            .iter()
+            .find(|f| f.name == "with")
+            .expect("with field");
+        let FieldValue::Nested(fields) = &with.value else {
+            panic!("expected nested with map, got {:?}", with.value);
+        };
+        let title = fields.iter().find(|f| f.name == "title").expect("title");
+        assert!(
+            matches!(&title.value, FieldValue::Symbol(s) if s == "issue/title"),
+            "got {:?}",
+            title.value,
+        );
+        let body = fields.iter().find(|f| f.name == "body").expect("body");
+        assert!(
+            matches!(&body.value, FieldValue::Symbol(s) if s == "space/route/view"),
+            "got {:?}",
+            body.value,
+        );
+    }
+
+    /// MIME-type-shaped plain scalars (`text/html`) now read as
+    /// qualified symbols (no `.` before the `/`), so the literal
+    /// MIME string must be quoted. The quoted form stays a string.
+    #[dialog_common::test]
+    fn it_parses_quoted_mime_type_as_string_literal() {
         let syntax = parse_clean(
             r#"
 page!:
-  type: text/html
+  type: "text/html"
 "#,
         );
         let Expression::Claim(Effectful {


### PR DESCRIPTION
Namespacing taught the anchor grammar to accept `/` (`attribute!: &issue/title`) but never taught the reference grammar the same thing. So a `concept!`'s `with:` field written the obvious way — `title: issue/title` — couldn't resolve: the value classifier saw a token that was neither a dotted-domain URI nor a slash-free symbol and fell it through to a string literal, which the analyzer rejects with `E_UNSUPPORTED_FIELD_VALUE`. You could declare a slash-named anchor but never point back at it.

The fix makes a `/`-joined bare identifier a qualified symbol — a name lookup, exactly like a bare symbol — so the reference grammar is symmetric with the anchor charset (and with `classify_head_name`, which already treats slash-without-dot as a name in head position). One or more slashes are allowed, so the existing `space/route/view` anchor is referenceable too. The analyzer needed no change: `FieldValue::Symbol` already resolves to the attribute's entity in both the `with:` and body paths.

The one behavioral cost: a MIME-shaped literal like `text/html` now reads as a symbol, so it must be quoted (`"text/html"`). That shape only appeared unquoted in one test fixture and two agent-facing guide docs, all updated here; everywhere else it's a Rust `.parse::<Attribute>()` string that never touches the classifier.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving the handling of MIME types and namespaced attributes in the codebase, ensuring that they are correctly interpreted as string literals or symbols, enhancing the parsing logic.

### Detailed summary
- Changed MIME type definitions from `text/html` to `"text/html"` in multiple files.
- Introduced a new function `is_qualified_symbol` to identify qualified symbols.
- Added tests to verify the resolution of namespaced attributes and parsing of quoted MIME types.
- Updated comments to clarify the interpretation of symbols and MIME types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->