### PR TITLE
chore(deps): bump dialog-db to tonk-2026-07-09

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1185,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1487,6 +1487,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "web-time",
 ]
@@ -1494,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1515,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1541,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-07#99602b2c6f446e5d9968c02c0ef77576143c54a5"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",
@@ -3622,6 +3623,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3642,12 +3644,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,22 +167,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-07" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
 
 [profile.dev]
 opt-level = 1

--- a/rust/dialog-reactor/src/env.rs
+++ b/rust/dialog-reactor/src/env.rs
@@ -14,6 +14,7 @@ use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Import, Put};
 use dialog_effects::authority::Identify;
+use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_effects::space::Load;
 use dialog_repository::RemoteSite;
@@ -119,10 +120,12 @@ pub trait PushProvider:
     + Provider<Put>
     + Provider<Resolve>
     + Provider<Publish>
+    + Provider<BlobRead>
     + Provider<Fork<RemoteSite, Get>>
     + Provider<Fork<RemoteSite, Put>>
     + Provider<Fork<RemoteSite, Resolve>>
     + Provider<Fork<RemoteSite, Publish>>
+    + Provider<Fork<RemoteSite, BlobImport>>
     + ConditionalSync
     + 'static
 {
@@ -132,10 +135,12 @@ impl<T> PushProvider for T where
         + Provider<Put>
         + Provider<Resolve>
         + Provider<Publish>
+        + Provider<BlobRead>
         + Provider<Fork<RemoteSite, Get>>
         + Provider<Fork<RemoteSite, Put>>
         + Provider<Fork<RemoteSite, Resolve>>
         + Provider<Fork<RemoteSite, Publish>>
+        + Provider<Fork<RemoteSite, BlobImport>>
         + ConditionalSync
         + 'static
 {


### PR DESCRIPTION
Picks up the latest published tonk tag. The new tag tightens `Branch::push`: it now demands `blob::Read` and a forked `blob::Import` capability from the env, so the reactor's `PushProvider` bound has to advertise them or `Push::perform` no longer satisfies the upstream signature.

Verified `cargo check` on both native and the `wasm32-unknown-unknown` target (where the reactor actually runs), plus `fmt` and `clippy -D warnings`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `PushProvider` trait in the `rust/dialog-reactor/src/env.rs` file by adding support for blob operations. It also updates the dependency versions in `Cargo.toml`.

### Detailed summary
- Added `BlobImport` and `BlobRead` to the `PushProvider` trait in `rust/dialog-reactor/src/env.rs`.
- Updated the dependency versions in `Cargo.toml` from `tonk-2026-07-07` to `tonk-2026-07-09`.
- Included `wasm-streams` and `tokio-util` in the dependencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->