### PR TITLE
fix: sealed-guest sharing and blank-canvas invite minting

### DIFF
--- a/rust/tonk-cli/src/share.rs
+++ b/rust/tonk-cli/src/share.rs
@@ -533,6 +533,14 @@ async fn prepare_share(
             branch: site::BRANCH_NAME.to_owned(),
         });
     }
+    // The upstream may have advanced since our last sync — a member
+    // joining writes a membership commit, for instance — which would
+    // make a bare push fail non-fast-forward. Pull-before-push
+    // reconciles first, mirroring `tonk eval`'s auto-sync. Best-effort:
+    // a pull failure still lets the push run and surface the real error.
+    if let Err(e) = sync::pull(site).await {
+        eprintln!("warning: pull before share failed: {e}");
+    }
     sync::push(site).await.map_err(ShareError::PushFailed)?;
     Ok(remote_record)
 }

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -155,7 +155,7 @@ view!:
         <tonk-page onmount=tonk:invite data-invite="tonk:invite"></tonk-page>
         <tonk-origin>
           <tonk-display
-            bind:subject="entity"
+            entity={subject}
             bind:base="data-base"
             model=tonk:agent-invite
             data-page="this repo">

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1332,6 +1332,18 @@ fn mount_portal_slide(host: &Element, inner: &Inner, display: &str) -> Option<Sl
     })
 }
 
+/// Marker attribute stamped on a `<tonk-display>` host once its event
+/// delegate is installed — the persistent, queryable twin of the one-shot
+/// `tonk-display:bound` event. A `<tonk-page onmount=…>` whose command is
+/// handled by this display's delegate reads it to learn the delegate is
+/// listening, so it can fire `mount` even if it connected (or reconnected
+/// across a view reconcile) *after* the announcement and missed the event.
+/// Cleared while a fresh delegate refresh is pending, so it never reads
+/// ready during the async descriptor-resolve window. This is a DOM contract
+/// shared with `<tonk-page>` in the `tonk-workspace` crate — keep the string
+/// in sync there.
+const BOUND_ATTR: &str = "data-bound";
+
 /// Walk the currently-mounted `<tonk-view>` slides, collect the
 /// distinct event types and concept names they reference via
 /// their `data-event-bindings` attribute, resolve each concept's
@@ -1352,6 +1364,12 @@ fn schedule_delegate_refresh(host: &Element, state: &Rc<RefCell<Inner>>) {
         s.delegate_generation = s.delegate_generation.wrapping_add(1);
         s.delegate_generation
     };
