### PR TITLE
fix(sw): key the app shell on / not /index.html

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -30,18 +30,17 @@ self.oninstall = event => {
     // `skipWaiting()` while the worker is in `waiting`, and at
     // top-level eval time the lifecycle hasn't reached install yet.
     //
-    // Precache the shell under `/index.html` so offline deep-link
-    // navigations have a fallback. `serveNavigation` caches each
-    // shell under the visited URL (e.g. `/`), so a route never
-    // visited online has no cache entry; its `/index.html` fallback
-    // would then only hit after a network fetch — which fails
-    // offline. Seeding the key here guarantees a first-visit-online
-    // install populates the shell every offline navigation falls
-    // back to.
+    // Precache the shell under `/` — the origin serves the shell
+    // HTML there (200), whereas `/index.html` is a 307 redirect to
+    // `/`. `cache.add` refuses to store a redirect, so seeding
+    // `/index.html` silently fails and every reload then serves a
+    // dead key. `serveNavigation` reads and writes the same `/`
+    // key, so a first-visit-online install populates the shell
+    // every later navigation falls back to.
     event.waitUntil((async () => {
         try {
             const cache = await caches.open(SHELL_CACHE);
-            await cache.add("/index.html");
+            await cache.add("/");
         } catch (err) {
             log("Shell precache failed:", err);
         }
@@ -112,22 +111,25 @@ self.addEventListener("online", onConnectivityChange);
 
 // Serve the precached app shell for every route navigation. The
 // SPA router resolves the actual path client-side, so there's
-// nothing URL-specific to serve — just hand back `/index.html`
-// from the cache, which means a navigation never waits on the
-// network (a network-first shell blocked slow loads on a full
-// round-trip even though the shell was already on disk).
+// nothing URL-specific to serve — just hand back the shell from
+// the cache, which means a navigation never waits on the network
+// (a network-first shell blocked slow loads on a full round-trip
+// even though the shell was already on disk).
 //
-// The shell is seeded by `oninstall` and re-seeded on every new
-// worker install, so a deploy refreshes it. The rare miss (first
-// visit racing the install, or a purged cache) fetches it once.
+// Keyed on `/`, where the origin serves the shell HTML (200).
+// `/index.html` is a 307 redirect to `/`, so it can't be cached
+// or served as the shell. The shell is seeded by `oninstall` and
+// re-seeded on every new worker install, so a deploy refreshes
+// it. The rare miss (first visit racing the install, or a purged
+// cache) fetches it once.
 async function serveNavigation() {
     const cache = await caches.open(SHELL_CACHE);
-    const cached = await cache.match("/index.html");
+    const cached = await cache.match("/");
     if (cached) return cached;
 
-    const response = await fetch("/index.html");
+    const response = await fetch("/");
     if (response.ok && response.type !== "opaque") {
-        cache.put("/index.html", response.clone()).catch(() => {});
+        cache.put("/", response.clone()).catch(() => {});
     }
     return response;
 }


### PR DESCRIPTION
## Why

Reloading any page on the deployed site broke: the navigation died with `net::ERR_FAILED` (a Chrome error page), and only unregistering the service worker recovered it. First load worked; every reload after that failed. It never reproduced on localhost.

## Cause

The cache-first navigation handler (#580) keyed the SPA shell on `/index.html`. But Cloudflare's asset server (`wrangler.toml` `not_found_handling = "single-page-application"`) serves the shell at `/` (200 HTML) and 307-redirects `/index.html` to `/`:

```
GET /            → 200  text/html   (the shell)
GET /index.html  → 307  Location: /
```

`cache.add` refuses to store a redirect, so the `oninstall` seed of `/index.html` silently failed. On reload `serveNavigation()` then missed the cache and fell to `fetch("/index.html")`, whose redirect chain fails inside the SW fetch handler, rejecting `respondWith` → `net::ERR_FAILED`. Unregistering the SW worked because the browser then fetched `/` from the network directly.

Localhost never hit it: Trunk serves `dist/index.html` as a real 200 file, so the `/index.html` key worked there by accident. The redirect only exists on the Cloudflare asset server.

## Fix

Seed and serve the shell under `/`, which returns the 200 HTML in both environments, so both `cache.add("/")` and the `fetch("/")` fallback succeed.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the caching strategy in the `service_worker.js` file to ensure that the shell HTML is correctly precached and served, enhancing offline navigation reliability.

### Detailed summary
- Updated comments to clarify the caching behavior of `/` versus `/index.html`.
- Changed `cache.add("/index.html")` to `cache.add("/")` for proper caching.
- Modified `serveNavigation` to fetch and cache the shell from `/` instead of `/index.html`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->