### PR TITLE
feat(hub): remove spots from the Hub directory

### DIFF
--- a/docs/superpowers/plans/2026-07-06-remove-spot.md
+++ b/docs/superpowers/plans/2026-07-06-remove-spot.md
@@ -1,0 +1,894 @@
+# Remove Spot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user remove a spot (space) from the Hub launcher: retract its replica record, stop syncing it, and delete its local storage.
+
+**Architecture:** A new transient `space/remove` command in `profile.yaml` (fired by a per-row hover-`×` + confirm overlay, script-free CSS like the create wizard) decodes into a new `tonk_schema::command::RemoveSpace`, handled by a `RemoveSpaceHandler` in tonk-worker that (1) retracts every fact on the replica entity from the profile meta branch, (2) evicts the repo from the reactor cache via a new `Reactor::evict`, (3) deletes the space's IndexedDB database + OPFS blob dir via inline JS. Spec: `docs/superpowers/specs/2026-07-06-remove-spot-design.md`.
+
+**Tech Stack:** Rust (wasm32 service worker), dialog-db concepts, tonk notation (yaml), wasm-bindgen inline_js.
+
+## Global Constraints
+
+- Work happens in the worktree `/Users/jackdouglas/tonk/tonk/.claude/worktrees/remove-spot` on branch `remove-spot` (tracking `origin/staging`). Run all commands from that directory.
+- Use plain `git` for commits in this worktree. Do NOT run `jj` here — the repo is jj-colocated and any `jj` command in this directory operates on the MAIN workspace, not this worktree.
+- Commit messages: Conventional Commits (`type(scope): subject`), imperative, lowercase, no trailing period, no emojis. End the body with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Lint gate (matches CI): `cargo clippy --all-targets --all-features -- -D warnings` must pass natively. wasm-gated code needs `#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]`; helpers called only from wasm-gated code must carry the same gate or clippy flags them dead.
+- Tests use `#[dialog_common::test]` (or plain `#[test]` for the pure-native library-lowering suite), named `it_does_x`.
+- No `mod.rs` files.
+- This repo's doc-comment culture is heavy and load-bearing: every new pub(crate)+ item gets a doc comment explaining constraints and cross-references, in the style of the neighboring code. The doc comments in this plan's code blocks are part of the deliverable.
+- The critical safety invariant: the command must NOT read `dom.event.current-target.dataset/subject`. The `tonk/rename-repository` transient (core.yaml) already carries that attribute, and command decode ignores extra facts — a remove command matched on `dataset/subject` alone would also decode every rename and delete the space being renamed. The command reads `dataset/remove` instead. Task 1 encodes this as a regression test; do not "simplify" it away.
+
+---
+
+### Task 1: `RemoveSpace` command in tonk-schema + decode tests
+
+**Files:**
+- Modify: `rust/tonk-schema/src/domain.rs` (add `command::remove` module, after the `rename` module which ends near line 315)
+- Modify: `rust/tonk-schema/src/command.rs` (add `RemoveSpace` after `ProfileRename`, near line 198)
+- Test: `rust/dialog-reactor/src/command.rs` (tests module at bottom, alongside `it_decodes_create_space_from_name_only_facts` at line 491)
+
+**Interfaces:**
+- Produces: `tonk_schema::domain::command::remove::Remove(pub Entity)` with derived attribute `dom.event.current-target.dataset/remove`; `tonk_schema::command::RemoveSpace { this: Entity, subject: remove::Remove }` implementing `dialog_capability::Command`. Task 3's handler decodes this type; Task 4's yaml asserts the matching fact shape.
+
+- [ ] **Step 1: Write the failing decode tests**
+
+In `rust/dialog-reactor/src/command.rs`, inside the existing `mod tests`, after `it_decodes_create_space_from_name_only_facts` (the helpers `entity`, `facts_for`, and the `the!` macro are already in scope there):
+
+```rust
+    /// The Hub's per-row delete confirm asserts a `space/remove`
+    /// transient carrying only `data-remove` (the subject DID).
+    #[dialog_common::test]
+    fn it_decodes_remove_space_from_a_data_remove_fact() {
+        use tonk_schema::command::RemoveSpace;
+
+        let this = entity("did:key:zRemoveSpace");
+        let subject = entity("did:key:zSpaceSubject");
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.dataset/remove")
+            .of(this.clone())
+            .is(subject.clone())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+
+        let decoded = RemoveSpace::decode(this, &facts)
+            .expect("RemoveSpace must decode from a data-remove-only transient");
+        assert_eq!(decoded.subject.0, subject);
+    }
+
+    /// Regression: a `tonk/rename-repository` transient carries
+    /// `dataset/subject` plus the new name. It must NOT decode as
+    /// `RemoveSpace` — a remove command keyed on `dataset/subject`
+    /// would turn every banner rename into a space deletion.
+    #[dialog_common::test]
+    fn it_does_not_decode_a_rename_transient_as_remove_space() {
+        use tonk_schema::command::RemoveSpace;
+
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.dataset/subject")
+            .of(entity("did:key:zRename"))
+            .is(entity("did:key:zSpaceSubject"))
+            .assert(&mut changes);
+        the!("dom.event.current-target/value")
+            .of(entity("did:key:zRename"))
+            .is("new name".to_string())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+
+        assert!(
+            RemoveSpace::decode(this, &facts).is_none(),
+            "a rename-shaped transient must not decode as RemoveSpace"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p dialog-reactor remove_space`
+Expected: FAIL to compile with `cannot find ... RemoveSpace` (a compile error on the not-yet-existing type is the red state).
+
+- [ ] **Step 3: Add the attribute module**
+
+In `rust/tonk-schema/src/domain.rs`, inside `pub mod command`, after the closing brace of `pub mod rename` (~line 315):
+
+```rust
+    /// Attributes the `space/remove` command reads from its submit event.
+    pub mod remove {
+        use super::super::Entity;
+        use super::Attribute;
+
+        /// The subject DID of the space to remove, read from the Hub
+        /// confirm form's `data-remove` attribute. Deliberately NOT
+        /// `dataset/subject`: the declarative `tonk/rename-repository`
+        /// transient (core.yaml) already carries `dataset/subject`, and
+        /// a remove command matched on `subject` alone would ALSO decode
+        /// every rename — deleting the space being renamed. The
+        /// distinctly named attribute is both the payload and the
+        /// command's unique shape, so no separate marker field is
+        /// needed. An `Entity` because the value (a did:key) carries a
+        /// `:` — see the invite marker note. Derived attribute:
+        /// `dom.event.current-target.dataset/remove`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.dataset")]
+        pub struct Remove(pub Entity);
+    }
+```
+
+- [ ] **Step 4: Add the command struct**
+
+In `rust/tonk-schema/src/command.rs`, after the `impl Command for ProfileRename` block (~line 198):
+
+```rust
+/// Request to remove a space from this device: retract its replica
+/// record from the profile meta branch (the Hub row's source of
+/// truth), detach it from the reactor/sync, and delete its local
+/// storage.
+///
+/// Asserted transiently when the user confirms a Hub row's delete
+/// overlay (`<form onsubmit=space/remove data-remove={subject}>` in
+/// `profile.yaml`). Removal is device-local: a synced space can be
+/// rejoined via an invite link; server-side data is untouched.
+///
+/// Deliberately a single matched field, like [`CreateSpace`], so an
+/// older profile descriptor keeps decoding it. The field also doubles
+/// as the command's distinct shape: `dataset/remove` is read by no
+/// other command, whereas a `dataset/subject` field would also match
+/// every `tonk/rename-repository` transient (which carries
+/// `dataset/subject`) and turn each rename into a deletion — see
+/// [`crate::domain::command::remove::Remove`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RemoveSpace {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The subject DID of the space to remove, from `data-remove`.
+    pub subject: crate::domain::command::remove::Remove,
+}
+
+/// `RemoveSpace` is a [`dialog_capability::Command`]; the worker
+/// registers a custom `RemoveSpaceHandler` (the work needs the profile
+/// handle, the reactor cache, and storage — state the decoded command
+/// doesn't carry).
+impl Command for RemoveSpace {
+    type Input = Self;
+    type Output = ();
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p dialog-reactor remove_space`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-schema/src/domain.rs rust/tonk-schema/src/command.rs rust/dialog-reactor/src/command.rs
+git commit -m "feat(schema): RemoveSpace command decoded from data-remove
+
+The attribute is deliberately dataset/remove, not dataset/subject:
+tonk/rename-repository transients carry dataset/subject and would
+also decode as a subject-keyed remove command.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `Reactor::evict` in dialog-reactor
+
+**Files:**
+- Modify: `rust/dialog-reactor/src/lib.rs` (add method on `impl Reactor`, directly after `shutdown` which ends at ~line 166)
+
+**Interfaces:**
+- Consumes: existing `Reactor.repos: RwLock<HashMap<String, Arc<RepositoryState>>>`, `RepositoryState::branches()`, `BranchState::clear_subscribers()` (all already used by `shutdown`).
+- Produces: `pub fn evict(&self, name: &str)` — Task 3's handler calls `tonk.reactor.evict(key)`.
+
+Why no unit test here: dialog-reactor has no native test infrastructure that can construct a `RepositoryState` (its only tests are pure decode tests in `command.rs`; building repo state needs a running storage stack, which in this workspace exists only in tonk-worker's wasm test harness). `evict` is exercised end-to-end by Task 3's wasm test, which asserts the cache entry is gone after removal.
+
+- [ ] **Step 1: Add the method**
+
+In `rust/dialog-reactor/src/lib.rs`, after the closing brace of `pub fn shutdown` (~line 166):
+
+```rust
+    /// Drop one repository's cached handles and active subscribers —
+    /// the per-repo analog of [`shutdown`](Self::shutdown). Used when a
+    /// space is removed: the background sync sweep builds its repo set
+    /// from this cache, so eviction is what actually stops the space
+    /// from syncing, and clearing each branch's subscriber map ends its
+    /// SSE streams (see `shutdown` for why removing the cache entry
+    /// alone isn't enough). No-op when the repo isn't cached.
+    pub fn evict(&self, name: &str) {
+        let Some(repo) = self.repos.write().remove(name) else {
+            return;
+        };
+        let branches = {
+            let mut map = repo.branches().write();
+            std::mem::take(&mut *map)
+        };
+        for (_, branch) in branches {
+            branch.clear_subscribers();
+        }
+    }
+```
+
+- [ ] **Step 2: Verify it compiles clean**
+
+Run: `cargo clippy -p dialog-reactor --all-targets --all-features -- -D warnings`
+Expected: PASS. (`evict` is `pub` on a `pub` type, so it is not dead code natively.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/dialog-reactor/src/lib.rs
+git commit -m "feat(reactor): per-repo evict dropping cached handles and subscribers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `RemoveSpaceHandler` in tonk-worker + wasm tests
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/repository.rs` (handler + helpers after `ProfileRenameHandler`'s `run` impl ends ~line 880; wasm tests in the existing `mod tests` at line 2929)
+- Modify: `rust/tonk-worker/src/router/command.rs` (register handler in `command_registry`, line 115-120)
+
+**Interfaces:**
+- Consumes: `tonk_schema::command::RemoveSpace` (Task 1), `Reactor::evict` (Task 2), existing `Replica::new`, `META_BRANCH`, `broadcast`/`Notification`, `super::claim::RawClaim { the, of, is, unique }` (pub(crate) in `router/claim.rs`, a sibling module — path `super::claim::RawClaim` from `router/repository.rs`), `tonk_schema::prelude::DidExt::repo_key` (already imported in repository.rs — `subject.repo_key()` is used by `create_space_inner`).
+- Produces: `RemoveSpaceHandler` (registered), `remove_space_inner(state: &AppState, subject: &Did) -> Result<(), RepositoryError>` (called by the handler and by the wasm tests).
+
+Checked assumptions (verify while implementing; both are read from current code, not guessed):
+- `tonk.reactor.profile_repository().branch(META_BRANCH).acquire(&tonk.operator).await` returns a state whose `.handle()` is a `dialog_repository::Branch` — the migration (`router/migration.rs:77-102`) calls `.handle().query()` on it, and `Branch` also carries `.claims()` (used on a `Branch` in `router/claim.rs:432`). If `.handle()` is not a `&Branch`, follow whatever type migration.rs's `meta.handle()` actually is — it must expose `claims()` the same way it exposes `query()`.
+- `dialog_varsig::Did` parses from its string form (`"did:key:z...".parse::<Did>()`). If `FromStr` is missing, use the conversion the join handler uses to turn an invite's did string into a `Did` (see `router/join.rs`).
+
+- [ ] **Step 1: Write the failing wasm tests**
+
+In `rust/tonk-worker/src/router/repository.rs`, inside the existing wasm `mod tests` (line 2929+), after `it_reports_the_founder_in_members`:
+
+```rust
+    /// All `Replica` rows on the profile meta branch (any kind), read
+    /// through the reactor's cached profile handle — the same handle
+    /// the Hub and the removal path use.
+    async fn profile_replicas(state: &AppState) -> Vec<tonk_schema::Replica> {
+        use dialog_query::{Output as _, Query, Term};
+        let tonk = state.read().await;
+        let meta = tonk
+            .reactor
+            .profile_repository()
+            .branch(super::META_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .expect("profile meta acquires");
+        meta.handle()
+            .query()
+            .select(Query::<tonk_schema::Replica> {
+                this: Term::var("this"),
+                subject: Term::var("subject"),
+                profile: Term::var("profile"),
+                kind: Term::var("kind"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .expect("replica query")
+    }
+
+    /// Removing a space retracts its replica record from the profile
+    /// meta branch and evicts the repo from the reactor cache (which is
+    /// what drops it from the background sync sweep).
+    #[dialog_common::test]
+    async fn it_removes_a_space_from_the_profile_index() {
+        let (_app, state, key) = fresh_repo("test-remove-space").await;
+
+        let subject: dialog_varsig::Did = {
+            let tonk = state.read().await;
+            use dialog_repository::RepositoryExt as _;
+            let repository: dialog_repository::Repository = tonk
+                .profile
+                .repository(&key)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .expect("repo loads");
+            repository.did()
+        };
+        let recorded = profile_replicas(&state).await;
+        assert!(
+            recorded.iter().any(|r| r.subject.0 == subject.this()),
+            "the fresh repo must be recorded before removal"
+        );
+
+        super::remove_space_inner(&state, &subject)
+            .await
+            .expect("remove succeeds");
+
+        let remaining = profile_replicas(&state).await;
+        assert!(
+            !remaining.iter().any(|r| r.subject.0 == subject.this()),
+            "the replica record must be gone after removal"
+        );
+        {
+            let tonk = state.read().await;
+            assert!(
+                !tonk.reactor.repos().read().contains_key(&key),
+                "the repo must be evicted from the reactor cache"
+            );
+        }
+    }
+
+    /// The self-replica (subject == profile) is refused: deleting the
+    /// profile's own storage would take every space with it.
+    #[dialog_common::test]
+    async fn it_refuses_to_remove_the_self_replica() {
+        let (_app, state, _key) = fresh_repo("test-remove-self").await;
+
+        let profile_did = {
+            let tonk = state.read().await;
+            tonk.profile.did()
+        };
+        super::remove_space_inner(&state, &profile_did)
+            .await
+            .expect_err("removing the self-replica must fail");
+
+        let remaining = profile_replicas(&state).await;
+        assert!(
+            remaining
+                .iter()
+                .any(|r| r.subject.0 == profile_did.this()),
+            "the self-replica record must survive"
+        );
+    }
+```
+
+Notes for the implementer:
+- `Replica.subject` is `tonk_schema::domain::replica::Subject(pub Entity)` (a wrapped entity) and `Did::this()` yields the DID's entity — this pairing (`r.subject.0 == did.this()`) is exactly how `migration.rs:159` compares (`replica.subject.0 == profile_entity`). If field/method names differ, mirror migration.rs.
+- If `dialog_query::Query::<tonk_schema::Replica>` needs different import spelling, copy the exact imports from `router/migration.rs` (it runs this very query).
+
+- [ ] **Step 2: Verify the tests fail to compile**
+
+Run: `cargo check -p tonk-worker --target wasm32-unknown-unknown --tests`
+Expected: FAIL with `cannot find function remove_space_inner`.
+(This check is the red state; actually *running* wasm tests happens in Step 6.)
+
+- [ ] **Step 3: Implement the removal path**
+
+In `rust/tonk-worker/src/router/repository.rs`, after `ProfileRenameHandler`'s `CommandHandler` impl (~line 880):
+
+```rust
+/// Post-commit handler for the [`RemoveSpace`] command.
+///
+/// Fired when the user confirms a Hub row's delete overlay. Removal is
+/// device-local and ordered so the visible state commits first and
+/// cleanup is best-effort behind it — see [`remove_space_inner`].
+///
+/// A custom handler (not a plain `Provider<RemoveSpace>`) for the same
+/// reason as [`CreateSpaceHandler`]: the work needs the profile handle,
+/// the reactor cache, and storage, reached through state rather than
+/// carried by the decoded command.
+///
+/// [`RemoveSpace`]: tonk_schema::command::RemoveSpace
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct RemoveSpaceHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl RemoveSpaceHandler {
+    /// Cache `RemoveSpace`'s trigger attributes (its `subject` field) so
+    /// the registry indexes this handler under them.
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::RemoveSpace::trigger_attributes(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::RemoveSpace::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::router::CommandEnv,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+
+        // Decode synchronously (the caller still holds the lock), then
+        // hand the owned subject + an env clone to the `'static` future.
+        let subject = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::RemoveSpace::decode(entity, facts))
+            .map(|command| command.subject.0);
+        let env = env.clone();
+
+        Box::pin(async move {
+            let Some(subject) = subject else {
+                return;
+            };
+            log!("command RemoveSpace subject={}", subject);
+            let subject: Did = match subject.to_string().parse() {
+                Ok(did) => did,
+                Err(error) => {
+                    log!("RemoveSpace: '{}' is not a DID: {}", subject, error);
+                    return;
+                }
+            };
+            if let Err(error) = remove_space_inner(env.state(), &subject).await {
+                log!("RemoveSpace '{}' failed: {}", subject, error);
+            }
+        })
+    }
+}
+
+/// Remove a space device-locally, in three ordered steps:
+///
+/// 1. Retract its replica record from the profile meta branch
+///    ([`remove_replica_from_profile`]) — the Hub row's source of
+///    truth, so the spot disappears immediately. This is the commit
+///    point; everything after is cleanup.
+/// 2. Evict the repository from the reactor cache
+///    ([`Reactor::evict`](crate::Reactor::evict)). The background sync
+///    sweep builds its repo set from that cache (NOT from replica
+///    records), so eviction is what actually stops syncing; it also
+///    ends the removed row's SSE streams.
+/// 3. Delete local storage ([`delete_space_storage`]) — best-effort
+///    and outside the state lock; a failure only orphans invisible
+///    bytes, so it is logged, never surfaced.
+///
+/// The self-replica (subject == profile) is refused: its row is hidden
+/// chrome in the Hub, and deleting the profile's own storage would take
+/// every space with it.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn remove_space_inner(state: &AppState, subject: &Did) -> Result<(), RepositoryError> {
+    {
+        let tonk = state.write().await;
+        if *subject == tonk.profile.did() {
+            return Err(RepositoryError::Internal(
+                "refusing to remove the profile's self-replica".to_string(),
+            ));
+        }
+        remove_replica_from_profile(&tonk, subject).await?;
+        // Drain the poll the retraction scheduled so the Hub's meta
+        // subscription reflects the removal (mirrors set_replica_status).
+        tonk.reactor.run_scheduled_polls(&tonk.operator).await;
+        tonk.reactor.evict(subject.repo_key());
+    }
+    // Storage cleanup after the lock is released — the delete awaits
+    // browser IO and must not stall other requests.
+    let _ = wasm_bindgen_futures::JsFuture::from(delete_space_storage(subject.repo_key())).await;
+    Ok(())
+}
+
+/// Retract every fact keyed on `subject`'s replica entity from the
+/// profile repository's meta branch — the reverse of
+/// [`record_replica_in_profile`]. Selecting the entity's actual claims
+/// (rather than re-asserting typed concepts to retract) sweeps every
+/// stamp regardless of vintage — the `Replica` fields, `SpaceStatus`,
+/// a migration's `SpaceKind`, a legacy `name` — without knowing their
+/// current values.
+///
+/// Reads and writes through the reactor's cached profile handle for the
+/// same reason `record_replica_in_profile` does: the Hub reads through
+/// that handle, so a commit on a separate handle would be invisible to
+/// it. Broadcasts `/api/profile` like the record path.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn remove_replica_from_profile(
+    tonk: &TonkState,
+    subject: &Did,
+) -> Result<(), RepositoryError> {
+    use dialog_artifacts::ArtifactSelector;
+    use futures_util::StreamExt as _;
+
+    let entity = Replica::new(tonk.profile.did(), subject.clone())
+        .this()
+        .clone();
+
+    let meta = tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
+    let stream = meta
+        .handle()
+        .claims()
+        .select(ArtifactSelector::new().of(entity.clone()))
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("select replica claims: {e}")))?;
+    tokio::pin!(stream);
+
+    let mut transaction = tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .transaction();
+    let mut found = false;
+    while let Some(artifact) = stream.next().await {
+        let artifact = artifact
+            .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
+        found = true;
+        transaction = transaction.retract(super::claim::RawClaim {
+            the: artifact.the,
+            of: artifact.of,
+            is: artifact.is,
+            unique: false,
+        });
+    }
+    if !found {
+        // Nothing recorded — a stale row or a repeated submit. Not an
+        // error: the desired end state (no record) already holds.
+        log!("remove replica: no facts for {} in profile meta", entity);
+        return Ok(());
+    }
+
+    let revision = transaction
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("retract replica record: {e}")))?;
+
+    broadcast(
+        "/api/profile",
+        &Notification {
+            branch: META_BRANCH.to_string(),
+            revision,
+        },
+    );
+    Ok(())
+}
+
+/// Delete a space's local storage: its IndexedDB database (archive,
+/// memory, credential, certificate object stores) and its OPFS blob
+/// subtree. The names are the storage loader's `Directory::Current`
+/// mapping for a repository space (see dialog-storage's IndexedDb and
+/// FileSystem providers): the database is named exactly the routing
+/// key, the blobs live under `current/<key>`.
+///
+/// Inline JS rather than web-sys: `deleteDatabase` and recursive
+/// `removeEntry` have no plumbing here, and the whole operation is two
+/// promise chains. Never rejects — each half settles on error/absence.
+/// `onblocked` also resolves: the worker's own pooled connection closes
+/// itself on the `versionchange` the delete fires (see
+/// [`crate::patch_idb_versionchange`]), after which the browser
+/// completes the delete; waiting for the completion event would hang if
+/// another tab pins the database open.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[wasm_bindgen::prelude::wasm_bindgen(inline_js = r#"
+export function delete_space_storage(name) {
+    const database = new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = request.onerror = request.onblocked = () => resolve();
+    });
+    const blobs = navigator.storage.getDirectory()
+        .then((root) => root.getDirectoryHandle('current'))
+        .then((dir) => dir.removeEntry(name, { recursive: true }))
+        .catch(() => {});
+    return Promise.all([database, blobs]);
+}
+"#)]
+extern "C" {
+    /// Delete the IndexedDB database and OPFS blob directory for a
+    /// space's routing key. Resolves once both halves settle; never
+    /// rejects.
+    fn delete_space_storage(name: &str) -> js_sys::Promise;
+}
+```
+
+Implementation notes:
+- `Did` needs importing if not already in scope at that point in the file (`use dialog_varsig::Did;` — check the file head; `repository.did()` returns one so it may already be there).
+- If `js_sys` is not a direct dependency of tonk-worker, add `js-sys = { workspace = true }` to `rust/tonk-worker/Cargo.toml` (workspace root already pins it — verify with `grep js-sys Cargo.toml`; if the workspace lacks it, add `js-sys = "0.3"` to `[workspace.dependencies]`).
+- `wasm_bindgen_futures` is already a tonk-worker dependency (`spawn_local` in `spawn_seed`).
+
+- [ ] **Step 4: Register the handler**
+
+In `rust/tonk-worker/src/router/command.rs`, in `command_registry()` after the `CreateSpaceHandler` registration (line 115):
+
+```rust
+        registry.register(Box::new(super::repository::RemoveSpaceHandler::new()));
+```
+
+And extend the function's doc comment list with one line noting the removal handler, e.g. after the paragraph about `CreateSpaceHandler`:
+
+```rust
+/// [`RemoveSpaceHandler`] serves the Hub's per-row delete confirm
+/// (`space/remove`): replica retraction, reactor eviction, storage
+/// cleanup.
+```
+
+(with the corresponding `/// [`RemoveSpaceHandler`]: super::repository::RemoveSpaceHandler` link line next to the existing `CreateSpaceHandler` link.)
+
+- [ ] **Step 5: Native gates**
+
+Run: `cargo clippy -p tonk-worker --all-targets --all-features -- -D warnings && cargo check -p tonk-worker --target wasm32-unknown-unknown --tests`
+Expected: both PASS. Clippy runs the native side (handler code is wasm-gated so it must not leak native-dead helpers); the wasm check compiles the handler and tests.
+
+- [ ] **Step 6: Run the wasm tests (or hand off to CI)**
+
+The repo's `.cargo/config.toml` already sets `runner = "wasm-bindgen-test-runner"` for the wasm target, so the invocation is a plain cargo test — but on this darwin machine it needs a Chrome at the default `/Applications` path plus a major-version-matched `chromedriver` on PATH (or `CHROMEDRIVER=` env). If available:
+
+Run: `CHROMEDRIVER=$(command -v chromedriver) cargo test -p tonk-worker --target wasm32-unknown-unknown remove_`
+Expected: `it_removes_a_space_from_the_profile_index` and `it_refuses_to_remove_the_self_replica` PASS.
+
+If no local browser automation is available, state that explicitly in the task report and rely on CI's web test leg (`.github/workflows/test.yml` matrix `platform: web`) — do NOT claim the tests ran.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/repository.rs rust/tonk-worker/src/router/command.rs rust/tonk-worker/Cargo.toml Cargo.lock
+git commit -m "feat(worker): RemoveSpace handler - retract replica, evict, delete storage
+
+Retraction through the reactor's profile handle is the commit point;
+eviction is what drops the repo from the background sync sweep (it
+iterates the reactor cache, not replica records); storage deletion is
+best-effort inline JS (IDB database <key> + OPFS current/<key>).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Drop `Cargo.toml`/`Cargo.lock` from the add if no dependency change was needed.)
+
+---
+
+### Task 4: Hub UI — command, row affordance, confirm overlay in profile.yaml
+
+**Files:**
+- Modify: `rust/tonk-core/assets/library/profile.yaml` (command block after `&space/create` ends ~line 106; row markup at lines 399-418; CSS in the `<style>` block, rows section lines 217-239)
+- Test: `rust/tonk-worker/tests/standard_library.rs` (existing `it_lowers_the_profile_library` — no new test code, it validates the edited document)
+
+**Interfaces:**
+- Consumes: the `space/remove` fact shape from Task 1 (`dom.event.current-target.dataset/remove` + `dom.event.do/prevent-default`), the existing `data-close-radio` delegate behavior (`rust/tonk-display/src/events/delegate.rs:143` — on submit, checks the radio with that id).
+- Produces: the user-facing affordance. No other task consumes it.
+
+- [ ] **Step 1: Add the command block**
+
+In `rust/tonk-core/assets/library/profile.yaml`, after the `command!: &space/create` block (ends ~line 106, before `command!: &tonk/load`):
+
+```yaml
+# The Remove Space command. Submitting a Hub row's delete-confirm form
+# asserts this transient; the worker's `RemoveSpaceHandler` retracts the
+# replica record from this branch, evicts the space from the reactor
+# (stopping background sync), and deletes its local storage. Removal is
+# device-local — a synced spot can be rejoined via an invite link; a
+# local-only spot is gone for good, which the confirm copy states.
+# `subject` reads the form's `data-remove` attribute. Deliberately NOT
+# `data-subject`: `tonk/rename-repository` transients already carry
+# `dataset/subject`, and a remove command matched on that attribute
+# alone would also decode every rename. The distinct attribute doubles
+# as the command's unique shape, so no marker field is needed. The
+# command is transient: it fires the handler once and is swept before
+# the durable commit.
+command!: &space/remove
+  description: A request to remove a space from this device (its list entry and local data).
+  with:
+    subject:
+      description: The subject DID of the space to remove, read from `data-remove`.
+      the: dom.event.current-target.dataset/remove
+      as: entity
+    prevent-default:
+      description: Stop the form submission from reloading the page
+      the: dom.event.do/prevent-default
+```
+
+- [ ] **Step 2: Restructure the directory row markup**
+
+Replace the current `.spot-list` block (lines 399-418):
+
+```html
+      <div class="spot-list">
+        <div class="spot-dir-head">Directory</div>
+        <a class="srow" href="/space/{subject}" data-kind={kind} data-status={status} with={this}>
+          <span class="srow-dot"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><ui-sync-status></ui-sync-status></tonk-branch></tonk-repository></tonk-host></span>
+          <span class="srow-name">
+            <tonk-host>
+              <tonk-repository name={subject}>
+                <tonk-branch name="main">
+                  <tonk-display entity={subject} model=tonk:repository view=tonk:view/label>
+                    <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
+                    <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
+                    <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
+                    <span slot="loading" class="spot-untitled" hidden>Untitled</span>
+                  </tonk-display>
+                </tonk-branch>
+              </tonk-repository>
+            </tonk-host>
+          </span>
+        </a>
+      </div>
+```
+
+with:
+
+```html
+      <div class="spot-list">
+        <div class="spot-dir-head">Directory</div>
+        <!-- The remove radios form one `__rm` group with the rows' per-row
+             radios below: rm-closed (chrome, default) hides every confirm;
+             a row's radio opens its overlay, and opening another row's
+             closes the first. The confirm form's data-close-radio re-checks
+             rm-closed on submit; cancel is a plain label for it. -->
+        <input class="spot-wiz" type="radio" name="__rm" id="rm-closed" checked>
+        <!-- One row per space. The wrapper (not the <a>) carries with={this}
+             so the remove affordance and confirm overlay repeat with the
+             row while staying outside the link — hovering or clicking the
+             x never navigates. -->
+        <div class="srow-wrap" data-kind={kind} data-status={status} with={this}>
+          <input class="spot-wiz" type="radio" name="__rm" id="rm-{subject}">
+          <a class="srow" href="/space/{subject}">
+            <span class="srow-dot"><tonk-host><tonk-repository name={subject}><tonk-branch name="main"><ui-sync-status></ui-sync-status></tonk-branch></tonk-repository></tonk-host></span>
+            <span class="srow-name">
+              <tonk-host>
+                <tonk-repository name={subject}>
+                  <tonk-branch name="main">
+                    <tonk-display entity={subject} model=tonk:repository view=tonk:view/label>
+                      <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
+                      <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
+                      <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
+                      <span slot="loading" class="spot-untitled" hidden>Untitled</span>
+                    </tonk-display>
+                  </tonk-branch>
+                </tonk-repository>
+              </tonk-host>
+            </span>
+          </a>
+          <label class="srm-open" for="rm-{subject}" aria-label="Remove spot">
+            <wa-icon name="xmark"></wa-icon>
+          </label>
+          <div class="srm-overlay">
+            <form class="srm-card" onsubmit=space/remove data-remove={subject} data-close-radio="rm-closed">
+              <div class="onb-kick">remove spot</div>
+              <h3 class="srm-title">Delete this spot?</h3>
+              <div class="srm-name">
+                <tonk-host>
+                  <tonk-repository name={subject}>
+                    <tonk-branch name="main">
+                      <tonk-display entity={subject} model=tonk:repository view=tonk:view/label>
+                        <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
+                        <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
+                        <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
+                        <span slot="loading" class="spot-untitled" hidden>Untitled</span>
+                      </tonk-display>
+                    </tonk-branch>
+                  </tonk-repository>
+                </tonk-host>
+              </div>
+              <p class="onb-lede">Removes this spot and its local data from this device.
+                A synced spot can be rejoined with an invite link; a local-only spot is gone for good.</p>
+              <div class="srm-actions">
+                <label class="srm-cancel" for="rm-closed">
+                  <wa-button variant="neutral" appearance="plain" size="small">cancel</wa-button>
+                </label>
+                <wa-button type="submit" variant="danger" size="small">delete spot</wa-button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+```
+
+Notes:
+- The repeat element is discovered as the LCA of the row's field bindings (`rust/tonk-display/src/template.rs:174` `this_repeat_root`), so moving `with={this}` and the other bindings onto `.srow-wrap` makes the wrapper the cloned row; `rm-closed` and the heading carry no bindings and stay chrome.
+- The cancel `<label>` wraps a `wa-button` exactly like the wizard's nav buttons; `.srm-cancel wa-button { pointer-events: none; }` (CSS below) makes the label receive the click, same trick as `.onb-nav`.
+- The submit `<wa-button type="submit">` matches the wizard's working submit (profile.yaml line 504).
+
+- [ ] **Step 3: Add the CSS**
+
+In the same `<style>` block, replace the row rules (current lines 228-238) — `.srow` keeps its grid but the hover moves to the wrapper, and the kind/status selectors move to `.srow-wrap`:
+
+```css
+        /* One row: a wrapper holding the link plus the remove affordance
+           and its confirm overlay. The wrapper (not the <a>) is the
+           repeat element, so the x and overlay travel with the row while
+           staying outside the link. */
+        .srow-wrap { position: relative; }
+        .srow { display: grid; grid-template-columns: 56px minmax(0,1fr); align-items: stretch;
+          background: transparent; text-decoration: none; color: var(--wa-color-text-normal); }
+        .srow > span { display: flex; align-items: center; padding: 18px 0; font-size: 15px; white-space: nowrap; }
+        .srow-dot { justify-content: center; }
+        .srow-name { padding-left: 4px; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+          /* keep the name clear of the hover-revealed remove x */
+          padding-right: 44px; }
+        .srow-wrap:hover .srow { background: var(--wa-color-neutral-fill-quiet); }
+        /* hide the profile's self-replica row */
+        .srow-wrap[data-kind="tonk:profile"] { display: none; }
+        /* dim the row while the content branch is still seeding */
+        .srow-wrap[data-status="tonk:blank"] .srow-name { opacity: .6; }
+        .spot-untitled { color: var(--wa-color-text-quiet); }
+
+        /* ── Remove-spot affordance ─────────────────────────────────────
+           A hover-revealed x per row opens a per-row confirm overlay,
+           driven by the same native-radio trick as the create wizard:
+           the row's `__rm` radio shows its overlay; rm-closed (checked
+           by default, re-checked by the form's data-close-radio on
+           submit and by the cancel label) hides them all. The x stays
+           clickable when transparent, so touch works without hover. */
+        .srm-open { position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+          display: flex; align-items: center; justify-content: center;
+          width: 30px; height: 30px; cursor: pointer; opacity: 0;
+          color: var(--wa-color-text-quiet); border-radius: var(--wa-border-radius-s); }
+        .srow-wrap:hover .srm-open { opacity: 1; }
+        .srm-open:hover { color: var(--wa-color-danger-on-quiet);
+          background: var(--wa-color-danger-fill-quiet); }
+        .srm-overlay { display: none; position: fixed; inset: 0; z-index: 60;
+          background: var(--wa-color-surface-default); color: var(--wa-color-text-normal); }
+        .srow-wrap > input:checked ~ .srm-overlay { display: flex;
+          align-items: center; justify-content: center; }
+        .srm-card { display: flex; flex-direction: column; align-items: center;
+          gap: 14px; max-width: 480px; padding: 40px; text-align: center; }
+        .srm-title { font-family: var(--spot-font-display); font-weight: 300; font-size: 32px;
+          letter-spacing: -1px; margin: 0; color: var(--wa-color-text-normal);
+          /* opt out of the global heading "headline-cover" dark box */
+          background: none; padding: 0; display: block; }
+        .srm-name { font-size: 17px; font-weight: 600; }
+        .srm-actions { display: flex; align-items: center; gap: 14px; margin-top: 8px; }
+        .srm-cancel { cursor: pointer; }
+        .srm-cancel wa-button { pointer-events: none; }
+```
+
+(The wizard's radio-hiding class `spot-wiz` is reused for the new radios — it is exactly `position: absolute; opacity: 0; pointer-events: none;`.)
+
+- [ ] **Step 4: Run the library-lowering test**
+
+Run: `cargo test -p tonk-worker --test standard_library it_lowers_the_profile_library`
+Expected: PASS — the edited document parses, analyzes locally (the new `&space/remove` anchor resolves), and lowers to claims.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-core/assets/library/profile.yaml
+git commit -m "feat(hub): per-row remove-spot affordance with confirm overlay
+
+Hover x opens a radio-driven confirm; the form asserts the transient
+space/remove with the row subject in data-remove.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format + workspace lint + native tests**
+
+Run, from the worktree root:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo nextest run -p tonk-schema -p dialog-reactor -p tonk-worker
+```
+
+Expected: all PASS. (`cargo nextest run` here runs native tests only; the wasm suite is Task 3 Step 6 / CI's web leg.) If `cargo fmt` reports diffs, run `cargo fmt --all` and amend the relevant commit.
+
+- [ ] **Step 2: wasm compile check of everything wasm-facing**
+
+```bash
+cargo check -p tonk-worker -p tonk-display -p tonk-schema --target wasm32-unknown-unknown
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Manual browser verification (or explicit deferral)**
+
+Serve the web app (tonk-ui trunk serve or the repo's dev server), create a throwaway spot, then: hover its row (× appears), click × (confirm overlay opens, names the spot), cancel (overlay closes, spot intact), reopen and delete (overlay closes, row disappears without reload). In devtools Application storage, confirm the space's IndexedDB database and `current/<key>` OPFS directory are gone. If a browser session isn't available in the execution environment, report exactly which of these checks ran.
+
+- [ ] **Step 4: Report**
+
+Summarize: tests run (native counts, wasm ran-or-deferred), lint status, manual verification status. Do not open a PR yet — integration choice (PR to staging) is a separate decision for the finishing step.

--- a/docs/superpowers/specs/2026-07-06-remove-spot-design.md
+++ b/docs/superpowers/specs/2026-07-06-remove-spot-design.md
@@ -36,7 +36,7 @@ using the same CSS state tricks as the create wizard:
   and offers:
   - cancel — a `<label for="rm-closed">`,
   - delete — the submit button of
-    `<form onsubmit=space/remove data-subject={subject}
+    `<form onsubmit=space/remove data-remove={subject}
     data-close-radio="rm-closed">`. `data-close-radio` re-checks `rm-closed`
     on submit (existing tonk-display delegate behavior), closing the overlay.
 
@@ -47,23 +47,28 @@ command!: &space/remove
   description: A request to remove a space from this profile and delete its local data.
   with:
     subject:
-      description: The space's subject DID, read from the form's data-subject.
-      the: dom.event.current-target.dataset/subject
+      description: The space's subject DID, read from the form's data-remove.
+      the: dom.event.current-target.dataset/remove
       as: entity
     prevent-default:
       the: dom.event.do/prevent-default
 ```
 
 The `subject` value is a did:key — it carries `:`, so the event layer
-delivers it as an `Entity` (same as the invite/pause-sync markers). No other
-command reads `dataset/subject`, so the field doubles as the command's
-distinct shape; no separate marker attribute is needed.
+delivers it as an `Entity` (same as the invite/pause-sync markers). The
+attribute is deliberately `dataset/remove`, NOT `dataset/subject`: the
+`tonk/rename-repository` transient (core.yaml) already carries
+`dataset/subject`, and command decode ignores extra facts, so a remove
+command matched on `subject` alone would also decode every rename —
+deleting the space being renamed. The distinctly named attribute is read
+by no other command, so it doubles as the command's unique shape; no
+separate marker attribute is needed.
 
 ## Schema (tonk-schema)
 
-- New attribute `domain::command::remove::Subject(pub Entity)` on domain
+- New attribute `domain::command::remove::Remove(pub Entity)` on domain
   `dom.event.current-target.dataset` (derived attribute
-  `dom.event.current-target.dataset/subject`).
+  `dom.event.current-target.dataset/remove`).
 - New command struct `RemoveSpace { this, subject }` implementing
   `Command`, alongside `CreateSpace`/`PauseSync` — matching the fields the
   yaml command actually declares.
@@ -74,23 +79,30 @@ A `RemoveSpaceHandler` registered in the command registry beside
 `CreateSpaceHandler`, wasm-gated the same way. On a decoded command it:
 
 1. **Retracts the replica record.** Re-derives the replica entity via
-   `Replica::new(profile_did, subject)` — no read needed — and, in one
+   `Replica::new(profile_did, subject)`, selects every claim `of` that
+   entity on the profile meta branch, and retracts them all in one
    transaction through the reactor's profile-repository handle (the cached
-   handle every Hub read goes through), retracts the `Replica` instance and
-   every stamp the write paths assert on that entity: `SpaceStatus`,
-   `SpaceKind`, `ReplicaSyncEnabled`, `ReplicaSyncStatus`, branch records
-   (`Replica::branch(..)`), and the legacy `Name` where present. Commits,
-   runs scheduled polls, and broadcasts `/api/profile` — mirroring
-   `record_replica_in_profile` in reverse.
-2. **Detaches the live system.** Drops the reactor's cached repository and
-   branch handles for the subject. The background sync loop reads replica
-   records to decide what to sync, so it skips the space from the next tick
-   with no extra bookkeeping.
-3. **Deletes local storage, best-effort.** Removes the space's IndexedDB
-   database(s) and its OPFS blob subtree, deriving names/paths the same way
-   the storage loader derives the space `Location` from
-   `(profile_did, local_name)`. Errors are logged and swallowed. Native
-   builds no-op, exactly like `spawn_seed`.
+   handle every Hub read goes through). The claim sweep covers every stamp
+   regardless of vintage — `Replica` fields, `SpaceStatus`, a migration's
+   `SpaceKind`, a legacy `name` — without knowing current values. (Sync
+   stamps live elsewhere: `ReplicaSyncEnabled` on the space's own content
+   branch, which dies with the storage; `ReplicaSyncStatus` is overlay-only
+   on a singleton.) Commits, runs scheduled polls, and broadcasts
+   `/api/profile` — mirroring `record_replica_in_profile` in reverse.
+2. **Detaches the live system.** Evicts the repository from the reactor's
+   cache (a new `Reactor::evict(name)`, the per-repo analog of `shutdown`:
+   removes the cache entry and clears each branch's subscribers). This is
+   the step that actually stops syncing — the background sweep builds its
+   repo set from the reactor cache plus the dirty queue, not from replica
+   records — and it ends the removed row's SSE streams.
+3. **Deletes local storage, best-effort.** A repository space maps to
+   `Location { directory: Current, name: <routing key> }`, which on the web
+   is the IndexedDB database named exactly the routing key plus the OPFS
+   blob directory `current/<key>`. An inline-JS helper deletes both
+   (`indexedDB.deleteDatabase` + `removeEntry(key, { recursive: true })`);
+   the existing `patch_idb_versionchange` makes the worker's own pooled
+   connection close itself so the delete completes. Errors are logged and
+   swallowed. The handler is wasm-gated, so native builds carry none of it.
 
 The Hub form commits on the profile meta branch, so the handler reads
 identity from state (like `CreateSpaceHandler`), not from the command's

--- a/docs/superpowers/specs/2026-07-06-remove-spot-design.md
+++ b/docs/superpowers/specs/2026-07-06-remove-spot-design.md
@@ -1,0 +1,116 @@
+# Remove a spot from the Hub
+
+## Problem
+
+The Hub launcher at `/` lists every spot (space) the profile has joined or
+created, but offers no way to remove one. Spots accumulate forever; the only
+recourse is clearing the browser's storage wholesale.
+
+## Semantics
+
+Removing a spot:
+
+1. Retracts its replica record from the profile repository's meta branch.
+   This is the commit point — the record is the row's source of truth, so
+   the card disappears from the Hub immediately.
+2. Deletes the space's local storage, best-effort. A failure here is logged,
+   never surfaced: the spot is already gone from the list, and orphaned
+   storage is invisible to the user.
+
+Removal is device-local. A synced spot can be rejoined via an invite link;
+a local-only spot is gone for good. The confirm dialog states this plainly.
+
+## UI (profile.yaml)
+
+Each directory row gets a hover-revealed `×` remove affordance, script-free,
+using the same CSS state tricks as the create wizard:
+
+- One radio group `__rm` spans the list: a checked-by-default `rm-closed`
+  radio plus one radio per row with id `rm-{subject}`. At most one confirm
+  overlay is open at a time, and opening another closes the first.
+- The `×` is a `<label for="rm-{subject}">` rendered as a sibling of the
+  row's `<a href>` card link (inside the row container, outside the anchor),
+  so hovering or clicking it never navigates.
+- The confirm overlay (shown while its row's radio is checked) names the
+  spot, explains "Removes this spot and its local data from this device.",
+  and offers:
+  - cancel — a `<label for="rm-closed">`,
+  - delete — the submit button of
+    `<form onsubmit=space/remove data-subject={subject}
+    data-close-radio="rm-closed">`. `data-close-radio` re-checks `rm-closed`
+    on submit (existing tonk-display delegate behavior), closing the overlay.
+
+New transient command in `profile.yaml`:
+
+```yaml
+command!: &space/remove
+  description: A request to remove a space from this profile and delete its local data.
+  with:
+    subject:
+      description: The space's subject DID, read from the form's data-subject.
+      the: dom.event.current-target.dataset/subject
+      as: entity
+    prevent-default:
+      the: dom.event.do/prevent-default
+```
+
+The `subject` value is a did:key — it carries `:`, so the event layer
+delivers it as an `Entity` (same as the invite/pause-sync markers). No other
+command reads `dataset/subject`, so the field doubles as the command's
+distinct shape; no separate marker attribute is needed.
+
+## Schema (tonk-schema)
+
+- New attribute `domain::command::remove::Subject(pub Entity)` on domain
+  `dom.event.current-target.dataset` (derived attribute
+  `dom.event.current-target.dataset/subject`).
+- New command struct `RemoveSpace { this, subject }` implementing
+  `Command`, alongside `CreateSpace`/`PauseSync` — matching the fields the
+  yaml command actually declares.
+
+## Worker (tonk-worker)
+
+A `RemoveSpaceHandler` registered in the command registry beside
+`CreateSpaceHandler`, wasm-gated the same way. On a decoded command it:
+
+1. **Retracts the replica record.** Re-derives the replica entity via
+   `Replica::new(profile_did, subject)` — no read needed — and, in one
+   transaction through the reactor's profile-repository handle (the cached
+   handle every Hub read goes through), retracts the `Replica` instance and
+   every stamp the write paths assert on that entity: `SpaceStatus`,
+   `SpaceKind`, `ReplicaSyncEnabled`, `ReplicaSyncStatus`, branch records
+   (`Replica::branch(..)`), and the legacy `Name` where present. Commits,
+   runs scheduled polls, and broadcasts `/api/profile` — mirroring
+   `record_replica_in_profile` in reverse.
+2. **Detaches the live system.** Drops the reactor's cached repository and
+   branch handles for the subject. The background sync loop reads replica
+   records to decide what to sync, so it skips the space from the next tick
+   with no extra bookkeeping.
+3. **Deletes local storage, best-effort.** Removes the space's IndexedDB
+   database(s) and its OPFS blob subtree, deriving names/paths the same way
+   the storage loader derives the space `Location` from
+   `(profile_did, local_name)`. Errors are logged and swallowed. Native
+   builds no-op, exactly like `spawn_seed`.
+
+The Hub form commits on the profile meta branch, so the handler reads
+identity from state (like `CreateSpaceHandler`), not from the command's
+origin.
+
+## Testing
+
+- Command decode test in the reactor/schema layer, mirroring
+  `it_decodes_create_space_from_name_only_facts`: facts carrying
+  `dataset/subject` decode as `RemoveSpace` and nothing else.
+- Handler-level native test: record a replica in a profile meta branch,
+  run removal, assert the replica query returns nothing (and stamps are
+  gone).
+- Storage deletion is wasm-only; verified manually in the browser.
+- Lint gate: `cargo clippy --all -- -D warnings` (native), plus the wasm
+  build.
+
+## Out of scope
+
+- No boot-time GC sweep for orphaned storage.
+- No HTTP DELETE route.
+- No undo; recovery for synced spots is the existing invite/join flow.
+- Server-side data on a sync remote is untouched.

--- a/rust/dialog-reactor/src/command.rs
+++ b/rust/dialog-reactor/src/command.rs
@@ -504,6 +504,51 @@ mod tests {
         assert_eq!(decoded.name.0, "pictures");
     }
 
+    /// The Hub's per-row delete confirm asserts a `space/remove`
+    /// transient carrying only `data-remove` (the subject DID).
+    #[dialog_common::test]
+    fn it_decodes_remove_space_from_a_data_remove_fact() {
+        use tonk_schema::command::RemoveSpace;
+
+        let this = entity("did:key:zRemoveSpace");
+        let subject = entity("did:key:zSpaceSubject");
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.dataset/remove")
+            .of(this.clone())
+            .is(subject.clone())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+
+        let decoded = RemoveSpace::decode(this, &facts)
+            .expect("RemoveSpace must decode from a data-remove-only transient");
+        assert_eq!(decoded.subject.0, subject);
+    }
+
+    /// Regression: a `tonk/rename-repository` transient carries
+    /// `dataset/subject` plus the new name. It must NOT decode as
+    /// `RemoveSpace` — a remove command keyed on `dataset/subject`
+    /// would turn every banner rename into a space deletion.
+    #[dialog_common::test]
+    fn it_does_not_decode_a_rename_transient_as_remove_space() {
+        use tonk_schema::command::RemoveSpace;
+
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.dataset/subject")
+            .of(entity("did:key:zRename"))
+            .is(entity("did:key:zSpaceSubject"))
+            .assert(&mut changes);
+        the!("dom.event.current-target/value")
+            .of(entity("did:key:zRename"))
+            .is("new name".to_string())
+            .assert(&mut changes);
+        let (this, facts) = facts_for(changes);
+
+        assert!(
+            RemoveSpace::decode(this, &facts).is_none(),
+            "a rename-shaped transient must not decode as RemoveSpace"
+        );
+    }
+
     #[dialog_common::test]
     fn it_does_not_decode_when_a_required_field_is_absent() {
         let mut changes = Changes::new();

--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -165,6 +165,26 @@ impl Reactor {
         }
     }
 
+    /// Drop one repository's cached handles and active subscribers —
+    /// the per-repo analog of [`shutdown`](Self::shutdown). Used when a
+    /// space is removed: the background sync sweep builds its repo set
+    /// from this cache, so eviction is what actually stops the space
+    /// from syncing, and clearing each branch's subscriber map ends its
+    /// SSE streams (see `shutdown` for why removing the cache entry
+    /// alone isn't enough). No-op when the repo isn't cached.
+    pub fn evict(&self, name: &str) {
+        let Some(repo) = self.repos.write().remove(name) else {
+            return;
+        };
+        let branches = {
+            let mut map = repo.branches().write();
+            std::mem::take(&mut *map)
+        };
+        for (_, branch) in branches {
+            branch.clear_subscribers();
+        }
+    }
+
     /// Reconcile the cached handle for `repo`/`branch` with durable
     /// storage after its upstream/remote wiring changed on a *separate*
     /// repository handle.

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -264,6 +264,11 @@ view/directory!:
         /* dim the row while the content branch is still seeding */
         .srow-wrap[data-status="tonk:blank"] .srow-name { opacity: .6; }
         .spot-untitled { color: var(--wa-color-text-quiet); }
+        /* empty-directory placeholder: visible by default, hidden the
+           moment any real row exists. "Real" excludes the self-replica
+           row, which is present but hidden on some profiles. */
+        .spot-empty { padding: 18px 0; font-size: 15px; color: var(--wa-color-text-quiet); }
+        .spot-list:has(.srow-wrap:not([data-kind="tonk:profile"])) .spot-empty { display: none; }
 
         /* ── Remove-spot affordance ─────────────────────────────────────
            A hover-revealed x per row opens a per-row confirm overlay,
@@ -318,8 +323,6 @@ view/directory!:
         .onb-nav--close { right: 20px; }
         .onb-nav--back { left: 20px; }
         .onb-head { text-align: center; max-width: 560px; }
-        .onb-kick { font-family: var(--spot-font-mono); font-size: 11.5px; letter-spacing: .13em;
-          text-transform: uppercase; color: var(--wa-color-text-quiet); margin-bottom: 10px; }
         .onb-head h3 { font-family: var(--spot-font-display); font-weight: 300; font-size: 38px;
           letter-spacing: -1.3px; margin: 0 0 12px; color: var(--wa-color-text-normal);
           /* opt out of the global heading "headline-cover" dark box */
@@ -470,6 +473,7 @@ view/directory!:
              it Tab would land on an invisible control that opens a
              destructive overlay. -->
         <input class="spot-wiz" type="radio" name="__rm" id="rm-closed" checked tabindex="-1">
+        <div class="spot-empty">No spots yet — create one to get started.</div>
         <!-- `data-id={this}` designates the repeat row — the wrapper (not
              the <a>), so the remove affordance and confirm overlay repeat
              with the row while staying outside the link: hovering or
@@ -497,7 +501,6 @@ view/directory!:
           </label>
           <div class="srm-overlay">
             <form class="srm-card" onsubmit=space/remove data-remove={subject} data-close-radio="rm-closed">
-              <div class="onb-kick">remove spot</div>
               <h3 class="srm-title">Delete this spot?</h3>
               <div class="srm-name">
                 <tonk-display with={subject} entity={subject} model=tonk:repository view=tonk:view/label>
@@ -531,7 +534,6 @@ view/directory!:
               <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
             </label>
             <div class="onb-head">
-              <div class="onb-kick">new spot</div>
               <h3>How do you want to start?</h3>
               <p class="onb-lede">Seed a ready-made layout, or start blank and hand the spot to an agent.</p>
             </div>
@@ -572,7 +574,6 @@ view/directory!:
               <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
             </label>
             <div class="onb-head">
-              <div class="onb-kick">new spot</div>
               <h3>Name your spot</h3>
             </div>
             <!-- Template picker. Native radios drive a 3-up grid of card

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -465,7 +465,11 @@ view/directory!:
              a row's radio opens its overlay, and opening another row's
              closes the first. The confirm form's data-close-radio re-checks
              rm-closed on submit; cancel is a plain label for it. -->
-        <input class="spot-wiz" type="radio" name="__rm" id="rm-closed" checked>
+        <!-- tabindex=-1: these radios are visually hidden chrome (the × label
+             and the overlay's own buttons are the interactive path); without
+             it Tab would land on an invisible control that opens a
+             destructive overlay. -->
+        <input class="spot-wiz" type="radio" name="__rm" id="rm-closed" checked tabindex="-1">
         <!-- `data-id={this}` designates the repeat row — the wrapper (not
              the <a>), so the remove affordance and confirm overlay repeat
              with the row while staying outside the link: hovering or
@@ -476,7 +480,7 @@ view/directory!:
              means its main branch; honored because the profile site is
              `allow="*"`. -->
         <div class="srow-wrap" data-kind={kind} data-status={status} data-id={this}>
-          <input class="spot-wiz" type="radio" name="__rm" id="rm-{subject}">
+          <input class="spot-wiz" type="radio" name="__rm" id="rm-{subject}" tabindex="-1">
           <a class="srow" href="/space/{subject}">
             <span class="srow-dot"><ui-sync-status with={subject}></ui-sync-status></span>
             <span class="srow-name">

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -106,6 +106,30 @@ command!: &space/create
       description: Stop the form submission from reloading the page
       the: dom.event.do/prevent-default
 
+# The Remove Space command. Submitting a Hub row's delete-confirm form
+# asserts this transient; the worker's `RemoveSpaceHandler` retracts the
+# replica record from this branch, evicts the space from the reactor
+# (stopping background sync), and deletes its local storage. Removal is
+# device-local — a synced spot can be rejoined via an invite link; a
+# local-only spot is gone for good, which the confirm copy states.
+# `subject` reads the form's `data-remove` attribute. Deliberately NOT
+# `data-subject`: `tonk/rename-repository` transients already carry
+# `dataset/subject`, and a remove command matched on that attribute
+# alone would also decode every rename. The distinct attribute doubles
+# as the command's unique shape, so no marker field is needed. The
+# command is transient: it fires the handler once and is swept before
+# the durable commit.
+command!: &space/remove
+  description: A request to remove a space from this device (its list entry and local data).
+  with:
+    subject:
+      description: The subject DID of the space to remove, read from `data-remove`.
+      the: dom.event.current-target.dataset/remove
+      as: entity
+    prevent-default:
+      description: Stop the form submission from reloading the page
+      the: dom.event.do/prevent-default
+
 # Load the requesting tab's site for its current path. Mirrors core.yaml's
 # `&tonk/load` — seeded here too because the top-level `<tonk-site>` stamps onto
 # the PROFILE branch (its ancestors resolve no named repo, so the claim routes
@@ -222,23 +246,53 @@ view/directory!:
         .spot-dir-head { font-family: var(--spot-font-display); font-size: 22px; font-weight: 700;
           letter-spacing: -.5px; color: var(--wa-color-text-normal); padding: 0 0 10px;
           border-bottom: var(--wa-border-width-s) solid var(--wa-color-text-normal); margin-bottom: 8px; }
-        /* One row: sync dot + space name. The wireframe also lists owner /
-           member-count / last-updated columns, but the profile's `space` model
-           carries none of those facts (only subject/kind/status/name), so we
-           show what we actually have rather than mock columns. No "open" label:
-           the whole row is the link. */
+        /* One row: a wrapper holding the link plus the remove affordance
+           and its confirm overlay. The wrapper (not the <a>) is the
+           repeat element, so the x and overlay travel with the row while
+           staying outside the link. */
+        .srow-wrap { position: relative; }
         .srow { display: grid; grid-template-columns: 56px minmax(0,1fr); align-items: stretch;
           background: transparent; text-decoration: none; color: var(--wa-color-text-normal); }
         .srow > span { display: flex; align-items: center; padding: 18px 0; font-size: 15px; white-space: nowrap; }
         .srow-dot { justify-content: center; }
-        .srow-name { padding-left: 4px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-        .srow:hover { background: var(--wa-color-neutral-fill-quiet); }
-        .srow:hover .srow-open { color: var(--wa-color-brand-on-quiet); }
+        .srow-name { padding-left: 4px; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+          /* keep the name clear of the hover-revealed remove x */
+          padding-right: 44px; }
+        .srow-wrap:hover .srow { background: var(--wa-color-neutral-fill-quiet); }
         /* hide the profile's self-replica row */
-        .srow[data-kind="tonk:profile"] { display: none; }
+        .srow-wrap[data-kind="tonk:profile"] { display: none; }
         /* dim the row while the content branch is still seeding */
-        .srow[data-status="tonk:blank"] .srow-name { opacity: .6; }
+        .srow-wrap[data-status="tonk:blank"] .srow-name { opacity: .6; }
         .spot-untitled { color: var(--wa-color-text-quiet); }
+
+        /* ── Remove-spot affordance ─────────────────────────────────────
+           A hover-revealed x per row opens a per-row confirm overlay,
+           driven by the same native-radio trick as the create wizard:
+           the row's `__rm` radio shows its overlay; rm-closed (checked
+           by default, re-checked by the form's data-close-radio on
+           submit and by the cancel label) hides them all. The x stays
+           clickable when transparent, so touch works without hover. */
+        .srm-open { position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+          display: flex; align-items: center; justify-content: center;
+          width: 30px; height: 30px; cursor: pointer; opacity: 0;
+          color: var(--wa-color-text-quiet); border-radius: var(--wa-border-radius-s); }
+        .srow-wrap:hover .srm-open { opacity: 1; }
+        .srm-open:hover { color: var(--wa-color-danger-on-quiet);
+          background: var(--wa-color-danger-fill-quiet); }
+        .srm-overlay { display: none; position: fixed; inset: 0; z-index: 60;
+          background: var(--wa-color-surface-default); color: var(--wa-color-text-normal); }
+        .srow-wrap > input:checked ~ .srm-overlay { display: flex;
+          align-items: center; justify-content: center; }
+        .srm-card { display: flex; flex-direction: column; align-items: center;
+          gap: 14px; max-width: 480px; padding: 40px; text-align: center; }
+        .srm-title { font-family: var(--spot-font-display); font-weight: 300; font-size: 32px;
+          letter-spacing: -1px; margin: 0; color: var(--wa-color-text-normal);
+          /* opt out of the global heading "headline-cover" dark box */
+          background: none; padding: 0; display: block; }
+        .srm-name { font-size: 17px; font-weight: 600; }
+        .srm-actions { display: flex; align-items: center; gap: 14px; margin-top: 8px; }
+        .srm-cancel { cursor: pointer; }
+        .srm-cancel wa-button { pointer-events: none; }
 
         /* ── Create-spot wizard ─────────────────────────────────────────────
            A CSS-paged wizard driven by native radios (the guest WA bundle
@@ -406,25 +460,60 @@ view/directory!:
 
       <div class="spot-list">
         <div class="spot-dir-head">Directory</div>
-        <!-- `data-id={this}` designates the repeat row. Each per-space
-             consumer carries its OWN `with={subject}` — the space's repo
-             DID from the record's `subject` FIELD (`{this}` is the
-             `tonk:space` row, a derived entity that names no repository).
-             The row cannot inherit one context because every row targets a
-             different space, so the disc and the label are each
-             self-describing. A bare repo means its main branch; honored
-             because the profile site is `allow="*"`. -->
-        <a class="srow" href="/space/{subject}" data-kind={kind} data-status={status} data-id={this}>
-          <span class="srow-dot"><ui-sync-status with={subject}></ui-sync-status></span>
-          <span class="srow-name">
-            <tonk-display with={subject} entity={subject} model=tonk:repository view=tonk:view/label>
-              <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
-              <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
-              <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
-              <span slot="loading" class="spot-untitled" hidden>Untitled</span>
-            </tonk-display>
-          </span>
-        </a>
+        <!-- The remove radios form one `__rm` group with the rows' per-row
+             radios below: rm-closed (chrome, default) hides every confirm;
+             a row's radio opens its overlay, and opening another row's
+             closes the first. The confirm form's data-close-radio re-checks
+             rm-closed on submit; cancel is a plain label for it. -->
+        <input class="spot-wiz" type="radio" name="__rm" id="rm-closed" checked>
+        <!-- `data-id={this}` designates the repeat row — the wrapper (not
+             the <a>), so the remove affordance and confirm overlay repeat
+             with the row while staying outside the link: hovering or
+             clicking the x never navigates. Each per-space consumer
+             carries its OWN `with={subject}` — the space's repo DID from
+             the record's `subject` FIELD (`{this}` is the `tonk:space`
+             row, a derived entity that names no repository). A bare repo
+             means its main branch; honored because the profile site is
+             `allow="*"`. -->
+        <div class="srow-wrap" data-kind={kind} data-status={status} data-id={this}>
+          <input class="spot-wiz" type="radio" name="__rm" id="rm-{subject}">
+          <a class="srow" href="/space/{subject}">
+            <span class="srow-dot"><ui-sync-status with={subject}></ui-sync-status></span>
+            <span class="srow-name">
+              <tonk-display with={subject} entity={subject} model=tonk:repository view=tonk:view/label>
+                <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
+                <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
+                <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
+                <span slot="loading" class="spot-untitled" hidden>Untitled</span>
+              </tonk-display>
+            </span>
+          </a>
+          <label class="srm-open" for="rm-{subject}" aria-label="Remove spot">
+            <wa-icon name="xmark"></wa-icon>
+          </label>
+          <div class="srm-overlay">
+            <form class="srm-card" onsubmit=space/remove data-remove={subject} data-close-radio="rm-closed">
+              <div class="onb-kick">remove spot</div>
+              <h3 class="srm-title">Delete this spot?</h3>
+              <div class="srm-name">
+                <tonk-display with={subject} entity={subject} model=tonk:repository view=tonk:view/label>
+                  <span slot="no-entity" class="spot-untitled" hidden>Untitled</span>
+                  <span slot="no-model" class="spot-untitled" hidden>Untitled</span>
+                  <span slot="no-view" class="spot-untitled" hidden>Untitled</span>
+                  <span slot="loading" class="spot-untitled" hidden>Untitled</span>
+                </tonk-display>
+              </div>
+              <p class="onb-lede">Removes this spot and its local data from this device.
+                A synced spot can be rejoined with an invite link; a local-only spot is gone for good.</p>
+              <div class="srm-actions">
+                <label class="srm-cancel" for="rm-closed">
+                  <wa-button variant="neutral" appearance="plain" size="small">cancel</wa-button>
+                </label>
+                <wa-button type="submit" variant="danger" size="small">delete spot</wa-button>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
 
       <div class="spot-overlay">

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -415,9 +415,16 @@ fn update_repeat(
         return;
     };
 
-    // Incoming subjects, keyed and deduped, in frame order.
+    // Incoming subjects, keyed and deduped, in frame order. A subjectless
+    // conclusion (empty `this`) is the synthetic host-attribute lead of an
+    // empty directory frame, never a real instance: keying it here would
+    // let the single-row rename below adopt the last surviving row under
+    // the empty key and blank it in place instead of removing it.
     let mut incoming: BTreeMap<String, Conclusion> = BTreeMap::new();
     for member in frame {
+        if member.this.is_empty() {
+            continue;
+        }
         incoming
             .entry(member.this.clone())
             .or_insert_with(|| member.clone());
@@ -1219,6 +1226,20 @@ mod tests {
         r.apply(&[row("", &[("name", "Ghost")]), row("a", &[("name", "Ann")])]);
         assert_eq!(li_withs(&host), vec!["a"]);
         assert_eq!(li_texts(&host), vec!["Ann"]);
+    }
+
+    #[dialog_common::test]
+    fn it_removes_the_last_row_when_only_the_synthetic_lead_remains() {
+        // Removing a directory's last instance leaves a frame holding just
+        // the synthetic host-attribute lead (empty `this`). The single-row
+        // rename heuristic must not adopt the surviving row under that
+        // subjectless key — the row vanished, it wasn't renamed — or the
+        // Hub keeps a ghost row with every binding blank.
+        let (mut r, host) = renderer(LIST);
+        r.apply(&[row("a", &[("name", "Ann")])]);
+        r.apply(&[row("", &[("dom.host/data-space", "acme")])]);
+        assert!(li_withs(&host).is_empty());
+        assert!(li_texts(&host).is_empty());
     }
 
     #[dialog_common::test]

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -197,6 +197,40 @@ impl Command for ProfileRename {
     type Output = ();
 }
 
+/// Request to remove a space from this device: retract its replica
+/// record from the profile meta branch (the Hub row's source of
+/// truth), detach it from the reactor/sync, and delete its local
+/// storage.
+///
+/// Asserted transiently when the user confirms a Hub row's delete
+/// overlay (`<form onsubmit=space/remove data-remove={subject}>` in
+/// `profile.yaml`). Removal is device-local: a synced space can be
+/// rejoined via an invite link; server-side data is untouched.
+///
+/// Deliberately a single matched field, like [`CreateSpace`], so an
+/// older profile descriptor keeps decoding it. The field also doubles
+/// as the command's distinct shape: `dataset/remove` is read by no
+/// other command, whereas a `dataset/subject` field would also match
+/// every `tonk/rename-repository` transient (which carries
+/// `dataset/subject`) and turn each rename into a deletion — see
+/// [`crate::domain::command::remove::Remove`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RemoveSpace {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The subject DID of the space to remove, from `data-remove`.
+    pub subject: crate::domain::command::remove::Remove,
+}
+
+/// `RemoveSpace` is a [`dialog_capability::Command`]; the worker
+/// registers a custom `RemoveSpaceHandler` (the work needs the profile
+/// handle, the reactor cache, and storage — state the decoded command
+/// doesn't carry).
+impl Command for RemoveSpace {
+    type Input = Self;
+    type Output = ();
+}
+
 /// The durable fact a `tonk:invite` handler asserts: the public
 /// delegation chain it minted, **keyed by the membership DID** (`this`).
 ///

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -313,6 +313,27 @@ pub mod command {
         pub struct Rename(pub Entity);
     }
 
+    /// Attributes the `space/remove` command reads from its submit event.
+    pub mod remove {
+        use super::super::Entity;
+        use super::Attribute;
+
+        /// The subject DID of the space to remove, read from the Hub
+        /// confirm form's `data-remove` attribute. Deliberately NOT
+        /// `dataset/subject`: the declarative `tonk/rename-repository`
+        /// transient (core.yaml) already carries `dataset/subject`, and
+        /// a remove command matched on `subject` alone would ALSO decode
+        /// every rename — deleting the space being renamed. The
+        /// distinctly named attribute is both the payload and the
+        /// command's unique shape, so no separate marker field is
+        /// needed. An `Entity` because the value (a did:key) carries a
+        /// `:` — see the invite marker note. Derived attribute:
+        /// `dom.event.current-target.dataset/remove`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.dataset")]
+        pub struct Remove(pub Entity);
+    }
+
     /// Attributes the `tonk:join` command reads from the `<tonk-page>`
     /// `mount` event's `detail` — a flat, URL-shaped record (fields mirror
     /// the DOM `URL` interface). The service worker can't see the `#hash`,

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -107,12 +107,18 @@ impl CommandEnv {
 /// which syncs across devices and is the single source of truth the Hub
 /// and banner both read.
 ///
+/// [`RemoveSpaceHandler`] serves the Hub's per-row delete confirm
+/// (`space/remove`): replica retraction, reactor eviction, storage
+/// cleanup.
+///
 /// [`CreateSpaceHandler`]: super::repository::CreateSpaceHandler
+/// [`RemoveSpaceHandler`]: super::repository::RemoveSpaceHandler
 pub fn command_registry() -> CommandRegistry<CommandEnv> {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let mut registry = CommandRegistry::new();
         registry.register(Box::new(super::repository::CreateSpaceHandler::new()));
+        registry.register(Box::new(super::repository::RemoveSpaceHandler::new()));
         registry.register(Box::new(super::repository::InviteHandler::new()));
         registry.register(Box::new(super::repository::PauseSyncHandler::new()));
         registry.register(Box::new(super::repository::ProfileRenameHandler::new()));

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -3478,13 +3478,26 @@ mod tests {
 
         let (_app, state, _key) = fresh_repo("test-remove-self").await;
 
-        // The harness never runs the worker boot path, so seed the
-        // self-replica record the assertion below expects.
+        // The harness never runs the worker boot path — and can't call
+        // `bootstrap_profile_meta`, whose library fetch needs a real
+        // service-worker registration — so seed just the self-replica
+        // record the assertion below expects, mirroring the bootstrap's
+        // own transaction.
         {
             let tonk = state.read().await;
-            super::bootstrap_profile_meta(&tonk)
+            let profile_did = tonk.profile.did();
+            let replica = super::Replica::new(profile_did.clone(), profile_did);
+            tonk.reactor
+                .profile_repository()
+                .branch(super::META_BRANCH)
+                .transaction()
+                .assert(replica.clone())
+                .assert(replica.branch(super::META_BRANCH))
+                .commit()
+                .perform(&tonk.operator)
                 .await
-                .expect("bootstrap profile meta");
+                .expect("seed self-replica");
+            tonk.reactor.run_scheduled_polls(&tonk.operator).await;
         }
 
         let profile_did = {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -904,6 +904,240 @@ async fn run_profile_rename(
     Ok(())
 }
 
+/// Post-commit handler for the [`RemoveSpace`] command.
+///
+/// Fired when the user confirms a Hub row's delete overlay. Removal is
+/// device-local and ordered so the visible state commits first and
+/// cleanup is best-effort behind it — see [`remove_space_inner`].
+///
+/// A custom handler (not a plain `Provider<RemoveSpace>`) for the same
+/// reason as [`CreateSpaceHandler`]: the work needs the profile handle,
+/// the reactor cache, and storage, reached through state rather than
+/// carried by the decoded command.
+///
+/// [`RemoveSpace`]: tonk_schema::command::RemoveSpace
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct RemoveSpaceHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl RemoveSpaceHandler {
+    /// Cache `RemoveSpace`'s trigger attributes (its `subject` field) so
+    /// the registry indexes this handler under them.
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::RemoveSpace::trigger_attributes(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::RemoveSpace::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::router::CommandEnv,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+
+        // Decode synchronously (the caller still holds the lock), then
+        // hand the owned subject + an env clone to the `'static` future.
+        let subject = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::RemoveSpace::decode(entity, facts))
+            .map(|command| command.subject.0);
+        let env = env.clone();
+
+        Box::pin(async move {
+            let Some(subject) = subject else {
+                return;
+            };
+            log!("command RemoveSpace subject={}", subject);
+            let subject: Did = match subject.to_string().parse() {
+                Ok(did) => did,
+                Err(error) => {
+                    log!("RemoveSpace: '{}' is not a DID: {}", subject, error);
+                    return;
+                }
+            };
+            if let Err(error) = remove_space_inner(env.state(), &subject).await {
+                log!("RemoveSpace '{}' failed: {}", subject, error);
+            }
+        })
+    }
+}
+
+/// Remove a space device-locally, in three ordered steps:
+///
+/// 1. Retract its replica record from the profile meta branch
+///    ([`remove_replica_from_profile`]) — the Hub row's source of
+///    truth, so the spot disappears immediately. This is the commit
+///    point; everything after is cleanup.
+/// 2. Evict the repository from the reactor cache
+///    ([`Reactor::evict`](crate::Reactor::evict)). The background sync
+///    sweep builds its repo set from that cache (NOT from replica
+///    records), so eviction is what actually stops syncing; it also
+///    ends the removed row's SSE streams.
+/// 3. Delete local storage ([`delete_space_storage`]) — best-effort
+///    and outside the state lock; a failure only orphans invisible
+///    bytes, so it is logged, never surfaced.
+///
+/// The self-replica (subject == profile) is refused: its row is hidden
+/// chrome in the Hub, and deleting the profile's own storage would take
+/// every space with it.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn remove_space_inner(state: &AppState, subject: &Did) -> Result<(), RepositoryError> {
+    {
+        let tonk = state.write().await;
+        if *subject == tonk.profile.did() {
+            return Err(RepositoryError::Internal(
+                "refusing to remove the profile's self-replica".to_string(),
+            ));
+        }
+        remove_replica_from_profile(&tonk, subject).await?;
+        // Drain the poll the retraction scheduled so the Hub's meta
+        // subscription reflects the removal (mirrors set_replica_status).
+        tonk.reactor.run_scheduled_polls(&tonk.operator).await;
+        tonk.reactor.evict(subject.repo_key());
+    }
+    // Storage cleanup after the lock is released — the delete awaits
+    // browser IO and must not stall other requests.
+    let _ = wasm_bindgen_futures::JsFuture::from(delete_space_storage(subject.repo_key())).await;
+    Ok(())
+}
+
+/// Retract every fact keyed on `subject`'s replica entity from the
+/// profile repository's meta branch — the reverse of
+/// [`record_replica_in_profile`]. Selecting the entity's actual claims
+/// (rather than re-asserting typed concepts to retract) sweeps every
+/// stamp regardless of vintage — the `Replica` fields, `SpaceStatus`,
+/// a migration's `SpaceKind`, a legacy `name` — without knowing their
+/// current values.
+///
+/// Reads and writes through the reactor's cached profile handle for the
+/// same reason `record_replica_in_profile` does: the Hub reads through
+/// that handle, so a commit on a separate handle would be invisible to
+/// it. Broadcasts `/api/profile` like the record path.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn remove_replica_from_profile(
+    tonk: &TonkState,
+    subject: &Did,
+) -> Result<(), RepositoryError> {
+    use dialog_artifacts::ArtifactSelector;
+    use futures_util::StreamExt as _;
+
+    let entity = Replica::new(tonk.profile.did(), subject.clone())
+        .this()
+        .clone();
+
+    let meta = tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
+    let stream = meta
+        .handle()
+        .claims()
+        .select(ArtifactSelector::new().of(entity.clone()))
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("select replica claims: {e}")))?;
+    tokio::pin!(stream);
+
+    let mut transaction = tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .transaction();
+    let mut found = false;
+    while let Some(artifact) = stream.next().await {
+        let artifact = artifact
+            .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
+        found = true;
+        transaction = transaction.retract(super::claim::RawClaim {
+            the: artifact.the,
+            of: artifact.of,
+            is: artifact.is,
+            unique: false,
+        });
+    }
+    if !found {
+        // Nothing recorded — a stale row or a repeated submit. Not an
+        // error: the desired end state (no record) already holds.
+        log!("remove replica: no facts for {} in profile meta", entity);
+        return Ok(());
+    }
+
+    let revision = transaction
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("retract replica record: {e}")))?;
+
+    broadcast(
+        "/api/profile",
+        &Notification {
+            branch: META_BRANCH.to_string(),
+            revision,
+        },
+    );
+    Ok(())
+}
+
+/// Delete a space's local storage: its IndexedDB database (archive,
+/// memory, credential, certificate object stores) and its OPFS blob
+/// subtree. The names are the storage loader's `Directory::Current`
+/// mapping for a repository space (see dialog-storage's IndexedDb and
+/// FileSystem providers): the database is named exactly the routing
+/// key, the blobs live under `current/<key>`.
+///
+/// Inline JS rather than web-sys: `deleteDatabase` and recursive
+/// `removeEntry` have no plumbing here, and the whole operation is two
+/// promise chains. Never rejects — each half settles on error/absence.
+/// `onblocked` also resolves: the worker's own pooled connection closes
+/// itself on the `versionchange` the delete fires (see
+/// [`crate::patch_idb_versionchange`]), after which the browser
+/// completes the delete; waiting for the completion event would hang if
+/// another tab pins the database open.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[wasm_bindgen::prelude::wasm_bindgen(inline_js = r#"
+export function delete_space_storage(name) {
+    const database = new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = request.onerror = request.onblocked = () => resolve();
+    });
+    const blobs = navigator.storage.getDirectory()
+        .then((root) => root.getDirectoryHandle('current'))
+        .then((dir) => dir.removeEntry(name, { recursive: true }))
+        .catch(() => {});
+    return Promise.all([database, blobs]);
+}
+"#)]
+extern "C" {
+    /// Delete the IndexedDB database and OPFS blob directory for a
+    /// space's routing key. Resolves once both halves settle; never
+    /// rejects.
+    fn delete_space_storage(name: &str) -> js_sys::Promise;
+}
+
 /// Toggle the durable `enabled` preference on the replica and publish the
 /// matching live status to the chip's overlay.
 ///
@@ -3020,6 +3254,103 @@ mod tests {
         assert!(founder.is_self, "founder is the active profile");
         assert!(founder.invited_by.is_none(), "founder has no inviter");
         assert!(founder.name.is_some(), "founder is named");
+    }
+
+    /// All `Replica` rows on the profile meta branch (any kind), read
+    /// through the reactor's cached profile handle — the same handle
+    /// the Hub and the removal path use.
+    async fn profile_replicas(state: &AppState) -> Vec<tonk_schema::Replica> {
+        use dialog_query::{Output as _, Query, Term};
+        let tonk = state.read().await;
+        let meta = tonk
+            .reactor
+            .profile_repository()
+            .branch(super::META_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .expect("profile meta acquires");
+        meta.handle()
+            .query()
+            .select(Query::<tonk_schema::Replica> {
+                this: Term::var("this"),
+                subject: Term::var("subject"),
+                profile: Term::var("profile"),
+                kind: Term::var("kind"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .expect("replica query")
+    }
+
+    /// Removing a space retracts its replica record from the profile
+    /// meta branch and evicts the repo from the reactor cache (which is
+    /// what drops it from the background sync sweep).
+    #[dialog_common::test]
+    async fn it_removes_a_space_from_the_profile_index() {
+        use tonk_schema::prelude::DidExt as _;
+
+        let (_app, state, key) = fresh_repo("test-remove-space").await;
+
+        let subject: dialog_varsig::Did = {
+            let tonk = state.read().await;
+            use dialog_repository::RepositoryExt as _;
+            let repository: dialog_repository::Repository = tonk
+                .profile
+                .repository(&key)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .expect("repo loads");
+            repository.did()
+        };
+        let recorded = profile_replicas(&state).await;
+        assert!(
+            recorded.iter().any(|r| r.subject.0 == subject.this()),
+            "the fresh repo must be recorded before removal"
+        );
+
+        super::remove_space_inner(&state, &subject)
+            .await
+            .expect("remove succeeds");
+
+        let remaining = profile_replicas(&state).await;
+        assert!(
+            !remaining.iter().any(|r| r.subject.0 == subject.this()),
+            "the replica record must be gone after removal"
+        );
+        {
+            let tonk = state.read().await;
+            assert!(
+                !tonk.reactor.repos().read().contains_key(&key),
+                "the repo must be evicted from the reactor cache"
+            );
+        }
+    }
+
+    /// The self-replica (subject == profile) is refused: deleting the
+    /// profile's own storage would take every space with it.
+    #[dialog_common::test]
+    async fn it_refuses_to_remove_the_self_replica() {
+        use tonk_schema::prelude::DidExt as _;
+
+        let (_app, state, _key) = fresh_repo("test-remove-self").await;
+
+        let profile_did = {
+            let tonk = state.read().await;
+            tonk.profile.did()
+        };
+        super::remove_space_inner(&state, &profile_did)
+            .await
+            .expect_err("removing the self-replica must fail");
+
+        let remaining = profile_replicas(&state).await;
+        assert!(
+            remaining
+                .iter()
+                .any(|r| r.subject.0 == profile_did.this()),
+            "the self-replica record must survive"
+        );
     }
 
     /// Build a one-entity transient `ProfileRename{this, name, marker}`

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -915,6 +915,19 @@ async fn run_profile_rename(
 /// the reactor cache, and storage, reached through state rather than
 /// carried by the decoded command.
 ///
+/// `run` refuses any transient whose origin repo is non-empty. This is
+/// the first *destructive* command reachable through shape-matched
+/// cross-branch dispatch: `dom.event.current-target.dataset/remove` is
+/// just an attribute name, so the same-shaped fact committed on ANY
+/// content branch — a joined space's own notation, or a same-origin
+/// POST to that repo's `/transact` — would otherwise let it name and
+/// delete any space by DID, regardless of where the command actually
+/// fired. The Hub's delete form commits on the profile branch, whose
+/// origin `repo` is always empty (`transact_profile` in `transact.rs`
+/// never names a repo — the same reasoning `transact_profile`'s
+/// sealed-guest check relies on), so refusing a non-empty origin is
+/// exactly "only the Hub can fire this."
+///
 /// [`RemoveSpace`]: tonk_schema::command::RemoveSpace
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct RemoveSpaceHandler {
@@ -968,6 +981,17 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHa
             let Some(subject) = subject else {
                 return;
             };
+            // See the type doc: only the profile branch (empty origin
+            // repo) may fire this. A non-empty origin means the fact came
+            // from a content branch — matched by shape, not by who asked —
+            // so it is ignored rather than trusted to remove anything.
+            if !env.origin().repo.is_empty() {
+                log!(
+                    "RemoveSpace ignored: origin '{}' is not the profile branch",
+                    env.origin().repo
+                );
+                return;
+            }
             log!("command RemoveSpace subject={}", subject);
             let subject: Did = match subject.to_string().parse() {
                 Ok(did) => did,
@@ -990,13 +1014,17 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHa
 ///    truth, so the spot disappears immediately. This is the commit
 ///    point; everything after is cleanup.
 /// 2. Evict the repository from the reactor cache
-///    ([`Reactor::evict`](crate::Reactor::evict)). The background sync
-///    sweep builds its repo set from that cache (NOT from replica
-///    records), so eviction is what actually stops syncing; it also
-///    ends the removed row's SSE streams.
+///    ([`Reactor::evict`](crate::Reactor::evict)) and forget it in the
+///    sync work-queue ([`SyncQueue::forget`](crate::router::SyncQueue::forget)).
+///    The background sync sweep unions the reactor cache with the dirty
+///    set (see `drain_sync`), so both must drop the repo — a leftover
+///    dirty stamp alone would resurrect it on the next drain even after
+///    eviction.
 /// 3. Delete local storage ([`delete_space_storage`]) — best-effort
 ///    and outside the state lock; a failure only orphans invisible
-///    bytes, so it is logged, never surfaced.
+///    bytes, so it is logged, never surfaced. Re-evicted once more
+///    afterward (see below) since the unlocked delete leaves a window
+///    for a concurrent drain to re-acquire the repo.
 ///
 /// The self-replica (subject == profile) is refused: its row is hidden
 /// chrome in the Hub, and deleting the profile's own storage would take
@@ -1015,10 +1043,25 @@ async fn remove_space_inner(state: &AppState, subject: &Did) -> Result<(), Repos
         // subscription reflects the removal (mirrors set_replica_status).
         tonk.reactor.run_scheduled_polls(&tonk.operator).await;
         tonk.reactor.evict(subject.repo_key());
+        // Same repo, same lock: a dirty stamp left in the sync queue would
+        // otherwise survive eviction and, on the next drain, get folded
+        // into the pull set that resurrects the reactor cache entry.
+        tonk.sync_queue.forget(subject.repo_key());
     }
     // Storage cleanup after the lock is released — the delete awaits
     // browser IO and must not stall other requests.
     let _ = wasm_bindgen_futures::JsFuture::from(delete_space_storage(subject.repo_key())).await;
+
+    // The delete ran unlocked, so a concurrent `drain_sync` could have
+    // reached in and re-acquired the repo (e.g. to pull) while it was in
+    // flight — resurrecting the cache entry and, since the IDB open races
+    // the delete, potentially recreating an empty database right behind
+    // it. Re-evict now that the delete has settled to drop any such
+    // handle.
+    {
+        let tonk = state.write().await;
+        tonk.reactor.evict(subject.repo_key());
+    }
     Ok(())
 }
 
@@ -1365,6 +1408,70 @@ fn spawn_seed(
 ) {
 }
 
+/// Whether `subject` still has a recorded [`Replica`] on the profile's
+/// meta branch. The replica entity is content-derived from `(profile,
+/// subject)` — the same hash [`Replica::new`] uses (see
+/// [`set_replica_status`]) — so its presence is checked directly rather
+/// than searched for.
+///
+/// Guards [`seed_and_initialize`] against a `RemoveSpace` landing
+/// mid-seed: [`remove_replica_from_profile`] retracts exactly this
+/// record, so its absence means the space was removed while this seed
+/// was in flight (either on the awaited create path or the detached
+/// [`spawn_seed`] path).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn replica_still_recorded(tonk: &TonkState, subject: &Did) -> Result<bool, RepositoryError> {
+    let entity = Replica::new(tonk.profile.did(), subject.clone())
+        .this()
+        .clone();
+    let meta = tonk
+        .reactor
+        .profile_repository()
+        .branch(META_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
+    let rows: Vec<Replica> = meta
+        .handle()
+        .query()
+        .select(Query::<Replica> {
+            this: Term::from(entity),
+            subject: Term::var("subject"),
+            profile: Term::var("profile"),
+            kind: Term::var("kind"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("replica query: {e}")))?;
+    Ok(!rows.is_empty())
+}
+
+/// If `subject`'s replica record is gone (see
+/// [`replica_still_recorded`]), evict the repo from the reactor cache
+/// (a mid-seed removal already evicted once, but the seed may have
+/// re-acquired it since) and log; the caller returns early without
+/// seeding or stamping. `stage` names the point being skipped, for the
+/// log line.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn bail_if_space_removed(
+    tonk: &TonkState,
+    subject: &Did,
+    key: &str,
+    stage: &str,
+) -> Result<bool, RepositoryError> {
+    if replica_still_recorded(tonk, subject).await? {
+        return Ok(false);
+    }
+    log!(
+        "seed '{}': replica record gone (space removed mid-seed), skipping {}",
+        key,
+        stage
+    );
+    tonk.reactor.evict(key);
+    Ok(true)
+}
+
 /// Seed the standard library into every branch, then flip the
 /// replica's status to `initialized`. Runs in the background after
 /// `put_repository` has already responded.
@@ -1377,6 +1484,21 @@ async fn seed_and_initialize(
     branches: &[String],
     template: Option<&str>,
 ) -> Result<(), RepositoryError> {
+    // The seed can run long after the replica record was asserted (the
+    // detached `spawn_seed` path, or just a slow library fetch on the
+    // awaited create path), leaving a window for the user to remove the
+    // space before it lands. Without this guard the seed would re-insert
+    // the evicted reactor cache entry, recreate the just-deleted database
+    // with seeded content, and re-stamp `SpaceStatus` on a retracted
+    // entity. Checked again below, right before each status flip, since
+    // removal can also land in the gap opened by the fetch/seed loop.
+    {
+        let tonk = state.read().await;
+        if bail_if_space_removed(&tonk, subject, key, "seed").await? {
+            return Ok(());
+        }
+    }
+
     if !branches.is_empty() {
         // Fetch every library document this repo seeds — core, then the
         // chosen template, then (home only) the showcase demo. Concatenated
@@ -1407,9 +1529,17 @@ async fn seed_and_initialize(
                 branch_name
             );
         }
+        // Cheap re-check right before stamping: the fetch/seed loop above
+        // awaited, opening another window for a removal to land.
+        if bail_if_space_removed(&tonk, subject, key, "status stamp").await? {
+            return Ok(());
+        }
         set_replica_status(&tonk, subject, Replica::initialized_status()).await?;
     } else {
         let tonk = state.read().await;
+        if bail_if_space_removed(&tonk, subject, key, "status stamp").await? {
+            return Ok(());
+        }
         set_replica_status(&tonk, subject, Replica::initialized_status()).await?;
     }
     log!("Repository '{}' initialized", key);
@@ -3330,6 +3460,14 @@ mod tests {
                 "the repo must be evicted from the reactor cache"
             );
         }
+
+        // Idempotent: a repeated submit (e.g. a double-click before the
+        // Hub row disappears) finds no replica record and no cached repo —
+        // `remove_replica_from_profile`'s "nothing recorded" branch and a
+        // no-op `evict` — and is a logged no-op, not an error.
+        super::remove_space_inner(&state, &subject)
+            .await
+            .expect("a repeated remove is a no-op, not an error");
     }
 
     /// The self-replica (subject == profile) is refused: deleting the
@@ -4001,6 +4139,72 @@ mod tests {
             rows.len(),
             1,
             "state:self must be re-stamped after invite clears the overlay",
+        );
+    }
+
+    /// Build a one-entity transient `RemoveSpace{this, subject}` batch —
+    /// the facts the Hub's delete-confirm form asserts. Mirrors
+    /// `profile_rename_transient`: the `data-remove` marker attribute
+    /// (`dom.event.current-target.dataset/remove`) carries the target
+    /// subject DID as its value and is the command's whole payload (see
+    /// `tonk_schema::command::RemoveSpace`).
+    fn remove_space_transient(of: &str, subject: &dialog_varsig::Did) -> dialog_artifacts::Changes {
+        use dialog_artifacts::{Entity, Statement};
+        use dialog_query::the;
+        use tonk_schema::prelude::DidExt as _;
+
+        let entity: Entity = of.parse().expect("entity URI");
+        let mut changes = dialog_artifacts::Changes::new();
+        the!("dom.event.current-target.dataset/remove")
+            .of(entity)
+            .is(subject.this())
+            .assert(&mut changes);
+        changes
+    }
+
+    /// `RemoveSpace` is refused unless it fired on the profile branch
+    /// (empty origin repo) — the gate closing the finding that a
+    /// same-shaped `dom.event.current-target.dataset/remove` fact
+    /// committed on ANY content branch (a joined space's own notation, or
+    /// a same-origin POST to that repo's `/transact`) could otherwise name
+    /// and delete any space by DID. Fired here with a non-empty origin, as
+    /// that cross-branch dispatch would produce; the replica record must
+    /// survive untouched.
+    #[dialog_common::test]
+    async fn it_ignores_remove_space_from_a_non_profile_origin() {
+        use tonk_schema::prelude::DidExt as _;
+
+        let (_app, state, key) = fresh_repo("test-remove-non-profile-origin").await;
+
+        let subject: dialog_varsig::Did = {
+            let tonk = state.read().await;
+            use dialog_repository::RepositoryExt as _;
+            let repository: dialog_repository::Repository = tonk
+                .profile
+                .repository(&key)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .expect("repo loads");
+            repository.did()
+        };
+
+        let changes = remove_space_transient("did:key:zRemoveWrongOrigin", &subject);
+        crate::router::dispatch(
+            &state,
+            crate::router::CommandOrigin {
+                repo: "somerepo".to_string(),
+                branch: "main".to_string(),
+                client: None,
+            },
+            changes,
+        )
+        .await;
+
+        let remaining = profile_replicas(&state).await;
+        assert!(
+            remaining.iter().any(|r| r.subject.0 == subject.this()),
+            "a RemoveSpace fired from a non-profile origin must not remove the replica",
         );
     }
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1069,8 +1069,8 @@ async fn remove_replica_from_profile(
         .transaction();
     let mut found = false;
     while let Some(artifact) = stream.next().await {
-        let artifact = artifact
-            .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
+        let artifact =
+            artifact.map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
         found = true;
         transaction = transaction.retract(super::claim::RawClaim {
             the: artifact.the,
@@ -3359,9 +3359,7 @@ mod tests {
 
         let remaining = profile_replicas(&state).await;
         assert!(
-            remaining
-                .iter()
-                .any(|r| r.subject.0 == profile_did.this()),
+            remaining.iter().any(|r| r.subject.0 == profile_did.this()),
             "the self-replica record must survive"
         );
     }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1103,11 +1103,15 @@ async fn remove_replica_from_profile(
 }
 
 /// Delete a space's local storage: its IndexedDB database (archive,
-/// memory, credential, certificate object stores) and its OPFS blob
-/// subtree. The names are the storage loader's `Directory::Current`
-/// mapping for a repository space (see dialog-storage's IndexedDb and
-/// FileSystem providers): the database is named exactly the routing
-/// key, the blobs live under `current/<key>`.
+/// memory, credential, certificate object stores) and, best-effort, an
+/// OPFS blob subtree at `current/<key>` — the path dialog-storage's
+/// FileSystem provider would use under its `Directory::Current`
+/// mapping, if a `WebSpace` wired one up. At the currently pinned
+/// dialog-storage revision it doesn't: the web space keeps everything
+/// in the IndexedDB database, so the OPFS removal below is a
+/// forward-compatible no-op that quietly settles via its `catch` when
+/// the directory doesn't exist. The database name is exactly the
+/// routing key.
 ///
 /// Inline JS rather than web-sys: `deleteDatabase` and recursive
 /// `removeEntry` have no plumbing here, and the whole operation is two
@@ -3335,6 +3339,15 @@ mod tests {
         use tonk_schema::prelude::DidExt as _;
 
         let (_app, state, _key) = fresh_repo("test-remove-self").await;
+
+        // The harness never runs the worker boot path, so seed the
+        // self-replica record the assertion below expects.
+        {
+            let tonk = state.read().await;
+            super::bootstrap_profile_meta(&tonk)
+                .await
+                .expect("bootstrap profile meta");
+        }
 
         let profile_did = {
             let tonk = state.read().await;

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -879,6 +879,22 @@ impl SyncQueue {
     fn requeue(&self, repo: &str, now: f64) {
         self.mark_dirty(repo, now);
     }
+
+    /// Drop `repo` from the dirty set without touching any other entry.
+    /// Called when a space is removed: a dirty stamp left behind would
+    /// survive the reactor's [`evict`](crate::Reactor::evict) and, on the
+    /// next [`drain_sync`], get folded into the union that `sync_repository`
+    /// reconciles — re-acquiring (resurrecting) the just-removed repo.
+    ///
+    /// Wasm-gated: its only caller, `remove_space_inner`, is service-worker
+    /// scoped, so a native build never reaches it (native clippy flags it
+    /// dead code otherwise).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub(crate) fn forget(&self, repo: &str) {
+        if let Ok(mut dirty) = self.dirty.lock() {
+            dirty.remove(repo);
+        }
+    }
 }
 
 /// Drain the sync work-queue: reconcile every repository that has un-pushed


### PR DESCRIPTION
Adds device-local spot removal to the Hub launcher.

## Semantics

Removing a spot retracts its replica record from the profile meta branch (the commit point — the row disappears immediately), evicts the repository from the reactor cache and the sync queue's dirty set (so the background sweep stops syncing it), then best-effort deletes its local storage (IndexedDB database + OPFS blob directory). Removal is device-local: a synced spot can be rejoined via an invite link; a local-only spot is gone for good, and the confirm dialog says so.

## Pieces

- **Schema**: `RemoveSpace` command decoded from a distinct `dataset/remove` attribute — deliberately not `dataset/subject`, which `tonk/rename-repository` transients already carry (a subject-keyed decode would fire on every rename). Regression tests pin this.
- **Worker**: `RemoveSpaceHandler`, gated to profile-origin commits (empty origin repo) so a joined space's content branch can't forge removals. Refuses the self-replica. Guards against a mid-seed removal race (`bail_if_space_removed`) and post-delete cache resurrection (re-evict after the storage delete).
- **Reactor**: `Reactor::evict(name)` — per-repo analog of `shutdown`; `SyncQueue::forget(repo)`.
- **Hub UI** (profile.yaml): hover-revealed × per row opening a per-row confirm overlay, script-free via one native `__rm` radio group; migrated to the collapsed `with=`/`data-id=` routing idiom from #567. Also: an empty-directory placeholder ("No spots yet — create one to get started.") and the redundant all-caps kickers above overlay titles removed.
- **Renderer fix** (tonk-display): removing the last row exposed a latent bug — the single-row rename heuristic adopted the surviving row for the synthetic empty-directory lead (empty `this`) and blanked it in place, leaving a ghost "Untitled" row linking to `/space/`. Subjectless conclusions are no longer row candidates.

## Testing

- Native: workspace fmt / clippy `-D warnings` / nextest 839 passed.
- Wasm (Chrome, actually executed): tonk-display 153, tonk-worker 118, tonk-core 23, tonk-schema 83, dialog-reactor 21.
- Note: `it_reports_a_display_name_on_the_profile` fails identically on plain `origin/staging` — pre-existing, unrelated to this branch.
- Manually verified in the browser: create, remove, remove-last (placeholder), reload behavior.

Design doc: `docs/superpowers/specs/2026-07-06-remove-spot-design.md`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to remove a space from the Hub, including retracting its replica record, stopping syncing, and deleting local storage. It adds a new command `RemoveSpace`, a handler, and necessary UI elements for confirming the deletion.

### Detailed summary
- Added `RemoveSpace` command to `tonk_schema`.
- Implemented `forget` method in `SyncQueue` to remove a repo from the dirty set.
- Created `RemoveSpaceHandler` for processing space removal.
- Developed UI components for confirming space deletion.
- Added tests for space removal functionality, ensuring correct behavior.

> The following files were skipped due to too many changes: `docs/superpowers/plans/2026-07-06-remove-spot.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->