+    // A fresh delegate is about to be (re)built asynchronously; until the
+    // install completes the host is not ready to handle events. Drop the
+    // readiness marker now (synchronously) so a `<tonk-page>` reading it
+    // during the resolve window does not fire into a half-installed
+    // delegate. The settling refresh re-stamps it on install.
+    let _ = host.remove_attribute(BOUND_ATTR);
     let host = host.clone();
     let state = state.clone();
     spawn_local(async move {
@@ -1469,6 +1487,12 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
     }
     s.delegate = Some(delegate);
     drop(s);
+
+    // Persist readiness as a queryable marker *before* announcing it, so a
+    // `<tonk-page>` that connects — or reconnects across a view reconcile —
+    // after this point can detect the delegate is installed without having
+    // caught the transient event below. See [`BOUND_ATTR`].
+    let _ = host.set_attribute(BOUND_ATTR, "");
 
     // The delegate's listeners are now attached. Announce it so any
     // mount-triggered element (e.g. `<tonk-page onmount=…>`) that

--- a/rust/tonk-workspace/src/page.rs
+++ b/rust/tonk-workspace/src/page.rs
@@ -43,13 +43,16 @@
 use custom_elements::CustomElement;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{CustomEvent, CustomEventInit, Event, HtmlElement, Url, window};
+use web_sys::{
+    CustomEvent, CustomEventInit, HtmlElement, MutationObserver, MutationObserverInit, Url, window,
+};
 
-/// Per-element state. Holds the `tonk-display:bound` listener (removed on
-/// disconnect) and a fired-once guard.
+/// Per-element state. Holds the `MutationObserver` watching the enclosing
+/// display's readiness marker (disconnected on disconnect) and its callback.
 #[derive(Default)]
 pub(crate) struct TonkPage {
-    bound_listener: Option<Closure<dyn FnMut(Event)>>,
+    observer: Option<MutationObserver>,
+    _callback: Option<Closure<dyn FnMut()>>,
 }
 
 impl CustomElement for TonkPage {
@@ -67,56 +70,61 @@ impl CustomElement for TonkPage {
     fn inject_children(&mut self, _this: &HtmlElement) {}
 
     fn connected_callback(&mut self, this: &HtmlElement) {
-        // Fire `mount` only once the host `<tonk-display>`'s event delegate
-        // is INSTALLED — not on raw connect. The delegate attaches its
-        // listeners asynchronously *after* the template renders (which is
-        // what mounts this element), so a `mount` fired on connect would
-        // hit no listener. The display announces install with
-        // `tonk-display:bound`; we wait for that, then fire once.
+        // Fire `mount` only once the `<tonk-display>` whose event delegate
+        // handles this page's `onmount` binding is actually listening —
+        // never on raw connect, when the delegate is still installing
+        // asynchronously (after the template renders) and a `mount` would
+        // hit no listener.
         //
-        // Chrome mounts before its delegate binds, so this ordering always
-        // holds for a `<tonk-page>` inside a view.
+        // That handler is the nearest ancestor `<tonk-display>`. It marks its
+        // delegate installed with a persistent `data-bound` attribute (see
+        // `DISPLAY_BOUND_ATTR`). We wait on that MARKER, not on the display's
+        // one-shot `tonk-display:bound` event: the event is fragile — it can
+        // fire before this element connects, or be missed when a view
+        // reconcile swaps the page across the announcement (the exact failure
+        // that stranded `onmount` forever). The marker is a persistent fact a
+        // `MutationObserver` cannot miss.
+        //
+        // So: check the marker synchronously on connect (it may already be
+        // set — e.g. we reconnected after the delegate installed), and
+        // otherwise observe the enclosing display until it appears.
+        // `try_fire_mount` fires only while the marker is present, and `fired`
+        // makes it exactly once.
         let host = this.clone();
-        // Fire-once guard, checked and set *before* dispatching `mount`.
-        // The page carries several `<tonk-display>`s, each announcing its
-        // own `tonk-display:bound`, and dispatching `mount` can synchronously
-        // trigger more renders/binds — so the listener can re-enter. Setting
-        // the flag first makes every re-entry an immediate no-op.
         let fired = std::rc::Rc::new(std::cell::Cell::new(false));
-        let listener = Closure::wrap(Box::new(move |_event: Event| {
-            if fired.replace(true) {
-                return;
-            }
-            if let Some(detail) = location_detail() {
-                dispatch_mount(&host, &detail);
-            }
-        }) as Box<dyn FnMut(Event)>);
 
-        // Listen on the document during the capture phase so we catch the
-        // `tonk-display:bound` event dispatched on the ancestor host (it
-        // does not bubble down).
-        if let Some(document) = window().and_then(|w| w.document()) {
-            let options = web_sys::AddEventListenerOptions::new();
-            options.set_capture(true);
-            let _ = document.add_event_listener_with_callback_and_add_event_listener_options(
-                "tonk-display:bound",
-                listener.as_ref().unchecked_ref(),
-                &options,
-            );
+        try_fire_mount(&host, &fired);
+        if fired.get() {
+            return;
         }
-        self.bound_listener = Some(listener);
+
+        let Some(display) = host.closest("tonk-display").ok().flatten() else {
+            return;
+        };
+        let callback = {
+            let host = host.clone();
+            let fired = fired.clone();
+            Closure::wrap(Box::new(move || {
+                try_fire_mount(&host, &fired);
+            }) as Box<dyn FnMut()>)
+        };
+        let Ok(observer) = MutationObserver::new(callback.as_ref().unchecked_ref()) else {
+            return;
+        };
+        let init = MutationObserverInit::new();
+        init.set_attributes(true);
+        init.set_attribute_filter(&js_sys::Array::of1(&JsValue::from_str(DISPLAY_BOUND_ATTR)));
+        let _ = observer.observe_with_options(&display, &init);
+
+        self.observer = Some(observer);
+        self._callback = Some(callback);
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
-        if let Some(listener) = self.bound_listener.take()
-            && let Some(document) = window().and_then(|w| w.document())
-        {
-            let _ = document.remove_event_listener_with_callback_and_bool(
-                "tonk-display:bound",
-                listener.as_ref().unchecked_ref(),
-                true,
-            );
+        if let Some(observer) = self.observer.take() {
+            observer.disconnect();
         }
+        self._callback = None;
     }
 }
 
@@ -203,6 +211,48 @@ fn set(object: &js_sys::Object, key: &str, value: &str) {
     let _ = js_sys::Reflect::set(object, &JsValue::from_str(key), &JsValue::from_str(value));
 }
 
+/// The persistent readiness marker a `<tonk-display>` stamps on its host
+/// once its event delegate is installed. DOM contract shared with
+/// `BOUND_ATTR` in the `tonk-display` crate — keep the string in sync.
+const DISPLAY_BOUND_ATTR: &str = "data-bound";
+
+/// Whether the nearest ancestor `<tonk-display>` — the one whose delegate
+/// handles this page's `onmount` binding — has installed its delegate, i.e.
+/// carries the readiness marker. `false` when there is no such ancestor
+/// (nothing would handle the command) or it has not bound yet.
+fn enclosing_display_ready(host: &HtmlElement) -> bool {
+    host.closest("tonk-display")
+        .ok()
+        .flatten()
+        .is_some_and(|display| display.has_attribute(DISPLAY_BOUND_ATTR))
+}
+
+/// Dispatch `mount` exactly once, and only after the enclosing display's
+/// delegate is ready to receive it. A no-op if already fired, if that
+/// display has not bound yet, or if the location can't be read — the marker
+/// observer will call again when the display's `data-bound` next changes.
+fn try_fire_mount(host: &HtmlElement, fired: &std::rc::Rc<std::cell::Cell<bool>>) {
+    if fired.get() {
+        return;
+    }
+    if !enclosing_display_ready(host) {
+        return;
+    }
+    if fired.replace(true) {
+        return;
+    }
+    // `mount` is a lifecycle signal — fire it once the enclosing display's
+    // delegate is ready. The location detail is best-effort: the top page and
+    // the `/join` flow carry a real URL, but inside a deeply nested sealed
+    // guest (the space view is `blob:null` inside `about:srcdoc`) the location
+    // is opaque and the host forwards no origin, so there is nothing to parse.
+    // The command bound here (e.g. `tonk:invite`) reads no `dom.event.detail`
+    // fields, so fire with an empty detail rather than stranding it — never
+    // firing was the bug that hung the "generating link" canvas.
+    let detail = location_detail().unwrap_or_default();
+    dispatch_mount(host, &detail);
+}
+
 /// Dispatch a bubbling `mount` `CustomEvent` carrying `detail` from `host`.
 fn dispatch_mount(host: &HtmlElement, detail: &js_sys::Object) {
     let init = CustomEventInit::new();
@@ -237,18 +287,28 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    /// A connected `<tonk-page>` fires `mount` only after the host's
-    /// delegate announces install via `tonk-display:bound` — NOT on raw
-    /// connect (the delegate isn't listening yet then). The mount event
-    /// bubbles and carries the parsed location.
+    /// Let queued `MutationObserver` microtasks flush before asserting.
+    async fn tick() {
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            let _ = window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
+        });
+        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+    }
+
+    /// A `<tonk-page>` fires `mount` once its enclosing `<tonk-display>` marks
+    /// its delegate installed (`data-bound`) — not on raw connect, when the
+    /// marker is still absent. The observer picks up the marker landing after
+    /// connect; the event bubbles and carries the parsed location.
     #[dialog_common::test]
-    async fn it_dispatches_mount_after_the_host_delegate_binds() {
+    async fn it_fires_when_the_display_marks_bound_after_connect() {
         register();
         let document = window().unwrap().document().unwrap();
         let body = document.body().unwrap();
 
-        // A wrapper to catch the bubbled event, like a <tonk-display> host.
-        let wrapper = document.create_element("div").unwrap();
+        // The enclosing display whose delegate would handle `onmount`.
+        let wrapper = document.create_element("tonk-display").unwrap();
         body.append_child(&wrapper).unwrap();
 
         let seen: std::rc::Rc<std::cell::RefCell<Option<js_sys::Object>>> =
@@ -268,21 +328,21 @@ mod tests {
         let page = document.create_element("tonk-page").unwrap();
         wrapper.append_child(&page).unwrap();
 
-        // Nothing yet — the page waits for the delegate-ready signal.
+        // Not on connect: the display hasn't marked its delegate ready.
         assert!(
             seen.borrow().is_none(),
-            "tonk-page must NOT fire mount on connect, before the delegate binds"
+            "tonk-page must NOT fire mount before its display marks bound"
         );
 
-        // The host's delegate announces it's installed.
-        wrapper
-            .dispatch_event(&CustomEvent::new("tonk-display:bound").unwrap())
-            .unwrap();
+        // The display installs its delegate: the marker lands. The page's
+        // observer picks it up on the next microtask.
+        wrapper.set_attribute(DISPLAY_BOUND_ATTR, "").unwrap();
+        tick().await;
 
         let detail = seen.borrow().clone();
         assert!(
             detail.is_some(),
-            "tonk-page must dispatch a bubbling mount event once the delegate binds"
+            "tonk-page must dispatch a bubbling mount once its display marks bound"
         );
         let detail = detail.unwrap();
 
@@ -304,6 +364,87 @@ mod tests {
                 .is_some(),
             "detail.searchParams should be a plain object",
         );
+
+        wrapper.remove();
+        drop(closure);
+    }
+
+    /// When the enclosing display is *already* marked bound at connect — the
+    /// marker predated this element, or a prior instance set it before a view
+    /// reconcile replaced the page — the page fires `mount` synchronously on
+    /// connect. This is the case the old event-only wait stranded.
+    #[dialog_common::test]
+    async fn it_fires_on_connect_when_the_display_is_already_bound() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let wrapper = document.create_element("tonk-display").unwrap();
+        wrapper.set_attribute(DISPLAY_BOUND_ATTR, "").unwrap();
+        body.append_child(&wrapper).unwrap();
+
+        let seen = std::rc::Rc::new(std::cell::Cell::new(0_u32));
+        let seen_cb = seen.clone();
+        let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |_event: Event| {
+            seen_cb.set(seen_cb.get() + 1);
+        }) as Box<dyn FnMut(Event)>);
+        wrapper
+            .add_event_listener_with_callback("mount", closure.as_ref().unchecked_ref())
+            .unwrap();
+
+        let page = document.create_element("tonk-page").unwrap();
+        wrapper.append_child(&page).unwrap();
+
+        assert_eq!(
+            seen.get(),
+            1,
+            "page must fire mount on connect when its display is already bound"
+        );
+
+        wrapper.remove();
+        drop(closure);
+    }
+
+    /// The page never fires while the marker is absent (a benign attribute
+    /// change is not the readiness signal), fires once the marker lands, and
+    /// then exactly once even as the marker toggles across a delegate rebuild.
+    #[dialog_common::test]
+    async fn it_fires_exactly_once_and_never_while_unmarked() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let wrapper = document.create_element("tonk-display").unwrap();
+        body.append_child(&wrapper).unwrap();
+
+        let seen = std::rc::Rc::new(std::cell::Cell::new(0_u32));
+        let seen_cb = seen.clone();
+        let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |_event: Event| {
+            seen_cb.set(seen_cb.get() + 1);
+        }) as Box<dyn FnMut(Event)>);
+        wrapper
+            .add_event_listener_with_callback("mount", closure.as_ref().unchecked_ref())
+            .unwrap();
+
+        let page = document.create_element("tonk-page").unwrap();
+        wrapper.append_child(&page).unwrap();
+
+        // A non-readiness attribute change must not fire mount.
+        wrapper.set_attribute("data-state", "loading").unwrap();
+        tick().await;
+        assert_eq!(seen.get(), 0, "no fire while the readiness marker is absent");
+
+        // Marker lands -> fires once.
+        wrapper.set_attribute(DISPLAY_BOUND_ATTR, "").unwrap();
+        tick().await;
+        assert_eq!(seen.get(), 1, "fires once the display marks bound");
+
+        // Marker clears then re-lands (a delegate rebuild) -> still once.
+        wrapper.remove_attribute(DISPLAY_BOUND_ATTR).unwrap();
+        tick().await;
+        wrapper.set_attribute(DISPLAY_BOUND_ATTR, "").unwrap();
+        tick().await;
+        assert_eq!(seen.get(), 1, "mount must fire exactly once");
 
         wrapper.remove();
         drop(closure);

