### PR TITLE
fix(ui): scroll long FAB menus, fix share wedge width/alignment (BUG-37)

### DIFF
--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -1240,6 +1240,14 @@ view/directory!: &profile/fab/view
              share roster re-anchors right (`.fab__share-menu`). */
           width: 100%;
           z-index: 100;
+          /* A long list (many members, many spots) must not run off screen:
+             cap the stack to the viewport minus the dock offset (16px), the
+             bar, the 7px gap and some breathing room, and scroll the rest.
+             Scrolling clips the ::before hover bridge — harmless, menus are
+             click-toggled, not hover-held. */
+          max-height: calc(100dvh - 96px);
+          overflow-y: auto;
+          overscroll-behavior: contain;
         }
         /* Dropdowns open AWAY from the docked edge — down from the top dock, up
            from the bottom, and horizontally into the viewport (rightward from a
@@ -1288,6 +1296,11 @@ view/directory!: &profile/fab/view
            reads as more of the same control, not a differently-coloured panel. */
         .fab__menu-item {
           display: block;
+          /* Keep natural height inside the height-capped menu: the item's
+             `overflow: hidden` zeroes its flex min-height, so without this
+             the cards compress to cram into `max-height` instead of letting
+             the menu scroll. */
+          flex: none;
           padding: 10px 16px;
           background: var(--fab-pill);
           border-radius: 2px;
@@ -1342,6 +1355,39 @@ view/directory!: &profile/fab/view
         .fab__share .fab__invite-display,
         .fab__share .fab__share-mint,
         .fab__share-mint tonk-view { display: contents; }
+        /* The share wedge is FIXED-WIDTH, sized to hold its widest state
+           ("copy invite link" + icon), so the label swapping between
+           share / copy invite link / copied never resizes the wedge — nor
+           the open roster, which is width-matched to it. Its label aligns
+           like every other row: toward the bar's inner edge — right when
+           the bar anchors left, left when mirrored on the right. */
+        .fab__share {
+          box-sizing: border-box;
+          width: 180px;
+        }
+        /* Pin the wedge's control (the "share" form pre-mint, the copy
+           control after) to the wedge's edge, ABSOLUTELY — out of the flex
+           flow entirely, where flow-based justify-content proved unreliable
+           through the display chain. `top: 50% / translateY` centres it on
+           the bar's axis. Aligned like every other row: the right edge when
+           the bar anchors left, the left edge when mirrored on the right.
+           (The segment keeps its height from the telescope tile's fixed
+           block-size, so lifting the control out of flow doesn't collapse
+           the wedge.) */
+        .fab__share .fab__share-form,
+        .fab__share .fab__invite {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          right: 22px;
+          left: auto;
+          margin: 0;
+        }
+        .fab-mirror .fab__share .fab__share-form,
+        .fab-mirror .fab__share .fab__invite {
+          left: 22px;
+          right: auto;
+        }
         .fab__share-form {
           display: inline-flex;
           align-items: center;
@@ -1388,6 +1434,11 @@ view/directory!: &profile/fab/view
           color: var(--fab-ink);
           background: transparent;
           transition: opacity 0.15s ease;
+          /* Centre the slotted label on the bar's axis — the shadow
+             button's own line box otherwise sits the label on its text
+             baseline, dropping it below the segment's vertical centre. */
+          display: inline-flex;
+          align-items: center;
         }
         .fab__invite::part(button):hover {
           background: transparent;
@@ -1403,6 +1454,13 @@ view/directory!: &profile/fab/view
           /* Slotted into <wa-copy-button>, so it inherits WebAwesome's body
              font (not the FAB's) — pin it back to the FAB face. */
           font-family: "IBM Plex Sans Condensed", var(--wa-font-family-heading, sans-serif);
+        }
+        /* The slot icons: cap to the label's text scale — wa-icon's default
+           box overshoots the cap height, inflating the label's line box and
+           pushing the text off the bar's vertical centre. */
+        .fab__invite-label wa-icon {
+          font-size: 0.85em;
+          line-height: 1;
         }
         /* The "Copied!" success state. WebAwesome tints its success slot green
            (`var(--wa-color-success-on-quiet)`), tuned for a light background and


### PR DESCRIPTION
## Problem

**BUG-37**: the FAB's member roster is an unbounded card stack — with enough members it runs off the top of the screen. The spot-switcher menu had the same unbounded growth. On top of that, the share wedge resized whenever its label swapped (`share` → `copy invite link` → `copied`), snapping the open roster's width along with it, its label ignored the bar's alignment convention, and the copy-button label sat below the bar's vertical centre (oversized icon + shadow-button baseline seating).

## Fix (CSS-only, in the FAB view stylesheet `rust/tonk-core/assets/library/profile.yaml`)

- **Cap + scroll the menus**: `.fab__menu` gets `max-height: calc(100dvh - 96px)` (viewport minus dock offset, bar, gap, breathing room) with `overflow-y: auto` / `overscroll-behavior: contain`. Covers both the share roster and the spot switcher.
- **Keep cards natural-height**: `.fab__menu-item { flex: none }` — the items' `overflow: hidden` zeroes their flex min-height, so without this they silently compress to cram into the cap instead of letting the menu scroll.
- **Fixed-width share wedge**: `.fab__share` is `180px` (border-box), sized for its widest state, so label swaps never resize the wedge or the roster.
- **Alignment + vertical centring**: the wedge's control (`.fab__share-form` pre-mint, `.fab__invite` after) is pinned absolutely to the wedge's edge — right edge when the bar docks left, left edge under `.fab-mirror` — matching the menu rows' convention, and centred on the bar's axis via `top: 50%/translateY`. The copy button's part is flex-centred and the `wa-icon`s capped to `0.85em` so the label sits on the bar's centreline.

## Verification

Driven end-to-end in the local dev app (`dev:web`) with Chrome DevTools: seeded 25 fake `tonk:member` facts into a fresh space via the worker's `/evaluate` API, opened the share roster — before: cards ran past the viewport top; after: the stack stops ~28px from the viewport edge, cards keep natural size, and scroll-into-view of the last member confirms the container scrolls. Spot-switcher menu regression-checked. Wedge width verified stable across share → copy invite link → copied, with the label left-aligned on a right-docked bar and vertically centred (verified by @goblin-oats).

Note on rollout: these styles live in the seeded profile library, so existing browser profiles pick them up only on re-seed (clear site data / dev hot-swap) — the known library-seeding limitation, not specific to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the styling and layout of the user interface components within the `profile.yaml` file, particularly for dropdown menus and share controls, ensuring proper alignment, sizing, and scrolling behavior.

### Detailed summary
- Added max-height and overflow properties for dropdown menus to manage content overflow.
- Set flex property to `none` for menu items to maintain natural height.
- Defined fixed width for the `.fab__share` component to avoid resizing.
- Used absolute positioning for share controls to ensure consistent alignment.
- Centered labels within the share form for better vertical alignment.
- Adjusted font size for icons within the invite label to maintain visual consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->