### PR TITLE
feat(workspace): adopt optionals — binder active field, retire tonk/active-sheet

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -876,6 +876,40 @@ mod tests {
                 .expect("concept assertion commits");
         }
 
+        /// Assert standalone attributes on the branch and publish
+        /// each under a name. Builds a throwaway concept descriptor
+        /// so [`assert_concept_named`] writes the `dialog.attribute/
+        /// {id,type,cardinality}` claims an `AttributeDefinition`
+        /// needs, then publishes a `dialog.name/referent` for each
+        /// attribute entity so a bare-symbol reference resolves it by
+        /// name (mirrors `attribute!: &name` in real notation).
+        ///
+        /// Each entry is `(published name, field key, `the` URI,
+        /// type label)`.
+        async fn attributes(&self, attrs: &[(&str, &str, &str, &str)]) {
+            let mut with = serde_json::Map::new();
+            for (_, field, the, ty) in attrs {
+                with.insert(
+                    (*field).into(),
+                    serde_json::json!({ "the": the, "as": ty, "cardinality": "one" }),
+                );
+            }
+            let descriptor: ConceptDescriptor =
+                serde_json::from_value(serde_json::json!({ "with": with }))
+                    .expect("descriptor JSON is well-formed");
+            self.assert_concept_named("__attrs", &descriptor).await;
+            for (name, field, _, _) in attrs {
+                let attr = descriptor
+                    .with()
+                    .iter()
+                    .find(|(f, _)| f == field)
+                    .map(|(_, a)| a)
+                    .expect("field is in the descriptor");
+                let entity: Entity = attr.to_uri().parse().expect("attribute URI");
+                self.publish_name(name, entity).await;
+            }
+        }
+
         /// Publish a `dialog.name/referent` claim binding `name`
         /// to `entity`. Used by tests that need a name to resolve
         /// to a specific entity (not a concept the test asserted).
@@ -1451,6 +1485,59 @@ concept!: &person
             "bare-reference `maybe:` field must emit an optional marker; saw {field_names:?}"
         );
         assert!(query.terms.get("optional.nickname").is_some());
+    }
+
+    /// A `maybe:` field referencing an attribute that lives on the
+    /// branch (not declared in the document) must resolve, exactly
+    /// like a `with:` field does. The prefetch phase has to gather
+    /// references from both blocks — gathering only `with:` left
+    /// branch attributes referenced solely from `maybe:` unresolved,
+    /// surfacing as a spurious "unknown name" error.
+    #[dialog_common::test]
+    async fn it_resolves_branch_attribute_referenced_from_maybe() {
+        // The branch holds two attributes published as the bare
+        // (dot-free) names `dir/title` and `dir/icon` so a reference
+        // parses as a name lookup, not a dotted-domain URI.
+        let fixture = new_fixture().await;
+        fixture
+            .attributes(&[
+                ("dir/title", "title", "xyz.tonk.dir/title", "Text"),
+                ("dir/icon", "icon", "xyz.tonk.dir/icon", "Text"),
+            ])
+            .await;
+
+        // A fresh concept references `title` from `with:` (control)
+        // and `icon` from `maybe:` (the path the bug broke) — both
+        // by published branch name, neither declared in this doc.
+        let syntax = must_parse(
+            r#"
+concept!: &card
+  description: "A card"
+  with:
+    title: dir/title
+  maybe:
+    icon: dir/icon
+"#,
+        );
+        let analysis = flat(fixture.analyze(&syntax).await.unwrap());
+        assert!(analysis.declarations.contains_key("card"));
+        let card = analysis.mutate.statements.last().unwrap();
+        let Statement::Assert(Application::Concept { query, .. }) = card else {
+            panic!("expected concept assertion");
+        };
+        let field_names: Vec<&str> = query.predicate.with().iter().map(|(n, _)| n).collect();
+        assert!(
+            field_names.contains(&"with.title"),
+            "required `with:` reference must resolve; saw {field_names:?}"
+        );
+        assert!(
+            field_names.contains(&"with.icon"),
+            "optional `maybe:` reference to a branch attribute must resolve; saw {field_names:?}"
+        );
+        assert!(
+            field_names.contains(&"optional.icon"),
+            "the `maybe:` field must still be marked optional; saw {field_names:?}"
+        );
     }
 
     /// A bare symbol in field-value position resolves through the

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -332,13 +332,15 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
     })
 }
 
