### PR TITLE
fix(sync): pull for an idle space via an idle-time poll (BUG-36)

### DIFF
--- a/plan/sw-driven-sync.md
+++ b/plan/sw-driven-sync.md
@@ -20,9 +20,50 @@ already sees every commit and knows which branches are open) and leaves the
 page responsible only for the *when* it cannot supply itself: the pull
 heartbeat. Pushes are self-driven SW-side via `event.waitUntil`.
 
+## Revision — as shipped (BUG-36)
+
+The original design below assumed *ordinary request traffic IS the heartbeat*:
+`on_fetch` schedules a debounced drain for every request, so a live tab keeps
+pulling for free. Two things about the shipped system broke that premise, and
+the fix restores it:
+
+1. **A booted, idle space makes no fetches.** The `/space` route renders in a
+   sealed guest whose data-plane (query/subscribe/transact) is relayed to the
+   top-page `<tonk-host>`, which *does* issue real `fetch`es (so they DO hit
+   `on_fetch` and DO schedule a drain — the relay is not the problem). But once
+   boot settles, the tab holds only long-lived SSE subscriptions and issues no
+   *new* fetch. No fetch → no scheduled drain → upstream edits never pull. This
+   is exactly the "idle backstop" the original design flagged and left open.
+
+2. **The heartbeat that would have covered it was dead.** The in-page 20s
+   interval only mounted from the now-orphaned `TonkSpaceSealed` path.
+
+**Shipped fix:**
+
+- **`POST /api/sync` exists but does NO work of its own.** It is a cheap request
+  whose *only* purpose is to be a fetch the SW's `on_fetch` hooks — so reaching
+  it schedules the standard debounced, generation-ticketed drain. The handler
+  returns `200` and does NOT call `drain_sync` (that would fire a second,
+  un-debounced drain and stack it). The poll thus **participates in the existing
+  scheduling machinery** rather than forcing a sync.
+- **The top-page `<tonk-host>` runs an idle poll loop** (`idle_sync.rs`):
+  `requestIdleCallback` re-arming every ~1s (2× the SW debounce) fires `POST
+  /api/sync`; it also polls immediately on `visibilitychange→visible` and
+  `online`. A hidden tab self-throttles (browsers cap `requestIdleCallback` to
+  ~1/10s when hidden), so no explicit visibility gating; Safari (no
+  `requestIdleCallback`) falls back to `setTimeout`. Only the top-page host
+  installs it — the sealed guest's proxy host relays up, so one loop per tab.
+- **`SYNC_DEBOUNCE_MS` lowered 2000 → 500** so reactive pulls feel near-immediate;
+  it is now the real rate-limiter on drain frequency.
+- **Background Sync tag collapsed to a bare `"sync"`.** `onsync` drains the whole
+  queue regardless of tag, so the per-repo `tonk-sync:{repo}` identity (and
+  `repo_from_sync_tag` / `SYNC_TAG_PREFIX`) is gone. `onsync` is a discrete OS
+  event with no fetch to hook, so it still calls `drain_sync` directly — the one
+  path that legitimately drains without the debounce.
+
 ## Design
 
-### Split of responsibility (revised — no poke endpoint, no page heartbeat)
+### Split of responsibility (revised — no poll endpoint, no page heartbeat)
 
 The page needs no sync responsibility at all. Every request the page already
 makes (query, subscribe, navigation, transact) flows through the SW's
@@ -37,13 +78,13 @@ makes (query, subscribe, navigation, transact) flows through the SW's
   push AND pull. A burst of boot queries collapses into one drain via the
   debounce; an idle drain (nothing dirty, all up to date) is just a cheap
   fetch+classify per open branch.
-- **No `POST /api/sync` poke endpoint, no sync-specific page machinery.** The
+- **No `POST /api/sync` poll endpoint, no sync-specific page machinery.** The
   page makes requests; that's the cadence. The Background Sync registration
   stays as the tab-closed backstop (fires the same drain).
 - **Idle backstop (not special).** A tab sitting with zero requests (no
   interaction, no live subscription traffic) would never trigger a drain, so
   upstream changes wouldn't pull. So the page still needs *some* low-frequency
-  traffic — but NOT a dedicated sync poke: any ordinary periodic request works,
+  traffic — but NOT a dedicated sync poll: any ordinary periodic request works,
   because `on_fetch` schedules the drain for every request. Reuse an existing
   endpoint (e.g. a periodic `/api/.../sync/status` read the chip already wants,
   or a profile/identity ping) rather than inventing a sync-specific route. The
@@ -114,7 +155,7 @@ status route. The queue may still hold a paused branch; the drain no-ops it.
   spawned work settles.
 - On commit, the transact handler `.spawn`s a **debounced** push drain of the
   just-committed repo into the bucket. Debounce collapses an edit burst into one
-  push. This makes pushes survive the tab backgrounding without any page poke.
+  push. This makes pushes survive the tab backgrounding without any page poll.
 
 ### 2b. Per-branch incremental status (NOT gated on the whole drain)
 
