### PR TITLE
fix(fab): persist the dock as a durable profile choice

### DIFF
--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -33,8 +33,8 @@
 //! The element does NOT use Shadow DOM — it is a transparent wrapper.
 
 use crate::logic::{
-    DOCK_CLASSES, Dock, corrected_min_width, dock_claim_json, mirrored, nearest_dock,
-    ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+    DOCK_CLASSES, Dock, corrected_min_width, dock_claim_json, dock_from_conclusions, mirrored,
+    nearest_dock, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -956,7 +956,7 @@ fn restore_position(this: &HtmlElement) {
             "dock": { "?": { "name": "dock" } }
         },
         "predicate": {
-            "description": "Persisted FAB dock (profile-meta claim).",
+            "description": "Persisted FAB dock (profile claim).",
             "with": {
                 "dock": { "the": "xyz.tonk.fab/dock", "cardinality": "one", "as": "Entity" }
             }
@@ -1028,18 +1028,14 @@ fn restore_position(this: &HtmlElement) {
     }
 }
 
-/// Extract the first row's `dock` from a `Conclusion[]` value returned by
-/// `window.tonk.query(...)` and resolve it to a `Dock`.
+/// Extract the persisted dock from a `Conclusion[]` value returned by
+/// `window.tonk.query(...)`. Decodes the JS value to JSON and delegates the
+/// row-shape parsing to [`dock_from_conclusions`], which is unit-tested
+/// against the `{ this, fields: { dock } }` conclusion shape.
 fn read_dock_from_rows(rows: &JsValue) -> Option<Dock> {
-    let arr = rows.dyn_ref::<js_sys::Array>()?;
-    let first = arr.get(0);
-    if first.is_undefined() || first.is_null() {
-        return None;
-    }
-    let sym = Reflect::get(&first, &"dock".into())
-        .ok()
-        .and_then(|v| v.as_string())?;
-    Dock::from_symbol(&sym)
+    let json = js_sys::JSON::stringify(rows).ok()?.as_string()?;
+    let value: serde_json::Value = serde_json::from_str(&json).ok()?;
+    dock_from_conclusions(&value)
 }
 
 /// Apply the default dock (bottom-right) to the element.

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -159,6 +159,25 @@ impl Dock {
     }
 }
 
+/// Resolve the persisted dock from a `/query` result (a `Conclusion[]` JSON
+/// value, the shape `window.tonk.query` yields).
+///
+/// A conclusion row is `{ this, fields: { dock, … } }`, so the projected
+/// `dock` symbol lives under `fields` — reading it off the row directly
+/// (an easy mistake that strands the dock at its default) finds nothing.
+/// Falls back to a flat `row.dock` so a change in the projection shape
+/// degrades to the default rather than a silent mismatch. `None` when the
+/// result is empty, malformed, or names an unknown dock symbol.
+pub fn dock_from_conclusions(rows: &Value) -> Option<Dock> {
+    let first = rows.as_array()?.first()?;
+    let symbol = first
+        .get("fields")
+        .and_then(|fields| fields.get("dock"))
+        .or_else(|| first.get("dock"))
+        .and_then(Value::as_str)?;
+    Dock::from_symbol(symbol)
+}
+
 /// Pick the corner nearest a drop. The vertical half of the viewport (height
 /// `vh`) picks top vs bottom and the horizontal half (width `vw`) picks left vs
 /// right, keyed off the drag's anchor point `(center_x, center_y)` — the grab
