### PR TITLE
refactor: rename view/artifact `model` to `concept`

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -2795,7 +2795,7 @@ concept!: &view
   with:
     concept:
       description: "Concept this view renders"
-      the:         xyz.tonk.view/model
+      the:         xyz.tonk.view/concept
       as:          Entity
       cardinality: one
     display:

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -2793,7 +2793,7 @@ concept!: &view
   this: tonk:view
   description: "A view"
   with:
-    model:
+    concept:
       description: "Concept this view renders"
       the:         xyz.tonk.view/model
       as:          Entity
@@ -2804,7 +2804,7 @@ concept!: &view
       as:          Text
       cardinality: one
 view!:
-  model: tonk:view
+  concept: tonk:view
   display: "x"
 "#,
         );
@@ -2831,7 +2831,7 @@ view!:
             use tonk_core::claim::ValueMap;
             use tonk_schema::transact::derive_this;
             let mut body = ValueMap::new();
-            body.insert("model".into(), Value::Entity(pinned.clone()));
+            body.insert("concept".into(), Value::Entity(pinned.clone()));
             body.insert("display".into(), Value::String("x".into()));
             derive_this(&pinned, &body)
         };

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -2822,7 +2822,7 @@ view!:
 
         // The view instance derives its subject from the pinned
         // predicate entity, so its `this` is `derive_this(tonk:view,