--- a/rust/tonk-workspace/src/page.rs
+++ b/rust/tonk-workspace/src/page.rs
@@ -432,7 +432,11 @@ mod tests {
         // A non-readiness attribute change must not fire mount.
         wrapper.set_attribute("data-state", "loading").unwrap();
         tick().await;
-        assert_eq!(seen.get(), 0, "no fire while the readiness marker is absent");
+        assert_eq!(
+            seen.get(),
+            0,
+            "no fire while the readiness marker is absent"
+        );
 
         // Marker lands -> fires once.
         wrapper.set_attribute(DISPLAY_BOUND_ATTR, "").unwrap();


### PR DESCRIPTION
Three independent fixes to the blank-canvas / sealed-guest sharing flow.

  ### `tonk share`: pull before push
  Share flavours pushed to the upstream without pulling first, so a share
  whose upstream had advanced since the last sync failed non-fast-forward.
  This bites routinely after a member joins — the join writes a membership
  commit, leaving the sharer's branch diverged, and the next `tonk share
  display` aborts with a push error. `prepare_share` now pulls before
  pushing (mirroring `tonk eval`'s auto-sync). Best-effort: a pull failure
  still lets the push run and surface the real error.

  ### onmount invite in nested sealed guests
  The blank canvas hung on "generating link" because `<tonk-page
  onmount=tonk:invite>` never dispatched its `mount` event, so the invite
  was never minted and `tonk:agent-invite` could not resolve. Two causes:

  1. The page waited for the enclosing display's one-shot
     `tonk-display:bound` event, which it missed when a view reconcile
     swapped the page across the (late, async) announcement.
  2. Even once ready, it refused to fire because `location_detail()`
     returns `None` in a deeply nested sealed guest (`blob:null` inside
     `about:srcdoc`), where the location is opaque and no origin is forwarded.

  Delegate readiness is now a persistent, queryable `data-bound` marker on
  the `<tonk-display>` host that `<tonk-page>` checks on connect and watches
  via a `MutationObserver` — immune to the missed event. `mount` always
  fires with best-effort location detail: `tonk:invite` reads no
  `dom.event.detail` fields, so an empty detail in a nested guest is fine,
  while the `/join` flow still runs where the URL is readable.

  ### template agent-invite entity from {subject}
  Bind the blank canvas's agent-invite display to the repo subject via
  `entity={subject}` (templated from the blank concept's
  `dialog.origin/subject` field) instead of the `<tonk-origin>` runtime
  `bind:subject="entity"`. Resolves to the same subject entity with one
  fewer moving part.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the event handling mechanism for the `tonk-display` and `tonk-page` components, ensuring that the lifecycle events are fired at the correct times based on the installation status of event delegates.

### Detailed summary
- Changed `entity` binding in `core.yaml`.
- Added comments in `share.rs` regarding synchronization before push operations.
- Introduced a `BOUND_ATTR` constant in `element.rs` to manage event delegate readiness.
- Updated delegate refresh logic to remove readiness markers during async operations.
- Implemented `DISPLAY_BOUND_ATTR` in `page.rs` for persistent readiness tracking.
- Modified event handling in `connected_callback` to use `MutationObserver` for detecting delegate readiness.
- Added tests to verify correct firing of `mount` events based on `tonk-display` state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->