### PR TITLE
fix(reactor): serve a subscriber that attaches during a poll

### DIFF
--- a/rust/dialog-reactor/src/subscription/reference.rs
+++ b/rust/dialog-reactor/src/subscription/reference.rs
@@ -17,7 +17,7 @@ use crate::BranchState;
 use crate::env::SelectProvider;
 use crate::{Conclusion, Frame};
 
-use super::state::{QueryHash, Status};
+use super::state::QueryHash;
 
 /// Names a subscription within a branch. Built from
 /// [`BranchSession::subscription`].
@@ -79,22 +79,17 @@ impl SubscriptionPoll<'_> {
         Self: 'a,
     {
         // Snapshot what we need out of the map lock: the engine
-        // handle, the projection terms, and whether any subscriber is
-        // Pending (needs a full snapshot rather than a delta).
-        let (slot, terms, any_pending) = {
+        // handle and the projection terms. Whether a subscriber needs
+        // a full snapshot is decided at fan-out time (under the lock),
+        // NOT here: a subscriber can attach while the engine poll below
+        // awaits, so a flag captured now would miss it and leave it
+        // hung on `loading` forever (the stuck-spinner race).
+        let (slot, terms) = {
             let subs = self.state.subscriptions().lock();
             let Some(subscription) = subs.get(&self.hash) else {
                 return;
             };
-            let any_pending = subscription
-                .subscribers
-                .iter()
-                .any(|s| s.status == Status::Pending);
-            (
-                Arc::clone(&subscription.engine),
-                subscription.terms.clone(),
-                any_pending,
-            )
+            (Arc::clone(&subscription.engine), subscription.terms.clone())
         };
 
         // Take the engine out of its slot so the poll runs without a
@@ -135,19 +130,19 @@ impl SubscriptionPoll<'_> {
         // tree) still re-evaluates on this poll — no re-seed here.
         let poll_result = engine.poll(env).await;
 
-        // Snapshot for Pending subscribers — projected from the
-        // engine's retained results, consistent with the poll we just
-        // ran. Built only when some subscriber needs it.
-        let snapshot_bytes = if any_pending {
-            let conclusions: Vec<Conclusion> = engine
-                .results()
-                .iter()
-                .map(|c| Conclusion::project(c, &terms))
-                .collect();
-            serialize(&Frame::Snapshot { conclusions })
-        } else {
-            None
-        };
+        // Project the engine's retained results while we still hold the
+        // engine — the snapshot any Pending subscriber will need. Kept as
+        // projected conclusions (not yet serialized) so the fan-out below
+        // can decide, under the map lock, whether a snapshot is actually
+        // needed. Serializing eagerly here would waste work on the common
+        // no-Pending poll; deferring it to fan-out is what lets us serve a
+        // subscriber that attached during the poll `await` above without
+        // paying for a snapshot when there is none.
+        let snapshot_conclusions: Vec<Conclusion> = engine
+            .results()
+            .iter()
+            .map(|c| Conclusion::project(c, &terms))
+            .collect();
 
         // Put the engine back before handling the poll outcome so the
         // slot is never left empty on an early return.
@@ -185,35 +180,17 @@ impl SubscriptionPoll<'_> {
             })
         });
 
-        // Fan out under the map lock.
+        // Fan out under the map lock. The delivery decision (snapshot to
+        // Pending, delta to Established) lives on `Subscription::deliver`
+        // so it re-checks the subscriber set HERE, under the lock, rather
+        // than off a flag captured before the poll `await` — a subscriber
+        // that attached during the poll is served its first snapshot now
+        // instead of hanging until some later write schedules another poll.
         let mut subs = self.state.subscriptions().lock();
         let Some(subscription) = subs.get_mut(&self.hash) else {
             return;
         };
-
-        subscription.subscribers.retain_mut(|subscriber| {
-            let bytes = match subscriber.status {
-                // A fresh (or reconnected) subscriber needs the full
-                // set, not a delta it has no base for.
-                Status::Pending => snapshot_bytes.clone(),
-                // An established subscriber only hears about changes.
-                Status::Established => delta_bytes.clone(),
-            };
-            let Some(bytes) = bytes else {
-                // Nothing to send this subscriber this round (an
-                // Established subscriber on a no-change poll, or a
-                // frame that failed to serialize) — keep it.
-                return true;
-            };
-            match subscriber.sender.send(bytes) {
-                Ok(()) => {
-                    subscriber.status = Status::Established;
-                    true
-                }
-                Err(_) => false,
-            }
-        });
-
+        subscription.deliver(&snapshot_conclusions, delta_bytes.as_ref());
         if subscription.subscribers.is_empty() {
             subs.remove(&self.hash);
         }

--- a/rust/dialog-reactor/src/subscription/state.rs
+++ b/rust/dialog-reactor/src/subscription/state.rs
@@ -16,8 +16,9 @@ use dialog_query::Parameters;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::Query;
+use crate::{Conclusion, Frame, Query};
 use bytes::Bytes;
+use dialog_common::log;
 
 /// The dialog engine backing one reactor subscription.
 ///