@@ -143,7 +184,7 @@ waiting for every space in the drain to complete.
   `<tonk-host>` ancestor and not inside a sealed guest) — nested sealed-guest
   hosts relay up, so one heartbeat covers the page. Avoids N redundant timers
   across nested iframes.
-- No per-repo bookkeeping in the page. The poke is parameterless.
+- No per-repo bookkeeping in the page. The poll is parameterless.
 - Keep the Background Sync registration on commit (tab-close durability); its
   SW `sync` handler calls the same `drain_sync`.
 

--- a/rust/tonk-host/Cargo.toml
+++ b/rust/tonk-host/Cargo.toml
@@ -48,6 +48,7 @@ web-sys = { workspace = true, features = [
   "RequestInit",
   "Response",
   "ServiceWorkerContainer",
+  "VisibilityState",
   "Window",
 ] }
 

--- a/rust/tonk-host/src/host.rs
+++ b/rust/tonk-host/src/host.rs
@@ -15,6 +15,7 @@ use std::rc::Rc;
 use custom_elements::CustomElement;
 use web_sys::{HtmlElement, window};
 
+use crate::idle_sync::{self, IdleSync};
 use crate::navigate::{self, NavigateListener};
 use crate::ops::{self, InstalledListener};
 use crate::query_cache::QueryCache;
