### PR TITLE
fix(worker): read lock on /evaluate, serialize its commit per branch

### DIFF
--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -60,7 +60,7 @@ pub use subscription::{QueryHash, Subscriber, SubscriptionPoll, SubscriptionRefe
 /// elements) can deserialize without depending on this crate.
 pub use tonk_schema::conclusion::Conclusion;
 pub use tonk_schema::query::Query;
-pub use transaction::{Commit, TransactionBuilder};
+pub use transaction::{COMMIT_RETRY_LIMIT, Commit, TransactionBuilder, is_head_moved};
 
 /// A reactive layer over dialog branches. Owned by the consumer's
 /// application state (e.g. the worker's `TonkState`).

--- a/rust/dialog-reactor/src/transaction.rs
+++ b/rust/dialog-reactor/src/transaction.rs
@@ -242,13 +242,20 @@ impl Commit<'_> {
 /// How many times a reactor commit refreshes-and-retries when a sync advanced
 /// the head under it. Transactions serialize via the transactor lock, so the
 /// only racer is sync; one retry settles it in practice.
-const COMMIT_RETRY_LIMIT: usize = 4;
+///
+/// Public so the worker's `/evaluate` route, which commits through dialog's
+/// `Transaction` directly, can bound its own retry loop to the same budget.
+pub const COMMIT_RETRY_LIMIT: usize = 4;
 
 /// Whether a commit error is the "head moved under us" version mismatch (a sync
 /// advanced the head between this commit's snapshot and its publish) — the
 /// signal to refresh and retry. Matched on the rendered error so the reactor
 /// need not import the dialog error hierarchy; the `VersionMismatch` leaf
 /// renders its distinctive text through the chain.
-fn is_head_moved(error: &CommitError) -> bool {
+///
+/// Public so callers that commit through dialog's `Transaction` directly rather
+/// than this `Commit` (e.g. the worker's `/evaluate` route) can run the same
+/// refresh-and-retry recovery this loop does.
+pub fn is_head_moved(error: &CommitError) -> bool {
     error.to_string().contains("Version mismatch")
 }

--- a/rust/tonk-worker/src/router/claim.rs
+++ b/rust/tonk-worker/src/router/claim.rs
@@ -235,8 +235,10 @@ pub async fn assert_claim(
     let value = parse_value(content_type, &body)?;
 
     // Build and commit the assertion through the reactor so
-    // subscriptions on this branch re-poll on success.
-    let tonk_state = state.write().await;
+    // subscriptions on this branch re-poll on success. A read lock: the commit
+    // serializes on the per-branch transactor lock inside `Commit::perform`, and
+    // the subscription re-poll only needs `&TonkState`.
+    let tonk_state = state.read().await;
 
     let claim = RawClaim {
         the: attribute,
@@ -303,8 +305,9 @@ pub async fn retract_claim(
     let content_type = headers.get("content-type").and_then(|v| v.to_str().ok());
     let value = parse_value(content_type, &body)?;
 
-    // Build and commit the retraction using the transaction API
-    let tonk_state = state.write().await;
+    // Build and commit the retraction using the transaction API. Read lock —
+    // see [`assert_claim`].
+    let tonk_state = state.read().await;
 
     // Parse attribute
     let attribute: Attribute = attribute_str

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -132,12 +132,21 @@ pub async fn evaluate(
     body: Bytes,
 ) -> Result<Json<EvaluateResponse>, TonkWorkerError> {
     log!("evaluate repo={}, branch={}", path.repo, path.branch);
-    let tonk_state = state.write().await;
-    let tonk_branch = tonk_state
-        .reactor
-        .repository(&path.repo)
-        .branch(&path.branch);
-    let result = evaluate_on_branch(&tonk_state, tonk_branch, body, query).await;
+    // A read lock, like `transact`. `evaluate_on_branch` reaches the reactor and
+    // operator by shared reference, and serializes its commit on the per-branch
+    // transactor lock rather than on the whole of `TonkState`. Holding the write
+    // lock here instead serialized every evaluate against every other request —
+    // including the language server, whose analysis holds a read guard for the
+    // length of a `didChange`. Since the editor auto-fires a dry-run evaluate on
+    // each fresh diagnostics frame, that made typing contend with itself.
+    let result = {
+        let tonk_state = state.read().await;
+        let tonk_branch = tonk_state
+            .reactor
+            .repository(&path.repo)
+            .branch(&path.branch);
+        evaluate_on_branch(&tonk_state, tonk_branch, body, query).await
+    };
 
     // A commit moves the branch head. Announce it on the branch's
     // channel so subscribed UIs refresh their revision/sync-state
@@ -182,9 +191,12 @@ pub async fn evaluate_profile(
     body: Bytes,
 ) -> Result<Json<EvaluateResponse>, TonkWorkerError> {
     log!("evaluate profile branch={}", path.branch);
-    let tonk_state = state.write().await;
-    let tonk_branch = tonk_state.reactor.profile_repository().branch(&path.branch);
-    let result = evaluate_on_branch(&tonk_state, tonk_branch, body, query).await;
+    // Read lock, for the reasons spelled out in [`evaluate`].
+    let result = {
+        let tonk_state = state.read().await;
+        let tonk_branch = tonk_state.reactor.profile_repository().branch(&path.branch);
+        evaluate_on_branch(&tonk_state, tonk_branch, body, query).await
+    };
 
     // Same durable-commit gate as [`evaluate`]: pure queries and dry
     // runs leave the head unchanged and announce nothing. The profile
@@ -229,6 +241,26 @@ async fn evaluate_on_branch<'a>(
         .acquire(&tonk_state.operator)
         .await
         .map_err(|e| TonkWorkerError::NotFound(e.to_string()))?;
+
+    // Serialize a committing evaluate on the branch's transactor lock — the same
+    // lock the reactor's `Commit::perform` takes for `/transact`. This document's
+    // commit is a *dialog* `Transaction::commit()`, which CASes against the head
+    // snapshot taken when `branch.transaction()` is built below but never retries.
+    // Without this lock a concurrent commit landing between that snapshot and our
+    // publish fails the whole document with a version mismatch. Holding it from
+    // before the snapshot to after the publish is what makes the CAS unreachable
+    // by another committer.
+    //
+    // A dry run (`transact=false`) writes nothing, so it never takes the lock.
+    // That's the auto-evaluate the editor fires on every fresh diagnostics frame;
+    // keeping it lock-free is the point of holding only a read guard on
+    // `TonkState` here.
+    let _transacting = if query.transact {
+        Some(session.transactor().lock().await)
+    } else {
+        None
+    };
+
     let branch = session.handle();
     let revision_before = branch.revision();
 

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -18,6 +18,7 @@ use ::axum::{
     http::HeaderMap,
 };
 use axum_wasm_macros::wasm_compat;
+use dialog_reactor::{COMMIT_RETRY_LIMIT, is_head_moved};
 use dialog_repository::Revision;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -245,11 +246,14 @@ async fn evaluate_on_branch<'a>(
     // Serialize a committing evaluate on the branch's transactor lock — the same
     // lock the reactor's `Commit::perform` takes for `/transact`. This document's
     // commit is a *dialog* `Transaction::commit()`, which CASes against the head
-    // snapshot taken when `branch.transaction()` is built below but never retries.
-    // Without this lock a concurrent commit landing between that snapshot and our
-    // publish fails the whole document with a version mismatch. Holding it from
-    // before the snapshot to after the publish is what makes the CAS unreachable
-    // by another committer.
+    // snapshot taken when `branch.transaction()` is built below. The lock excludes
+    // the common racer — another committer (a transact, an invite/join/pause) —
+    // so those line up here instead of one losing the CAS and having to retry.
+    // A sync is the exception the lock can't cover: it advances the head while
+    // only briefly holding this lock and releases it between its network fetch and
+    // its cell advance, so it can still land in our snapshot→publish window. The
+    // commit loop below handles that residual case by refreshing and retrying,
+    // exactly as `Commit::perform` does.
     //
     // A dry run (`transact=false`) writes nothing, so it never takes the lock.
     // That's the auto-evaluate the editor fires on every fresh diagnostics frame;
@@ -262,88 +266,128 @@ async fn evaluate_on_branch<'a>(
     };
 
     let branch = session.handle();
-    let revision_before = branch.revision();
 
-    // Fold the branch's session overlay (ephemeral facts kept out of
-    // storage, e.g. an invite's private seed) into the evaluation
-    // transaction so every evaluation — the inspector running
-    // `invitation:`, preview or explicit — sees the same facts a
-    // `query`/`subscribe` does. Folding it here (not gated on
-    // `transact`) is what keeps the read paths consistent; the overlay
-    // is read-only and gets `induce`-swept on commit (below) so it never
-    // lands durably.
-    let overlay = session.overlay();
-    // The evaluation's match queries (`txn.query()` inside the
-    // evaluator) resolve stored `db.rule/*` rules automatically — rule
-    // resolution is built into the branch query's layer stack, so the
-    // inspector's dry-run preview shows the same deductions a committed
-    // `query` / `subscribe` returns.
-    let txn = branch.transaction().integrate(overlay.clone());
+    // Evaluate, then commit if the document writes, refreshing and retrying on a
+    // head that moved under us. The transactor lock above excludes other
+    // *committers*, but a pull advances the head while only briefly holding that
+    // lock (and releases it between its network `prepare` and its `commit`), so a
+    // sync can still land between the transaction's head snapshot below and our
+    // publish. `/transact` handles this the same way (`Commit::perform`'s retry
+    // loop); this is the evaluate-side equivalent.
+    //
+    // The retry re-enters at `branch.transaction()` — not just `.commit()` —
+    // because the evaluated transaction borrows the pre-refresh tree: after a
+    // refresh we must re-run the evaluation against the new head. Evaluation is
+    // pure over (document, head), so replaying it is safe; the document's
+    // statements are idempotent asserts/retracts.
+    let mut attempt = 0;
+    let response = loop {
+        let revision_before = branch.revision();
 
-    let t_eval = web_time::Instant::now();
-    let evaluated = syntax
-        .evaluate(txn)
-        .perform(&tonk_state.operator)
-        .await
-        .map_err(map_evaluate_error)?;
-    let eval_ms = t_eval.elapsed().as_millis();
+        // Fold the branch's session overlay (ephemeral facts kept out of
+        // storage, e.g. an invite's private seed) into the evaluation
+        // transaction so every evaluation — the inspector running
+        // `invitation:`, preview or explicit — sees the same facts a
+        // `query`/`subscribe` does. Folding it here (not gated on
+        // `transact`) is what keeps the read paths consistent; the overlay
+        // is read-only and gets `induce`-swept on commit (below) so it never
+        // lands durably.
+        let overlay = session.overlay();
+        // The evaluation's match queries (`txn.query()` inside the
+        // evaluator) resolve stored `db.rule/*` rules automatically — rule
+        // resolution is built into the branch query's layer stack, so the
+        // inspector's dry-run preview shows the same deductions a committed
+        // `query` / `subscribe` returns.
+        let txn = branch.transaction().integrate(overlay.clone());
 
-    // Compute the post-evaluation matches before any commit
-    // decision: the txn's overlay already reflects every mutation
-    // and induce-pass derivation, so this is the same answer a
-    // post-commit branch query would give.
-    let t_matches = web_time::Instant::now();
-    let matches_after = evaluated
-        .matches_after(&tonk_state.operator)
-        .await
-        .map_err(map_evaluate_error)?;
-    let matches_ms = t_matches.elapsed().as_millis();
-
-    // A document commits when it writes anything. `rule!:` is a
-    // mutation (the `!` says so) and the analyzer lifts it into a
-    // `Statement::InstallEffect`, so a document with any planned
-    // statement is the single commit signal.
-    let response = if query.transact && evaluated.analysis.analysis.has_statements() {
-        let t_commit = web_time::Instant::now();
-        // Sweep the overlay before the durable write: the transaction
-        // folded the session overlay in for reads, but those ephemeral
-        // facts (e.g. an invite seed) must never persist. Retracting them
-        // here cancels the integrated asserts so only the document's own
-        // statements land.
-        let revision_after = evaluated
-            .txn
-            .integrate(session.overlay_retraction())
-            .commit()
+        let t_eval = web_time::Instant::now();
+        let evaluated = syntax
+            .evaluate(txn)
             .perform(&tonk_state.operator)
             .await
-            .map_err(|e| map_evaluate_error(EvaluateError::Query(format!("commit: {e}"))))?;
-        let commit_ms = t_commit.elapsed().as_millis();
-        // Re-poll subscriptions so SSE clients see the new state.
-        // The chain commits via dialog directly; the reactor's
-        // subscription registry is the worker's responsibility.
-        let t_poll = web_time::Instant::now();
-        session.poll(&tonk_state.operator).await;
-        let poll_ms = t_poll.elapsed().as_millis();
-        let timing = format!(
-            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | matches {matches_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
-        );
-        log!("{timing}");
-        // Tee timing onto a BroadcastChannel so a page (or DevTools
-        // listener) can read seed numbers without the SW console — the
-        // seed runs background in the SW, so its logs never reach the
-        // page console.
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-        if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
-            let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
+            .map_err(map_evaluate_error)?;
+        let eval_ms = t_eval.elapsed().as_millis();
+
+        // Compute the post-evaluation matches before any commit
+        // decision: the txn's overlay already reflects every mutation
+        // and induce-pass derivation, so this is the same answer a
+        // post-commit branch query would give.
+        let t_matches = web_time::Instant::now();
+        let matches_after = evaluated
+            .matches_after(&tonk_state.operator)
+            .await
+            .map_err(map_evaluate_error)?;
+        let matches_ms = t_matches.elapsed().as_millis();
+
+        // A document commits when it writes anything. `rule!:` is a
+        // mutation (the `!` says so) and the analyzer lifts it into a
+        // `Statement::InstallEffect`, so a document with any planned
+        // statement is the single commit signal.
+        if query.transact && evaluated.analysis.analysis.has_statements() {
+            let t_commit = web_time::Instant::now();
+            // Sweep the overlay before the durable write: the transaction
+            // folded the session overlay in for reads, but those ephemeral
+            // facts (e.g. an invite seed) must never persist. Retracting them
+            // here cancels the integrated asserts so only the document's own
+            // statements land.
+            let commit = evaluated
+                .txn
+                .integrate(session.overlay_retraction())
+                .commit()
+                .perform(&tonk_state.operator)
+                .await;
+            let revision_after = match commit {
+                Ok(revision) => revision,
+                Err(e) if is_head_moved(&e) && attempt < COMMIT_RETRY_LIMIT => {
+                    attempt += 1;
+                    log!("evaluate commit raced (attempt {attempt}); refreshing head and retrying");
+                    // Refresh the handle's view of the head, then loop to re-run
+                    // the evaluation against it. If even the refresh fails, give
+                    // up with the original mismatch.
+                    branch
+                        .refresh(&tonk_state.operator)
+                        .await
+                        .map_err(|refresh_err| {
+                            map_evaluate_error(EvaluateError::Query(format!(
+                                "commit: {e}; refresh after race failed: {refresh_err}"
+                            )))
+                        })?;
+                    continue;
+                }
+                Err(e) => {
+                    return Err(map_evaluate_error(EvaluateError::Query(format!(
+                        "commit: {e}"
+                    ))));
+                }
+            };
+            let commit_ms = t_commit.elapsed().as_millis();
+            // Re-poll subscriptions so SSE clients see the new state.
+            // The chain commits via dialog directly; the reactor's
+            // subscription registry is the worker's responsibility.
+            let t_poll = web_time::Instant::now();
+            session.poll(&tonk_state.operator).await;
+            let poll_ms = t_poll.elapsed().as_millis();
+            let timing = format!(
+                "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | matches {matches_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
+            );
+            log!("{timing}");
+            // Tee timing onto a BroadcastChannel so a page (or DevTools
+            // listener) can read seed numbers without the SW console — the
+            // seed runs background in the SW, so its logs never reach the
+            // page console.
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
+                let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
+            }
+            break EvaluateResponse {
+                revision_before,
+                revision_after: Some(revision_after),
+                matches_before: evaluated.matches,
+                matches_after,
+                commits: evaluated.commits,
+            };
         }
-        EvaluateResponse {
-            revision_before,
-            revision_after: Some(revision_after),
-            matches_before: evaluated.matches,
-            matches_after,
-            commits: evaluated.commits,
-        }
-    } else {
+
         // Pure-query or dry-run: drop the transaction without
         // committing. The pre-mutation matches double as "after"
         // because no mutations actually landed. Zero out
@@ -353,13 +397,13 @@ async fn evaluate_on_branch<'a>(
         // branch is untouched.
         let mut commits = evaluated.commits;
         commits.claims = 0;
-        EvaluateResponse {
+        break EvaluateResponse {
             revision_before: revision_before.clone(),
             revision_after: revision_before,
             matches_before: evaluated.matches.clone(),
             matches_after: evaluated.matches,
             commits,
-        }
+        };
     };
 
     Ok(Json(response))

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -443,6 +443,10 @@ pub async fn pull(
         params.branch
     );
 
+    // A write lock, unlike `sync`. Dropping to a read lock would let a commit
+    // race the pull, and this route — unlike `sync` — has no refresh-and-retry
+    // loop to recover from the resulting head CAS failure. It is not on a hot
+    // path (`/sync` is what the app calls), so excluding writers costs nothing.
     let tonk_state = state.write().await;
 
     let session = tonk_state
@@ -497,6 +501,7 @@ pub async fn push(
         params.branch
     );
 
+    // Write lock — see [`pull`]. Same no-retry caveat, same cold path.
     let tonk_state = state.write().await;
 
     let session = tonk_state
@@ -688,8 +693,6 @@ pub async fn sync(
     {
         let tonk_state = state.read().await;
         if !is_sync_enabled(&tonk_state, &params.repo, &params.branch).await {
-            drop(tonk_state);
-            let tonk_state = state.write().await;
             publish_paused_status(&tonk_state, &params.repo, &params.branch).await;
             log!("sync of {}/{} skipped: paused", params.repo, params.branch);
             return Ok(Json(SyncResponse {
@@ -701,15 +704,14 @@ pub async fn sync(
         }
     }
 
-    // Flip the chip to `pending` for the duration. This runs in its OWN brief
-    // write-lock scope that drops before the long pull/push lock below, so the
-    // overlay write + subscription re-poll reach the chip *before* the sync
-    // begins (a mid-sync publish wouldn't — the chip's re-poll needs the read
-    // lock the long write lock holds). The settled status is published by the
-    // status check the controller runs after `/sync` returns.
+    // Flip the chip to `pending` before the sync begins, so the overlay write +
+    // subscription re-poll reach the chip up front rather than mid-pull. The
+    // settled status is published by the status check the controller runs after
+    // `/sync` returns. A read lock: the stamp lands in the branch's session
+    // overlay, which has its own interior lock.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
-        let tonk_state = state.write().await;
+        let tonk_state = state.read().await;
         publish_sync_status_attr(
             &tonk_state,
             &params.repo,

--- a/rust/tonk-worker/src/router/transfer.rs
+++ b/rust/tonk-worker/src/router/transfer.rs
@@ -67,7 +67,9 @@ pub async fn export(
     Path(path): Path<EvaluatePath>,
 ) -> Result<Response, TonkWorkerError> {
     log!("export repo={}, branch={}", path.repo, path.branch);
-    let tonk_state = state.write().await;
+    // Read lock — the export only reads, and it walks every artifact on the
+    // branch, so a write lock here stalled unrelated requests for the whole walk.
+    let tonk_state = state.read().await;
     let tonk_branch = tonk_state
         .reactor
         .repository(&path.repo)
@@ -122,6 +124,10 @@ pub async fn import(
         path.branch,
         body.len()
     );
+    // A write lock. `Import::perform` commits through the branch handle directly,
+    // so it takes no per-branch transactor lock and its CAS never retries. This
+    // is a cold, explicit upload — excluding concurrent writers costs nothing and
+    // keeps a racing commit from failing the whole import.
     let tonk_state = state.write().await;
     let tonk_branch = tonk_state
         .reactor


### PR DESCRIPTION
Follows up the June 22 lock rework. That pass dropped `/transact`, `/sync`, `/pull` and `/push` to a read lock on `TonkState` and moved commit serialization onto a per-branch lock — but `/evaluate` was left holding the write lock across parse, evaluate, and commit.

Because `tokio`'s `RwLock` is write-preferring, one write-lock holder stalls every new reader. The language server holds a `TonkState` read guard for the length of a `didChange` (and holds the global `Mutex<Server>` while it does), and the editor auto-fires a dry-run evaluate on every fresh diagnostics frame. So typing contended with itself: an auto-evaluate took the write lock, and the next LSP request queued behind it while holding the server mutex, head-of-line blocking every other cell and tab.

The catch is that `/evaluate` can't just drop to a read lock. Its commit is a *dialog* `Transaction::commit()` (it needs the raw transaction to thread through the evaluator), which CASes against the head snapshot and never retries — unlike `/transact`, which commits through the reactor builder that takes the per-branch transactor lock and refresh-retries on a moved head. The global write lock was the only thing serializing evaluate-vs-evaluate and evaluate-vs-transact commits; removing it alone would trade contention for version-mismatch failures.

So the committing path now takes `session.transactor()` — the same per-branch lock `/transact` uses — held from before the head snapshot through the publish. A dry run (`transact=false`), which is the hot auto-evaluate path, takes no lock at all.

Same read-lock downgrade for the claim routes and the read-only CSV export, plus the `sync` status stamps (removing a pointless drop-read-then-take-write upgrade). `pull`, `push` and `import` deliberately keep the write lock: they commit through the unlocked dialog path and, unlike `sync`, have no refresh-and-retry loop, so excluding writers is what keeps a racing commit from failing them — and none is on a hot path.

Verified: `cargo fmt` + `clippy -D warnings` clean; native suite green; the tonk-worker wasm suite green in headless Chrome, including the two `/evaluate` tests that commit through the new transactor lock. (Two profile-identity tests fail under the full wasm run on `staging` today, independent of this change — they pass in isolation and fail identically on the base.)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the locking mechanism in the `tonk-worker` and `dialog-reactor` to enhance concurrency and reduce contention during read and write operations.

### Detailed summary
- Changed `write()` locks to `read()` locks in multiple locations to optimize performance.
- Made `COMMIT_RETRY_LIMIT` and `is_head_moved` public for broader accessibility.
- Updated documentation comments to clarify locking behaviors and transaction handling.
- Refactored `evaluate_on_branch` to handle retries for head movements during commits.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->