### PR TITLE
fix(fab): decouple sync pause from space-side views

### DIFF
--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -242,31 +242,11 @@ command!: &tonk/load
       the: xyz.tonk.site/path
       as: text
 
-# Toggle auto-sync for the space in scope. No chrome currently submits this —
-# the FAB's double-click pause gesture was removed as unintuitive — but the
-# command and its worker handler stay for a future, visible affordance.
-# `time` carries the click timestamp so each submit is a distinct transient and
-# reliably re-fires the toggle handler. The worker reads the origin repo, flips
-# the durable `enabled` preference, and publishes the matching status — the
-# command carries no payload beyond the timestamp.
-command!: &tonk/pause-sync
-  this: tonk:pause-sync
-  description: Toggle auto-sync (pause ⇄ resume) for the space in scope.
-  with:
-    time:
-      description: The submit event's timestamp; makes each click distinct.
-      the: dom.event/time-stamp
-      as: float
-    marker:
-      description: |
-          Per-command marker read from a pause affordance's `data-pause-sync`.
-          Gives `tonk:pause-sync` an attribute no other command carries, so
-          this transient does not also decode as `tonk:invite`.
-      the: dom.event.current-target.dataset/pause-sync
-      as: entity
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
+# NOTE: `tonk:pause-sync` is defined on the PROFILE branch (profile.yaml), not
+# here. The FAB's `<ui-sync-status onpause=tonk:pause-sync>` cap dispatches it on
+# the profile context carrying the target space, so pause needs nothing seeded
+# on a space's own branch. It used to live here and be submitted by a hidden
+# space-side form, which broke on any space seeded before that form existed.
 
 # The durable, public half of an invite: the base58 delegation chain the
 # handler minted, keyed by the membership DID. Replicates like any fact —
@@ -755,37 +735,11 @@ view/directory!:
       <button type="submit" class="fab__share-trigger">share</button>
     </form>
 
-# A view kind holding the FAB's hidden pause-sync form. Distinct attribute
-# (`xyz.tonk.view/fab-pause`) so `tonk:repository` can carry it alongside its
-# other views; selected via `view=tonk:view/fab-pause`.
-concept!: &view/fab-pause
-  this: tonk:view/fab-pause
-  description: A view kind holding the FAB's pause-sync form.
-  with:
-    model:
-      description: Concept this view renders.
-      the: xyz.tonk.view/model
-      cardinality: one
-      as: entity
-    display:
-      description: HTML template — the hidden pause-sync form.
-      the: xyz.tonk.view/fab-pause
-      cardinality: one
-      as: text
-
-# The FAB's pause-sync FORM, authored on the SPACE branch (a `tonk:repository`
-# view) for the SAME two reasons the share trigger above is: mounted via
-# `<tonk-display with={space} model="tonk:repository" view="tonk:view/fab-pause">`,
-# its `onsubmit=tonk:pause-sync` binding resolves its descriptor against this
-# branch AND dispatches its claim inside the space's `with` context, so the
-# worker reads the space as the command's origin repo. Submitted by the FAB's
-# alt/option-click gesture (tonk-fab element.rs); `data-pause-sync` is the
-# marker `tonk:pause-sync` decodes against.
-view/fab-pause!:
-  this: id:tonk:repository/fab-pause
-  model: tonk:repository
-  display: |
-    <form id="fab-pause-sync-form" data-pause-sync="tonk:pause-sync" onsubmit=tonk:pause-sync></form>
+# NOTE: the FAB's pause affordance is no longer a space-side view. It moved to
+# the host-chrome `<ui-sync-status onpause=tonk:pause-sync>` cap, which
+# dispatches the profile-branch `tonk:pause-sync` command (profile.yaml)
+# carrying the target space. So there is no `tonk:view/fab-pause` here anymore —
+# an older space missing it no longer breaks the FAB.
 
 # The repository's own name, stored in its content branch so the repo
 # is self-describing — the name travels with the repository rather than

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -639,6 +639,31 @@ command!: &profile/rename
       the: dom.event.current-target.dataset/rename
       as: entity
 
