### PR TITLE
fix: profile 404 route + precache offline shell

### DIFF
--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -1855,3 +1855,47 @@ view!: &space-view
   display: |
     <tonk-site with="main@{id}" allow="main@{id}" path={rest}></tonk-site>
     <tonk-display with="main@profile:tonk" model="tonk:profile/fab" data-space="{id}"></tonk-display>
+
+# The catch-all: any path no static/`/space/…` route claims lands here. The
+# router matches most-specific-first, so this `{*rest}` span never shadows `/`,
+# `/join`, `/inspector`, `/diagnose`, or `/space/{id}` — it only catches what
+# nothing else does (a mistyped `/board`, a stale deep link). Without it such a
+# path matches no route, the site is never stamped, and the shell spins forever.
+route!: &route/not-found
+  this: id:tonk:route/not-found
+  path: "/{*rest}"
+  concept: tonk:not-found
+
+concept!: &not-found
+  this: tonk:not-found
+  description: The 404 page — a path the profile has no route for.
+  with:
+    # The attempted path, picked off the site, shown back to the user.
+    path:
+      description: The active path, picked off the site.
+      the: xyz.tonk.site/path
+      cardinality: one
+      as: text
+
+view!: &not-found-view
+  this: id:tonk:not-found/view
+  model: tonk:not-found
+  display: |
+    <div class="display-view-slot">
+      <style>
+        .nf { display: flex; flex-direction: column; align-items: center;
+              justify-content: center; gap: 8px; height: 100%; padding: 32px;
+              text-align: center; color: var(--wa-color-text-normal); }
+        .nf__code { font-size: 3rem; font-weight: 600; line-height: 1;
+                    color: var(--wa-color-text-quiet); }
+        .nf__msg { font-size: 1rem; color: var(--wa-color-text-quiet); }
+        .nf__path { font-family: var(--wa-font-family-code, monospace);
+                    color: var(--wa-color-text-normal); }
+        .nf__home { margin-top: 8px; text-decoration: none; }
+      </style>
+      <div class="nf">
+        <div class="nf__code">404</div>
+        <div class="nf__msg">No page at <span class="nf__path">{path}</span></div>
+        <a class="nf__home" href="/"><wa-button variant="brand">Back to Hub</wa-button></a>
+      </div>
+    </div>

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -2,6 +2,11 @@ import init, { activate } from "./worker.js";
 
 const log = (...args) => console.log("[Tonk Service Worker]", ...args);
 
+// Shell cache name. Kept in step with `cache.rs`'s `SHELL_CACHE`.
+// Declared up here (not beside `serveNavigation`) because
+// `oninstall` precaches the shell into it.
+const SHELL_CACHE = "TONK_SHELL_v1";
+
 let tonkServiceWorkerResolves;
 
 // Static import at top-level is forced on us: dynamic `import()`
@@ -24,7 +29,23 @@ self.oninstall = event => {
     // of the script, where it's a no-op — the browser only honors
     // `skipWaiting()` while the worker is in `waiting`, and at
     // top-level eval time the lifecycle hasn't reached install yet.
-    event.waitUntil(self.skipWaiting());
+    //
+    // Precache the shell under `/index.html` so offline deep-link
+    // navigations have a fallback. `serveNavigation` caches the shell
+    // under the visited URL (e.g. `/`), never `/index.html`, so its
+    // `cache.match("/index.html")` fallback would otherwise only hit
+    // after a network fetch — which fails offline. Seeding it here
+    // guarantees a first-visit-online install populates the key every
+    // offline navigation falls back to.
+    event.waitUntil((async () => {
+        try {
+            const cache = await caches.open(SHELL_CACHE);
+            await cache.add("/index.html");
+        } catch (err) {
+            log("Shell precache failed:", err);
+        }
+        await self.skipWaiting();
+    })());
     log("Installed");
 };
 
@@ -102,8 +123,8 @@ self.addEventListener("online", onConnectivityChange);
 // view client and how the rewrite should map. The Rust side
 // itself runs static cacheable GETs through the same shell
 // cache so this isn't a separate cache from the navigation
-// case, just a different entry point.
-const SHELL_CACHE = "TONK_SHELL_v1";
+// case, just a different entry point. (`SHELL_CACHE` is declared at
+// the top of the file so `oninstall` can precache into it.)
 
 async function serveNavigation(request) {
     const cache = await caches.open(SHELL_CACHE);


### PR DESCRIPTION
Two navigation gaps, found while chasing why offline deep-links fail.

**Unmatched profile paths spin forever.** The profile route table (`/`, `/join`, `/inspector`, `/diagnose`, `/space/…`) has no fallback, so a path nothing claims — a mistyped `/board`, a stale deep link — matches no route. With no match the SW never stamps the site, and `<tonk-display model=tonk:site>` sits in its loading state indefinitely. Adding a `/{*rest}` catch-all to a small 404 page closes that: the router matches most-specific-first, so the catch-all only catches what nothing else does and never shadows a real route. The 404's "Back to Hub" is a real `<a href="/">` so the sealed guest's click relay drives the host navigation (a `<wa-button href>` wouldn't — the relay matches `a[href]`).

**Offline deep-links have no shell to fall back to.** `serveNavigation` serves `cache.match("/index.html")` when the network is down, but nothing ever put `/index.html` in the cache — a `/` visit caches the shell under key `/`. So loading `/inspector` cold while offline fell through to a network fetch and failed, even though starting at `/` and navigating client-side worked. Precaching the shell at SW install guarantees the offline fallback key exists.

Verified both in the browser: offline `/inspector` serves the shell; `/board` renders the 404 and "Back to Hub" returns to the Hub.

Note: the profile library is seeded once at profile creation (hot-swap only reseeds `core.yaml`), so existing profiles need a reseed to pick up the new route. Worth deciding separately whether profile-library seeding should re-run idempotently on SW update.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a 404 error handling route in `profile.yaml` and enhances the service worker in `service_worker.js` to precache the shell under `/index.html`, ensuring offline navigations have a fallback.

### Detailed summary
- Added a catch-all route for undefined paths in `profile.yaml`.
- Defined a 404 page with a user-friendly message and a link back to the hub.
- Updated `service_worker.js` to precache `/index.html` for offline access.
- Improved error handling during the precaching process in the service worker.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->