@@ -123,4 +124,208 @@ pub struct Subscription {
     pub terms: Parameters,
     /// Open downstream channels with their delivery status.
     pub subscribers: Vec<SubscriberSession>,
+}
+
+impl Subscription {
+    /// Fan a poll's result out to every subscriber, advancing each to
+    /// [`Established`](Status::Established) once served.
+    ///
+    /// - A [`Pending`](Status::Pending) subscriber gets a full
+    ///   [`Frame::Snapshot`] built from `snapshot_conclusions` (the
+    ///   engine's retained results, projected to wire rows). This is the
+    ///   race-safe half: the Pending set is read HERE, at delivery, not
+    ///   from a flag captured before the poll's `await` — so a subscriber
+    ///   that attached while the poll ran is still served its first frame
+    ///   now rather than left hung on `loading` until an unrelated write
+    ///   happens to schedule another poll (which, on a quiescent branch,
+    ///   may never come).
+    /// - An [`Established`](Status::Established) subscriber gets
+    ///   `delta_bytes` when the poll reported a non-empty change, and
+    ///   nothing otherwise.
+    ///
+    /// The snapshot is serialized lazily and at most once, only when a
+    /// Pending subscriber is actually present. A subscriber whose channel
+    /// has closed is dropped.
+    pub fn deliver(&mut self, snapshot_conclusions: &[Conclusion], delta_bytes: Option<&Bytes>) {
+        fan_out(&mut self.subscribers, snapshot_conclusions, delta_bytes);
+    }
+}
+
+/// Deliver a poll's result to a subscriber set (see
+/// [`Subscription::deliver`]). Split out from the `Subscription` method so
+/// the delivery logic — the race-sensitive part — is exercised directly by
+/// tests without fabricating a dialog engine.
+fn fan_out(
+    subscribers: &mut Vec<SubscriberSession>,
+    snapshot_conclusions: &[Conclusion],
+    delta_bytes: Option<&Bytes>,
+) {
+    // Memoized snapshot bytes: `None` = not built yet, `Some(inner)` =
+    // built (`inner` may itself be `None` if serialization failed).
+    let mut snapshot_bytes: Option<Option<Bytes>> = None;
+
+    subscribers.retain_mut(|subscriber| {
+        let bytes = match subscriber.status {
+            Status::Pending => snapshot_bytes
+                .get_or_insert_with(|| serialize_snapshot(snapshot_conclusions.to_vec()))
+                .clone(),
+            Status::Established => delta_bytes.cloned(),
+        };
+        let Some(bytes) = bytes else {
+            // Nothing to send this subscriber this round (an Established
+            // subscriber on a no-change poll, or a frame that failed to
+            // serialize) — keep it.
+            return true;
+        };
+        match subscriber.sender.send(bytes) {
+            Ok(()) => {
+                subscriber.status = Status::Established;
+                true
+            }
+            Err(_) => false,
+        }
+    });
+}
+
+/// Serialize a [`Frame::Snapshot`] to wire bytes, logging and dropping on
+/// failure (a serialization error is not worth killing the fan-out).
+fn serialize_snapshot(conclusions: Vec<Conclusion>) -> Option<Bytes> {
+    match serde_json::to_vec(&Frame::Snapshot { conclusions }) {
+        Ok(bytes) => Some(Bytes::from(bytes)),
+        Err(err) => {
+            log!("[reactor] failed to serialize snapshot frame: {err}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(missing_docs)]
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use std::collections::BTreeMap;
+
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    use super::*;
+
+    /// One row of a snapshot.
+    fn conclusion(this: &str) -> Conclusion {
+        Conclusion {
+            this: this.to_owned(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    /// A subscriber in the given delivery state, paired with its receiver.
+    fn subscriber(status: Status) -> (SubscriberSession, UnboundedReceiver<Bytes>) {
+        let (sender, receiver) = unbounded_channel();
+        (SubscriberSession { sender, status }, receiver)
+    }
+
+    /// Decode a delivered frame off a receiver.
+    fn recv(receiver: &mut UnboundedReceiver<Bytes>) -> Option<Frame> {
+        receiver
+            .try_recv()
+            .ok()
+            .map(|bytes| serde_json::from_slice(&bytes).expect("frame decodes"))
+    }
+
+    /// A Pending subscriber must receive its snapshot on the next fan-out —
+    /// even when it is the ONLY pending subscriber and every other is
+    /// Established. The regression: the snapshot used to be built off a flag
+    /// captured before the engine poll, so a subscriber that attached during
+    /// the poll (or after that flag was read) was silently kept unserved and
+    /// its `<tonk-display>` hung on `loading` forever. Delivery now decides
+    /// per-subscriber at fan-out, so this can't happen.
+    #[dialog_common::test]
+    fn it_snapshots_a_pending_subscriber_even_beside_established_ones() {
+        let (established, mut established_rx) = subscriber(Status::Established);
+        let (pending, mut pending_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![established, pending];
+
+        // A no-change poll: no delta for the Established subscriber, but the
+        // Pending one still needs its first snapshot.
+        fan_out(&mut subscribers, &[conclusion("id:one")], None);
+
+        // The Pending subscriber got a Snapshot and is now Established.
+        match recv(&mut pending_rx) {
+            Some(Frame::Snapshot { conclusions }) => {
+                assert_eq!(conclusions, vec![conclusion("id:one")]);
+            }
+            other => panic!("pending subscriber must get a Snapshot, got {other:?}"),
+        }
+        assert_eq!(subscribers[1].status, Status::Established);
+
+        // The Established subscriber got nothing on a no-change poll.
+        assert!(
+            recv(&mut established_rx).is_none(),
+            "established subscriber gets no frame when the delta is empty"
+        );
+    }
+
+    /// The snapshot is serialized at most once regardless of how many
+    /// Pending subscribers there are, and every one of them receives it.
+    #[dialog_common::test]
+    fn it_serves_every_pending_subscriber_one_snapshot() {
+        let (a, mut a_rx) = subscriber(Status::Pending);
+        let (b, mut b_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![a, b];
+
+        fan_out(&mut subscribers, &[conclusion("id:x")], None);
+
+        for rx in [&mut a_rx, &mut b_rx] {
+            assert!(
+                matches!(recv(rx), Some(Frame::Snapshot { .. })),
+                "each pending subscriber receives the snapshot"
+            );
+        }
+        assert!(subscribers.iter().all(|s| s.status == Status::Established));
+    }
+
+    /// An Established subscriber receives a non-empty delta; a Pending one
+    /// added in the same round still gets a full snapshot, not the delta.
+    #[dialog_common::test]
+    fn it_sends_deltas_to_established_and_snapshots_to_pending() {
+        let (established, mut established_rx) = subscriber(Status::Established);
+        let (pending, mut pending_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![established, pending];
+
+        let delta = Bytes::from(
+            serde_json::to_vec(&Frame::Delta {
+                asserted: vec![],
+                retracted: vec![],
+            })
+            .unwrap(),
+        );
+        fan_out(&mut subscribers, &[conclusion("id:one")], Some(&delta));
+
+        assert!(
+            matches!(recv(&mut established_rx), Some(Frame::Delta { .. })),
+            "established subscriber gets the delta"
+        );
+        assert!(
+            matches!(recv(&mut pending_rx), Some(Frame::Snapshot { .. })),
+            "pending subscriber gets a snapshot, not the delta"
+        );
+    }
+
+    /// A subscriber whose receiver has been dropped is pruned from the set.
+    #[dialog_common::test]
+    fn it_drops_a_subscriber_whose_channel_closed() {
+        let (live, mut live_rx) = subscriber(Status::Pending);
+        let (dead, dead_rx) = subscriber(Status::Pending);
+        drop(dead_rx);
+        let mut subscribers = vec![live, dead];
+
+        fan_out(&mut subscribers, &[conclusion("id:one")], None);
+
+        assert_eq!(subscribers.len(), 1, "the closed subscriber is pruned");
+        assert!(matches!(recv(&mut live_rx), Some(Frame::Snapshot { .. })));
+    }
 }


### PR DESCRIPTION
## Why

A `<tonk-display>` sometimes gets stuck on `data-state="loading"` (the never-ending spinner) — most visibly a nested `<tonk-site model="tonk:site">` whose `tonk:site` stamp races the guest's subscription. The subscription is established but never receives its first frame.

## Cause

`SubscriptionPoll::perform` decided whether to build a `Frame::Snapshot` from an `any_pending` flag captured **before** the engine poll's `await`. A subscriber that attaches while that poll is running (a very common race: the guest subscribes at almost the same moment the `tonk:load` claim stamps `tonk:site` and triggers the poll) is not counted in that flag, so no snapshot is built for it. At fan-out it's `Pending` but `snapshot_bytes` is `None`, so it's silently kept unserved. The comment claimed "the next scheduled poll re-serves it" — but on a quiescent branch (nothing else writes), no next poll is ever scheduled, and the subscriber hangs forever.

## Fix

Decide delivery per subscriber **at fan-out**, under the map lock, instead of off a pre-poll flag. The snapshot is projected from the just-polled engine results and serialized lazily — built only if a subscriber is actually `Pending` at delivery time. A subscriber that attached during the poll is therefore served its first snapshot in the same poll that ran because of it.

The fan-out is extracted into `Subscription::deliver` / `fan_out`, and four regression tests cover it directly (Pending-beside-Established, multiple Pending, delta-to-Established + snapshot-to-Pending in one round, closed-channel pruning) — the delivery logic that had the race is now exercised without needing a live dialog engine.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the subscription delivery mechanism in the `dialog-reactor` by ensuring that subscribers receive the correct data based on their status, particularly addressing issues with pending subscribers not receiving timely snapshots.

### Detailed summary
- Removed the `Status` import from `super::state`.
- Simplified logic to determine if subscribers need a snapshot during polling.
- Introduced `Subscription::deliver` method to handle delivery logic.
- Added a `fan_out` function to manage subscriber notifications.
- Implemented lazy serialization for snapshot bytes.
- Improved handling of subscriber states during delivery.
- Added tests to ensure correct behavior for pending and established subscribers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->