### PR TITLE
perf(ui): mount the site before the profile bootstrap

### DIFF
--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -6,6 +6,8 @@
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::prelude::*;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_futures::spawn_local;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[wasm_bindgen(main)]
@@ -23,14 +25,12 @@ async fn main() {
     // `route!` table decides what to render.
     tonk_portal::register_site();
 
-    // Ensure the default repository + profile exist before routing.
-    let _ = tonk_ui::api::init().await;
-
-    // Install the host AFTER init: init awaits service-worker readiness, so
-    // everything the host wires up runs against a controlling SW. Nothing
-    // dispatches consumer events before `mount_root` below, so the late
-    // install loses no operations. (Sync cadence is SW-owned — the page
-    // runs no heartbeat.)
+    // Install the host IO surface and mount `<tonk-site>` right away —
+    // first paint no longer waits on any data round-trip. Every `/api/*`
+    // fetch the host issues self-gates on service-worker readiness
+    // (`tonk_host::ready::wait`, memoized), so mounting before the SW is
+    // controlling loses nothing: the site's own routing fetches block
+    // themselves until the worker is up.
     tonk_host::install();
 
     // Dev-only hot reload client. `debug_assertions` is on under `trunk serve`
@@ -39,6 +39,17 @@ async fn main() {
     inject_hot_swap();
 
     mount_root();
+
+    // Ensure the profile has at least one space, off the critical path.
+    // `init` awaits SW readiness then a `GET /api/profile` (a ~1.6s
+    // first-touch main-branch transact) and, on a fresh profile, a space
+    // create — none of which the first paint needs. The Hub renders its
+    // space directory through a LIVE `<tonk-display>` subscription, so a
+    // space created here populates it reactively with no reload. The
+    // returned client id is unused, so the result is discarded.
+    spawn_local(async {
+        let _ = tonk_ui::api::init().await;
+    });
 }
 
 /// Mount the single `<tonk-site>` root into `<body>` — the top-level router.


### PR DESCRIPTION
## Why

The page's `main()` awaited `api::init()` *before* mounting `<tonk-site>`, so first paint blocked on a full service-worker round-trip: a `GET /api/profile` that triggers a ~1.6s first-touch main-branch transact (branch acquire + materialize), plus — on a brand-new profile — a space-create round-trip. None of that is needed to paint the app shell; `<tonk-site>` could route immediately.

## How

Mount `<tonk-site>` first, then run `init()` via `spawn_local` (fire-and-forget) instead of awaiting it. Two facts make this safe:

- **Host fetches self-gate on SW readiness.** `tonk_host`'s HTTP layer already calls `ready::wait()` (memoized) on every request, so the site's own routing/subscription fetches block themselves until the worker is controlling the page. Mounting before that changes nothing about correctness — the old `init().await` gate was redundant with this.
- **The Hub is reactive.** It renders its space directory through a live `<tonk-display>` subscription (the model resolve is a subscription, not a mount-time snapshot). On a fresh profile the Hub renders empty and populates the moment the background `init()` creates the default space — no reload.

`init()`'s return value (a client id) was already discarded, so nothing downstream depended on it having completed.

This is the first step toward making profile bootstrap fully a service-worker concern; a follow-up can move the create itself SW-side so the page doesn't orchestrate it at all.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the asynchronous initialization process in the `main` function of the `ui.rs` file for the WebAssembly target. It improves performance by allowing the UI to mount immediately without waiting for the API initialization.

### Detailed summary
- Added `wasm_bindgen_futures::spawn_local` for async task management.
- Removed synchronous waiting for `tonk_ui::api::init()` before mounting.
- Added a new asynchronous call to `tonk_ui::api::init()` using `spawn_local` to ensure profile initialization occurs off the critical path.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->