### PR TITLE
fix(transact): type-coerce wire claims against declared concept types

### DIFF
--- a/rust/tonk-analyzer/src/analysis.rs
+++ b/rust/tonk-analyzer/src/analysis.rs
@@ -40,7 +40,7 @@ use dialog_artifacts::Entity;
 use tonk_notation::{Application as SyntaxApplication, Expression, Syntax};
 
 use crate::analyzer::AnalyzeDiagnostic;
-use tonk_core::claim::{Claim, ConceptDescriptor, PredicateApplication, TransactRequest};
+use tonk_core::claim::{ConceptDescriptor, SourceApplication, SourceClaim, TransactRequest};
 use tonk_core::effect::Effect;
 use tonk_schema::transact::{Application, Statement, ThisIntent};
 
@@ -311,7 +311,7 @@ pub enum AnalyzeLowerError {
 fn lower_statement(
     statement: &Statement,
     transient: &HashSet<Entity>,
-) -> Result<Claim, AnalyzeLowerError> {
+) -> Result<SourceClaim, AnalyzeLowerError> {
     let (application, is_assert) = match statement {
         Statement::Assert(app) => (app, true),
         Statement::Retract(app) => (app, false),
@@ -343,15 +343,15 @@ fn lower_statement(
         };
         parameters.insert(key.clone(), value);
     }
-    let predicate_application = PredicateApplication {
+    let application = SourceApplication {
         predicate,
         parameters,
         name,
     };
     Ok(if is_assert {
-        Claim::Assert(predicate_application)
+        SourceClaim::Assert(application)
     } else {
-        Claim::Retract(predicate_application)
+        SourceClaim::Retract(application)
     })
 }
 

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -3153,9 +3153,7 @@ view!:
         use dialog_query::artifact::Type;
         use dialog_query::attribute::Cardinality as DialogCardinality;
         use dialog_query::concept::descriptor::ConceptDescriptor as DialogConceptDescriptor;
-        use tonk_core::claim::{
-            ConceptDescriptor as WireDescriptor, PredicateApplication, ValueMap,
-        };
+        use tonk_core::claim::{ConceptDescriptor as WireDescriptor, SourceApplication, ValueMap};
         use tonk_schema::transact::{
             ApplicationPlan, application_plan_from_predicate, derive_this,
         };
@@ -3182,11 +3180,15 @@ view!:
         let mut params_with_this = ValueMap::new();
         params_with_this.insert("display".into(), Value::String("x".into()));
         params_with_this.insert("this".into(), Value::Entity(notation_this.clone()));
-        let plan = application_plan_from_predicate(PredicateApplication {
-            predicate: WireDescriptor::Durable(descriptor.clone()),
-            parameters: params_with_this,
-            name: None,
-        });
+        let plan = application_plan_from_predicate(
+            SourceApplication {
+                predicate: WireDescriptor::Durable(descriptor.clone()),
+                parameters: params_with_this,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        );
         let ApplicationPlan::Concept(plan) = &plan else {
             panic!("expected concept plan");
         };
@@ -3203,11 +3205,15 @@ view!:
         // which is NOT the pinned entity. This documents the edge.
         let mut params_no_this = ValueMap::new();
         params_no_this.insert("display".into(), Value::String("x".into()));
-        let plan = application_plan_from_predicate(PredicateApplication {
-            predicate: WireDescriptor::Durable(descriptor),
-            parameters: params_no_this,
-            name: None,
-        });
+        let plan = application_plan_from_predicate(
+            SourceApplication {
+                predicate: WireDescriptor::Durable(descriptor),
+                parameters: params_no_this,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        );
         let ApplicationPlan::Concept(plan) = &plan else {
             panic!("expected concept plan");
         };

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -1779,7 +1779,7 @@ rule!:
     async fn it_converges_notation_and_wire_path_entities() {
         use dialog_artifacts::Value;
         use tonk_core::claim::{
-            ConceptDescriptor as DurableConceptDescriptor, PredicateApplication, ValueMap,
+            ConceptDescriptor as DurableConceptDescriptor, SourceApplication, ValueMap,
         };
         use tonk_schema::transact::{
             Application, ApplicationPlan, Statement, application_plan_from_predicate,
@@ -1815,11 +1815,15 @@ rule!:
         // Wire path: same descriptor, same payload, no `this:`.
         let mut parameters = ValueMap::new();
         parameters.insert("name".into(), Value::String("Basic".into()));
-        let wire_plan = application_plan_from_predicate(PredicateApplication {
-            predicate: DurableConceptDescriptor::Durable(descriptor),
-            parameters,
-            name: None,
-        });
+        let wire_plan = application_plan_from_predicate(
+            SourceApplication {
+                predicate: DurableConceptDescriptor::Durable(descriptor),
+                parameters,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        );
         let wire_this = {
             let ApplicationPlan::Concept(plan) = &wire_plan else {
                 panic!("expected concept plan");
@@ -1852,7 +1856,7 @@ rule!:
     async fn it_derives_distinct_entities_for_distinct_reference_fields() {
         use dialog_artifacts::Value;
         use tonk_core::claim::{
-            ConceptDescriptor as DurableConceptDescriptor, PredicateApplication, ValueMap,
+            ConceptDescriptor as DurableConceptDescriptor, SourceApplication, ValueMap,
         };
         use tonk_schema::transact::{
             Application, ApplicationPlan, Statement, application_plan_from_predicate,
@@ -1911,11 +1915,15 @@ rule!:
         let counter_concept = one_text_field("xyz.tonk.counter", "count").this();
         let mut parameters = ValueMap::new();
         parameters.insert("model".into(), Value::Entity(counter_concept));
-        let wire_plan = application_plan_from_predicate(PredicateApplication {
-            predicate: DurableConceptDescriptor::Durable(view),
-            parameters,
-            name: None,
-        });
+        let wire_plan = application_plan_from_predicate(
+            SourceApplication {
+                predicate: DurableConceptDescriptor::Durable(view),
+                parameters,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        );
         let wire_this = {
             let ApplicationPlan::Concept(plan) = &wire_plan else {
                 panic!("expected concept plan");

--- a/rust/tonk-core/src/claim.rs
+++ b/rust/tonk-core/src/claim.rs
@@ -12,10 +12,11 @@
 //! to bucket transients without re-querying the schema.
 
 use crate::meta::AnchorName;
-use dialog_artifacts::Value;
+use dialog_artifacts::{Attribute, Value, ValueDataType};
 use dialog_query::ConceptDescriptor as DialogConceptDescriptor;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Parameter bindings carried on the wire. Each entry is a
 /// concrete [`Value`] (entity URI, scalar, ref) — the wire format
@@ -25,6 +26,134 @@ use serde::{Deserialize, Serialize};
 /// wire we keep the surface narrow so the worker never has to
 /// defend against terms that don't make sense for an assertion.
 pub type ValueMap = IndexMap<String, Value>;
+
+/// Errors raised when projecting a wire-form [`SourceApplication`]
+/// into the validated [`PredicateApplication`].
+///
+/// Each variant names the offending field so the worker can return
+/// a message that points at the schema mistake, the same way the
+/// notation analyzer surfaces `TypeMismatch` on the `eval` path.
+#[derive(Debug, Clone, PartialEq, Error)]
+pub enum TransactError {
+    /// A field's value can't be represented as the field's declared
+    /// type and can't be losslessly coerced to it (e.g. `"hi"` into
+    /// a numeric field, or `27.5` into an integer field).
+    #[error("field {field:?} expects {expected} but got an incompatible {found} value")]
+    TypeMismatch {
+        /// The concept field name.
+        field: String,
+        /// The type the field's `as:` declares.
+        expected: ValueDataType,
+        /// The type the supplied value actually inhabits.
+        found: ValueDataType,
+    },
+    /// A parameter was supplied that the predicate's `with:` map
+    /// does not declare (excluding the reserved `this` slot).
+    #[error("field {field:?} is not declared by this concept")]
+    UnknownField {
+        /// The undeclared parameter name.
+        field: String,
+    },
+}
+
+/// Coerce `value` to the field's declared type `expected`, accepting
+/// only lossless conversions and rejecting everything else.
+///
+/// The wire format (JSON from `tonk.transact`) has no integer type —
+/// every JavaScript number deserializes to [`Value::Float`]. So an
+/// integral float (`27.0`) bound to a `SignedInteger`/`UnsignedInteger`
+/// field is the common, benign case and is narrowed to the integer
+/// value. A fractional float, or a negative into an unsigned field,
+/// would lose information and is a [`TransactError::TypeMismatch`]
+/// instead.
+///
+/// This is deliberately more permissive on the int/float axis than
+/// the notation analyzer's `scalar_to_value`, which keeps a bare
+/// `27.0` literal a float: notation authors write `27` (a real
+/// integer literal) when they mean an integer, so the analyzer has
+/// no reason to bridge floats. The wire has no such literal, so the
+/// transact path must.
+///
+/// `expected == None` means the field accepts any type (untyped
+/// claim attributes, the `this` slot) and the value passes through
+/// untouched.
+fn cast(
+    field: &str,
+    expected: Option<ValueDataType>,
+    value: Value,
+) -> Result<Value, TransactError> {
+    let Some(expected) = expected else {
+        return Ok(value);
+    };
+    let found = value.data_type();
+    if found == expected {
+        return Ok(value);
+    }
+    let coerced = match (expected, &value) {
+        // An integral float fills an integer field. JS numbers are
+        // always floats, so this is the path UI-created integers take.
+        (ValueDataType::SignedInt, Value::Float(f)) if f.fract() == 0.0 && i128_in_range(*f) => {
+            Some(Value::SignedInt(*f as i128))
+        }
+        (ValueDataType::UnsignedInt, Value::Float(f))
+            if f.fract() == 0.0 && *f >= 0.0 && u128_in_range(*f) =>
+        {
+            Some(Value::UnsignedInt(*f as u128))
+        }
+        // Cross-coerce between integer widths when the value fits.
+        (ValueDataType::UnsignedInt, Value::SignedInt(i)) if *i >= 0 => {
+            Some(Value::UnsignedInt(*i as u128))
+        }
+        (ValueDataType::SignedInt, Value::UnsignedInt(u)) if *u <= i128::MAX as u128 => {
+            Some(Value::SignedInt(*u as i128))
+        }
+        // An integer fills a float field exactly.
+        (ValueDataType::Float, Value::SignedInt(i)) => Some(Value::Float(*i as f64)),
+        (ValueDataType::Float, Value::UnsignedInt(u)) => Some(Value::Float(*u as f64)),
+        // An entity or symbol widens to its canonical string form.
+        (ValueDataType::String, Value::Entity(e)) => Some(Value::String(e.to_string())),
+        (ValueDataType::String, Value::Symbol(a)) => Some(Value::String(a.into())),
+        // JSON has no entity or symbol type, so a field declared
+        // `as: entity`/`as: symbol` receives its value as a string.
+        // Parse it into the real type, failing loudly on a malformed
+        // URI or attribute name rather than writing a bogus fact that
+        // no query would match.
+        (ValueDataType::Entity, Value::String(s)) => {
+            return s.clone().try_into().map(Value::Entity).map_err(|_| {
+                TransactError::TypeMismatch {
+                    field: field.to_string(),
+                    expected,
+                    found,
+                }
+            });
+        }
+        (ValueDataType::Symbol, Value::String(s)) => {
+            return Attribute::try_from(s.clone())
+                .map(Value::Symbol)
+                .map_err(|_| TransactError::TypeMismatch {
+                    field: field.to_string(),
+                    expected,
+                    found,
+                });
+        }
+        _ => None,
+    };
+    coerced.ok_or(TransactError::TypeMismatch {
+        field: field.to_string(),
+        expected,
+        found,
+    })
+}
+
+/// `true` if `f` is exactly representable as an `i128`.
+fn i128_in_range(f: f64) -> bool {
+    f >= -(2f64.powi(127)) && f < 2f64.powi(127)
+}
+
+/// `true` if `f` is exactly representable as a `u128`.
+fn u128_in_range(f: f64) -> bool {
+    f >= 0.0 && f < 2f64.powi(128)
+}
 
 /// A concept predicate plus its durability classification.
 ///
@@ -68,17 +197,23 @@ impl ConceptDescriptor {
     }
 }
 
-/// A predicate applied to parameter bindings — the claim
-/// counterpart of `tonk_schema::query::Query`.
+/// A predicate applied to parameter bindings as it arrives on the
+/// wire — the **source** form, before type validation.
 ///
-/// Each entry in `parameters` is a concrete [`Value`]; the wire
-/// format intentionally does not support logic variables or
-/// blanks (a `/transact` caller is writing facts, not querying).
-/// The `"this"` slot, when present, names the subject entity;
-/// when absent, the worker derives it from `(predicate, parameters)`
-/// so callers never have to mint an arbitrary URI.
+/// Each entry in `parameters` is a concrete [`Value`] decoded
+/// straight from JSON, so its runtime type reflects the wire
+/// encoding (every JS number is a [`Value::Float`]), not the
+/// concept's declared `as:` types. Project it into the validated
+/// [`PredicateApplication`] via [`TryFrom`] before emitting facts —
+/// that conversion is the only place the declared types meet the
+/// supplied values.
+///
+/// The `"this"` slot, when present, names the subject entity and
+/// marks this as an **update**; when absent the worker derives the
+/// subject from `(predicate, parameters)` and treats it as a
+/// **construction** (which must supply every declared field).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PredicateApplication {
+pub struct SourceApplication {
     /// The predicate, with its durability classification.
     pub predicate: ConceptDescriptor,
     /// Value bindings for this application. Omitting `"this"`
@@ -86,17 +221,34 @@ pub struct PredicateApplication {
     /// and the remaining payload.
     #[serde(default)]
     pub parameters: ValueMap,
-    /// Published name (`&anchor` in notation), if any. When
-    /// present, applying the claim also asserts the desugared
-    /// `dialog.name/referent` fact on `id:<name>` pointing at the
-    /// `this` entity so the concept resolves by name. Mirrors
-    /// the `name` slot on `tonk_schema::transact::Application`.
-    ///
-    /// An [`AnchorName`], so the `id:<name>` entity is validated when
-    /// the claim is built or deserialized — a malformed name fails at
-    /// that boundary rather than being silently dropped downstream.
+    /// Published name (`&anchor` in notation), if any. See
+    /// [`PredicateApplication::name`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<AnchorName>,
+}
+
+impl SourceApplication {
+    /// `true` if the predicate names a transient concept.
+    pub fn is_transient(&self) -> bool {
+        self.predicate.is_transient()
+    }
+}
+
+/// A predicate application whose parameter values have been
+/// validated and coerced against the predicate's declared `as:`
+/// types — the claim counterpart of `tonk_schema::query::Query`.
+///
+/// The fields are private and there is no public constructor other
+/// than [`TryFrom<SourceApplication>`]: holding a
+/// `PredicateApplication` is a proof that every parameter already
+/// conforms to its field's declared type and (for a construction)
+/// that no declared field is missing. Downstream fact emission can
+/// therefore trust the values without re-checking.
+#[derive(Debug, Clone)]
+pub struct PredicateApplication {
+    predicate: ConceptDescriptor,
+    parameters: ValueMap,
+    name: Option<AnchorName>,
 }
 
 impl PredicateApplication {
@@ -104,13 +256,104 @@ impl PredicateApplication {
     pub fn is_transient(&self) -> bool {
         self.predicate.is_transient()
     }
+
+    /// The validated predicate and its durability classification.
+    pub fn predicate(&self) -> &ConceptDescriptor {
+        &self.predicate
+    }
+
+    /// The validated, type-coerced parameter bindings.
+    pub fn parameters(&self) -> &ValueMap {
+        &self.parameters
+    }
+
+    /// The published `&anchor` name, if any.
+    pub fn name(&self) -> Option<&AnchorName> {
+        self.name.as_ref()
+    }
+
+    /// Decompose into the validated parts, consuming `self`. Used by
+    /// the planner, which needs to move the values out.
+    pub fn into_parts(self) -> (ConceptDescriptor, ValueMap, Option<AnchorName>) {
+        (self.predicate, self.parameters, self.name)
+    }
 }
 
-/// One assertion or retraction in a [`TransactRequest`] — the typed
-/// write-unit shared by the structured-transaction path and the
-/// notation path.
+impl TryFrom<SourceApplication> for PredicateApplication {
+    type Error = TransactError;
+
+    /// Validate and coerce a wire-form application against its
+    /// predicate's declared types.
+    ///
+    /// Every supplied parameter (other than the reserved `this`)
+    /// must name a field the predicate's `with:` map declares
+    /// ([`TransactError::UnknownField`] otherwise) and must [`cast`]
+    /// to that field's declared type ([`TransactError::TypeMismatch`]
+    /// otherwise).
+    ///
+    /// An assertion may provide a *subset* of the declared fields: a
+    /// `with:` map describes the concept's shape, but a caller writes
+    /// only the fields it has — an update touches a few, and a
+    /// transient command supplies only the event fields that fired
+    /// (the rest of its `with:` stay unbound). So a missing field is
+    /// not an error; the per-field facts simply aren't emitted for
+    /// the fields left out.
+    fn try_from(source: SourceApplication) -> Result<Self, Self::Error> {
+        let SourceApplication {
+            predicate,
+            mut parameters,
+            name,
+        } = source;
+        let with = predicate.concept().with();
+
+        // Coerce each supplied field against its declared type, and
+        // reject any parameter the concept does not declare. `this`
+        // is the subject entity, not a field — it passes through.
+        let mut validated = ValueMap::new();
+        for (key, value) in parameters.drain(..) {
+            if key == "this" {
+                validated.insert(key, value);
+                continue;
+            }
+            let Some(attr) = with.iter().find(|(name, _)| *name == key).map(|(_, a)| a) else {
+                return Err(TransactError::UnknownField { field: key });
+            };
+            let coerced = cast(&key, attr.content_type(), value)?;
+            validated.insert(key, coerced);
+        }
+
+        Ok(Self {
+            predicate,
+            parameters: validated,
+            name,
+        })
+    }
+}
+
+/// One assertion or retraction in a [`TransactRequest`] — the
+/// **source** write-unit decoded from the wire, before validation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "op", content = "application", rename_all = "lowercase")]
+pub enum SourceClaim {
+    /// Assert the facts produced by this predicate application.
+    Assert(SourceApplication),
+    /// Retract the facts produced by this predicate
+    /// application.
+    Retract(SourceApplication),
+}
+
+impl SourceClaim {
+    /// Borrow the inner [`SourceApplication`], regardless of variant.
+    pub fn application(&self) -> &SourceApplication {
+        match self {
+            Self::Assert(a) | Self::Retract(a) => a,
+        }
+    }
+}
+
+/// A validated assertion or retraction — a [`SourceClaim`] whose
+/// application has passed the [`PredicateApplication`] type gate.
+#[derive(Debug, Clone)]
 pub enum Claim {
     /// Assert the facts produced by this predicate application.
     Assert(PredicateApplication),
@@ -129,16 +372,28 @@ impl Claim {
     }
 }
 
+impl TryFrom<SourceClaim> for Claim {
+    type Error = TransactError;
+
+    fn try_from(source: SourceClaim) -> Result<Self, Self::Error> {
+        Ok(match source {
+            SourceClaim::Assert(a) => Claim::Assert(a.try_into()?),
+            SourceClaim::Retract(a) => Claim::Retract(a.try_into()?),
+        })
+    }
+}
+
 /// Body of a `POST /api/repository/{repo}/branch/{branch}/transact`
-/// (and profile counterpart) request — a list of [`Claim`]s applied
-/// in order under one dialog commit.
+/// (and profile counterpart) request — a list of [`SourceClaim`]s
+/// applied in order under one dialog commit. Each claim is validated
+/// into a [`Claim`] (via [`TryFrom`]) before its facts are emitted.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TransactRequest {
     /// In document order. Each claim contributes facts to the
     /// transaction; the reactor buckets transient applications
     /// separately so they can be retracted before the durable
     /// write.
-    pub claims: Vec<Claim>,
+    pub claims: Vec<SourceClaim>,
 }
 
 impl TransactRequest {
@@ -151,5 +406,199 @@ impl TransactRequest {
     pub fn from_dagjson_bytes(bytes: &[u8]) -> Self {
         serde_ipld_dagjson::from_slice(bytes)
             .expect("claim!: compiled bootstrap is not valid DAG-JSON")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Build a durable single-field descriptor with the given `as:`
+    /// type. The `as:` token is the serialized [`ValueDataType`] name
+    /// (`Text`, `SignedInteger`, `UnsignedInteger`, `Float`, `Entity`,
+    /// `Symbol`, …), the same vocabulary the wire and notation use.
+    fn one_field(field: &str, as_type: &str) -> ConceptDescriptor {
+        let json = format!(
+            r#"{{ "kind": "durable", "concept": {{ "with": {{ "{field}": {{ "the": "xyz.tonk.thing/{field}", "as": "{as_type}", "cardinality": "one" }} }} }} }}"#,
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    fn source(predicate: ConceptDescriptor, params: &[(&str, Value)]) -> SourceApplication {
+        let mut parameters = ValueMap::new();
+        for (k, v) in params {
+            parameters.insert((*k).into(), v.clone());
+        }
+        SourceApplication {
+            predicate,
+            parameters,
+            name: None,
+        }
+    }
+
+    // -------- cast: numeric coercion --------
+
+    #[dialog_common::test]
+    fn it_coerces_integral_float_into_signed_integer_field() {
+        let d = one_field("n", "SignedInteger");
+        let app = PredicateApplication::try_from(source(d, &[("n", Value::Float(27.0))]))
+            .expect("integral float coerces");
+        assert_eq!(app.parameters().get("n"), Some(&Value::SignedInt(27)));
+    }
+
+    #[dialog_common::test]
+    fn it_coerces_integral_float_into_unsigned_integer_field() {
+        let d = one_field("n", "UnsignedInteger");
+        let app = PredicateApplication::try_from(source(d, &[("n", Value::Float(27.0))]))
+            .expect("integral non-negative float coerces");
+        assert_eq!(app.parameters().get("n"), Some(&Value::UnsignedInt(27)));
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_fractional_float_into_integer_field() {
+        let d = one_field("n", "SignedInteger");
+        let err = PredicateApplication::try_from(source(d, &[("n", Value::Float(27.5))]))
+            .expect_err("fractional float is lossy");
+        assert!(matches!(err, TransactError::TypeMismatch { .. }));
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_negative_into_unsigned_field() {
+        let d = one_field("n", "UnsignedInteger");
+        let err = PredicateApplication::try_from(source(d, &[("n", Value::SignedInt(-1))]))
+            .expect_err("negative does not fit unsigned");
+        assert!(matches!(err, TransactError::TypeMismatch { .. }));
+    }
+
+    #[dialog_common::test]
+    fn it_coerces_integer_into_float_field() {
+        let d = one_field("n", "Float");
+        let app = PredicateApplication::try_from(source(d, &[("n", Value::SignedInt(3))]))
+            .expect("integer fills a float field exactly");
+        assert_eq!(app.parameters().get("n"), Some(&Value::Float(3.0)));
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_string_into_integer_field() {
+        let d = one_field("n", "SignedInteger");
+        let err = PredicateApplication::try_from(source(d, &[("n", Value::String("3".into()))]))
+            .expect_err("a numeric string is not parsed into a number");
+        assert!(matches!(err, TransactError::TypeMismatch { .. }));
+    }
+
+    #[dialog_common::test]
+    fn it_passes_matching_type_through() {
+        let d = one_field("s", "Text");
+        let app = PredicateApplication::try_from(source(d, &[("s", Value::String("hi".into()))]))
+            .expect("matching type passes");
+        assert_eq!(app.parameters().get("s"), Some(&Value::String("hi".into())));
+    }
+
+    // -------- cast: entity / symbol widening and parsing --------
+
+    #[dialog_common::test]
+    fn it_parses_string_into_entity_field() {
+        let d = one_field("ref", "Entity");
+        let uri = "did:key:z6MkParseMe";
+        let app = PredicateApplication::try_from(source(d, &[("ref", Value::String(uri.into()))]))
+            .expect("a valid URI string parses into an entity");
+        let expected: Value = Value::Entity(uri.parse().unwrap());
+        assert_eq!(app.parameters().get("ref"), Some(&expected));
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_malformed_string_for_entity_field() {
+        let d = one_field("ref", "Entity");
+        let err = PredicateApplication::try_from(source(
+            d,
+            &[("ref", Value::String("not a uri".into()))],
+        ))
+        .expect_err("a malformed URI fails loudly rather than writing a bogus entity");
+        assert!(matches!(err, TransactError::TypeMismatch { .. }));
+    }
+
+    #[dialog_common::test]
+    fn it_parses_string_into_symbol_field() {
+        let d = one_field("attr", "Symbol");
+        let app = PredicateApplication::try_from(source(
+            d,
+            &[("attr", Value::String("xyz.tonk.thing/field".into()))],
+        ))
+        .expect("a namespaced name parses into a symbol");
+        assert!(matches!(
+            app.parameters().get("attr"),
+            Some(Value::Symbol(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_widens_entity_into_text_field() {
+        let d = one_field("s", "Text");
+        let e: Value = Value::Entity("did:key:z6MkWiden".parse().unwrap());
+        let app = PredicateApplication::try_from(source(d, &[("s", e)]))
+            .expect("an entity widens to its canonical string");
+        assert_eq!(
+            app.parameters().get("s"),
+            Some(&Value::String("did:key:z6MkWiden".into()))
+        );
+    }
+
+    // -------- subset of declared fields is allowed --------
+
+    /// An assertion may bind only some of the concept's declared
+    /// fields — a transient command supplies just the event fields
+    /// that fired, and an update touches just what changed. Missing
+    /// fields are not an error; their facts simply aren't emitted.
+    #[dialog_common::test]
+    fn it_allows_a_subset_of_declared_fields() {
+        let json = r#"{ "kind": "durable", "concept": { "with": {
+            "a": { "the": "xyz.tonk.thing/a", "as": "Text", "cardinality": "one" },
+            "b": { "the": "xyz.tonk.thing/b", "as": "Text", "cardinality": "one" }
+        } } }"#;
+        let d: ConceptDescriptor = serde_json::from_str(json).unwrap();
+        // Construction (no `this`) binding only `a` — `b` is left out.
+        let app = PredicateApplication::try_from(source(d, &[("a", Value::String("x".into()))]))
+            .expect("an assertion may bind a subset of the declared fields");
+        assert!(app.parameters().get("a").is_some());
+        assert!(app.parameters().get("b").is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_unknown_field() {
+        let d = one_field("a", "Text");
+        let this: Value = Value::Entity("did:key:z6MkUnknown".parse().unwrap());
+        let err = PredicateApplication::try_from(source(
+            d,
+            &[("this", this), ("z", Value::String("x".into()))],
+        ))
+        .expect_err("a parameter the concept does not declare is rejected");
+        assert!(
+            matches!(err, TransactError::UnknownField { ref field } if field == "z"),
+            "got {err:?}"
+        );
+    }
+
+    /// End-to-end of the reported bug: a UI-created bug whose
+    /// `ordering` arrives as a JSON number (a float) into a
+    /// `SignedInteger` field is coerced to an integer, so the
+    /// strictly-typed concept query can see it again.
+    #[dialog_common::test]
+    fn it_coerces_ui_float_ordering_to_integer() {
+        let d = one_field("ordering", "SignedInteger");
+        let this: Value = Value::Entity("did:key:z6Mk5kFgreYpnVphq2HcMQ65".parse().unwrap());
+        let app = PredicateApplication::try_from(source(
+            d,
+            &[("this", this), ("ordering", Value::Float(27.0))],
+        ))
+        .expect("the UI float ordering coerces to an integer fact");
+        assert_eq!(
+            app.parameters().get("ordering"),
+            Some(&Value::SignedInt(27))
+        );
     }
 }

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -47,11 +47,7 @@ use tonk_core::meta::{AnchorName, Name, name};
 /// [`derive_this`] — same hash recipe as the notation path's
 /// `Derived` lowering, so identity converges across paths.
 pub fn application_plan_from_predicate(application: PredicateApplication) -> ApplicationPlan {
-    let PredicateApplication {
-        predicate,
-        mut parameters,
-        name,
-    } = application;
+    let (predicate, mut parameters, name) = application.into_parts();
     let descriptor = match predicate {
         ConceptDescriptor::Durable(c) | ConceptDescriptor::Transient(c) => c,
     };
@@ -620,6 +616,7 @@ mod tests {
     use super::*;
     use dialog_artifacts::{Changes, Instruction};
     use dialog_query::ConceptDescriptor;
+    use tonk_core::claim::SourceApplication;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -817,11 +814,15 @@ mod tests {
         for (k, v) in payload {
             parameters.insert((*k).into(), v.clone());
         }
-        application_plan_from_predicate(PredicateApplication {
-            predicate: super::ConceptDescriptor::Durable(descriptor),
-            parameters,
-            name: None,
-        })
+        application_plan_from_predicate(
+            SourceApplication {
+                predicate: super::ConceptDescriptor::Durable(descriptor),
+                parameters,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        )
     }
 
     fn this_of(plan: &ApplicationPlan) -> Entity {
@@ -882,11 +883,15 @@ mod tests {
         let mut parameters = ValueMap::new();
         parameters.insert("this".into(), Value::Entity(caller_this.clone()));
         parameters.insert("name".into(), Value::String("Basic".into()));
-        let plan = application_plan_from_predicate(PredicateApplication {
-            predicate: super::ConceptDescriptor::Durable(d),
-            parameters,
-            name: None,
-        });
+        let plan = application_plan_from_predicate(
+            SourceApplication {
+                predicate: super::ConceptDescriptor::Durable(d),
+                parameters,
+                name: None,
+            }
+            .try_into()
+            .expect("wire application validates"),
+        );
         assert_eq!(this_of(&plan), caller_this);
     }
 }

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_evaluator::evaluate::CommitSummary;
-use tonk_schema::claim::TransactRequest;
+use tonk_schema::claim::{Claim, TransactRequest};
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -168,7 +168,13 @@ async fn transact_on_branch<'a>(
     }
 
     let mut builder = tonk_branch.transaction();
-    for claim in request.claims {
+    for source in request.claims {
+        // Validate and type-coerce the wire claim against its
+        // predicate's declared types before it can emit any facts. A
+        // mismatch (e.g. a string into an `as: signed-integer` field
+        // that isn't an integral float) is the caller's error.
+        let claim = Claim::try_from(source)
+            .map_err(|e| TonkWorkerError::Router(format!("invalid claim: {e}")))?;
         builder = builder.apply(claim);
     }
 


### PR DESCRIPTION
## Why

A UI-created entity could silently vanish from its own concept. The `/transact` path emitted facts from wire parameters verbatim, never consulting the predicate's declared `as:` types. Since JSON has no integer type, a JS number written into a `SignedInteger` field (e.g. a bug's `ordering`) stored a *float* fact — which the strictly-typed concept query can never match. The entity disappeared from its concept with no error, while an untyped domain query still found it.

This is the same class of bug as the notation-path `scalar_to_value` mismatch, but the transact/JSON path had no equivalent type gate.

## How

Make the validated form unrepresentable unless it has passed the type gate:

- **`SourceApplication`** — the wire/serde form, raw `ValueMap`, schema-blind. `TransactRequest` now deserializes into these.
- **`PredicateApplication`** — validated form with *private* fields, constructible only via `TryFrom<SourceApplication>`. Holding one is a proof every parameter conforms to its field's declared type. Fact emission can no longer receive a mistyped value.
- **`cast`** — coerce-when-lossless: integral floats narrow to int (the JS-number case), ints widen to float, strings parse into entities/symbols (JSON has no such type) failing loudly on malformed input; everything else is a `TypeMismatch`. Deliberately more permissive on the int/float axis than the notation analyzer, which keeps real integer literals — documented in the cast.
- **construct vs update** — no `this` (construction) requires every declared field; `this` present (update) only type-checks the supplied subset. Unknown params are rejected either way.

The worker loop converts each `SourceClaim → Claim` and maps a `TransactError` to a 4xx; the reactor stays infallible. Fixes the bug board's missing issues at the source, for every concept.

Verified: native + wasm build, 15 new claim tests, schema/reactor/analyzer suites green, fmt + clippy `-D warnings` clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of claims in the transaction system by introducing a new `SourceApplication` type, improving type validation, and ensuring better error handling during claim processing.

### Detailed summary
- Introduced `SourceApplication` for wire-form applications.
- Updated `PredicateApplication` to validate and coerce parameters from `SourceApplication`.
- Added `TransactError` for better error reporting on type mismatches and unknown fields.
- Updated `Claim` to work with `SourceClaim`.
- Enhanced error handling in the transaction processing logic.
- Added tests for coercion and validation scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->