### PR TITLE
perf(reactor): skip subscription re-poll on a no-op pull

### DIFF
--- a/rust/dialog-reactor/src/pull.rs
+++ b/rust/dialog-reactor/src/pull.rs
@@ -20,8 +20,12 @@ impl<'a> Pull<'a> {
         Self { branch }
     }
 
-    /// Execute the pull. On success, every subscription on the
-    /// branch is re-evaluated.
+    /// Execute the pull. Subscriptions are re-evaluated **only when the pull
+    /// actually moved the branch tree** — a pull that finds no upstream change
+    /// (the common case for a periodic background sync) leaves every query
+    /// result identical, so re-polling would be pure waste. Skipping it is the
+    /// difference between an idle sync being invisible and it re-running every
+    /// subscription on the branch on every tick.
     ///
     /// Two phases: the network-bound fetch + rebase
     /// ([`prepare`](dialog_repository::PreparedPull)) runs lock-free, then the
@@ -37,6 +41,10 @@ impl<'a> Pull<'a> {
     {
         let cached = self.branch.acquire(env).await?;
 
+        // The tree we're at before the pull. Compared against the post-commit
+        // revision to decide whether anything actually changed.
+        let before = cached.handle().revision().map(|r| r.tree);
+
         // Fetch + rebase + persist blocks — no cell writes, no lock.
         let prepared = cached.handle().pull().prepare(env).await?;
 
@@ -47,7 +55,18 @@ impl<'a> Pull<'a> {
             prepared.commit(env).await?
         };
 
-        cached.poll(env).await;
+        // Re-poll subscriptions only if the tree moved. A `None` revision (a
+        // no-op pull) or a merge that netted the same tree changes no query
+        // result, so the poll is skipped — an idle background sync does no
+        // subscription work at all.
+        let changed = match &revision {
+            Some(after) => before.as_ref() != Some(&after.tree),
+            None => false,
+        };
+        if changed {
+            cached.poll(env).await;
+        }
+
         Ok(revision)
     }
 }


### PR DESCRIPTION
## Why

`Pull::perform` re-polled **every subscription on the branch** after every pull — including when the pull found no upstream change, which is the common case for a periodic background sync. Re-running every query when nothing moved is pure waste.

This was the dominant cause of "sync makes everything slow": with sync enabled, each idle tick re-evaluated the whole branch's subscriptions, so reload/navigation dragged; pausing sync made it visibly snappier. The sync genuinely finds nothing new, yet we did a full re-poll anyway.

## Fix

Capture the branch tree before the pull and compare it to the post-commit revision; only re-poll when it actually moved. A `None`/no-op commit, or a merge that netted the same tree, changes no query result and is skipped — so an idle background sync now does zero subscription work.

Gating here, not in the poll path, is deliberate: **pulls never touch the session overlay**, so unchanged-tree ⇒ nothing changed. Overlay writes (e.g. the sync-status stamp the pause dot reads) DO change query results without moving the tree, so the poll path itself must stay eager — moving the check there would silently stall overlay-driven updates.

## Measured

Query during an active sync dropped from ~1752ms to ~460ms, and idle syncs no longer re-run subscriptions at all. (Stacks with the dialog-storage cache-lock fix — dialog-db#373 — which independently cut sync latency from 6-8s to ~600ms.)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `pull` functionality by optimizing subscription re-evaluation. It ensures that subscriptions are only re-evaluated if the branch tree has changed after a pull, avoiding unnecessary re-polling during idle background syncs.

### Detailed summary
- Updated documentation to clarify that subscriptions are re-evaluated only if the branch tree has moved.
- Introduced a variable `before` to store the tree state before the pull.
- Added logic to check if the tree has changed (`changed` variable) to determine if polling is necessary.
- Modified polling behavior to skip re-polling when no changes occur.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->