@@ -55,6 +56,10 @@ pub(crate) struct TonkHost {
     /// `navigator.serviceWorker` `message` listener that performs
     /// worker-requested navigations (the main-thread navigate provider).
     navigate: RefCell<Option<NavigateListener>>,
+    /// Idle sync heartbeat: polls `POST /api/sync` on a `requestIdleCallback`
+    /// loop (and on refocus/reconnect) so an idle tab still pulls upstream
+    /// changes. Only the top-page host installs it.
+    idle_sync: RefCell<Option<IdleSync>>,
 }
 
 impl CustomElement for TonkHost {
@@ -77,6 +82,9 @@ impl CustomElement for TonkHost {
         // ask the page to redirect by posting `{ type: "navigate", href }`
         // to its client, and this listener performs it.
         *self.navigate.borrow_mut() = navigate::install();
+        // Install the idle sync heartbeat so an idle tab keeps pulling upstream
+        // changes even when it makes no other requests.
+        *self.idle_sync.borrow_mut() = idle_sync::install();
     }
 
     fn disconnected_callback(&mut self, this: &HtmlElement) {
@@ -84,6 +92,9 @@ impl CustomElement for TonkHost {
         ops::detach_all(this, &listeners);
         if let Some(navigate) = self.navigate.borrow_mut().take() {
             navigate.remove();
+        }
+        if let Some(idle_sync) = self.idle_sync.borrow_mut().take() {
+            idle_sync.remove();
         }
         if let Some(state) = self.state.borrow_mut().take() {
             let mut s = state.borrow_mut();

--- a/rust/tonk-host/src/idle_sync.rs
+++ b/rust/tonk-host/src/idle_sync.rs
@@ -1,0 +1,181 @@
+//! Idle sync heartbeat for the top-page `<tonk-host>`.
+//!
+//! The service worker pulls upstream changes as a side effect of ordinary
+//! request traffic: every `fetch` through its `on_fetch` schedules a debounced
+//! drain. That premise holds while the page keeps making requests — but a space
+//! that has finished booting and is only holding open SSE subscriptions makes no
+//! *new* fetch, so no drain re-fires and remote edits never arrive.
+//!
+//! This closes that gap. While the tab is open it polls `POST /api/sync` on a
+//! `requestIdleCallback` loop (re-arming every [`IDLE_REARM_MS`]), so an idle
+//! viewer still pulls. It also polls immediately when the tab becomes visible
+//! or comes back online, so a refocus reconciles at once rather than waiting for
+//! the next tick. The poll does no work server-side — `/api/sync` returns `200`
+//! and the drain is scheduled by `on_fetch` seeing the request — so each poll
+//! participates in the SW's own debounce/coalescing rather than forcing a sync.
+//!
+//! `requestIdleCallback` is throttled to ~one call / 10s on a hidden tab (per
+//! spec), so a backgrounded tab self-limits without any explicit gating. Where
+//! `requestIdleCallback` is unavailable (Safari) it falls back to `setTimeout`.
+//!
+//! Only the real top-page `<tonk-host>` installs this. The sealed guest runs a
+//! proxy host that relays over `window.tonk`; its fetches already reach the top
+//! page (and thus `on_fetch`) through the bridge, so one heartbeat per tab is
+//! enough.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{RequestInit, VisibilityState, window};
+
+/// The parameterless drain endpoint every poll hits.
+const SYNC_ENDPOINT: &str = "/api/sync";
+
+/// How long after an idle poll before arming the next one, on a visible tab.
+/// Twice the SW drain debounce: the debounce is the real rate-limiter, this
+/// just keeps the pump primed.
+const IDLE_REARM_MS: i32 = 1_000;
+
+/// A handle owning the installed idle-sync listeners and loop. Dropping it (or
+/// calling [`remove`](IdleSync::remove)) stops the `requestIdleCallback` loop
+/// and detaches the `visibilitychange` / `online` listeners.
+pub(crate) struct IdleSync {
+    /// Flips true on teardown; the self-rescheduling idle loop checks it and
+    /// stops instead of arming another callback.
+    disposed: Rc<Cell<bool>>,
+    /// Kept alive so the listeners stay registered; detached in [`remove`].
+    visibility: Closure<dyn FnMut()>,
+    online: Closure<dyn FnMut()>,
+}
+
+impl IdleSync {
+    /// Detach the event listeners and stop the idle loop.
+    pub(crate) fn remove(self) {
+        self.disposed.set(true);
+        if let Some(win) = window() {
+            let doc = win.document();
+            if let Some(doc) = doc {
+                let _ = doc.remove_event_listener_with_callback(
+                    "visibilitychange",
+                    self.visibility.as_ref().unchecked_ref(),
+                );
+            }
+            let _ = win.remove_event_listener_with_callback(
+                "online",
+                self.online.as_ref().unchecked_ref(),
+            );
+        }
+    }
+}
+
+/// Fire one `POST /api/sync`, fire-and-forget. Failures are ignored: a missed
+/// poll just means the next one (or ordinary traffic) reconciles.
+fn poll() {
+    let Some(win) = window() else { return };
+    let init = RequestInit::new();
+    init.set_method("POST");
+    let _ = win.fetch_with_str_and_init(SYNC_ENDPOINT, &init);
+}
+
+/// Arm the next idle poll via `requestIdleCallback`, re-arming itself until the
+/// host is disposed. Falls back to `setTimeout` where `requestIdleCallback` is
+/// absent (Safari). Re-scheduling from inside the callback keeps exactly one
+/// pending poll in flight; successive idle polls are spaced by
+/// [`IDLE_REARM_MS`] so a visible idle tab doesn't busy-loop.
+fn arm(disposed: Rc<Cell<bool>>) {
+    if disposed.get() {
+        return;
+    }
+    let Some(win) = window() else { return };
+
+    let disposed_for_cb = disposed.clone();
+    let callback = Closure::once_into_js(move || {
+        if disposed_for_cb.get() {
+            return;
+        }
+        poll();
+        // Space the next idle poll by IDLE_REARM_MS, then arm another idle
+        // callback. `requestIdleCallback` can fire back-to-back on a busy
+        // visible tab, so this timer is what bounds the idle cadence.
+        if let Some(win) = window() {
+            let disposed = disposed_for_cb.clone();
+            let next = Closure::once_into_js(move || arm(disposed));
+            let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+                next.unchecked_ref(),
+                IDLE_REARM_MS,
+            );
+        }
+    });
+
+    // `requestIdleCallback` isn't in web-sys; reach it off `window` and fall
+    // back to a `setTimeout` on the same cadence where it's missing.
+    let ric = js_sys::Reflect::get(&win, &JsValue::from_str("requestIdleCallback")).ok();
+    let scheduled = match ric {
+        Some(f) if f.is_function() => js_sys::Reflect::apply(
+            f.unchecked_ref(),
+            &win,
+            &js_sys::Array::of1(callback.unchecked_ref()),
+        )
+        .is_ok(),
+        _ => false,
+    };
+
+    if !scheduled {
+        let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+            callback.unchecked_ref(),
+            IDLE_REARM_MS,
+        );
+    }
+}
+
+/// Install the idle-sync heartbeat: start the `requestIdleCallback` loop and
+/// listen for `visibilitychange` / `online` to poll immediately on refocus or
+/// reconnect. Returns `None` when there is no `window`/`document` (e.g. a test
+/// stub), leaving the SW's ordinary-traffic drain as the only path.
+pub(crate) fn install() -> Option<IdleSync> {
+    let win = window()?;
+    let doc = win.document()?;
+
+    let disposed = Rc::new(Cell::new(false));
+
+    // Immediate poll when the tab becomes visible again — a refocus reconciles
+    // at once rather than waiting for the next idle tick.
+    let visibility = {
+        let disposed = disposed.clone();
+        Closure::wrap(Box::new(move || {
+            if disposed.get() {
+                return;
+            }
+            if let Some(doc) = window().and_then(|w| w.document())
+                && doc.visibility_state() == VisibilityState::Visible
+            {
+                poll();
+            }
+        }) as Box<dyn FnMut()>)
+    };
+    doc.add_event_listener_with_callback("visibilitychange", visibility.as_ref().unchecked_ref())
+        .ok()?;
+
+    // Immediate poll when connectivity returns.
+    let online = {
+        let disposed = disposed.clone();
+        Closure::wrap(Box::new(move || {
+            if !disposed.get() {
+                poll();
+            }
+        }) as Box<dyn FnMut()>)
+    };
+    win.add_event_listener_with_callback("online", online.as_ref().unchecked_ref())
+        .ok()?;
+
+    // Kick the steady idle loop.
+    arm(disposed.clone());
+
+    Some(IdleSync {
+        disposed,
+        visibility,
+        online,
+    })
+}

--- a/rust/tonk-host/src/lib.rs
+++ b/rust/tonk-host/src/lib.rs
@@ -68,6 +68,8 @@ mod host;
 #[cfg(target_arch = "wasm32")]
 mod http;
 #[cfg(target_arch = "wasm32")]
+mod idle_sync;
+#[cfg(target_arch = "wasm32")]
 mod navigate;
 #[cfg(target_arch = "wasm32")]
 mod ops;

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -160,9 +160,9 @@ self.onmessage = event => {
     );
 };
 
-// Background Sync API event handler. The tag carries the repository
-// identity (`tonk-sync:{repo}`); a rejected promise here tells the
-// user agent to retry the sync with backoff.
+// Background Sync API event handler. A single bare `sync` tag: the worker
+// drains the whole queue regardless, so the tag carries no identity. A
+// rejected promise here tells the user agent to retry the sync with backoff.
 self.onsync = event => {
     log("Background sync event:", event.tag);
     event.waitUntil(

--- a/rust/tonk-ui/src/components.rs
+++ b/rust/tonk-ui/src/components.rs
@@ -215,15 +215,14 @@ mod tests {
         // Check remote branch state before sync
         let _inspect_result = driver.execute(inspect_script, vec![]).await?;
 
-        // Register sync using the Background Sync API. The tag carries
-        // the repository identity (`tonk-sync:{repo}`) so the worker's
-        // `sync` event handler knows which repo's upstream branches to
-        // sweep.
+        // Register sync using the Background Sync API. A single bare `sync`
+        // tag: the worker's `onsync` drains the whole work-queue (every dirty
+        // and open repo), so it needs no per-repo identity in the tag.
         driver
             .execute(
                 r#"
                 const registration = await navigator.serviceWorker.ready;
-                await registration.sync.register('tonk-sync:home');
+                await registration.sync.register('sync');
                 "#,
                 vec![],
             )

--- a/rust/tonk-ui/src/sync_controller.rs
+++ b/rust/tonk-ui/src/sync_controller.rs
@@ -20,7 +20,7 @@
 //! Each pass does one of two things, decided by the per-repository pause
 //! preference: a full **sync** (pull then push every upstream branch, then a
 //! status check). A `LocalCommit` additionally registers a durable
-//! Background-Sync tag (`tonk-sync:{repo}`) so the push survives the tab
+//! Background-Sync tag (a single bare `sync`) so the push survives the tab
 //! closing, where the browser supports it.
 //!
 //! Pause is NOT a controller concern: it lives as a durable fact
@@ -94,12 +94,11 @@ extern "C" {
     async fn tonkRegisterSync(tag: &str) -> Result<JsValue, JsValue>;
 }
 
-/// The background-sync tag for `repo`. The worker parses the repo back
-/// out of it ([`tonk_worker::repo_from_sync_tag`]); the identity has
-/// to ride in the tag because a `sync` event delivers only a string.
-fn sync_tag(repo: &str) -> String {
-    format!("tonk-sync:{repo}")
-}
+/// The Background-Sync tag. A single bare tag: the SW's `onsync` drains the
+/// whole work-queue (every dirty + open repo) regardless of tag, so it needs
+/// no per-repo identity. Registering the same tag repeatedly coalesces into
+/// one pending sync.
+const SYNC_TAG: &str = "sync";
 
 /// Whether this browser offers one-shot Background Sync. Chromium does;
 /// Safari and Firefox don't, and there a `LocalCommit` skips the durable
@@ -168,10 +167,9 @@ impl Controller {
         // so the push survives the tab closing — then still runs an in-page
         // sync now. Other triggers just sync in-page.
         if trigger == Trigger::LocalCommit && sync_manager_available() {
-            let tag = sync_tag(&repo);
-            log!("sync[local-commit] {repo} → register background sync '{tag}'");
+            log!("sync[local-commit] {repo} → register background sync '{SYNC_TAG}'");
             spawn_local(async move {
-                if let Err(err) = tonkRegisterSync(&tag).await {
+                if let Err(err) = tonkRegisterSync(SYNC_TAG).await {
                     log!(
                         "sync[local-commit] background register rejected ({err:?}); syncing in-page"
                     );
@@ -286,7 +284,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_builds_a_sync_tag_the_worker_can_parse() {
-        assert_eq!(sync_tag("home"), "tonk-sync:home");
+    fn it_registers_a_single_bare_sync_tag() {
+        assert_eq!(SYNC_TAG, "sync");
     }
 }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -28,8 +28,7 @@ pub use repository::{
 mod sync;
 pub use dialog_repository::Revision;
 pub use sync::{
-    SyncQueue, SyncResponse, SyncStatusResponse, branches_to_sync, drain_sync, repo_from_sync_tag,
-    sync_repository,
+    SyncQueue, SyncResponse, SyncStatusResponse, branches_to_sync, drain_sync, sync_repository,
 };
 // Re-exported so API consumers (the UI) can name the state without
 // depending on `tonk-schema` directly.
@@ -181,6 +180,9 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
             post(repository::attach_remote),
         )
         // Sync operations
+        // The single parameterless drain: the page's idle heartbeat pokes this
+        // and the SW's Background-Sync `onsync` reaches the same drain here.
+        .route("/api/sync", post(sync::drain))
         .route(
             "/api/repository/{repo}/branch/{branch}/sync",
             post(sync::sync),
@@ -573,6 +575,37 @@ pub mod tests {
             .await
             .expect("Failed to read response body");
         assert_eq!(body.as_ref(), b"Hello, Tonk!");
+    }
+
+    /// `POST /api/sync` is the idle heartbeat's poll target. It must do NO work
+    /// of its own — the drain is scheduled by the SW's `on_fetch` seeing the
+    /// request, so the route only has to exist and ack. Even with no repository
+    /// open it returns `200 {"ok": true}` immediately (it never touches state),
+    /// which is exactly why a poll participates in the debounce instead of
+    /// forcing a fresh drain per call.
+    #[dialog_common::test]
+    async fn it_acks_the_idle_sync_poll_without_draining() {
+        let state = test_state().await;
+        let (app, _lsp) = api_router(state);
+
+        let request = Request::builder()
+            .uri("/api/sync")
+            .method("POST")
+            .body(Body::empty())
+            .expect("Failed to build request");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("Failed to execute request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("response body is JSON");
+        assert_eq!(json, serde_json::json!({ "ok": true }));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -287,22 +287,6 @@ fn is_head_moved(error: &crate::reactor::ReactorError) -> bool {
     error.to_string().contains("Version mismatch")
 }
 
-/// Tag prefix every durable background sync carries; the repository
-/// name follows the colon. A `sync` event delivers only this string
-/// and the worker has no notion of an "active repository", so the
-/// repo identity has to ride along in the tag.
-const SYNC_TAG_PREFIX: &str = "tonk-sync:";
-
-/// Parse the repository name out of a background-sync tag.
-///
-/// Tags are `tonk-sync:{repo}`. Anything not matching that shape — a
-/// bare or differently-prefixed tag, an empty repo — yields `None`,
-/// so a malformed tag becomes a no-op rather than an error.
-pub fn repo_from_sync_tag(tag: &str) -> Option<&str> {
-    tag.strip_prefix(SYNC_TAG_PREFIX)
-        .filter(|repo| !repo.is_empty())
-}
-
 /// Branch names in `branches` that have an upstream, sorted for a
 /// stable sweep order. Branches without an upstream have nowhere to
 /// sync to, so they're skipped. Shared with the in-page sweep so the
@@ -822,7 +806,7 @@ pub async fn sync(
 
 /// The set of repositories that have local commits not yet pushed.
 ///
-/// The service worker owns *what* needs syncing; the page only pokes *when*
+/// The service worker owns *what* needs syncing; the page only polls *when*
 /// (`POST /api/sync`). A commit enqueues its repo here (from the transact
 /// handler, where the route is known); a successful drain clears it. The pull
 /// side is not tracked — [`drain`] pulls every currently-open repository so a
@@ -871,9 +855,11 @@ impl SyncQueue {
 /// per-repo [`sync_repository`] sweep, which pulls+pushes each upstream branch
 /// and honors the durable pause preference.
 ///
-/// This is the single parameterless drain the page's `<tonk-host>` heartbeat
-/// pokes (`POST /api/sync`) and the SW's own post-commit `event.waitUntil`
-/// push run through. Branches are synced per-repo; repos run sequentially here
+/// Two callers reach this: the per-fetch `schedule_sync_drain` (debounced,
+/// generation-ticketed — the path the `<tonk-host>` idle poll to `POST
+/// /api/sync` rides on, since `on_fetch` schedules it) and the SW's own
+/// Background-Sync `onsync` (a discrete OS event with no fetch to hook, so it
+/// drains directly). Branches are synced per-repo; repos run sequentially here
 /// (the reactor serializes branch state anyway), priority-ordered by activity.
 pub async fn drain_sync(state: &AppState) {
     // Dirty repos first (push priority), then every other open repo (pull).
@@ -907,6 +893,24 @@ pub async fn drain_sync(state: &AppState) {
             tonk.sync_queue.requeue(&repo, now);
         }
     }
+}
+
+/// `POST /api/sync` — the idle heartbeat's poll endpoint.
+///
+/// Deliberately does NO work of its own: the drain is scheduled by the SW's
+/// `on_fetch`, which runs `schedule_sync_drain` for EVERY request (debounced,
+/// generation-ticketed) before routing. So merely *reaching* this route already
+/// enqueued a coalesced drain on the event's `wait_until`. Draining here too
+/// would fire a second, un-debounced drain and stack it on the scheduled one —
+/// so the poll participates in the same scheduling machinery precisely by
+/// leaving the drain to `on_fetch`.
+///
+/// The page's `<tonk-host>` idle loop polls this so an otherwise-idle tab (only
+/// open subscriptions, no other traffic) keeps generating the request the
+/// heartbeat rides on. Always `200`.
+#[wasm_compat]
+pub async fn drain() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "ok": true }))
 }
 
 /// A millisecond wall-clock stamp for activity priority. `Date.now()` in the SW
@@ -949,22 +953,6 @@ mod tests {
             upstream: None,
             revision: None,
         }
-    }
-
-    #[dialog_common::test]
-    fn it_parses_the_repo_from_a_well_formed_tag() {
-        assert_eq!(repo_from_sync_tag("tonk-sync:home"), Some("home"));
-    }
-
-    #[dialog_common::test]
-    fn it_ignores_a_tag_without_the_sync_prefix() {
-        assert_eq!(repo_from_sync_tag("home"), None);
-        assert_eq!(repo_from_sync_tag("other-tag"), None);
-    }
-
-    #[dialog_common::test]
-    fn it_ignores_a_prefix_only_tag_with_an_empty_repo() {
-        assert_eq!(repo_from_sync_tag("tonk-sync:"), None);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -421,17 +421,110 @@ mod route_for_tests {
             "bridge module must bypass the rewrite, got {r:?}",
         );
     }
+
+    // The scheduler's clock is passed in (not `Date::now()`), so these drive it
+    // with fixed timestamps — no real time, fully deterministic.
+
+    #[dialog_common::test]
+    fn it_coalesces_a_burst_into_the_last_ticket() {
+        let s = SyncScheduler::default();
+        // Three requests in the same instant: only the last ticket is current,
+        // so the first two wake and no-op, the last drains.
+        let t1 = s.next(0.0);
+        let t2 = s.next(0.0);
+        let t3 = s.next(0.0);
+        let wake = SYNC_DEBOUNCE_MS as f64;
+        assert!(
+            !s.should_drain(t1, wake),
+            "superseded ticket must not drain"
+        );
+        assert!(
+            !s.should_drain(t2, wake),
+            "superseded ticket must not drain"
+        );
+        assert!(s.should_drain(t3, wake), "latest ticket drains");
+    }
+
+    #[dialog_common::test]
+    fn it_forces_a_drain_when_traffic_never_settles() {
+        let s = SyncScheduler::default();
+        // A request arrives every 100ms, faster than the 500ms debounce, so no
+        // ticket is ever the latest when it wakes. Without the cap this starves
+        // forever; with it, once the burst has been pending SYNC_MAX_WAIT_MS an
+        // earlier ticket drains despite the newer requests.
+        let first = s.next(0.0);
+        for i in 1..=40 {
+            s.next(i as f64 * 100.0);
+        }
+        // `first` woke long ago and is not the latest — but the burst began at
+        // t=0 and we're now past the cap, so it drains.
+        assert!(
+            s.should_drain(first, SYNC_MAX_WAIT_MS as f64),
+            "max-wait cap must force a drain under continuous traffic",
+        );
+        // Just before the cap, the same non-latest ticket must NOT drain.
+        assert!(
+            !s.should_drain(first, SYNC_MAX_WAIT_MS as f64 - 1.0),
+            "before the cap, a superseded ticket still defers",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_restarts_the_cap_clock_after_a_drain() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        // Drain at the trailing edge, which clears the burst clock.
+        assert!(s.should_drain(t1, SYNC_DEBOUNCE_MS as f64));
+        s.begin_drain();
+        s.end_drain();
+        // A fresh burst after the drain starts a NEW cap clock at t=10_000. Use a
+        // superseded ticket (t2, then t3 bumps the generation) so `is_latest` is
+        // false and only the cap can trigger a drain — that's what proves the
+        // clock reset. If the cap still measured from wall-clock zero, t2 would
+        // already be past the cap; it must instead measure from t=10_000.
+        let t2 = s.next(10_000.0);
+        let _t3 = s.next(10_050.0);
+        assert!(
+            !s.should_drain(t2, 10_000.0 + SYNC_MAX_WAIT_MS as f64 - 1.0),
+            "cap must measure from the post-drain burst start, not wall-clock zero",
+        );
+        assert!(
+            s.should_drain(t2, 10_000.0 + SYNC_MAX_WAIT_MS as f64),
+            "once the new burst passes the cap, a superseded ticket drains",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_never_overlaps_two_drains() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        s.begin_drain();
+        // While a drain is in flight, even a past-the-cap ticket must wait.
+        assert!(
+            !s.should_drain(t1, SYNC_MAX_WAIT_MS as f64 * 10.0),
+            "in_flight guard must block a second concurrent drain",
+        );
+        s.end_drain();
+    }
 }
 
-/// Trailing-edge debounce coordinator for the background sync drain.
+/// Trailing-edge debounce coordinator for the background sync drain, with a
+/// max-wait cap so continuous traffic can't defer the drain forever.
 ///
 /// Every `on_fetch` bumps `generation` and captures its value, then schedules a
-/// drain after a quiet window. After the window the request drains ONLY if its
-/// captured generation still equals the current one — i.e. no newer request
-/// arrived to supersede it. So a burst of requests collapses into a single
-/// trailing-edge drain (the last request wins); earlier ones wake and no-op.
-/// `in_flight` guards against two drains overlapping if a new winner fires while
-/// the previous drain is still running.
+/// drain after a quiet window. After the window the request drains if its
+/// captured generation is still current (no newer request superseded it) —
+/// bursts collapse into one trailing-edge drain, the last request wins.
+///
+/// The trap that alone leaves open: a tab making requests *faster* than the
+/// debounce window keeps bumping the generation, so no ticket is ever the last
+/// one and the drain starves indefinitely. So `pending_since` stamps when the
+/// current un-drained burst began; once it has waited [`SYNC_MAX_WAIT_MS`], a
+/// woken ticket drains even though newer requests exist. Cleared on every drain,
+/// so the cap measures from the first request after the last drain.
+///
+/// `in_flight` guards against two drains overlapping if a new winner (or a
+/// max-wait firing) starts while the previous drain is still running.
 ///
 /// Single-threaded SW, so plain `Cell`s behind `Rc` — no atomics needed.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -439,29 +532,68 @@ mod route_for_tests {
 struct SyncScheduler {
     generation: std::rc::Rc<std::cell::Cell<u64>>,
     in_flight: std::rc::Rc<std::cell::Cell<bool>>,
+    /// Wall-clock ms when the current un-drained burst began, or `None` when the
+    /// last drain cleared it. The max-wait cap measures from here.
+    pending_since: std::rc::Rc<std::cell::Cell<Option<f64>>>,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl SyncScheduler {
     /// Bump the generation and return the new value — the caller's ticket. The
-    /// caller drains only if this ticket is still current after the debounce.
-    fn next(&self) -> u64 {
+    /// caller drains only if this ticket is still current after the debounce (or
+    /// the max-wait cap has elapsed). `now` starts the burst clock if this is
+    /// the first request since the last drain.
+    fn next(&self, now: f64) -> u64 {
+        if self.pending_since.get().is_none() {
+            self.pending_since.set(Some(now));
+        }
         let next = self.generation.get().wrapping_add(1);
         self.generation.set(next);
         next
     }
 
-    /// Whether `ticket` is still the latest scheduled drain (nothing superseded
-    /// it) and no drain is already running.
-    fn should_drain(&self, ticket: u64) -> bool {
-        self.generation.get() == ticket && !self.in_flight.get()
+    /// Whether a woken ticket should drain now. True when no drain is already
+    /// running AND either the ticket is still the latest (normal trailing edge)
+    /// or the current burst has been pending past [`SYNC_MAX_WAIT_MS`] (the cap,
+    /// so continuous traffic can't starve the drain).
+    fn should_drain(&self, ticket: u64, now: f64) -> bool {
+        if self.in_flight.get() {
+            return false;
+        }
+        let is_latest = self.generation.get() == ticket;
+        let capped = self
+            .pending_since
+            .get()
+            .is_some_and(|since| now - since >= SYNC_MAX_WAIT_MS as f64);
+        is_latest || capped
+    }
+
+    /// Mark a drain as started: take the `in_flight` guard and clear the burst
+    /// clock so the max-wait cap restarts from the next request.
+    fn begin_drain(&self) {
+        self.in_flight.set(true);
+        self.pending_since.set(None);
+    }
+
+    /// Release the `in_flight` guard once a drain finishes.
+    fn end_drain(&self) {
+        self.in_flight.set(false);
     }
 }
 
 /// Quiet window before a request's scheduled sync drain fires. A burst of boot
-/// queries collapses into one drain at the trailing edge.
+/// queries collapses into one drain at the trailing edge. Kept short so a
+/// reactive pull (and the `<tonk-host>` idle poll every ~2× this) feels
+/// near-immediate; it is the real rate-limiter on drain frequency.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-const SYNC_DEBOUNCE_MS: i32 = 2_000;
+const SYNC_DEBOUNCE_MS: i32 = 500;
+
+/// Max-wait cap on the trailing-edge debounce: however continuous the request
+/// traffic, a drain fires at least this often. Without it, a tab making
+/// requests faster than [`SYNC_DEBOUNCE_MS`] resets the window every time and
+/// the drain never runs. Measured from the first request after the last drain.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const SYNC_MAX_WAIT_MS: i32 = 3_000;
 
 /// The main Tonk service worker that handles browser fetch events.
 ///
@@ -720,9 +852,11 @@ impl TonkServiceWorker {
     /// `onsync` event — the tab-closed backstop for the in-fetch drain.
     ///
     /// The SW owns the sync work-queue (repos with un-pushed commits) and knows
-    /// every open repo, so the event needs no per-repo identity: the tag is just
-    /// `"sync"`. The handler drains the queue — push the dirty set, pull every
-    /// open repo — exactly like the per-fetch `event.waitUntil` drain.
+    /// every open repo, so the event needs no per-repo identity: the tag is a
+    /// single bare `"sync"`, ignored here. This funnels to the same
+    /// [`drain_sync`](crate::router::drain_sync) as `POST /api/sync` and the
+    /// per-fetch `event.waitUntil` drain — push the dirty set, pull every open
+    /// repo.
     ///
     /// # Returns
     ///
@@ -743,16 +877,16 @@ impl TonkServiceWorker {
 ///
 /// Bumps the scheduler's generation, captures the ticket, and hands
 /// `event.wait_until` a promise that sleeps the debounce window and then drains
-/// ONLY if the ticket is still current (no newer request superseded it) and no
-/// drain is already running. `wait_until` keeps the SW alive through the sleep,
-/// so the trailing-edge drain actually runs even when the originating request
-/// finished long before. Failures are swallowed — a background drain never
-/// rejects the fetch.
+/// if the ticket is still current (no newer request superseded it) OR the
+/// max-wait cap has elapsed, and no drain is already running. `wait_until` keeps
+/// the SW alive through the sleep, so the trailing-edge drain actually runs even
+/// when the originating request finished long before. Failures are swallowed —
+/// a background drain never rejects the fetch.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn schedule_sync_drain(event: &FetchEvent, scheduler: &SyncScheduler, state: &AppState) {
     use wasm_bindgen::JsCast;
 
-    let ticket = scheduler.next();
+    let ticket = scheduler.next(js_sys::Date::now());
     let scheduler = scheduler.clone();
     let state = state.clone();
 
@@ -760,13 +894,14 @@ fn schedule_sync_drain(event: &FetchEvent, scheduler: &SyncScheduler, state: &Ap
         // Quiet window: a burst of requests collapses into one drain.
         let _ = crate::sleep(web_time::Duration::from_millis(SYNC_DEBOUNCE_MS as u64)).await;
 
-        if !scheduler.should_drain(ticket) {
-            // A newer request superseded us, or a drain is already running.
+        if !scheduler.should_drain(ticket, js_sys::Date::now()) {
+            // A newer request superseded us (and the max-wait cap hasn't
+            // elapsed), or a drain is already running.
             return Ok(JsValue::UNDEFINED);
         }
-        scheduler.in_flight.set(true);
+        scheduler.begin_drain();
         crate::router::drain_sync(&state).await;
-        scheduler.in_flight.set(false);
+        scheduler.end_drain();
         Ok(JsValue::UNDEFINED)
     });
 


### PR DESCRIPTION
The redesigned sync makes ordinary fetch traffic the heartbeat: the SW's `on_fetch` schedules a debounced drain that pulls every open repo. That works while the page keeps making requests, but a `/space` that has finished booting holds only long-lived SSE subscriptions and issues no new fetch, so no drain re-fires and a second client's edits never arrive. This is the "idle backstop" the original plan flagged and left open.

The fix restores the premise for the idle case rather than adding a parallel sync path. The top-page `<tonk-host>` runs a `requestIdleCallback` loop that fetches `POST /api/sync` (re-arming at ~2× the debounce, and immediately on `visibilitychange→visible` / `online`). The endpoint deliberately does no work of its own — reaching it is what matters, because `on_fetch` sees the request and schedules the normal debounced, generation-ticketed drain. So an idle poll participates in the existing coalescing instead of forcing a fresh drain per call.

While in there, two related tightenings: a **max-wait cap** on the debounce so a tab making requests faster than the window can't starve the drain forever, and the debounce lowered 2000→500ms so reactive pulls feel near-immediate. The Background-Sync tag is collapsed to a bare `sync` (the SW drains the whole queue regardless of tag), retiring the `tonk-sync:{repo}` scheme.

Verified: `SyncScheduler` unit tests cover coalescing, the max-wait cap, cap-clock reset after a drain, and the no-overlap guard; `POST /api/sync` acks without draining. Native clippy `-D warnings` clean; wasm builds/tests green. The idle-loop DOM glue is browser-runtime behavior not covered by unit tests — worth a two-client manual check before merge.

Spec updated in `plan/sw-driven-sync.md` (Revision — as shipped). Resolves BUG-36.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the background synchronization mechanism in the `tonk` project by introducing an idle sync feature, simplifying the sync tag, and improving the overall sync logic to ensure changes are pulled even when the tab is idle.

### Detailed summary
- Added `VisibilityState` to the `Cargo.toml`.
- Introduced a new `idle_sync` module for handling idle synchronization.
- Simplified the Background Sync API by using a single bare `sync` tag.
- Implemented an idle sync heartbeat that polls `/api/sync` during idle periods.
- Removed per-repo identity in sync tags; the worker drains the entire queue.
- Enhanced documentation to reflect changes in sync behavior and design.
- Added tests for idle sync polling and behavior under different conditions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->