-        // {model, display})` — NOT derived from the descriptor hash.
+        // {concept, display})` — NOT derived from the descriptor hash.
         let instance = analysis.mutate.statements.last().unwrap();
         let Statement::Assert(Application::Concept { query, .. }) = instance else {
             panic!("expected view instance assertion");
@@ -3044,7 +3044,7 @@ xyz.tonk:
     /// old `Resolver`-trait world made simulating an I/O failure
     /// trivial; under the source-and-env world the failure has
     /// to come from a misbehaving `QueryEnv`, which the existing
-    /// helpers don't model. Re-enabling this test waits on a
+    /// helpers don't concept. Re-enabling this test waits on a
     /// failure-injecting env helper.
     #[dialog_common::test]
     #[ignore = "scope-env refactor: needs a failure-injecting QueryEnv helper"]

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -510,7 +510,7 @@ fn this_term_for_assertion(
 /// Project an assertion body into the [`ValueMap`] shape fed to
 /// [`derive_this`] for entity derivation. Every field contributes
 /// its *resolved* value, with references (bare symbols, URIs)
-/// resolved to the entity they name — so a view's `model: counter`
+/// resolved to the entity they name — so a view's `concept: counter`
 /// identifies the view by the concept it points at, not merely by
 /// the fields that happen to be literals.
 ///

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -1411,7 +1411,10 @@ rule!:\n\
     async fn it_lifts_a_rule_with_an_equality_constraint_premise() {
         let fixture = new_fixture().await;
         fixture
-            .declare("artifact", one_entity_field("io.gozala.artifact", "model"))
+            .declare(
+                "artifact",
+                one_entity_field("io.gozala.artifact", "concept"),
+            )
             .await;
         fixture
             .declare("request", one_text_field("io.gozala.request", "name"))
@@ -1424,7 +1427,7 @@ rule!:
     - assert: request
       where: { this: ?this, name: ?name }
     - assert: ==
-      where: { this: ?model, is: about:blank }
+      where: { this: ?concept, is: about:blank }
 "#;
         let parsed = parse(doc);
         assert!(
@@ -1450,7 +1453,10 @@ rule!:
     async fn it_rejects_unknown_constraint_operand() {
         let fixture = new_fixture().await;
         fixture
-            .declare("artifact", one_entity_field("io.gozala.artifact", "model"))
+            .declare(
+                "artifact",
+                one_entity_field("io.gozala.artifact", "concept"),
+            )
             .await;
 
         let doc = r#"
@@ -1481,7 +1487,10 @@ rule!:
     async fn it_rejects_missing_constraint_operand() {
         let fixture = new_fixture().await;
         fixture
-            .declare("artifact", one_entity_field("io.gozala.artifact", "model"))
+            .declare(
+                "artifact",
+                one_entity_field("io.gozala.artifact", "concept"),
+            )
             .await;
 
         let doc = r#"
@@ -1596,9 +1605,9 @@ view!:\n\
 
         let fixture = new_fixture().await;
 
-        // A `view` concept whose sole field, `model`, is an entity
+        // A `view` concept whose sole field, `concept`, is an entity
         // reference, plus two distinct concepts it can point at.
-        let view = one_entity_field("xyz.tonk.view", "model");
+        let view = one_entity_field("xyz.tonk.view", "concept");
         fixture.declare("view", view.clone()).await;
         fixture
             .declare("counter", one_text_field("xyz.tonk.counter", "count"))
@@ -1607,10 +1616,13 @@ view!:\n\
             .declare("greeting", one_text_field("xyz.tonk.greeting", "message"))
             .await;
 
-        // Helper: lower a `view!: { model: <name> }` document and
+        // Helper: lower a `view!: { concept: <name> }` document and
         // pull the derived `this` entity out of the lone statement.
-        async fn notation_this_for(fixture: &Fixture<impl FixtureEnv>, model_name: &str) -> Entity {
-            let doc = format!("view!:\n  model: {model_name}\n");
+        async fn notation_this_for(
+            fixture: &Fixture<impl FixtureEnv>,
+            concept_name: &str,
+        ) -> Entity {
+            let doc = format!("view!:\n  concept: {concept_name}\n");
             let syntax = parse(&doc).syntax.expect("parsed syntax");
             let analysis = fixture
                 .analyze(&syntax)
@@ -1646,7 +1658,7 @@ view!:\n\
         // entity, so both paths see identical `(predicate, payload)`.
         let counter_concept = one_text_field("xyz.tonk.counter", "count").this();
         let mut parameters = ValueMap::new();
-        parameters.insert("model".into(), Value::Entity(counter_concept));
+        parameters.insert("concept".into(), Value::Entity(counter_concept));
         let wire_plan = application_plan_from_predicate(PredicateApplication {
             predicate: DurableConceptDescriptor::Durable(view),
             parameters,
@@ -1679,14 +1691,14 @@ view!:\n\
     async fn it_rejects_unresolved_reference_in_derived_entity() {
         let fixture = new_fixture().await;
         // Declare `view` (so the head concept resolves) but NOT the
-        // concept its `model` points at.
+        // concept its `concept` points at.
         fixture
-            .declare("view", one_entity_field("xyz.tonk.view", "model"))
+            .declare("view", one_entity_field("xyz.tonk.view", "concept"))
             .await;
 
         let doc = "\
 view!: &broken\n\
-\x20 model: nonexistent\n";
+\x20 concept: nonexistent\n";
         let syntax = parse(doc).syntax.expect("parsed syntax");
         let err = fixture
             .analyze(&syntax)

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -457,7 +457,7 @@ fn parse_rule_body(application: &SyntaxApplication) -> Result<RuleBody<'_>, Anal
             }
             "description" => {
                 // Description is preserved on the descriptor through
-                // dialog's planner; we don't model it on the analyzer
+                // dialog's planner; we don't concept it on the analyzer
                 // side beyond shape validation.
                 if !matches!(&field.value, FieldValue::Literal(Scalar::String(_))) {
                     return Err(AnalyzeError::at(
@@ -1464,7 +1464,7 @@ rule!:
   assert!: artifact
   when:
     - assert: ==
-      where: { this: ?model, equals: about:blank }
+      where: { this: ?concept, equals: about:blank }
 "#;
         let parsed = parse(doc);
         let syntax = parsed.syntax.expect("parsed syntax");
@@ -1498,7 +1498,7 @@ rule!:
   assert!: artifact
   when:
     - assert: ==
-      where: { this: ?model }
+      where: { this: ?concept }
 "#;
         let parsed = parse(doc);
         let syntax = parsed.syntax.expect("parsed syntax");
@@ -1583,7 +1583,7 @@ view!:\n\
 
     /// Entity derivation includes reference fields, not just
     /// literals — so a concept identified by an entity *reference*
-    /// (e.g. a view's `model`) gets a distinct, correct entity.
+    /// (e.g. a view's `concept`) gets a distinct, correct entity.
     ///
     /// Regression guard for a `body_digest` defect: it used to
     /// include only literal scalars and skip references, so two
@@ -1591,7 +1591,7 @@ view!:\n\
     /// to the **same** entity, and the notation path diverged from
     /// the wire path (`application_plan_from_predicate`), which
     /// always included the reference. Two facets are asserted:
-    ///   1. distinctness — different `model` ⇒ different entity;
+    ///   1. distinctness — different `concept` ⇒ different entity;
     ///   2. convergence  — notation and wire paths agree.
     #[dialog_common::test]
     async fn it_derives_distinct_entities_for_distinct_reference_fields() {
@@ -1642,12 +1642,12 @@ view!:\n\
         let view_of_counter = notation_this_for(&fixture, "counter").await;
         let view_of_greeting = notation_this_for(&fixture, "greeting").await;
 
-        // Facet 1 — distinctness. Today both drop `model` from the
+        // Facet 1 — distinctness. Today both drop `concept` from the
         // digest and collide on `derive_this(view, {})`.
         assert_ne!(
             view_of_counter, view_of_greeting,
-            "views for different models must be different entities; \
-             body_digest dropping the `model` reference makes them collide"
+            "views for different concepts must be different entities; \
+             body_digest dropping the `concept` reference makes them collide"
         );
 
         // Facet 2 — convergence with the wire path for the counter
@@ -1677,14 +1677,14 @@ view!:\n\
         assert_eq!(
             view_of_counter, wire_this,
             "notation and wire paths must derive the same entity when the body \
-             carries a `model` reference"
+             carries a `concept` reference"
         );
     }
 
     /// A reference field that doesn't resolve is an error, not a
-    /// silent skip. Dropping the unresolved `model` from the digest
+    /// silent skip. Dropping the unresolved `concept` from the digest
     /// would fold the view into the entity it would have had with
-    /// no model at all — deriving the wrong subject. The anchor
+    /// no concept at all — deriving the wrong subject. The anchor
     /// (`&broken`) routes derivation through `body_digest` in the
     /// resolve pass, so this exercises that path specifically.
     #[dialog_common::test]

--- a/rust/tonk-board/src/board.rs
+++ b/rust/tonk-board/src/board.rs
@@ -12,7 +12,7 @@
 //!
 //! 2. **Mount a `<tonk-display>`** against the resolved entity
 //!    with `concept="board-view"` (no `view`, so the built-in view
-//!    for that model is used). The view template chain drives
+//!    for that concept is used). The view template chain drives
 //!    strip / column / tile rendering.
 
 use std::cell::RefCell;
@@ -190,7 +190,7 @@ fn mount_display(host: &Element, entity: &str) {
     let Ok(display) = document.create_element("tonk-display") else {
         return;
     };
-    let _ = display.set_attribute("entity", entity);
+    let _ = display.set_attribute("this", entity);
     // No `view` attribute: with `concept="board-view"` the display
     // resolves the built-in view whose `concept` is `board-view`.
     let _ = display.set_attribute("concept", "board-view");

--- a/rust/tonk-board/src/board.rs
+++ b/rust/tonk-board/src/board.rs
@@ -11,7 +11,7 @@
 //!    standard library at repository creation, not by this element.
 //!
 //! 2. **Mount a `<tonk-display>`** against the resolved entity
-//!    with `model="board-view"` (no `view`, so the built-in view
+//!    with `concept="board-view"` (no `view`, so the built-in view
 //!    for that model is used). The view template chain drives
 //!    strip / column / tile rendering.
 
@@ -191,9 +191,9 @@ fn mount_display(host: &Element, entity: &str) {
         return;
     };
     let _ = display.set_attribute("entity", entity);
-    // No `view` attribute: with `model="board-view"` the display
-    // resolves the built-in view whose `model` is `board-view`.
-    let _ = display.set_attribute("model", "board-view");
+    // No `view` attribute: with `concept="board-view"` the display
+    // resolves the built-in view whose `concept` is `board-view`.
+    let _ = display.set_attribute("concept", "board-view");
     let _ = host.append_child(&display);
 }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -126,8 +126,8 @@ enum Command {
 
     /// Render a `<tonk-display>` view to HTML, headlessly.
     ///
-    /// Route grammar: `/{model}` (directory), `/{entity}@{model}`
-    /// (one entity), `/{entity}@{model}!{view}` (explicit view).
+    /// Route grammar: `/{concept}` (directory), `/{entity}@{concept}`
+    /// (one entity), `/{entity}@{concept}!{view}` (explicit view).
     /// Writes HTML to stdout unless `--out <file>` is given.
     #[command(
         after_help = "Examples:\n  tonk render person\n  tonk render alice@person\n  tonk render alice@person!card --out alice.html"
@@ -273,13 +273,13 @@ enum ShareCommand {
         /// The view's anchor name (the `&name` on its `view!:`),
         /// forwarded as `?view=`. `<tonk-display>` resolves it to
         /// the view entity the name points at and reads that
-        /// view's own `model`. Omit it for carousel mode (every
-        /// view published for `--concept`). Mutually exclusive with        /// `--concept`: a named view declares its own model.
+        /// view's own `concept`. Omit it for carousel mode (every
+        /// view published for `--concept`). Mutually exclusive with        /// `--concept`: a named view declares its own concept.
         #[arg(long, value_name = "NAME", conflicts_with = "concept")]
         view: Option<String>,
         /// Concept name (validated locally) or URI for carousel
         /// mode, forwarded as `?concept=`. Not needed with `--view`
-        /// (the view declares its own model); required when
+        /// (the view declares its own concept); required when
         /// `--view` is omitted.
         #[arg(long, value_name = "CONCEPT", required_unless_present = "view")]
         concept: Option<String>,

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -258,10 +258,10 @@ enum ShareCommand {
     /// `/space/<space-name>/branch/main/display/<subject>` with
     /// the supplied `--view` carried across as a query parameter.
     /// Use this for declarative views built against the `view`
-    /// concept (`{model, display}`), identified by their anchor
+    /// concept (`{concept, display}`), identified by their anchor
     /// name — `share view` is for the iframe viewer.
     #[command(
-        after_help = "Examples:\n  tonk share display alice --view person-card\n  tonk share display alice --model person"
+        after_help = "Examples:\n  tonk share display alice --view person-card\n  tonk share display alice --concept person"
     )]
     Display {
         /// Bookmark name or `did:key:…` entity URI for the
@@ -274,16 +274,15 @@ enum ShareCommand {
         /// forwarded as `?view=`. `<tonk-display>` resolves it to
         /// the view entity the name points at and reads that
         /// view's own `model`. Omit it for carousel mode (every
-        /// view published for `--model`). Mutually exclusive with
-        /// `--model`: a named view declares its own model.
-        #[arg(long, value_name = "NAME", conflicts_with = "model")]
+        /// view published for `--concept`). Mutually exclusive with        /// `--concept`: a named view declares its own model.
+        #[arg(long, value_name = "NAME", conflicts_with = "concept")]
         view: Option<String>,
         /// Concept name (validated locally) or URI for carousel
-        /// mode, forwarded as `?model=`. Not needed with `--view`
+        /// mode, forwarded as `?concept=`. Not needed with `--view`
         /// (the view declares its own model); required when
         /// `--view` is omitted.
         #[arg(long, value_name = "CONCEPT", required_unless_present = "view")]
-        model: Option<String>,
+        concept: Option<String>,
         /// Override the URL prefix the launcher is built against.
         #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
         ui_base: String,
@@ -852,7 +851,7 @@ async fn share_op(command: ShareCommand) -> ExitCode {
         ShareCommand::Display {
             subject,
             view,
-            model,
+            concept,
             ui_base,
             space_name,
             remote,
@@ -862,8 +861,14 @@ async fn share_op(command: ShareCommand) -> ExitCode {
                 remote,
                 space_name,
             };
-            match share::share_display(&site, &subject, view.as_deref(), model.as_deref(), options)
-                .await
+            match share::share_display(
+                &site,
+                &subject,
+                view.as_deref(),
+                concept.as_deref(),
+                options,
+            )
+            .await
             {
                 Ok(outcome) => {
                     print_share_display_outcome(&outcome);
@@ -912,8 +917,8 @@ fn print_share_display_outcome(outcome: &ShareDisplayOutcome) {
     if let Some(view) = &outcome.view_name {
         eprintln!("view:    {}", view);
     }
-    if let Some(model) = &outcome.model {
-        eprintln!("model:   {}", model);
+    if let Some(concept) = &outcome.concept {
+        eprintln!("concept: {}", concept);
     }
     eprintln!("space:   {}", outcome.space_name);
     eprintln!(

--- a/rust/tonk-cli/src/render.rs
+++ b/rust/tonk-cli/src/render.rs
@@ -1,7 +1,7 @@
 //! `tonk render <route>` — headless server-side rendering of a
 //! `<tonk-display>` view to an HTML string.
 //!
-//! The model -> view -> entity -> HTML orchestration lives in
+//! The concept -> view -> entity -> HTML orchestration lives in
 //! [`tonk_render::page`]; this module is just the tonk-side wiring:
 //! it implements [`tonk_render::QueryBackend`] over a [`TonkSite`]'s
 //! reactor (the on-disk `.tonk/` `main` branch) and re-exports the

--- a/rust/tonk-cli/src/share.rs
+++ b/rust/tonk-cli/src/share.rs
@@ -13,7 +13,7 @@
 //! - [`share_display`] points at the `<tonk-display>` route —
 //!   `then=<subject>?view=<view-name>` (maps to `/space/<name>/<subject>`
 //!   via the `*subject` wildcard). `<view-name>` is the view's anchor name;
-//!   the view carries its own `model`.
+//!   the view carries its own `concept`.
 //!
 //! The launcher URL extends the standard invite URL with two
 //! extra query parameters:
@@ -113,10 +113,10 @@ pub struct ShareDisplayOutcome {
     pub subject_entity: Entity,
     /// View anchor name forwarded as `?view=`, when supplied.
     pub view_name: Option<String>,
-    /// Model (concept name or URI) forwarded as `?model=`, when
+    /// Concept (name or URI) forwarded as `?concept=`, when
     /// supplied — carousel mode only; with `--view` the view
     /// declares its own model. Mirrors what the caller passed.
-    pub model: Option<String>,
+    pub concept: Option<String>,
     /// `name=` value embedded into the URL.
     pub space_name: String,
 }
@@ -392,12 +392,12 @@ pub async fn share_view(
 /// 2. Validate the model when it looks like a name.
 /// 3. Run the shared share prep.
 /// 4. Mint the invite.
-/// 5. Compose the launcher URL with the `?view=&model=` suffix.
+/// 5. Compose the launcher URL with the `?view=&concept=` suffix.
 pub async fn share_display(
     site: &TonkSite,
     subject: &str,
     view_name: Option<&str>,
-    model: Option<&str>,
+    concept: Option<&str>,
     options: ShareOptions,
 ) -> Result<ShareDisplayOutcome, ShareError> {
     let (entity, subject_name) =
@@ -407,7 +407,7 @@ pub async fn share_display(
     // Validate the model when it's a bare identifier. URI-shaped
     // models (anything containing `:`) pass through — same
     // convention as `did:key:…` subjects.
-    if let Some(name) = model.filter(|m| !m.contains(':')) {
+    if let Some(name) = concept.filter(|m| !m.contains(':')) {
         let concepts = schema::list_concepts(site)
             .await
             .map_err(|e| ShareError::Io(format!("failed to list concepts: {e}")))?;
@@ -426,7 +426,7 @@ pub async fn share_display(
     // Bookmarks survive entity-URI changes (re-asserting a view
     // body produces a new entity); the name does not.
     let subject_segment = subject_name.as_deref().unwrap_or(subject);
-    let then = compose_display_then(subject_segment, view_name, model);
+    let then = compose_display_then(subject_segment, view_name, concept);
     let url = mint_and_compose(
         site,
         options.ui_base.as_deref(),
@@ -443,14 +443,14 @@ pub async fn share_display(
         subject_name,
         subject_entity: entity,
         view_name: view_name.map(str::to_owned),
-        model: model.map(str::to_owned),
+        concept: concept.map(str::to_owned),
         space_name,
     })
 }
 
 /// Build the `then=` suffix for a display share: a path under the
-/// recipient's space root with optional `view` / `model` query
-/// parameters appended. The `view`/`model` values are
+/// recipient's space root with optional `view` / `concept` query
+/// parameters appended. The `view`/`concept` values are
 /// form-urlencoded so a stray `&` or `?` in a name doesn't corrupt
 /// the inner query when tonk-ui pastes it onto its space-root path.
 /// The `subject` is left verbatim as a path segment — `did:key:…`
@@ -460,7 +460,7 @@ pub async fn share_display(
 /// The display route is `space/:space/*subject` — a wildcard that
 /// captures the remainder after the space prefix, so the suffix is
 /// just `{subject}` with no leading `display/` keyword segment.
-fn compose_display_then(subject: &str, view: Option<&str>, model: Option<&str>) -> String {
+fn compose_display_then(subject: &str, view: Option<&str>, concept: Option<&str>) -> String {
     let mut path = subject.to_owned();
     let mut pairs = form_urlencoded::Serializer::new(String::new());
     let mut has_any = false;
@@ -468,8 +468,8 @@ fn compose_display_then(subject: &str, view: Option<&str>, model: Option<&str>) 
         pairs.append_pair("view", view);
         has_any = true;
     }
-    if let Some(model) = model {
-        pairs.append_pair("model", model);
+    if let Some(concept) = concept {
+        pairs.append_pair("concept", concept);
         has_any = true;
     }
     if has_any {

--- a/rust/tonk-cli/src/share.rs
+++ b/rust/tonk-cli/src/share.rs
@@ -97,7 +97,7 @@ pub struct ShareOutcome {
 pub struct ShareDisplayOutcome {
     /// The launcher URL — `then=` resolves to the
     /// `<tonk-display>` route with `?view=…` (the view's anchor
-    /// name), and `?model=…` only in carousel mode.
+    /// name), and `?concept=…` only in carousel mode.
     pub url: String,
     /// Local name of the remote whose endpoint got embedded.
     pub remote_name: String,
@@ -115,7 +115,7 @@ pub struct ShareDisplayOutcome {
     pub view_name: Option<String>,
     /// Concept (name or URI) forwarded as `?concept=`, when
     /// supplied — carousel mode only; with `--view` the view
-    /// declares its own model. Mirrors what the caller passed.
+    /// declares its own concept. Mirrors what the caller passed.
     pub concept: Option<String>,
     /// `name=` value embedded into the URL.
     pub space_name: String,
@@ -372,11 +372,11 @@ pub async fn share_view(
 }
 
 /// Push the local repo and mint a launcher URL that points at
-/// the `<tonk-display>` route with the supplied view and model
+/// the `<tonk-display>` route with the supplied view and concept
 /// selectors baked into the query string.
 ///
 /// Subject resolution is identical to [`share_view`] (bookmark
-/// name or `did:key:…` URI). The model argument can be a concept
+/// name or `did:key:…` URI). The concept argument can be a concept
 /// name (validated against the local schema) or a URI (passed
 /// through verbatim). The view argument is forwarded without
 /// validation: `<tonk-display>` resolves the name to a view
@@ -389,7 +389,7 @@ pub async fn share_view(
 /// Steps parallel [`share_view`]:
 ///
 /// 1. Resolve the subject to an entity + optional bookmark.
-/// 2. Validate the model when it looks like a name.
+/// 2. Validate the concept when it looks like a name.
 /// 3. Run the shared share prep.
 /// 4. Mint the invite.
 /// 5. Compose the launcher URL with the `?view=&concept=` suffix.
@@ -404,8 +404,8 @@ pub async fn share_display(
         resolve_bookmark_or_uri(site, subject, |t| ShareError::SubjectNotFound { target: t })
             .await?;
 
-    // Validate the model when it's a bare identifier. URI-shaped
-    // models (anything containing `:`) pass through — same
+    // Validate the concept when it's a bare identifier. URI-shaped
+    // concepts (anything containing `:`) pass through — same
     // convention as `did:key:…` subjects.
     if let Some(name) = concept.filter(|m| !m.contains(':')) {
         let concepts = schema::list_concepts(site)

--- a/rust/tonk-cli/tests/notation.rs
+++ b/rust/tonk-cli/tests/notation.rs
@@ -36,7 +36,7 @@ mod when_evaluating_a_document {
         // library — the same `core.yaml` the tonk-ui service worker
         // seeds at repository creation — so the renderer's `tonk:view`
         // concept is present without the user defining it.
-        // `<tonk-display>` queries `tonk:view` by `model`, so views
+        // `<tonk-display>` queries `tonk:view` by `concept`, so views
         // authored through tonk resolve and render instead of
         // showing "View not found".
         let test = common::TestSite::new().await?;

--- a/rust/tonk-cli/tests/render.rs
+++ b/rust/tonk-cli/tests/render.rs
@@ -35,7 +35,7 @@ async fn seeded() -> Result<TestSite> {
     test.eval_inline(PERSON_CONCEPT).await?;
     test.eval_inline(
         r#"view!: &person-card
-  model: person
+  concept: person
   display: "<article><h2>{name}</h2></article>"
 "#,
     )
@@ -76,11 +76,11 @@ async fn it_renders_one_entity_through_its_view() -> Result<()> {
 async fn it_injects_dom_host_fields_for_nested_resolution() -> Result<()> {
     let test = TestSite::new().await?;
     test.eval_inline(PERSON_CONCEPT).await?;
-    // A view that reads {dom.host/model} into an attribute.
+    // A view that reads {dom.host/concept} into an attribute.
     test.eval_inline(
         r#"view!: &person-card
-  model: person
-  display: "<article data-model=\"{dom.host/model}\"><h2>{name}</h2></article>"
+  concept: person
+  display: "<article data-model=\"{dom.host/concept}\"><h2>{name}</h2></article>"
 "#,
     )
     .await?;
@@ -88,7 +88,7 @@ async fn it_injects_dom_host_fields_for_nested_resolution() -> Result<()> {
 
     let route = RenderRoute::parse("bob@person")?;
     let html = render::render(&test.site, &route).await?;
-    // {dom.host/model} resolves to the route's model name.
+    // {dom.host/concept} resolves to the route's model name.
     assert!(
         html.contains("data-model=\"person\""),
         "dom.host/model resolved: {html}"
@@ -105,7 +105,7 @@ async fn it_renders_a_directory_of_every_instance() -> Result<()> {
     // `tonk:_` default carousel so the test asserts this exact template.
     test.eval_inline(
         r#"view/directory!: &people
-  model: person
+  concept: person
   display: "<ul><li data-id=\"{this}\">{name}</li></ul>"
 "#,
     )
@@ -153,7 +153,7 @@ async fn it_falls_back_to_the_default_model_view() -> Result<()> {
     // A view keyed to the `tonk:_` default model rather than `person`.
     test.eval_inline(
         r#"view!: &fallback
-  model: tonk:_
+  concept: tonk:_
   display: "<div class=\"default\">{name}</div>"
 "#,
     )

--- a/rust/tonk-cli/tests/render.rs
+++ b/rust/tonk-cli/tests/render.rs
@@ -1,4 +1,4 @@
-//! Behavioural tests for `tonk render`: the full model -> view ->
+//! Behavioural tests for `tonk render`: the full concept -> view ->
 //! entity resolution and HTML rendering against a seeded `.tonk`
 //! site. The route-parser unit tests live in `src/render.rs`; these
 //! exercise the resolve / render / recurse / fallback paths that need
@@ -80,7 +80,7 @@ async fn it_injects_dom_host_fields_for_nested_resolution() -> Result<()> {
     test.eval_inline(
         r#"view!: &person-card
   concept: person
-  display: "<article data-model=\"{dom.host/concept}\"><h2>{name}</h2></article>"
+  display: "<article data-concept=\"{dom.host/concept}\"><h2>{name}</h2></article>"
 "#,
     )
     .await?;
@@ -88,10 +88,10 @@ async fn it_injects_dom_host_fields_for_nested_resolution() -> Result<()> {
 
     let route = RenderRoute::parse("bob@person")?;
     let html = render::render(&test.site, &route).await?;
-    // {dom.host/concept} resolves to the route's model name.
+    // {dom.host/concept} resolves to the route's concept name.
     assert!(
-        html.contains("data-model=\"person\""),
-        "dom.host/model resolved: {html}"
+        html.contains("data-concept=\"person\""),
+        "dom.host/concept resolved: {html}"
     );
     Ok(())
 }
@@ -101,7 +101,7 @@ async fn it_renders_a_directory_of_every_instance() -> Result<()> {
     let test = TestSite::new().await?;
     test.eval_inline(PERSON_CONCEPT).await?;
     // A person-specific directory view (the built-in `view/directory`
-    // concept, keyed to `model: person`). Overrides the stdlib's
+    // concept, keyed to `concept: person`). Overrides the stdlib's
     // `tonk:_` default carousel so the test asserts this exact template.
     test.eval_inline(
         r#"view/directory!: &people
@@ -127,7 +127,7 @@ async fn it_renders_a_directory_of_every_instance() -> Result<()> {
 }
 
 #[dialog_common::test]
-async fn it_errors_when_no_view_exists_for_the_model() -> Result<()> {
+async fn it_errors_when_no_view_exists_for_the_concept() -> Result<()> {
     let test = TestSite::new().await?;
     test.eval_inline(PERSON_CONCEPT).await?;
     test.eval_inline("person!: &alice\n  name: Alice\n").await?;
@@ -141,16 +141,16 @@ async fn it_errors_when_no_view_exists_for_the_model() -> Result<()> {
     Ok(())
 }
 
-// The `tonk:_` wildcard-model sentinel: a view keyed to it renders
-// any model that has no specific view. `tonk:_` is a valid entity
-// URI, so it satisfies the `model` field's `as: entity` type under
+// The `tonk:_` wildcard-concept sentinel: a view keyed to it renders
+// any concept that has no specific view. `tonk:_` is a valid entity
+// URI, so it satisfies the `concept` field's `as: entity` type under
 // dialog's strict Entity/Text typing (the old `_:_` text sentinel
 // did not — see BUG-16).
 #[dialog_common::test]
-async fn it_falls_back_to_the_default_model_view() -> Result<()> {
+async fn it_falls_back_to_the_default_concept_view() -> Result<()> {
     let test = TestSite::new().await?;
     test.eval_inline(PERSON_CONCEPT).await?;
-    // A view keyed to the `tonk:_` default model rather than `person`.
+    // A view keyed to the `tonk:_` default concept rather than `person`.
     test.eval_inline(
         r#"view!: &fallback
   concept: tonk:_
@@ -164,7 +164,7 @@ async fn it_falls_back_to_the_default_model_view() -> Result<()> {
     let html = render::render(&test.site, &route).await?;
     assert!(
         html.contains("class=\"default\"") && html.contains("Alice"),
-        "default-model view rendered: {html}"
+        "default-concept view rendered: {html}"
     );
     Ok(())
 }
@@ -183,13 +183,13 @@ async fn it_renders_empty_chrome_for_a_missing_entity() -> Result<()> {
 }
 
 #[dialog_common::test]
-async fn it_errors_on_an_unknown_model() -> Result<()> {
+async fn it_errors_on_an_unknown_concept() -> Result<()> {
     let test = seeded().await?;
     let route = RenderRoute::parse("nope")?;
     let err = render::render(&test.site, &route).await.unwrap_err();
     assert!(
         err.to_string().contains("no concept matched"),
-        "expected unknown-model error, got: {err}"
+        "expected unknown-concept error, got: {err}"
     );
     Ok(())
 }

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1228,7 +1228,7 @@ mod when_sharing_a_display {
     }
 
     #[dialog_common::test]
-    async fn it_produces_a_launcher_url_with_view_and_model_in_the_then_suffix() -> Result<()> {
+    async fn it_produces_a_launcher_url_with_view_and_concept_in_the_then_suffix() -> Result<()> {
         let test = shareable_display_site().await?;
         let outcome = share::share_display(
             &test.site,
@@ -1262,7 +1262,7 @@ mod when_sharing_a_display {
     }
 
     #[dialog_common::test]
-    async fn it_omits_query_params_when_neither_view_nor_model_is_supplied() -> Result<()> {
+    async fn it_omits_query_params_when_neither_view_nor_concept_is_supplied() -> Result<()> {
         let test = shareable_display_site().await?;
         let outcome =
             share::share_display(&test.site, "buy-milk", None, None, ShareOptions::default())
@@ -1364,7 +1364,7 @@ mod when_sharing_a_display {
     }
 
     #[dialog_common::test]
-    async fn it_errors_when_the_model_concept_is_not_defined() -> Result<()> {
+    async fn it_errors_when_the_concept_is_not_defined() -> Result<()> {
         let test = shareable_display_site().await?;
         let result = share::share_display(
             &test.site,
@@ -1382,8 +1382,8 @@ mod when_sharing_a_display {
     }
 
     #[dialog_common::test]
-    async fn it_accepts_a_uri_shaped_model_without_validation() -> Result<()> {
-        // A `:`-bearing model passes through without a concept
+    async fn it_accepts_a_uri_shaped_concept_without_validation() -> Result<()> {
+        // A `:`-bearing concept passes through without a concept
         // lookup. Mirrors the convention for `did:key:…` subjects.
         let test = shareable_display_site().await?;
         let outcome = share::share_display(

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1244,7 +1244,7 @@ mod when_sharing_a_display {
 
         assert_eq!(outcome.subject_name.as_deref(), Some("buy-milk"));
         assert_eq!(outcome.view_name.as_deref(), Some("basic"));
-        assert_eq!(outcome.model.as_deref(), Some("task"));
+        assert_eq!(outcome.concept.as_deref(), Some("task"));
         assert_eq!(outcome.remote_name, "origin");
 
         let url = Url::parse(&outcome.url)?;
@@ -1256,7 +1256,7 @@ mod when_sharing_a_display {
         // so the URL survives entity-URI churn.
         assert_eq!(
             pairs.get("then").map(String::as_str),
-            Some("buy-milk?view=basic&model=task"),
+            Some("buy-milk?view=basic&concept=task"),
         );
         Ok(())
     }
@@ -1337,7 +1337,7 @@ mod when_sharing_a_display {
             .collect();
         // URI subjects land in `then=` verbatim — no bookmark to
         // prefer over them.
-        let expected = format!("{entity}?view=basic&model=task");
+        let expected = format!("{entity}?view=basic&concept=task");
         assert_eq!(
             pairs.get("then").map(String::as_str),
             Some(expected.as_str())
@@ -1401,7 +1401,7 @@ mod when_sharing_a_display {
             .collect();
         assert_eq!(
             pairs.get("then").map(String::as_str),
-            Some("buy-milk?model=did%3Akey%3AzPretendConcept"),
+            Some("buy-milk?concept=did%3Akey%3AzPretendConcept"),
         );
         Ok(())
     }

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -19,7 +19,7 @@
 # ============================================================
 
 # The `view` concept. Shape matches what `<tonk-display>` queries
-# (resolve.rs `view_predicate`): a `model` (the concept it renders)
+# (resolve.rs `view_predicate`): a `concept` (the concept it renders)
 # and a `display` (the HTML template). Pinned to the stable
 # `tonk:view` URI so <tonk-display> can refer to the built-in view
 # concept directly, without a name-resolution round-trip.
@@ -53,24 +53,24 @@ concept!: &view/directory
       cardinality: one
       as: text
 
-# The default directory view: `model: tonk:_` matches any model with no
-# specific `view/directory`. `tonk:_` is the wildcard-model sentinel — a
-# valid entity URI standing in for "no specific model" (the `model` field
+# The default directory view: `concept: tonk:_` matches any concept with no
+# specific `view/directory`. `tonk:_` is the wildcard-concept sentinel — a
+# valid entity URI standing in for "no specific concept" (the `concept` field
 # is `as: entity`, so the value must be a real entity, not bare text).
-# <tonk-display> with no `entity` resolves a directory view for the model
-# first; finding none, it falls back to this. It renders the model's
+# <tonk-display> with no `entity` resolves a directory view for the concept
+# first; finding none, it falls back to this. It renders the concept's
 # instances in a <wa-carousel>, one slide per instance, each a nested
 # single-entity <tonk-display> (which then resolves its own view, or this
-# default's detail counterpart). The nested `model` is threaded from the
+# default's detail counterpart). The nested `concept` is threaded from the
 # host via `{dom.host/concept}`, since an instance carries no pointer to
-# its own model.
+# its own concept.
 view/directory!:
   this: id:tonk:view/directory/default
   concept: tonk:_
   display: |
     <wa-carousel class="vertical seamless" pagination orientation="vertical">
       <wa-carousel-item subject={this}>
-        <tonk-display entity={this} concept={dom.host/concept} />
+        <tonk-display this={this} concept={dom.host/concept} />
       </wa-carousel-item>
     </wa-carousel>
 
@@ -79,10 +79,10 @@ view/directory!:
 # WORKSPACE
 # ============================================================
 
-# The `artifact` concept. Binds an entity to a model and a view,
+# The `artifact` concept. Binds an entity to a concept and a view,
 # plus the tab metadata (title, icon) the viewer shell shows. Its
-# (entity, model, view) map one-to-one onto
-# `<tonk-display entity model view>`. Pinned to `tonk:artifact` so
+# (entity, concept, view) map one-to-one onto
+# `<tonk-display entity concept view>`. Pinned to `tonk:artifact` so
 # the viewer can query artifacts by a stable concept entity.
 concept!: &artifact
   this: tonk:artifact
@@ -124,7 +124,7 @@ concept!: &artifact
 # `xyz.tonk.artifact/title` attribute, and its view renders the
 # "empty artifact" canvas (a deeplink to hand to an agent, plus
 # instructions). Pinned to `tonk:empty-artifact` so the create rule can
-# point a new sheet's `model` at it by a stable URI.
+# point a new sheet's `concept` at it by a stable URI.
 concept!: &empty-artifact
   this: tonk:empty-artifact
   description: A newly created, not-yet-configured sheet awaiting content.
@@ -136,7 +136,7 @@ concept!: &empty-artifact
       as: text
 
 # The `sheet` concept: one tab in a workspace. A sheet is an
-# artifact (same title/icon/entity/model/view fields, same attribute
+# artifact (same title/icon/entity/concept/view fields, same attribute
 # URIs) plus an `order` lexicographic key that positions the tab. So
 # every sheet is also a valid artifact; the extra `order` field is
 # what makes it a workspace member.
@@ -333,7 +333,7 @@ concept!: &invitation
       cardinality: one
       as: text
 
-# The invite-link view — the default view for the `invitation` model, so
+# The invite-link view — the default view for the `invitation` concept, so
 # `<tonk-display concept=invitation>` mounts it with no explicit `view=`. It
 # renders only once the handler has asserted both halves for the repo's
 # subject (before that the display is empty). The readonly input shows the
@@ -373,7 +373,7 @@ view!: &invitation/link
 # The agent-invite concept: the live `tonk:invitation` joined with the
 # repository's display `name`, both keyed by the repo subject. The rule
 # below derives it so the agent-prompt view can template the repo name and
-# the invite URL from one model. It resolves only once the invitation's
+# the invite URL from one concept. It resolves only once the invitation's
 # both halves (durable authorization + overlay credential) exist, so the
 # canvas shows "Generating link…" until the mint lands.
 concept!: &tonk/agent-invite
@@ -424,7 +424,7 @@ rule!:
 # `<tonk-display concept=tonk:agent-invite>` mounts it with no explicit
 # `view=`. It renders a full, paste-able agent prompt (task + bootstrap
 # commands) with the minted invite URL embedded, instead of a bare link.
-# The repo `{name}` and invite `{access}`/`{remote}`/`{code}` are model
+# The repo `{name}` and invite `{access}`/`{remote}`/`{code}` are concept
 # fields; the page title arrives as the `data-page` host attribute and the
 # origin base as `data-base` (from `<tonk-origin>`). `<wa-copy-button>`
 # copies the assembled prompt via its `value`.
@@ -508,7 +508,7 @@ concept!: &member
       cardinality: one
       as: text
 
-# A single roster row — the default view for `model: tonk:member`. Each
+# A single roster row — the default view for `concept: tonk:member`. Each
 # member is one entry in the "shared with" list: a sigil-glyph avatar, the
 # member's display name (with the DID tail beneath as a fallback id), and a
 # role badge.
@@ -661,13 +661,13 @@ view/directory!:
           border-color: var(--wa-color-surface-border);
         }
       </style>
-      <tonk-display entity={this} concept={dom.host/concept} />
+      <tonk-display this={this} concept={dom.host/concept} />
     </div>
 
 # The repository's own name, stored in its content branch so the repo
 # is self-describing — the name travels with the repository rather than
 # living only in the joining profile's replica index. The banner reads
-# it via `<tonk-display concept=tonk:repository entity={subject}>`;
+# it via `<tonk-display concept=tonk:repository this={subject}>`;
 # `tonk/rename-repository` edits it. The concept is pinned to
 # `tonk:repository` so the display can resolve its view, but its
 # *instances* are keyed by the replica's `subject` DID (the entity the
@@ -720,7 +720,7 @@ rule!:
 # `onchange` fires on commit (blur or Enter), reading the new value from
 # `dom.event.current-target/value`; the rename rule above then writes it
 # back. The banner mounts this via `<tonk-display concept=tonk:repository
-# entity={subject}>`, so a repo with no name yet (just the seeded
+# this={subject}>`, so a repo with no name yet (just the seeded
 # "Untitled") still renders an editable field.
 view!:
   this: id:tonk:repository/name-view
@@ -816,7 +816,7 @@ concept!: &view/label
       as: text
 
 # The repository's name as plain, non-editable text. The Hub card
-# mounts this via `<tonk-display concept=tonk:repository entity={subject}
+# mounts this via `<tonk-display concept=tonk:repository this={subject}
 # view=tonk:view/label>` inside a per-space `<tonk-repository>` routing
 # context, so each card shows its own space's current name (read from
 # that space's `tonk/repository`, the cross-device source of truth)
@@ -863,7 +863,7 @@ concept!: &workspace/sheet-order
       as: text
 
 # Retract the order: when `close-sheet` fires, drop the closed sheet's
-# `order` triple. The sheet's artifact facts (title/entity/model/...)
+# `order` triple. The sheet's artifact facts (title/entity/concept/...)
 # persist - only the `order` that made it a `tonk:sheet` is removed, so
 # the directory query (which requires `order`) no longer matches it and
 # the tab disappears. The artifact could be re-promoted to a sheet
@@ -883,7 +883,7 @@ rule!:
 # `title`/`subtitle`/`icon` and `<tonk-sheet-binder>` projects the tab
 # strip from the same attributes; the view supplies only the
 # attributes and the content. The sheet's content renders directly
-# from the sheet's own `entity`/`model`/`view` fields - a sheet is
+# from the sheet's own `entity`/`concept`/`view` fields - a sheet is
 # self-describing, so no intermediate concept is needed.
 
 
@@ -893,7 +893,7 @@ view!:
   concept: tonk:sheet
   display: |
     <tonk-sheet sheet={this} order={order} title={title} subtitle={subtitle} icon={icon}>
-      <tonk-display entity={entity} concept={concept} view={view} />
+      <tonk-display this={entity} concept={concept} view={view} />
     </tonk-sheet>
 
 # The empty-artifact canvas: what a freshly created sheet renders until
@@ -1082,9 +1082,9 @@ concept!: &portal
       cardinality: one
       as: text
 
-# One view per concept, keyed by `model`. Each nested
-# `<tonk-display>` passes only `concept=…` (and `entity=…`); with no
-# `view` attribute it resolves the view whose `model` matches. The
+# One view per concept, keyed by `concept`. Each nested
+# `<tonk-display>` passes only `concept=…` (and `this=…`); with no
+# `view` attribute it resolves the view whose `concept` matches. The
 # chain iterates one level of the hierarchy per template via
 # `subject={field}` and bottoms out in the tile's content display.
 
@@ -1148,14 +1148,14 @@ view!:
           display: contents;
         }
       </style>
-      <tonk-display entity={column} concept=column-view />
+      <tonk-display this={column} concept=column-view />
     </tonk-strip>
 
 view/directory!:
   this: tonk:board/directory
   concept: board
   display: |
-    <tonk-display entity={this} concept={dom.host/concept} view={dom.host/view} />
+    <tonk-display this={this} concept={dom.host/concept} view={dom.host/view} />
 
 view!:
   this: tonk:board/column
@@ -1240,7 +1240,7 @@ view!:
         }
       </style>
       <div class="tile" subject={tile}>
-        <tonk-display entity={tile} concept=tile />
+        <tonk-display this={tile} concept=tile />
       </div>
     </tonk-column>
 
@@ -1248,7 +1248,7 @@ view!:
   this: tonk:board/tile
   concept: tile
   display: |
-    <tonk-display entity={entity} concept={concept} />
+    <tonk-display this={entity} concept={concept} />
 
 view!:
   this: tonk:inspector
@@ -1268,7 +1268,7 @@ view/directory!:
 # `<tonk-portal>` element. `html:` forces the binding through
 # setAttribute so `attributeChangedCallback` fires. Users never write
 # this; nesting a `<tonk-display concept=portal>` over a portal entity
-# resolves it by model and renders it.
+# resolves it by concept and renders it.
 view!:
   this: tonk:portal
   concept: portal
@@ -1372,7 +1372,7 @@ concept!: &space
 
 
 # Set the binder shell as the space's default view. The space route mounts
-# `<tonk-display entity={replica} concept=tonk/space>`; this alias resolves
+# `<tonk-display this={replica} concept=tonk/space>`; this alias resolves
 # `tonk/space` to `tonk:binder`, so the single-mode `tonk:shell` view (the topbar
 # over the sheet binder) renders for that one replica's binder.
 name!:
@@ -1406,7 +1406,7 @@ command!: &workspace/create-sheet
 
 
 # A created sheet is self-describing: its `entity` is the sheet entity
-# itself (`?this`), its `model` is `tonk:empty-artifact`, and its `view`
+# itself (`?this`), its `concept` is `tonk:empty-artifact`, and its `view`
 # is the built-in default. The companion rule below asserts the
 # `empty-artifact` title against that same entity, so the empty-artifact
 # canvas can render the sheet's name. `entity: ?this` is expressed as an
@@ -1544,43 +1544,43 @@ concept!: &site
       cardinality: one
       as: entity
     concept:
-      description: Matched route's concept (the model the shell mounts).
+      description: Matched route's concept (the concept the shell mounts).
       the: xyz.tonk.site/concept
       cardinality: one
       as: entity
 
-# A site renders the route model it matched. The shell mounts a fixed
-# `<tonk-display entity=site:… concept=tonk:site>`; this view nests into the
-# matched `{concept}` on the SAME site entity, so the route model
+# A site renders the route concept it matched. The shell mounts a fixed
+# `<tonk-display this=site:… concept=tonk:site>`; this view nests into the
+# matched `{concept}` on the SAME site entity, so the route concept
 # (e.g. `tonk:space/route`) resolves on the site (picking its `site/*` fields)
-# and its own view renders. One indirection: site → its matched route model.
+# and its own view renders. One indirection: site → its matched route concept.
 view!: &site/view
   this: id:tonk:site/view
   concept: tonk:site
   display: |
-    <tonk-display entity={this} concept={concept} />
+    <tonk-display this={this} concept={concept} />
 
 # ============================================================
-# ROUTING — routes are models picked by the SW per tab
+# ROUTING — routes are concepts picked by the SW per tab
 # ============================================================
 #
-# A `route!` maps a path pattern to a route MODEL. The SW (Level 1) matches the
-# remaining path after the space prefix, picks the route model, and asserts the
-# tab's `tonk:site` with `concept` = that model. The guest mounts
-# `<tonk-display entity=site:… concept={the matched concept}>`; the route model
+# A `route!` maps a path pattern to a route CONCEPT. The SW (Level 1) matches the
+# remaining path after the space prefix, picks the route concept, and asserts the
+# tab's `tonk:site` with `concept` = that concept. The guest mounts
+# `<tonk-display this=site:… concept={the matched concept}>`; the route concept
 # resolves on the site entity (picking the `site/*` fields it needs) and its
 # view renders. Patterns use axum/matchit 0.8 brace syntax (`{section}`), fed to
 # `matchit::insert`.
 #
-# Route models are distinct PINNED concepts (`tonk:space/route`, …). Two routes
+# Route concepts are distinct PINNED concepts (`tonk:space/route`, …). Two routes
 # with the same field shape stay distinct by their pinned `this`, so their views
-# never collide — `model` discriminates.
+# never collide — `concept` discriminates.
 
 # The durable route table the SW reads to build its matchit router: a path
-# pattern → the route model to render. `route!` instances populate it.
+# pattern → the route concept to render. `route!` instances populate it.
 concept!: &route
   this: tonk:route
-  description: A route — maps a path pattern to the model the SW mounts.
+  description: A route — maps a path pattern to the concept the SW mounts.
   with:
     path:
       description: The axum/matchit path pattern.
@@ -1588,7 +1588,7 @@ concept!: &route
       cardinality: one
       as: text
     concept:
-      description: The route model to render when this path matches.
+      description: The route concept to render when this path matches.
       the: xyz.tonk.route/concept
       cardinality: one
       as: entity
@@ -1596,7 +1596,7 @@ concept!: &route
 
 
 
-# ---- Route models and their views ----
+# ---- Route concepts and their views ----
 
 # The space's default page — a bare `/space/{name}/`. Picks the tab's `replica`
 # off the site entity and renders a view of it (the binder, by default).
@@ -1614,7 +1614,7 @@ view!: &space/route/view
   this: id:tonk:space/route/view
   concept: tonk:space/route
   display: |
-    <tonk-display entity={replica} concept=tonk/space />
+    <tonk-display this={replica} concept=tonk/space />
 
 # ---- Seeded routes (bootstrap) ----
 #
@@ -1623,7 +1623,7 @@ route!: &route/space
   this: id:tonk:route/space
   path: "/"
   concept: tonk:space/route
-# The sync chip — the default view for `model: tonk:sync`. A pill whose dot
+# The sync chip — the default view for `concept: tonk:sync`. A pill whose dot
 # colour + label come from `status` via CSS (rules in the shell topbar's
 # <style>). The chip is the pause-trigger: clicking it opens the "Pause sync?"
 # confirm dialog (`data-dialog`). When paused, a `resume` button overlays on
@@ -1639,10 +1639,10 @@ view!: &sync/chip
       <button class="workspace__sync-resume" type="submit" form="pause-sync-form" aria-label="Resume sync" title="Resume sync"></button>
     </span>
 
-# The workspace shell — the single-mode view for `model: tonk:binder`. Rendered
+# The workspace shell — the single-mode view for `concept: tonk:binder`. Rendered
 # for ONE concrete replica (the binder instance IS the replica entity), so
 # `{this}`/`{subject}`/`{active}` resolve to that tab's replica. The route mounts
-# it via `<tonk-display entity={replica} concept=tonk/space>` (tonk/space aliases
+# it via `<tonk-display this={replica} concept=tonk/space>` (tonk/space aliases
 # tonk:binder), so the shell is scoped to this tab's replica, not folded over
 # every replica.
 view!:
@@ -1787,7 +1787,7 @@ view!:
       <div class="workspace__topbar">
         <span class="workspace__brand">tonk</span>
         <a class="workspace__crumb" href="/">&lsaquo; all repos</a>
-        <span class="workspace__title"><tonk-display entity={subject} concept=tonk:repository></tonk-display></span>
+        <span class="workspace__title"><tonk-display this={subject} concept=tonk:repository></tonk-display></span>
         <!-- The sync chip: subscribes to the `tonk:sync` `state:here` overlay
              the worker stamps on THIS space branch (the one the shell is
              already scoped to), so it needs no extra repository context. The
@@ -1795,7 +1795,7 @@ view!:
              status lands — which is honest, since a status check / sync fires
              on load. Without the slot `<tonk-display>` would dump the
              missing-instance notation as text. -->
-        <tonk-display entity=state:here concept=tonk:sync>
+        <tonk-display this=state:here concept=tonk:sync>
           <span slot="no-entity" class="workspace__sync" data-sync-status="sync:pending" role="button" tabindex="0" data-dialog="open pause-sync" aria-label="Pause sync" title="Pause sync"></span>
         </tonk-display>
         <span class="workspace__spacer"></span>
@@ -1809,7 +1809,7 @@ view!:
                nothing while `state:self` is briefly absent (e.g. just after
                an overlay clear) — without it `<tonk-display>` would dump the
                missing-instance notation as text, mirroring the sync chip. -->
-          <tonk-display entity=state:self concept=tonk:identity>
+          <tonk-display this=state:self concept=tonk:identity>
             <span slot="no-entity" class="workspace__identity" aria-hidden="true"></span>
           </tonk-display>
           <!-- One click both opens the share dialog (`data-dialog`) and
@@ -1866,7 +1866,7 @@ view!:
            keypair, delegates the origin repo to it, asserts the public
            `tonk:authorization` durably and the private seed as an
            overlay-only `tonk:credential` — both keyed by the repo's
-           subject DID. The nested `<tonk-display entity={subject}>`
+           subject DID. The nested `<tonk-display this={subject}>`
            resolves the `tonk:invitation` join (authorization + credential)
            and composes the link. `<tonk-origin>` supplies the `data-base`
            (`{origin}/join`) host attribute so the template can build an
@@ -1894,7 +1894,7 @@ view!:
         <form id="share-form" data-invite="tonk:invite" onsubmit=tonk:invite></form>
         <tonk-origin>
           <tonk-display
-            entity={subject}
+            this={subject}
             concept=invitation
             bind:base="data-base">
             <!-- Until the handler asserts both halves of the invitation,
@@ -2296,7 +2296,7 @@ view/directory!:
             <button type="button" class="workspace-launchpad__add" data-create>+ add artifact</button>
           </div>
         </div>
-        <tonk-display entity={this} concept=tonk:sheet />
+        <tonk-display this={this} concept=tonk:sheet />
       </tonk-sheet-binder>
     </div>
 
@@ -2338,7 +2338,7 @@ concept!: &tonk/binder
 # prior one). The binder is the replica's (one per device, bound through
 # `tonk/replica`), so the command needs only the sheet — no binder id
 # plumbed through the DOM. The shell view reads `{active}` straight off
-# the binder model to seed the live tab; the binder element owns the live
+# the binder concept to seed the live tab; the binder element owns the live
 # selection thereafter, so this write only persists the default for the
 # next mount.
 rule!:
@@ -2382,7 +2382,7 @@ tonk/initialize!:
 # ============================================================
 concept!: &diagnose
   this: dialog:diagnose
-  description: Marker model for the search-tree inspector view.
+  description: Marker concept for the search-tree inspector view.
   with:
     name:
       description: A label for the inspector (unused; satisfies the concept shape).
@@ -2392,7 +2392,7 @@ concept!: &diagnose
 
 # A directory-kind view (not a plain `view!`): a `/space/{repo}/dialog:diagnose`
 # URL carries no entity, so `<tonk-display>` resolves a `view/directory`
-# for the model. The inspector needs no entity — it renders the whole
+# for the concept. The inspector needs no entity — it renders the whole
 # branch's tree — so the directory view is the right kind.
 view/directory!:
   this: id:dialog:diagnose/view

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -29,7 +29,7 @@ concept!: &view
   with:
     concept:
       description: Concept this view renders
-      the: xyz.tonk.view/model
+      the: xyz.tonk.view/concept
       cardinality: one
       as: entity
     display:
@@ -44,7 +44,7 @@ concept!: &view/directory
   with:
     concept:
       description: Concept this view renders
-      the: xyz.tonk.view/model
+      the: xyz.tonk.view/concept
       cardinality: one
       as: entity
     display:
@@ -110,7 +110,7 @@ concept!: &artifact
       as: entity
     concept:
       description: Concept used to display the entity
-      the: xyz.tonk.artifact/model
+      the: xyz.tonk.artifact/concept
       cardinality: one
       as: entity
     view:
@@ -166,7 +166,7 @@ concept!: &workspace/sheet
       as: entity
     concept:
       description: Concept used to display the entity
-      the: xyz.tonk.artifact/model
+      the: xyz.tonk.artifact/concept
       cardinality: one
       as: entity
     view:
@@ -806,7 +806,7 @@ concept!: &view/label
   with:
     concept:
       description: Concept this view renders
-      the: xyz.tonk.view/model
+      the: xyz.tonk.view/concept
       cardinality: one
       as: entity
     display:
@@ -1050,7 +1050,7 @@ concept!: &tile
       as: text
     concept:
       description: Concept the tile body renders
-      the: xyz.tonk.tile/model
+      the: xyz.tonk.tile/concept
       cardinality: one
       as: entity
     entity:

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -25,9 +25,9 @@
 # concept directly, without a name-resolution round-trip.
 concept!: &view
   this: tonk:view
-  description: A display template (model, display) for rendering an entity
+  description: A display template (concept, display) for rendering an entity
   with:
-    model:
+    concept:
       description: Concept this view renders
       the: xyz.tonk.view/model
       cardinality: one
@@ -42,7 +42,7 @@ concept!: &view/directory
   this: tonk:view/directory
   description: A directory view used by tonk-display when entity is not set.
   with:
-    model:
+    concept:
       description: Concept this view renders
       the: xyz.tonk.view/model
       cardinality: one
@@ -62,15 +62,15 @@ concept!: &view/directory
 # instances in a <wa-carousel>, one slide per instance, each a nested
 # single-entity <tonk-display> (which then resolves its own view, or this
 # default's detail counterpart). The nested `model` is threaded from the
-# host via `{dom.host/model}`, since an instance carries no pointer to
+# host via `{dom.host/concept}`, since an instance carries no pointer to
 # its own model.
 view/directory!:
   this: id:tonk:view/directory/default
-  model: tonk:_
+  concept: tonk:_
   display: |
     <wa-carousel class="vertical seamless" pagination orientation="vertical">
       <wa-carousel-item subject={this}>
-        <tonk-display entity={this} model={dom.host/model} />
+        <tonk-display entity={this} concept={dom.host/concept} />
       </wa-carousel-item>
     </wa-carousel>
 
@@ -108,8 +108,8 @@ concept!: &artifact
       the: xyz.tonk.artifact/entity
       cardinality: one
       as: entity
-    model:
-      description: Model concept used to display the entity
+    concept:
+      description: Concept used to display the entity
       the: xyz.tonk.artifact/model
       cardinality: one
       as: entity
@@ -164,8 +164,8 @@ concept!: &workspace/sheet
       the: xyz.tonk.artifact/entity
       cardinality: one
       as: entity
-    model:
-      description: Model concept used to display the entity
+    concept:
+      description: Concept used to display the entity
       the: xyz.tonk.artifact/model
       cardinality: one
       as: entity
@@ -334,7 +334,7 @@ concept!: &invitation
       as: text
 
 # The invite-link view — the default view for the `invitation` model, so
-# `<tonk-display model=invitation>` mounts it with no explicit `view=`. It
+# `<tonk-display concept=invitation>` mounts it with no explicit `view=`. It
 # renders only once the handler has asserted both halves for the repo's
 # subject (before that the display is empty). The readonly input shows the
 # assembled absolute URL: `{base}?access={access}{remote}#{code}`, where
@@ -345,7 +345,7 @@ concept!: &invitation
 # knows where to sync from. `<wa-copy-button>` copies the same value.
 view!: &invitation/link
   this: id:invitation/link
-  model: invitation
+  concept: invitation
   display: |
     <div class="invite-link">
       <style>
@@ -421,7 +421,7 @@ rule!:
         code: ?code
 
 # The agent-prompt view — the default view for `tonk:agent-invite`, so
-# `<tonk-display model=tonk:agent-invite>` mounts it with no explicit
+# `<tonk-display concept=tonk:agent-invite>` mounts it with no explicit
 # `view=`. It renders a full, paste-able agent prompt (task + bootstrap
 # commands) with the minted invite URL embedded, instead of a bare link.
 # The repo `{name}` and invite `{access}`/`{remote}`/`{code}` are model
@@ -430,7 +430,7 @@ rule!:
 # copies the assembled prompt via its `value`.
 view!:
   this: id:agent-invite/prompt
-  model: tonk:agent-invite
+  concept: tonk:agent-invite
   display: |
     <div class="agent-prompt">
       <style>
@@ -528,7 +528,7 @@ concept!: &member
 # kept (visually hidden) only to drive the attribute.
 view!: &member/row
   this: id:tonk:member/row
-  model: tonk:member
+  concept: tonk:member
   display: |
     <div class="roster__row" data-role={role}>
       <tonk-sigil class="roster__avatar" did={member}></tonk-sigil>
@@ -540,11 +540,11 @@ view!: &member/row
     </div>
 
 # The roster — every `tonk:member` instance rendered as a row. Mounted
-# in the invite panel via `<tonk-display model=tonk:member>` (no
+# in the invite panel via `<tonk-display concept=tonk:member>` (no
 # `entity`, so the directory view resolves and iterates all members).
 view/directory!:
   this: id:tonk:member/roster
-  model: tonk:member
+  concept: tonk:member
   display: |
     <div class="roster">
       <style>
@@ -661,13 +661,13 @@ view/directory!:
           border-color: var(--wa-color-surface-border);
         }
       </style>
-      <tonk-display entity={this} model={dom.host/model} />
+      <tonk-display entity={this} concept={dom.host/concept} />
     </div>
 
 # The repository's own name, stored in its content branch so the repo
 # is self-describing — the name travels with the repository rather than
 # living only in the joining profile's replica index. The banner reads
-# it via `<tonk-display model=tonk:repository entity={subject}>`;
+# it via `<tonk-display concept=tonk:repository entity={subject}>`;
 # `tonk/rename-repository` edits it. The concept is pinned to
 # `tonk:repository` so the display can resolve its view, but its
 # *instances* are keyed by the replica's `subject` DID (the entity the
@@ -719,12 +719,12 @@ rule!:
 # `data-subject` so the `tonk/rename-repository` command can read it.
 # `onchange` fires on commit (blur or Enter), reading the new value from
 # `dom.event.current-target/value`; the rename rule above then writes it
-# back. The banner mounts this via `<tonk-display model=tonk:repository
+# back. The banner mounts this via `<tonk-display concept=tonk:repository
 # entity={subject}>`, so a repo with no name yet (just the seeded
 # "Untitled") still renders an editable field.
 view!:
   this: id:tonk:repository/name-view
-  model: tonk:repository
+  concept: tonk:repository
   display: |
     <tonk-editable
       class="workspace__title-input"
@@ -764,7 +764,7 @@ concept!: &tonk/identity
 # marker that distinguishes this transient from `tonk/rename-repository`.
 view!:
   this: id:tonk:identity/chip
-  model: tonk:identity
+  concept: tonk:identity
   display: |
     <span class="workspace__identity">
       <tonk-sigil class="workspace__identity-avatar" did={did}></tonk-sigil>
@@ -804,7 +804,7 @@ concept!: &view/label
   this: tonk:view/label
   description: A plain, read-only label view selected via `view=tonk:view/label`.
   with:
-    model:
+    concept:
       description: Concept this view renders
       the: xyz.tonk.view/model
       cardinality: one
@@ -816,14 +816,14 @@ concept!: &view/label
       as: text
 
 # The repository's name as plain, non-editable text. The Hub card
-# mounts this via `<tonk-display model=tonk:repository entity={subject}
+# mounts this via `<tonk-display concept=tonk:repository entity={subject}
 # view=tonk:view/label>` inside a per-space `<tonk-repository>` routing
 # context, so each card shows its own space's current name (read from
 # that space's `tonk/repository`, the cross-device source of truth)
 # rather than an editable banner. Falls back to nothing when unset.
 view/label!:
   this: id:tonk:repository/label-view
-  model: tonk:repository
+  concept: tonk:repository
   display: |
     {name}
 
@@ -890,10 +890,10 @@ rule!:
 
 view!:
   this: id:tonk-workspace/sheet-mount
-  model: tonk:sheet
+  concept: tonk:sheet
   display: |
     <tonk-sheet sheet={this} order={order} title={title} subtitle={subtitle} icon={icon}>
-      <tonk-display entity={entity} model={model} view={view} />
+      <tonk-display entity={entity} concept={concept} view={view} />
     </tonk-sheet>
 
 # The empty-artifact canvas: what a freshly created sheet renders until
@@ -903,7 +903,7 @@ view!:
 # Awesome tokens so it follows the active theme.
 view!:
   this: tonk:empty-artifact/view
-  model: tonk:empty-artifact
+  concept: tonk:empty-artifact
   display: |
     <div class="empty-artifact">
       <style>
@@ -938,7 +938,7 @@ view!:
         .empty-artifact__glyph { color: var(--wa-color-text-quiet); flex: none; }
         /* The agent-link panel: an uppercase mono label over the
            declarative invite. `<tonk-origin>` + `<tonk-display
-           model=tonk:agent-invite>` mint on mount and render the prompt
+           concept=tonk:agent-invite>` mint on mount and render the prompt
            (see the `id:agent-invite/prompt` view). */
         .empty-artifact__deeplink {
           display: flex;
@@ -986,7 +986,7 @@ view!:
           <tonk-display
             bind:subject="entity"
             bind:base="data-base"
-            model=tonk:agent-invite
+            concept=tonk:agent-invite
             data-page="{title}">
             <div slot="no-entity" class="empty-artifact__deeplink-label">Generating link…</div>
           </tonk-display>
@@ -1048,7 +1048,7 @@ concept!: &tile
       the: xyz.tonk.tile/order
       cardinality: one
       as: text
-    model:
+    concept:
       description: Concept the tile body renders
       the: xyz.tonk.tile/model
       cardinality: one
@@ -1072,7 +1072,7 @@ concept!: &inspector
 # author-supplied HTML document into a sandboxed iframe, for work the
 # declarative template stack can't express (canvas, WebGL, widgets).
 # The `content` is first-class dialog data, fetched by a nested
-# `<tonk-display model=portal>` like any other concept.
+# `<tonk-display concept=portal>` like any other concept.
 concept!: &portal
   description: Imperative HTML rendered in an isolated iframe
   with:
@@ -1083,19 +1083,19 @@ concept!: &portal
       as: text
 
 # One view per concept, keyed by `model`. Each nested
-# `<tonk-display>` passes only `model=…` (and `entity=…`); with no
+# `<tonk-display>` passes only `concept=…` (and `entity=…`); with no
 # `view` attribute it resolves the view whose `model` matches. The
 # chain iterates one level of the hierarchy per template via
 # `subject={field}` and bottoms out in the tile's content display.
 
 view!:
   this: tonk:board
-  model: board
+  concept: board
   display: |
     <tonk-strip>
       <style>
         /* Board layout travels with the view, so any route that
-           mounts `model=board` renders the strip identically
+           mounts `concept=board` renders the strip identically
            (board route, bare display route, embedded tile). The strip
            caps its OWN height at the viewport (`block-size: 100dvh`)
            rather than borrowing a fixed height from the document — so
@@ -1148,18 +1148,18 @@ view!:
           display: contents;
         }
       </style>
-      <tonk-display entity={column} model=column-view />
+      <tonk-display entity={column} concept=column-view />
     </tonk-strip>
 
 view/directory!:
   this: tonk:board/directory
-  model: board
+  concept: board
   display: |
-    <tonk-display entity={this} model={dom.host/model} view={dom.host/view} />
+    <tonk-display entity={this} concept={dom.host/concept} view={dom.host/view} />
 
 view!:
   this: tonk:board/column
-  model: column-view
+  concept: column-view
   display: |
     <tonk-column style="--col-w: {width};">
       <style>
@@ -1240,19 +1240,19 @@ view!:
         }
       </style>
       <div class="tile" subject={tile}>
-        <tonk-display entity={tile} model=tile />
+        <tonk-display entity={tile} concept=tile />
       </div>
     </tonk-column>
 
 view!:
   this: tonk:board/tile
-  model: tile
+  concept: tile
   display: |
-    <tonk-display entity={entity} model={model} />
+    <tonk-display entity={entity} concept={concept} />
 
 view!:
   this: tonk:inspector
-  model: inspector
+  concept: inspector
   display: |
     <tonk-inspector source={source} />
 
@@ -1260,18 +1260,18 @@ view!:
 
 view/directory!:
   this: tonk:inspector/directory
-  model: inspector
+  concept: inspector
   display: |
     <tonk-inspector source=home />
 
 # The canonical bridge from the `portal` concept to the
 # `<tonk-portal>` element. `html:` forces the binding through
 # setAttribute so `attributeChangedCallback` fires. Users never write
-# this; nesting a `<tonk-display model=portal>` over a portal entity
+# this; nesting a `<tonk-display concept=portal>` over a portal entity
 # resolves it by model and renders it.
 view!:
   this: tonk:portal
-  model: portal
+  concept: portal
   display: |
     <tonk-portal html:content={content} />
 
@@ -1372,7 +1372,7 @@ concept!: &space
 
 
 # Set the binder shell as the space's default view. The space route mounts
-# `<tonk-display entity={replica} model=tonk/space>`; this alias resolves
+# `<tonk-display entity={replica} concept=tonk/space>`; this alias resolves
 # `tonk/space` to `tonk:binder`, so the single-mode `tonk:shell` view (the topbar
 # over the sheet binder) renders for that one replica's binder.
 name!:
@@ -1427,7 +1427,7 @@ rule!:
         is: ?this
     - assert: ==
       where:
-        this: ?model
+        this: ?concept
         is: tonk:empty-artifact
     - assert: ==
       where:
@@ -1550,15 +1550,15 @@ concept!: &site
       as: entity
 
 # A site renders the route model it matched. The shell mounts a fixed
-# `<tonk-display entity=site:… model=tonk:site>`; this view nests into the
+# `<tonk-display entity=site:… concept=tonk:site>`; this view nests into the
 # matched `{concept}` on the SAME site entity, so the route model
 # (e.g. `tonk:space/route`) resolves on the site (picking its `site/*` fields)
 # and its own view renders. One indirection: site → its matched route model.
 view!: &site/view
   this: id:tonk:site/view
-  model: tonk:site
+  concept: tonk:site
   display: |
-    <tonk-display entity={this} model={concept} />
+    <tonk-display entity={this} concept={concept} />
 
 # ============================================================
 # ROUTING — routes are models picked by the SW per tab
@@ -1567,7 +1567,7 @@ view!: &site/view
 # A `route!` maps a path pattern to a route MODEL. The SW (Level 1) matches the
 # remaining path after the space prefix, picks the route model, and asserts the
 # tab's `tonk:site` with `concept` = that model. The guest mounts
-# `<tonk-display entity=site:… model={the matched concept}>`; the route model
+# `<tonk-display entity=site:… concept={the matched concept}>`; the route model
 # resolves on the site entity (picking the `site/*` fields it needs) and its
 # view renders. Patterns use axum/matchit 0.8 brace syntax (`{section}`), fed to
 # `matchit::insert`.
@@ -1612,9 +1612,9 @@ concept!: &space/route
 
 view!: &space/route/view
   this: id:tonk:space/route/view
-  model: tonk:space/route
+  concept: tonk:space/route
   display: |
-    <tonk-display entity={replica} model=tonk/space />
+    <tonk-display entity={replica} concept=tonk/space />
 
 # ---- Seeded routes (bootstrap) ----
 #
@@ -1632,7 +1632,7 @@ route!: &route/space
 # resume, no dialog. The worker owns the state and the toggle.
 view!: &sync/chip
   this: id:tonk:sync/chip
-  model: tonk:sync
+  concept: tonk:sync
   display: |
     <span class="workspace__sync-control" data-sync-status={status}>
       <span class="workspace__sync" data-sync-status={status} role="button" tabindex="0" data-dialog="open pause-sync" aria-label="Pause sync" title="Pause sync"></span>
@@ -1642,12 +1642,12 @@ view!: &sync/chip
 # The workspace shell — the single-mode view for `model: tonk:binder`. Rendered
 # for ONE concrete replica (the binder instance IS the replica entity), so
 # `{this}`/`{subject}`/`{active}` resolve to that tab's replica. The route mounts
-# it via `<tonk-display entity={replica} model=tonk/space>` (tonk/space aliases
+# it via `<tonk-display entity={replica} concept=tonk/space>` (tonk/space aliases
 # tonk:binder), so the shell is scoped to this tab's replica, not folded over
 # every replica.
 view!:
   this: tonk:shell
-  model: tonk:binder
+  concept: tonk:binder
   display: |
     <div class="workspace-directory">
       <style>
@@ -1787,7 +1787,7 @@ view!:
       <div class="workspace__topbar">
         <span class="workspace__brand">tonk</span>
         <a class="workspace__crumb" href="/">&lsaquo; all repos</a>
-        <span class="workspace__title"><tonk-display entity={subject} model=tonk:repository></tonk-display></span>
+        <span class="workspace__title"><tonk-display entity={subject} concept=tonk:repository></tonk-display></span>
         <!-- The sync chip: subscribes to the `tonk:sync` `state:here` overlay
              the worker stamps on THIS space branch (the one the shell is
              already scoped to), so it needs no extra repository context. The
@@ -1795,7 +1795,7 @@ view!:
              status lands — which is honest, since a status check / sync fires
              on load. Without the slot `<tonk-display>` would dump the
              missing-instance notation as text. -->
-        <tonk-display entity=state:here model=tonk:sync>
+        <tonk-display entity=state:here concept=tonk:sync>
           <span slot="no-entity" class="workspace__sync" data-sync-status="sync:pending" role="button" tabindex="0" data-dialog="open pause-sync" aria-label="Pause sync" title="Pause sync"></span>
         </tonk-display>
         <span class="workspace__spacer"></span>
@@ -1809,7 +1809,7 @@ view!:
                nothing while `state:self` is briefly absent (e.g. just after
                an overlay clear) — without it `<tonk-display>` would dump the
                missing-instance notation as text, mirroring the sync chip. -->
-          <tonk-display entity=state:self model=tonk:identity>
+          <tonk-display entity=state:self concept=tonk:identity>
             <span slot="no-entity" class="workspace__identity" aria-hidden="true"></span>
           </tonk-display>
           <!-- One click both opens the share dialog (`data-dialog`) and
@@ -1895,7 +1895,7 @@ view!:
         <tonk-origin>
           <tonk-display
             entity={subject}
-            model=invitation
+            concept=invitation
             bind:base="data-base">
             <!-- Until the handler asserts both halves of the invitation,
                  the display has no instance to render. A `no-entity` slot
@@ -1913,18 +1913,18 @@ view!:
              iterates every member, one row each (sigil + DID + role). -->
         <div class="roster-section">
           <p class="roster-section__label">Shared with</p>
-          <tonk-display model=tonk:member></tonk-display>
+          <tonk-display concept=tonk:member></tonk-display>
         </div>
         <p class="share-dialog__note">Everyone who follows this link becomes a member of this space. The link stays active, so share it only with people you want to let in.</p>
       </wa-dialog>
 
-      <tonk-display model=workspace/sheet data-binder={this} data-active={active} />
+      <tonk-display concept=workspace/sheet data-binder={this} data-active={active} />
     </div>
 
 
 view/directory!:
   this: tonk:sheet-binder
-  model: tonk:sheet
+  concept: tonk:sheet
   display: |
     <div class="workspace">
       <style>
@@ -2296,7 +2296,7 @@ view/directory!:
             <button type="button" class="workspace-launchpad__add" data-create>+ add artifact</button>
           </div>
         </div>
-        <tonk-display entity={this} model=tonk:sheet />
+        <tonk-display entity={this} concept=tonk:sheet />
       </tonk-sheet-binder>
     </div>
 
@@ -2396,6 +2396,6 @@ concept!: &diagnose
 # branch's tree — so the directory view is the right kind.
 view/directory!:
   this: id:dialog:diagnose/view
-  model: dialog:diagnose
+  concept: dialog:diagnose
   display: |
     <tonk-tree></tonk-tree>

--- a/rust/tonk-core/assets/library/demo.yaml
+++ b/rust/tonk-core/assets/library/demo.yaml
@@ -142,7 +142,7 @@ view!:
       <div class="sheet__head">
         <span>day</span><span>item</span><span>time</span><span>cost</span>
       </div>
-      <tonk-display entity={stop} concept=stop></tonk-display>
+      <tonk-display this={stop} concept=stop></tonk-display>
       <div class="sheet__total">
         <span>total</span><span></span><span>-</span>
       </div>
@@ -150,7 +150,7 @@ view!:
 
 # The stop-row view, published under the built-in `view` concept
 # (no `this:` pin needed) so the nested `<tonk-display concept=stop>`
-# resolves it by model.
+# resolves it by concept.
 view!:
   concept: stop
   display: |
@@ -267,7 +267,7 @@ stop!:
   time: "-"
   cost: "EUR 820"
 
-# Two sheets (= artifacts + order). Each sheet's `entity`/`model`/
+# Two sheets (= artifacts + order). Each sheet's `entity`/`concept`/
 # `view` point at the trip it displays; `order` positions the tab.
 workspace/sheet!:
   this: id:tonk-workspace/sheet/itinerary
@@ -292,7 +292,7 @@ workspace/sheet!:
 # A portal entity: a self-contained HTML document (with its own
 # script + canvas) rendered into a sandboxed iframe. This is the
 # imperative escape hatch - the kind of drawing the declarative
-# template stack cannot express. `model: portal` on the sheet below
+# template stack cannot express. `concept: portal` on the sheet below
 # resolves the portal view, which mounts `<tonk-portal>` over it.
 portal!:
   this: id:tonk-workspace/sketch
@@ -341,9 +341,9 @@ portal!:
       </body>
     </html>
 
-# The portal sheet. `model: portal` (not `trip`) routes the sheet
+# The portal sheet. `concept: portal` (not `trip`) routes the sheet
 # content through the portal view to `<tonk-portal>`. No `view:`
-# override - the default model-resolved view is the portal bridge.
+# override - the default concept-resolved view is the portal bridge.
 workspace/sheet!:
   this: id:tonk-workspace/sheet/sketch
   title: "Sketch"

--- a/rust/tonk-core/assets/library/demo.yaml
+++ b/rust/tonk-core/assets/library/demo.yaml
@@ -79,12 +79,12 @@ concept!: &stop
 
 # The trip view: a sheet with a header row, then one nested
 # `<tonk-display>` per stop. The nested display omits `view`, so it
-# resolves the built-in view for `model=stop` (the stop-row view
+# resolves the built-in view for `concept=stop` (the stop-row view
 # below). A cardinality-many `{stop}` binding repeats the element
 # per value.
 view!:
   this: id:tonk-workspace/trip-view
-  model: trip
+  concept: trip
   display: |
     <div class="sheet">
       <style>
@@ -142,17 +142,17 @@ view!:
       <div class="sheet__head">
         <span>day</span><span>item</span><span>time</span><span>cost</span>
       </div>
-      <tonk-display entity={stop} model=stop></tonk-display>
+      <tonk-display entity={stop} concept=stop></tonk-display>
       <div class="sheet__total">
         <span>total</span><span></span><span>-</span>
       </div>
     </div>
 
 # The stop-row view, published under the built-in `view` concept
-# (no `this:` pin needed) so the nested `<tonk-display model=stop>`
+# (no `this:` pin needed) so the nested `<tonk-display concept=stop>`
 # resolves it by model.
 view!:
-  model: stop
+  concept: stop
   display: |
     <div class="sheet__row">
       <span>{day}</span><span>{item}</span><span>{time}</span><span>{cost}</span>
@@ -275,7 +275,7 @@ workspace/sheet!:
   subtitle: "day-by-day plan - 5 days - 7 stops"
   icon: "table-list"
   entity: id:tonk-workspace/itinerary
-  model: trip
+  concept: trip
   view: tonk:view
   order: "a"
 
@@ -285,7 +285,7 @@ workspace/sheet!:
   subtitle: "where we sleep - 1 booking"
   icon: "table-list"
   entity: id:tonk-workspace/lodging
-  model: trip
+  concept: trip
   view: tonk:view
   order: "b"
 
@@ -350,7 +350,7 @@ workspace/sheet!:
   subtitle: "an imperative canvas in a sandboxed iframe"
   icon: "palette"
   entity: id:tonk-workspace/sketch
-  model: portal
+  concept: portal
   view: tonk:view
   order: "c"
 
@@ -374,7 +374,7 @@ inspector!: &home-inspector
 
 tile!: &inspector-tile
   order: "a"
-  model: inspector
+  concept: inspector
   entity: home-inspector
 
 column-view!: &column-a

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -93,7 +93,7 @@ concept!: &view/directory
   with:
     concept:
       description: Concept this view renders
-      the: xyz.tonk.view/model
+      the: xyz.tonk.view/concept
       cardinality: one
       as: entity
     display:
@@ -214,7 +214,7 @@ concept!: &view
   with:
     concept:
       description: Concept this view renders
-      the: xyz.tonk.view/model
+      the: xyz.tonk.view/concept
       cardinality: one
       as: entity
     display:

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -12,7 +12,7 @@
 # Lowering runs `analyze_local` (no running system), so every
 # `&anchor` / bare-name reference must resolve within this file. Both
 # definitions below are self-contained: the directory view's
-# `model: space` resolves to the `&space` anchor here.
+# `concept: space` resolves to the `&space` anchor here.
 
 # A space (replica) the profile has access to. These records live on
 # the profile repository's meta branch — one per repository this device
@@ -84,7 +84,7 @@ command!: &space/create
       the: dom.event.do/prevent-default
 
 # The `view/directory` concept — the shape `<tonk-display>` queries to
-# find a directory view (a `model` + a `display` template under
+# find a directory view (a `concept` + a `display` template under
 # `xyz.tonk.view/directory`). The `view/directory!:` instance below is
 # an instance of it, so its concept must be present on this branch too.
 concept!: &view/directory
@@ -111,7 +111,7 @@ concept!: &view/directory
 # name={subject}>` opens that space's routing context and a
 # `<tonk-display concept=tonk:repository view=tonk:view/label>` inside it
 # shows the repo's current name (the cross-device source of truth).
-# Rendered as a directory (no entity) over the `space` model on the
+# Rendered as a directory (no entity) over the `space` concept on the
 # profile meta branch.
 view/directory!:
   this: id:tonk:space/directory
@@ -134,7 +134,7 @@ view/directory!:
       <a class="hub-card" href="/space/{subject}" data-kind={kind} data-status={status} with={this}>
         <span class="hub-card__sigil"><tonk-sigil>{subject}</tonk-sigil></span>
         <span class="hub-card__body">
-          <span class="hub-card__name"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><tonk-display entity={subject} concept=tonk:repository view=tonk:view/label><span slot="no-entity" class="hub-card__untitled" hidden>Untitled</span><span slot="no-concept" class="hub-card__untitled" hidden>Untitled</span><span slot="no-view" class="hub-card__untitled" hidden>Untitled</span><span slot="loading" class="hub-card__untitled" hidden>Untitled</span></tonk-display></tonk-branch></tonk-repository></tonk-host></span>
+          <span class="hub-card__name"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><tonk-display this={subject} concept=tonk:repository view=tonk:view/label><span slot="no-entity" class="hub-card__untitled" hidden>Untitled</span><span slot="no-concept" class="hub-card__untitled" hidden>Untitled</span><span slot="no-view" class="hub-card__untitled" hidden>Untitled</span><span slot="loading" class="hub-card__untitled" hidden>Untitled</span></tonk-display></tonk-branch></tonk-repository></tonk-host></span>
           <span class="hub-card__url">/space/{subject}</span>
           <span class="hub-card__status"></span>
         </span>
@@ -204,7 +204,7 @@ concept!: &join/failure
       as: text
 
 # The `view` concept — the shape `<tonk-display>` queries to resolve a
-# default (entity-set) view: a `model` + a `display` template. The
+# default (entity-set) view: a `concept` + a `display` template. The
 # join-failure `view!:` instance below is an instance of it, so its concept
 # must be present on this branch. (The Hub above gets by with only
 # `view/directory`; the join failure needs an entity-set view, hence this.)
@@ -243,7 +243,7 @@ view/directory!:
         <div slot="header"><h1>Joining…</h1></div>
         <wa-spinner></wa-spinner>
         <div class="join-status" with={this}>
-          <tonk-display entity={this} concept=tonk:join/failure>
+          <tonk-display this={this} concept=tonk:join/failure>
             <!-- While the join is pending there is a `tonk:join/status` but
                  no `tonk:join/failure` yet: stay quiet (empty slots) instead
                  of the built-in "Not found" callout. The failure view only

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -91,7 +91,7 @@ concept!: &view/directory
   this: tonk:view/directory
   description: A directory view used by tonk-display when entity is not set.
   with:
-    model:
+    concept:
       description: Concept this view renders
       the: xyz.tonk.view/model
       cardinality: one
@@ -109,13 +109,13 @@ concept!: &view/directory
 # The card's name is NOT read from this profile-side record — it is read
 # from the listed space's OWN repository: a nested `<tonk-repository
 # name={subject}>` opens that space's routing context and a
-# `<tonk-display model=tonk:repository view=tonk:view/label>` inside it
+# `<tonk-display concept=tonk:repository view=tonk:view/label>` inside it
 # shows the repo's current name (the cross-device source of truth).
 # Rendered as a directory (no entity) over the `space` model on the
 # profile meta branch.
 view/directory!:
   this: id:tonk:space/directory
-  model: space
+  concept: space
   display: |
     <div class="hub">
       <header class="hub-header">
@@ -134,7 +134,7 @@ view/directory!:
       <a class="hub-card" href="/space/{subject}" data-kind={kind} data-status={status} with={this}>
         <span class="hub-card__sigil"><tonk-sigil>{subject}</tonk-sigil></span>
         <span class="hub-card__body">
-          <span class="hub-card__name"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><tonk-display entity={subject} model=tonk:repository view=tonk:view/label><span slot="no-entity" class="hub-card__untitled" hidden>Untitled</span><span slot="no-model" class="hub-card__untitled" hidden>Untitled</span><span slot="no-view" class="hub-card__untitled" hidden>Untitled</span><span slot="loading" class="hub-card__untitled" hidden>Untitled</span></tonk-display></tonk-branch></tonk-repository></tonk-host></span>
+          <span class="hub-card__name"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><tonk-display entity={subject} concept=tonk:repository view=tonk:view/label><span slot="no-entity" class="hub-card__untitled" hidden>Untitled</span><span slot="no-concept" class="hub-card__untitled" hidden>Untitled</span><span slot="no-view" class="hub-card__untitled" hidden>Untitled</span><span slot="loading" class="hub-card__untitled" hidden>Untitled</span></tonk-display></tonk-branch></tonk-repository></tonk-host></span>
           <span class="hub-card__url">/space/{subject}</span>
           <span class="hub-card__status"></span>
         </span>
@@ -212,7 +212,7 @@ concept!: &view
   this: tonk:view
   description: A display template for rendering an entity.
   with:
-    model:
+    concept:
       description: Concept this view renders
       the: xyz.tonk.view/model
       cardinality: one
@@ -224,18 +224,18 @@ concept!: &view
       as: text
 
 # The /join view — a directory view for `tonk:join/status`, mounted by a
-# no-entity `<tonk-display model=tonk:join/status>` (see the Leptos /join
+# no-entity `<tonk-display concept=tonk:join/status>` (see the Leptos /join
 # route). Directory chrome renders even with zero instances, so the
 # `<tonk-page>` trigger mounts and fires `tonk:join` on load before any
 # status exists. The per-instance repeat shows a spinner while pending and
-# the failure callout (`model=tonk:join/failure`) once a join fails. On
+# the failure callout (`concept=tonk:join/failure`) once a join fails. On
 # success there is no status to show: the worker posts a navigate message
 # to the originating client (see `<tonk-host>`), which redirects into
 # `/space/<subject>` while the chrome's "Joining…" stands until the page
 # leaves.
 view/directory!:
   this: id:tonk:join/status/view
-  model: tonk:join/status
+  concept: tonk:join/status
   display: |
     <main class="join-view">
       <tonk-page onmount=tonk:join></tonk-page>
@@ -243,13 +243,13 @@ view/directory!:
         <div slot="header"><h1>Joining…</h1></div>
         <wa-spinner></wa-spinner>
         <div class="join-status" with={this}>
-          <tonk-display entity={this} model=tonk:join/failure>
+          <tonk-display entity={this} concept=tonk:join/failure>
             <!-- While the join is pending there is a `tonk:join/status` but
                  no `tonk:join/failure` yet: stay quiet (empty slots) instead
                  of the built-in "Not found" callout. The failure view only
                  renders once a failure is actually recorded. -->
             <span slot="no-entity"></span>
-            <span slot="no-model"></span>
+            <span slot="no-concept"></span>
             <span slot="loading"></span>
           </tonk-display>
         </div>
@@ -257,11 +257,11 @@ view/directory!:
     </main>
 
 # The failure view — the default view for `tonk:join/failure`, so the join
-# directory's per-instance `<tonk-display model=tonk:join/failure>` renders
+# directory's per-instance `<tonk-display concept=tonk:join/failure>` renders
 # it only when a failure exists (i.e. status: failed). Shows the reason.
 view!: &join/failure-view
   this: id:tonk:join/failure/view
-  model: tonk:join/failure
+  concept: tonk:join/failure
   display: |
     <wa-callout variant="danger" class="join-error">
       <wa-icon slot="icon" name="circle-exclamation"></wa-icon>

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1889,7 +1889,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    /// Only the subject inputs (`entity`/`concept`/`view`) re-resolve what
+    /// Only the subject inputs (`this`/`concept`/`view`) re-resolve what
     /// the display renders, so only those force a teardown. A host-context
     /// attribute like `data-active` (threaded in for a template to read
     /// as `{dom.host/data-active}`) leaves the resolved view unchanged and
@@ -1897,7 +1897,7 @@ mod tests {
     /// the whole subtree on every selection change.
     #[dialog_common::test]
     fn it_tears_down_only_on_subject_input_changes() {
-        assert!(resolves_template("entity"));
+        assert!(resolves_template("this"));
         assert!(resolves_template("concept"));
         assert!(resolves_template("view"));
         assert!(

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -40,7 +40,7 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::{CustomEvent, CustomEventInit, Element, HtmlElement, Node, window};
 
 use crate::resolve::{
-    directory_view_predicate, entity_query, instances_query, looks_like_uri, view_by_model_query,
+    directory_view_predicate, entity_query, instances_query, looks_like_uri, view_by_concept_query,
     view_predicate,
 };
 use crate::state::{self, State};
@@ -95,16 +95,16 @@ struct Inner {
     /// a one-shot) so a concept seeded *after* the element mounts
     /// pushes a frame and the display recovers from `no-model` without
     /// a reload. Each model frame (re)starts the downstream view +
-    /// entity flow via `handle_model_frame`.
-    model_sub: Option<HostSubscription>,
+    /// entity flow via `handle_concept_frame`.
+    concept_sub: Option<HostSubscription>,
     /// Bumped every time a model frame (re)starts the downstream flow.
     /// A downstream async chain captures this at spawn and bails if a
     /// newer model frame has superseded it, mirroring `generation` but
     /// scoped to the model→downstream restart so a late model frame
     /// doesn't race an in-flight downstream setup.
     downstream_generation: u64,
-    /// The `(model_entity, descriptor_json)` the current downstream flow
-    /// was started for, recorded **synchronously** in `handle_model_frame`
+    /// The `(concept_entity, descriptor_json)` the current downstream flow
+    /// was started for, recorded **synchronously** in `handle_concept_frame`
     /// before the async `start_downstream` spawns. The model subscription
     /// re-pushes a frame on every branch revision (including unrelated
     /// data writes); this lets the handler skip restarting the downstream
@@ -121,7 +121,7 @@ struct Inner {
     /// values is order-independent, so an unrelated branch write (which
     /// re-pushes the same concept with shuffled keys) no longer counts as
     /// a change and the list is not torn down.
-    resolved_model: Option<(String, serde_json::Value)>,
+    resolved_concept: Option<(String, serde_json::Value)>,
     /// Cancels the view (or views-for-model) subscription on
     /// disconnect / attribute change. Dropping the handle calls
     /// the host's `cancel()` and dispatches `tonk-unsubscribe`.
@@ -177,15 +177,15 @@ struct Inner {
     portal_descriptor: Option<String>,
     /// The resolved model entity, surfaced to the portal as its `model`
     /// attribute (the bridge's `context.model`).
-    portal_model: Option<String>,
+    portal_concept: Option<String>,
     /// The view-concept descriptor used to resolve a view by model.
     /// Retained so the `_:_` default-view fallback can re-query against
     /// the same view concept when the model-specific view frame is
     /// empty.
     view_descriptor: Option<serde_json::Value>,
-    /// The resolved model entity (`model_entity`), retained for the
+    /// The resolved model entity (`concept_entity`), retained for the
     /// `_:_` fallback query and for comparison.
-    model_entity: Option<String>,
+    concept_entity: Option<String>,
     /// True when the currently-mounted slide came from the `_:_`
     /// default view rather than a model-specific view. A non-empty
     /// model-specific view frame replaces it (the specific view takes
@@ -203,9 +203,9 @@ impl Inner {
         Self {
             disposed: false,
             generation: 0,
-            model_sub: None,
+            concept_sub: None,
             downstream_generation: 0,
-            resolved_model: None,
+            resolved_concept: None,
             view_sub: None,
             entity_sub: None,
             last_frame: Vec::new(),
@@ -217,9 +217,9 @@ impl Inner {
             delegate_generation: 0,
             depth_annotator: None,
             portal_descriptor: None,
-            portal_model: None,
+            portal_concept: None,
             view_descriptor: None,
-            model_entity: None,
+            concept_entity: None,
             default_slide: false,
             directory: false,
         }
@@ -228,13 +228,13 @@ impl Inner {
     fn abort_all(&mut self) {
         // Dropping the subscriptions cancels via the host and
         // dispatches `tonk-unsubscribe`.
-        self.model_sub.take();
+        self.concept_sub.take();
         self.view_sub.take();
         self.entity_sub.take();
         // Forget the resolved concept so a restart (attribute change /
         // reconnect) re-resolves and remounts even if the new model
         // happens to resolve to the same concept.
-        self.resolved_model = None;
+        self.resolved_concept = None;
         // Drop the delegate — its impl removes listeners from the
         // host on Drop.
         self.delegate.take();
@@ -262,7 +262,7 @@ impl CustomElement for TonkDisplay {
         // restarting. `data-base` lets a wrapping `<tonk-origin>` deliver
         // the invite-URL base (`{origin}/join`) into the view after mount.
         // See `attribute_changed_callback`.
-        &["entity", "model", "view", "data-active", "data-base"]
+        &["entity", "concept", "view", "data-active", "data-base"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -430,7 +430,7 @@ fn on_reset(host: &Element, state: &Rc<RefCell<Inner>>, payload: JsValue, opts: 
         }
     };
     match tag.as_deref() {
-        Some("model") => handle_model_frame(host, state, conclusions),
+        Some("concept") => handle_concept_frame(host, state, conclusions),
         Some("view") => handle_view_frame(host, state, conclusions),
         Some("entity") => handle_entity_frame(host, state, conclusions),
         _ => {
@@ -600,7 +600,7 @@ fn check_downstream(
 /// subscription. The model resolve is a live subscription (not a
 /// one-shot) so a concept seeded *after* the element mounts pushes a
 /// frame and the display leaves `no-model` without a reload. Each
-/// model frame routes to `handle_model_frame`, which (re)starts the
+/// model frame routes to `handle_concept_frame`, which (re)starts the
 /// downstream view + entity flow ([`start_downstream`]).
 ///
 /// Attribute errors (bad `entity`, missing `model`, carousel) surface
@@ -632,7 +632,7 @@ async fn run(
 
     // `view="about:blank"` is the carousel sentinel: enumerate every
     // view defined for the model. This is the two-step flow from the
-    // design (step 1: query the `{model}` display contract for all
+    // design (step 1: query the `{concept}` display contract for all
     // conforming view kinds; step 2: resolve each kind's template).
     // Step 2 is not built yet, so carousel surfaces a clear error
     // rather than rendering a half-resolved frame.
@@ -645,13 +645,13 @@ async fn run(
 
     // `model` is required: it both projects the subject's fields and
     // constrains the view query.
-    let model = host
-        .get_attribute("model")
+    let concept = host
+        .get_attribute("concept")
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             ErrorDetail::new(
                 ErrorKind::Descriptor,
-                "<tonk-display> requires a `model` attribute",
+                "<tonk-display> requires a `concept` attribute",
             )
         })?;
 
@@ -659,26 +659,26 @@ async fn run(
     // name rarely lands late; an attribute change restarts the flow),
     // then *subscribe* to its phase-1 concept query so a concept seeded
     // after mount pushes a frame. The empty frame is `no-model`, not a
-    // hard error — `handle_model_frame` keeps the subscription and
+    // hard error — `handle_concept_frame` keeps the subscription and
     // starts the downstream flow once the concept lands.
-    let model_q = resolve_model_query(host, &model).await?;
+    let concept_q = resolve_concept_query(host, &concept).await?;
     check_generation(&state, generation)?;
-    let model_body = to_body(&model_q)?;
-    let model_tag = JsValue::from_str("model");
-    let model_sub = host_consumer::subscribe(host, &model_body, Some(&model_tag))?;
+    let concept_body = to_body(&concept_q)?;
+    let concept_tag = JsValue::from_str("concept");
+    let concept_sub = host_consumer::subscribe(host, &concept_body, Some(&concept_tag))?;
     {
         let mut s = state.borrow_mut();
         if s.generation != generation {
             return Err(ErrorDetail::new(ErrorKind::Descriptor, "superseded"));
         }
-        s.model_sub = Some(model_sub);
+        s.concept_sub = Some(concept_sub);
     }
     Ok(())
 }
 
-/// Phase 2: with the model concept resolved (`model_entity` +
+/// Phase 2: with the model concept resolved (`concept_entity` +
 /// `descriptor_json`), open the view + entity subscriptions. Invoked
-/// from `handle_model_frame` on every non-empty model frame, so a
+/// from `handle_concept_frame` on every non-empty model frame, so a
 /// branch revision that (re)defines the model — or a view that lands
 /// later — re-runs this against the freshest descriptor. Tears down
 /// the prior view/entity subscriptions first and bumps
@@ -686,7 +686,7 @@ async fn run(
 async fn start_downstream(
     host: &Element,
     state: Rc<RefCell<Inner>>,
-    model_entity: String,
+    concept_entity: String,
     descriptor_json: String,
     downstream_generation: u64,
 ) -> Result<(), ErrorDetail> {
@@ -714,7 +714,7 @@ async fn start_downstream(
             // model subscription leaves once the view concept lands and
             // the next model frame re-runs this. Other resolve failures
             // still propagate.
-            match resolve_model(host, view_ref).await {
+            match resolve_concept(host, view_ref).await {
                 Ok((_, view_descriptor_json)) => {
                     check_downstream(&state, downstream_generation)?;
                     serde_json::from_str(&view_descriptor_json).map_err(|e| {
@@ -722,7 +722,7 @@ async fn start_downstream(
                     })?
                 }
                 Err(err) if err.kind == ErrorKind::UnknownSource => {
-                    let model = host.get_attribute("model").unwrap_or_default();
+                    let concept = host.get_attribute("concept").unwrap_or_default();
                     state::set_absence(
                         host,
                         State::NoView,
@@ -730,7 +730,7 @@ async fn start_downstream(
                         &format!(
                             r#"view:
   this: {view_ref}
-  model: {model}"#
+  concept: {concept}"#
                         ),
                     );
                     return Ok(());
@@ -739,7 +739,7 @@ async fn start_downstream(
             }
         }
     };
-    let view_q = view_by_model_query(&view_descriptor, &model_entity).map_err(|e| {
+    let view_q = view_by_concept_query(&view_descriptor, &concept_entity).map_err(|e| {
         ErrorDetail::new(ErrorKind::Descriptor, format!("view-by-model query: {e}"))
     })?;
     let view_body = to_body(&view_q)?;
@@ -792,7 +792,7 @@ async fn start_downstream(
         // model-specific view frame is empty, `handle_view_frame`
         // re-queries the same view concept with `model = _:_`.
         s.view_descriptor = Some(view_descriptor.clone());
-        s.model_entity = Some(model_entity.clone());
+        s.concept_entity = Some(concept_entity.clone());
         // Context handed to a `<tonk-portal>` if a view frame routes
         // here in portal mode: the subject's model entity (the
         // bridge's `context.model`) and its descriptor (so the bridge
@@ -800,7 +800,7 @@ async fn start_downstream(
         // fetches data itself, so the entity subscription above just
         // no-ops against the portal (it has no `draw`).
         s.portal_descriptor = Some(descriptor_json);
-        s.portal_model = Some(model_entity);
+        s.portal_concept = Some(concept_entity);
     }
     dispatch_event(host, "tonk-display:connected", None);
     Ok(())
@@ -868,21 +868,21 @@ fn first_field(value: &JsValue, field: &str) -> Result<Option<String>, ErrorDeta
 /// resolve — the concept carries a `Name` claim but no
 /// `dialog.meta/name`, so a direct `name`-filtered Phase-1 would miss
 /// it. A value that is already a URI skips name resolution.
-async fn resolve_model(host: &Element, source: &str) -> Result<(String, String), ErrorDetail> {
-    let phase1_q = resolve_model_query(host, source).await?;
+async fn resolve_concept(host: &Element, source: &str) -> Result<(String, String), ErrorDetail> {
+    let phase1_q = resolve_concept_query(host, source).await?;
     let result = host_consumer::query(host, &to_body(&phase1_q)?).await?;
     extract_phase1(&result)
 }
 
 /// Build the phase-1 concept query for `source` *without executing it*.
 ///
-/// Splits the front half of [`resolve_model`]: a bare bookmark name is
+/// Splits the front half of [`resolve_concept`]: a bare bookmark name is
 /// resolved through the Name concept (`id:<name>` →
 /// `dialog.name/referent`) into a concept URI (a one-shot `query`),
 /// then `phase1_query` is built from the resolved `ParsedSource`. The
 /// caller decides whether to run it once or open a subscription on it —
 /// the model link subscribes so a late-seeded concept recovers.
-async fn resolve_model_query(host: &Element, source: &str) -> Result<Query, ErrorDetail> {
+async fn resolve_concept_query(host: &Element, source: &str) -> Result<Query, ErrorDetail> {
     let parsed: ParsedSource = parse_source(source);
     let parsed = if parsed.is_uri() {
         parsed
@@ -903,7 +903,7 @@ async fn resolve_model_query(host: &Element, source: &str) -> Result<Query, Erro
     Ok(phase1_query(&parsed))
 }
 
-/// Route a `"model"` subscription frame. The model resolve is a live
+/// Route a `"concept"` subscription frame. The model resolve is a live
 /// subscription, so this fires on every branch revision touching the
 /// concept-of-concepts view:
 ///
@@ -914,20 +914,20 @@ async fn resolve_model_query(host: &Element, source: &str) -> Result<Query, Erro
 /// - **resolved row** → bump `downstream_generation` and (re)start the
 ///   downstream view + entity flow against the freshest descriptor, so
 ///   a model (re)definition or a late-landing view is picked up.
-fn handle_model_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
+fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
     let resolved = extract_phase1_conclusion(conclusions);
-    let Some((model_entity, descriptor_json)) = resolved else {
+    let Some((concept_entity, descriptor_json)) = resolved else {
         // The concept is not on the branch yet. Stay subscribed; the
         // embedder may skin `no-model` via a `slot="no-model"` child,
         // otherwise the built-in fallback names the missing model.
-        let model = host.get_attribute("model").unwrap_or_default();
+        let concept = host.get_attribute("concept").unwrap_or_default();
         state::set_absence(
             host,
-            State::NoModel,
-            "Model not found",
+            State::NoConcept,
+            "Concept not found",
             &format!(
                 r#"concept:
-  this: {model}"#
+  this: {concept}"#
             ),
         );
         return;
@@ -944,7 +944,7 @@ fn handle_model_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: V
         // view/entity subscriptions and wipe the rendered rows. The
         // entity subscription already streams data updates in place.
         //
-        // The comparison is against `resolved_model`, set synchronously
+        // The comparison is against `resolved_concept`, set synchronously
         // here (not `start_downstream`'s async tail), so a burst of model
         // frames during one write doesn't each see a stale value and
         // remount.
@@ -958,11 +958,11 @@ fn handle_model_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: V
         // still compares.
         let next_descriptor = serde_json::from_str::<serde_json::Value>(&descriptor_json)
             .unwrap_or_else(|_| serde_json::Value::String(descriptor_json.clone()));
-        let next = (model_entity.clone(), next_descriptor);
-        if s.resolved_model.as_ref() == Some(&next) {
+        let next = (concept_entity.clone(), next_descriptor);
+        if s.resolved_concept.as_ref() == Some(&next) {
             return;
         }
-        s.resolved_model = Some(next);
+        s.resolved_concept = Some(next);
         s.downstream_generation = s.downstream_generation.wrapping_add(1);
         s.downstream_generation
     };
@@ -972,7 +972,7 @@ fn handle_model_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: V
         if let Err(err) = start_downstream(
             &host,
             state.clone(),
-            model_entity,
+            concept_entity,
             descriptor_json,
             downstream_generation,
         )
@@ -991,7 +991,7 @@ fn handle_model_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: V
 }
 
 /// Decode a phase-1 subscription frame (already-deserialized
-/// `Vec<Conclusion>`) into `(model_entity, descriptor_json)`. Returns
+/// `Vec<Conclusion>`) into `(concept_entity, descriptor_json)`. Returns
 /// `None` for an empty frame or a row missing the `source` descriptor —
 /// both are the `no-model` steady state, not a hard error.
 fn extract_phase1_conclusion(conclusions: Vec<Conclusion>) -> Option<(String, String)> {
@@ -1026,7 +1026,7 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     // document mounted into a `<tonk-portal>` — whose bridge fetches
     // the entity's own data through the live `tonk` object — rather
     // than interpolated inline. `type` rides the view query only when
-    // the view concept declares it (see `view_by_model_query`), so an
+    // the view concept declares it (see `view_by_concept_query`), so an
     // ordinary view never trips this; a `display` change just reloads
     // the portal's `content` in place.
     // No model-specific view resolved: fall back to the `_:_` default
@@ -1140,7 +1140,7 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
 /// that has no specific view of that kind. `tonk:_` is the
 /// wildcard-model entity seeded by core.yaml. See
 /// `tonk-core/docs/templates.md`.
-const DEFAULT_MODEL: &str = "tonk:_";
+const DEFAULT_CONCEPT: &str = "tonk:_";
 
 /// Query the `_:_` default view (same view concept, `model = _:_`) and
 /// mount its template as the default slide. Spawned from
@@ -1162,7 +1162,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
         // forever — there is genuinely no presentation for this model
         // (not even the `_:_` default is seeded).
         let resolved = async {
-            let query = view_by_model_query(&descriptor, DEFAULT_MODEL).ok()?;
+            let query = view_by_concept_query(&descriptor, DEFAULT_CONCEPT).ok()?;
             let body = to_body(&query).ok()?;
             let result = host_consumer::query(&host, &body).await.ok()?;
             first_field(&result, "display").ok().flatten()
@@ -1242,7 +1242,7 @@ fn mount_notation_fallback(host: &Element, state: &Rc<RefCell<Inner>>, conclusio
     };
     let _ = script.set_attribute("type", "text/tonk-notation");
     let head = host
-        .get_attribute("model")
+        .get_attribute("concept")
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "concept".to_owned());
     let text = crate::notation_format::format(&conclusion.this, &conclusion.fields, &head, None);
@@ -1325,8 +1325,8 @@ fn mount_portal_slide(host: &Element, inner: &Inner, display: &str) -> Option<Sl
     if let Some(entity) = host.get_attribute("entity") {
         let _ = portal.set_attribute("entity", &entity);
     }
-    if let Some(model) = inner.portal_model.as_ref() {
-        let _ = portal.set_attribute("model", model);
+    if let Some(concept) = inner.portal_concept.as_ref() {
+        let _ = portal.set_attribute("concept", concept);
     }
     if let Some(descriptor) = inner.portal_descriptor.as_ref() {
         let _ = Reflect::set(
@@ -1440,9 +1440,9 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
             }
         }
         // Resolve through the same name-first path as the model/view
-        // (`resolve_model`), so an event-handler concept named after a
+        // (`resolve_concept`), so an event-handler concept named after a
         // pinned-`this` concept resolves via the Name index too.
-        match resolve_model(host, name).await {
+        match resolve_concept(host, name).await {
             Ok((_entity, descriptor_json)) => {
                 match serde_json::from_str::<serde_json::Value>(&descriptor_json) {
                     Ok(value) => {
@@ -1527,7 +1527,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
         // The resolved model concept's descriptor (parsed), so the
         // no-entity diagnostic can name the concept's required attributes
         // and probe which ones the entity is actually missing.
-        let descriptor = s.resolved_model.as_ref().map(|(_, value)| value.clone());
+        let descriptor = s.resolved_concept.as_ref().map(|(_, value)| value.clone());
         let empty = serialize_conclusions(&[]);
         for slide in s.slides.values() {
             call_render(&slide.view_el, &empty);
@@ -1600,7 +1600,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
 /// isn't available (or has no `with:` map) falls back to the bare
 /// `model: / this:` notation — there is nothing to diff against.
 async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value>) {
-    let model = host.get_attribute("model").unwrap_or_default();
+    let concept = host.get_attribute("concept").unwrap_or_default();
     let entity = host.get_attribute("entity").unwrap_or_default();
 
     // Without a descriptor `with:` map there is nothing to probe; keep the
@@ -1615,7 +1615,7 @@ async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value
             State::NoEntity,
             "Not found",
             &format!(
-                r#"{model}:
+                r#"{concept}:
   this: {entity}"#
             ),
         );
@@ -1660,7 +1660,7 @@ async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value
         }
     }
 
-    state::set_no_entity_diagnostic(host, &model, &entity, &present, &missing);
+    state::set_no_entity_diagnostic(host, &concept, &entity, &present, &missing);
 }
 
 /// Refresh the trailing notation slide's source `<script>` with
@@ -1671,7 +1671,7 @@ fn update_notation(host: &Element, inner: &Inner, conclusion: &Conclusion) {
         return;
     };
     let head = host
-        .get_attribute("model")
+        .get_attribute("concept")
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "concept".to_owned());
     let text = crate::notation_format::format(&conclusion.this, &conclusion.fields, &head, None);
@@ -1828,7 +1828,7 @@ fn with_host_attributes(host: &Element, conclusion: &Conclusion) -> Conclusion {
 /// the in-place path to re-run the query without rebuilding the DOM,
 /// which is a larger change left for later.
 fn resolves_template(name: &str) -> bool {
-    matches!(name, "entity" | "model" | "view")
+    matches!(name, "entity" | "concept" | "view")
 }
 
 /// Re-project the host's current attributes into the mounted view(s)
@@ -1898,7 +1898,7 @@ mod tests {
     #[dialog_common::test]
     fn it_tears_down_only_on_subject_input_changes() {
         assert!(resolves_template("entity"));
-        assert!(resolves_template("model"));
+        assert!(resolves_template("concept"));
         assert!(resolves_template("view"));
         assert!(
             !resolves_template("data-active"),
@@ -2109,7 +2109,7 @@ mod tests {
             /// Tags of every subscription opened.
             subscribe_tags: Vec<String>,
             /// The phase-1 model concept frame, auto-pushed the moment
-            /// the `"model"` subscription opens — the model resolve is a
+            /// the `"concept"` subscription opens — the model resolve is a
             /// live subscription now, not a one-shot. `None` makes the
             /// model subscription stay empty (the `no-model` state).
             model_frame: Option<JsValue>,
@@ -2121,7 +2121,7 @@ mod tests {
             }
 
             /// Like [`install`] but with an explicit model concept frame
-            /// auto-pushed on the `"model"` subscription. `None` leaves
+            /// auto-pushed on the `"concept"` subscription. `None` leaves
             /// the model subscription empty so the display sits in
             /// `no-model`.
             fn install_with_model(
@@ -2183,7 +2183,7 @@ mod tests {
                                 // soon as the model subscription opens, so
                                 // the downstream flow starts the way a live
                                 // host would on the first revision.
-                                if tag == "model" {
+                                if tag == "concept" {
                                     s.model_frame.clone()
                                 } else {
                                     None
@@ -2195,8 +2195,11 @@ mod tests {
                             let _ = Reflect::set(&detail, &"subscription".into(), &sub);
                             if let Some(frame) = model_frame {
                                 let opts = Object::new();
-                                let _ =
-                                    Reflect::set(&opts, &"tag".into(), &JsValue::from_str("model"));
+                                let _ = Reflect::set(
+                                    &opts,
+                                    &"tag".into(),
+                                    &JsValue::from_str("concept"),
+                                );
                                 if let Ok(reset) = Reflect::get(&consumer, &"reset".into())
                                     && let Ok(reset) = reset.dyn_into::<Function>()
                                 {
@@ -2253,11 +2256,11 @@ mod tests {
             }
         }
 
-        fn mount_display(host: &FakeHost, view: &str, model: &str, entity: &str) -> Element {
+        fn mount_display(host: &FakeHost, view: &str, concept: &str, entity: &str) -> Element {
             register();
             let display = document().create_element("tonk-display").unwrap();
             display.set_attribute("view", view).unwrap();
-            display.set_attribute("model", model).unwrap();
+            display.set_attribute("concept", concept).unwrap();
             display.set_attribute("entity", entity).unwrap();
             host.container.append_child(&display).unwrap();
             display
@@ -2266,10 +2269,10 @@ mod tests {
         // The flow resolves two concepts in order: the subject `model`
         // concept (projected for the entity query) then the `view`
         // concept (the query predicate). The view concept declares a
-        // `type` attribute, so `view_by_model_query` projects `type` and
+        // `type` attribute, so `view_by_concept_query` projects `type` and
         // each view frame carries the value that decides portal mode.
         //
-        // `resolve_model` resolves a bare name through the Name concept
+        // `resolve_concept` resolves a bare name through the Name concept
         // first (`id:<name>` → `dialog.name/referent`), then runs the
         // Phase-1 concept query by `this`. So each bare-name resolution
         // is TWO queries: a name lookup, then the concept lookup. The
@@ -2279,7 +2282,7 @@ mod tests {
         fn name_row(entity: &str) -> JsValue {
             rows(&[("did:key:zName", &[("entity", entity)])])
         }
-        // The model concept resolves through a live `"model"`
+        // The model concept resolves through a live `"concept"`
         // subscription now, so its phase-1 row is auto-pushed as the
         // model frame (see `install_with_model`) rather than answered as
         // a one-shot. The remaining one-shots are the model *name*
@@ -2318,7 +2321,7 @@ mod tests {
                     "did:key:zViewConcept",
                     &[(
                         "source",
-                        r#"{"with":{"model":{"the":"xyz.tonk.view/model","as":"Entity","cardinality":"one"},"display":{"the":"xyz.tonk.view/display","as":"Text","cardinality":"one"},"type":{"the":"xyz.tonk.view/type","as":"Text","cardinality":"one"}}}"#,
+                        r#"{"with":{"concept":{"the":"xyz.tonk.view/model","as":"Entity","cardinality":"one"},"display":{"the":"xyz.tonk.view/display","as":"Text","cardinality":"one"},"type":{"the":"xyz.tonk.view/type","as":"Text","cardinality":"one"}}}"#,
                     )],
                 )]),
             ]
@@ -2347,7 +2350,7 @@ mod tests {
                     &[
                         ("display", "<h1>monolith</h1>"),
                         ("type", "text/html"),
-                        ("model", "did:key:zModel"),
+                        ("concept", "did:key:zModel"),
                     ],
                 )]),
             );
@@ -2382,7 +2385,7 @@ mod tests {
             // `draw`).
             assert_eq!(
                 host.subscribe_tags(),
-                vec!["model".to_owned(), "view".to_owned(), "entity".to_owned()],
+                vec!["concept".to_owned(), "view".to_owned(), "entity".to_owned()],
             );
         }
 
@@ -2415,7 +2418,7 @@ mod tests {
             tags.sort();
             assert_eq!(
                 tags,
-                vec!["entity".to_owned(), "model".to_owned(), "view".to_owned()],
+                vec!["entity".to_owned(), "concept".to_owned(), "view".to_owned()],
                 "inline mode opens the model, view, and entity subscriptions",
             );
         }
@@ -2435,28 +2438,28 @@ mod tests {
             // Wait for the model subscription, then deliver an empty frame
             // — that lands the display in `no-model`.
             for _ in 0..200 {
-                if host.subscribe_tags().contains(&"model".to_owned()) {
+                if host.subscribe_tags().contains(&"concept".to_owned()) {
                     break;
                 }
                 sleep(5).await;
             }
-            host.push_frame("model", &rows(&[]));
+            host.push_frame("concept", &rows(&[]));
             for _ in 0..200 {
-                if display.get_attribute("data-state").as_deref() == Some("no-model") {
+                if display.get_attribute("data-state").as_deref() == Some("no-concept") {
                     break;
                 }
                 sleep(5).await;
             }
             assert_eq!(
                 display.get_attribute("data-state").as_deref(),
-                Some("no-model"),
+                Some("no-concept"),
                 "an absent model concept is `no-model`, not an error",
             );
 
             // The concept lands: the model subscription pushes a non-empty
             // frame, the downstream view + entity subs open, and a view +
             // entity frame render the row live.
-            host.push_frame("model", &model_concept_frame());
+            host.push_frame("concept", &model_concept_frame());
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"view".to_owned())
                     && host.subscribe_tags().contains(&"entity".to_owned())
@@ -2629,7 +2632,7 @@ mod tests {
             );
             register();
             let display = document().create_element("tonk-display").unwrap();
-            display.set_attribute("model", "counter").unwrap();
+            display.set_attribute("concept", "counter").unwrap();
             display.set_attribute("entity", "id:demo-counter").unwrap();
             host.container.append_child(&display).unwrap();
             for _ in 0..200 {
@@ -2696,7 +2699,7 @@ mod tests {
             // key-order-stable. The guard must treat it as unchanged: the
             // mounted <tonk-view> survives, no remount, no wiped list.
             let subs_before = host.subscribe_tags().len();
-            host.push_frame("model", &model_concept_frame_reordered());
+            host.push_frame("concept", &model_concept_frame_reordered());
             sleep(50).await;
 
             assert!(
@@ -2728,7 +2731,7 @@ mod tests {
         fn directory_resolve_responses() -> Vec<JsValue> {
             vec![name_row("did:key:zModel")]
         }
-        // The directory model concept, auto-pushed on the `"model"`
+        // The directory model concept, auto-pushed on the `"concept"`
         // subscription (the built-in directory view predicate needs no
         // branch lookup, so only the model name lookup remains a
         // one-shot).
@@ -2748,11 +2751,11 @@ mod tests {
             )
         }
 
-        fn mount_directory(host: &FakeHost, model: &str) -> Element {
+        fn mount_directory(host: &FakeHost, concept: &str) -> Element {
             register();
             crate::view::register();
             let display = document().create_element("tonk-display").unwrap();
-            display.set_attribute("model", model).unwrap();
+            display.set_attribute("concept", concept).unwrap();
             host.container.append_child(&display).unwrap();
             display
         }
@@ -2913,7 +2916,7 @@ mod tests {
                     "did:key:zView",
                     &[(
                         "display",
-                        "<div><tonk-display entity={this} model=item data-id={this}></tonk-display><p class=\"after\">keep me</p></div>",
+                        "<div><tonk-display entity={this} concept=item data-id={this}></tonk-display><p class=\"after\">keep me</p></div>",
                     )],
                 )]),
             );

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -2321,7 +2321,7 @@ mod tests {
                     "did:key:zViewConcept",
                     &[(
                         "source",
-                        r#"{"with":{"concept":{"the":"xyz.tonk.view/model","as":"Entity","cardinality":"one"},"display":{"the":"xyz.tonk.view/display","as":"Text","cardinality":"one"},"type":{"the":"xyz.tonk.view/type","as":"Text","cardinality":"one"}}}"#,
+                        r#"{"with":{"concept":{"the":"xyz.tonk.view/concept","as":"Entity","cardinality":"one"},"display":{"the":"xyz.tonk.view/display","as":"Text","cardinality":"one"},"type":{"the":"xyz.tonk.view/type","as":"Text","cardinality":"one"}}}"#,
                     )],
                 )]),
             ]

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -2418,8 +2418,8 @@ mod tests {
             tags.sort();
             assert_eq!(
                 tags,
-                vec!["entity".to_owned(), "concept".to_owned(), "view".to_owned()],
-                "inline mode opens the model, view, and entity subscriptions",
+                vec!["concept".to_owned(), "entity".to_owned(), "view".to_owned()],
+                "inline mode opens the concept, view, and entity subscriptions",
             );
         }
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -4,8 +4,8 @@
 //! mounts a dumb-renderer `<tonk-view>` as a slide.
 //!
 //! The `view` attribute names a view *concept* (named or URI); the
-//! `model` attribute names the subject's model concept. Resolution
-//! queries the view concept constrained to that model and reads the
+//! `concept` attribute names the subject's concept. Resolution
+//! queries the view concept constrained to that concept and reads the
 //! row's `display` field as the template — the view concept's
 //! descriptor maps the `display` field name to whatever attribute
 //! that view kind declares it under, so any conforming view kind
@@ -15,10 +15,10 @@
 //! fresh one carrying the new children.
 //!
 //! `view="about:blank"` is reserved for a future carousel mode
-//! (enumerate every view for the model); it currently errors.
+//! (enumerate every view for the concept); it currently errors.
 //!
 //! Subscriptions live in `<tonk-display>` only — slide elements
-//! never open their own. One model resolution + one view
+//! never open their own. One concept resolution + one view
 //! subscription + one entity subscription per attribute set.
 
 use std::cell::RefCell;
@@ -46,7 +46,7 @@ use crate::resolve::{
 use crate::state::{self, State};
 
 /// Sentinel `view` value that selects carousel mode — enumerate
-/// every view defined for the model instead of rendering one. Uses
+/// every view defined for the concept instead of rendering one. Uses
 /// `about:blank` to match the "blank view" convention (a new
 /// artifact's `view` is `about:blank` until a presentation is
 /// chosen).
@@ -90,28 +90,28 @@ struct Inner {
     /// covers the cross-`Inner` race where a custom element
     /// detaches and re-attaches.
     generation: u64,
-    /// Cancels the phase-1 **model** subscription on disconnect /
-    /// attribute change. The model resolve is a live subscription (not
+    /// Cancels the phase-1 **concept** subscription on disconnect /
+    /// attribute change. The concept resolve is a live subscription (not
     /// a one-shot) so a concept seeded *after* the element mounts
-    /// pushes a frame and the display recovers from `no-model` without
-    /// a reload. Each model frame (re)starts the downstream view +
+    /// pushes a frame and the display recovers from `no-concept` without
+    /// a reload. Each concept frame (re)starts the downstream view +
     /// entity flow via `handle_concept_frame`.
     concept_sub: Option<HostSubscription>,
-    /// Bumped every time a model frame (re)starts the downstream flow.
+    /// Bumped every time a concept frame (re)starts the downstream flow.
     /// A downstream async chain captures this at spawn and bails if a
-    /// newer model frame has superseded it, mirroring `generation` but
-    /// scoped to the model→downstream restart so a late model frame
+    /// newer concept frame has superseded it, mirroring `generation` but
+    /// scoped to the concept→downstream restart so a late concept frame
     /// doesn't race an in-flight downstream setup.
     downstream_generation: u64,
     /// The `(concept_entity, descriptor_json)` the current downstream flow
     /// was started for, recorded **synchronously** in `handle_concept_frame`
-    /// before the async `start_downstream` spawns. The model subscription
+    /// before the async `start_downstream` spawns. The concept subscription
     /// re-pushes a frame on every branch revision (including unrelated
     /// data writes); this lets the handler skip restarting the downstream
     /// flow when the resolved concept is unchanged, so a plain write
     /// updates the entity rows in place instead of tearing the whole host
     /// down and remounting. Must be set here (not in `start_downstream`'s
-    /// tail) so back-to-back model frames during one write don't all see
+    /// tail) so back-to-back concept frames during one write don't all see
     /// a stale value and each trigger a remount.
     ///
     /// The descriptor is stored **parsed** (`serde_json::Value`), not as
@@ -122,7 +122,7 @@ struct Inner {
     /// re-pushes the same concept with shuffled keys) no longer counts as
     /// a change and the list is not torn down.
     resolved_concept: Option<(String, serde_json::Value)>,
-    /// Cancels the view (or views-for-model) subscription on
+    /// Cancels the view (or views-for-concept) subscription on
     /// disconnect / attribute change. Dropping the handle calls
     /// the host's `cancel()` and dispatches `tonk-unsubscribe`.
     view_sub: Option<HostSubscription>,
@@ -170,29 +170,29 @@ struct Inner {
     /// event that bubbles up through this element. Dropped on
     /// disconnect.
     depth_annotator: Option<tonk_host::DepthAnnotator>,
-    /// The model concept's descriptor JSON, handed to a `<tonk-portal>`
+    /// The concept's descriptor JSON, handed to a `<tonk-portal>`
     /// so its no-argument `tonk.subscribe()` can build the scoped-entity
     /// query. Set on every connect; only read when a view frame routes
     /// to portal mode (its projected `type` is `text/html`).
     portal_descriptor: Option<String>,
-    /// The resolved model entity, surfaced to the portal as its `model`
-    /// attribute (the bridge's `context.model`).
+    /// The resolved concept entity, surfaced to the portal as its `concept`
+    /// attribute (the bridge's `context.concept`).
     portal_concept: Option<String>,
-    /// The view-concept descriptor used to resolve a view by model.
+    /// The view-concept descriptor used to resolve a view by concept.
     /// Retained so the `_:_` default-view fallback can re-query against
-    /// the same view concept when the model-specific view frame is
+    /// the same view concept when the concept-specific view frame is
     /// empty.
     view_descriptor: Option<serde_json::Value>,
-    /// The resolved model entity (`concept_entity`), retained for the
+    /// The resolved concept entity (`concept_entity`), retained for the
     /// `_:_` fallback query and for comparison.
     concept_entity: Option<String>,
     /// True when the currently-mounted slide came from the `_:_`
-    /// default view rather than a model-specific view. A non-empty
-    /// model-specific view frame replaces it (the specific view takes
+    /// default view rather than a concept-specific view. A non-empty
+    /// concept-specific view frame replaces it (the specific view takes
     /// over); set false then.
     default_slide: bool,
     /// Directory mode: `true` when the host has no `entity`, so the
-    /// entity subscription matches every instance of the model (`this`
+    /// entity subscription matches every instance of the concept (`this`
     /// unbound) and the frame is grouped by `this` (`select_rows`)
     /// rather than folded to one conclusion.
     directory: bool,
@@ -232,7 +232,7 @@ impl Inner {
         self.view_sub.take();
         self.entity_sub.take();
         // Forget the resolved concept so a restart (attribute change /
-        // reconnect) re-resolves and remounts even if the new model
+        // reconnect) re-resolves and remounts even if the new concept
         // happens to resolve to the same concept.
         self.resolved_concept = None;
         // Drop the delegate — its impl removes listeners from the
@@ -253,7 +253,7 @@ impl CustomElement for TonkDisplay {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        // `entity`/`model`/`view` are the subject inputs: a change to any
+        // `entity`/`concept`/`view` are the subject inputs: a change to any
         // restarts the resolve/subscribe flow. `data-active` / `data-base`
         // are host-context attributes a parent threads in (read by a
         // template as `{dom.host/<attr>}`); a change to one does not alter
@@ -262,7 +262,7 @@ impl CustomElement for TonkDisplay {
         // restarting. `data-base` lets a wrapping `<tonk-origin>` deliver
         // the invite-URL base (`{origin}/join`) into the view after mount.
         // See `attribute_changed_callback`.
-        &["entity", "concept", "view", "data-active", "data-base"]
+        &["this", "concept", "view", "data-active", "data-base"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -306,8 +306,8 @@ impl CustomElement for TonkDisplay {
             return;
         };
 
-        // Only a subject input — `entity`/`model`/`view` — changes what
-        // this display resolves (a different entity, model, or view
+        // Only a subject input — `entity`/`concept`/`view` — changes what
+        // this display resolves (a different entity, concept, or view
         // template), so only those tear down and restart the
         // resolve/subscribe flow. Every other observed attribute is
         // host-context (e.g. `data-active`, threaded in for a template to
@@ -535,7 +535,7 @@ fn loud_state(err: &ErrorDetail) -> State {
 /// chrome — but **preserve the embedder's state-slot children**
 /// (`[slot]`), which are authored input, not rendered output. Without
 /// this guard `set_inner_html("")` would delete the embedder's
-/// `slot="no-model"` etc. on a flow restart, so a later absence state
+/// `slot="no-concept"` etc. on a flow restart, so a later absence state
 /// couldn't find them and would fall back to the built-in callout even
 /// though the embedder provided content.
 fn clear_host(host: &Element, inner: &mut Inner) {
@@ -582,7 +582,7 @@ fn check_generation(state: &Rc<RefCell<Inner>>, generation: u64) -> Result<(), E
 }
 
 /// Like [`check_generation`] but for the downstream flow restarted by
-/// each model frame: bail if the element was disposed or a newer model
+/// each concept frame: bail if the element was disposed or a newer concept
 /// frame bumped `downstream_generation` while this chain awaited.
 fn check_downstream(
     state: &Rc<RefCell<Inner>>,
@@ -596,16 +596,16 @@ fn check_downstream(
     }
 }
 
-/// Phase 1: validate the attributes and open the **model**
-/// subscription. The model resolve is a live subscription (not a
+/// Phase 1: validate the attributes and open the **concept**
+/// subscription. The concept resolve is a live subscription (not a
 /// one-shot) so a concept seeded *after* the element mounts pushes a
-/// frame and the display leaves `no-model` without a reload. Each
-/// model frame routes to `handle_concept_frame`, which (re)starts the
+/// frame and the display leaves `no-concept` without a reload. Each
+/// concept frame routes to `handle_concept_frame`, which (re)starts the
 /// downstream view + entity flow ([`start_downstream`]).
 ///
-/// Attribute errors (bad `entity`, missing `model`, carousel) surface
-/// here as `malformed`; an *absent* model concept is not an error —
-/// it is the `no-model` steady state the subscription recovers from.
+/// Attribute errors (bad `entity`, missing `concept`, carousel) surface
+/// here as `malformed`; an *absent* concept is not an error —
+/// it is the `no-concept` steady state the subscription recovers from.
 async fn run(
     host: &Element,
     state: Rc<RefCell<Inner>>,
@@ -613,8 +613,8 @@ async fn run(
 ) -> Result<(), ErrorDetail> {
     // `entity` is optional. Present → single mode: render that one
     // entity. Absent → directory mode: render every instance of the
-    // model (`this` unbound) through the model's directory view.
-    let entity = host.get_attribute("entity").filter(|s| !s.is_empty());
+    // concept (`this` unbound) through the concept's directory view.
+    let entity = host.get_attribute("this").filter(|s| !s.is_empty());
     if let Some(entity) = &entity
         && !looks_like_uri(entity)
     {
@@ -626,12 +626,12 @@ async fn run(
 
     // The `view` attribute names a view *concept* (named or URI);
     // when omitted, the built-in `view` concept (`tonk:view`) is
-    // used. The `model` attribute names the subject's model concept
+    // used. The `concept` attribute names the subject's concept
     // and constrains which view row to render.
     let view = host.get_attribute("view").filter(|s| !s.is_empty());
 
     // `view="about:blank"` is the carousel sentinel: enumerate every
-    // view defined for the model. This is the two-step flow from the
+    // view defined for the concept. This is the two-step flow from the
     // design (step 1: query the `{concept}` display contract for all
     // conforming view kinds; step 2: resolve each kind's template).
     // Step 2 is not built yet, so carousel surfaces a clear error
@@ -643,7 +643,7 @@ async fn run(
         ));
     }
 
-    // `model` is required: it both projects the subject's fields and
+    // `concept` is required: it both projects the subject's fields and
     // constrains the view query.
     let concept = host
         .get_attribute("concept")
@@ -655,10 +655,10 @@ async fn run(
             )
         })?;
 
-    // Resolve the model name to its concept URI (one-shot — a bookmark
+    // Resolve the concept name to its concept URI (one-shot — a bookmark
     // name rarely lands late; an attribute change restarts the flow),
     // then *subscribe* to its phase-1 concept query so a concept seeded
-    // after mount pushes a frame. The empty frame is `no-model`, not a
+    // after mount pushes a frame. The empty frame is `no-concept`, not a
     // hard error — `handle_concept_frame` keeps the subscription and
     // starts the downstream flow once the concept lands.
     let concept_q = resolve_concept_query(host, &concept).await?;
@@ -676,10 +676,10 @@ async fn run(
     Ok(())
 }
 
-/// Phase 2: with the model concept resolved (`concept_entity` +
+/// Phase 2: with the concept resolved (`concept_entity` +
 /// `descriptor_json`), open the view + entity subscriptions. Invoked
-/// from `handle_concept_frame` on every non-empty model frame, so a
-/// branch revision that (re)defines the model — or a view that lands
+/// from `handle_concept_frame` on every non-empty concept frame, so a
+/// branch revision that (re)defines the concept — or a view that lands
 /// later — re-runs this against the freshest descriptor. Tears down
 /// the prior view/entity subscriptions first and bumps
 /// `downstream_generation` so a stale chain bails.
@@ -690,7 +690,7 @@ async fn start_downstream(
     descriptor_json: String,
     downstream_generation: u64,
 ) -> Result<(), ErrorDetail> {
-    let entity = host.get_attribute("entity").filter(|s| !s.is_empty());
+    let entity = host.get_attribute("this").filter(|s| !s.is_empty());
     let directory = entity.is_none();
     let view = host.get_attribute("view").filter(|s| !s.is_empty());
 
@@ -699,20 +699,20 @@ async fn start_downstream(
     // descriptor is known (`view_predicate`), so no resolve is
     // needed; a named/URI view concept is resolved from the branch.
     // The descriptor maps the `display` field name to whatever
-    // attribute that view kind declares it under, so `view_by_model`
+    // attribute that view kind declares it under, so `view_by_concept`
     // reads the right template regardless of the kind.
     let view_descriptor: serde_json::Value = match view.as_deref() {
         // No explicit `view`: the built-in detail view (`tonk:view`) in
         // single mode, or the directory view (`tonk:view/directory`) in
         // directory mode. Both fall back to their `_:_` default when
-        // the model has no specific view of that kind.
+        // the concept has no specific view of that kind.
         None if directory => directory_view_predicate(),
         None => view_predicate(),
         Some(view_ref) => {
             // An explicit `view` whose concept is not on the branch is
             // `no-view`, not a hard error: a recoverable absence the
-            // model subscription leaves once the view concept lands and
-            // the next model frame re-runs this. Other resolve failures
+            // concept subscription leaves once the view concept lands and
+            // the next concept frame re-runs this. Other resolve failures
             // still propagate.
             match resolve_concept(host, view_ref).await {
                 Ok((_, view_descriptor_json)) => {
@@ -740,12 +740,12 @@ async fn start_downstream(
         }
     };
     let view_q = view_by_concept_query(&view_descriptor, &concept_entity).map_err(|e| {
-        ErrorDetail::new(ErrorKind::Descriptor, format!("view-by-model query: {e}"))
+        ErrorDetail::new(ErrorKind::Descriptor, format!("view-by-concept query: {e}"))
     })?;
     let view_body = to_body(&view_q)?;
 
     // Single mode pins `this` to the entity; directory mode leaves
-    // `this` unbound so the query matches every instance of the model.
+    // `this` unbound so the query matches every instance of the concept.
     let entity_q = match &entity {
         Some(entity) => entity_query(&descriptor_json, entity),
         None => instances_query(&descriptor_json),
@@ -753,7 +753,7 @@ async fn start_downstream(
     .map_err(|e| ErrorDetail::new(ErrorKind::Descriptor, format!("entity query: {e}")))?;
     let entity_body = to_body(&entity_q)?;
 
-    // A fresh model frame re-runs the downstream flow: tear down the
+    // A fresh concept frame re-runs the downstream flow: tear down the
     // prior view/entity subscriptions and any mounted slide so we
     // remount cleanly against the freshest descriptor.
     {
@@ -763,7 +763,7 @@ async fn start_downstream(
         clear_host(host, &mut s);
     }
 
-    // The view query is model-constrained, so it resolves to one
+    // The view query is concept-constrained, so it resolves to one
     // presentation. Mount in single mode.
     ensure_carousel(host, &state, true);
 
@@ -779,7 +779,7 @@ async fn start_downstream(
 
     {
         let mut s = state.borrow_mut();
-        // Final generation check — if a newer model frame restarted the
+        // Final generation check — if a newer concept frame restarted the
         // downstream flow between opening the subscriptions, drop them
         // so we don't orphan them (the newer flow's are already stored).
         if s.downstream_generation != downstream_generation {
@@ -789,13 +789,13 @@ async fn start_downstream(
         s.entity_sub = Some(entity_sub);
         s.directory = directory;
         // Retained for the `_:_` default-view fallback: if the
-        // model-specific view frame is empty, `handle_view_frame`
-        // re-queries the same view concept with `model = _:_`.
+        // concept-specific view frame is empty, `handle_view_frame`
+        // re-queries the same view concept with `concept = _:_`.
         s.view_descriptor = Some(view_descriptor.clone());
         s.concept_entity = Some(concept_entity.clone());
         // Context handed to a `<tonk-portal>` if a view frame routes
-        // here in portal mode: the subject's model entity (the
-        // bridge's `context.model`) and its descriptor (so the bridge
+        // here in portal mode: the subject's concept entity (the
+        // bridge's `context.concept`) and its descriptor (so the bridge
         // can build its own entity query). A text/html view's iframe
         // fetches data itself, so the entity subscription above just
         // no-ops against the portal (it has no `draw`).
@@ -863,7 +863,7 @@ fn first_field(value: &JsValue, field: &str) -> Result<Option<String>, ErrorDeta
 /// A bare name is first resolved through the **Name concept**
 /// (`id:<name>` → `dialog.name/referent`) into a concept entity URI,
 /// then that URI drives the Phase-1 concept-of-concepts lookup by
-/// `this`. This is the path that makes a model or view named after a
+/// `this`. This is the path that makes a concept or view named after a
 /// concept pinned to a `this:` URI (e.g. `workspace` → `tonk:workspace`)
 /// resolve — the concept carries a `Name` claim but no
 /// `dialog.meta/name`, so a direct `name`-filtered Phase-1 would miss
@@ -881,7 +881,7 @@ async fn resolve_concept(host: &Element, source: &str) -> Result<(String, String
 /// `dialog.name/referent`) into a concept URI (a one-shot `query`),
 /// then `phase1_query` is built from the resolved `ParsedSource`. The
 /// caller decides whether to run it once or open a subscription on it —
-/// the model link subscribes so a late-seeded concept recovers.
+/// the concept link subscribes so a late-seeded concept recovers.
 async fn resolve_concept_query(host: &Element, source: &str) -> Result<Query, ErrorDetail> {
     let parsed: ParsedSource = parse_source(source);
     let parsed = if parsed.is_uri() {
@@ -903,23 +903,23 @@ async fn resolve_concept_query(host: &Element, source: &str) -> Result<Query, Er
     Ok(phase1_query(&parsed))
 }
 
-/// Route a `"concept"` subscription frame. The model resolve is a live
+/// Route a `"concept"` subscription frame. The concept resolve is a live
 /// subscription, so this fires on every branch revision touching the
 /// concept-of-concepts view:
 ///
-/// - **empty frame** → `no-model` (the concept is not on the branch
+/// - **empty frame** → `no-concept` (the concept is not on the branch
 ///   *yet*). No teardown; the subscription stays open and recovers the
 ///   instant the concept lands. This is the fix for the latched red box
 ///   on a still-seeding fresh space.
 /// - **resolved row** → bump `downstream_generation` and (re)start the
 ///   downstream view + entity flow against the freshest descriptor, so
-///   a model (re)definition or a late-landing view is picked up.
+///   a concept (re)definition or a late-landing view is picked up.
 fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Vec<Conclusion>) {
     let resolved = extract_phase1_conclusion(conclusions);
     let Some((concept_entity, descriptor_json)) = resolved else {
         // The concept is not on the branch yet. Stay subscribed; the
-        // embedder may skin `no-model` via a `slot="no-model"` child,
-        // otherwise the built-in fallback names the missing model.
+        // embedder may skin `no-concept` via a `slot="no-concept"` child,
+        // otherwise the built-in fallback names the missing concept.
         let concept = host.get_attribute("concept").unwrap_or_default();
         state::set_absence(
             host,
@@ -937,7 +937,7 @@ fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions:
         if s.disposed {
             return;
         }
-        // The model subscription re-pushes on every branch revision,
+        // The concept subscription re-pushes on every branch revision,
         // including plain entity-data writes. Restart the downstream
         // flow only when the *resolved concept* actually changed —
         // otherwise an unrelated write would tear down and remount the
@@ -945,7 +945,7 @@ fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions:
         // entity subscription already streams data updates in place.
         //
         // The comparison is against `resolved_concept`, set synchronously
-        // here (not `start_downstream`'s async tail), so a burst of model
+        // here (not `start_downstream`'s async tail), so a burst of concept
         // frames during one write doesn't each see a stale value and
         // remount.
         //
@@ -980,7 +980,7 @@ fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions:
         {
             // Only surface if still current — a stale downstream chain's
             // failure (a `check_downstream` "superseded", or a real
-            // error a newer model frame has since replaced) shouldn't
+            // error a newer concept frame has since replaced) shouldn't
             // overwrite a healthy newer flow's state. The generation
             // guard covers both: a superseded chain fails the check.
             if state.borrow().downstream_generation == downstream_generation {
@@ -993,7 +993,7 @@ fn handle_concept_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions:
 /// Decode a phase-1 subscription frame (already-deserialized
 /// `Vec<Conclusion>`) into `(concept_entity, descriptor_json)`. Returns
 /// `None` for an empty frame or a row missing the `source` descriptor —
-/// both are the `no-model` steady state, not a hard error.
+/// both are the `no-concept` steady state, not a hard error.
 fn extract_phase1_conclusion(conclusions: Vec<Conclusion>) -> Option<(String, String)> {
     let first = conclusions.into_iter().next()?;
     let source = ipld_str(first.fields.get("source")).map(str::to_owned)?;
@@ -1002,7 +1002,7 @@ fn extract_phase1_conclusion(conclusions: Vec<Conclusion>) -> Option<(String, St
 
 /// Key each incoming view-frame conclusion by its view entity
 /// (`this`), paired with the `display` template. The view query is
-/// model-constrained, so each row is a distinct view instance keyed
+/// concept-constrained, so each row is a distinct view instance keyed
 /// by its own entity URI. A conclusion with no `display` string is
 /// dropped.
 fn slide_keys(conclusions: Vec<Conclusion>) -> BTreeMap<String, String> {
@@ -1029,11 +1029,11 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     // the view concept declares it (see `view_by_concept_query`), so an
     // ordinary view never trips this; a `display` change just reloads
     // the portal's `content` in place.
-    // No model-specific view resolved: fall back to the `_:_` default
+    // No concept-specific view resolved: fall back to the `_:_` default
     // view (a directory carousel, or the notation dump for a detail
-    // view). Re-query the same view concept with `model = _:_` and
-    // render its result. The model-specific subscription stays live, so
-    // if a view for this model is defined later its frame is non-empty
+    // view). Re-query the same view concept with `concept = _:_` and
+    // render its result. The concept-specific subscription stays live, so
+    // if a view for this concept is defined later its frame is non-empty
     // and the branch below mounts it, replacing the default. Skip if
     // we're already showing the default (avoid re-querying every empty
     // frame).
@@ -1045,7 +1045,7 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
         }
         return;
     }
-    // A model-specific view arrived: it wins over any default slide.
+    // A concept-specific view arrived: it wins over any default slide.
     // Clearing the flag lets the normal slide reconciliation below
     // replace the default `<tonk-view>` (keyed differently) and the
     // stale default slide is dropped as a vanished key.
@@ -1135,17 +1135,17 @@ fn handle_view_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: Ve
     dispatch_event(host, "tonk-display:template", Some(JsValue::from_str("ok")));
 }
 
-/// The sentinel model entity for a default view: a `view!`/
-/// `view/directory!` declared with `model: tonk:_` matches any model
+/// The sentinel concept entity for a default view: a `view!`/
+/// `view/directory!` declared with `concept: tonk:_` matches any concept
 /// that has no specific view of that kind. `tonk:_` is the
-/// wildcard-model entity seeded by core.yaml. See
+/// wildcard-concept entity seeded by core.yaml. See
 /// `tonk-core/docs/templates.md`.
 const DEFAULT_CONCEPT: &str = "tonk:_";
 
-/// Query the `_:_` default view (same view concept, `model = _:_`) and
+/// Query the `_:_` default view (same view concept, `concept = _:_`) and
 /// mount its template as the default slide. Spawned from
-/// `handle_view_frame` when the model-specific view frame is empty. The
-/// model-specific subscription stays live; a later non-empty frame
+/// `handle_view_frame` when the concept-specific view frame is empty. The
+/// concept-specific subscription stays live; a later non-empty frame
 /// replaces this default (see the `default_slide` flag).
 fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
     let descriptor = {
@@ -1159,7 +1159,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
     spawn_local(async move {
         // If the default view can't be built or resolves to nothing,
         // settle to Empty rather than leaving the element on `loading`
-        // forever — there is genuinely no presentation for this model
+        // forever — there is genuinely no presentation for this concept
         // (not even the `_:_` default is seeded).
         let resolved = async {
             let query = view_by_concept_query(&descriptor, DEFAULT_CONCEPT).ok()?;
@@ -1169,7 +1169,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
         }
         .await;
         let Some(display) = resolved else {
-            // No specific view and no `_:_` default view for this model.
+            // No specific view and no `_:_` default view for this concept.
             // If the entity has data, fall back to a notation dump so
             // it's still inspectable; otherwise settle (the entity
             // frame decides not-found vs empty).
@@ -1186,7 +1186,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
             return;
         };
         // Another frame may have raced ahead while we were querying: if
-        // a model-specific view landed (default_slide cleared with a
+        // a concept-specific view landed (default_slide cleared with a
         // slide present), don't clobber it with the default.
         let mut s = state.borrow_mut();
         if s.disposed || (!s.default_slide && !s.slides.is_empty()) {
@@ -1214,7 +1214,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
             s.slides.insert("__default__".to_owned(), slide);
             s.default_slide = true;
             // Rendered through the `_:_` default view, not a
-            // model-specific one — observably `default-view` so an
+            // concept-specific one — observably `default-view` so an
             // embedder can tell "rendered the way I intended" from
             // "rendered through the generic fallback".
             state::set(&host, State::DefaultView);
@@ -1222,7 +1222,7 @@ fn spawn_default_view(host: &Element, state: &Rc<RefCell<Inner>>) {
     });
 }
 
-/// Ultimate fallback when an entity has data but its model has no view
+/// Ultimate fallback when an entity has data but its concept has no view
 /// (neither a specific view nor the `_:_` default): mount a
 /// `<tonk-notation>` rendering the conclusion as syntax-highlighted
 /// notation, so any entity is at least inspectable. `<tonk-notation>`
@@ -1264,7 +1264,7 @@ fn mount_notation_fallback(host: &Element, state: &Rc<RefCell<Inner>>, conclusio
     );
     s.default_slide = true;
     // The notation dump is the ultimate `_:_` fallback — also
-    // `default-view`, not a model-specific render.
+    // `default-view`, not a concept-specific render.
     state::set(host, State::DefaultView);
 }
 
@@ -1322,8 +1322,8 @@ fn mount_portal_slide(host: &Element, inner: &Inner, display: &str) -> Option<Sl
     let document = window()?.document()?;
     let portal = document.create_element("tonk-portal").ok()?;
     let _ = portal.set_attribute("content", display);
-    if let Some(entity) = host.get_attribute("entity") {
-        let _ = portal.set_attribute("entity", &entity);
+    if let Some(entity) = host.get_attribute("this") {
+        let _ = portal.set_attribute("this", &entity);
     }
     if let Some(concept) = inner.portal_concept.as_ref() {
         let _ = portal.set_attribute("concept", concept);
@@ -1439,7 +1439,7 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
                 return;
             }
         }
-        // Resolve through the same name-first path as the model/view
+        // Resolve through the same name-first path as the concept/view
         // (`resolve_concept`), so an event-handler concept named after a
         // pinned-`this` concept resolves via the Name index too.
         match resolve_concept(host, name).await {
@@ -1524,7 +1524,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
         // launchpad on. Single mode signals `no-entity` — that one row
         // is absent.
         let directory = s.directory;
-        // The resolved model concept's descriptor (parsed), so the
+        // The resolved concept's descriptor (parsed), so the
         // no-entity diagnostic can name the concept's required attributes
         // and probe which ones the entity is actually missing.
         let descriptor = s.resolved_concept.as_ref().map(|(_, value)| value.clone());
@@ -1572,7 +1572,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
     if !s.slides.is_empty() || s.notation_source.is_some() {
         // A default (`_:_`) slide renders through the generic fallback,
         // so the display is `default-view`, not `ready`. A frame with a
-        // model-specific slide is genuinely `ready`.
+        // concept-specific slide is genuinely `ready`.
         let rendered = if s.default_slide {
             State::DefaultView
         } else {
@@ -1583,7 +1583,7 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
     dispatch_event(host, "tonk-display:result", Some(event_detail(&first)));
 }
 
-/// Explain why the single entity did not match its model concept.
+/// Explain why the single entity did not match its concept.
 ///
 /// The entity is on the branch but the concept query (a conjunction over
 /// every required attribute) matched nothing — so at least one required
@@ -1598,10 +1598,10 @@ fn handle_entity_frame(host: &Element, state: &Rc<RefCell<Inner>>, conclusions: 
 /// The result drives the loud `no-entity` absence: a structured summary
 /// on top, the raw present facts as notation below. A descriptor that
 /// isn't available (or has no `with:` map) falls back to the bare
-/// `model: / this:` notation — there is nothing to diff against.
+/// `concept: / this:` notation — there is nothing to diff against.
 async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value>) {
     let concept = host.get_attribute("concept").unwrap_or_default();
-    let entity = host.get_attribute("entity").unwrap_or_default();
+    let entity = host.get_attribute("this").unwrap_or_default();
 
     // Without a descriptor `with:` map there is nothing to probe; keep the
     // old bare notation so the state still renders something meaningful.
@@ -1705,7 +1705,7 @@ fn ensure_carousel(host: &Element, state: &Rc<RefCell<Inner>>, single_mode: bool
 
     // Trailing notation slide — present whenever a carousel is
     // mounted. Lets the user fall back to a syntax-highlighted
-    // entity dump regardless of how many views the model has
+    // entity dump regardless of how many views the concept has
     // published. The `<script type="text/tonk-notation">` child
     // carries the source; updating its `textContent` is what
     // `<tonk-notation>` watches via its MutationObserver.
@@ -1791,12 +1791,12 @@ fn serialize_conclusions(conclusions: &[Conclusion]) -> JsValue {
 
 /// Return a copy of `conclusion` with the host `<tonk-display>`'s own
 /// attributes added to its fields under `dom.host/<attr>` keys, so a
-/// template can reference them with `{dom.host/model}` etc. — the
+/// template can reference them with `{dom.host/concept}` etc. — the
 /// render-time counterpart of the `dom.event/*` namespace (see
 /// `events::path`). Scalars, constant across the render: a directory
-/// template threads the outer model into each nested
-/// `<tonk-display entity={this} model={dom.host/model}>` this way,
-/// since an instance carries no pointer to its own model.
+/// template threads the outer concept into each nested
+/// `<tonk-display this={this} concept={dom.host/concept}>` this way,
+/// since an instance carries no pointer to its own concept.
 ///
 /// The augmentation is render-only — the cached/notation/event
 /// conclusion stays unaugmented. The substituter resolves
@@ -1816,19 +1816,19 @@ fn with_host_attributes(host: &Element, conclusion: &Conclusion) -> Conclusion {
 }
 
 /// Whether a change to `name` resolves a different view template —
-/// `entity`/`model`/`view` are the subject inputs that decide what this
+/// `entity`/`concept`/`view` are the subject inputs that decide what this
 /// display resolves, so a change to any tears down and restarts the
 /// flow. Every other observed attribute is host-context (threaded in
 /// for a template to read as `{dom.host/<name>}`) and updates in place.
 ///
-/// Conservative for now: a `model` change tears down even when the
-/// resolved view template is unchanged (a model only re-projects the
+/// Conservative for now: a `concept` change tears down even when the
+/// resolved view template is unchanged (a concept only re-projects the
 /// field set). The ideal is to tear down solely on a view *template*
 /// change and otherwise re-resolve the projection in place; that needs
 /// the in-place path to re-run the query without rebuilding the DOM,
 /// which is a larger change left for later.
 fn resolves_template(name: &str) -> bool {
-    matches!(name, "entity" | "concept" | "view")
+    matches!(name, "this" | "concept" | "view")
 }
 
 /// Re-project the host's current attributes into the mounted view(s)
@@ -1889,7 +1889,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    /// Only the subject inputs (`entity`/`model`/`view`) re-resolve what
+    /// Only the subject inputs (`entity`/`concept`/`view`) re-resolve what
     /// the display renders, so only those force a teardown. A host-context
     /// attribute like `data-active` (threaded in for a template to read
     /// as `{dom.host/data-active}`) leaves the resolved view unchanged and
@@ -1935,7 +1935,7 @@ mod tests {
     }
 
     // Each slide keys off its own view entity URI (`this`), paired
-    // with the view's `display` template. The model-constrained
+    // with the view's `display` template. The concept-constrained
     // query resolves to one row in the common case, but the keying
     // is uniform regardless of how many rows arrive.
     #[dialog_common::test]
@@ -1964,37 +1964,37 @@ mod tests {
         assert!(slide_keys(rows).is_empty());
     }
 
-    // An empty model frame is the `no-model` steady state, not an error:
+    // An empty concept frame is the `no-concept` steady state, not an error:
     // `extract_phase1_conclusion` returns `None` so the handler keeps the
     // subscription and waits for the concept.
     #[dialog_common::test]
-    fn it_reads_no_model_from_an_empty_phase1_frame() {
+    fn it_reads_no_concept_from_an_empty_phase1_frame() {
         assert!(extract_phase1_conclusion(Vec::new()).is_none());
     }
 
-    // A resolved phase-1 row yields the model entity + descriptor.
+    // A resolved phase-1 row yields the concept entity + descriptor.
     #[dialog_common::test]
-    fn it_reads_the_model_entity_and_descriptor_from_a_phase1_row() {
+    fn it_reads_the_concept_entity_and_descriptor_from_a_phase1_row() {
         let mut fields = BTreeMap::new();
         fields.insert(
             "source".to_owned(),
             Ipld::String("{\"with\":{}}".to_owned()),
         );
         let row = Conclusion {
-            this: "did:key:zModel".to_owned(),
+            this: "did:key:zConcept".to_owned(),
             fields,
         };
         let resolved = extract_phase1_conclusion(vec![row]).expect("a row resolves");
-        assert_eq!(resolved.0, "did:key:zModel");
+        assert_eq!(resolved.0, "did:key:zConcept");
         assert_eq!(resolved.1, "{\"with\":{}}");
     }
 
     // A row missing the `source` descriptor is treated as unresolved
-    // (`no-model`), not a half-resolved model.
+    // (`no-concept`), not a half-resolved concept.
     #[dialog_common::test]
-    fn it_treats_a_phase1_row_without_source_as_no_model() {
+    fn it_treats_a_phase1_row_without_source_as_no_concept() {
         let row = Conclusion {
-            this: "did:key:zModel".to_owned(),
+            this: "did:key:zConcept".to_owned(),
             fields: BTreeMap::new(),
         };
         assert!(extract_phase1_conclusion(vec![row]).is_none());
@@ -2034,7 +2034,7 @@ mod tests {
     // --- Display hook: routing a `text/html` view to a portal ---
     //
     // Driven through the real `<tonk-display>` flow against a fake host
-    // that answers the resolve one-shots in order (model concept → view
+    // that answers the resolve one-shots in order (concept → view
     // concept) and captures the subscriptions. Portal mode is decided
     // per view frame: a row whose projected `type` is `text/html`
     // mounts a `<tonk-portal>`; any other row renders inline through
@@ -2108,25 +2108,25 @@ mod tests {
             subs: BTreeMap<String, Element>,
             /// Tags of every subscription opened.
             subscribe_tags: Vec<String>,
-            /// The phase-1 model concept frame, auto-pushed the moment
-            /// the `"concept"` subscription opens — the model resolve is a
+            /// The phase-1 concept frame, auto-pushed the moment
+            /// the `"concept"` subscription opens — the concept resolve is a
             /// live subscription now, not a one-shot. `None` makes the
-            /// model subscription stay empty (the `no-model` state).
-            model_frame: Option<JsValue>,
+            /// concept subscription stay empty (the `no-concept` state).
+            concept_frame: Option<JsValue>,
         }
 
         impl FakeHost {
             fn install(query_responses: Vec<JsValue>) -> FakeHost {
-                Self::install_with_model(query_responses, None)
+                Self::install_with_concept(query_responses, None)
             }
 
-            /// Like [`install`] but with an explicit model concept frame
+            /// Like [`install`] but with an explicit concept frame
             /// auto-pushed on the `"concept"` subscription. `None` leaves
-            /// the model subscription empty so the display sits in
-            /// `no-model`.
-            fn install_with_model(
+            /// the concept subscription empty so the display sits in
+            /// `no-concept`.
+            fn install_with_concept(
                 query_responses: Vec<JsValue>,
-                model_frame: Option<JsValue>,
+                concept_frame: Option<JsValue>,
             ) -> FakeHost {
                 let container = document().create_element("div").unwrap();
                 document().body().unwrap().append_child(&container).unwrap();
@@ -2135,7 +2135,7 @@ mod tests {
                     answered: 0,
                     subs: BTreeMap::new(),
                     subscribe_tags: Vec::new(),
-                    model_frame,
+                    concept_frame,
                 }));
                 let mut listeners = Vec::new();
 
@@ -2175,16 +2175,16 @@ mod tests {
                                 .and_then(|v| v.as_string())
                                 .unwrap_or_default();
                             let consumer: Element = ev.target().unwrap().dyn_into().unwrap();
-                            let model_frame = {
+                            let concept_frame = {
                                 let mut s = state.borrow_mut();
                                 s.subscribe_tags.push(tag.clone());
                                 s.subs.insert(tag.clone(), consumer.clone());
-                                // Auto-push the model concept frame as
-                                // soon as the model subscription opens, so
+                                // Auto-push the concept frame as
+                                // soon as the concept subscription opens, so
                                 // the downstream flow starts the way a live
                                 // host would on the first revision.
                                 if tag == "concept" {
-                                    s.model_frame.clone()
+                                    s.concept_frame.clone()
                                 } else {
                                     None
                                 }
@@ -2193,7 +2193,7 @@ mod tests {
                             let noop = Function::new_no_args("");
                             let _ = Reflect::set(&sub, &"cancel".into(), &noop);
                             let _ = Reflect::set(&detail, &"subscription".into(), &sub);
-                            if let Some(frame) = model_frame {
+                            if let Some(frame) = concept_frame {
                                 let opts = Object::new();
                                 let _ = Reflect::set(
                                     &opts,
@@ -2261,12 +2261,12 @@ mod tests {
             let display = document().create_element("tonk-display").unwrap();
             display.set_attribute("view", view).unwrap();
             display.set_attribute("concept", concept).unwrap();
-            display.set_attribute("entity", entity).unwrap();
+            display.set_attribute("this", entity).unwrap();
             host.container.append_child(&display).unwrap();
             display
         }
 
-        // The flow resolves two concepts in order: the subject `model`
+        // The flow resolves two concepts in order: the subject `concept`
         // concept (projected for the entity query) then the `view`
         // concept (the query predicate). The view concept declares a
         // `type` attribute, so `view_by_concept_query` projects `type` and
@@ -2278,33 +2278,33 @@ mod tests {
         // is TWO queries: a name lookup, then the concept lookup. The
         // fixture answers in dispatch order, so a name-resolution row
         // precedes each concept row. `mount_display` uses bare names for
-        // both `model` and `view`, hence two name/concept pairs.
+        // both `concept` and `view`, hence two name/concept pairs.
         fn name_row(entity: &str) -> JsValue {
             rows(&[("did:key:zName", &[("entity", entity)])])
         }
-        // The model concept resolves through a live `"concept"`
+        // The concept resolves through a live `"concept"`
         // subscription now, so its phase-1 row is auto-pushed as the
-        // model frame (see `install_with_model`) rather than answered as
-        // a one-shot. The remaining one-shots are the model *name*
+        // concept frame (see `install_with_concept`) rather than answered as
+        // a one-shot. The remaining one-shots are the concept *name*
         // lookup and the view name + concept lookups (the explicit
         // `view=` resolve is still a one-shot inside `start_downstream`).
-        fn model_concept_frame() -> JsValue {
+        fn concept_frame() -> JsValue {
             rows(&[(
-                "did:key:zModel",
+                "did:key:zConcept",
                 &[(
                     "source",
                     r#"{"with":{"count":{"the":"counter/count","as":"UnsignedInteger","cardinality":"one"}}}"#,
                 )],
             )])
         }
-        /// The same concept descriptor as [`model_concept_frame`] but
+        /// The same concept descriptor as [`concept_frame`] but
         /// with the object keys in a *different order* — what the worker
         /// actually emits between revisions (its descriptor serialization
         /// is not key-order-stable). Byte-different, semantically
-        /// identical: the model-frame guard must treat it as unchanged.
-        fn model_concept_frame_reordered() -> JsValue {
+        /// identical: the concept-frame guard must treat it as unchanged.
+        fn concept_frame_reordered() -> JsValue {
             rows(&[(
-                "did:key:zModel",
+                "did:key:zConcept",
                 &[(
                     "source",
                     r#"{"with":{"count":{"cardinality":"one","as":"UnsignedInteger","the":"counter/count"}}}"#,
@@ -2313,8 +2313,8 @@ mod tests {
         }
         fn resolve_responses() -> Vec<JsValue> {
             vec![
-                // model name `counter` → did:key:zModel
-                name_row("did:key:zModel"),
+                // concept name `counter` → did:key:zConcept
+                name_row("did:key:zConcept"),
                 // view name `counter` → did:key:zViewConcept
                 name_row("did:key:zViewConcept"),
                 rows(&[(
@@ -2329,12 +2329,11 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_mounts_a_portal_for_a_text_html_view_frame() {
-            let host =
-                FakeHost::install_with_model(resolve_responses(), Some(model_concept_frame()));
+            let host = FakeHost::install_with_concept(resolve_responses(), Some(concept_frame()));
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
 
-            // Wait for the flow to open its subscriptions (model, then
-            // view + entity once the model frame resolves).
+            // Wait for the flow to open its subscriptions (concept, then
+            // view + entity once the concept frame resolves).
             for _ in 0..200 {
                 if host.subscribe_tags().len() >= 3 {
                     break;
@@ -2350,7 +2349,7 @@ mod tests {
                     &[
                         ("display", "<h1>monolith</h1>"),
                         ("type", "text/html"),
-                        ("concept", "did:key:zModel"),
+                        ("concept", "did:key:zConcept"),
                     ],
                 )]),
             );
@@ -2364,7 +2363,7 @@ mod tests {
                 "the view's HTML document becomes the portal content",
             );
             assert_eq!(
-                portal.get_attribute("entity").as_deref(),
+                portal.get_attribute("this").as_deref(),
                 Some("id:demo-counter"),
                 "the portal is scoped to the displayed entity",
             );
@@ -2373,14 +2372,14 @@ mod tests {
                 .and_then(|v| v.as_string());
             assert!(
                 descriptor.is_some_and(|d| d.contains("counter/count")),
-                "the model descriptor is handed to the portal",
+                "the concept descriptor is handed to the portal",
             );
             assert!(
                 display.query_selector("tonk-view").unwrap().is_none(),
                 "a portal view renders no inline <tonk-view>",
             );
-            // The model subscription opens first, then the view + entity
-            // subs once the model frame resolves; the entity sub just
+            // The concept subscription opens first, then the view + entity
+            // subs once the concept frame resolves; the entity sub just
             // no-ops against the portal (a `<tonk-portal>` exposes no
             // `draw`).
             assert_eq!(
@@ -2391,8 +2390,7 @@ mod tests {
 
         #[dialog_common::test]
         async fn it_renders_inline_and_subscribes_to_the_entity_when_no_type() {
-            let host =
-                FakeHost::install_with_model(resolve_responses(), Some(model_concept_frame()));
+            let host = FakeHost::install_with_concept(resolve_responses(), Some(concept_frame()));
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
 
             for _ in 0..200 {
@@ -2424,19 +2422,19 @@ mod tests {
         }
 
         // The fix for the latched red box on a still-seeding space: when
-        // the model concept is not on the branch yet, the model resolve
+        // the concept is not on the branch yet, the concept resolve
         // is an *empty subscription frame*, not a hard error. The display
-        // sits in `no-model` with no callout, stays subscribed, and
+        // sits in `no-concept` with no callout, stays subscribed, and
         // recovers the instant the concept lands — no reload.
         #[dialog_common::test]
-        async fn it_recovers_from_no_model_when_the_concept_lands_late() {
-            // No auto model frame: the model subscription opens, and its
+        async fn it_recovers_from_no_concept_when_the_concept_lands_late() {
+            // No auto concept frame: the concept subscription opens, and its
             // first frame is empty (the concept has not synced yet).
             let host = FakeHost::install(resolve_responses());
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
 
-            // Wait for the model subscription, then deliver an empty frame
-            // — that lands the display in `no-model`.
+            // Wait for the concept subscription, then deliver an empty frame
+            // — that lands the display in `no-concept`.
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"concept".to_owned()) {
                     break;
@@ -2453,13 +2451,13 @@ mod tests {
             assert_eq!(
                 display.get_attribute("data-state").as_deref(),
                 Some("no-concept"),
-                "an absent model concept is `no-model`, not an error",
+                "an absent concept is `no-concept`, not an error",
             );
 
-            // The concept lands: the model subscription pushes a non-empty
+            // The concept lands: the concept subscription pushes a non-empty
             // frame, the downstream view + entity subs open, and a view +
             // entity frame render the row live.
-            host.push_frame("concept", &model_concept_frame());
+            host.push_frame("concept", &concept_frame());
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"view".to_owned())
                     && host.subscribe_tags().contains(&"entity".to_owned())
@@ -2514,8 +2512,7 @@ mod tests {
         // display to `offline` with a loud danger callout.
         #[dialog_common::test]
         async fn it_goes_offline_on_a_subscription_error() {
-            let host =
-                FakeHost::install_with_model(resolve_responses(), Some(model_concept_frame()));
+            let host = FakeHost::install_with_concept(resolve_responses(), Some(concept_frame()));
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"entity".to_owned()) {
@@ -2550,8 +2547,7 @@ mod tests {
         // transport failure: it drives `unauthorized`, not `offline`.
         #[dialog_common::test]
         async fn it_goes_unauthorized_on_a_403() {
-            let host =
-                FakeHost::install_with_model(resolve_responses(), Some(model_concept_frame()));
+            let host = FakeHost::install_with_concept(resolve_responses(), Some(concept_frame()));
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"entity".to_owned()) {
@@ -2576,17 +2572,17 @@ mod tests {
         // An explicit `view=` whose concept is absent on the branch is the
         // recoverable `no-view` state — a danger fallback naming the
         // missing view (a missing view concept is a config error, like a
-        // missing model). The model resolves (auto-pushed frame); the view
+        // missing concept). The concept resolves (auto-pushed frame); the view
         // name + concept one-shots return empty, so the view resolve fails
         // with `UnknownSource`.
         #[dialog_common::test]
         async fn it_goes_no_view_when_an_explicit_view_is_absent() {
-            // One-shot responses: the model name lookup resolves; the view
+            // One-shot responses: the concept name lookup resolves; the view
             // name lookup + view concept lookup are left empty (default
             // empty array), so the explicit view never resolves.
-            let host = FakeHost::install_with_model(
-                vec![name_row("did:key:zModel")],
-                Some(model_concept_frame()),
+            let host = FakeHost::install_with_concept(
+                vec![name_row("did:key:zConcept")],
+                Some(concept_frame()),
             );
             let display = mount_display(&host, "missing-view", "counter", "id:demo-counter");
             for _ in 0..200 {
@@ -2607,33 +2603,33 @@ mod tests {
             assert_eq!(
                 callout.get_attribute("variant").as_deref(),
                 Some("danger"),
-                "a missing view concept is a danger, like a missing model",
+                "a missing view concept is a danger, like a missing concept",
             );
         }
 
-        // When the model has no model-specific view but a `_:_` default
+        // When the concept has no concept-specific view but a `_:_` default
         // view is seeded, the empty view frame falls back to it: the
         // display renders the default presentation and reports
         // `default-view` (observably distinct from `ready`).
         #[dialog_common::test]
         async fn it_renders_the_default_view_when_no_specific_view_exists() {
-            // One-shots in dispatch order: the bare model name `counter`
+            // One-shots in dispatch order: the bare concept name `counter`
             // resolves through the Name concept first, THEN the `_:_`
             // fallback query `spawn_default_view` makes returns a `display`
-            // template. The model concept itself is the auto-pushed frame,
+            // template. The concept itself is the auto-pushed frame,
             // and NO explicit `view=` is set so the built-in view predicate
             // is used (no extra view-concept resolve one-shot).
-            let host = FakeHost::install_with_model(
+            let host = FakeHost::install_with_concept(
                 vec![
-                    name_row("did:key:zModel"),
+                    name_row("did:key:zConcept"),
                     rows(&[("did:key:zDefaultView", &[("display", "<p>{count}</p>")])]),
                 ],
-                Some(model_concept_frame()),
+                Some(concept_frame()),
             );
             register();
             let display = document().create_element("tonk-display").unwrap();
             display.set_attribute("concept", "counter").unwrap();
-            display.set_attribute("entity", "id:demo-counter").unwrap();
+            display.set_attribute("this", "id:demo-counter").unwrap();
             host.container.append_child(&display).unwrap();
             for _ in 0..200 {
                 if host.subscribe_tags().contains(&"view".to_owned())
@@ -2643,8 +2639,8 @@ mod tests {
                 }
                 sleep(5).await;
             }
-            // The model-specific view subscription pushes an EMPTY frame —
-            // no view for this model — which triggers the `_:_` fallback.
+            // The concept-specific view subscription pushes an EMPTY frame —
+            // no view for this concept — which triggers the `_:_` fallback.
             host.push_frame("view", &rows(&[]));
             host.push_frame("entity", &rows(&[("id:demo-counter", &[("count", "9")])]));
 
@@ -2665,16 +2661,15 @@ mod tests {
             );
         }
 
-        // The model subscription re-pushes on EVERY branch revision,
-        // including unrelated data writes. An identical model frame must
+        // The concept subscription re-pushes on EVERY branch revision,
+        // including unrelated data writes. An identical concept frame must
         // NOT restart the downstream flow — that would `clear_host` and
         // remount, wiping the rendered rows (the Hub list flashing empty
-        // while a new space is added). A repeat model frame is a no-op;
+        // while a new space is added). A repeat concept frame is a no-op;
         // data updates flow through the entity subscription in place.
         #[dialog_common::test]
-        async fn it_does_not_remount_on_a_repeat_model_frame() {
-            let host =
-                FakeHost::install_with_model(resolve_responses(), Some(model_concept_frame()));
+        async fn it_does_not_remount_on_a_repeat_concept_frame() {
+            let host = FakeHost::install_with_concept(resolve_responses(), Some(concept_frame()));
             let display = mount_display(&host, "counter", "counter", "id:demo-counter");
 
             for _ in 0..200 {
@@ -2692,24 +2687,24 @@ mod tests {
                 .await
                 .expect("renders the row");
 
-            // A second model frame arrives (an unrelated write revised
+            // A second concept frame arrives (an unrelated write revised
             // the branch). It carries the SAME concept but with the
             // descriptor's keys in a different order — exactly what the
             // worker emits, since its descriptor serialization is not
             // key-order-stable. The guard must treat it as unchanged: the
             // mounted <tonk-view> survives, no remount, no wiped list.
             let subs_before = host.subscribe_tags().len();
-            host.push_frame("concept", &model_concept_frame_reordered());
+            host.push_frame("concept", &concept_frame_reordered());
             sleep(50).await;
 
             assert!(
                 view.is_connected(),
-                "a key-reordered repeat model frame must not tear down the mounted view",
+                "a key-reordered repeat concept frame must not tear down the mounted view",
             );
             assert_eq!(
                 host.subscribe_tags().len(),
                 subs_before,
-                "a key-reordered repeat model frame must not reopen the view/entity subscriptions",
+                "a key-reordered repeat concept frame must not reopen the view/entity subscriptions",
             );
 
             // A later entity frame still updates the existing slide in
@@ -2725,19 +2720,19 @@ mod tests {
         // --- Directory mode: empty -> content live flip ---
         //
         // Directory mode (no `entity` attribute) resolves only the
-        // subject `model` concept; the built-in directory view predicate
+        // subject `concept` concept; the built-in directory view predicate
         // needs no branch lookup, so two query responses suffice: the
-        // model name lookup and the concept row.
+        // concept name lookup and the concept row.
         fn directory_resolve_responses() -> Vec<JsValue> {
-            vec![name_row("did:key:zModel")]
+            vec![name_row("did:key:zConcept")]
         }
-        // The directory model concept, auto-pushed on the `"concept"`
+        // The directory concept, auto-pushed on the `"concept"`
         // subscription (the built-in directory view predicate needs no
-        // branch lookup, so only the model name lookup remains a
+        // branch lookup, so only the concept name lookup remains a
         // one-shot).
-        fn directory_model_frame() -> JsValue {
+        fn directory_concept_frame() -> JsValue {
             rows(&[(
-                "did:key:zModel",
+                "did:key:zConcept",
                 &[(
                     "source",
                     r#"{"with":{"title":{"the":"item/title","as":"Text","cardinality":"one"}}}"#,
@@ -2745,9 +2740,9 @@ mod tests {
             )])
         }
         fn install_directory() -> FakeHost {
-            FakeHost::install_with_model(
+            FakeHost::install_with_concept(
                 directory_resolve_responses(),
-                Some(directory_model_frame()),
+                Some(directory_concept_frame()),
             )
         }
 
@@ -2847,7 +2842,7 @@ mod tests {
         // (the `{this}` element) must survive rendering — it is chrome,
         // not part of the repeat. Regression for the binder's
         // `[slot="empty"]` launchpad: `<tonk-sheet-binder>` holds the
-        // repeat `<tonk-display entity={this}>` and a static `<div
+        // repeat `<tonk-display this={this}>` and a static `<div
         // slot="empty">` as direct siblings; the launchpad was dropped
         // when it sat *after* the repeat element. (A static node BEFORE
         // the repeat element survived, which is what made the bug
@@ -2908,7 +2903,7 @@ mod tests {
                 sleep(5).await;
             }
 
-            // Repeat root is a nested `<tonk-display entity={this}>` (a
+            // Repeat root is a nested `<tonk-display this={this}>` (a
             // custom element); the `<p class="after">` follows it.
             host.push_frame(
                 "view",
@@ -2916,7 +2911,7 @@ mod tests {
                     "did:key:zView",
                     &[(
                         "display",
-                        "<div><tonk-display entity={this} concept=item data-id={this}></tonk-display><p class=\"after\">keep me</p></div>",
+                        "<div><tonk-display this={this} concept=item data-id={this}></tonk-display><p class=\"after\">keep me</p></div>",
                     )],
                 )]),
             );

--- a/rust/tonk-display/src/lib.rs
+++ b/rust/tonk-display/src/lib.rs
@@ -2,7 +2,7 @@
 //! entity using a view template stored on the branch.
 //!
 //! The element coordinates three live data flows:
-//! 1. One-shot resolution of the `model` concept descriptor.
+//! 1. One-shot resolution of the `concept` descriptor.
 //! 2. A live subscription on the matching `view` row so a template
 //!    edited on the branch swaps the rendered DOM.
 //! 3. A live subscription on the entity's attributes that patches

--- a/rust/tonk-display/src/notation_format.rs
+++ b/rust/tonk-display/src/notation_format.rs
@@ -262,9 +262,9 @@ mod tests {
 
     #[test]
     fn it_leaves_uri_values_unquoted() {
-        let f = fields(&[("model", json!("xyz.tonk.view/greeting"))]);
+        let f = fields(&[("concept", json!("xyz.tonk.view/greeting"))]);
         let out = format("did:key:zX", &f, "view", None);
-        assert!(out.contains("model: xyz.tonk.view/greeting\n"));
+        assert!(out.contains("concept: xyz.tonk.view/greeting\n"));
     }
 
     #[test]

--- a/rust/tonk-display/src/notation_tokens.rs
+++ b/rust/tonk-display/src/notation_tokens.rs
@@ -31,7 +31,7 @@ pub enum Decoration {
     /// A `?variable` or `_` blank field value.
     Variable,
     /// A field name (the level-3 mapping key — `this`, `message`,
-    /// `model`, etc.). In the editor these are painted by
+    /// `concept`, etc.). In the editor these are painted by
     /// CodeMirror's YAML grammar via the `--tonk-code-key`
     /// variable; we don't have Lezer here so the tokenizer emits
     /// the same class explicitly.
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn it_decorates_a_bare_symbol_value() {
-        let text = "view!:\n  model: greeting\n";
+        let text = "view!:\n  concept: greeting\n";
         let marks = collect_marks(text);
         assert!(
             marks

--- a/rust/tonk-display/src/state.rs
+++ b/rust/tonk-display/src/state.rs
@@ -31,15 +31,15 @@ use web_sys::{Element, window};
 pub enum State {
     /// A resolve query is in flight; nothing known yet.
     Loading,
-    /// Row(s) rendered by a model-specific view.
+    /// Row(s) rendered by a concept-specific view.
     Ready,
-    /// No model-specific view defined; the built-in `_:_` fallback
+    /// No concept-specific view defined; the built-in `_:_` fallback
     /// view is rendering. Rows render, but via the generic fallback.
     DefaultView,
-    /// The `model` concept is not defined on the branch (yet). The
-    /// model subscription stays open and recovers when it lands.
+    /// The `concept` concept is not defined on the branch (yet). The
+    /// concept subscription stays open and recovers when it lands.
     NoConcept,
-    /// Model resolved; an explicit `view` was requested but is not
+    /// Concept resolved; an explicit `view` was requested but is not
     /// defined and there is no `_:_` fallback to fall through to.
     NoView,
     /// Single mode: concept + view resolved, the entity **row** is
@@ -53,7 +53,7 @@ pub enum State {
     Unauthorized,
     /// Transport failure / the service worker is unreachable.
     Offline,
-    /// Author/protocol error — a bad `model`/`entity` attribute or a
+    /// Author/protocol error — a bad `concept`/`entity` attribute or a
     /// decode failure. Recovers when the author fixes the attribute.
     Malformed,
 }
@@ -128,7 +128,7 @@ const ERROR_CALLOUT_ATTR: &str = "data-tonk-display-error";
 /// with the same state.
 ///
 /// Transitioning to any non-loud state removes a callout a prior loud
-/// state injected, so a recoverable absence (`no-model` / `no-entity`)
+/// state injected, so a recoverable absence (`no-concept` / `no-entity`)
 /// or a recovery to `ready` never leaves a stale red box behind.
 #[cfg(target_arch = "wasm32")]
 pub fn set(host: &Element, state: State) {
@@ -138,7 +138,7 @@ pub fn set(host: &Element, state: State) {
     }
     // Any state set through this path (rather than `set_absence`) clears a
     // lingering absence fallback — e.g. recovery to `ready` /
-    // `default-view` after a `no-model`, so the informative callout does
+    // `default-view` after a `no-concept`, so the informative callout does
     // not sit beside the rendered content.
     remove_absence_callout(host);
     // The default-view notice coexists with rendered content, so it is
@@ -162,12 +162,12 @@ pub fn set(host: &Element, state: State) {
 #[cfg(target_arch = "wasm32")]
 const DEFAULT_NOTICE_ATTR: &str = "data-tonk-display-default-notice";
 
-/// Inject a `<wa-callout variant="warning">` telling the viewer that the model
+/// Inject a `<wa-callout variant="warning">` telling the viewer that the concept
 /// has no view of its own, so the built-in default presentation (the `_:_` view
 /// or the notation dump) is shown instead. Same shape as the absence callouts
 /// ([`set_absence`]) — a `circle-info` icon and a plain text label — but
-/// `warning` (theme yellow), not the `danger` red of a missing model/view: a
-/// model without its own view still renders something, so it is a heads-up, not
+/// `warning` (theme yellow), not the `danger` red of a missing concept/view: a
+/// concept without its own view still renders something, so it is a heads-up, not
 /// an error. Unlike the absence callouts it coexists with the rendered fallback
 /// content rather than replacing it, so it is **prepended** (sits on top, above
 /// the default presentation). An embedder can suppress it with a
@@ -197,7 +197,7 @@ fn set_default_notice(host: &Element) {
         let _ = icon.set_attribute("name", "circle-info");
         let _ = callout.append_child(&icon);
     }
-    // Name the model so the viewer knows exactly which one lacks a view.
+    // Name the concept so the viewer knows exactly which one lacks a view.
     let concept = host.get_attribute("concept").unwrap_or_default();
     let text = if concept.is_empty() {
         "No view for this concept; showing the default.".to_owned()
@@ -301,7 +301,7 @@ fn remove_error_callout(host: &Element) {
 #[cfg(target_arch = "wasm32")]
 const ABSENCE_CALLOUT_ATTR: &str = "data-tonk-display-absence";
 
-/// Enter a recoverable-absence `state` (`no-model` / `no-view` /
+/// Enter a recoverable-absence `state` (`no-concept` / `no-view` /
 /// `no-entity`), naming what was missing: a prose `label` plus a
 /// `notation` snippet (e.g. `{ this: did:key:… }`) rendered as
 /// syntax-highlighted, monospace `<tonk-notation>`.
@@ -341,7 +341,7 @@ pub fn set_absence(host: &Element, state: State, label: &str, notation: &str) {
     let Ok(callout) = document.create_element("wa-callout") else {
         return;
     };
-    // A missing model/view concept is a config/authoring problem the
+    // A missing concept/view concept is a config/authoring problem the
     // display can't render around → `danger`. A missing *instance*
     // (`no-entity`) is also `danger`: the entity is on the branch but
     // does not match the concept (some required attribute is absent), so
@@ -359,7 +359,7 @@ pub fn set_absence(host: &Element, state: State, label: &str, notation: &str) {
         let _ = icon.set_attribute("name", "circle-info");
         let _ = callout.append_child(&icon);
     }
-    // The callout is just the message strip — a short title like "Model
+    // The callout is just the message strip — a short title like "Concept
     // not found". It carries no query detail itself.
     let label_text = document.create_text_node(label);
     let _ = callout.append_child(&label_text);
@@ -403,7 +403,7 @@ pub fn set_absence(host: &Element, state: State, label: &str, notation: &str) {
 }
 
 /// Loud `no-entity` diagnostic: the entity is on the branch but does not
-/// match its model concept because one or more required attributes are
+/// match its concept because one or more required attributes are
 /// absent. Renders the concept as an entity dump where every required
 /// attribute is a line — present ones carry their value, missing ones
 /// render as a squiggled `_` with a `<wa-tooltip>` naming the absent
@@ -439,7 +439,7 @@ pub fn set_no_entity_diagnostic(
         return;
     };
 
-    // The loud callout strip — danger, like a missing model/view.
+    // The loud callout strip — danger, like a missing concept/view.
     if let Ok(callout) = document.create_element("wa-callout") {
         let _ = callout.set_attribute("variant", "danger");
         let _ = callout.set_attribute(ABSENCE_CALLOUT_ATTR, "");
@@ -672,7 +672,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     #[dialog_common::test]
     fn it_does_not_inject_a_callout_for_a_recoverable_absence() {
-        // `no-model` is a still-seeding card, not an error: the
+        // `no-concept` is a still-seeding card, not an error: the
         // embedder skins it from `data-state` (CSS placeholder). The
         // display must not force a red callout into the host.
         let host = host();
@@ -691,7 +691,7 @@ mod tests {
     #[dialog_common::test]
     fn it_clears_a_prior_callout_when_recovering_to_a_quiet_state() {
         // A loud failure injects a callout; a later recovery to a
-        // quiet state (e.g. the concept lands → no-model→no-entity, or
+        // quiet state (e.g. the concept lands → no-concept→no-entity, or
         // straight to ready) must clear it so no red box latches.
         let host = host();
         set_error(&host, State::Offline, "Connection failed", "boom");
@@ -710,10 +710,10 @@ mod tests {
 
     #[cfg(target_arch = "wasm32")]
     #[dialog_common::test]
-    fn it_injects_a_danger_fallback_naming_the_missing_model() {
-        // A bare `<tonk-display>` (no slot child) with a missing model
+    fn it_injects_a_danger_fallback_naming_the_missing_concept() {
+        // A bare `<tonk-display>` (no slot child) with a missing concept
         // must NOT render blank — it shows a callout with the query that
-        // matched nothing. A missing model concept is a config error the
+        // matched nothing. A missing concept is a config error the
         // display can't render around → `danger`.
         let host = host();
         set_absence(
@@ -734,7 +734,7 @@ mod tests {
         assert_eq!(
             callout.get_attribute("variant").as_deref(),
             Some("danger"),
-            "a missing model is a danger, not informative",
+            "a missing concept is a danger, not informative",
         );
         assert_eq!(
             callout.text_content().unwrap().trim(),
@@ -764,7 +764,7 @@ mod tests {
             &host,
             State::NoView,
             "Not found",
-            "view:\n  this: tonk:view/x\n  model: person",
+            "view:\n  this: tonk:view/x\n  concept: person",
         );
         assert_eq!(host.get_attribute("data-state").as_deref(), Some("no-view"));
         let callout = host

--- a/rust/tonk-display/src/state.rs
+++ b/rust/tonk-display/src/state.rs
@@ -23,7 +23,7 @@ use web_sys::{Element, window};
 /// the matching one, hiding the rest — see [`update_slot_children`]). For
 /// a state with no embedder slot, the display mounts a built-in fallback:
 /// a neutral, informative callout for the recoverable absences
-/// ([`State::NoModel`] / [`State::NoView`] / [`State::NoEntity`], via
+/// ([`State::NoConcept`] / [`State::NoView`] / [`State::NoEntity`], via
 /// [`set_absence`]) and a loud danger callout for the broken states
 /// ([`State::Malformed`] / [`State::Offline`] / [`State::Unauthorized`],
 /// via [`set_error`]). See `plan/tonk-display-states.md`.
@@ -38,7 +38,7 @@ pub enum State {
     DefaultView,
     /// The `model` concept is not defined on the branch (yet). The
     /// model subscription stays open and recovers when it lands.
-    NoModel,
+    NoConcept,
     /// Model resolved; an explicit `view` was requested but is not
     /// defined and there is no `_:_` fallback to fall through to.
     NoView,
@@ -66,7 +66,7 @@ impl State {
             State::Loading => "loading",
             State::Ready => "ready",
             State::DefaultView => "default-view",
-            State::NoModel => "no-model",
+            State::NoConcept => "no-concept",
             State::NoView => "no-view",
             State::NoEntity => "no-entity",
             State::Empty => "empty",
@@ -78,7 +78,7 @@ impl State {
 
     /// Whether this state is a *loud* failure — it drives a danger
     /// callout via [`set_error`]. The recoverable absences
-    /// ([`State::NoModel`], [`State::NoView`], [`State::NoEntity`]) are
+    /// ([`State::NoConcept`], [`State::NoView`], [`State::NoEntity`]) are
     /// not loud: they get a neutral informative fallback via
     /// [`set_absence`] (or the embedder's slot), so a still-seeding card
     /// reads as a quiet placeholder rather than a red error.
@@ -198,11 +198,11 @@ fn set_default_notice(host: &Element) {
         let _ = callout.append_child(&icon);
     }
     // Name the model so the viewer knows exactly which one lacks a view.
-    let model = host.get_attribute("model").unwrap_or_default();
-    let text = if model.is_empty() {
-        "No view for this model; showing the default.".to_owned()
+    let concept = host.get_attribute("concept").unwrap_or_default();
+    let text = if concept.is_empty() {
+        "No view for this concept; showing the default.".to_owned()
     } else {
-        format!("No view for {model}; showing the default.")
+        format!("No view for {concept}; showing the default.")
     };
     let label = document.create_text_node(&text);
     let _ = callout.append_child(&label);
@@ -307,7 +307,7 @@ const ABSENCE_CALLOUT_ATTR: &str = "data-tonk-display-absence";
 /// syntax-highlighted, monospace `<tonk-notation>`.
 ///
 /// The embedder may handle the state itself by providing a light-DOM
-/// child with `slot="<state>"` (e.g. `<span slot="no-model">…</span>`).
+/// child with `slot="<state>"` (e.g. `<span slot="no-concept">…</span>`).
 /// `<tonk-display>` is light-DOM (no shadow root), so a bare `slot=`
 /// attribute would otherwise render *always*; this fn drives the
 /// projection manually — it shows the child whose `slot` matches the
@@ -349,7 +349,7 @@ pub fn set_absence(host: &Element, state: State, label: &str, notation: &str) {
     // not a quiet still-syncing placeholder. The variant carries the
     // severity; the icon is the same info glyph for every absence.
     let variant = match state {
-        State::NoModel | State::NoView | State::NoEntity => "danger",
+        State::NoConcept | State::NoView | State::NoEntity => "danger",
         _ => "neutral",
     };
     let _ = callout.set_attribute("variant", variant);
@@ -420,7 +420,7 @@ pub fn set_absence(host: &Element, state: State, label: &str, notation: &str) {
 #[cfg(target_arch = "wasm32")]
 pub fn set_no_entity_diagnostic(
     host: &Element,
-    model: &str,
+    concept: &str,
     entity: &str,
     present: &[(String, String)],
     missing: &[(String, String)],
@@ -461,7 +461,7 @@ pub fn set_no_entity_diagnostic(
     // expressions where a field name is not unique — a line number points
     // at exactly one row whatever the shape. Line 0 is the head; the first
     // field (`this`) is line 1.
-    let mut source = format!("{model}:\n  this: {entity}\n");
+    let mut source = format!("{concept}:\n  this: {entity}\n");
     let mut line = 2usize; // head (0), `this` (1) already emitted.
     for (field, value) in present {
         source.push_str(&format!("  {field}: {value}\n"));
@@ -560,7 +560,7 @@ fn is_state_slot(slot: &str) -> bool {
         "loading"
             | "ready"
             | "default-view"
-            | "no-model"
+            | "no-concept"
             | "no-view"
             | "no-entity"
             | "empty"
@@ -603,7 +603,7 @@ mod tests {
         assert_eq!(State::Loading.as_str(), "loading");
         assert_eq!(State::Ready.as_str(), "ready");
         assert_eq!(State::DefaultView.as_str(), "default-view");
-        assert_eq!(State::NoModel.as_str(), "no-model");
+        assert_eq!(State::NoConcept.as_str(), "no-concept");
         assert_eq!(State::NoView.as_str(), "no-view");
         assert_eq!(State::NoEntity.as_str(), "no-entity");
         assert_eq!(State::Empty.as_str(), "empty");
@@ -618,7 +618,7 @@ mod tests {
         // `data-state`, not a forced callout, so a still-seeding card
         // never flashes a red box. The genuinely-broken states stay loud.
         assert!(!State::Loading.is_loud());
-        assert!(!State::NoModel.is_loud());
+        assert!(!State::NoConcept.is_loud());
         assert!(!State::NoView.is_loud());
         assert!(!State::NoEntity.is_loud());
         assert!(!State::DefaultView.is_loud());
@@ -676,10 +676,10 @@ mod tests {
         // embedder skins it from `data-state` (CSS placeholder). The
         // display must not force a red callout into the host.
         let host = host();
-        set(&host, State::NoModel);
+        set(&host, State::NoConcept);
         assert_eq!(
             host.get_attribute("data-state").as_deref(),
-            Some("no-model")
+            Some("no-concept")
         );
         assert!(
             host.query_selector("wa-callout").unwrap().is_none(),
@@ -716,11 +716,16 @@ mod tests {
         // matched nothing. A missing model concept is a config error the
         // display can't render around → `danger`.
         let host = host();
-        set_absence(&host, State::NoModel, "Not found", "concept:\n  this: test");
+        set_absence(
+            &host,
+            State::NoConcept,
+            "Not found",
+            "concept:\n  this: test",
+        );
 
         assert_eq!(
             host.get_attribute("data-state").as_deref(),
-            Some("no-model")
+            Some("no-concept")
         );
         let callout = host
             .query_selector("wa-callout")
@@ -815,12 +820,17 @@ mod tests {
         let host = host();
         let document = web_sys::window().unwrap().document().unwrap();
         let mine = document.create_element("span").unwrap();
-        mine.set_attribute("slot", "no-model").unwrap();
+        mine.set_attribute("slot", "no-concept").unwrap();
         mine.set_attribute("hidden", "").unwrap();
         mine.set_text_content(Some("Untitled"));
         host.append_child(&mine).unwrap();
 
-        set_absence(&host, State::NoModel, "No matching concept ", "{ this: x }");
+        set_absence(
+            &host,
+            State::NoConcept,
+            "No matching concept ",
+            "{ this: x }",
+        );
 
         assert!(
             host.query_selector("wa-callout").unwrap().is_none(),
@@ -839,7 +849,7 @@ mod tests {
         // the child whose `slot` matches the current state is visible.
         let host = host();
         let document = web_sys::window().unwrap().document().unwrap();
-        for state in ["no-model", "no-entity", "loading"] {
+        for state in ["no-concept", "no-entity", "loading"] {
             let s = document.create_element("span").unwrap();
             s.set_attribute("slot", state).unwrap();
             s.set_attribute("hidden", "").unwrap();
@@ -859,7 +869,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(!shown.has_attribute("hidden"), "matching slot is shown");
-        let other = host.query_selector("[slot=\"no-model\"]").unwrap().unwrap();
+        let other = host
+            .query_selector("[slot=\"no-concept\"]")
+            .unwrap()
+            .unwrap();
         assert!(
             other.has_attribute("hidden"),
             "non-matching slot stays hidden",

--- a/rust/tonk-display/src/template.rs
+++ b/rust/tonk-display/src/template.rs
@@ -1018,14 +1018,14 @@ mod tests {
         assert_eq!(root, Some(vec![0]));
     }
 
-    // 4. <div data-model={dom.host/model}>    [0]     attr dom.host ref
+    // 4. <div data-model={dom.host/concept}>    [0]     attr dom.host ref
     //      <span data-this={this} data-name={name}>  [0, 0] attrs
     //    The {dom.host/*} reference is ignored for repeat resolution, so
     //    the inner <span> (holding {this} and {name}) repeats.
     #[dialog_common::test]
     fn it_ignores_dom_host_refs_when_resolving_the_repeat_node() {
         let root = this_repeat_root(&[
-            attr_binding(&[0], "data-model", "dom.host/model"),
+            attr_binding(&[0], "data-model", "dom.host/concept"),
             attr_binding(&[0, 0], "data-this", "this"),
             attr_binding(&[0, 0], "data-name", "name"),
         ]);

--- a/rust/tonk-display/src/template.rs
+++ b/rust/tonk-display/src/template.rs
@@ -514,7 +514,7 @@ mod dom {
         #[dialog_common::test]
         fn it_skips_a_template_nested_in_a_component() {
             let host = host_with(
-                "<tonk-display entity=\"did:key:zBook\"><ul><template><li>{title}</li></template></ul></tonk-display>",
+                "<tonk-display this=\"did:key:zBook\"><ul><template><li>{title}</li></template></ul></tonk-display>",
             );
             assert!(find_template(&host).is_none());
         }
@@ -524,7 +524,7 @@ mod dom {
         #[dialog_common::test]
         fn it_prefers_an_own_template_over_one_inside_a_nested_component() {
             let host = host_with(
-                "<tonk-display entity=\"did:key:zBook\"><template data-which=\"nested\"><li>{b}</li></template></tonk-display><template data-which=\"own\"><p>{a}</p></template>",
+                "<tonk-display this=\"did:key:zBook\"><template data-which=\"nested\"><li>{b}</li></template></tonk-display><template data-which=\"own\"><p>{a}</p></template>",
             );
             let found = find_template(&host).expect("a usable own template");
             assert_eq!(found.get_attribute("data-which").as_deref(), Some("own"));
@@ -546,7 +546,7 @@ mod dom {
         #[dialog_common::test]
         fn it_finds_an_own_template_in_a_wrapper_preceding_a_component() {
             let host = host_with(
-                "<div><template data-which=\"own\"><p>{a}</p></template></div><tonk-display entity=\"did:key:zBook\"><template data-which=\"nested\"><li>{b}</li></template></tonk-display>",
+                "<div><template data-which=\"own\"><p>{a}</p></template></div><tonk-display this=\"did:key:zBook\"><template data-which=\"nested\"><li>{b}</li></template></tonk-display>",
             );
             let found = find_template(&host).expect("own template in the leading wrapper");
             assert_eq!(found.get_attribute("data-which").as_deref(), Some("own"));
@@ -1018,14 +1018,14 @@ mod tests {
         assert_eq!(root, Some(vec![0]));
     }
 
-    // 4. <div data-model={dom.host/concept}>    [0]     attr dom.host ref
+    // 4. <div data-concept={dom.host/concept}>    [0]     attr dom.host ref
     //      <span data-this={this} data-name={name}>  [0, 0] attrs
     //    The {dom.host/*} reference is ignored for repeat resolution, so
     //    the inner <span> (holding {this} and {name}) repeats.
     #[dialog_common::test]
     fn it_ignores_dom_host_refs_when_resolving_the_repeat_node() {
         let root = this_repeat_root(&[
-            attr_binding(&[0], "data-model", "dom.host/concept"),
+            attr_binding(&[0], "data-concept", "dom.host/concept"),
             attr_binding(&[0, 0], "data-this", "this"),
             attr_binding(&[0, 0], "data-name", "name"),
         ]);

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -505,7 +505,7 @@ mod tests {
         // raises the iteration root above the inner element so
         // each value gets its own <li> wrapper.
         let host = mount(
-            "<ul><li subject={item}><tonk-display entity={item} model=todo></tonk-display></li></ul>",
+            "<ul><li subject={item}><tonk-display entity={item} concept=todo></tonk-display></li></ul>",
         );
         call_draw(
             &host,

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -283,7 +283,7 @@ mod tests {
     #[dialog_common::test]
     fn it_preserves_a_nested_component_template() {
         let host = mount(
-            "<div class=\"app\"><tonk-display entity=\"did:key:zBook\"><ul><template><li>{title}</li></template></ul></tonk-display></div>",
+            "<div class=\"app\"><tonk-display this=\"did:key:zBook\"><ul><template><li>{title}</li></template></ul></tonk-display></div>",
         );
         call_draw(&host, &detail("did:key:zLibrary", &[]));
         assert!(
@@ -474,7 +474,7 @@ mod tests {
         // clone (which is what the `<li>` direct-child-of-<ul>
         // rule effectively forbids in semantic terms).
         let host = mount(
-            "<ul><li subject={item}><tonk-display entity={item}>{item}</tonk-display></li></ul>",
+            "<ul><li subject={item}><tonk-display this={item}>{item}</tonk-display></li></ul>",
         );
         call_draw(
             &host,
@@ -505,7 +505,7 @@ mod tests {
         // raises the iteration root above the inner element so
         // each value gets its own <li> wrapper.
         let host = mount(
-            "<ul><li subject={item}><tonk-display entity={item} concept=todo></tonk-display></li></ul>",
+            "<ul><li subject={item}><tonk-display this={item} concept=todo></tonk-display></li></ul>",
         );
         call_draw(
             &host,
@@ -521,7 +521,7 @@ mod tests {
                 displays
                     .item(i)
                     .and_then(|n| n.dyn_into::<Element>().ok())
-                    .and_then(|el| el.get_attribute("entity"))
+                    .and_then(|el| el.get_attribute("this"))
             })
             .collect();
         assert_eq!(

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -3167,11 +3167,11 @@ concept!: &workspace/sheet
       as: entity
       cardinality: one
       description: "entity"
-    model:
+    concept:
       the: xyz.tonk.artifact/model
       as: entity
       cardinality: one
-      description: "model"
+      description: "concept"
     order:
       the: xyz.tonk.sheet/order
       as: text
@@ -3207,7 +3207,7 @@ rule!:
     - assert: ==
       where: { this: ?entity, is: ?this }
     - assert: ==
-      where: { this: ?model, is: tonk:empty-artifact }
+      where: { this: ?concept, is: tonk:empty-artifact }
 
 rule!:
   assert!: empty-artifact

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -2510,7 +2510,7 @@ ping!:\n\
     /// active sheet) must leave `active` pointing at the same sheet —
     /// removing a background tab never steals focus.
     ///
-    /// Mirrors the `core.yaml` workspace model: a `workspace` concept
+    /// Mirrors the `core.yaml` workspace concept: a `workspace` concept
     /// (with `active` + `sheet`), the `workspace/active-sheet` and
     /// `workspace/sheet-member` projections, the transient
     /// `close-sheet` command, and the two close rules (retract the
@@ -2523,7 +2523,7 @@ ping!:\n\
         let repo = test_repo(&operator, &profile).await;
         let branch = repo.branch("main").open().perform(&operator).await?;
 
-        // Declare the workspace model + close rules, then seed a
+        // Declare the workspace concept + close rules, then seed a
         // workspace owning three sheets with `a` active, asserted at
         // `about:blank` across multiple statements — mirroring exactly
         // how core.yaml seeds the demo workspace.
@@ -2737,7 +2737,7 @@ workspace!:
     /// command carries (`next`). The companion to
     /// [`it_keeps_active_when_a_background_sheet_closes`]: here the
     /// reassign rule *must* fire, because the closed sheet is the
-    /// active one. Shares the same workspace model.
+    /// active one. Shares the same workspace concept.
     #[dialog_common::test]
     async fn it_moves_active_to_the_neighbour_when_the_active_sheet_closes() -> anyhow::Result<()> {
         let (operator, profile) = test_operator_with_profile().await;
@@ -3126,7 +3126,7 @@ workspace!:
     }
 
     /// The real `core.yaml` create flow: a `create-sheet` command mints
-    /// a self-describing empty sheet (entity = the sheet itself, model =
+    /// a self-describing empty sheet (entity = the sheet itself, concept =
     /// empty-artifact), titles its empty-artifact entity with the typed
     /// name, and auto-activates it. Mirrors the three create rules in
     /// the standard library.
@@ -3293,7 +3293,7 @@ workspace!:
             "the new sheet/empty-artifact should be titled \"Notes\"; saw {title:?}"
         );
 
-        // The sheet's entity points at itself, and its model is the
+        // The sheet's entity points at itself, and its concept is the
         // empty-artifact concept.
         let entity: Vec<dialog_query::Claim> = branch
             .query()
@@ -3311,7 +3311,7 @@ workspace!:
                 .any(|c| format!("{:?}", c.is).contains("zNewSheet")),
             "the sheet's entity should be self-referential; saw {entity:?}"
         );
-        let model: Vec<dialog_query::Claim> = branch
+        let concept: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
                 Term::from(the!("xyz.tonk.artifact/model"))
@@ -3322,10 +3322,10 @@ workspace!:
             .try_vec()
             .await?;
         assert!(
-            model
+            concept
                 .iter()
                 .any(|c| format!("{:?}", c.is).contains("tonk:empty-artifact")),
-            "the sheet's model should be tonk:empty-artifact; saw {model:?}"
+            "the sheet's concept should be tonk:empty-artifact; saw {concept:?}"
         );
 
         // The workspace auto-activated the new sheet.

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -3168,7 +3168,7 @@ concept!: &workspace/sheet
       cardinality: one
       description: "entity"
     concept:
-      the: xyz.tonk.artifact/model
+      the: xyz.tonk.artifact/concept
       as: entity
       cardinality: one
       description: "concept"
@@ -3314,7 +3314,7 @@ workspace!:
         let concept: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::from(the!("xyz.tonk.artifact/model"))
+                Term::from(the!("xyz.tonk.artifact/concept"))
                     .of(Term::from(new_sheet.clone()))
                     .is(Term::<dialog_artifacts::Entity>::var("v")),
             ))

--- a/rust/tonk-guest/src/guest_host.rs
+++ b/rust/tonk-guest/src/guest_host.rs
@@ -64,7 +64,7 @@ impl CustomElement for GuestHost {
         // `data-tonk-entity="site"` gets its `entity` set to the host's site
         // (the X-Tonk-Site the host stamps on the HTTP queries it issues on this
         // guest's behalf — `window.tonk.context.site`). That is how the routing
-        // shell (`<tonk-display model=tonk:site data-tonk-entity="site">`)
+        // shell (`<tonk-display concept=tonk:site data-tonk-entity="site">`)
         // resolves its own tab's location/route: the site entity carries the
         // `tonk:site` facts the SW stamped. Deferred until `window.tonk.ready`
         // resolves, since the context (with the site) arrives asynchronously
@@ -225,7 +225,7 @@ fn fill_site_entities(root: &HtmlElement) {
     };
     for i in 0..matches.length() {
         if let Some(el) = matches.item(i).and_then(|n| n.dyn_into::<Element>().ok()) {
-            let _ = el.set_attribute("entity", &site);
+            let _ = el.set_attribute("this", &site);
         }
     }
 }

--- a/rust/tonk-guest/src/guest_host.rs
+++ b/rust/tonk-guest/src/guest_host.rs
@@ -61,7 +61,7 @@ impl CustomElement for GuestHost {
 
     fn connected_callback(&mut self, this: &HtmlElement) {
         // Bind the per-tab `site` entity: any descendant that opted in with
-        // `data-tonk-entity="site"` gets its `entity` set to the host's site
+        // `data-tonk-entity="site"` gets its `this` set to the host's site
         // (the X-Tonk-Site the host stamps on the HTTP queries it issues on this
         // guest's behalf — `window.tonk.context.site`). That is how the routing
         // shell (`<tonk-display concept=tonk:site data-tonk-entity="site">`)

--- a/rust/tonk-host/src/bridge.rs
+++ b/rust/tonk-host/src/bridge.rs
@@ -33,7 +33,7 @@ fn tonk_global() -> Result<JsValue, ErrorDetail> {
 }
 
 /// Read a string field off the bridge `window.tonk.context`, if present and
-/// non-empty. The host populates the context (`{this, model, origin, repo,
+/// non-empty. The host populates the context (`{this, concept, origin, repo,
 /// branch}`) in its `ready` envelope; guest controls read routing they can't
 /// resolve from the DOM (the `<tonk-repository>`/`<tonk-branch>` ancestors
 /// live outside the iframe) from here.

--- a/rust/tonk-host/src/query_cache.rs
+++ b/rust/tonk-host/src/query_cache.rs
@@ -1,7 +1,7 @@
 //! Tiny LRU for `tonk-query` responses.
 //!
 //! Every `<tonk-display>` mount fires a phase-1 query to resolve
-//! its model concept's descriptor. With multiple displays
+//! its concept's descriptor. With multiple displays
 //! mounted in a chain (board → column → tile → inspector-view),
 //! that's N serial HTTP round-trips for what's effectively a
 //! few unique concept lookups — measured at ~900 ms across the

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -139,7 +139,7 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     });
   }
   var tonk={
-    context:{this:"",model:""},
+    context:{this:"",concept:""},
     ready:ready,
     query:function(body){return call("query",{body:body});},
     transact:function(request){return call("transact",{request:request});},
@@ -1306,7 +1306,7 @@ fn no_arg_entity_query(host: &Element) -> Result<JsValue, String> {
         .filter(|s| !s.is_empty())
         .ok_or("tonk.subscribe()/query() with no argument requires a scoped `entity`")?;
     let descriptor = read_descriptor(host)
-        .ok_or("tonk.subscribe()/query() with no argument requires a model descriptor")?;
+        .ok_or("tonk.subscribe()/query() with no argument requires a concept descriptor")?;
     let query = crate::query::entity_query(&descriptor, &entity)
         .map_err(|e| format!("entity query: {e}"))?;
     serde_wasm_bindgen::to_value(&query).map_err(|e| format!("query body: {e}"))
@@ -1330,7 +1330,7 @@ fn read_descriptor(host: &Element) -> Option<String> {
 fn build_context(host: &Element) -> Object {
     let context = Object::new();
     let this = host.get_attribute("entity").unwrap_or_default();
-    let model = host.get_attribute("model").unwrap_or_default();
+    let concept = host.get_attribute("concept").unwrap_or_default();
     let location = window().map(|w| w.location());
     let origin = location
         .as_ref()
@@ -1369,7 +1369,7 @@ fn build_context(host: &Element) -> Object {
     // actually stamped.
     let site = tonk_host::bridge::site_id();
     let _ = Reflect::set(&context, &"this".into(), &JsValue::from_str(&this));
-    let _ = Reflect::set(&context, &"model".into(), &JsValue::from_str(&model));
+    let _ = Reflect::set(&context, &"concept".into(), &JsValue::from_str(&concept));
     let _ = Reflect::set(&context, &"origin".into(), &JsValue::from_str(&origin));
     let _ = Reflect::set(&context, &"path".into(), &JsValue::from_str(&path));
     let _ = Reflect::set(&context, &"hash".into(), &JsValue::from_str(&hash));
@@ -1679,15 +1679,15 @@ mod tests {
     fn relay_consumer(
         host: &FakeHost,
         entity: Option<&str>,
-        model: Option<&str>,
+        concept: Option<&str>,
         descriptor: Option<&str>,
     ) -> Element {
         let consumer = document().create_element("div").expect("div");
         if let Some(e) = entity {
             consumer.set_attribute("entity", e).expect("entity");
         }
-        if let Some(m) = model {
-            consumer.set_attribute("model", m).expect("model");
+        if let Some(m) = concept {
+            consumer.set_attribute("concept", m).expect("concept");
         }
         if let Some(d) = descriptor {
             let _ = Reflect::set(
@@ -1816,7 +1816,7 @@ mod tests {
             get_str(&context, "this").as_deref(),
             Some("id:demo-counter")
         );
-        assert_eq!(get_str(&context, "model").as_deref(), Some("counter"));
+        assert_eq!(get_str(&context, "concept").as_deref(), Some("counter"));
     }
 
     #[dialog_common::test]
@@ -2054,7 +2054,7 @@ mod tests {
         host: &FakeHost,
         content: &str,
         entity: Option<&str>,
-        model: Option<&str>,
+        concept: Option<&str>,
         descriptor: Option<&str>,
     ) -> Element {
         crate::register();
@@ -2065,8 +2065,8 @@ mod tests {
         if let Some(e) = entity {
             portal.set_attribute("entity", e).expect("entity");
         }
-        if let Some(m) = model {
-            portal.set_attribute("model", m).expect("model");
+        if let Some(m) = concept {
+            portal.set_attribute("concept", m).expect("concept");
         }
         if let Some(d) = descriptor {
             let _ = Reflect::set(portal.as_ref(), &"descriptor".into(), &JsValue::from_str(d));

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -13,7 +13,7 @@
 //!
 //! ```text
 //! window.tonk = {
-//!   context: { this, model },
+//!   context: { this, concept },
 //!   query(body?)      -> Promise<Conclusion[]>,
 //!   subscribe(body?)  -> ReadableStream<Conclusion[]>,
 //!   transact(request) -> Promise<receipt>,
@@ -1302,9 +1302,9 @@ fn query_body(host: &Element, arg: &JsValue) -> Result<JsValue, String> {
 
 fn no_arg_entity_query(host: &Element) -> Result<JsValue, String> {
     let entity = host
-        .get_attribute("entity")
+        .get_attribute("this")
         .filter(|s| !s.is_empty())
-        .ok_or("tonk.subscribe()/query() with no argument requires a scoped `entity`")?;
+        .ok_or("tonk.subscribe()/query() with no argument requires a scoped `this`")?;
     let descriptor = read_descriptor(host)
         .ok_or("tonk.subscribe()/query() with no argument requires a concept descriptor")?;
     let query = crate::query::entity_query(&descriptor, &entity)
@@ -1318,8 +1318,8 @@ fn read_descriptor(host: &Element) -> Option<String> {
         .and_then(|v| v.as_string())
 }
 
-/// Build the `context` object (`{ this, model, origin, repo, branch }`) the
-/// iframe receives in its `ready` envelope. `this`/`model` come from the
+/// Build the `context` object (`{ this, concept, origin, repo, branch }`) the
+/// iframe receives in its `ready` envelope. `this`/`concept` come from the
 /// host's attributes; `origin` is the host page's real origin (the opaque
 /// guest's is `"null"`); `repo`/`branch` come from the portal's
 /// `<tonk-repository>`/`<tonk-branch>` ancestors — those routing elements
@@ -1329,7 +1329,7 @@ fn read_descriptor(host: &Element) -> Option<String> {
 /// from `window.tonk.context` rather than the DOM/`window.location`.
 fn build_context(host: &Element) -> Object {
     let context = Object::new();
-    let this = host.get_attribute("entity").unwrap_or_default();
+    let this = host.get_attribute("this").unwrap_or_default();
     let concept = host.get_attribute("concept").unwrap_or_default();
     let location = window().map(|w| w.location());
     let origin = location
@@ -1365,7 +1365,7 @@ fn build_context(host: &Element) -> Object {
     // are ultimately issued by the host's `<tonk-host>` over HTTP, which stamps
     // THIS site on `X-Tonk-Site` — so the SW keys this tab's `tonk:site` facts by
     // it, not by the guest's own `guest:…` id. Guest content that renders the
-    // routing indirection binds `entity` to this so it resolves the facts the SW
+    // routing indirection binds `this` to this so it resolves the facts the SW
     // actually stamped.
     let site = tonk_host::bridge::site_id();
     let _ = Reflect::set(&context, &"this".into(), &JsValue::from_str(&this));
@@ -1674,8 +1674,8 @@ mod tests {
     }
 
     /// A consumer element that dispatches the bridge's events: a `<div>`
-    /// under the fake host carrying the scoped `entity` / `model` and the
-    /// model `descriptor` the relay reads for no-argument calls.
+    /// under the fake host carrying the scoped `this` / `concept` and the
+    /// concept `descriptor` the relay reads for no-argument calls.
     fn relay_consumer(
         host: &FakeHost,
         entity: Option<&str>,
@@ -1684,7 +1684,7 @@ mod tests {
     ) -> Element {
         let consumer = document().create_element("div").expect("div");
         if let Some(e) = entity {
-            consumer.set_attribute("entity", e).expect("entity");
+            consumer.set_attribute("this", e).expect("this");
         }
         if let Some(m) = concept {
             consumer.set_attribute("concept", m).expect("concept");
@@ -2063,7 +2063,7 @@ mod tests {
             .expect("tonk-portal");
         portal.set_attribute("content", content).expect("content");
         if let Some(e) = entity {
-            portal.set_attribute("entity", e).expect("entity");
+            portal.set_attribute("this", e).expect("this");
         }
         if let Some(m) = concept {
             portal.set_attribute("concept", m).expect("concept");

--- a/rust/tonk-portal/src/element.rs
+++ b/rust/tonk-portal/src/element.rs
@@ -42,7 +42,7 @@ impl CustomElement for TonkPortal {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["content", "entity", "concept", "runtime"]
+        &["content", "this", "concept", "runtime"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -146,7 +146,7 @@ impl CustomElement for TonkPortal {
             "content" => reload(&host, &state),
             // A re-scope reloads the iframe so the bootstrap re-runs
             // author code; the fresh `context` rides the new handshake.
-            "entity" | "concept" => reload(&host, &state),
+            "this" | "concept" => reload(&host, &state),
             _ => {}
         }
     }

--- a/rust/tonk-portal/src/element.rs
+++ b/rust/tonk-portal/src/element.rs
@@ -42,7 +42,7 @@ impl CustomElement for TonkPortal {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["content", "entity", "model", "runtime"]
+        &["content", "entity", "concept", "runtime"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -146,7 +146,7 @@ impl CustomElement for TonkPortal {
             "content" => reload(&host, &state),
             // A re-scope reloads the iframe so the bootstrap re-runs
             // author code; the fresh `context` rides the new handshake.
-            "entity" | "model" => reload(&host, &state),
+            "entity" | "concept" => reload(&host, &state),
             _ => {}
         }
     }

--- a/rust/tonk-portal/src/lib.rs
+++ b/rust/tonk-portal/src/lib.rs
@@ -13,11 +13,11 @@
 //! one imperative thing — assign the iframe's `srcdoc`. The iframe
 //! always fills its container. The
 //! `content` is itself first-class dialog data: the `portal` concept
-//! holds it, and a nested `<tonk-display model=portal>` fetches it,
+//! holds it, and a nested `<tonk-display concept=portal>` fetches it,
 //! exactly as a board column fetches its tiles.
 //!
 //! This crate ships the element. The `portal` concept and its canonical
-//! view (resolved by model) that bridges it to the element live in the
+//! view (resolved by concept) that bridges it to the element live in the
 //! standard library (`tonk-core/assets/library/core.yaml`), seeded by
 //! the service worker at repository creation.
 

--- a/rust/tonk-portal/src/query.rs
+++ b/rust/tonk-portal/src/query.rs
@@ -1,7 +1,7 @@
 //! Wire-query construction for the no-argument bridge calls.
 //!
 //! `tonk.subscribe()` / `tonk.query()` with no argument stream the
-//! portal's scoped entity. This builds that query from the model
+//! portal's scoped entity. This builds that query from the
 //! concept's descriptor and the scoped entity URI — the same shape
 //! `<tonk-display>` builds for its entity subscription, so the
 //! imperative escape hatch reads exactly what the declarative path
@@ -14,7 +14,7 @@ use tonk_schema::query::Query;
 /// Build the scoped-entity query: pin `this` to `entity` and project
 /// every field in the descriptor's `with:` map as a variable. The
 /// descriptor is the raw JSON `<tonk-display>` resolves for the
-/// model concept (`{ "with": { <field>: { the, as, cardinality } } }`)
+/// concept (`{ "with": { <field>: { the, as, cardinality } } }`)
 /// and doubles as the query predicate.
 pub fn entity_query(descriptor_json: &str, entity: &str) -> Result<Query, serde_json::Error> {
     let predicate: Value = serde_json::from_str(descriptor_json)?;

--- a/rust/tonk-render/src/page.rs
+++ b/rust/tonk-render/src/page.rs
@@ -1,7 +1,7 @@
-//! Headless `model -> view -> entity -> HTML` page orchestration.
+//! Headless `concept -> view -> entity -> HTML` page orchestration.
 //!
 //! The host-agnostic half of server-side `<tonk-display>` rendering.
-//! It runs the same model/view/entity resolution the browser component
+//! It runs the same concept/view/entity resolution the browser component
 //! runs, feeds the result through the shared [`tonk_template`] planner
 //! and this crate's headless renderer, and recursively expands nested
 //! `<tonk-display>` elements. Where the pure renderer ([`crate::render`])
@@ -61,7 +61,7 @@ pub enum RenderError {
     #[error("render queries must be concept queries, not formulas")]
     NotConceptQuery,
 
-    /// No concept matched a model/view name or URI.
+    /// No concept matched a concept/view name or URI.
     #[error("no concept matched `{0}`")]
     NoConcept(String),
 
@@ -69,7 +69,7 @@ pub enum RenderError {
     #[error("{0}")]
     Descriptor(String),
 
-    /// No view resolved for a model (no model-specific view and no
+    /// No view resolved for a concept (no concept-specific view and no
     /// `tonk:_` default).
     #[error("no view found for concept `{0}` (no concept-specific view and no `tonk:_` default)")]
     NoView(String),

--- a/rust/tonk-render/src/page.rs
+++ b/rust/tonk-render/src/page.rs
@@ -71,7 +71,7 @@ pub enum RenderError {
 
     /// No view resolved for a model (no model-specific view and no
     /// `tonk:_` default).
-    #[error("no view found for model `{0}` (no model-specific view and no `tonk:_` default)")]
+    #[error("no view found for concept `{0}` (no concept-specific view and no `tonk:_` default)")]
     NoView(String),
 
     /// A bookmark name did not resolve to an entity.

--- a/rust/tonk-render/src/page/orchestrate.rs
+++ b/rust/tonk-render/src/page/orchestrate.rs
@@ -15,7 +15,7 @@ use tonk_schema::conclusion::Conclusion;
 use tonk_template::fold::select_rows;
 use tonk_template::resolve::{
     directory_view_predicate, entity_query, instances_query, looks_like_uri, name_query,
-    parse_source, phase1_query, view_by_model_query, view_predicate,
+    parse_source, phase1_query, view_by_concept_query, view_predicate,
 };
 use tonk_template::{build_plan_nodes, split_plan, this_repeat_root};
 
@@ -50,7 +50,7 @@ async fn render_guarded<B: QueryBackend>(
         return Err(RenderError::RecursionDepth(MAX_DEPTH));
     }
     if visited.contains(route) {
-        return Err(RenderError::RenderCycle(route.model.clone()));
+        return Err(RenderError::RenderCycle(route.concept.clone()));
     }
     visited.push(route.clone());
     let out = render_at_depth(backend, route, depth, visited).await;
@@ -65,7 +65,7 @@ async fn render_at_depth<B: QueryBackend>(
     visited: &mut Vec<RenderRoute>,
 ) -> Result<String, RenderError> {
     // 1. Resolve the model concept to its entity URI + descriptor.
-    let (model_entity, descriptor_json) = resolve_model(backend, &route.model).await?;
+    let (concept_entity, descriptor_json) = resolve_concept(backend, &route.concept).await?;
 
     // 2. Resolve the target entity, if any (bookmark name -> URI).
     let entity_uri = match &route.entity {
@@ -79,7 +79,7 @@ async fn render_at_depth<B: QueryBackend>(
     //    the `display` template + optional `type`.
     let view_descriptor = match &route.view {
         Some(view_name) => {
-            let (_, view_desc_json) = resolve_model(backend, view_name).await?;
+            let (_, view_desc_json) = resolve_concept(backend, view_name).await?;
             serde_json::from_str(&view_desc_json).map_err(|e| {
                 RenderError::Descriptor(format!(
                     "view concept `{view_name}` descriptor invalid: {e}"
@@ -89,9 +89,9 @@ async fn render_at_depth<B: QueryBackend>(
         None if entity_uri.is_some() => view_predicate(),
         None => directory_view_predicate(),
     };
-    let view = resolve_view(backend, &view_descriptor, &model_entity).await?;
+    let view = resolve_view(backend, &view_descriptor, &concept_entity).await?;
     let Some(view) = view else {
-        return Err(RenderError::NoView(route.model.clone()));
+        return Err(RenderError::NoView(route.concept.clone()));
     };
 
     // 4. Portal views (type=text/html) render as an isolated iframe.
@@ -110,7 +110,7 @@ async fn render_at_depth<B: QueryBackend>(
 
     // 6. Parse the template, collect bindings, plan, and render. Inject
     //    the host attributes (model/entity/view) as `dom.host/*` fields
-    //    so a nested `<tonk-display model={dom.host/model}>` resolves,
+    //    so a nested `<tonk-display model={dom.host/concept}>` resolves,
     //    matching the browser's `with_host_attributes`.
     let mut roots = crate::parse_fragment(&view.display);
     let bindings = crate::collect_bindings(&mut roots);
@@ -130,12 +130,12 @@ async fn render_at_depth<B: QueryBackend>(
 
 /// The host attributes a `<tonk-display>` would carry, as
 /// `dom.host/<attr>` fields, so templates that reference
-/// `{dom.host/model}` (the directory -> detail idiom) resolve.
+/// `{dom.host/concept}` (the directory -> detail idiom) resolve.
 fn host_fields(route: &RenderRoute) -> BTreeMap<String, Ipld> {
     let mut fields = BTreeMap::new();
     fields.insert(
-        "dom.host/model".to_string(),
-        Ipld::String(route.model.clone()),
+        "dom.host/concept".to_string(),
+        Ipld::String(route.concept.clone()),
     );
     if let Some(entity) = &route.entity {
         fields.insert("dom.host/entity".to_string(), Ipld::String(entity.clone()));
@@ -160,7 +160,7 @@ struct ResolvedView {
 /// `tonk:workspace`, resolves), then a Phase-1 concept lookup runs
 /// against the resolved URI. An unresolved name falls through to the
 /// Phase-1 name lookup, which reports a clean "no concept matched".
-async fn resolve_model<B: QueryBackend>(
+async fn resolve_concept<B: QueryBackend>(
     backend: &B,
     name_or_uri: &str,
 ) -> Result<(String, String), RenderError> {
@@ -204,7 +204,7 @@ async fn resolve_name<B: QueryBackend>(backend: &B, name: &str) -> Result<String
 /// model-specific view is absent the browser re-queries the view
 /// concept constrained to this sentinel; we mirror that. `tonk:_`
 /// is the wildcard-model entity seeded by core.yaml.
-const DEFAULT_MODEL: &str = "tonk:_";
+const DEFAULT_CONCEPT: &str = "tonk:_";
 
 /// Resolve the view template by querying the view concept constrained
 /// to the model. Falls back to the `tonk:_` default-model view when
@@ -213,13 +213,13 @@ const DEFAULT_MODEL: &str = "tonk:_";
 async fn resolve_view<B: QueryBackend>(
     backend: &B,
     view_descriptor: &serde_json::Value,
-    model_entity: &str,
+    concept_entity: &str,
 ) -> Result<Option<ResolvedView>, RenderError> {
-    if let Some(view) = query_view(backend, view_descriptor, model_entity).await? {
+    if let Some(view) = query_view(backend, view_descriptor, concept_entity).await? {
         return Ok(Some(view));
     }
     // No model-specific view: try the `tonk:_` default.
-    query_view(backend, view_descriptor, DEFAULT_MODEL).await
+    query_view(backend, view_descriptor, DEFAULT_CONCEPT).await
 }
 
 /// Run the view-by-model query for one model value and read the first
@@ -227,9 +227,9 @@ async fn resolve_view<B: QueryBackend>(
 async fn query_view<B: QueryBackend>(
     backend: &B,
     view_descriptor: &serde_json::Value,
-    model_entity: &str,
+    concept_entity: &str,
 ) -> Result<Option<ResolvedView>, RenderError> {
-    let query = view_by_model_query(view_descriptor, model_entity)
+    let query = view_by_concept_query(view_descriptor, concept_entity)
         .map_err(|e| RenderError::QueryConstruction(format!("view query: {e}")))?;
     let rows = run_query(backend, query).await?;
     let Some(row) = rows.into_iter().next() else {
@@ -299,7 +299,7 @@ fn expand_nested_nodes<'a, B: QueryBackend>(
 
 /// Build a child route from a nested `<tonk-display>`'s attributes.
 /// Requires a non-empty `model`; `entity` and `view` are optional. A
-/// missing or empty `model` (e.g. a `{dom.host/model}` that resolved
+/// missing or empty `model` (e.g. a `{dom.host/concept}` that resolved
 /// to nothing) yields `None` so the nested display is left as-is
 /// rather than triggering a bogus "no concept matched" on an empty
 /// name. Empty `entity`/`view` attributes are likewise treated as
@@ -312,9 +312,9 @@ fn route_from_attrs(attrs: &[(String, String)]) -> Option<RenderRoute> {
             .map(|(_, v)| v.clone())
             .filter(|v| !v.is_empty())
     };
-    let model = get("model")?;
+    let concept = get("concept")?;
     Some(RenderRoute {
-        model,
+        concept,
         entity: get("entity"),
         view: get("view"),
     })

--- a/rust/tonk-render/src/page/orchestrate.rs
+++ b/rust/tonk-render/src/page/orchestrate.rs
@@ -1,6 +1,6 @@
 //! The render orchestrator: `route -> conclusions -> HTML`.
 //!
-//! Runs the same model -> view -> entity resolution the browser
+//! Runs the same concept -> view -> entity resolution the browser
 //! component runs, against a [`QueryBackend`], then feeds the result
 //! through the shared `tonk-template` planner and this crate's pure
 //! headless renderer ([`crate::render`]). Nested `<tonk-display>`
@@ -35,7 +35,7 @@ pub async fn render<B: QueryBackend>(
     render_guarded(backend, route, 0, &mut visited).await
 }
 
-/// Render with both a depth backstop and a `(model, entity, view)`
+/// Render with both a depth backstop and a `(concept, entity, view)`
 /// visited-set: the depth cap catches runaway recursion, while the
 /// visited-set distinguishes a genuine cycle (a view that nests
 /// itself with the same parameters) from legitimately deep but finite
@@ -64,7 +64,7 @@ async fn render_at_depth<B: QueryBackend>(
     depth: usize,
     visited: &mut Vec<RenderRoute>,
 ) -> Result<String, RenderError> {
-    // 1. Resolve the model concept to its entity URI + descriptor.
+    // 1. Resolve the concept to its entity URI + descriptor.
     let (concept_entity, descriptor_json) = resolve_concept(backend, &route.concept).await?;
 
     // 2. Resolve the target entity, if any (bookmark name -> URI).
@@ -75,7 +75,7 @@ async fn render_at_depth<B: QueryBackend>(
     };
 
     // 3. Resolve the view: pick the view predicate (explicit concept,
-    //    or built-in detail/directory), query it by model, and read
+    //    or built-in detail/directory), query it by concept, and read
     //    the `display` template + optional `type`.
     let view_descriptor = match &route.view {
         Some(view_name) => {
@@ -109,8 +109,8 @@ async fn render_at_depth<B: QueryBackend>(
     let folded = select_rows(rows);
 
     // 6. Parse the template, collect bindings, plan, and render. Inject
-    //    the host attributes (model/entity/view) as `dom.host/*` fields
-    //    so a nested `<tonk-display model={dom.host/concept}>` resolves,
+    //    the host attributes (concept/entity/view) as `dom.host/*` fields
+    //    so a nested `<tonk-display concept={dom.host/concept}>` resolves,
     //    matching the browser's `with_host_attributes`.
     let mut roots = crate::parse_fragment(&view.display);
     let bindings = crate::collect_bindings(&mut roots);
@@ -153,8 +153,8 @@ struct ResolvedView {
     is_portal: bool,
 }
 
-/// Resolve a model/view concept name (or URI) to `(entity_uri,
-/// descriptor_json)`. Mirrors the browser's `resolve_model_query`: a
+/// Resolve a concept/view concept name (or URI) to `(entity_uri,
+/// descriptor_json)`. Mirrors the browser's `resolve_concept_query`: a
 /// non-URI source is first resolved through the Name concept (so a
 /// pinned concept addressed by its bookmark name, e.g. `workspace` ->
 /// `tonk:workspace`, resolves), then a Phase-1 concept lookup runs
@@ -200,15 +200,15 @@ async fn resolve_name<B: QueryBackend>(backend: &B, name: &str) -> Result<String
         .ok_or_else(|| RenderError::Descriptor(format!("name `{name}` has no referent")))
 }
 
-/// The model the built-in default view is keyed under. When a
-/// model-specific view is absent the browser re-queries the view
+/// The concept the built-in default view is keyed under. When a
+/// concept-specific view is absent the browser re-queries the view
 /// concept constrained to this sentinel; we mirror that. `tonk:_`
-/// is the wildcard-model entity seeded by core.yaml.
+/// is the wildcard-concept entity seeded by core.yaml.
 const DEFAULT_CONCEPT: &str = "tonk:_";
 
 /// Resolve the view template by querying the view concept constrained
-/// to the model. Falls back to the `tonk:_` default-model view when
-/// the model has no specific one, matching the browser's
+/// to the concept. Falls back to the `tonk:_` default-concept view when
+/// the concept has no specific one, matching the browser's
 /// `spawn_default_view`. Returns `None` only when neither exists.
 async fn resolve_view<B: QueryBackend>(
     backend: &B,
@@ -218,11 +218,11 @@ async fn resolve_view<B: QueryBackend>(
     if let Some(view) = query_view(backend, view_descriptor, concept_entity).await? {
         return Ok(Some(view));
     }
-    // No model-specific view: try the `tonk:_` default.
+    // No concept-specific view: try the `tonk:_` default.
     query_view(backend, view_descriptor, DEFAULT_CONCEPT).await
 }
 
-/// Run the view-by-model query for one model value and read the first
+/// Run the view-by-concept query for one concept value and read the first
 /// row's `display` + `type`.
 async fn query_view<B: QueryBackend>(
     backend: &B,
@@ -253,7 +253,7 @@ async fn run_query<B: QueryBackend>(
 }
 
 /// Find and recursively render nested `<tonk-display>` elements in
-/// `html`. Each nested element carries `model` / `entity` / `view`
+/// `html`. Each nested element carries `concept` / `entity` / `view`
 /// attributes (already substituted by the parent render), which we
 /// turn into a child route.
 async fn expand_nested<B: QueryBackend>(
@@ -298,8 +298,8 @@ fn expand_nested_nodes<'a, B: QueryBackend>(
 }
 
 /// Build a child route from a nested `<tonk-display>`'s attributes.
-/// Requires a non-empty `model`; `entity` and `view` are optional. A
-/// missing or empty `model` (e.g. a `{dom.host/concept}` that resolved
+/// Requires a non-empty `concept`; `entity` and `view` are optional. A
+/// missing or empty `concept` (e.g. a `{dom.host/concept}` that resolved
 /// to nothing) yields `None` so the nested display is left as-is
 /// rather than triggering a bogus "no concept matched" on an empty
 /// name. Empty `entity`/`view` attributes are likewise treated as

--- a/rust/tonk-render/src/page/route.rs
+++ b/rust/tonk-render/src/page/route.rs
@@ -1,4 +1,4 @@
-//! The parsed render route — the `{entity}@{model}!{view}` shorthand
+//! The parsed render route — the `{entity}@{concept}!{view}` shorthand
 //! shared by the SW/display routes and `tonk render`.
 
 use crate::page::RenderError;
@@ -6,10 +6,10 @@ use crate::page::RenderError;
 /// A parsed render route.
 ///
 /// Grammar (mirrors the SW/display route shorthand):
-/// - `/{model}` — directory: every instance of the model.
-/// - `/{entity}@{model}` — a single entity of the model.
-/// - `/{entity}@{model}!{view}` — a single entity, explicit view.
-/// - `/{model}!{view}` — directory with an explicit view concept.
+/// - `/{concept}` — directory: every instance of the concept.
+/// - `/{entity}@{concept}` — a single entity of the concept.
+/// - `/{entity}@{concept}!{view}` — a single entity, explicit view.
+/// - `/{concept}!{view}` — directory with an explicit view concept.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RenderRoute {
     /// The concept name or URI.
@@ -37,7 +37,7 @@ impl RenderRoute {
             Some((_, _)) => return Err(invalid("route has a trailing `!` with no view".into())),
             None => (s, None),
         };
-        // Then split entity@model.
+        // Then split entity@concept.
         let (entity, concept) = match head.split_once('@') {
             Some((e, m)) if !e.is_empty() && !m.is_empty() => (Some(e.to_string()), m.to_string()),
             Some(_) => return Err(invalid(format!("route `{input}` has an empty side of `@`"))),
@@ -60,7 +60,7 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[dialog_common::test]
-    fn it_parses_a_bare_model_route() {
+    fn it_parses_a_bare_concept_route() {
         let r = RenderRoute::parse("/person").unwrap();
         assert_eq!(r.concept, "person");
         assert_eq!(r.entity, None);
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_parses_entity_at_model() {
+    fn it_parses_entity_at_concept() {
         let r = RenderRoute::parse("alice@person").unwrap();
         assert_eq!(r.concept, "person");
         assert_eq!(r.entity.as_deref(), Some("alice"));
@@ -76,7 +76,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_parses_entity_at_model_bang_view() {
+    fn it_parses_entity_at_concept_bang_view() {
         let r = RenderRoute::parse("/alice@person!card").unwrap();
         assert_eq!(r.concept, "person");
         assert_eq!(r.entity.as_deref(), Some("alice"));

--- a/rust/tonk-render/src/page/route.rs
+++ b/rust/tonk-render/src/page/route.rs
@@ -12,8 +12,8 @@ use crate::page::RenderError;
 /// - `/{model}!{view}` — directory with an explicit view concept.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RenderRoute {
-    /// The model concept name or URI.
-    pub model: String,
+    /// The concept name or URI.
+    pub concept: String,
     /// The target entity (bookmark name or URI). `None` => directory
     /// mode (render every instance).
     pub entity: Option<String>,
@@ -38,13 +38,13 @@ impl RenderRoute {
             None => (s, None),
         };
         // Then split entity@model.
-        let (entity, model) = match head.split_once('@') {
+        let (entity, concept) = match head.split_once('@') {
             Some((e, m)) if !e.is_empty() && !m.is_empty() => (Some(e.to_string()), m.to_string()),
             Some(_) => return Err(invalid(format!("route `{input}` has an empty side of `@`"))),
             None => (None, head.to_string()),
         };
         Ok(RenderRoute {
-            model,
+            concept,
             entity,
             view,
         })
@@ -62,7 +62,7 @@ mod tests {
     #[dialog_common::test]
     fn it_parses_a_bare_model_route() {
         let r = RenderRoute::parse("/person").unwrap();
-        assert_eq!(r.model, "person");
+        assert_eq!(r.concept, "person");
         assert_eq!(r.entity, None);
         assert_eq!(r.view, None);
     }
@@ -70,7 +70,7 @@ mod tests {
     #[dialog_common::test]
     fn it_parses_entity_at_model() {
         let r = RenderRoute::parse("alice@person").unwrap();
-        assert_eq!(r.model, "person");
+        assert_eq!(r.concept, "person");
         assert_eq!(r.entity.as_deref(), Some("alice"));
         assert_eq!(r.view, None);
     }
@@ -78,7 +78,7 @@ mod tests {
     #[dialog_common::test]
     fn it_parses_entity_at_model_bang_view() {
         let r = RenderRoute::parse("/alice@person!card").unwrap();
-        assert_eq!(r.model, "person");
+        assert_eq!(r.concept, "person");
         assert_eq!(r.entity.as_deref(), Some("alice"));
         assert_eq!(r.view.as_deref(), Some("card"));
     }
@@ -86,7 +86,7 @@ mod tests {
     #[dialog_common::test]
     fn it_parses_directory_with_view() {
         let r = RenderRoute::parse("person!directory").unwrap();
-        assert_eq!(r.model, "person");
+        assert_eq!(r.concept, "person");
         assert_eq!(r.entity, None);
         assert_eq!(r.view.as_deref(), Some("directory"));
     }
@@ -95,7 +95,7 @@ mod tests {
     fn it_keeps_a_did_key_entity_uri() {
         let r = RenderRoute::parse("did:key:zABC@person").unwrap();
         assert_eq!(r.entity.as_deref(), Some("did:key:zABC"));
-        assert_eq!(r.model, "person");
+        assert_eq!(r.concept, "person");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-render/src/parse.rs
+++ b/rust/tonk-render/src/parse.rs
@@ -405,15 +405,15 @@ mod quote_tests {
 
     #[test]
     fn it_parses_unquoted_brace_attribute_like_the_browser() {
-        // Browser: <article data-model="{dom.host/model}"><h2>x</h2></article>
-        let r = parse_fragment("<article data-model={dom.host/model}><h2>x</h2></article>");
+        // Browser: <article data-model="{dom.host/concept}"><h2>x</h2></article>
+        let r = parse_fragment("<article data-model={dom.host/concept}><h2>x</h2></article>");
         let Node::Element(article) = &r[0] else {
             panic!("expected <article>, got {r:?}");
         };
         assert_eq!(article.tag, "article");
         assert_eq!(
             article.attrs,
-            vec![("data-model".to_string(), "{dom.host/model}".to_string())]
+            vec![("data-model".to_string(), "{dom.host/concept}".to_string())]
         );
         // <h2> is a child of <article>, not mis-parsed into it.
         assert!(matches!(&article.children[0], Node::Element(h) if h.tag == "h2"));
@@ -478,24 +478,24 @@ mod quote_tests {
 
     #[test]
     fn it_keeps_an_unquoted_value_with_a_colon() {
-        // Browser: model="tonk:repository".
+        // Browser: concept="tonk:repository".
         assert_eq!(
-            first_attrs("<tonk-display entity={subject} model=tonk:repository></tonk-display>"),
+            first_attrs("<tonk-display entity={subject} concept=tonk:repository></tonk-display>"),
             vec![
                 ("entity".to_string(), "{subject}".to_string()),
-                ("model".to_string(), "tonk:repository".to_string()),
+                ("concept".to_string(), "tonk:repository".to_string()),
             ]
         );
     }
 
     #[test]
     fn it_parses_a_self_closing_custom_element_with_unquoted_values() {
-        // Browser: <tonk-display model="workspace/sheet" data-active="{active}">
+        // Browser: <tonk-display concept="workspace/sheet" data-active="{active}">
         // (the trailing /> is ignored for a non-void element).
         assert_eq!(
-            first_attrs("<tonk-display model=workspace/sheet data-active={active} />"),
+            first_attrs("<tonk-display concept=workspace/sheet data-active={active} />"),
             vec![
-                ("model".to_string(), "workspace/sheet".to_string()),
+                ("concept".to_string(), "workspace/sheet".to_string()),
                 ("data-active".to_string(), "{active}".to_string()),
             ]
         );

--- a/rust/tonk-render/src/parse.rs
+++ b/rust/tonk-render/src/parse.rs
@@ -405,15 +405,15 @@ mod quote_tests {
 
     #[test]
     fn it_parses_unquoted_brace_attribute_like_the_browser() {
-        // Browser: <article data-model="{dom.host/concept}"><h2>x</h2></article>
-        let r = parse_fragment("<article data-model={dom.host/concept}><h2>x</h2></article>");
+        // Browser: <article data-concept="{dom.host/concept}"><h2>x</h2></article>
+        let r = parse_fragment("<article data-concept={dom.host/concept}><h2>x</h2></article>");
         let Node::Element(article) = &r[0] else {
             panic!("expected <article>, got {r:?}");
         };
         assert_eq!(article.tag, "article");
         assert_eq!(
             article.attrs,
-            vec![("data-model".to_string(), "{dom.host/concept}".to_string())]
+            vec![("data-concept".to_string(), "{dom.host/concept}".to_string())]
         );
         // <h2> is a child of <article>, not mis-parsed into it.
         assert!(matches!(&article.children[0], Node::Element(h) if h.tag == "h2"));
@@ -480,9 +480,9 @@ mod quote_tests {
     fn it_keeps_an_unquoted_value_with_a_colon() {
         // Browser: concept="tonk:repository".
         assert_eq!(
-            first_attrs("<tonk-display entity={subject} concept=tonk:repository></tonk-display>"),
+            first_attrs("<tonk-display this={subject} concept=tonk:repository></tonk-display>"),
             vec![
-                ("entity".to_string(), "{subject}".to_string()),
+                ("this".to_string(), "{subject}".to_string()),
                 ("concept".to_string(), "tonk:repository".to_string()),
             ]
         );

--- a/rust/tonk-render/tests/p.rs
+++ b/rust/tonk-render/tests/p.rs
@@ -1,11 +1,11 @@
 #[test]
 fn probe_attr_brace() {
     let r = tonk_render::parse_fragment(
-        r#"<article data-model={dom.host/model}><h2>{name}</h2></article>"#,
+        r#"<article data-model={dom.host/concept}><h2>{name}</h2></article>"#,
     );
     eprintln!("UNQUOTED: {:#?}", r);
     let r2 = tonk_render::parse_fragment(
-        r#"<article data-model="{dom.host/model}"><h2>{name}</h2></article>"#,
+        r#"<article data-model="{dom.host/concept}"><h2>{name}</h2></article>"#,
     );
     eprintln!("QUOTED: {:#?}", r2);
 }

--- a/rust/tonk-render/tests/p.rs
+++ b/rust/tonk-render/tests/p.rs
@@ -1,11 +1,11 @@
 #[test]
 fn probe_attr_brace() {
     let r = tonk_render::parse_fragment(
-        r#"<article data-model={dom.host/concept}><h2>{name}</h2></article>"#,
+        r#"<article data-concept={dom.host/concept}><h2>{name}</h2></article>"#,
     );
     eprintln!("UNQUOTED: {:#?}", r);
     let r2 = tonk_render::parse_fragment(
-        r#"<article data-model="{dom.host/concept}"><h2>{name}</h2></article>"#,
+        r#"<article data-concept="{dom.host/concept}"><h2>{name}</h2></article>"#,
     );
     eprintln!("QUOTED: {:#?}", r2);
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -98,7 +98,7 @@ pub mod sync {
 /// parsed to an [`Entity`]), stamped by the service worker onto the
 /// Level-0-resolved branch's overlay. All cardinality one: a navigation
 /// re-stamps the same entity and supersedes, so the site always reflects the
-/// tab's latest location + route. Route models pick whichever of these they
+/// tab's latest location + route. Route concepts pick whichever of these they
 /// need (e.g. `replica`) as their own fields, so they resolve on the site entity.
 ///
 /// [`Entity`]: dialog_artifacts::Entity
@@ -130,7 +130,7 @@ pub mod site {
     #[cardinality(one)]
     pub struct Route(pub Entity);
 
-    /// The matched route's concept — the model the shell mounts on the site.
+    /// The matched route's concept — the concept the shell mounts on the site.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.site")]
     #[cardinality(one)]
@@ -138,7 +138,7 @@ pub mod site {
 }
 
 /// Attributes for the durable `tonk:route` table the SW reads to build its
-/// matchit router: a path pattern → the route model to mount.
+/// matchit router: a path pattern → the route concept to mount.
 pub mod route {
     use super::{Attribute, Entity};
 
@@ -148,7 +148,7 @@ pub mod route {
     #[cardinality(one)]
     pub struct Path(pub String);
 
-    /// The route model to mount when this path matches.
+    /// The route concept to mount when this path matches.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.route")]
     #[cardinality(one)]

--- a/rust/tonk-schema/src/repository.rs
+++ b/rust/tonk-schema/src/repository.rs
@@ -8,7 +8,7 @@
 //! per-profile cache to fall stale when another device renames it.
 //!
 //! The concept is pinned to the `tonk:repository` URI so a
-//! `<tonk-display model=tonk:repository>` can resolve its view, but its
+//! `<tonk-display concept=tonk:repository>` can resolve its view, but its
 //! *instances* are keyed by the repository's subject DID (the entity the
 //! name attaches to). The standard-library `tonk/rename-repository` rule
 //! writes it; the banner and the Hub card read it.

--- a/rust/tonk-schema/src/site.rs
+++ b/rust/tonk-schema/src/site.rs
@@ -6,9 +6,9 @@
 //! chip uses but keyed per tab instead of a singleton. Multiple tabs coexist as
 //! distinct site entities; a view scoped to a tab's site reads only its context.
 //!
-//! Route models (e.g. `tonk:space/route`) pick the `site/*` fields they need and
-//! resolve on the same site entity; the shell mounts the matched route model
-//! ([`Site::concept`]) on the site entity, and that model's view renders.
+//! Route concepts (e.g. `tonk:space/route`) pick the `site/*` fields they need and
+//! resolve on the same site entity; the shell mounts the matched route concept
+//! ([`Site::concept`]) on the site entity, and that concept's view renders.
 
 // The `#[derive(Concept)]` macro generates helper types without doc comments.
 // Suppress the crate-level `missing_docs` lint for this module so the macros
@@ -36,7 +36,7 @@ pub struct Site {
     pub replica: Replica,
     /// The matched route entity (the route-table entry).
     pub route: SiteRoute,
-    /// The matched route's concept — the model the shell mounts.
+    /// The matched route's concept — the concept the shell mounts.
     pub concept: SiteConcept,
 }
 
@@ -62,7 +62,7 @@ impl Site {
 }
 
 /// A durable route — one row of the table the SW reads to build its matchit
-/// router: a path pattern → the route model to mount. `route!` instances in the
+/// router: a path pattern → the route concept to mount. `route!` instances in the
 /// library populate it; the SW queries them on a branch and feeds
 /// `path` → `concept` to `matchit`.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -71,6 +71,6 @@ pub struct Route {
     pub this: Entity,
     /// The axum/matchit path pattern.
     pub path: RouteTablePath,
-    /// The route model mounted when this path matches.
+    /// The route concept mounted when this path matches.
     pub concept: RoutePathConcept,
 }

--- a/rust/tonk-template/src/lib.rs
+++ b/rust/tonk-template/src/lib.rs
@@ -154,7 +154,7 @@ pub enum BindingKind {
 /// subject). The renderer renders `chrome` once, then clones the repeat
 /// element once per conclusion, rendering `body` against each. See
 /// [`this_repeat_root`] for how the repeat element is chosen and
-/// `tonk-core/docs/templates.md` for the model.
+/// `tonk-core/docs/templates.md` for the concept.
 #[derive(Debug, Clone, Default)]
 pub struct BindingPlan {
     /// Plan nodes outside the repeat element — bindings and iterations
@@ -283,7 +283,7 @@ pub fn binding_fields(binding: &Binding) -> Vec<String> {
 }
 
 /// A field name in the `dom.host/` namespace — the host element's own
-/// attributes injected into the conclusion (e.g. `{dom.host/model}`).
+/// attributes injected into the conclusion (e.g. `{dom.host/concept}`).
 /// These describe the *outer* host, not the repeated subject, so they
 /// never participate in repeat-node resolution.
 fn is_dom_host_field(name: &str) -> bool {
@@ -335,7 +335,7 @@ fn refers_subject(binding: &Binding) -> bool {
 ///    — `{this}` is *deeper* than `{count}`, so it is not on the
 ///    outermost ref-bearing element. Repeat node falls back to the
 ///    fragment root (`<div>`).
-/// 4. `<div data-model={dom.host/model}><span data-this={this} ...>` —
+/// 4. `<div data-concept={dom.host/concept}><span data-this={this} ...>` —
 ///    the `{dom.host/*}` reference is ignored; the `<span>` holding
 ///    `{this}` repeats.
 ///

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -1,7 +1,7 @@
 //! Wire-query construction for `<tonk-display>`.
 //!
-//! - [`view_by_model_query`] — resolve a view by querying a view
-//!   *concept* (the predicate) constrained to a `model`, projecting
+//! - [`view_by_concept_query`] — resolve a view by querying a view
+//!   *concept* (the predicate) constrained to a `concept`, projecting
 //!   `display` (and `type` when the concept declares it).
 //! - [`entity_query`] — subscribe to a single entity by URI,
 //!   projecting every field in the model concept's descriptor.
@@ -17,18 +17,18 @@ use tonk_schema::query::Query;
 
 /// Build the live view-resolution query for the new design: given a
 /// view *concept* descriptor (the concept named by the `view`
-/// attribute, or the built-in `view`) and a `model_entity`, find the
-/// instance of that view concept whose `model` field equals
-/// `model_entity`, projecting `display` (the template) and, if the
+/// attribute, or the built-in `view`) and a `concept_entity`, find the
+/// instance of that view concept whose `concept` field equals
+/// `concept_entity`, projecting `display` (the template) and, if the
 /// descriptor declares it, `type` (the render mode).
 ///
-/// The view concept is the query predicate; `model` is the
+/// The view concept is the query predicate; `concept` is the
 /// constraint. The view attribute thus names a concept whose
 /// `display` we query for, rather than an anchor that resolves to
 /// one fixed entity.
-pub fn view_by_model_query(
+pub fn view_by_concept_query(
     view_descriptor: &Value,
-    model_entity: &str,
+    concept_entity: &str,
 ) -> Result<Query, serde_json::Error> {
     let has_type = view_descriptor
         .get("with")
@@ -36,7 +36,7 @@ pub fn view_by_model_query(
         .is_some();
     let mut terms: IndexMap<String, Value> = IndexMap::new();
     terms.insert("this".into(), json!({ "?": { "name": "view" } }));
-    terms.insert("model".into(), json!(model_entity));
+    terms.insert("concept".into(), json!(concept_entity));
     terms.insert("display".into(), json!({ "?": { "name": "display" } }));
     if has_type {
         terms.insert("type".into(), json!({ "?": { "name": "type" } }));
@@ -69,7 +69,7 @@ pub fn entity_query(descriptor_json: &str, entity: &str) -> Result<Query, serde_
 
 /// The descriptor of the built-in `view` concept.
 ///
-/// Two fields: `model` (entity — the concept being displayed) and
+/// Two fields: `concept` (entity — the concept being displayed) and
 /// `display` (text — the HTML template). Used as the default view
 /// predicate when `<tonk-display>` has no `view` attribute, so the
 /// built-in presentation resolves without reading the concept from
@@ -79,24 +79,24 @@ pub fn entity_query(descriptor_json: &str, entity: &str) -> Result<Query, serde_
 pub fn view_predicate() -> Value {
     json!({
         "with": {
-            "model":   { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
+            "concept": { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
             "display": { "the": "xyz.tonk.view/display", "as": "Text",   "cardinality": "one" }
         }
     })
 }
 
 /// The descriptor of the built-in **directory** view concept
-/// (`tonk:view/directory`). Same `model` field as [`view_predicate`],
-/// but its template lives under `xyz.tonk.view/directory` so a model
+/// (`tonk:view/directory`). Same `concept` field as [`view_predicate`],
+/// but its template lives under `xyz.tonk.view/directory` so a concept
 /// can declare a detail view and a directory view independently (both
-/// keyed by `model`). Used as the default view predicate when
+/// keyed by `concept`). Used as the default view predicate when
 /// `<tonk-display>` has no `entity` (directory mode). The `display`
-/// term name is kept so `view_by_model_query` and the renderer read
+/// term name is kept so `view_by_concept_query` and the renderer read
 /// the template uniformly regardless of view kind.
 pub fn directory_view_predicate() -> Value {
     json!({
         "with": {
-            "model":   { "the": "xyz.tonk.view/model",     "as": "Entity", "cardinality": "one" },
+            "concept": { "the": "xyz.tonk.view/model",     "as": "Entity", "cardinality": "one" },
             "display": { "the": "xyz.tonk.view/directory", "as": "Text",   "cardinality": "one" }
         }
     })
@@ -413,11 +413,11 @@ mod tests {
     fn the_view_predicate_has_no_name_field() {
         let p = view_predicate();
         let with = p.get("with").and_then(|v| v.as_object()).expect("with");
-        assert!(with.contains_key("model"));
+        assert!(with.contains_key("concept"));
         assert!(with.contains_key("display"));
         assert!(
             !with.contains_key("name"),
-            "the built-in view concept is keyed by (concept, model), not a `name` field"
+            "the built-in view concept is keyed by concept, not a `name` field"
         );
     }
 
@@ -453,14 +453,15 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_builds_a_view_by_model_query_constraining_model() {
-        // The view concept is the predicate; `model` is pinned to
-        // the subject's model entity and `display` flows back.
+    fn it_builds_a_view_by_concept_query_constraining_concept() {
+        // The view concept is the predicate; `concept` is pinned to
+        // the subject's concept entity and `display` flows back.
         let predicate = view_predicate();
-        let q = view_by_model_query(&predicate, "concept:zCounter").expect("view_by_model_query");
-        let model = q.terms.get("model").expect("model term");
+        let q =
+            view_by_concept_query(&predicate, "concept:zCounter").expect("view_by_concept_query");
+        let concept = q.terms.get("concept").expect("concept term");
         assert_eq!(
-            serde_json::to_value(model).unwrap(),
+            serde_json::to_value(concept).unwrap(),
             json!("concept:zCounter"),
         );
         let display = q.terms.get("display").expect("display term");
@@ -479,12 +480,13 @@ mod tests {
         // projected so the render-mode fork can read it.
         let predicate = json!({
             "with": {
-                "model":   { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
+                "concept": { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
                 "type":    { "the": "xyz.tonk.view/type",    "as": "Text",   "cardinality": "one" },
                 "display": { "the": "xyz.tonk.view/display", "as": "Text",   "cardinality": "one" }
             }
         });
-        let q = view_by_model_query(&predicate, "concept:zCounter").expect("view_by_model_query");
+        let q =
+            view_by_concept_query(&predicate, "concept:zCounter").expect("view_by_concept_query");
         let typ = q.terms.get("type").expect("type term");
         assert_eq!(
             serde_json::to_value(typ).unwrap(),

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -79,7 +79,7 @@ pub fn entity_query(descriptor_json: &str, entity: &str) -> Result<Query, serde_
 pub fn view_predicate() -> Value {
     json!({
         "with": {
-            "concept": { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
+            "concept": { "the": "xyz.tonk.view/concept",   "as": "Entity", "cardinality": "one" },
             "display": { "the": "xyz.tonk.view/display", "as": "Text",   "cardinality": "one" }
         }
     })
@@ -96,7 +96,7 @@ pub fn view_predicate() -> Value {
 pub fn directory_view_predicate() -> Value {
     json!({
         "with": {
-            "concept": { "the": "xyz.tonk.view/model",     "as": "Entity", "cardinality": "one" },
+            "concept": { "the": "xyz.tonk.view/concept",     "as": "Entity", "cardinality": "one" },
             "display": { "the": "xyz.tonk.view/directory", "as": "Text",   "cardinality": "one" }
         }
     })
@@ -480,7 +480,7 @@ mod tests {
         // projected so the render-mode fork can read it.
         let predicate = json!({
             "with": {
-                "concept": { "the": "xyz.tonk.view/model",   "as": "Entity", "cardinality": "one" },
+                "concept": { "the": "xyz.tonk.view/concept",   "as": "Entity", "cardinality": "one" },
                 "type":    { "the": "xyz.tonk.view/type",    "as": "Text",   "cardinality": "one" },
                 "display": { "the": "xyz.tonk.view/display", "as": "Text",   "cardinality": "one" }
             }

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -4,7 +4,7 @@
 //!   *concept* (the predicate) constrained to a `concept`, projecting
 //!   `display` (and `type` when the concept declares it).
 //! - [`entity_query`] — subscribe to a single entity by URI,
-//!   projecting every field in the model concept's descriptor.
+//!   projecting every field in the concept's descriptor.
 //! - [`view_predicate`] — the descriptor JSON of the built-in
 //!   `view` concept, used as the default view predicate when the
 //!   `<tonk-display>` has no `view` attribute.
@@ -44,7 +44,7 @@ pub fn view_by_concept_query(
     serde_json::from_value(json!({ "terms": terms, "predicate": view_descriptor }))
 }
 
-/// Build the live entity subscription query: given the model
+/// Build the live entity subscription query: given the concept
 /// concept's `descriptor_json` (raw JSON from a Phase-1 resolve)
 /// and the target `entity` URI, return a query that pins `this` to
 /// `entity` and projects every field in the descriptor's `with:`
@@ -104,7 +104,7 @@ pub fn directory_view_predicate() -> Value {
 
 /// Build the live **directory** subscription query: like
 /// [`entity_query`] but with `this` left as a variable instead of
-/// pinned, so the query matches *every* instance of the model. The
+/// pinned, so the query matches *every* instance of the concept. The
 /// worker emits one flat row per (instance, many-value) tuple; the
 /// caller groups them by `this`. Used when `<tonk-display>` has no
 /// `entity` (directory mode).
@@ -226,9 +226,9 @@ fn hex_digit(b: u8) -> Option<u8> {
 /// including concepts pinned to a `this:` URI (e.g. `&workspace` +
 /// `this: tonk:workspace` → `id:workspace` → `tonk:workspace`). A
 /// concept's `dialog.meta/name` claim, by contrast, is only emitted
-/// when its `this:` is *derived*, so resolving a model/view name
+/// when its `this:` is *derived*, so resolving a concept/view name
 /// against `dialog.meta/name` misses pinned concepts. Resolving names
-/// here and feeding the resulting URI to [`phase1_query`] makes model,
+/// here and feeding the resulting URI to [`phase1_query`] makes concept,
 /// view, and entity name resolution agree.
 ///
 /// Reads back as `(entity)` — the referent URI.

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -590,7 +590,7 @@ mod tests {
         let setup = r#"
 attribute!: &view-concept
   description: "view concept"
-  the:         xyz.tonk.view/model
+  the:         xyz.tonk.view/concept
   as:          entity
   cardinality: one
 

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -588,8 +588,8 @@ mod tests {
         // `counter-name` is a bookmark we navigate to from the
         // display route.
         let setup = r#"
-attribute!: &view-model
-  description: "view model"
+attribute!: &view-concept
+  description: "view concept"
   the:         xyz.tonk.view/model
   as:          entity
   cardinality: one
@@ -603,7 +603,7 @@ attribute!: &view-display
 concept!: &view
   description: "A rendered view of an entity"
   with:
-    model:   view-model
+    concept:   view-concept
     display: view-display
 
 concept!: &counter
@@ -634,7 +634,7 @@ rule!:
       where: { of: 1, with: ?m, is: ?count }
 
 view!: &counter-view
-  model:   counter
+  concept:   counter
   display: "<div><button onclick=increment data-counter={this}>+</button><span class=\"value\">{count}</span></div>"
 
 counter!: &my-counter
@@ -674,8 +674,8 @@ counter!: &my-counter
         );
 
         // Navigate to the display route for the named counter. The
-        // `{entity}@{model}!{view}` subject encoding carries the
-        // view and model into the path: `my-counter@counter!counter-view`.
+        // `{entity}@{concept}!{view}` subject encoding carries the
+        // view and concept into the path: `my-counter@counter!counter-view`.
         // The route resolves the bookmark `my-counter` to its
         // entity URI via the built-in Name index.
         driver

--- a/rust/tonk-ui/src/components/display.rs
+++ b/rust/tonk-ui/src/components/display.rs
@@ -6,14 +6,14 @@
 //! are captured whole instead of being truncated at the first slash.
 //!
 //! Mounts a `<tonk-display>` element. With no `subject` the space's
-//! default model ([`SPACE_CONCEPT`]) is shown. Otherwise the segment
+//! default concept ([`SPACE_CONCEPT`]) is shown. Otherwise the segment
 //! encodes up to three attributes with `@` and `!` delimiters:
 //!
-//! - `{model}` — directory mode: only `model` is set, so the element
-//!   renders every instance of the model (e.g. `trip`).
-//! - `{entity}@{model}` — `entity` + `model` (e.g.
+//! - `{concept}` — directory mode: only `concept` is set, so the element
+//!   renders every instance of the concept (e.g. `trip`).
+//! - `{entity}@{concept}` — `entity` + `concept` (e.g.
 //!   `id:x@trip`).
-//! - `{entity}@{model}!{view}` — all three (e.g.
+//! - `{entity}@{concept}!{view}` — all three (e.g.
 //!   `id:x@trip!tonk:view`).
 //!
 //! The entity part resolves to a concrete URI before mounting:
@@ -26,7 +26,7 @@
 //!   rendered and the element is never mounted. (Directory mode
 //!   supplies no entity, so there is nothing to resolve.)
 //!
-//! The model and view parts pass through verbatim as the `model` /
+//! The concept and view parts pass through verbatim as the `concept` /
 //! `view` attributes.
 //!
 //! Doing name resolution at the route (rather than inside
@@ -47,7 +47,7 @@ use crate::api;
 use crate::error::TonkUiError;
 use tonk_schema::parse_space;
 
-/// The model a bare `/space/{name}/` renders — the space's primary
+/// The concept a bare `/space/{name}/` renders — the space's primary
 /// interface. A user can override it per repository; it presets to the
 /// workspace concept from the wireframes.
 const SPACE_CONCEPT: &str = "tonk/space";
@@ -59,9 +59,9 @@ pub struct TonkDisplayParams {
 }
 
 /// Display route. Parses the path's `subject` segment into
-/// `entity`/`model`/`view` (see the module docs), resolves the
+/// `entity`/`concept`/`view` (see the module docs), resolves the
 /// optional entity to a URI, and mounts a `<tonk-display>` with those
-/// attributes. With no entity it is directory mode (only `model`).
+/// attributes. With no entity it is directory mode (only `concept`).
 #[component]
 #[allow(clippy::unused_unit)]
 pub fn TonkDisplayView() -> impl IntoView {
@@ -79,13 +79,13 @@ pub fn TonkDisplayView() -> impl IntoView {
     let space_name = Signal::derive_local(move || space_ref.get().map(|s| s.name));
     let branch_name = Signal::derive_local(move || space_ref.get().map(|s| s.branch));
     // The `*subject` segment encodes up to three attributes:
-    //   `{model}`                 → directory mode: only `model`.
-    //   `{entity}@{model}`        → `entity` + `model`.
-    //   `{entity}@{model}!{view}` → `entity` + `model` + `view`.
-    // `@` separates the (optional) entity from the model; `!`
+    //   `{concept}`                 → directory mode: only `concept`.
+    //   `{entity}@{concept}`        → `entity` + `concept`.
+    //   `{entity}@{concept}!{view}` → `entity` + `concept` + `view`.
+    // `@` separates the (optional) entity from the concept; `!`
     // separates the (optional) view. The entity may be a bookmark
-    // name (resolved below); the model/view pass through verbatim.
-    // Absent (`/space/{name}/`) → the space's default model.
+    // name (resolved below); the concept/view pass through verbatim.
+    // Absent (`/space/{name}/`) → the space's default concept.
     let segment = Signal::derive_local(move || {
         params
             .get()
@@ -116,7 +116,7 @@ pub fn TonkDisplayView() -> impl IntoView {
     // Resolve the entity part (if present) → entity URI. URIs pass
     // through; names hit the worker via a `Name` query. In directory
     // mode (no `@`, so no entity) this resolves to `None` and the
-    // element mounts with only `model`. The Suspense below waits on
+    // element mounts with only `concept`. The Suspense below waits on
     // the resolve before rendering anything substantive.
     let resolved_entity = LocalResource::new(move || {
         let space = space_name.get();
@@ -138,7 +138,7 @@ pub fn TonkDisplayView() -> impl IntoView {
     });
 
     // The mount node + a single Effect that reads every signal it
-    // cares about. When any of (entity-resolution, view, model)
+    // cares about. When any of (entity-resolution, view, concept)
     // updates, the effect re-runs and rebuilds the `<tonk-display>`
     // host with current attribute values. Creating an Effect inside
     // `view!` (the previous shape) racey-mounted multiple hosts as
@@ -170,7 +170,7 @@ pub fn TonkDisplayView() -> impl IntoView {
                 // element itself. `entity` is set only when present
                 // (absent in directory mode).
                 if let Some(uri) = uri {
-                    let _ = host.set_attribute("entity", &uri);
+                    let _ = host.set_attribute("this", &uri);
                 }
                 if let Some(m) = concept_name.get() {
                     let _ = host.set_attribute("concept", &m);
@@ -218,7 +218,7 @@ pub fn TonkDisplayView() -> impl IntoView {
 }
 
 /// The `<tonk-display>` attributes encoded in a display-route path
-/// segment. `model` is always present; `entity` and `view` are
+/// segment. `concept` is always present; `entity` and `view` are
 /// optional.
 #[derive(Clone)]
 struct Subject {
@@ -229,14 +229,14 @@ struct Subject {
 
 /// Parse a display-route path segment into its attributes. Grammar:
 ///
-/// - `{model}`                 → `entity: None, model, view: None`
-/// - `{entity}@{model}`        → `entity, model, view: None`
-/// - `{entity}@{model}!{view}` → `entity, model, view`
+/// - `{concept}`                 → `entity: None, concept, view: None`
+/// - `{entity}@{concept}`        → `entity, concept, view: None`
+/// - `{entity}@{concept}!{view}` → `entity, concept, view`
 ///
-/// `@` separates an optional entity from the model; `!` separates an
-/// optional view. Entity URIs / model / view names may contain `:`
+/// `@` separates an optional entity from the concept; `!` separates an
+/// optional view. Entity URIs / concept / view names may contain `:`
 /// and `/`, but not `@` or `!`, so the split is unambiguous. The view
-/// is split off first so a `!` after the model is honored even when
+/// is split off first so a `!` after the concept is honored even when
 /// there is no `@`.
 fn parse_subject(segment: &str) -> Subject {
     let (head, view) = match segment.split_once('!') {

--- a/rust/tonk-ui/src/components/display.rs
+++ b/rust/tonk-ui/src/components/display.rs
@@ -6,7 +6,7 @@
 //! are captured whole instead of being truncated at the first slash.
 //!
 //! Mounts a `<tonk-display>` element. With no `subject` the space's
-//! default model ([`SPACE_MODEL`]) is shown. Otherwise the segment
+//! default model ([`SPACE_CONCEPT`]) is shown. Otherwise the segment
 //! encodes up to three attributes with `@` and `!` delimiters:
 //!
 //! - `{model}` — directory mode: only `model` is set, so the element
@@ -50,7 +50,7 @@ use tonk_schema::parse_space;
 /// The model a bare `/space/{name}/` renders — the space's primary
 /// interface. A user can override it per repository; it presets to the
 /// workspace concept from the wireframes.
-const SPACE_MODEL: &str = "tonk/space";
+const SPACE_CONCEPT: &str = "tonk/space";
 
 #[derive(Params, PartialEq, Clone, Debug)]
 pub struct TonkDisplayParams {
@@ -97,13 +97,13 @@ pub fn TonkDisplayView() -> impl IntoView {
         Some(s) => parse_subject(&s),
         None => Subject {
             entity: None,
-            model: SPACE_MODEL.to_owned(),
+            concept: SPACE_CONCEPT.to_owned(),
             view: None,
         },
     });
     let entity_name = Signal::derive_local(move || parsed.get().entity.filter(|s| !s.is_empty()));
-    let model_name =
-        Signal::derive_local(move || Some(parsed.get().model).filter(|s| !s.is_empty()));
+    let concept_name =
+        Signal::derive_local(move || Some(parsed.get().concept).filter(|s| !s.is_empty()));
     let view_name = Signal::derive_local(move || parsed.get().view.filter(|s| !s.is_empty()));
 
     // Run background sync for the space while the workspace is shown —
@@ -172,8 +172,8 @@ pub fn TonkDisplayView() -> impl IntoView {
                 if let Some(uri) = uri {
                     let _ = host.set_attribute("entity", &uri);
                 }
-                if let Some(m) = model_name.get() {
-                    let _ = host.set_attribute("model", &m);
+                if let Some(m) = concept_name.get() {
+                    let _ = host.set_attribute("concept", &m);
                 }
                 if let Some(v) = view_name.get() {
                     let _ = host.set_attribute("view", &v);
@@ -223,7 +223,7 @@ pub fn TonkDisplayView() -> impl IntoView {
 #[derive(Clone)]
 struct Subject {
     entity: Option<String>,
-    model: String,
+    concept: String,
     view: Option<String>,
 }
 
@@ -243,13 +243,13 @@ fn parse_subject(segment: &str) -> Subject {
         Some((head, view)) => (head, Some(view.to_owned())),
         None => (segment, None),
     };
-    let (entity, model) = match head.split_once('@') {
-        Some((entity, model)) => (Some(entity.to_owned()), model.to_owned()),
+    let (entity, concept) = match head.split_once('@') {
+        Some((entity, concept)) => (Some(entity.to_owned()), concept.to_owned()),
         None => (None, head.to_owned()),
     };
     Subject {
         entity,
-        model,
+        concept,
         view,
     }
 }

--- a/rust/tonk-ui/src/components/hub.rs
+++ b/rust/tonk-ui/src/components/hub.rs
@@ -3,7 +3,7 @@
 //! A repository picker: the set of spaces this profile can open,
 //! rendered as cards that link to `/space/{name}`. The list lives on
 //! the profile repository's meta branch (one `space`/replica record per
-//! repository), so the Hub is a `<tonk-display model=space>` directory
+//! repository), so the Hub is a `<tonk-display concept=space>` directory
 //! mounted under a `<tonk-repository profile>` — the `profile` flag
 //! routes its queries to the profile-as-repository endpoint
 //! (`/api/profile/branch/meta/query`) rather than a named repo.

--- a/rust/tonk-ui/src/components/inspector.rs
+++ b/rust/tonk-ui/src/components/inspector.rs
@@ -13,7 +13,7 @@
 //! context (the `<tonk-repository>` / `<tonk-branch>` ancestors a
 //! display route mounts) annotates space + branch and performs the
 //! IO — exactly as `<tonk-display>` consumes the host. Dropped into
-//! a board tile via `<tonk-display model=inspector>`, it evaluates
+//! a board tile via `<tonk-display concept=inspector>`, it evaluates
 //! against whatever space the route is showing.
 
 // The inspector is a DOM custom element that consumes the host via

--- a/rust/tonk-ui/src/components/launcher.rs
+++ b/rust/tonk-ui/src/components/launcher.rs
@@ -33,15 +33,15 @@ pub fn TonkLauncher() -> impl IntoView {
                     // `{branch}@{name}` (branch defaults to `main`);
                     // `*subject` is a wildcard so entity URIs containing `/`
                     // (e.g. `id:tonk-workspace/itinerary`) are captured whole
-                    // rather than truncated. Models like `board` and
+                    // rather than truncated. Concepts like `board` and
                     // `inspector` are reached here too, as directory views
                     // (`/space/{name}/board`, `/space/{name}/inspector`).
                     //
                     //   /space/{name}/                       default view
                     //   /space/{branch}@{name}/              + branch
-                    //   /space/{name}/{model}/               directory
-                    //   /space/{name}/{entity}@{model}/*     artifact
-                    //   /space/{name}/{entity}@{model}!{view}/*  ad-hoc
+                    //   /space/{name}/{concept}/               directory
+                    //   /space/{name}/{entity}@{concept}/*     artifact
+                    //   /space/{name}/{entity}@{concept}!{view}/*  ad-hoc
                     // SPIKE: the bare `/space/:space` route now renders the
                     // space's default view inside a SEALED opaque-origin
                     // iframe (the new architecture). The `/*subject` routes

--- a/rust/tonk-ui/src/components/route_views.rs
+++ b/rust/tonk-ui/src/components/route_views.rs
@@ -14,7 +14,7 @@
 use custom_elements::CustomElement;
 use web_sys::{HtmlElement, window};
 
-/// The Tonk Hub at `/`: a `<tonk-display model="space">` directory over the
+/// The Tonk Hub at `/`: a `<tonk-display concept="space">` directory over the
 /// profile's meta branch. Cards link to `/space/{subject}`.
 #[derive(Default)]
 pub(crate) struct TonkHubElement;
@@ -35,7 +35,7 @@ impl CustomElement for TonkHubElement {
     fn connected_callback(&mut self, _this: &HtmlElement) {}
 }
 
-/// The `/join` view: a `<tonk-display model="tonk:join/status">` directory
+/// The `/join` view: a `<tonk-display concept="tonk:join/status">` directory
 /// over the profile's meta branch. Its chrome holds the
 /// `<tonk-page onmount=tonk:join>` trigger that fires the join command.
 #[derive(Default)]
@@ -65,7 +65,7 @@ const ROUTE_VIEW_MARKUP_HUB: &str = r#"<main class="hub-route">
   <tonk-repository class="display-route" name="home" profile>
     <tonk-branch name="meta">
       <div class="display-view-slot">
-        <tonk-display model="space"></tonk-display>
+        <tonk-display concept="space"></tonk-display>
       </div>
     </tonk-branch>
   </tonk-repository>
@@ -75,7 +75,7 @@ const ROUTE_VIEW_MARKUP_JOIN: &str = r#"<main class="join-route">
   <tonk-repository class="display-route" name="home" profile>
     <tonk-branch name="meta">
       <div class="display-view-slot">
-        <tonk-display model="tonk:join/status"></tonk-display>
+        <tonk-display concept="tonk:join/status"></tonk-display>
       </div>
     </tonk-branch>
   </tonk-repository>

--- a/rust/tonk-ui/src/components/space_sealed.rs
+++ b/rust/tonk-ui/src/components/space_sealed.rs
@@ -1,6 +1,6 @@
 //! `/space/:space` — the sealed-iframe space view (spike).
 //!
-//! Renders the space's default view (`<tonk-display model=tonk/space>`)
+//! Renders the space's default view (`<tonk-display concept=tonk/space>`)
 //! **inside a sealed opaque-origin iframe** via `<tonk-portal runtime>`. The
 //! outer document provides only the routing context and the data plane:
 //!
@@ -10,7 +10,7 @@
 //!     <tonk-branch name=main>       ← annotates branch
 //!       <tonk-portal runtime        ← sealed iframe + window.tonk bridge +
 //!         content="<tonk-display       injected element runtime
-//!           model=tonk/space>">
+//!           concept=tonk/space>">
 //! ```
 //!
 //! Inside the guest, a real `<tonk-display>` dispatches its query/subscribe
@@ -18,7 +18,7 @@
 //! which relays them over `window.tonk` to the outer portal, which bubbles
 //! them to the real `<tonk-host>` → SW. The space/branch annotation happens
 //! outer-side from the `<tonk-repository>`/`<tonk-branch>` ancestors, so the
-//! guest only needs the `model`.
+//! guest only needs the `concept`.
 
 use leptos::prelude::*;
 use leptos_router::hooks::use_params;
@@ -77,7 +77,7 @@ pub fn TonkSpaceSealed() -> impl IntoView {
     // asserts the tab's `tonk:site` (so the display has something to resolve) and
     // returns the `site:<client-id>` entity the SW keys it on, which the host
     // caches for the guest context. We gate the portal mount on it so the guest's
-    // `<tonk-display model=tonk:site>` never queries an unstamped site. The
+    // `<tonk-display concept=tonk:site>` never queries an unstamped site. The
     // resource tracks `route_path`, so a client-side navigation re-registers the
     // site for the new path.
     let site = LocalResource::new(move || {
@@ -115,7 +115,7 @@ pub fn TonkSpaceSealed() -> impl IntoView {
     // `display: contents` (the app CSS `tonk-host:has(> .display-view-slot)`
     // rule).
     //
-    // The space renders the tab's SITE. The fixed `model=tonk:site` resolves the
+    // The space renders the tab's SITE. The fixed `concept=tonk:site` resolves the
     // `tonk:site` instance the SW stamped on this tab's `site:<uuid>` entity; its
     // view nests into the matched route's `{concept}` on the same entity, which
     // resolves and renders. `data-tonk-entity="site"` is the seam — the guest

--- a/rust/tonk-ui/src/components/space_sealed.rs
+++ b/rust/tonk-ui/src/components/space_sealed.rs
@@ -123,7 +123,7 @@ pub fn TonkSpaceSealed() -> impl IntoView {
     // the host, unknown when this markup is built).
     const CONTENT: &str = "<tonk-host>\
 <div class=\"display-view-slot\">\
-<tonk-display model=tonk:site data-tonk-entity=\"site\"></tonk-display>\
+<tonk-display concept=tonk:site data-tonk-entity=\"site\"></tonk-display>\
 </div>\
 </tonk-host>";
 

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -586,7 +586,7 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
             // at creation), a joined space's content, including its `tonk/space`
             // view, only arrives over the pull from the remote. Redirecting
             // before that pull lands would drop the recipient on a branch with
-            // no view — `<tonk-display>` would resolve "Model not found".
+            // no view — `<tonk-display>` would resolve "Concept not found".
             //
             // So pull the content branch now, while the "Joining…" spinner is
             // still up, and only navigate once it has landed. A renewed replica
@@ -657,7 +657,7 @@ fn build_invite_url(command: &tonk_schema::command::Join) -> String {
 /// Pull the freshly joined replica's `main` content branch from its remote,
 /// so the standard-library views (notably `tonk/space`) are present before
 /// the recipient is redirected into the space. Without this the redirect can
-/// land on an empty branch and `<tonk-display>` resolves "Model not found".
+/// land on an empty branch and `<tonk-display>` resolves "Concept not found".
 ///
 /// A pull failure is logged, not fatal: the redirect still fires (the
 /// recipient lands on the space and a later sync / reload fills it in) — far

--- a/rust/tonk-worker/src/router/profile.rs
+++ b/rust/tonk-worker/src/router/profile.rs
@@ -27,7 +27,7 @@ const META_BRANCH: &str = "meta";
 /// index carries no display name: the space's name lives in its own
 /// `tonk/repository` concept on its content branch, so the UI resolves
 /// the label from the space's own repo (per-space `<tonk-display
-/// model=tonk:repository>`), not from this listing.
+/// concept=tonk:repository>`), not from this listing.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpaceEntry {
     /// Routing/storage key — the `subject` DID suffix. The URL segment

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1811,7 +1811,7 @@ pub async fn bootstrap_profile_meta(tonk: &TonkState) -> Result<(), RepositoryEr
 
     // Seed the standard library onto the profile meta branch so a
     // `<tonk-display>` reading the profile (the Hub at `/`) can resolve
-    // the library's concepts and views — the `space` model and its
+    // the library's concepts and views — the `space` concept and its
     // directory view — there, the same way a named repo's content
     // branch carries them. Idempotent: re-evaluating the library
     // de-duplicates rather than minting fresh claims, so it's safe on

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -7,7 +7,7 @@
 //! its current path; the SW reads the requesting **client id**, derives the site
 //! entity (`site:<client-id>`), asserts a [`Site`] `{path, anchor, replica,
 //! route, concept}` on the Level-0-resolved branch's overlay, and returns the
-//! site id. The page renders `<tonk-display entity={site} model=tonk:site>`; the
+//! site id. The page renders `<tonk-display this={site} concept=tonk:site>`; the
 //! `tonk:site` view nests into the matched `{concept}` and renders.
 //!
 //! The same endpoint handles navigation updates: the page re-calls it on each
@@ -162,7 +162,7 @@ async fn origin_entity(
 }
 
 /// Match `rest` (the Level 1 remaining path) against the branch's durable
-/// `tonk:route` table, returning the matched `(route entity, route model)`.
+/// `tonk:route` table, returning the matched `(route entity, route concept)`.
 ///
 /// Builds a fresh `matchit::Router` per call from the queried routes. Routes are
 /// inserted in stable entity-URI order so a `matchit` conflict (two structurally

--- a/rust/tonk-workspace/src/binder.rs
+++ b/rust/tonk-workspace/src/binder.rs
@@ -12,7 +12,7 @@
 //! 2. **Active** — the `active` attribute names the LIVE sheet (the
 //!    one shown, its tab `is-active`). It is owned by the binder: only
 //!    the click handler sets it, so switching is instant. The data
-//!    model never writes `active` directly — a fact change must not
+//!    concept never writes `active` directly — a fact change must not
 //!    yank the live tab. Instead the view supplies a separate,
 //!    NON-observed `default-active` attribute (the persisted selection,
 //!    like a form control's `defaultValue`); the binder reads it ONCE

--- a/rust/tonk-workspace/src/origin.rs
+++ b/rust/tonk-workspace/src/origin.rs
@@ -7,7 +7,7 @@
 //!
 //! ```html
 //! <tonk-origin>
-//!   <tonk-display bind:base="data-base" model=invitation entity={subject}>
+//!   <tonk-display bind:base="data-base" concept=invitation this={subject}>
 //!     <wa-input readonly value="{dom.host/data-base}?access={access}#{code}">
 //!     </wa-input>
 //!   </tonk-display>
@@ -70,7 +70,7 @@ fn join_base() -> String {
 /// The repository subject DID — `window.tonk.context.repo`, the same value
 /// the `<tonk-repository name=…>` ancestor carries. Provided as the
 /// `subject` bind value so a template can mount a display at the repo
-/// subject (`<tonk-display entity={subject}>`) — e.g. to resolve the
+/// subject (`<tonk-display this={subject}>`) — e.g. to resolve the
 /// `tonk:invitation` join, which keys on the subject. `None` when there is
 /// no bridge context (the element running outside a sealed guest with no
 /// `<tonk-repository>` to read).
@@ -192,13 +192,13 @@ mod tests {
             .dyn_into()
             .unwrap();
         let sink = document.create_element("tonk-display").unwrap();
-        sink.set_attribute("bind:subject", "entity").unwrap();
+        sink.set_attribute("bind:subject", "this").unwrap();
         host.append_child(&sink).unwrap();
         body.append_child(&host).unwrap();
 
         distribute(&host, "http://x/join", Some("did:key:zX"));
 
-        assert_eq!(sink.get_attribute("entity").as_deref(), Some("did:key:zX"));
+        assert_eq!(sink.get_attribute("this").as_deref(), Some("did:key:zX"));
         host.remove();
     }
 
@@ -216,15 +216,15 @@ mod tests {
             .dyn_into()
             .unwrap();
         let sink = document.create_element("tonk-display").unwrap();
-        sink.set_attribute("bind:subject", "entity").unwrap();
+        sink.set_attribute("bind:subject", "this").unwrap();
         host.append_child(&sink).unwrap();
         body.append_child(&host).unwrap();
 
         distribute(&host, "http://x/join", None);
 
         assert!(
-            !sink.has_attribute("entity"),
-            "no subject context → entity stays unset",
+            !sink.has_attribute("this"),
+            "no subject context → this stays unset",
         );
         host.remove();
     }

--- a/rust/tonk-workspace/src/page.rs
+++ b/rust/tonk-workspace/src/page.rs
@@ -7,7 +7,7 @@
 //!
 //! ```html
 //! <tonk-page onmount=tonk/join>
-//!   <tonk-display model=tonk:join/status entity=tonk:join/status></tonk-display>
+//!   <tonk-display concept=tonk:join/status this=tonk:join/status></tonk-display>
 //! </tonk-page>
 //! ```
 //!


### PR DESCRIPTION
A view's `model` is the concept it renders. Naming the same thing two ways (`model` in views/artifacts, `concept` everywhere a concept is defined) was a steady source of confusion. This standardizes on `concept`.

Renamed the author-facing surface and the internal identifiers that mirror it:

- **Web component attribute** `<tonk-display model=…>` → `concept=` (also `<tonk-portal>`, the `observed_attributes`, and the `{dom.host/model}` host field → `{dom.host/concept}`).
- **core.yaml field key** `model:` on the view / artifact / tile concepts → `concept:`, plus every per-instance binding and the rule variables that fill it.
- **Query term name**, the `"model"` subscription frame tag, and the `data-state="no-model"` → `"no-concept"`.
- **Internal symbols** for consistency: `view_by_model_query` → `view_by_concept_query`, `resolve_model` → `resolve_concept`, `DEFAULT_MODEL` → `DEFAULT_CONCEPT`, `State::NoModel` → `NoConcept`, `RenderRoute`/`Subject.model` → `.concept`, and the CLI `--model` flag / `?model=` query param → `--concept` / `?concept=`.

No data migration: the stored attribute URIs (`xyz.tonk.view/model`, `xyz.tonk.artifact/model`, `xyz.tonk.tile/model`) are deliberately left frozen, so the field is renamed only at the notation/identifier layer. Already-seeded repos keep resolving; fresh repos re-seed from the updated `core.yaml` on `init`. Hard rename, no `model` alias.

Verified: full workspace `cargo build` + `cargo test` green (incl. the end-to-end CLI seed+render against the renamed `core.yaml`), wasm build of the web-component crates green, fmt + clippy `-D warnings` clean.

Closes BUG-19.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming instances of `model` to `concept` across various files in the `tonk` codebase, reflecting a shift in terminology for better clarity and consistency.

### Detailed summary
- Changed `model` attributes to `concept` in HTML components.
- Updated comments and documentation to reflect the terminology change.
- Renamed variables and parameters from `model` to `concept` in Rust code.
- Adjusted test cases to use the new `concept` terminology.

> The following files were skipped due to too many changes: `rust/tonk-portal/src/bridge.rs`, `rust/tonk-core/assets/library/profile.yaml`, `rust/tonk-analyzer/src/analyzer/rule.rs`, `rust/tonk-ui/src/components/display.rs`, `rust/tonk-template/src/resolve.rs`, `rust/tonk-render/src/page/orchestrate.rs`, `rust/tonk-display/src/state.rs`, `rust/tonk-core/assets/library/core.yaml`, `rust/tonk-display/src/element.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->