-/// Gather the attribute references a `concept!`'s `with:` map makes
-/// by bare symbol / `?var` / URI, as [`Need`]s. Inline attribute
-/// definitions (a nested mapping) declare their own entity and
-/// need no resolution, so they're skipped here.
+/// Gather the attribute references a `concept!`'s `with:` and
+/// `maybe:` maps make by bare symbol / `?var` / URI, as [`Need`]s.
+/// Both required and optional fields can reference branch attributes
+/// by name or URI, so both blocks must be prefetched. Inline
+/// attribute definitions (a nested mapping) declare their own entity
+/// and need no resolution, so they're skipped here.
 fn collect_concept_with_needs(assertion: &tonk_notation::Application, needs: &mut Vec<Need>) {
     for field in &assertion.fields {
-        if field.name != "with" {
+        if field.name != "with" && field.name != "maybe" {
             continue;
         }
         let FieldValue::Nested(inner) = &field.value else {

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -828,12 +828,13 @@ view/label!:
     {name}
 
 # Tab close. Clicking a tab's close button fires the transient
-# `close-sheet` command. `sheet` is the closed sheet; `next` is the
-# neighbour the binder picked (by tab order) to fall back to when the
-# closed sheet was the active one. The two rules below (a) retract the
-# sheet's `order` so it no longer matches the sheet directory (the tab
-# disappears; the underlying artifact survives), and (b) move the
-# binder's `active` to `next` if the closed sheet was active.
+# `close-sheet` command carrying just the closed sheet. The rule below
+# retracts the sheet's `order` so it no longer matches the sheet
+# directory (the tab disappears; the underlying artifact survives).
+# Reassigning the live selection to a neighbour is the binder element's
+# job: on close it moves `active` to the neighbour and dispatches an
+# `activate` (the single `active` writer), so no `next` field and no
+# reassign rule are needed here.
 command!: &workspace/close-sheet
   description: A request to close `sheet`, demoting it back to a plain artifact.
   with:
@@ -846,10 +847,6 @@ command!: &workspace/close-sheet
         close also read as an activate request and select the closed
         tab.
       the: dom.event.detail/closed
-      as: entity
-    next:
-      description: The neighbour sheet to activate if the closed one was active
-      the: dom.event.detail/next
       as: entity
 
 # A minimal projection of a sheet's `order` key - the one field a
@@ -879,22 +876,6 @@ rule!:
       where: { sheet: ?this }
     - assert: workspace/sheet-order
       where: { this: ?this, order: ?order }
-
-# Reassign active: when the closed sheet was the binder's active one,
-# point `active` at the neighbour the binder supplied. The binder is
-# the replica's (bound through `tonk/replica`); the `active: ?sheet`
-# join gates this to the active-sheet case, so closing a non-active
-# sheet leaves `active` untouched (no match).
-rule!:
-  description: Moves the binder's active pointer to the neighbour when the active sheet closes
-  assert!: tonk/active-sheet
-  when:
-    - assert: workspace/close-sheet
-      where: { sheet: ?sheet, next: ?active }
-    - assert: tonk/replica
-      where: { this: ?this, subject: ?subject }
-    - assert: tonk/active-sheet
-      where: { this: ?this, active: ?sheet }
 
 # The sheet-mount view (default view for `workspace/sheet`): wraps the
 # sheet's content in a `<tonk-sheet>` carrying its metadata as
@@ -1475,17 +1456,18 @@ rule!:
 
 rule!:
   description: Activates the freshly created sheet
-  assert!: tonk/active-sheet
+  assert!: tonk/binder
   when:
     - assert: workspace/create-sheet
       where:
         this: ?active
         name: ?title
         order: ?order
-    # The active sheet is the replica's (bound through `tonk/replica`);
-    # point its `active` at the new sheet so creating lands the user on
+    # The binder is the replica's (bound through `tonk/replica`); record
+    # its default `active` at the new sheet so creating lands the user on
     # the new empty artifact (the head's `active` field unifies with the
-    # created sheet `?active`).
+    # created sheet `?active`). `subject` carries the replica's identity so
+    # the partial update keeps the binder's required field.
     - assert: tonk/replica
       where:
         this: ?this
@@ -1936,7 +1918,7 @@ view!:
         <p class="share-dialog__note">Everyone who follows this link becomes a member of this space. The link stays active, so share it only with people you want to let in.</p>
       </wa-dialog>
 
-      <tonk-display model=workspace/sheet data-binder={this} />
+      <tonk-display model=workspace/sheet data-binder={this} data-active={active} />
     </div>
 
 
@@ -2306,8 +2288,7 @@ view/directory!:
         }
       </style>
 
-      <tonk-sheet-binder class="workspace__binder" onactivate=workspace/activate-sheet onclose=workspace/close-sheet oncreate=workspace/create-sheet>
-        <tonk-display slot="active" entity={dom.host/data-binder} model=tonk:active-sheet><span slot="no-entity"></span></tonk-display>
+      <tonk-sheet-binder class="workspace__binder" default-active={dom.host/data-active} onactivate=workspace/activate-sheet onclose=workspace/close-sheet oncreate=workspace/create-sheet>
         <div slot="empty" class="workspace-launchpad" hidden>
           <div class="workspace-launchpad__inner">
             <h1 class="workspace-launchpad__title">nothing here yet.</h1>
@@ -2339,38 +2320,29 @@ concept!: &tonk/binder
         repository-name banner — no bridge view needed.
       the: dialog.origin/subject
       as: entity
-
-concept!: &tonk/active-sheet
-  this: tonk:active-sheet
-  description: A an active sheet on the binder
-  with:
+  maybe:
     active:
-      description: Currently active sheet
+      description: |
+        The binder's default/initial sheet selection — like a form
+        control's `defaultValue`. Optional: a freshly created or joined
+        replica has selected no tab yet, so the field is simply absent
+        and the binder falls back to the first sheet by order. The
+        binder element owns the LIVE selection in its own DOM state
+        (instant on click); this field only seeds the initial selection
+        on mount and records the latest pick so it survives a reload.
       the: xyz.tonk.binder/active
       as: entity
 
-# The active-sheet feed — the default view for `tonk:active-sheet`. The
-# shell slots `<tonk-display model=tonk:active-sheet>` into the binder's
-# `[slot="active"]`; this view renders just the active sheet id as bare
-# text, which `<tonk-sheet-binder>` reads to highlight the live tab. When
-# no `tonk/active-sheet` fact exists yet (a freshly created or joined
-# replica that never selected a tab), the model resolves nothing and the
-# slot stays empty, so the binder falls back to the first sheet by order.
-view!:
-  this: id:active-sheet/feed
-  model: tonk:active-sheet
-  display: |
-    {active}
-
-# Tab selection: when an `activate-sheet` command fires, point the
-# active sheet at the clicked one (replacing the prior selection). The
-# active sheet is the replica's (one per device, bound through
+# Tab selection: when an `activate-sheet` command fires, record the
+# clicked sheet as the binder's default `active` selection (replacing the
+# prior one). The binder is the replica's (one per device, bound through
 # `tonk/replica`), so the command needs only the sheet — no binder id
-# plumbed through the DOM. Mirrors the close/create rules. The slotted
-# `<tonk-display model=tonk:active-sheet>` reads this back to light the
-# live tab.
+# plumbed through the DOM. The shell view reads `{active}` straight off
+# the binder model to seed the live tab; the binder element owns the live
+# selection thereafter, so this write only persists the default for the
+# next mount.
 rule!:
-  assert!: tonk/active-sheet
+  assert!: tonk/binder
   when:
     - assert: workspace/activate-sheet
       where: { sheet: ?active }

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -33,6 +33,7 @@
 //! through a `<tonk-display>`), so a `MutationObserver` re-projects as
 //! they land.
 
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -105,8 +106,24 @@ impl CustomElement for TonkSheetBinder {
         if old == new {
             return;
         }
+        // Skip the callback when it fires re-entrantly from our own
+        // `active` write inside `project` (seeding from `default-active`).
+        // The in-progress `project` renders with the seeded value, so a
+        // nested re-project is redundant — and re-entering would deadlock
+        // the custom-element harness mutex held across this callback.
+        if PROJECTING.with(Cell::get) {
+            return;
+        }
         project(this);
     }
+}
+
+thread_local! {
+    /// Set while [`project`] runs so a synchronous `active` write it makes
+    /// (seeding from `default-active`) does not re-enter via
+    /// `attribute_changed_callback`. wasm is single-threaded, so a plain
+    /// `Cell` suffices.
+    static PROJECTING: Cell<bool> = const { Cell::new(false) };
 }
 
 /// CSS class names the consuming view styles.
@@ -143,6 +160,18 @@ const EMPTY: &str = "data-empty";
 /// Build/refresh the tab strip from the `<tonk-sheet>` children, then
 /// apply ordering + the active state. Idempotent.
 fn project(this: &HtmlElement) {
+    // Mark this pass so a synchronous `active` write (the `default-active`
+    // seed in `active_sheet`) does not re-enter `attribute_changed_callback`.
+    // The drop guard clears the flag on every exit path.
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            PROJECTING.with(|p| p.set(false));
+        }
+    }
+    PROJECTING.with(|p| p.set(true));
+    let _reset = Reset;
+
     let Some(document) = window().and_then(|w| w.document()) else {
         return;
     };

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -888,13 +888,14 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_dispatches_close_with_the_neighbour_as_next() {
+    async fn it_dispatches_close_carrying_only_the_closed_sheet() {
         let binder = mount_binder("a", &[("a", "a", "First"), ("b", "b", "Second")]);
         let (closed, _closed_l) = capture_detail("close", "closed");
         let (next, _next_l) = capture_detail("close", "next");
 
-        // Click the close button of the first tab. Its neighbour by
-        // order is the second sheet, so `next` should be `b`.
+        // Click the close button of the first tab. The `close` event
+        // carries only `closed`; the neighbour switch is handled by a
+        // separate `activate` dispatch, so `close` has no `next` field.
         let close = binder
             .query_selector(&format!(".{TAB}[data-sheet=\"a\"] .{CLOSE}"))
             .unwrap()
@@ -902,16 +903,41 @@ mod tests {
         close.dyn_ref::<HtmlElement>().unwrap().click();
 
         assert_eq!(closed.borrow().as_deref(), Some("a"));
-        assert_eq!(next.borrow().as_deref(), Some("b"));
+        assert_eq!(
+            next.borrow().as_deref(),
+            None,
+            "close no longer carries a next field",
+        );
         binder.remove();
     }
 
     #[dialog_common::test]
-    async fn it_falls_back_to_about_blank_next_when_closing_the_only_sheet() {
-        // Closing the last sheet has no neighbour, so `next` falls back to
-        // `about:blank` rather than being omitted: the `close-sheet`
-        // command's `next` field is required, and an absent event field
-        // would fail the whole command build, leaving the tab unclosable.
+    async fn it_activates_the_neighbour_when_closing_the_active_sheet() {
+        // Closing the active sheet hands selection to its neighbour via a
+        // separate `activate` event (the single writer a click uses), not
+        // through a `next` field on `close`.
+        let binder = mount_binder("a", &[("a", "a", "First"), ("b", "b", "Second")]);
+        let (activated, _activated_l) = capture_detail("activate", "sheet");
+
+        let close = binder
+            .query_selector(&format!(".{TAB}[data-sheet=\"a\"] .{CLOSE}"))
+            .unwrap()
+            .expect("close button on active tab a");
+        close.dyn_ref::<HtmlElement>().unwrap().click();
+
+        assert_eq!(
+            activated.borrow().as_deref(),
+            Some("b"),
+            "closing the active sheet activates its neighbour",
+        );
+        binder.remove();
+    }
+
+    #[dialog_common::test]
+    async fn it_omits_next_when_closing_the_only_sheet() {
+        // Closing the last sheet has no neighbour: `active` is removed and
+        // the `close` event carries only `closed` (no `next`). Reopening
+        // therefore starts with no selection and reveals the launchpad.
         let binder = mount_binder("a", &[("a", "a", "Only")]);
         let (closed, _closed_l) = capture_detail("close", "closed");
         let (next, _next_l) = capture_detail("close", "next");
@@ -925,8 +951,13 @@ mod tests {
         assert_eq!(closed.borrow().as_deref(), Some("a"));
         assert_eq!(
             next.borrow().as_deref(),
-            Some("about:blank"),
-            "the only sheet has no neighbour, so next falls back to about:blank",
+            None,
+            "the only sheet has no neighbour, so close carries no next",
+        );
+        assert_eq!(
+            binder.get_attribute("active"),
+            None,
+            "closing the last sheet clears active",
         );
         binder.remove();
     }

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -9,9 +9,15 @@
 //! 1. **Project tabs** — for each `<tonk-sheet>` child it builds one
 //!    tab button (bullet + title) in a strip it owns, keyed by the
 //!    sheet's `sheet` attribute.
-//! 2. **Active** — the `active` attribute names the live sheet. The
-//!    matching `<tonk-sheet>` panel is shown (the rest hidden) and the
-//!    matching tab gets `is-active`.
+//! 2. **Active** — the `active` attribute names the LIVE sheet (the
+//!    one shown, its tab `is-active`). It is owned by the binder: only
+//!    the click handler sets it, so switching is instant. The data
+//!    model never writes `active` directly — a fact change must not
+//!    yank the live tab. Instead the view supplies a separate,
+//!    NON-observed `default-active` attribute (the persisted selection,
+//!    like a form control's `defaultValue`); the binder reads it ONCE
+//!    at connect to seed `active` when unset, and ignores later changes
+//!    to it, so a data update never switches the tab.
 //! 3. **Ordering** — sheets and their tabs are ordered by each
 //!    sheet's `order` attribute. The view's `{sheet}` iteration is
 //!    CID-keyed (not author-controllable), so the binder is what makes
@@ -109,6 +115,13 @@ const TAB: &str = "tonk-sheet-binder__tab";
 const TAB_LABEL: &str = "tonk-sheet-binder__tab-label";
 const CLOSE: &str = "tonk-sheet-binder__close";
 const ACTIVE: &str = "is-active";
+
+/// The non-observed attribute the view sets from the persisted
+/// `tonk/binder.active` fact. Read once at connect to seed the live
+/// `active` selection; later changes are ignored (it is deliberately
+/// absent from [`observed_attributes`]) so a data update never switches
+/// the tab. The live-selection counterpart is the `active` attribute.
+const DEFAULT_ACTIVE: &str = "default-active";
 /// The "+" add-sheet button shown at the end of the strip when idle.
 const ADD: &str = "tonk-sheet-binder__add";
 /// The inline create form shown in place of the "+" button while
@@ -151,8 +164,8 @@ fn project(this: &HtmlElement) {
     // persist the wrong sheet and steal focus from the genuinely-active
     // one. Keeping `active` untouched means once the real active sheet
     // re-mounts the next `project()` shows it again, and a genuinely
-    // stale pointer is corrected by the data model (the active-sheet
-    // rules), not by the binder guessing.
+    // stale seed is corrected when the click handler next sets `active`,
+    // not by the binder guessing.
     let shown = if sheets.iter().any(|s| s.id == active) {
         active.clone()
     } else {
@@ -196,40 +209,39 @@ fn project(this: &HtmlElement) {
     ensure_add_control(this, &strip, &document);
 }
 
-/// The active sheet id the binder should show. Read from the
-/// `[slot="active"]` child's text — the consuming view slots a
-/// `<tonk-display model=tonk:active-sheet>` there, which renders the
-/// binder entity's recorded `active` sheet id (and nothing when no
-/// `active` fact exists yet, e.g. a freshly joined replica). An empty
-/// result lets `project()` fall back to the first sheet by order.
-///
-/// Falls back to the `active` attribute when no slot is present, so a
-/// view that sets `active` directly (or an older markup) still works.
-/// The slot wins when both are present — it is the live, queryable
-/// source; the attribute is the static legacy path.
+/// The active sheet id the binder should show. The live `active`
+/// attribute wins once set (the click handler owns it); otherwise it
+/// is seeded ONCE from `default-active`, the non-observed attribute the
+/// consuming view sets from the binder entity's persisted
+/// `tonk/binder.active` field (empty when no selection exists yet, e.g.
+/// a freshly joined replica). An empty result lets `project()` fall
+/// back to the first sheet by order.
 fn active_sheet(this: &HtmlElement) -> String {
     // The binder's own `active` attribute is the source of truth once set:
     // the click handler sets it optimistically on selection, so switching is
-    // instant and immune to the persisted `tonk/active-sheet` fact changing
-    // underneath (which would otherwise yank the tab around). It behaves like
-    // a form control's value after the user has interacted.
+    // instant and immune to the persisted selection changing underneath
+    // (which would otherwise yank the tab around). It behaves like a form
+    // control's value after the user has interacted.
     if let Some(active) = this.get_attribute("active").filter(|s| !s.is_empty()) {
         return active;
     }
 
-    // Not yet set: seed it ONCE from the `[slot="active"]` display, which
-    // renders the persisted `tonk:active-sheet` id (the default / initial
-    // selection, like `defaultValue`). Writing it onto the attribute makes
-    // the binder own it from here on; a later slot change is ignored. An
-    // empty slot (no persisted active — a fresh replica) leaves the
-    // attribute unset so `project()` falls back to the first sheet.
-    if let Ok(Some(slot)) = this.query_selector(":scope > [slot=\"active\"]") {
-        let seed = slot.text_content().unwrap_or_default();
-        let seed = seed.trim();
-        if !seed.is_empty() {
-            let _ = this.set_attribute("active", seed);
-            return seed.to_owned();
-        }
+    // Not yet set: seed it ONCE from `default-active`, the NON-observed
+    // attribute the view sets from the persisted `tonk/binder.active` fact
+    // (the default / initial selection, like `defaultValue`). Writing it
+    // onto `active` makes the binder own it from here on; because
+    // `default-active` is not in `observed_attributes`, a later fact-driven
+    // change to it does NOT fire `attribute_changed_callback`, so a data
+    // update never switches the live tab. Empty (no persisted active — a
+    // fresh replica) leaves `active` unset so `project()` falls back to the
+    // first sheet.
+    if let Some(seed) = this
+        .get_attribute(DEFAULT_ACTIVE)
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        let _ = this.set_attribute("active", &seed);
+        return seed;
     }
     String::new()
 }
@@ -521,30 +533,35 @@ fn install_click(this: &HtmlElement, slot: &ClickClosure) {
             return;
         };
 
-        // Close button: don't activate — retract the sheet. Tell the
-        // command which sheet to fall back to (the neighbour by
-        // order) so closing the active tab reveals an adjacent one
-        // rather than leaving the workspace blank.
+        // Close button: don't activate — retract the sheet.
         if node.closest(&format!(".{CLOSE}")).ok().flatten().is_some() {
             event.stop_propagation();
             let next = neighbour(&host, &sheet);
 
-            // Optimistic: if the closed sheet was active, move `active`
-            // to the neighbour *before* the data round-trip retracts
-            // the sheet. Otherwise `active` keeps pointing at a sheet
-            // that is about to vanish, and once its `<tonk-sheet>` panel
-            // is gone the panel CSS (`:has(tonk-sheet:not([hidden]))`)
-            // finds no visible panel and collapses the layout. Pointing
-            // `active` at the surviving neighbour now keeps a panel
-            // shown throughout. With no neighbour (the last sheet),
-            // `active` moves to `about:blank` so the binder reads as
-            // empty and reveals the launchpad. The command (fired below)
-            // persists the same `active` via the reassign rule.
+            // If the closed sheet was the live one, hand selection to the
+            // neighbour *before* the data round-trip retracts the sheet.
+            // Otherwise `active` keeps pointing at a sheet about to vanish,
+            // and once its `<tonk-sheet>` panel is gone the panel CSS
+            // (`:has(tonk-sheet:not([hidden]))`) finds no visible panel and
+            // collapses the layout. With a neighbour we move `active` to it
+            // (live switch) and dispatch `activate` so the new selection is
+            // persisted as the binder's default — the same single writer
+            // a click uses. With no neighbour (the last sheet) we clear
+            // `active` so the binder reads as empty and reveals the
+            // launchpad; nothing is persisted, so reopening starts fresh.
             if host.get_attribute("active").as_deref() == Some(sheet.as_str()) {
-                let _ = host.set_attribute("active", next.as_deref().unwrap_or(NO_NEIGHBOUR));
+                match next.as_deref() {
+                    Some(neighbour) => {
+                        let _ = host.set_attribute("active", neighbour);
+                        dispatch_activate(&host, neighbour);
+                    }
+                    None => {
+                        let _ = host.remove_attribute("active");
+                    }
+                }
             }
 
-            dispatch_close(&host, &sheet, next.as_deref());
+            dispatch_close(&host, &sheet);
             return;
         }
 
@@ -623,30 +640,21 @@ fn neighbour(this: &HtmlElement, sheet: &str) -> Option<String> {
         .map(|s| s.id.clone())
 }
 
-/// Dispatch `close` with `detail = { closed, next }`, bubbling +
-/// composed. The closed sheet is carried as `closed` (NOT `sheet`):
-/// the `activate` event uses `sheet`, and the workspace's
-/// `activate-sheet` command reads `dom.event.detail/sheet`, so a close
-/// carrying `sheet` would also match that command and select the
-/// closed tab. `next` is the neighbour to activate after the close; when
-/// the closed sheet was the only one it falls back to `about:blank` (the
-/// "no selection" sentinel) so the command always has a value to bind —
-/// the `close-sheet` command's `next` field is required, and an absent
-/// event field would fail the whole command build, leaving the last tab
-/// unclosable. Reassigning active to `about:blank` renders as empty, so
-/// closing the last sheet reveals the launchpad.
-const NO_NEIGHBOUR: &str = "about:blank";
-fn dispatch_close(host: &HtmlElement, closed: &str, next: Option<&str>) {
+/// Dispatch `close` with `detail = { closed }`, bubbling + composed.
+/// The closed sheet is carried as `closed` (NOT `sheet`): the
+/// `activate` event uses `sheet`, and the workspace's `activate-sheet`
+/// command reads `dom.event.detail/sheet`, so a close carrying `sheet`
+/// would also match that command and select the closed tab. The close
+/// command only retracts the sheet's `order` (demoting it); reassigning
+/// the live selection to the neighbour is handled in the click handler,
+/// which dispatches an `activate` for the neighbour — so the event
+/// carries no `next`.
+fn dispatch_close(host: &HtmlElement, closed: &str) {
     let detail = js_sys::Object::new();
     let _ = js_sys::Reflect::set(
         &detail,
         &JsValue::from_str("closed"),
         &JsValue::from_str(closed),
-    );
-    let _ = js_sys::Reflect::set(
-        &detail,
-        &JsValue::from_str("next"),
-        &JsValue::from_str(next.unwrap_or(NO_NEIGHBOUR)),
     );
     let init = CustomEventInit::new();
     init.set_detail(&detail);
@@ -790,13 +798,12 @@ fn reobserve(observer: &MutationObserver, target: &HtmlElement) {
     let init = MutationObserverInit::new();
     init.set_child_list(true);
     init.set_subtree(true);
+    // Watch attributes (incl. the non-observed `default-active` seed, which
+    // the consuming view sets after connect as its `<tonk-display>` resolves)
+    // so the first appearance re-runs `project()` and seeds the binder's
+    // live `active`. The observer is disconnected during `project()`, so the
+    // binder's own attribute writes don't re-trigger this.
     init.set_attributes(true);
-    // The active-sheet `[slot="active"]` display surfaces the seed id as a
-    // text node that lands asynchronously; watch character data so the first
-    // resolve re-runs `project()` and seeds the binder's `active`. The
-    // observer is disconnected during `project()`, so the binder's own text
-    // writes don't re-trigger this.
-    init.set_character_data(true);
     let _ = observer.observe_with_options(target, &init);
 }
 


### PR DESCRIPTION
Optionals shipped in #481; this begins adopting them where we previously faked optionality with sentinels and carrier concepts.

The binder's active sheet was tracked by a separate `tonk/active-sheet` concept purely because we couldn't give the binder itself an optional `active` field. With `maybe:` that workaround is unnecessary: `tonk/binder` now carries an optional `active` field directly, and `tonk/active-sheet` (plus its feed view) is gone. The activate-sheet and create-sheet rules assert onto `tonk/binder`; the reassign-on-close rule is dropped.

To keep the regression we fixed earlier from coming back — where writing `active` on the binder element would yank the visible tab — initial selection and live selection are kept as separate writers, mirroring HTML's `defaultValue`/`value`. The directory view seeds the element via a non-observed `default-active` attribute (read once), while the live, click-owned `active` attribute stays the sole writer the binder observes. Closing the last sheet removes `active` rather than reassigning it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the handling of attribute references in the `tonk` framework, particularly regarding `with:` and `maybe:` fields. It improves error handling, updates documentation, and refines the logic for managing active sheets in the UI.

### Detailed summary
- Updated documentation to clarify handling of `with:` and `maybe:` fields.
- Modified `collect_concept_with_needs` to include `maybe:` fields.
- Introduced `attributes` function to assert and publish attributes.
- Added tests for resolving branch attributes from `maybe:`.
- Changed `close-sheet` command to omit `next` from the close event.
- Updated logic in the `install_click` function to manage active sheets correctly.
- Refined handling of `active` and `default-active` attributes in the binder.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->