### PR TITLE
fix(dev): point dev:web /ucan/ proxy at staging.tonk.xyz

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
           "dev:web" = {
             description = "Start a dev server (set UCAN_ENDPOINT to override /ucan/ proxy)";
             command = ''
-              ENDPOINT="''${UCAN_ENDPOINT:-https://tonk-access-service.tonk.workers.dev/ucan/}"
+              ENDPOINT="''${UCAN_ENDPOINT:-https://staging.tonk.xyz/ucan/}"
               trunk serve --config ./rust/tonk-ui/Trunk.toml --proxy-backend "$ENDPOINT"
             '';
           };


### PR DESCRIPTION
The local dev server creates a `home` space and immediately tries to sync it, but sync was failing with Cloudflare 404 / `error code: 1042`.

The access service moved to custom domains (`hub.tonk.xyz` prod, `staging.tonk.xyz` staging) and its `tonk-access-service.tonk.workers.dev` hostname no longer routes — but `dev:web` still defaulted the Trunk `/ucan/` proxy backend at that dead workers.dev URL. The deployed app is unaffected because there `/ucan/` is same-origin; only the local proxy default was stale.

Point the default at the live `staging.tonk.xyz/ucan/`. `UCAN_ENDPOINT` still overrides it (e.g. a local access service or `hub.tonk.xyz`).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ENDPOINT` variable in the `flake.nix` file to point to a new staging URL for the UCAN service.

### Detailed summary
- Changed the `ENDPOINT` default value from `https://tonk-access-service.tonk.workers.dev/ucan/` to `https://staging.tonk.xyz/ucan/`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->