+# Toggle auto-sync (pause ⇄ resume) for a space. Dispatched by the FAB's
+# `<ui-sync-status onpause=…>` cap on alt/option-click. Defined here on the
+# PROFILE branch (not on each space's branch) and dispatched on the profile
+# context, so the FAB's pause affordance depends on nothing seeded per-space —
+# older spaces missing a `fab-pause` view no longer break it. The `space` field
+# names WHICH replica to flip; the worker's PauseSyncHandler reads it in place
+# of the dispatch origin. `time` makes each click a distinct transient so the
+# toggle reliably re-fires; `marker` keeps the shape distinct from `tonk:invite`.
+command!: &tonk/pause-sync
+  this: tonk:pause-sync
+  description: Toggle auto-sync (pause ⇄ resume) for a space.
+  with:
+    time:
+      description: The click's timestamp; makes each dispatch a distinct transient.
+      the: dom.event/time-stamp
+      as: float
+    space:
+      description: The target space DID — the replica whose auto-sync is flipped.
+      the: xyz.tonk.pause-sync/space
+      as: entity
+    marker:
+      description: Per-command marker keeping the shape distinct from tonk:invite.
+      the: dom.event.current-target.dataset/pause-sync
+      as: entity
+
 # A no-entity directory view over the single profile-name row → an inline
 # editable bound to the name. Mounted in the FAB bar via
 # `<tonk-display model="tonk:profile/name">`. The `<tonk-editable>` commits on
@@ -674,16 +699,12 @@ view/directory!: &profile/fab/view
              context the repo-name display below uses). It subscribes to the
              space's `state:here` sync status and updates as the background drain
              reconciles. When collapsed the whole bar shrinks to just this cap