@@ -229,9 +248,9 @@ pub fn dock_claim_json(dock: Dock) -> Value {
             "op": "assert",
             "application": {
                 "predicate": {
-                    "kind": "transient",
+                    "kind": "durable",
                     "concept": {
-                        "description": "Persisted FAB dock (profile-meta claim).",
+                        "description": "Persisted FAB dock (profile claim).",
                         "with": {
                             "dock": {
                                 "the": "xyz.tonk.fab/dock",
@@ -555,13 +574,46 @@ mod persist {
         assert_eq!(v["claims"][0]["op"], "assert");
         let app = &v["claims"][0]["application"];
         assert_eq!(app["parameters"]["dock"], "tonk:bottom-left");
-        // verify predicate shape matches claim.rs serde derive
-        assert_eq!(app["predicate"]["kind"], "transient");
+        // The dock is a durable profile choice: it must survive commits,
+        // not evaporate as a transient at the timestep it's written.
+        assert_eq!(app["predicate"]["kind"], "durable");
         assert_eq!(
             app["predicate"]["concept"]["with"]["dock"]["the"],
             "xyz.tonk.fab/dock"
         );
         assert_eq!(app["parameters"]["this"], "state:fab");
+    }
+
+    #[test]
+    fn reads_the_dock_from_a_conclusion_row() {
+        // The exact `Conclusion[]` shape `window.tonk.query` returns: the
+        // projected `dock` lives under `fields`, not on the row. Reading it
+        // off the row directly is the regression that stranded restore at
+        // its default even though the fact was persisted.
+        let rows = json!([{
+            "this": "state:fab",
+            "fields": { "this": "state:fab", "dock": "tonk:bottom-left" }
+        }]);
+        assert_eq!(dock_from_conclusions(&rows), Some(Dock::BottomLeft));
+    }
+
+    #[test]
+    fn reads_the_dock_from_a_flat_row() {
+        // Fallback shape: a flat `row.dock` still resolves, so a projection
+        // change degrades to a working read rather than a silent default.
+        let rows = json!([{ "dock": "tonk:top-right" }]);
+        assert_eq!(dock_from_conclusions(&rows), Some(Dock::TopRight));
+    }
+
+    #[test]
+    fn empty_result_has_no_dock() {
+        assert_eq!(dock_from_conclusions(&json!([])), None);
+    }
+
+    #[test]
+    fn unknown_symbol_has_no_dock() {
+        let rows = json!([{ "fields": { "dock": "tonk:middle" } }]);
+        assert_eq!(dock_from_conclusions(&rows), None);
     }
 }
 


### PR DESCRIPTION
## Why

The FAB dock position stopped surviving reloads. It's meant to be a profile-level choice you set once, so it should be stored on the profile and restored on every load.

## Approach

Two bugs were stacked, which is why it looked like nothing persisted at all:

1. **The write evaporated.** The dock was asserted as a `transient` concept. The reactor asserts transients so effects can read them within the timestep, then retracts them before the durable commit — so the fact never reached storage. The dock is a durable choice, so it's now a `durable` claim. Verified: the durable write round-trips through `/api/profile/branch/main/query`, the transient one returned `[]`.

2. **The read looked in the wrong place.** Even once stored, restore read `dock` off the conclusion row directly, but a conclusion is shaped `{ this, fields: { dock } }` — the projected value lives under `fields`. So the restore always fell through to the default corner. The row-shape parsing moved into a pure `dock_from_conclusions` with unit tests covering the nested shape, a flat fallback, an empty result, and an unknown symbol.

## Verified

In the browser: set a dock, reload, FAB restores to exactly that corner; the stored value is unchanged by the restore. `cargo test -p tonk-fab` (32 pass, 4 new), clippy clean, wasm build clean.

## Note

This surfaced after the profile branch moved from `meta` to `main` (#570), but the root cause is independent — the transient/read bugs predate it (likely since the routing collapse removed the `<tonk-repository profile>` annotation that had been routing these ops). The fix is orthogonal to the branch name.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the handling of dock information in the `tonk-fab` application by refining the extraction process from query results and updating the associated documentation.

### Detailed summary
- Added `dock_from_conclusions` function to extract `dock` from `Conclusion[]` JSON.
- Updated `read_dock_from_rows` to use `dock_from_conclusions`.
- Changed description from "Persisted FAB dock (profile-meta claim)" to "Persisted FAB dock (profile claim)".
- Updated the `dock_claim_json` to reflect changes in dock persistence.
- Added unit tests for various scenarios of dock extraction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->