### PR TITLE
feat: profile on main branch, /inspector + /diagnose routes

### DIFF
--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -149,8 +149,8 @@ impl Reactor {
             std::mem::take(&mut *map)
         };
         // The profile-as-repository lives in its own slot, not in
-        // `repos`. The Hub subscribes to its meta branch
-        // (`/api/profile/branch/meta/query` SSE), so it must be drained
+        // `repos`. The Hub subscribes to its main branch
+        // (`/api/profile/branch/main/query` SSE), so it must be drained
         // too — otherwise that one stream stays open and pins the
         // outgoing worker in `waiting` on every update.
         let profile = self.profile_repo.write().take();

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -1316,9 +1316,9 @@ concept!: &db/branch:
       as: entity
 
 # A space (replica) the profile has access to. These records live on
-# the profile repository's meta branch — one per repository this device
+# the profile repository's main branch — one per repository this device
 # has joined or created. The Tonk Hub at `/` queries them on the profile
-# meta branch (`with="meta@profile:tonk"`) so the user can pick which space to open.
+# main branch (`with="main@profile:tonk"`) so the user can pick which space to open.
 concept!: &space
   this: tonk:space
   description: A repository this profile can open, by its local name.

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -15,9 +15,9 @@
 # `model: space` resolves to the `&space` anchor here.
 
 # A space (replica) the profile has access to. These records live on
-# the profile repository's meta branch — one per repository this device
-# has joined or created. The Hub queries them on the profile meta branch
-# (the top site's `with="meta@profile:tonk"` context) so the user can pick
+# the profile repository's main branch — one per repository this device
+# has joined or created. The Hub queries them on the profile main branch
+# (the top site's `with="main@profile:tonk"` context) so the user can pick
 # which space to open.
 concept!: &space
   this: tonk:space
@@ -532,8 +532,8 @@ view/directory!:
 # FAB — floating action button view (rendered in the FAB portal iframe)
 # ============================================================
 #
-# These declarations live on profile/meta because the FAB portal is
-# scoped to the profile branch (`with="meta@profile:tonk"`). The
+# These declarations live on the profile branch because the FAB portal is
+# scoped to it (`with="main@profile:tonk"`). The
 # guest renders `tonk:profile/fab` via a `<tonk-display>` mounted
 # by the shell's FAB portal content string.
 #
@@ -1596,7 +1596,7 @@ view!: &join/failure-view
 # ============================================================
 #
 # The profile is itself a routable target: `<tonk-site path=…>` posts to
-# `/api/profile/branch/meta/site`, the SW asserts this tab's `tonk:site` on this
+# `/api/profile/branch/main/site`, the SW asserts this tab's `tonk:site` on this
 # branch (matching the path against the `route!` table below), and the element
 # renders `<tonk-display entity=site:… model=tonk:site>`. The site view nests the
 # matched `{concept}` on the same site entity — the same indirection a space uses.
@@ -1729,6 +1729,60 @@ view!: &join/route-view
       <tonk-display model="tonk:join/status"></tonk-display>
     </div>
 
+# The /inspector and /diagnose routes: the same query-inspector and
+# search-tree views a space exposes, but pinned to the PROFILE branch so
+# you can explore the profile DB (the hub's replicas, the member name,
+# sync state) directly. `<tonk-inspector>` and `<tonk-tree>` resolve their
+# repository from their own `with` — here the profile endpoint — so they
+# query `/api/profile/branch/main/query` rather than a named space.
+route!: &route/inspector
+  this: id:tonk:route/inspector
+  path: "/inspector"
+  concept: tonk:inspector/route
+
+concept!: &inspector/route
+  this: tonk:inspector/route
+  description: The /inspector page — a query inspector over the profile DB.
+  with:
+    # A route model must declare at least one field; the view doesn't read
+    # it (the inspector needs no entity — it inspects the whole branch).
+    path:
+      description: The active path, picked off the site.
+      the: xyz.tonk.site/path
+      cardinality: one
+      as: text
+
+view!: &inspector/route-view
+  this: id:tonk:inspector/route/view
+  model: tonk:inspector/route
+  display: |
+    <div class="display-view-slot">
+      <tonk-inspector with="main@profile:tonk" source=home></tonk-inspector>
+    </div>
+
+route!: &route/diagnose
+  this: id:tonk:route/diagnose
+  path: "/diagnose"
+  concept: tonk:diagnose/route
+
+concept!: &diagnose/route
+  this: tonk:diagnose/route
+  description: The /diagnose page — the search-tree inspector over the profile DB.
+  with:
+    path:
+      description: The active path, picked off the site.
+      the: xyz.tonk.site/path
+      cardinality: one
+      as: text
+
+view!: &diagnose/route-view
+  this: id:tonk:diagnose/route/view
+  model: tonk:diagnose/route
+  display: |
+    <div class="display-view-slot">
+      <tonk-tree with="main@profile:tonk"></tonk-tree>
+    </div>
+
 # The space route: the profile routes ANY `/space/{id}/...` to the same UI — a
 # full-size repo portal with the FAB floating on top — and hands the rest of the
 # path to a NESTED `<tonk-site>` inside the portal, which routes it against the
