### PR TITLE
feat(notation): retract concept fields via `field: _` / `..: _`

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -313,17 +313,43 @@ fn expand(
                         claims.push(Statement::Assert(inline));
                         claim_labels.push(None);
                     }
-                    collect_unbound_variables(&declaration.application, &working, &mut requires);
+                    // `predicate`/`this`/`anchor` describe the head for
+                    // the analysis tree. A normal declaration derives
+                    // them from its asserted application; a
+                    // retraction-only `concept!:` body has no
+                    // assertion, so probe its first retraction
+                    // application instead.
+                    let probe = declaration
+                        .application
+                        .as_ref()
+                        .or(declaration.retractions.first());
                     // A declaration head applies the built-in
                     // `concept` / `attribute` schema — that schema
                     // is durable; the declared concept's own
                     // transience is a field of the body, not the
                     // predicate this assertion applies.
-                    predicate = predicate_of(&declaration.application, false);
-                    this = declaration.application.this().clone();
-                    anchor = declaration.application.name().map(str::to_owned);
-                    claims.push(Statement::Assert(declaration.application));
-                    claim_labels.push(None);
+                    predicate = probe
+                        .map(|app| predicate_of(app, false))
+                        .unwrap_or(Predicate::Domain(a.predicate.source.clone()));
+                    this = probe
+                        .map(|app| app.this().clone())
+                        .unwrap_or(ThisIntent::Derived);
+                    anchor = declaration
+                        .application
+                        .as_ref()
+                        .and_then(|app| app.name().map(str::to_owned));
+                    // Retractions emit first so the dissociate sees the
+                    // prior state before any re-assert lands.
+                    for retraction in declaration.retractions {
+                        collect_unbound_variables(&retraction, &working, &mut requires);
+                        claims.push(Statement::Retract(retraction));
+                        claim_labels.push(None);
+                    }
+                    if let Some(application) = declaration.application {
+                        collect_unbound_variables(&application, &working, &mut requires);
+                        claims.push(Statement::Assert(application));
+                        claim_labels.push(None);
+                    }
                     is_declaration = true;
                 } else if is_rule_claim(a) {
                     // `rule!:` claims lower to a single
@@ -908,6 +934,68 @@ mod tests {
                 let entity: Entity = attr.to_uri().parse().expect("attribute URI");
                 self.publish_name(name, entity).await;
             }
+        }
+
+        /// Assert a concept at an explicit pinned `entity` (rather
+        /// than the content-derived `descriptor.this()`), so a test
+        /// can reference it via `this: <entity>` in the notation —
+        /// the form a `concept!:` field retraction targets. Each
+        /// field is `(field, the, "Text")`; `optional` widens none.
+        async fn assert_concept_at(&self, entity: &Entity, fields: &[(&str, &str)]) {
+            let mut with = serde_json::Map::new();
+            for (field, the) in fields {
+                with.insert(
+                    (*field).into(),
+                    serde_json::json!({ "the": the, "as": "Text", "cardinality": "one" }),
+                );
+            }
+            let descriptor: ConceptDescriptor =
+                serde_json::from_value(serde_json::json!({ "with": with }))
+                    .expect("descriptor JSON is well-formed");
+            let mut txn = self.branch.transaction();
+            for (_, attr) in descriptor.with().iter() {
+                let attr_entity: Entity = attr.to_uri().parse().expect("attribute URI");
+                txn = txn
+                    .assert(
+                        the!("dialog.attribute/id")
+                            .of(attr_entity.clone())
+                            .is(format!("{}/{}", attr.domain(), attr.name())),
+                    )
+                    .assert(
+                        the!("dialog.attribute/type")
+                            .of(attr_entity.clone())
+                            .is("Text".to_owned()),
+                    )
+                    .assert(
+                        the!("dialog.attribute/cardinality")
+                            .of(attr_entity.clone())
+                            .is("one".to_owned()),
+                    )
+                    .assert(
+                        the!("dialog.meta/description")
+                            .of(attr_entity)
+                            .is(String::new()),
+                    );
+            }
+            // Pin the concept at `entity` by emitting its facts there
+            // directly (mirrors `emit_concept_facts`): the marker plus
+            // one `dialog.concept.with/<field>` per field.
+            txn = txn.assert(
+                the!("dialog.meta/concept")
+                    .of(entity.clone())
+                    .is("db:concept".parse::<Entity>().expect("db:concept")),
+            );
+            for (field, attr) in descriptor.with().iter() {
+                let attr_entity: Entity = attr.to_uri().parse().expect("attribute URI");
+                let the = format!("dialog.concept.with/{field}")
+                    .parse::<dialog_query::attribute::The>()
+                    .expect("with attribute parses");
+                txn = txn.assert(the.of(entity.clone()).is(attr_entity));
+            }
+            txn.commit()
+                .perform(&self.operator)
+                .await
+                .expect("pinned concept assertion commits");
         }
 
         /// Publish a `dialog.name/referent` claim binding `name`
