### PR TITLE
chore(deps): bump dialog-db to tonk-2026-07-09-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "base58",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "base58",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "base58",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "blake3",
  "convert_case 0.6.0",
@@ -1185,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "async-trait",
  "base58",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09#e58e56861dbdbddea5f0a9a94f135328b348ea6d"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-09-2#cff7b3d7ace682784c6da3a49e647d122a2de1a2"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,22 +167,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-09-2" }
 
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
Picks up [dialog-db #387](https://github.com/dialog-db/dialog-db/pull/387).

A retract used to write a `State::Removed` tombstone into every index ordering unconditionally — even for a fact with no committed prior. A transient concept (asserted and retracted in the same commit, e.g. the `Load` command a `<tonk-site>` fires on every page load) therefore left tombstones the base tree never had, moving the branch head. On a synced replica that mints a fresh revision whose only content is a tombstone for a fact that never existed, so an otherwise-idle replica pushed a **no-op revision to the remote on every load**.

The fix consults a snapshot of the committed tree: a retract tombstones only when there was a committed prior (so the removal still propagates on merge); otherwise it deletes the keys, cancelling an in-batch assert to nothing. This removes the per-load push churn.

Pure internal change in `dialog-artifacts` — no API surface moved, so no tonk-side code changes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Cargo.toml` file by changing the tags of multiple dependencies from `tonk-2026-07-09` to `tonk-2026-07-09-2`, indicating a new version of the `dialog-db` repository is being used.

### Detailed summary
- Updated tags for the following dependencies:
  - `dialog-artifacts`
  - `dialog-capability`
  - `dialog-common`
  - `dialog-credentials`
  - `dialog-csv`
  - `dialog-effects`
  - `dialog-operator`
  - `dialog-query`
  - `dialog-remote-s3`
  - `dialog-remote-ucan-s3`
  - `dialog-repository`
  - `dialog-search-tree`
  - `dialog-storage`
  - `dialog-ucan`
  - `dialog-ucan-core`
  - `dialog-varsig`
- Updated source links in the `Cargo.lock` for all packages to reflect the new tag `tonk-2026-07-09-2`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->