@@ -1779,4 +1833,4 @@ view!: &space-view
   model: tonk:space/chrome
   display: |
     <tonk-site with="main@{id}" allow="main@{id}" path={rest}></tonk-site>
-    <tonk-display with="meta@profile:tonk" model="tonk:profile/fab" data-space="{id}"></tonk-display>
+    <tonk-display with="main@profile:tonk" model="tonk:profile/fab" data-space="{id}"></tonk-display>

--- a/rust/tonk-host/src/bridge.rs
+++ b/rust/tonk-host/src/bridge.rs
@@ -80,7 +80,7 @@ pub async fn ensure_site(path: &str) -> Result<String, ErrorDetail> {
 
 /// Register this document's site against a per-branch `/site` endpoint (`url`),
 /// matching `path` on that branch. The branch is named in `url` (e.g.
-/// `/api/profile/branch/meta/site`), so the SW does no document-path routing.
+/// `/api/profile/branch/main/site`), so the SW does no document-path routing.
 /// Returns and caches the `site:<client-id>` entity, like [`ensure_site`].
 #[cfg(target_arch = "wasm32")]
 pub async fn ensure_site_on(url: &str, path: &str) -> Result<String, ErrorDetail> {

--- a/rust/tonk-host/src/http.rs
+++ b/rust/tonk-host/src/http.rs
@@ -100,7 +100,7 @@ pub(crate) async fn post_site(path: &str) -> Result<String, ErrorDetail> {
 /// `POST` a per-branch `/site` endpoint (`url`) to register this document's site
 /// on an explicit branch and read back the `site:<client-id>` entity. Like
 /// [`post_site`] but the branch is named in `url` (e.g.
-/// `/api/profile/branch/meta/site`), so the SW does no document-path routing —
+/// `/api/profile/branch/main/site`), so the SW does no document-path routing —
 /// it matches `path` against that branch's route table. The path rides both the
 /// `X-Tonk-Path` header (legacy `/api/site` reads it there) and the JSON body
 /// (the per-branch endpoint reads `{path}`), so one builder serves both.

--- a/rust/tonk-host/src/location.rs
+++ b/rust/tonk-host/src/location.rs
@@ -5,7 +5,7 @@
 //!
 //! - `main@did:key:zAlice` — the `main` branch of Alice's repository.
 //! - `did:key:zAlice` — a bare repo means its default branch.
-//! - `meta@profile:tonk` — a `profile:<name>` repo token names the
+//! - `main@profile:tonk` — a `profile:<name>` repo token names the
 //!   profile-as-repository endpoint (`/api/profile/branch/…`), not a
 //!   named repository. The name (`tonk`, the profile the worker
 //!   opens) is carried for forward compatibility; today the profile
@@ -198,7 +198,7 @@ pub enum ParseError {
     EmptyBranch(String),
     /// A `branch@` token with nothing after the `@`.
     EmptyRepo(String),
-    /// A profile token without a name (`profile` / `meta@profile:`).
+    /// A profile token without a name (`profile` / `main@profile:`).
     ProfileNeedsName(String),
     /// An empty `allow` attribute — a site must declare its reach.
     EmptyAllow,
@@ -251,9 +251,9 @@ mod tests {
 
     #[dialog_common::test]
     fn it_parses_a_named_profile_token() {
-        let location: Location = "meta@profile:tonk".parse().unwrap();
+        let location: Location = "main@profile:tonk".parse().unwrap();
         assert_eq!(location.repo, Repo::Profile("tonk".into()));
-        assert_eq!(location.branch(), Some("meta"));
+        assert_eq!(location.branch(), Some("main"));
         assert_eq!(location.space(), None);
         assert!(location.profile());
     }
@@ -261,16 +261,16 @@ mod tests {
     #[dialog_common::test]
     fn it_rejects_a_profile_token_without_a_name() {
         assert_eq!(
-            "meta@profile".parse::<Location>(),
-            Err(ParseError::ProfileNeedsName("meta@profile".into()))
+            "main@profile".parse::<Location>(),
+            Err(ParseError::ProfileNeedsName("main@profile".into()))
         );
         assert_eq!(
             "profile".parse::<Location>(),
             Err(ParseError::ProfileNeedsName("profile".into()))
         );
         assert_eq!(
-            "meta@profile:".parse::<Location>(),
-            Err(ParseError::ProfileNeedsName("meta@profile:".into()))
+            "main@profile:".parse::<Location>(),
+            Err(ParseError::ProfileNeedsName("main@profile:".into()))
         );
     }
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_round_trips_locations_through_display() {
-        for token in ["main@did:key:zAlice", "did:key:zAlice", "meta@profile:tonk"] {
+        for token in ["main@did:key:zAlice", "did:key:zAlice", "main@profile:tonk"] {
             let location: Location = token.parse().unwrap();
             assert_eq!(location.to_string(), token);
         }

--- a/rust/tonk-inspector/src/element.rs
+++ b/rust/tonk-inspector/src/element.rs
@@ -337,15 +337,19 @@ impl NotebookCell {
 
 /// Resolve `(repo, branch)` from this element's OWN `with="branch@repo"`
 /// attribute (forwarded onto it by the mounting `<tonk-display>`; routing
-/// is never inferred from DOM ancestors). `None` when absent, unstamped,
-/// or a profile context (the inspector evaluates against
-/// `/api/repository/{repo}/…`, which a profile location cannot name).
+/// is never inferred from DOM ancestors). `None` when absent or unstamped.
+///
+/// The pair only labels the cells' LSP buffer URIs and the header — the
+/// actual evaluate routes through the host consumer, which re-resolves the
+/// route (space/branch/profile) from this element's `with`. A profile
+/// context has no repository segment, so it labels as `profile`; the
+/// evaluate still targets `/api/profile/branch/{branch}/…`.
 fn resolve_context(el: &HtmlElement) -> Option<(String, String)> {
     let location: tonk_host::location::Location = el
         .get_attribute("with")
         .filter(|v| !v.is_empty() && !v.contains('{'))
         .and_then(|v| v.parse().ok())?;
-    let repo = location.space()?.to_owned();
+    let repo = location.space().unwrap_or("profile").to_owned();
     Some((repo, location.effective_branch().to_owned()))
 }
 

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -2103,9 +2103,9 @@ mod tests {
 
     #[dialog_common::test]
     fn it_pins_an_unrouted_operation_to_the_portals_with() {
-        let state = routed_state(Some("meta@profile:tonk"), "*");
+        let state = routed_state(Some("main@profile:tonk"), "*");
         let route = forwarded_route(&state, &route_envelope(None)).expect("pinned route");
-        assert_eq!(route, (None, Some("meta".into()), true));
+        assert_eq!(route, (None, Some("main".into()), true));
 
         let state = routed_state(Some("main@did:key:zA"), "main@did:key:zA");
         let route = forwarded_route(&state, &route_envelope(None)).expect("pinned route");
@@ -2117,7 +2117,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_honors_a_forwarded_route_the_allow_lists() {
-        let state = routed_state(Some("meta@profile:tonk"), "*");
+        let state = routed_state(Some("main@profile:tonk"), "*");
         let route =
             forwarded_route(&state, &route_envelope(Some("did:key:zB"))).expect("honored route");
         assert_eq!(route, (Some("did:key:zB".into()), None, false));

--- a/rust/tonk-tree/src/model.rs
+++ b/rust/tonk-tree/src/model.rs
@@ -67,16 +67,25 @@ pub struct Loader {
 }
 
 impl Loader {
-    pub fn new(repo: &str, branch: &str) -> Self {
-        // A HOST-RELATIVE URL (no origin prefix) so the request routes correctly
-        // everywhere: on a normal page it resolves same-origin; inside a sealed
-        // (opaque-origin) guest `window.location.origin` is the string "null", so
-        // an absolute URL would be `null/api/…` and fail — but the guest's
-        // `window.fetch` proxy reroutes host-relative `/api/…` paths over the
-        // bridge to the host's real origin (where the SW serves them).
-        Self {
-            url: format!("/api/repository/{repo}/branch/{branch}/query"),
-        }
+    /// Build a loader for a routing [`Location`] — a named space
+    /// (`/api/repository/{repo}/branch/{branch}/query`) or the profile
+    /// endpoint (`/api/profile/branch/{branch}/query`). The profile has
+    /// no repository segment, so a `main@profile:tonk` context targets
+    /// the parallel profile surface rather than a named repo.
+    ///
+    /// A HOST-RELATIVE URL (no origin prefix) so the request routes correctly
+    /// everywhere: on a normal page it resolves same-origin; inside a sealed
+    /// (opaque-origin) guest `window.location.origin` is the string "null", so
+    /// an absolute URL would be `null/api/…` and fail — but the guest's
+    /// `window.fetch` proxy reroutes host-relative `/api/…` paths over the
+    /// bridge to the host's real origin (where the SW serves them).
+    pub fn new(location: &tonk_host::location::Location) -> Self {
+        let branch = location.effective_branch();
+        let url = match location.space() {
+            Some(repo) => format!("/api/repository/{repo}/branch/{branch}/query"),
+            None => format!("/api/profile/branch/{branch}/query"),
+        };
+        Self { url }
     }
 
     /// POST a formula query and return the decoded rows.

--- a/rust/tonk-tree/src/web.rs
+++ b/rust/tonk-tree/src/web.rs
@@ -98,7 +98,7 @@ impl CustomElement for TonkTreeElement {
 
 /// Resolve the repo/branch, build the panes, and kick off the root load.
 fn start(this: &HtmlElement, slot: &RefCell<Option<Shared>>) {
-    let Some((repo, branch)) = resolve(this) else {
+    let Some(location) = resolve(this) else {
         mount_error(
             this,
             "no repository in context (set with=\"branch@repo\" or mount inside a routed <tonk-display>)",
@@ -108,7 +108,7 @@ fn start(this: &HtmlElement, slot: &RefCell<Option<Shared>>) {
 
     let shadow = ensure_shadow(this);
     let state = Rc::new(RefCell::new(State {
-        loader: Loader::new(&repo, &branch),
+        loader: Loader::new(&location),
         nodes: HashMap::new(),
         children: HashMap::new(),
         root: None,
@@ -140,19 +140,21 @@ fn start(this: &HtmlElement, slot: &RefCell<Option<Shared>>) {
     });
 }
 
-/// Resolve `repo`/`branch` from attributes or the nearest `with`
-/// ancestor. A profile context has no repository segment, so it does
-/// not satisfy the tree (which queries `/api/repository/{repo}/…`).
-fn resolve(this: &HtmlElement) -> Option<(String, String)> {
-    let context = own_with(this);
-    let repo = this
-        .get_attribute("repo")
-        .or_else(|| context.as_ref().and_then(|c| c.space().map(str::to_owned)))?;
-    let branch = this
-        .get_attribute("branch")
-        .or_else(|| context.as_ref().and_then(|c| c.branch().map(str::to_owned)))
-        .unwrap_or_else(|| "main".to_owned());
-    Some((repo, branch))
+/// Resolve the routing [`Location`] the tree queries against. An
+/// explicit `repo`/`branch` attribute pair names a space directly;
+/// otherwise the element's own `with` context (a named space or the
+/// profile endpoint) drives it. Returns `None` only when neither is
+/// present, so the tree can inspect either a space or the profile DB.
+fn resolve(this: &HtmlElement) -> Option<tonk_host::location::Location> {
+    use tonk_host::location::{Location, Repo};
+    if let Some(repo) = this.get_attribute("repo") {
+        let branch = this.get_attribute("branch");
+        return Some(Location {
+            repo: Repo::Named(repo),
+            branch,
+        });
+    }
+    own_with(this)
 }
 
 /// This element's OWN parsed `with` context, skipping an unstamped `{…}`

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -50,15 +50,15 @@ fn mount_root() {
     let Some(body) = document.body() else {
         return;
     };
-    // `<tonk-site with="meta@profile:tonk" allow="*">`: `with` routes the site's
-    // `tonk:load` claim and its guest's queries at the profile meta branch —
+    // `<tonk-site with="main@profile:tonk" allow="*">`: `with` routes the site's
+    // `tonk:load` claim and its guest's queries at the profile's main branch —
     // the profile's route! table picks what to render. `allow="*"` makes this
     // the privileged site: its guest (the trusted profile chrome) may reach
     // into any space (hub cards, sync chips, the FAB space list).
     let Ok(site) = document.create_element("tonk-site") else {
         return;
     };
-    let _ = site.set_attribute("with", "meta@profile:tonk");
+    let _ = site.set_attribute("with", "main@profile:tonk");
     let _ = site.set_attribute("allow", "*");
     // `<tonk-site>` never reads `window.location`; the page owns the document
     // path. Set it as `path` and keep it current on navigation (popstate /

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -22,7 +22,7 @@ pub use inspect::{BranchStatusResponse, RemoteBranchStatusResponse, RemoteStatus
 mod repository;
 pub use repository::{
     BranchConfiguration, MemberInfo, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,
-    UpstreamConfiguration, bootstrap_profile_meta,
+    UpstreamConfiguration, bootstrap_profile,
 };
 
 mod sync;

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -53,8 +53,9 @@ use super::repository::{
 };
 use crate::{TonkWorkerError, worker::TonkState};
 
-/// Name of the meta branch on the profile repository.
-const META_BRANCH: &str = "meta";
+/// The single branch the profile repository lives on (`main`; the
+/// profile has no content/meta split).
+const PROFILE_BRANCH: &str = "main";
 
 /// Default upstream branch wired up when the invite carries a
 /// `remote=` URL.
@@ -426,7 +427,7 @@ async fn find_replica_for_subject(
     let profile_meta = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| {
@@ -540,7 +541,7 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
     let session = match tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
     {

--- a/rust/tonk-worker/src/router/migration.rs
+++ b/rust/tonk-worker/src/router/migration.rs
@@ -33,9 +33,9 @@ use tonk_schema::{LegacyReplica, Replica, SpaceKind, SpaceStatus, prelude::DidEx
 use super::AppState;
 use crate::TonkWorkerError;
 
-/// Meta branch name on the profile repository. Mirrors the private
-/// copies in sibling modules.
-const META_BRANCH: &str = "meta";
+/// The single branch the profile repository lives on. Mirrors the
+/// private copies in sibling modules.
+const PROFILE_BRANCH: &str = "main";
 
 /// Tally of what the migration stamped.
 #[derive(Clone, Copy, Debug, Default)]
@@ -77,7 +77,7 @@ async fn run_migration(state: AppState) -> Result<MigrationReport, TonkWorkerErr
     let meta = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| {
@@ -146,7 +146,7 @@ async fn run_migration(state: AppState) -> Result<MigrationReport, TonkWorkerErr
     let mut transaction = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction();
     let mut report = MigrationReport::default();
 

--- a/rust/tonk-worker/src/router/profile.rs
+++ b/rust/tonk-worker/src/router/profile.rs
@@ -17,8 +17,8 @@ use crate::TonkWorkerError;
 /// Name of the meta branch on the profile repository — mirrors
 /// the constant in `super::repository`. Keeping a private copy
 /// rather than exporting the one from `super::repository` avoids
-/// a cross-module coupling for a one-character string.
-const META_BRANCH: &str = "meta";
+/// a cross-module coupling for a short string.
+const PROFILE_BRANCH: &str = "main";
 
 /// One space the profile owns, as listed by `GET /api/profile`.
 ///
@@ -40,14 +40,14 @@ pub struct SpaceEntry {
 /// Response body for `GET /api/profile`.
 ///
 /// `profile` describes the profile "as a repository" (see
-/// [`bootstrap_profile_meta`]) so the UI can render it the same
+/// [`bootstrap_profile`]) so the UI can render it the same
 /// way it renders any other space — populated by
 /// [`build_repository_info`], which reads the profile's meta
 /// branch and surfaces its branches and remotes. `space` lists every
 /// replica this profile owns — enough to populate the sidebar without
 /// per-repo round-trips.
 ///
-/// [`bootstrap_profile_meta`]: super::repository::bootstrap_profile_meta
+/// [`bootstrap_profile`]: super::repository::bootstrap_profile
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProfileInfo {
     /// [`RepositoryInfo`] for the profile itself — same shape as
@@ -105,7 +105,7 @@ pub async fn get_profile(
     let session = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| {

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -14,8 +14,10 @@ use crate::worker::TonkState;
 #[cfg(target_arch = "wasm32")]
 use tonk_schema::{MemberName, Membership};
 
-// The meta and content branch name constants, as used throughout router code.
-const META_BRANCH: &str = "meta";
+// The profile repository lives on `main` (it has no content/meta
+// split); spaces re-stamp member names on their own `main` content
+// branch.
+const PROFILE_BRANCH: &str = "main";
 // Only the wasm-gated rename handler re-stamps member names, so this and
 // `restamp_member_name` exist only on the wasm target (the worker's real
 // runtime). Gating them keeps the native `clippy -D warnings` build clean.
@@ -30,7 +32,7 @@ pub(crate) async fn resolve_display_name(tonk: &TonkState) -> String {
     let session = match tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
     {
@@ -78,7 +80,7 @@ pub(crate) async fn ensure_display_name(tonk: &TonkState) -> Result<(), Reposito
     let session = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| {
@@ -104,7 +106,7 @@ pub(crate) async fn ensure_display_name(tonk: &TonkState) -> Result<(), Reposito
     let name = petname(&tonk.profile.did());
     tonk.reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction()
         .assert(ProfileName::new(profile_entity, name))
         .commit()
@@ -135,7 +137,7 @@ async fn profile_space_keys(tonk: &TonkState) -> Vec<String> {
     let session = match tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
     {
@@ -308,7 +310,7 @@ mod tests {
         let profile_entity = tonk.profile.did().this();
         tonk.reactor
             .profile_repository()
-            .branch(META_BRANCH)
+            .branch(PROFILE_BRANCH)
             .transaction()
             .assert(ProfileName::new(profile_entity, "brave-lynx".into()))
             .commit()
@@ -325,7 +327,7 @@ mod tests {
         let profile_entity = tonk.profile.did().this();
         tonk.reactor
             .profile_repository()
-            .branch(META_BRANCH)
+            .branch(PROFILE_BRANCH)
             .transaction()
             .assert(ProfileName::new(profile_entity, "brave-lynx".into()))
             .commit()

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -35,10 +35,17 @@ use tonk_schema::{
 use super::AppState;
 use crate::{Notification, RepositoryError, TonkWorkerError, broadcast, worker::TonkState};
 
-/// Name of the meta branch every repository has alongside its
-/// content branches. The meta branch stores schema concepts
-/// describing the repository itself (see [`tonk_schema`]).
+/// Name of the device-local meta branch every *space* repository has
+/// alongside its content branch. It stores local bookkeeping — the
+/// local [`Replica`] record, remotes config, and branch enumeration —
+/// that must never replicate (see [`tonk_schema`]).
 const META_BRANCH: &str = "meta";
+
+/// The single branch the *profile* repository lives on. The profile
+/// has no content/meta split (its whole state is device-local hub
+/// bookkeeping), so it uses `main` like any repository's default
+/// branch rather than a separate meta branch.
+const PROFILE_BRANCH: &str = "main";
 
 /// Configuration for a single remote.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -870,7 +877,7 @@ async fn run_profile_rename(
     // 1. Persist the override on the profile meta branch.
     tonk.reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction()
         .assert(tonk_schema::ProfileName::new(
             profile_entity,
@@ -1092,7 +1099,7 @@ async fn remove_replica_from_profile(
     let meta = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
@@ -1108,7 +1115,7 @@ async fn remove_replica_from_profile(
     let mut transaction = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction();
     let mut found = false;
     while let Some(artifact) = stream.next().await {
@@ -1138,7 +1145,7 @@ async fn remove_replica_from_profile(
     broadcast(
         "/api/profile",
         &Notification {
-            branch: META_BRANCH.to_string(),
+            branch: PROFILE_BRANCH.to_string(),
             revision,
         },
     );
@@ -1427,7 +1434,7 @@ async fn replica_still_recorded(tonk: &TonkState, subject: &Did) -> Result<bool,
     let meta = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .acquire(&tonk.operator)
         .await
         .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
@@ -2111,7 +2118,7 @@ async fn record_replica_in_profile(
     let revision = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction()
         .assert(replica)
         .assert(status)
@@ -2132,7 +2139,7 @@ async fn record_replica_in_profile(
     broadcast(
         "/api/profile",
         &Notification {
-            branch: META_BRANCH.to_string(),
+            branch: PROFILE_BRANCH.to_string(),
             revision,
         },
     );
@@ -2163,7 +2170,7 @@ async fn set_replica_status(
     let revision = tonk
         .reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction()
         .assert(stamp)
         .commit()
@@ -2178,7 +2185,7 @@ async fn set_replica_status(
     broadcast(
         "/api/profile",
         &Notification {
-            branch: META_BRANCH.to_string(),
+            branch: PROFILE_BRANCH.to_string(),
             revision,
         },
     );
@@ -2209,7 +2216,7 @@ pub(super) async fn mark_replica_initialized(
 /// `(profile, subject)` / `(replica, name)`), so re-asserting the
 /// same facts produces the same entities and attribute values and
 /// the dialog layer deduplicates.
-pub async fn bootstrap_profile_meta(tonk: &TonkState) -> Result<(), RepositoryError> {
+pub async fn bootstrap_profile(tonk: &TonkState) -> Result<(), RepositoryError> {
     let profile_did = tonk.profile.did();
     let replica = Replica::new(profile_did.clone(), profile_did);
 
@@ -2219,17 +2226,17 @@ pub async fn bootstrap_profile_meta(tonk: &TonkState) -> Result<(), RepositoryEr
     // `Repository::from` handle would leave the reader stale.
     tonk.reactor
         .profile_repository()
-        .branch(META_BRANCH)
+        .branch(PROFILE_BRANCH)
         .transaction()
         .assert(replica.clone())
-        .assert(replica.branch(META_BRANCH))
+        .assert(replica.branch(PROFILE_BRANCH))
         .commit()
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
-            RepositoryError::Internal(format!("Failed to bootstrap profile meta: {}", e))
+            RepositoryError::Internal(format!("Failed to bootstrap profile branch: {}", e))
         })?;
-    log!("Profile meta bootstrapped");
+    log!("Profile branch bootstrapped");
 
     // Stamp a durable display name (the deterministic petname) when none is
     // stored yet, so the FAB's sealed profile-branch `<tonk-display
@@ -2253,18 +2260,18 @@ pub async fn bootstrap_profile_meta(tonk: &TonkState) -> Result<(), RepositoryEr
     Ok(())
 }
 
-/// Fetch and seed the lean profile library onto the profile meta
+/// Fetch and seed the lean profile library onto the profile
 /// branch. SW-only — the fetch needs a service-worker scope.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn seed_profile_library(tonk: &TonkState) -> Result<(), RepositoryError> {
     let library = fetch_standard_library(PROFILE_LIBRARY_URL)
         .await
         .map_err(|e| RepositoryError::Internal(format!("fetch profile library: {e}")))?;
-    super::evaluate::evaluate_profile_body(tonk, META_BRANCH, library, true)
+    super::evaluate::evaluate_profile_body(tonk, PROFILE_BRANCH, library, true)
         .await
         .map(|_| ())
         .map_err(|e| {
-            RepositoryError::Internal(format!("seed standard library on profile meta: {e}"))
+            RepositoryError::Internal(format!("seed standard library on profile branch: {e}"))
         })
 }
 
@@ -3399,7 +3406,7 @@ mod tests {
         let meta = tonk
             .reactor
             .profile_repository()
-            .branch(super::META_BRANCH)
+            .branch(super::PROFILE_BRANCH)
             .acquire(&tonk.operator)
             .await
             .expect("profile meta acquires");
@@ -3479,7 +3486,7 @@ mod tests {
         let (_app, state, _key) = fresh_repo("test-remove-self").await;
 
         // The harness never runs the worker boot path — and can't call
-        // `bootstrap_profile_meta`, whose library fetch needs a real
+        // `bootstrap_profile`, whose library fetch needs a real
         // service-worker registration — so seed just the self-replica
         // record the assertion below expects, mirroring the bootstrap's
         // own transaction.
@@ -3489,10 +3496,10 @@ mod tests {
             let replica = super::Replica::new(profile_did.clone(), profile_did);
             tonk.reactor
                 .profile_repository()
-                .branch(super::META_BRANCH)
+                .branch(super::PROFILE_BRANCH)
                 .transaction()
                 .assert(replica.clone())
-                .assert(replica.branch(super::META_BRANCH))
+                .assert(replica.branch(super::PROFILE_BRANCH))
                 .commit()
                 .perform(&tonk.operator)
                 .await
@@ -3667,7 +3674,7 @@ mod tests {
             &state,
             crate::router::CommandOrigin {
                 repo: String::new(),
-                branch: "meta".to_string(),
+                branch: "main".to_string(),
                 client: None,
             },
             changes,

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -330,7 +330,7 @@ mod profile_write_boundary {
         let result = transact_profile(
             axum::extract::State(state),
             axum::extract::Path(super::ProfileTransactPath {
-                branch: "meta".to_owned(),
+                branch: "main".to_owned(),
             }),
             Some(Extension(client_id)),
             HeaderMap::new(),

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::{
     LspHub,
     axum::{RequestConversion, ResponseConversion},
-    bootstrap_profile_meta,
+    bootstrap_profile,
     router::{AppState, BridgeRegistry, ClientId, ViewBindings, api_router_with_state},
 };
 use axum::{
@@ -699,7 +699,7 @@ impl TonkServiceWorker {
             commands: crate::router::command_registry(),
             sync_queue: Default::default(),
         };
-        bootstrap_profile_meta(&state)
+        bootstrap_profile(&state)
             .await
             .map_err(|e| JsError::new(&format!("Failed to bootstrap profile meta: {}", e)))?;
 


### PR DESCRIPTION
## Why

The profile repository never had a content/meta split — its entire state (hub replicas, member name, sync flags) lived on a bespoke `meta` branch while every other repository defaults to `main`. This aligns the profile with that convention so there's one less special case to reason about, and it lets the profile DB be inspected through the same routes a space exposes.

Two things gated the inspector/diagnose routes: they only knew how to target a named-repo endpoint (`/api/repository/{repo}/…`), and the tree/inspector context resolvers bailed on a profile location because it has no repo segment. Both now understand the profile endpoint.

## Approach

**Only the profile branch moves.** `meta` is overloaded: the profile uses it as its single branch, but each *space* repo has both `main` (synced roster + content) and `meta` (device-local Replica record, remotes, branch enumeration that must never replicate). Verified the roster (Membership/MemberName/Invitation) already lives on the space's `main` — the member list you see is read from there, not `meta` — so collapsing space `meta` would merge private bookkeeping into synced content. Spaces keep their split; only the profile's branch becomes `main`. Rename-forward only: existing meta-branch profiles are not auto-migrated.

Concretely, the worker's overloaded `META_BRANCH` constant is split into `PROFILE_BRANCH = "main"` (profile paths) and `META_BRANCH = "meta"` (space paths). The site `with` context, templates, and location-grammar examples move to `main@profile:tonk`. The CLI's `META_BRANCH` operates on space repos and is unchanged.

`/inspector` and `/diagnose` are added as profile routes mounting `<tonk-inspector source=home>` and `<tonk-tree>` pinned to the profile. The tree `Loader` and the inspector context resolver now accept a profile `Location` and build `/api/profile/branch/{branch}/query`.

## Verified

Fresh profile in the browser: hub renders on `main` (all profile ops hit `/api/profile/branch/main/…`, zero `meta`), `/diagnose` renders the search-tree over the profile DB, `/inspector` mounts with a working LSP. fmt, clippy `-D warnings`, native tests, and wasm `--no-run` for touched crates all green.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `meta` branch to `main` across various modules in the codebase, improving clarity and consistency in branch naming for the profile repository.

### Detailed summary
- Changed `branch: "meta"` to `branch: "main"` in multiple files.
- Updated function names to replace `bootstrap_profile_meta` with `bootstrap_profile`.
- Adjusted comments and constants to reflect the new branch name.
- Modified test cases to use the `main` branch instead of `meta`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->