### PR TITLE
feat(slide): add `eval --dry-run` to preview without committing

### DIFF
--- a/rust/slide/src/bin/slide.rs
+++ b/rust/slide/src/bin/slide.rs
@@ -332,7 +332,7 @@ enum RemoteCommand {
 
 #[derive(Args, Debug)]
 #[command(
-    after_help = "Examples:\n  slide eval -c 'person:'\n  slide eval ./doc.notation\n  cat doc.notation | slide eval -\n  slide eval -c 'person:' --format json\n  slide eval ./doc.notation --no-sync"
+    after_help = "Examples:\n  slide eval -c 'person:'\n  slide eval ./doc.notation\n  cat doc.notation | slide eval -\n  slide eval -c 'person:' --format json\n  slide eval ./doc.notation --no-sync\n  slide eval ./doc.notation --dry-run"
 )]
 struct EvalArgs {
     /// Inline document. Mutually exclusive with the positional
@@ -360,6 +360,15 @@ struct EvalArgs {
     /// settable via the `SLIDE_NO_SYNC` environment variable.
     #[arg(long = "no-sync")]
     no_sync: bool,
+
+    /// Run the document without committing: analyze, query, and
+    /// plan, then drop the transaction. Query matches are returned
+    /// and the commit summary shows zero claims; the branch is left
+    /// untouched. Implies `--no-sync` (a preview never touches the
+    /// remote). Mirrors the worker's `transact=false` preview the
+    /// notebook editor uses to render results as you type.
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -453,6 +462,7 @@ async fn eval(args: EvalArgs) -> ExitCode {
     let options = eval::Options {
         format: args.format.into(),
         quiet: args.quiet,
+        dry_run: args.dry_run,
     };
 
     let site = match site::SlideSite::discover_and_open(&cwd).await {
@@ -460,7 +470,9 @@ async fn eval(args: EvalArgs) -> ExitCode {
         Err(err) => return print_error(err.to_string()),
     };
 
-    let sync = auto_sync::enabled(args.no_sync);
+    // A dry run never commits, so there's nothing to push; force
+    // auto-sync off so a preview can't pull the remote in either.
+    let sync = !args.dry_run && auto_sync::enabled(args.no_sync);
     match auto_sync::run_eval(&site, source, options, sync).await {
         Ok(outcome) => {
             let mut stdout = std::io::stdout().lock();

--- a/rust/slide/src/eval.rs
+++ b/rust/slide/src/eval.rs
@@ -65,6 +65,11 @@ pub struct Options {
     pub format: Format,
     /// Suppress the matches section and emit only the envelope.
     pub quiet: bool,
+    /// Run analysis + queries + planning but drop the transaction
+    /// instead of committing. Mirrors the worker's `transact=false`
+    /// preview: `commits.claims` is zeroed and `revision_after ==
+    /// revision_before`, so the branch is left untouched.
+    pub dry_run: bool,
 }
 
 impl Default for Options {
@@ -72,6 +77,7 @@ impl Default for Options {
         Self {
             format: Format::Notation,
             quiet: false,
+            dry_run: false,
         }
     }
 }
@@ -159,10 +165,11 @@ pub async fn run_against_site(
         .await
         .map_err(map_evaluate_error)?;
 
-    // Slide always commits when there are mutation statements
-    // (the CLI doesn't have a dry-run mode today). Pure-query
-    // docs short-circuit so we don't pay for a no-op commit.
-    let (response, committed) = if evaluated.analysis.analysis.has_statements() {
+    // Commit only a mutating document that wasn't run as a dry
+    // run. Pure-query docs and `--dry-run` short-circuit so we
+    // don't pay for (or apply) a commit.
+    let (response, committed) = if !options.dry_run && evaluated.analysis.analysis.has_statements()
+    {
         let revision_after = evaluated
             .txn
             .commit()
@@ -184,13 +191,20 @@ pub async fn run_against_site(
             true,
         )
     } else {
+        // Pure-query or dry-run: drop the transaction. The
+        // pre-mutation matches double as "after" because nothing
+        // landed. Zero `claims` so the summary reflects what *did*
+        // commit (nothing), not what *would* have — same contract
+        // the worker's `transact=false` preview honors.
+        let mut commits = evaluated.commits;
+        commits.claims = 0;
         (
             EvaluateResponse {
                 revision_before: revision_before.clone(),
                 revision_after: revision_before,
                 matches_before: evaluated.matches.clone(),
                 matches_after: evaluated.matches,
-                commits: evaluated.commits,
+                commits,
             },
             false,
         )

--- a/rust/slide/src/guide-index.md
+++ b/rust/slide/src/guide-index.md
@@ -15,6 +15,9 @@ them, and publish views that render those facts.
    - `slide eval <path>`       — from a file
    - `<doc> | slide eval -`    — from stdin
    A committing eval auto-syncs (pull-before / push-after) unless `--no-sync`.
+   Add `--dry-run` to preview a document without committing: queries run and
+   matches come back, but the transaction is dropped and the branch is left
+   untouched (zero claims, unchanged revision). Implies `--no-sync`.
 3. Share a live view: `slide share display <entity> --view <name>`.
 4. Render a view to HTML headlessly: `slide render <route>` —
    `slide render person` (directory), `slide render alice@person` (one

--- a/rust/slide/tests/notation.rs
+++ b/rust/slide/tests/notation.rs
@@ -190,6 +190,78 @@ task!:
         assert_eq!(total, 0);
         Ok(())
     }
+
+    #[dialog_common::test]
+    async fn it_does_not_commit_a_dry_run_mutation() -> Result<()> {
+        use slide::eval::Options;
+        use slide::output::Format;
+
+        let test = common::TestSite::new().await?;
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+
+        let dry_run = Options {
+            format: Format::Notation,
+            quiet: false,
+            dry_run: true,
+        };
+        let outcome = test
+            .eval_inline_with(
+                "task!: &t\n  title: \"Drafted, not saved\"\n  done: false\n",
+                dry_run,
+            )
+            .await?;
+
+        // A dry run plans but drops the transaction: nothing
+        // committed, zero claims, and the branch head is unmoved.
+        assert!(!outcome.committed);
+        assert_eq!(outcome.response.commits.claims, 0);
+        assert_eq!(
+            outcome.response.revision_before,
+            outcome.response.revision_after,
+        );
+
+        // The task never landed: a follow-up query finds nothing.
+        let after = test.eval_inline("task:\n  this: ?t\n").await?;
+        let total: usize = after
+            .response
+            .matches_after
+            .iter()
+            .map(|b| b.results.len())
+            .sum();
+        assert_eq!(total, 0, "dry-run mutation must not persist");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_matches_for_a_dry_run_query() -> Result<()> {
+        use slide::eval::Options;
+        use slide::output::Format;
+
+        let test = common::TestSite::new().await?;
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+        test.eval_inline("task!: &t\n  title: \"Real task\"\n  done: false\n")
+            .await?;
+
+        // A pure query under --dry-run still surfaces matches.
+        let dry_run = Options {
+            format: Format::Notation,
+            quiet: false,
+            dry_run: true,
+        };
+        let outcome = test
+            .eval_inline_with("task:\n  this: ?t\n  title: ?title\n", dry_run)
+            .await?;
+        let total: usize = outcome
+            .response
+            .matches_after
+            .iter()
+            .map(|b| b.results.len())
+            .sum();
+        assert_eq!(total, 1, "dry-run query should still return matches");
+        Ok(())
+    }
 }
 
 mod when_reporting_errors {
@@ -250,6 +322,7 @@ task!: &ax
                 eval::Options {
                     format: Format::Notation,
                     quiet: false,
+                    dry_run: false,
                 },
             )
             .await?;


### PR DESCRIPTION
`slide eval` commits any document with mutation statements, so there was no way to see what a write would do (the matches it returns, the entity it would mint) without actually applying it. The web worker's `/evaluate` route already solved this with `transact=false`, which the notebook editor uses to render results as you type without committing. The CLI had no equivalent, and `--no-sync` is not a substitute: it still commits locally and leaves the branch diverged from upstream.

`--dry-run` runs the same analyze → query → plan pipeline and then drops the transaction instead of committing. It reuses the machinery that was already there: `matches_after` is computed against the txn overlay before the commit decision, so the only change is gating the `commit()` call. The dry-run path zeros `claims` and leaves the revision unchanged, matching the worker's `transact=false` contract exactly, and it implies `--no-sync` so a preview never reaches the remote.

Filed as BUG-15 in the squash space.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `--dry-run` option for the `slide` CLI, allowing users to preview document changes without committing. It modifies the evaluation process to support this feature, ensuring that no changes are applied while still providing query results.

### Detailed summary
- Added `--dry-run` option to preview changes without committing.
- Introduced `dry_run` field in `Options` struct in `eval.rs`.
- Updated logic in `run_against_site` to handle `dry_run` cases.
- Modified `EvalArgs` struct to include `dry_run` argument.
- Implemented tests to verify behavior of dry runs in `notation.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->