-             (a floating disc); dragging grabs it. `.fab__circle` sizes the disc. -->
-        <span class="fab__seg fab__cap-l fab__circle"><ui-sync-status with={dom.host/data-space}></ui-sync-status></span>
-        <!-- Hidden pause-sync form, submitted by alt/option-click on the cap
-             (element.rs). Lives in a SPACE-branch view (core.yaml's
-             `tonk:view/fab-pause`) mounted inside the space's `with` context —
-             so its `onsubmit=tonk:pause-sync` binding both resolves its
-             descriptor AND routes its claim to the space's content branch,
-             where the worker's handler flips the durable preference. The
-             cap's `<ui-sync-status>` ring shows the resulting paused state. -->
-        <tonk-display class="fab__pause" with={dom.host/data-space} model="tonk:repository" view="tonk:view/fab-pause" hidden></tonk-display>
+             (a floating disc); dragging grabs it. `.fab__circle` sizes the disc.
+             `onpause=tonk:pause-sync` wires the alt/option-click pause gesture:
+             the element dispatches that PROFILE-branch command carrying its own
+             space (from `with`), so pause needs nothing seeded on the space —
+             no hidden form, no space-side view. -->
+        <span class="fab__seg fab__cap-l fab__circle"><ui-sync-status with={dom.host/data-space} onpause="tonk:pause-sync"></ui-sync-status></span>
         <!-- ACCOUNT — its own segment (wireframe's `mr_oats`): the signed-in
              profile name, an inline editable that renames the profile. Shown
              whenever the bar is expanded (no disclosure gate). -->

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -34,7 +34,7 @@
 
 use crate::logic::{
     DOCK_CLASSES, Dock, corrected_min_width, dock_claim_json, dock_from_conclusions, mirrored,
-    nearest_dock, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+    nearest_dock, pause_claim_json, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -197,8 +197,9 @@ fn wrap_telescope_tiles(element: &HtmlElement) {
 /// detection, no timers. The listener sits on the `<tonk-fab>` host and
 /// routes by the event target:
 ///
-/// - CIRCLE cap: `click` folds/expands the bar; alt/option-`click` toggles
-///   pause ⇄ resume of sync (the cap's ring already shows the state).
+/// - CIRCLE cap: `click` folds/expands the bar. Alt/option-`click` is the pause
+///   gesture, handled by the cap's own `<ui-sync-status onpause=…>` — so this
+///   handler leaves an alt-click alone (no fold) and lets it toggle sync there.
 /// - SPOT segment: `click` toggles the switcher menu.
 /// - SHARE segment: `click` toggles the roster menu.
 ///
@@ -209,9 +210,14 @@ fn attach_gestures(element: &HtmlElement) {
         let Some(t) = e.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
             return;
         };
-        if t.closest(".fab__cap-l").ok().flatten().is_some() {
+        if let Some(cap) = t.closest(".fab__cap-l").ok().flatten() {
+            // Alt/option-click toggles sync pause; a plain click folds/expands.
+            // Pause is dispatched here (on the FAB, which reliably receives the
+            // click — the cloned `<ui-sync-status>` inside the cap cannot own a
+            // live DOM listener) reading the target space + command off the
+            // cap's `<ui-sync-status with=… onpause=…>`.
             if e.alt_key() {
-                submit_pause_form(&el_click);
+                dispatch_pause_from_cap(&cap);
             } else {
                 toggle_telescope(&el_click);
             }
@@ -247,24 +253,55 @@ fn attach_gestures(element: &HtmlElement) {
     on_click.forget();
 }
 
-/// Toggle pause ⇄ resume: submit the hidden pause form (`tonk:view/fab-pause`,
-/// mounted space-scoped by the FAB template), whose `onsubmit=tonk:pause-sync`
-/// binding fires the toggle command against the space's content branch.
-/// `requestSubmit()` (not `submit()`) so the form's `submit` event — which the
-/// command delegation listens for — actually fires. The cap's
-/// `<ui-sync-status>` ring reflects the result via its live subscription.
-fn submit_pause_form(element: &HtmlElement) {
-    let Some(form) = element
-        .query_selector("#fab-pause-sync-form")
-        .ok()
-        .flatten()
+/// Toggle sync pause for the active space. Reads the target space and the
+/// command URI off the cap's `<ui-sync-status with="branch@repo" onpause=…>`
+/// (the space DID was baked into `with` at render time from
+/// `{dom.host/data-space}`), builds the `tonk:pause-sync` transient, and
+/// dispatches it through `window.tonk.transact` — routeless, so it lands on the
+/// FAB portal's own context (`main@profile:tonk`, where the command is defined
+/// and its handler reads the target space from the command). Nothing space-side
+/// is required, and this runs from the FAB's own click listener, which — unlike
+/// a listener on the cloned `<ui-sync-status>` — reliably receives the click.
+fn dispatch_pause_from_cap(cap: &Element) {
+    let Some(status) = cap.query_selector("ui-sync-status").ok().flatten() else {
+        return;
+    };
+    let command = status
+        .get_attribute("onpause")
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| "tonk:pause-sync".to_owned());
+    // The cap's `with` is a `branch@repo` location (or a bare repo); the space
+    // is the repo half. The FAB renders `<ui-sync-status with={dom.host/data-
+    // space}>`, so this is the active space's DID with no branch prefix.
+    let Some(space) = status
+        .get_attribute("with")
+        .filter(|w| !w.is_empty() && !w.contains('{'))
+        .map(|w| w.rsplit('@').next().unwrap_or(&w).to_owned())
+        .filter(|s| !s.is_empty())
     else {
         return;
     };
-    if let Ok(request_submit) = Reflect::get(form.as_ref(), &"requestSubmit".into())
-        && let Ok(request_submit) = request_submit.dyn_into::<Function>()
-    {
-        let _ = request_submit.call0(form.as_ref());
+
+    let claim = pause_claim_json(&command, &space, js_sys::Date::now());
+    let json_str = match serde_json::to_string(&claim) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let Some(win) = window() else { return };
+    let Some(tonk) = Reflect::get(&win, &"tonk".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Object>().ok())
+    else {
+        return;
+    };
+    let Some(transact) = Reflect::get(&tonk, &"transact".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Function>().ok())
+    else {
+        return;
+    };
+    if let Some(obj) = js_sys::JSON::parse(&json_str).ok() {
+        transact.call1(&tonk, &obj).ok();
     }
 }
 

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -33,8 +33,8 @@
 //! The element does NOT use Shadow DOM — it is a transparent wrapper.
 
 use crate::logic::{
-    DOCK_CLASSES, Dock, corrected_min_width, dock_claim_json, mirrored, nearest_dock,
-    ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+    DOCK_CLASSES, Dock, corrected_min_width, dock_claim_json, dock_from_conclusions, mirrored,
+    nearest_dock, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -956,7 +956,7 @@ fn restore_position(this: &HtmlElement) {
             "dock": { "?": { "name": "dock" } }
         },
         "predicate": {
-            "description": "Persisted FAB dock (profile-meta claim).",
+            "description": "Persisted FAB dock (profile claim).",
             "with": {
                 "dock": { "the": "xyz.tonk.fab/dock", "cardinality": "one", "as": "Entity" }
             }
@@ -1028,18 +1028,14 @@ fn restore_position(this: &HtmlElement) {
     }
 }
 
-/// Extract the first row's `dock` from a `Conclusion[]` value returned by
-/// `window.tonk.query(...)` and resolve it to a `Dock`.
+/// Extract the persisted dock from a `Conclusion[]` value returned by
+/// `window.tonk.query(...)`. Decodes the JS value to JSON and delegates the
+/// row-shape parsing to [`dock_from_conclusions`], which is unit-tested
+/// against the `{ this, fields: { dock } }` conclusion shape.
 fn read_dock_from_rows(rows: &JsValue) -> Option<Dock> {
-    let arr = rows.dyn_ref::<js_sys::Array>()?;
-    let first = arr.get(0);
-    if first.is_undefined() || first.is_null() {
-        return None;
-    }
-    let sym = Reflect::get(&first, &"dock".into())
-        .ok()
-        .and_then(|v| v.as_string())?;
-    Dock::from_symbol(&sym)
+    let json = js_sys::JSON::stringify(rows).ok()?.as_string()?;
+    let value: serde_json::Value = serde_json::from_str(&json).ok()?;
+    dock_from_conclusions(&value)
 }
 
 /// Apply the default dock (bottom-right) to the element.

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -159,6 +159,25 @@ impl Dock {
     }
 }
 
+/// Resolve the persisted dock from a `/query` result (a `Conclusion[]` JSON
+/// value, the shape `window.tonk.query` yields).
+///
+/// A conclusion row is `{ this, fields: { dock, … } }`, so the projected
+/// `dock` symbol lives under `fields` — reading it off the row directly
+/// (an easy mistake that strands the dock at its default) finds nothing.
+/// Falls back to a flat `row.dock` so a change in the projection shape
+/// degrades to the default rather than a silent mismatch. `None` when the
+/// result is empty, malformed, or names an unknown dock symbol.
+pub fn dock_from_conclusions(rows: &Value) -> Option<Dock> {
+    let first = rows.as_array()?.first()?;
+    let symbol = first
+        .get("fields")
+        .and_then(|fields| fields.get("dock"))
+        .or_else(|| first.get("dock"))
+        .and_then(Value::as_str)?;
+    Dock::from_symbol(symbol)
+}
+
 /// Pick the corner nearest a drop. The vertical half of the viewport (height
 /// `vh`) picks top vs bottom and the horizontal half (width `vw`) picks left vs
 /// right, keyed off the drag's anchor point `(center_x, center_y)` — the grab
@@ -229,9 +248,9 @@ pub fn dock_claim_json(dock: Dock) -> Value {
             "op": "assert",
             "application": {
                 "predicate": {
-                    "kind": "transient",
+                    "kind": "durable",
                     "concept": {
-                        "description": "Persisted FAB dock (profile-meta claim).",
+                        "description": "Persisted FAB dock (profile claim).",
                         "with": {
                             "dock": {
                                 "the": "xyz.tonk.fab/dock",
@@ -555,13 +574,46 @@ mod persist {
         assert_eq!(v["claims"][0]["op"], "assert");
         let app = &v["claims"][0]["application"];
         assert_eq!(app["parameters"]["dock"], "tonk:bottom-left");
-        // verify predicate shape matches claim.rs serde derive
-        assert_eq!(app["predicate"]["kind"], "transient");
+        // The dock is a durable profile choice: it must survive commits,
+        // not evaporate as a transient at the timestep it's written.
+        assert_eq!(app["predicate"]["kind"], "durable");
         assert_eq!(
             app["predicate"]["concept"]["with"]["dock"]["the"],
             "xyz.tonk.fab/dock"
         );
         assert_eq!(app["parameters"]["this"], "state:fab");
+    }
+
+    #[test]
+    fn reads_the_dock_from_a_conclusion_row() {
+        // The exact `Conclusion[]` shape `window.tonk.query` returns: the
+        // projected `dock` lives under `fields`, not on the row. Reading it
+        // off the row directly is the regression that stranded restore at
+        // its default even though the fact was persisted.
+        let rows = json!([{
+            "this": "state:fab",
+            "fields": { "this": "state:fab", "dock": "tonk:bottom-left" }
+        }]);
+        assert_eq!(dock_from_conclusions(&rows), Some(Dock::BottomLeft));
+    }
+
+    #[test]
+    fn reads_the_dock_from_a_flat_row() {
+        // Fallback shape: a flat `row.dock` still resolves, so a projection
+        // change degrades to a working read rather than a silent default.
+        let rows = json!([{ "dock": "tonk:top-right" }]);
+        assert_eq!(dock_from_conclusions(&rows), Some(Dock::TopRight));
+    }
+
+    #[test]
+    fn empty_result_has_no_dock() {
+        assert_eq!(dock_from_conclusions(&json!([])), None);
+    }
+
+    #[test]
+    fn unknown_symbol_has_no_dock() {
+        let rows = json!([{ "fields": { "dock": "tonk:middle" } }]);
+        assert_eq!(dock_from_conclusions(&rows), None);
     }
 }
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -269,6 +269,41 @@ pub fn dock_claim_json(dock: Dock) -> Value {
     })
 }
 
+/// Build a `TransactRequest` JSON body for the `tonk:pause-sync` command.
+///
+/// A transient command asserting the target `space` (the DID to pause) with a
+/// per-click `time` so each dispatch is a distinct transient, plus the `marker`
+/// (the command URI) that keeps the shape distinct from `tonk:invite`. `this`
+/// is omitted so the worker mints it from `(descriptor, parameters)`. Dispatched
+/// routeless via `window.tonk.transact`, so it lands on the FAB portal's own
+/// `main@profile:tonk` context where the command lives; the worker's handler
+/// reads `space` to flip that replica — nothing space-side is required.
+pub fn pause_claim_json(command: &str, space: &str, time: f64) -> Value {
+    json!({
+        "claims": [{
+            "op": "assert",
+            "application": {
+                "predicate": {
+                    "kind": "transient",
+                    "concept": {
+                        "description": "Toggle auto-sync (pause ⇄ resume) for a space.",
+                        "with": {
+                            "time":   { "the": "dom.event/time-stamp", "as": "Float" },
+                            "space":  { "the": "xyz.tonk.pause-sync/space", "as": "Entity" },
+                            "marker": { "the": "dom.event.current-target.dataset/pause-sync", "as": "Entity" }
+                        }
+                    }
+                },
+                "parameters": {
+                    "time": time,
+                    "space": space,
+                    "marker": command
+                }
+            }
+        }]
+    })
+}
+
 /// The inline `min-width` (px) to stamp on a bar segment when its dropdown
 /// opens: the menu's natural (max-content) width when that EXCEEDS the
 /// segment, so the rung widens — whitespace filling around its label — and
@@ -582,6 +617,27 @@ mod persist {
             "xyz.tonk.fab/dock"
         );
         assert_eq!(app["parameters"]["this"], "state:fab");
+    }
+
+    #[test]
+    fn pause_claim_carries_the_space_and_is_transient() {
+        let v = pause_claim_json("tonk:pause-sync", "did:key:zSpace", 123.0);
+        let app = &v["claims"][0]["application"];
+        assert_eq!(v["claims"][0]["op"], "assert");
+        // A command is a one-timestep transient, not a durable fact.
+        assert_eq!(app["predicate"]["kind"], "transient");
+        // The target space rides the command so the handler needn't read it
+        // from the dispatch origin — this is what lets pause dispatch from the
+        // profile branch and depend on nothing seeded per-space.
+        assert_eq!(app["parameters"]["space"], "did:key:zSpace");
+        assert_eq!(app["parameters"]["marker"], "tonk:pause-sync");
+        assert_eq!(app["parameters"]["time"], 123.0);
+        assert_eq!(
+            app["predicate"]["concept"]["with"]["space"]["the"],
+            "xyz.tonk.pause-sync/space"
+        );
+        // `this` is omitted so the worker mints it from (descriptor, params).
+        assert!(app["parameters"].get("this").is_none());
     }
 
     #[test]

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -146,13 +146,17 @@ impl Command for Invite {
     type Output = ();
 }
 
-/// Toggle background sync for the origin repo's replica.
+/// Toggle background sync for a space's replica.
 ///
-/// Dispatched when the sync chip is clicked. Carries only a timestamp so
-/// each click is a distinct transient (re-firing the handler); the handler
-/// reads the replica's current `auto-sync` preference and flips it. The
-/// repo is read from the command origin, the profile from the worker — the
-/// two that key the replica.
+/// Dispatched when the FAB's sync cap is alt/option-clicked. Carries the
+/// target `space` (the DID to pause) and a timestamp so each click is a
+/// distinct transient (re-firing the handler); the handler reads the
+/// replica's current `auto-sync` preference for that space and flips it.
+///
+/// The `space` field is what lets this command live on and dispatch from the
+/// PROFILE branch: the handler reads the target space from the command rather
+/// than the dispatch origin, so the FAB's pause affordance needs no view or
+/// command seeded on each space's own branch.
 #[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
 pub struct PauseSync {
     /// The command entity (a fresh id per click).
@@ -160,10 +164,13 @@ pub struct PauseSync {
     /// The click event's timestamp — distinguishes one click from the next
     /// so the transient re-fires.
     pub time: crate::domain::command::invite::TimeStamp,
-    /// Per-command marker (read from the pause form's `data-pause-sync`) that
-    /// gives `PauseSync` an attribute no other command carries — so this
-    /// transient does NOT also decode as `tonk:invite` (which shares the same
-    /// `{this, time}` shape). See [`crate::domain::command::pause_sync::PauseSync`].
+    /// The target space DID — the replica to pause/resume. Read by the handler
+    /// in place of the dispatch origin.
+    pub space: crate::domain::command::pause_sync::Space,
+    /// Per-command marker that gives `PauseSync` an attribute no other command
+    /// carries — so this transient does NOT also decode as `tonk:invite` (which
+    /// shares the same `{this, time}` shape). See
+    /// [`crate::domain::command::pause_sync::PauseSync`].
     pub marker: crate::domain::command::pause_sync::PauseSync,
 }
 

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -271,19 +271,29 @@ pub mod command {
         pub struct Invite(pub Entity);
     }
 
-    /// Attributes the `tonk:pause-sync` command reads from its submit event.
+    /// Attributes the `tonk:pause-sync` command carries.
     pub mod pause_sync {
         use super::super::Entity;
         use super::Attribute;
 
-        /// The per-command marker read from a `data-pause-sync` attribute on
-        /// the pause form — `tonk:pause-sync`'s distinct attribute, so it never
-        /// shares a shape with `tonk:invite` (see [`super::invite::Invite`]).
-        /// The derived attribute is `dom.event.current-target.dataset/pause-sync`.
-        /// An `Entity` for the same reason as the invite marker.
+        /// The per-command marker — `tonk:pause-sync`'s distinct attribute, so
+        /// it never shares a shape with `tonk:invite` (see
+        /// [`super::invite::Invite`]). An `Entity` for the same reason as the
+        /// invite marker. The derived attribute is
+        /// `dom.event.current-target.dataset/pause-sync`.
         #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
         #[domain("dom.event.current-target.dataset")]
         pub struct PauseSync(pub Entity);
+
+        /// The target space DID (its subject `did:key`). The pause affordance
+        /// (the FAB's `<ui-sync-status>`) carries this so the command names the
+        /// space to pause explicitly, rather than the handler reading it off
+        /// the dispatch origin. That lets the command be defined and dispatched
+        /// on the PROFILE branch — the FAB depends on nothing seeded per-space.
+        /// The derived attribute is `xyz.tonk.pause-sync/space`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.pause-sync")]
+        pub struct Space(pub Entity);
     }
 
     /// Attributes the `profile/rename` command reads from the identity

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -744,23 +744,33 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PauseSyncHand
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
         use crate::reactor::Decode as _;
+        use tonk_schema::prelude::DidExt as _;
 
-        // Decode synchronously only to confirm this is a `PauseSync`; it
-        // carries no payload the handler needs (the repo comes from the
-        // origin, the toggle is read from durable state).
-        let is_pause = facts
+        // Decode synchronously to read the target space off the command — the
+        // handler flips THAT space's replica, not the dispatch origin's, so the
+        // command can be dispatched from the profile branch. The repo key is
+        // the space DID's suffix; a space's content branch is always `main`.
+        let target = facts
             .first()
             .map(|artifact| artifact.of.clone())
             .and_then(|entity| tonk_schema::command::PauseSync::decode(entity, facts))
-            .is_some();
+            .and_then(|command| {
+                command
+                    .space
+                    .0
+                    .to_string()
+                    .parse::<dialog_varsig::Did>()
+                    .ok()
+            })
+            .map(|did| did.repo_key().to_owned());
         let env = env.clone();
 
         Box::pin(async move {
-            if !is_pause {
+            let Some(repo) = target else {
+                log!("PauseSync: no/unparseable target space, skipping");
                 return;
-            }
-            let repo = env.origin().repo.clone();
-            let branch = env.origin().branch.clone();
+            };
+            let branch = CONTENT_BRANCH.to_string();
             log!("command PauseSync repo={} branch={}", repo, branch);
 
             if let Err(error) = run_pause_sync(&env, &repo, &branch).await {

--- a/rust/tonk-workspace/src/ui_sync_status.rs
+++ b/rust/tonk-workspace/src/ui_sync_status.rs
@@ -13,11 +13,14 @@
 //! old `<tonk-sync-badge>`, which one-shot-fetched on mount + commit + toggle
 //! (none of which recur on the Hub, so it froze on a stale reading).
 //!
-//! Resolves its space from its `with="branch@repo"` attribute (or the nearest
-//! `with` ancestor) and subscribes through that routing context — the same way
-//! every consumer reaches the worker. Read-only: no pause affordance (that stays on the
-//! topbar chip). The `.sync` / `.disc` CSS lives in the app stylesheet, so the
-//! disc styles wherever this mounts; the caller sizes it with `font-size`.
+//! Resolves its space from its `with="branch@repo"` attribute and subscribes
+//! through that routing context — the same way every consumer reaches the
+//! worker. Read-only: it renders the disc but dispatches nothing. The FAB's
+//! alt/option-click pause reads this element's `with`/`onpause` and dispatches
+//! from its own handler (the cap's `<ui-sync-status>` is cloned, so a listener
+//! on it wouldn't reliably fire — see `tonk-fab`). The `.sync` / `.disc` CSS
+//! lives in the app stylesheet, so the disc styles wherever this mounts; the
+//! caller sizes it with `font-size`.
 
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
## Why

The FAB's pause affordance mounted a hidden `<tonk-display view=tonk:view/fab-pause>` scoped to the active space, so any space seeded before that view existed rendered a loud "View not found" in the FAB. Sync status already avoids this by being host-chrome that needs nothing seeded per-space; pause now follows suit.

## Approach

`tonk:pause-sync` moves to the profile branch and carries the target space as a field; its handler reads that instead of the dispatch origin, so the command can be defined and dispatched on the profile branch. The FAB dispatches it from its own click handler — reading the space + command off the cap's `<ui-sync-status with= onpause=>` — routeless via `window.tonk.transact`, landing on the profile context.

The dispatch lives on the FAB, not on `<ui-sync-status>`, because `<tonk-display>` mounts the FAB view by `cloneNode`-ing the authored subtree: a DOM listener added inside the cloned `<ui-sync-status>`'s `connected_callback` does not reliably receive the click, whereas the FAB's own `attach_gestures` (guarded by the `__tonkFabBound` property-reset pattern precisely for this clone reality) does. The dead space-side pause form/view is removed.

## Verified

On a space seeded before the pause view existed: FAB renders with no "View not found". Alt/option-click flips the sync status (`idle`/`pending` → `paused` → back) on the space branch and the disc reflects it. `cargo test -p tonk-fab -p tonk-schema` (33 + 115), clippy clean, wasm build clean.

## Note

Depends on and builds atop the dock fix (#571, already merged). The branch merge in the history is staging catching up.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk:pause-sync` command to allow toggling auto-sync for specific spaces, ensuring that the command can be dispatched from the profile branch without needing space-specific views. It improves how the pause functionality is handled in the UI.

### Detailed summary
- Updated documentation for `tonk:pause-sync` to clarify its function.
- Changed `PauseSync` command to include a target space DID.
- Removed hidden pause form; integrated pause functionality directly in `<ui-sync-status>`.
- Modified event handling to dispatch pause commands directly from the FAB.
- Added tests for `pause_claim_json` to verify correct parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->