@@ -1822,6 +1910,179 @@ person!:
             assert!(
                 matches!(q.terms.get(field), Some(Term::Variable { name: None, .. })),
                 "field {field:?} should be blank"
+            );
+        }
+    }
+
+    /// `concept!: { this: <pinned>, with: { f: _ } }` retracts the
+    /// named field from a stored concept: a `Statement::Retract`
+    /// carrying the `with.f` term bound to the field's stored
+    /// attribute entity, and nothing else (no marker, no other
+    /// field).
+    #[dialog_common::test]
+    async fn it_retracts_a_named_field_from_a_concept() {
+        let fixture = new_fixture().await;
+        let entity: Entity = "did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv"
+            .parse()
+            .expect("valid entity");
+        fixture
+            .assert_concept_at(
+                &entity,
+                &[
+                    ("name", "io.gozala.person/name"),
+                    ("age", "io.gozala.person/age"),
+                ],
+            )
+            .await;
+        let syntax = must_parse(
+            r#"
+concept!:
+  this: did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv
+  with:
+    age: _
+"#,
+        );
+        let analysis = flat(fixture.analyze(&syntax).await.unwrap());
+        // A pure retraction emits exactly one statement: the retract.
+        let retracts: Vec<_> = analysis
+            .mutate
+            .statements
+            .iter()
+            .filter_map(|s| match s {
+                Statement::Retract(Application::Concept { query, .. }) => Some(query),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(retracts.len(), 1, "exactly one concept retraction");
+        let q = retracts[0];
+        // `with.age` is blank: the evaluator dissociates whatever the
+        // branch holds for age (the instance-retraction model).
+        assert!(
+            matches!(
+                q.terms.get("with.age"),
+                Some(Term::Variable { name: None, .. })
+            ),
+            "with.age is a blank retraction directive",
+        );
+        // `name` is untouched — no term for it, and no marker term.
+        assert!(
+            q.terms.get("with.name").is_none(),
+            "the kept field is not retracted",
+        );
+        assert!(
+            q.terms.get("concept").is_none(),
+            "the concept marker is not retracted",
+        );
+        // No assert side for a retraction-only body.
+        assert!(
+            !analysis
+                .mutate
+                .statements
+                .iter()
+                .any(|s| matches!(s, Statement::Assert(Application::Concept { .. }))),
+            "retraction-only body emits no concept assertion",
+        );
+    }
+
+    /// `..: _` on a pinned concept retracts every stored field.
+    #[dialog_common::test]
+    async fn it_retracts_every_field_from_a_concept_via_rest() {
+        let fixture = new_fixture().await;
+        let entity: Entity = "did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv"
+            .parse()
+            .expect("valid entity");
+        fixture
+            .assert_concept_at(
+                &entity,
+                &[
+                    ("name", "io.gozala.person/name"),
+                    ("age", "io.gozala.person/age"),
+                ],
+            )
+            .await;
+        let syntax = must_parse(
+            r#"
+concept!:
+  this: did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv
+  ..: _
+"#,
+        );
+        let analysis = flat(fixture.analyze(&syntax).await.unwrap());
+        let q = analysis
+            .mutate
+            .statements
+            .iter()
+            .find_map(|s| match s {
+                Statement::Retract(Application::Concept { query, .. }) => Some(query),
+                _ => None,
+            })
+            .expect("a concept retraction");
+        for field in ["name", "age"] {
+            assert!(
+                q.terms.get(&format!("with.{field}")).is_some(),
+                "`..: _` retracts every stored field, including {field}",
+            );
+        }
+    }
+
+    /// Retracting a field the concept doesn't carry is a hard error
+    /// (strict policy): there's no stored triple to dissociate.
+    #[dialog_common::test]
+    async fn it_rejects_retracting_an_absent_field() {
+        let fixture = new_fixture().await;
+        let entity: Entity = "did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv"
+            .parse()
+            .expect("valid entity");
+        fixture
+            .assert_concept_at(&entity, &[("name", "io.gozala.person/name")])
+            .await;
+        let syntax = must_parse(
+            r#"
+concept!:
+  this: did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv
+  with:
+    nonexistent: _
+"#,
+        );
+        let err = fixture.analyze(&syntax).await.unwrap_err();
+        assert!(
+            matches!(err.kind, AnalyzeErrorKind::InvalidConceptBody { .. }),
+            "expected InvalidConceptBody for absent-field retraction, got {err:?}",
+        );
+    }
+
+    /// Retracting against a concept that doesn't exist on the branch
+    /// is a hard error — the attribute value to dissociate is unknown.
+    #[dialog_common::test]
+    async fn it_rejects_retraction_against_unknown_concept() {
+        let syntax = must_parse(
+            r#"
+concept!:
+  this: did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv
+  with:
+    age: _
+"#,
+        );
+        let err = analyze_empty(&syntax).await.unwrap_err();
+        assert!(
+            matches!(err.kind, AnalyzeErrorKind::InvalidConceptBody { .. }),
+            "expected InvalidConceptBody for unknown-concept retraction, got {err:?}",
+        );
+    }
+
+    /// `..` is the top-level rest-retraction marker, not a field
+    /// name. Nested inside a `with:`/`maybe:` block it must be a
+    /// parse error, not a silent "retract a field named `..`".
+    #[dialog_common::test]
+    async fn it_rejects_rest_marker_nested_in_a_block() {
+        for block in ["with", "maybe"] {
+            let syntax = must_parse(&format!(
+                "concept!:\n  this: id:thing\n  {block}:\n    ..: _\n"
+            ));
+            let err = analyze_empty(&syntax).await.unwrap_err();
+            assert!(
+                matches!(err.kind, AnalyzeErrorKind::InvalidConceptBody { .. }),
+                "expected InvalidConceptBody for `..` nested in `{block}:`, got {err:?}",
             );
         }
     }

--- a/rust/tonk-analyzer/src/analyzer/declaration.rs
+++ b/rust/tonk-analyzer/src/analyzer/declaration.rs
@@ -31,11 +31,17 @@ use tonk_schema::transact::{Application, ThisIntent};
 /// the branch by the time anything reads back. Empty for
 /// `attribute!` heads.
 pub(crate) struct DeclaredApplication {
-    /// The head's own `Application`, ready to commit.
-    pub application: Application,
+    /// The head's own `Application`, ready to commit. `None` for a
+    /// retraction-only `concept!:` body (`with: { f: _ }` / `..: _`
+    /// with no asserted fields), which emits only `retractions`.
+    pub application: Option<Application>,
     /// Anonymous attribute applications declared inline inside
     /// this concept's `with:` map. Empty for `attribute!` heads.
     pub inline_attributes: Vec<Application>,
+    /// Per-field retraction applications emitted as
+    /// `Statement::Retract` — one per `concept!:` field retraction
+    /// (`with: { f: _ }` / `..: _`). Empty otherwise.
+    pub retractions: Vec<Application>,
 }
 
 /// Parsed `attribute!` body — descriptor plus entity URI.
@@ -157,12 +163,39 @@ pub(crate) fn parse_attribute_fields(
     Ok(AttributeBody { descriptor, entity })
 }
 
+/// A field the concept body asks to retract via `field: _`,
+/// regardless of which block (`with:`/`maybe:`) it appeared under.
+/// The emitter resolves the field's stored attribute (and its
+/// optional sibling) from the branch, so the block is immaterial
+/// here — only the name matters.
+pub(crate) struct RetractedField {
+    pub name: String,
+}
+
+/// `..: _` rest-retraction: the body asks to drop *every* stored
+/// field of the concept. The concrete field set isn't known from
+/// the source — it's read from the concept's existing facts on the
+/// branch at emission time.
+pub(crate) struct RestRetraction;
+
 /// Parsed `concept!` body — descriptor plus entity URI plus any
 /// inline attribute definitions that need to be registered as
 /// their own meta-head plans alongside the concept's own.
 pub(crate) struct ConceptBody {
     pub descriptor: ConceptDescriptor,
     pub entity: Entity,
+    /// Fields named for retraction via `field: _`. Never enter the
+    /// descriptor's with-map (a retracted field must not become a
+    /// required field, feed `concept_schema`, or shift the
+    /// content-derived entity).
+    pub retracted: Vec<RetractedField>,
+    /// `Some` when the body carried `..: _` — retract all stored
+    /// fields of the concept.
+    pub rest_retraction: Option<RestRetraction>,
+    /// `true` when the body asserts no fields (a retraction-only
+    /// `concept!:`). `descriptor` then holds an unemitted stub; the
+    /// graph skips the concept assertion and emits only retractions.
+    pub asserts_nothing: bool,
     /// `true` when the body carried the `transient:` tag (bare
     /// key with no value, or the explicit `transient: true`).
     /// Drives emission of the `dialog.concept/transient` marker
@@ -187,6 +220,8 @@ pub(crate) fn parse_concept_body(
     // are required; `maybe:` fields are optional.
     let mut fields: Vec<(String, AttributeDefinition, bool)> = Vec::new();
     let mut inline_attributes: Vec<AttributeBody> = Vec::new();
+    let mut retracted: Vec<RetractedField> = Vec::new();
+    let mut rest_retraction: Option<RestRetraction> = None;
     // A concept's entity is content-derived from its descriptor by
     // default, but a `this: <uri>` pins it to a stable, chosen
     // entity (e.g. `tonk:view`) so the concept is referenceable by
@@ -197,10 +232,14 @@ pub(crate) fn parse_concept_body(
     // to reject duplicates across `with:`/`maybe:`.
     let mut seen: BTreeMap<String, lsp_types::Range> = BTreeMap::new();
     for field in &assertion.fields {
-        // `..:` is the rest-retraction marker and never contributes
-        // to a concept descriptor. `this:` is read below as the
-        // optional entity pin; it likewise doesn't become a field.
+        // `..: _` is the rest-retraction marker: drop every stored
+        // field of the concept. It never contributes to the
+        // descriptor. `this:` is read below as the optional entity
+        // pin; it likewise doesn't become a field.
         if field.name == ".." {
+            if matches!(field.value, FieldValue::Blank) {
+                rest_retraction = Some(RestRetraction);
+            }
             continue;
         }
         if field.name == "this" {
@@ -221,6 +260,7 @@ pub(crate) fn parse_concept_body(
                     scope,
                     &mut fields,
                     &mut inline_attributes,
+                    &mut retracted,
                     &mut seen,
                 )?;
             }
@@ -231,6 +271,7 @@ pub(crate) fn parse_concept_body(
                     scope,
                     &mut fields,
                     &mut inline_attributes,
+                    &mut retracted,
                     &mut seen,
                 )?;
             }
@@ -243,10 +284,13 @@ pub(crate) fn parse_concept_body(
             }
         }
     }
-    // A concept must declare at least one *required* field. An empty
-    // `with:` or a body with only `maybe:` fields would constrain
-    // nothing and match every entity.
-    if !fields.iter().any(|(_, _, optional)| !optional) {
+    // A retraction-only body (`with: { field: _ }` or `..: _`) is a
+    // valid edit of an existing concept and carries no asserted
+    // fields. Otherwise a concept must declare at least one
+    // *required* field — an empty `with:` or a body with only
+    // `maybe:` fields would constrain nothing and match every entity.
+    let is_retraction_only = !retracted.is_empty() || rest_retraction.is_some();
+    if !is_retraction_only && !fields.iter().any(|(_, _, optional)| !optional) {
         return Err(AnalyzeErrorKind::InvalidConceptBody {
             reason: "`with:` is required and must declare at least one field".into(),
         }
@@ -269,19 +313,63 @@ pub(crate) fn parse_concept_body(
             (name.clone(), value)
         })
         .collect();
-    shape.insert("with".into(), serde_json::Value::Object(with_obj));
-    let descriptor: ConceptDescriptor = serde_json::from_value(serde_json::Value::Object(shape))
-        .map_err(|e| AnalyzeErrorKind::InvalidConceptBody {
-            reason: e.to_string(),
+    // A descriptor must carry at least one field. A retraction-only
+    // body (`with: { f: _ }` / `..: _` with nothing left to assert)
+    // has none — it asserts nothing, so the descriptor is a stub
+    // never emitted (the emitter skips the assertion when the
+    // descriptor is empty) and the entity must come from the `this:`
+    // pin. Mark the stub so `with()` reports empty downstream.
+    let asserts_nothing = with_obj.is_empty();
+    if asserts_nothing {
+        let mut stub = serde_json::Map::new();
+        stub.insert(STUB_FIELD.into(), stub_attr());
+        shape.insert("with".into(), serde_json::Value::Object(stub));
+    } else {
+        shape.insert("with".into(), serde_json::Value::Object(with_obj));
+    }
+    let raw_descriptor: ConceptDescriptor =
+        serde_json::from_value(serde_json::Value::Object(shape)).map_err(|e| {
+            AnalyzeErrorKind::InvalidConceptBody {
+                reason: e.to_string(),
+            }
         })?;
     // `this:` pins the entity; otherwise derive it from the
-    // descriptor (content-addressed).
-    let entity = pinned_entity.unwrap_or_else(|| descriptor.this());
+    // descriptor (content-addressed). A retraction-only body has no
+    // content to derive from, so the pin is mandatory.
+    let entity = match pinned_entity {
+        Some(e) => e,
+        None if asserts_nothing => {
+            return Err(AnalyzeErrorKind::InvalidConceptBody {
+                reason: "a retraction-only `concept!:` body (`field: _` / `..: _`) \
+                         must pin the concept with `this: <uri>`"
+                    .into(),
+            }
+            .into());
+        }
+        None => raw_descriptor.this(),
+    };
+    let descriptor = raw_descriptor;
     Ok(ConceptBody {
         descriptor,
         entity,
+        retracted,
+        rest_retraction,
+        asserts_nothing,
         transient,
         inline_attributes,
+    })
+}
+
+/// Placeholder field for the stub descriptor a retraction-only body
+/// carries — valid (a descriptor needs ≥1 field) but never emitted.
+const STUB_FIELD: &str = "_";
+
+/// The placeholder attribute spec paired with [`STUB_FIELD`].
+fn stub_attr() -> serde_json::Value {
+    serde_json::json!({
+        "the": "dialog.concept/stub",
+        "as": "Text",
+        "cardinality": "one",
     })
 }
 
@@ -319,14 +407,16 @@ fn parse_concept_this(field: &tonk_notation::Field) -> Result<Option<Entity>, An
 /// required (`with:`) or set-widened (`maybe:`).
 ///
 /// Appends `(name, definition, optional)` to `fields`, registers any
-/// inline definitions in `inline_attributes`, and rejects a field
-/// name already seen in either block via `seen`.
+/// inline definitions in `inline_attributes`, collects `field: _`
+/// retractions into `retracted`, and rejects a field name already
+/// seen in either block via `seen`.
 fn parse_concept_field_block(
     field: &SyntaxField,
     optional: bool,
     scope: &Scope,
     fields: &mut Vec<(String, AttributeDefinition, bool)>,
     inline_attributes: &mut Vec<AttributeBody>,
+    retracted: &mut Vec<RetractedField>,
     seen: &mut BTreeMap<String, lsp_types::Range>,
 ) -> Result<(), AnalyzeError> {
     let block = if optional { "maybe" } else { "with" };
@@ -342,6 +432,21 @@ fn parse_concept_field_block(
         .into());
     };
     for sub in inner {
+        // `..` is the top-level rest-retraction marker, not a field
+        // name. Nested in a `with:`/`maybe:` block it would otherwise
+        // be misread as a field literally named `..`; reject it with a
+        // pointer to the correct placement.
+        if sub.name == ".." {
+            return Err(AnalyzeError::at(
+                AnalyzeErrorKind::InvalidConceptBody {
+                    reason: format!(
+                        "`..:` is the rest-retraction marker and must be a direct \
+                         child of the `concept!:` body, not nested inside `{block}:`"
+                    ),
+                },
+                sub.name_range,
+            ));
+        }
         // Reject a field name declared twice (in one block or across
         // `with:`/`maybe:`) — a field is required or optional, never
         // both. Anchor the diagnostic at the second occurrence.
@@ -354,7 +459,16 @@ fn parse_concept_field_block(
                 sub.name_range,
             ));
         }
-        if let FieldValue::Nested(attr_fields) = &sub.value {
+        if matches!(sub.value, FieldValue::Blank) {
+            // `field: _` retracts the named field from the stored
+            // concept. It is NOT a reference and never enters the
+            // descriptor — recorded separately so the emitter
+            // dissociates `dialog.concept.<block>/<field>` (plus the
+            // `optional` sibling) without re-asserting anything.
+            retracted.push(RetractedField {
+                name: sub.name.clone(),
+            });
+        } else if let FieldValue::Nested(attr_fields) = &sub.value {
             // Inline attribute definition. Parse it as an attribute
             // body and register it for emission as a separate
             // meta-head plan.
@@ -546,6 +660,133 @@ pub(crate) fn concept_application(
         this: ThisIntent::Uri(entity.clone()),
         name,
     }
+}
+
+/// Lower a `concept!:` body's field retractions (`with: { f: _ }`,
+/// `maybe: { f: _ }`, `..: _`) into retraction [`Application`]s.
+///
+/// `resolved` is the concept as read off the branch (the scope's
+/// prefetch). Retraction is strict: a body that asks to drop a field
+/// must target a concept that exists on the branch and actually
+/// carries that field — otherwise there's no `dialog.concept.with/…`
+/// triple to dissociate (its value is unknown). Both cases surface
+/// as [`AnalyzeErrorKind::InvalidConceptBody`].
+pub(crate) fn build_concept_retractions(
+    entity: &Entity,
+    retracted: &[RetractedField],
+    rest: Option<&RestRetraction>,
+    resolved: Option<&ConceptDescriptor>,
+) -> Result<Vec<Application>, AnalyzeError> {
+    if retracted.is_empty() && rest.is_none() {
+        return Ok(Vec::new());
+    }
+    let Some(stored) = resolved else {
+        return Err(AnalyzeErrorKind::InvalidConceptBody {
+            reason: format!(
+                "field retraction (`field: _` / `..: _`) requires the concept \
+                 `{entity}` to already exist on the branch, but no concept was \
+                 found there"
+            ),
+        }
+        .into());
+    };
+
+    // `..: _` drops every stored field; otherwise drop just the named
+    // ones, verifying each is actually present.
+    let field_names: Vec<String> = if rest.is_some() {
+        stored
+            .with()
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect()
+    } else {
+        for field in retracted {
+            if !stored
+                .with()
+                .iter()
+                .any(|(name, _)| name == field.name.as_str())
+            {
+                return Err(AnalyzeErrorKind::InvalidConceptBody {
+                    reason: format!(
+                        "cannot retract field `{}` from concept `{entity}`: \
+                         the concept has no such field on the branch",
+                        field.name
+                    ),
+                }
+                .into());
+            }
+        }
+        retracted.iter().map(|f| f.name.clone()).collect()
+    };
+
+    Ok(concept_field_retraction(stored, entity, &field_names)
+        .into_iter()
+        .collect())
+}
+
+/// Build a retraction `Application::Concept` that dissociates the
+/// named `fields` from a stored concept, leaving the concept's
+/// marker and every other field intact.
+///
+/// `stored` is the concept as resolved off the branch — it supplies
+/// each retracted field's attribute `the:` so the predicate maps the
+/// field to the right `dialog.concept.with/<field>` relation. The
+/// field terms are emitted **blank** (`Term::blank()`): the evaluator
+/// reads each as a retraction directive and queries the branch for
+/// the stored value to dissociate (mirroring how instance `..: _`
+/// retraction resolves its targets). Only `this` + one blank
+/// `with.<field>` term per retracted field is set — no
+/// `concept`/`name`/`description`/`transient` term, so a
+/// `Statement::Retract` of this application touches nothing else.
+///
+/// Returns `None` when none of `fields` is present on the stored
+/// concept (nothing to retract).
+fn concept_field_retraction(
+    stored: &ConceptDescriptor,
+    entity: &Entity,
+    fields: &[String],
+) -> Option<Application> {
+    // Pull the stored field set as JSON so each retracted field's
+    // descriptor (carrying its `the:` attribute) can be lifted into a
+    // sub-descriptor of exactly the fields being dropped.
+    let stored_json = serde_json::to_value(stored).expect("ConceptDescriptor is serializable");
+    let stored_with = stored_json
+        .get("with")
+        .and_then(serde_json::Value::as_object);
+
+    let mut sub_with = serde_json::Map::new();
+    for field in fields {
+        if let Some(entry) = stored_with.and_then(|w| w.get(field)) {
+            sub_with.insert(field.clone(), entry.clone());
+        }
+    }
+    if sub_with.is_empty() {
+        return None;
+    }
+
+    let sub_descriptor: ConceptDescriptor =
+        serde_json::from_value(serde_json::json!({ "with": sub_with }))
+            .expect("sub-descriptor of a valid descriptor is valid");
+
+    let mut terms = Parameters::new();
+    terms.insert("this".into(), Term::Constant(Value::Entity(entity.clone())));
+    for (field_name, _attr) in sub_descriptor.with().iter() {
+        // Blank term → the evaluator dissociates whatever value the
+        // branch holds for this field (no need to recompute the
+        // attribute entity analyzer-side).
+        terms.insert(
+            format!("with.{field_name}"),
+            Term::<dialog_query::Any>::blank(),
+        );
+    }
+    Some(Application::Concept {
+        query: ConceptQuery {
+            terms,
+            predicate: concept_schema(&sub_descriptor),
+        },
+        this: ThisIntent::Uri(entity.clone()),
+        name: None,
+    })
 }
 
 /// Build the `dialog.attribute` built-in schema descriptor. Its

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -37,8 +37,8 @@ use tonk_schema::rule::{Rule, RuleResolveError};
 
 use super::assertion::{body_digest, derive_head_intent};
 use super::declaration::{
-    DeclaredApplication, attribute_application, concept_application, parse_attribute_body,
-    parse_concept_body,
+    DeclaredApplication, attribute_application, build_concept_retractions, concept_application,
+    parse_attribute_body, parse_concept_body,
 };
 use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::rule::{collect_rule_concepts, is_rule_retract_body, parse_rule_this_entity};
@@ -82,6 +82,13 @@ enum Need {
     },
     /// The installed rule a `rule!: ..: _` retract targets.
     Rule {
+        entity: Entity,
+        range: lsp_types::Range,
+    },
+    /// The stored concept a `concept!:` field retraction
+    /// (`with: { f: _ }` / `..: _`) reads its existing fields from.
+    /// Keyed by the body's `this:`-pinned entity.
+    ConceptByEntity {
         entity: Entity,
         range: lsp_types::Range,
     },
@@ -136,6 +143,13 @@ pub(crate) struct Resolved {
 /// during the declaration registration or `expand`.
 pub(crate) trait Resolve {
     async fn concept(&self, name: &str) -> Result<Option<ConceptDefinition>, ResolveError>;
+    /// Resolve a concept by its entity URI (e.g. a `this:`-pinned
+    /// concept like `tonk:binder`). Used by field retraction to read
+    /// the concept's stored fields off the branch.
+    async fn concept_by_entity(
+        &self,
+        entity: &Entity,
+    ) -> Result<Option<ConceptDefinition>, ResolveError>;
     async fn attribute(&self, name: &str) -> Result<Option<AttributeDefinition>, ResolveError>;
     async fn attribute_by_entity(
         &self,
@@ -152,6 +166,12 @@ pub(crate) struct LocalOnly;
 
 impl Resolve for LocalOnly {
     async fn concept(&self, _: &str) -> Result<Option<ConceptDefinition>, ResolveError> {
+        Ok(None)
+    }
+    async fn concept_by_entity(
+        &self,
+        _: &Entity,
+    ) -> Result<Option<ConceptDefinition>, ResolveError> {
         Ok(None)
     }
     async fn attribute(&self, _: &str) -> Result<Option<AttributeDefinition>, ResolveError> {
@@ -188,6 +208,15 @@ impl<'a, 'e, Env> BranchResolver<'a, 'e, Env> {
 impl<Env: QueryEnv> Resolve for BranchResolver<'_, '_, Env> {
     async fn concept(&self, name: &str) -> Result<Option<ConceptDefinition>, ResolveError> {
         ConceptReference::from(NamedReference(name.to_owned()))
+            .resolve(self.source.clone())
+            .perform(self.env)
+            .await
+    }
+    async fn concept_by_entity(
+        &self,
+        entity: &Entity,
+    ) -> Result<Option<ConceptDefinition>, ResolveError> {
+        ConceptReference::from(entity.clone())
             .resolve(self.source.clone())
             .perform(self.env)
             .await
@@ -339,7 +368,26 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
 /// attribute definitions (a nested mapping) declare their own entity
 /// and need no resolution, so they're skipped here.
 fn collect_concept_with_needs(assertion: &tonk_notation::Application, needs: &mut Vec<Need>) {
+    // A retraction (`with: { f: _ }`, `maybe: { f: _ }`, or `..: _`)
+    // reads the concept's stored fields off the branch. Track whether
+    // the body carries one so a single `ConceptByEntity` need is
+    // registered against the `this:`-pinned entity below.
+    let mut has_retraction = false;
+    let mut this_entity: Option<(Entity, lsp_types::Range)> = None;
     for field in &assertion.fields {
+        if field.name == "this"
+            && let FieldValue::Uri(uri) = &field.value
+            && let Ok(entity) = uri.parse::<Entity>()
+        {
+            this_entity = Some((entity, field.value_range));
+            continue;
+        }
+        if field.name == ".." {
+            if matches!(field.value, FieldValue::Blank) {
+                has_retraction = true;
+            }
+            continue;
+        }
         if field.name != "with" && field.name != "maybe" {
             continue;
         }
@@ -348,6 +396,9 @@ fn collect_concept_with_needs(assertion: &tonk_notation::Application, needs: &mu
         };
         for sub in inner {
             match &sub.value {
+                // `f: _` is a retraction, not a reference — no
+                // attribute need; the value is read from the branch.
+                FieldValue::Blank => has_retraction = true,
                 FieldValue::Nested(_) => {} // inline definition, no need
                 FieldValue::Symbol(name) | FieldValue::Variable(name) => {
                     needs.push(Need::Attribute {
@@ -366,6 +417,9 @@ fn collect_concept_with_needs(assertion: &tonk_notation::Application, needs: &mu
                 _ => {}
             }
         }
+    }
+    if has_retraction && let Some((entity, range)) = this_entity {
+        needs.push(Need::ConceptByEntity { entity, range });
     }
 }
 
@@ -422,6 +476,25 @@ impl Graph {
                         scope.record_attribute(None, def);
                     }
                 }
+                // A field retraction reads the pinned concept's stored
+                // fields. Resolved here (Pass 1), before declaration
+                // bodies emit in Pass 2, so the retract lowering finds
+                // it cached on the scope.
+                Need::ConceptByEntity { entity, range } => {
+                    if scope.resolved_concept(entity).is_some() {
+                        continue;
+                    }
+                    let found = resolver.concept_by_entity(entity).await.map_err(|e| {
+                        AnalyzeError::at(
+                            AnalyzeErrorKind::ResolverFailed {
+                                context: format!("concept {entity}"),
+                                reason: e.to_string(),
+                            },
+                            *range,
+                        )
+                    })?;
+                    scope.record_resolved_concept(entity, found);
+                }
                 _ => {}
             }
         }
@@ -473,8 +546,9 @@ impl Graph {
                     declared.insert(
                         pending.index,
                         DeclaredApplication {
-                            application,
+                            application: Some(application),
                             inline_attributes: Vec::new(),
+                            retractions: Vec::new(),
                         },
                     );
                 }
@@ -486,15 +560,6 @@ impl Graph {
                     // explicit `transient:` inside a `command!:`
                     // body is redundant and silently ignored.
                     let transient = matches!(kind, DeclarationKind::Command) || plan.transient;
-                    let descriptor = if transient {
-                        DurableConceptDescriptor::Transient(plan.descriptor.clone())
-                    } else {
-                        DurableConceptDescriptor::Durable(plan.descriptor.clone())
-                    };
-                    let concept = ConceptDef {
-                        entity: entity.clone(),
-                        descriptor,
-                    };
                     let (this, name) = derive_head_intent(&a.fields, anchor, scope)?;
                     let variable = match &this {
                         ThisIntent::Variable(v) => Some(v.clone()),
@@ -513,24 +578,59 @@ impl Graph {
                     if let Some(name) = &variable {
                         scope.bind_variable(name, entity.clone(), variable_range)?;
                     }
-                    scope.record_concept(
-                        name.as_ref()
-                            .map(AnchorName::as_str)
-                            .or(variable.as_deref()),
-                        concept,
-                    );
+                    // A retraction-only body carries a stub descriptor
+                    // that asserts nothing — don't register it as an
+                    // in-doc concept, or later references would resolve
+                    // to the stub instead of the real branch concept.
+                    if !plan.asserts_nothing {
+                        let descriptor = if transient {
+                            DurableConceptDescriptor::Transient(plan.descriptor.clone())
+                        } else {
+                            DurableConceptDescriptor::Durable(plan.descriptor.clone())
+                        };
+                        scope.record_concept(
+                            name.as_ref()
+                                .map(AnchorName::as_str)
+                                .or(variable.as_deref()),
+                            ConceptDef {
+                                entity: entity.clone(),
+                                descriptor,
+                            },
+                        );
+                    }
                     let inline_attributes = plan
                         .inline_attributes
                         .into_iter()
                         .map(|attr| attribute_application(&attr.descriptor, &attr.entity, None))
                         .collect();
-                    let application =
-                        concept_application(&plan.descriptor, &entity, name, transient);
+                    // Field retractions (`with: { f: _ }` / `..: _`)
+                    // dissociate stored fields read off the branch.
+                    let resolved = scope.resolved_concept(&entity).flatten();
+                    let retractions = build_concept_retractions(
+                        &entity,
+                        &plan.retracted,
+                        plan.rest_retraction.as_ref(),
+                        resolved.as_ref().map(|def| def.descriptor.concept()),
+                    )?;
+                    // A retraction-only body (no asserted fields)
+                    // emits no concept assertion — only the
+                    // retractions; its descriptor is an unemitted stub.
+                    let application = if plan.asserts_nothing {
+                        None
+                    } else {
+                        Some(concept_application(
+                            &plan.descriptor,
+                            &entity,
+                            name,
+                            transient,
+                        ))
+                    };
                     declared.insert(
                         pending.index,
                         DeclaredApplication {
                             application,
                             inline_attributes,
+                            retractions,
                         },
                     );
                 }
@@ -604,7 +704,10 @@ impl Graph {
                     })?;
                     scope.record_resolved_rule(entity, rule);
                 }
-                Need::Attribute { .. } | Need::AttributeByEntity { .. } => {}
+                // Resolved in Pass 1 (before declaration bodies emit).
+                Need::Attribute { .. }
+                | Need::AttributeByEntity { .. }
+                | Need::ConceptByEntity { .. } => {}
             }
         }
 
@@ -686,6 +789,13 @@ mod tests {
 
     impl Resolve for Counting {
         async fn concept(&self, _: &str) -> Result<Option<ConceptDefinition>, ResolveError> {
+            self.bump();
+            Ok(None)
+        }
+        async fn concept_by_entity(
+            &self,
+            _: &Entity,
+        ) -> Result<Option<ConceptDefinition>, ResolveError> {
             self.bump();
             Ok(None)
         }

--- a/rust/tonk-analyzer/src/analyzer/scope.rs
+++ b/rust/tonk-analyzer/src/analyzer/scope.rs
@@ -60,6 +60,15 @@ pub(crate) struct Scope {
     /// synchronously. A key present with no entry means the entity
     /// holds no installed rule (retracting something absent).
     pub(crate) resolved_rules: Mutex<HashMap<String, Option<Rule>>>,
+    /// Entity → [`ConceptDefinition`] read off the branch for a
+    /// `concept!:` field retraction (`with: { f: _ }` / `..: _`).
+    /// Populated by
+    /// [`record_resolved_concept`](Self::record_resolved_concept)
+    /// during the graph's resolve phase so the retract lowering reads
+    /// the stored fields synchronously. A key present with `None`
+    /// means the entity holds no concept (retracting from something
+    /// absent).
+    pub(crate) resolved_concepts: Mutex<HashMap<String, Option<ConceptDefinition>>>,
 }
 
 impl Scope {
@@ -73,6 +82,7 @@ impl Scope {
             in_doc_concepts_by_entity: Mutex::new(HashMap::new()),
             named_entities: Mutex::new(HashMap::new()),
             resolved_rules: Mutex::new(HashMap::new()),
+            resolved_concepts: Mutex::new(HashMap::new()),
         }
     }
 
@@ -229,5 +239,29 @@ impl Scope {
     /// nothing is installed at `entity`.
     pub(crate) fn record_resolved_rule(&self, entity: &Entity, rule: Option<Rule>) {
         self.resolved_rules.lock().insert(entity.to_string(), rule);
+    }
+
+    /// Sync lookup of a concept resolved off the branch for a field
+    /// retraction. `Some(Some(def))` is the stored concept;
+    /// `Some(None)` is a confirmed-absent entity; `None` means the
+    /// entity was never resolved.
+    pub(crate) fn resolved_concept(&self, entity: &Entity) -> Option<Option<ConceptDefinition>> {
+        self.resolved_concepts
+            .lock()
+            .get(&entity.to_string())
+            .cloned()
+    }
+
+    /// Record the concept resolved for a `concept!:` field retraction
+    /// so the retract lowering reads its stored fields synchronously.
+    /// `None` means no concept is stored at `entity`.
+    pub(crate) fn record_resolved_concept(
+        &self,
+        entity: &Entity,
+        concept: Option<ConceptDefinition>,
+    ) {
+        self.resolved_concepts
+            .lock()
+            .insert(entity.to_string(), concept);
     }
 }


### PR DESCRIPTION
Editing a concept used to be additive only. You could add a field to a stored concept, but there was no way to drop one: omitting a field from a `this:`-pinned `concept!:` body silently left the old `dialog.concept.with/<field>` fact behind, so the concept kept a field you thought you'd removed. This is the stale-field problem behind the legacy `tonk:binder` `active` field (BUG-20).

Since concept fields are just facts and `concept!:` is an assertion of the `concept` concept like any other head, the natural fix is to let `_` carry its usual retract meaning inside a concept body:

```
concept!:
  this: tonk:binder
  with:
    active: _      # retract the active field
```

`with: { f: _ }` / `maybe: { f: _ }` retract a named field; a top-level `..: _` retracts every field. We deliberately did NOT make concept assertion a diff-and-replace (omitting a field does not auto-retract it) so it stays consistent with every other assertion head.

The pinned concept is read off the branch to map each field to its relation; the field term is emitted blank so the evaluator dissociates whatever value the branch actually holds (the same machinery instance `..: _` already uses) rather than recomputing it. Retraction is strict: it must pin with `this: <uri>`, the concept must exist, and each named field must be present, else a clear `InvalidConceptBody` error. A `..:` nested inside `with:`/`maybe:` is rejected rather than silently misread as a field literally named `..`.

Verified end-to-end against the CLI (single-field retract, `..: _` retract-all, marker/other-field survival, and each strict-error case).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements for handling concept retractions in the `tonk-analyzer`. It adds support for recording and resolving concepts, alongside implementing necessary changes to the parsing and emission of concept bodies, specifically for retraction scenarios.

### Detailed summary
- Added `resolved_concepts` to `Scope` for tracking concepts during retractions.
- Introduced methods `resolved_concept` and `record_resolved_concept` for managing concept state.
- Updated `Resolved` trait with `concept_by_entity` for resolving concepts by entity URI.
- Enhanced `collect_concept_with_needs` to track retraction needs.
- Modified `Graph` to handle concept retractions during analysis.
- Updated `DeclaredApplication` to include retraction applications.
- Enhanced `ConceptBody` to manage retracted fields and rest retractions.
- Implemented `build_concept_retractions` to create retraction applications.
- Added tests for concept retraction scenarios, ensuring proper behavior and error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->