### PR TITLE
feat: <tonk-upload> web-UI blob upload

### DIFF
--- a/docs/superpowers/plans/2026-07-09-blob-upload.md
+++ b/docs/superpowers/plans/2026-07-09-blob-upload.md
@@ -1,0 +1,1012 @@
+# `<tonk-upload>` Web-UI Blob Upload — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a web-UI path to ingest a picked file into the branch's blob store: a worker `POST …/blob` route, and a headless native `<tonk-upload>` element with a nice default UI that ingests → previews → emits the resulting `blob:<hash>`.
+
+**Architecture:** Two parts. (1) A `POST /api/repository/{repo}/branch/{branch}/blob` handler in `tonk-worker` that buffers the body, writes it via `Blob::import`, asserts the `xyz.tonk.blob/*` facts, and returns JSON. (2) A native `<tonk-upload>` custom element (the `custom-elements` crate + `CustomElement` trait, mirroring `<tonk-tree>`) that runs in the sealed guest: it reads the file to bytes, POSTs via the relayed `window.fetch`, swaps its preview to the read route, and dispatches a `tonk-upload` event. Shadow DOM holds the mechanism; the author restyles via slots/parts/state.
+
+**Tech Stack:** Rust; axum-in-wasm (`tonk-worker`); `wasm-bindgen`/`web-sys` + the `custom-elements` crate (`tonk-display`); `dialog-repository::Blob` for the store.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-blob-upload-design.md`.
+
+## Global Constraints
+
+- Always `#[dialog_common::test]` (never `#[test]`/`#[tokio::test]`). Worker route tests: `#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))] mod tests` + `wasm_bindgen_test_configure!(run_in_service_worker)`. Element tests: `run_in_browser`.
+- Lint gate is the workspace `nix develop .#ci -c cargo clippy --all-targets --all-features -- -D warnings` **plus** `cargo fmt --all -- --check`. Per-crate clippy without `--all-features` is NOT sufficient.
+- No `mod.rs`; no phase/RFC references in code/comments.
+- dialog-db dep stays on `branch = "main"` (the checkout with the blob API).
+- Route URL shapes, exact: ingest `POST /api/repository/{repo}/branch/{branch}/blob` (no entity segment); read (already exists) `GET /api/repository/{repo}/branch/{branch}/blob/{entity}`.
+- Ingest request: raw bytes body; `Content-Type` header = the blob MIME; `X-Tonk-Blob-Name` header = filename (optional).
+- Success event: bubbling, composed `CustomEvent('tonk-upload')`, `detail = { blob, contentType, name, size }`. No event on failure.
+- Custom elements are defined via the `custom-elements` crate: `impl CustomElement for T { … }` + `T::define("tag")`. Do NOT hand-roll `customElements.define`. Mirror `rust/tonk-tree/src/web.rs`.
+
+---
+
+### Task 1: Worker `POST …/blob` ingest route
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/blob.rs` (add `upload` handler + a `BlobUploadResponse` struct + test)
+- Modify: `rust/tonk-worker/src/router.rs:266-273` (add the `post` route)
+
+**Interfaces:**
+- Consumes: `super::AppState`, `crate::TonkWorkerError` (`Router`/`NotFound`/`Internal`); the existing `serve` handler's branch-open pattern; `dialog_repository::{Blob, RepositoryExt}`, `dialog_effects::blob::BlobError`, `dialog_artifacts::{Attribute, Value}`, `futures_util::stream`.
+- Produces: `pub async fn upload(...) -> Result<Response, TonkWorkerError>` at `POST …/blob`, responding JSON `{ entity, contentType, name, size }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `rust/tonk-worker/src/router/blob.rs` (alongside `it_serves_blob_bytes_with_the_asserted_content_type`):
+
+```rust
+#[dialog_common::test]
+async fn it_uploads_bytes_and_serves_them_back() {
+    let tonk = test_state().await;
+    let app_state = Arc::new(RwLock::new(tonk));
+    let (app, _lsp) = api_router_from_state(app_state.clone());
+    let repo = put_repo(&app, "blob-upload").await;
+
+    let payload = b"\x89PNG\r\n\x1a\nupload".to_vec();
+
+    // Upload via the new POST route.
+    let up = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                .method("POST")
+                .header("content-type", "image/png")
+                .header("x-tonk-blob-name", "shot.png")
+                .body(Body::from(payload.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(up.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(up.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let entity = json["entity"].as_str().unwrap().to_string();
+    assert!(entity.starts_with("blob:"), "entity is a blob ref: {entity}");
+    assert_eq!(json["contentType"], "image/png");
+    assert_eq!(json["name"], "shot.png");
+    assert_eq!(json["size"], payload.len());
+
+    // The GET route serves the same bytes + Content-Type from the asserted fact.
+    let got = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/repository/{repo}/branch/main/blob/{entity}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(got.status(), StatusCode::OK);
+    assert_eq!(got.headers().get("content-type").unwrap(), "image/png");
+    let got_body = axum::body::to_bytes(got.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(got_body.as_ref(), payload.as_slice());
+
+    // Idempotent: same bytes → same entity.
+    let up2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                .method("POST")
+                .header("content-type", "image/png")
+                .body(Body::from(payload.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body2 = axum::body::to_bytes(up2.into_body(), usize::MAX).await.unwrap();
+    let json2: serde_json::Value = serde_json::from_slice(&body2).unwrap();
+    assert_eq!(json2["entity"], entity, "content-addressed: re-upload yields same entity");
+
+    // Empty body → 400.
+    let empty = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                .method("POST")
+                .header("content-type", "image/png")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `nix develop .#ci -c bash -c 'cargo nextest run -p tonk-worker -E "test(it_uploads_bytes)" 2>&1 | tail -20'` (or the full `nix develop -c test:web:debug`).
+Expected: FAIL — the crate doesn't compile (`blob::upload`, the route, don't exist) or the POST 404s.
+
+- [ ] **Step 3: Add the handler**
+
+In `rust/tonk-worker/src/router/blob.rs`, add above the test module. Reuse the existing imports; add `axum::http::HeaderMap`, `dialog_artifacts::{Attribute, Value}`, `futures_util::stream`, `serde::Serialize` as needed.
+
+```rust
+/// JSON body of a successful `POST …/blob`.
+#[derive(Debug, Serialize)]
+pub struct BlobUploadResponse {
+    /// The content-addressed `blob:<hash>` entity the bytes were stored under.
+    pub entity: String,
+    /// MIME type recorded for the blob (from the request `Content-Type`).
+    #[serde(rename = "contentType")]
+    pub content_type: String,
+    /// File name recorded for the blob, if the `X-Tonk-Blob-Name` header was set.
+    pub name: Option<String>,
+    /// Size of the stored bytes.
+    pub size: usize,
+}
+
+/// Handler for `POST /api/repository/{repo}/branch/{branch}/blob`.
+///
+/// Buffers the request body, writes it into the branch's content-addressed
+/// blob store, and asserts the blob's `xyz.tonk.blob/content-type` (and
+/// `xyz.tonk.blob/name`, when the `X-Tonk-Blob-Name` header is present)
+/// facts — so the read route and `<tonk-display model=tonk:blob>` work
+/// immediately. Idempotent by content address. Buffered, not streamed.
+#[wasm_compat]
+pub async fn upload(
+    State(state): State<AppState>,
+    Path((repo, branch)): Path<(String, String)>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<Response, TonkWorkerError> {
+    if body.is_empty() {
+        return Err(TonkWorkerError::Router("empty upload body".to_string()));
+    }
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let name = headers
+        .get("x-tonk-blob-name")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let size = body.len();
+
+    let tonk = state.read().await;
+    let repository = tonk
+        .profile
+        .repository(&repo)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::NotFound(format!("Repository '{repo}' not found: {e}")))?;
+    let branch_handle = repository
+        .branch(branch.as_str())
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("Failed to open branch '{branch}': {e}")))?;
+
+    // Ingest bytes into the content-addressed store.
+    let bytes = body.to_vec();
+    let source = stream::once(async move { Ok::<_, BlobError>(bytes) });
+    let entity = Blob::import(source)
+        .write(branch_handle.blobs())
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("write blob: {e}")))?;
+
+    // Assert extrinsic metadata as ordinary facts on the blob entity, mirroring
+    // `tonk blob add`. `RawClaim` + reactor commit so subscriptions re-poll.
+    let ct_attr: Attribute = "xyz.tonk.blob/content-type"
+        .parse()
+        .map_err(|e| TonkWorkerError::Internal(format!("bad attribute: {e}")))?;
+    let mut tx = branch_handle
+        .transaction()
+        .assert(crate::router::claim::RawClaim {
+            of: entity.clone(),
+            the: ct_attr,
+            is: Value::String(content_type.clone()),
+        });
+    if let Some(n) = &name {
+        let name_attr: Attribute = "xyz.tonk.blob/name"
+            .parse()
+            .map_err(|e| TonkWorkerError::Internal(format!("bad attribute: {e}")))?;
+        tx = tx.assert(crate::router::claim::RawClaim {
+            of: entity.clone(),
+            the: name_attr,
+            is: Value::String(n.clone()),
+        });
+    }
+    tx.commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("assert metadata: {e}")))?;
+
+    let payload = BlobUploadResponse {
+        entity: entity.to_string(),
+        content_type,
+        name,
+        size,
+    };
+    let json = serde_json::to_string(&payload)
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize: {e}")))?;
+    let mut response = (StatusCode::OK, json).into_response();
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    Ok(response)
+}
+```
+
+> **Implementer note:** the exact `transaction().assert(...)` / `RawClaim` shape and the `commit().perform(...)` call must match the reactor API used by `router/claim.rs::assert_claim` (`RawClaim` is defined at `router/claim.rs:96-118`) and the CLI's `rust/tonk-cli/src/blob.rs::add` (which asserts the same two attributes via `ContentType::of(entity).is(...)`). If `branch_handle.transaction()` isn't the right entry point in the worker (the worker commits through the reactor session, not a bare branch), use the same commit path `assert_claim`/`transfer::import` use and adapt — the *behaviour* (assert content-type[+name], then broadcast) is the contract, not this exact call. Read `router/claim.rs:206-286` and `router/transfer.rs:114-158` before writing this, and follow whichever commit+broadcast path they use.
+
+- [ ] **Step 4: Register the route**
+
+In `rust/tonk-worker/src/router.rs`, change the blob route block (currently only `get(blob::serve)` at ~line 270) so the collection path also takes a POST:
+
+```rust
+        // Content-addressed blob bytes: GET serves an entity's bytes; POST
+        // ingests a new blob into the branch store and returns its ref.
+        .route(
+            "/api/repository/{repo}/branch/{branch}/blob",
+            post(blob::upload),
+        )
+        .route(
+            "/api/repository/{repo}/branch/{branch}/blob/{entity}",
+            get(blob::serve),
+        )
+```
+
+Ensure `post` is imported (the file already imports `get`; add `post` to the `use ::axum::{…, routing::post}` group if absent).
+
+- [ ] **Step 5: Run the test — confirm pass**
+
+Run: `nix develop .#ci -c bash -c 'cargo nextest run -p tonk-worker -E "test(it_uploads_bytes)" 2>&1 | tail -20'`
+Expected: PASS.
+
+- [ ] **Step 6: Lint gate**
+
+Run: `nix develop .#ci -c cargo clippy -p tonk-worker --all-targets --all-features -- -D warnings` and `nix develop .#ci -c cargo fmt -p tonk-worker -- --check`
+Expected: both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/blob.rs rust/tonk-worker/src/router.rs
+git commit -m "feat(tonk-worker): POST blob upload route ingests bytes + asserts metadata"
+```
+
+---
+
+### Task 2: Factor the `{branch}@{repo}`→URL helper
+
+Extract the branch/repo parse currently inline in `blob_image_src` (added in the display feature) so `<tonk-upload>` reuses it. Pure refactor — the existing `tonk:blob` `<img>` test must stay green.
+
+**Files:**
+- Modify: `rust/tonk-display/src/element.rs` (the `blob_image_src` helper)
+- Create: `rust/tonk-display/src/blob_url.rs` (the shared helper) + declare `mod blob_url;` in `rust/tonk-display/src/lib.rs`
+
+**Interfaces:**
+- Produces: `pub(crate) fn branch_repo(with: &str) -> Option<(String, String)>` returning `(branch, repo)`, and `pub(crate) fn blob_read_url(with: &str, entity: &str) -> Option<String>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rust/tonk-display/src/blob_url.rs`:
+
+```rust
+//! Shared helpers for building blob route URLs from a `<tonk-display>`/
+//! `<tonk-upload>` `with="{branch}@{repo}"` context attribute.
+
+/// Parse a `with="{branch}@{repo}"` context into `(branch, repo)`. Returns
+/// `None` if `with` is empty or still an unsubstituted `{…}` template. A bare
+/// token with no `@` is a repo on the default branch `main`.
+pub(crate) fn branch_repo(with: &str) -> Option<(String, String)> {
+    if with.is_empty() || with.contains('{') {
+        return None;
+    }
+    let (branch, repo) = match with.split_once('@') {
+        Some((branch, repo)) => (branch, repo),
+        None => ("main", with),
+    };
+    if repo.is_empty() {
+        return None;
+    }
+    Some((branch.to_string(), repo.to_string()))
+}
+
+/// The read URL for a blob entity, scoped by `with`. `None` if `with` is unusable.
+pub(crate) fn blob_read_url(with: &str, entity: &str) -> Option<String> {
+    let (branch, repo) = branch_repo(with)?;
+    Some(format!("/api/repository/{repo}/branch/{branch}/blob/{entity}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_parses_branch_and_repo() {
+        assert_eq!(
+            branch_repo("main@did:key:zX"),
+            Some(("main".into(), "did:key:zX".into()))
+        );
+        assert_eq!(branch_repo("did:key:zX"), Some(("main".into(), "did:key:zX".into())));
+        assert_eq!(branch_repo(""), None);
+        assert_eq!(branch_repo("{branch}@{repo}"), None);
+    }
+
+    #[dialog_common::test]
+    fn it_builds_the_read_url() {
+        assert_eq!(
+            blob_read_url("main@repo", "blob:zH").as_deref(),
+            Some("/api/repository/repo/branch/main/blob/blob:zH"),
+        );
+        assert_eq!(blob_read_url("{x}", "blob:zH"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — confirm it fails**
+
+Run: `nix develop .#ci -c bash -c 'cargo build -p tonk-display 2>&1 | tail'`
+Expected: FAIL — `mod blob_url;` isn't declared yet, so the module/test isn't compiled in (or `cargo test` can't find it).
+
+- [ ] **Step 3: Wire the module and reuse it in `blob_image_src`**
+
+Add `mod blob_url;` to `rust/tonk-display/src/lib.rs` (next to the other `mod` decls). Then rewrite `blob_image_src` in `element.rs` to delegate — replace its inline `with` parse + `format!` with:
+
+```rust
+fn blob_image_src(host: &Element) -> Option<String> {
+    let entity = host.get_attribute("entity")?;
+    let with = host.get_attribute("with")?;
+    crate::blob_url::blob_read_url(&with, &entity)
+}
+```
+
+(Keep the surrounding `handle_blob_image_frame` logic unchanged.)
+
+- [ ] **Step 4: Run tests — confirm pass**
+
+Run: `nix develop .#ci -c bash -c 'cargo nextest run -p tonk-display -E "test(blob_url) + test(it_mounts_an_img_for_a_blob_model)" 2>&1 | tail -20'`
+Expected: the two new `blob_url` tests PASS and the existing `it_mounts_an_img_for_a_blob_model` still PASSES (proving the refactor is behavior-preserving).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `nix develop .#ci -c cargo clippy -p tonk-display --all-targets --all-features -- -D warnings` (clean), then:
+
+```bash
+git add rust/tonk-display/src/blob_url.rs rust/tonk-display/src/lib.rs rust/tonk-display/src/element.rs
+git commit -m "refactor(tonk-display): factor shared with->blob-url helper"
+```
+
+---
+
+### Task 3: `<tonk-upload>` element — registration + default shadow UI
+
+Create the element skeleton: registered custom element, shadow root, default UI (trigger slot + preview part + status part) + `STYLE`, `data-state=idle`. No upload logic yet.
+
+**Files:**
+- Create: `rust/tonk-display/src/upload.rs`
+- Modify: `rust/tonk-display/src/lib.rs` (`mod upload;` + call `upload::register()` in the crate's `register()` fan-out at lib.rs:78-85)
+
+**Interfaces:**
+- Consumes: the `custom-elements` crate (`CustomElement`, `::define`), `web-sys` (`HtmlElement`, `ShadowRoot`, `ShadowRootInit`, `ShadowRootMode`, `Element`, `Event`, `HtmlInputElement`), `wasm_bindgen`.
+- Produces: `pub fn register()` defining `<tonk-upload>`; `struct TonkUploadElement` implementing `CustomElement`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `rust/tonk-display/src/upload.rs`, add the test module (mirrors the no-FakeHost pattern from `element.rs`'s `mod hook`):
+
+```rust
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    fn document() -> web_sys::Document {
+        web_sys::window().unwrap().document().unwrap()
+    }
+    async fn sleep(ms: i32) {
+        let p = js_sys::Promise::new(&mut |res, _| {
+            let _ = web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&res, ms);
+        });
+        let _ = JsFuture::from(p).await;
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_default_shadow_ui() {
+        super::register();
+        let el = document().create_element("tonk-upload").unwrap();
+        el.set_attribute("with", "main@did:key:zSpace").unwrap();
+        document().body().unwrap().append_child(&el).unwrap();
+
+        let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+        let mut root = None;
+        for _ in 0..200 {
+            if let Some(r) = host.shadow_root() {
+                if r.query_selector("input[type=file]").unwrap().is_some() {
+                    root = Some(r);
+                    break;
+                }
+            }
+            sleep(5).await;
+        }
+        let root = root.expect("shadow UI built");
+        assert!(root.query_selector("input[type=file]").unwrap().is_some());
+        assert!(root.query_selector("[part=button]").unwrap().is_some());
+        assert!(root.query_selector("[part=preview]").unwrap().is_some());
+        assert!(root.query_selector("[part=status]").unwrap().is_some());
+        assert_eq!(host.get_attribute("data-state").as_deref(), Some("idle"));
+    }
+}
+```
+
+- [ ] **Step 2: Run it — confirm it fails**
+
+Run: `nix develop .#ci -c bash -c 'cargo build -p tonk-display 2>&1 | tail'`
+Expected: FAIL — `upload` module/`register` doesn't exist.
+
+- [ ] **Step 3: Implement the skeleton**
+
+Write the element above the test module in `rust/tonk-display/src/upload.rs`, mirroring `rust/tonk-tree/src/web.rs:48-208, 652-658`:
+
+```rust
+//! `<tonk-upload>` — a headless native blob-upload primitive.
+//!
+//! The mechanism (file input, ingest fetch, state machine, preview) lives in
+//! Shadow DOM; the author restyles it via the `trigger` slot, `::part()`
+//! (`base`/`button`/`preview`/`status`), `--tonk-upload-*` CSS vars, and the
+//! reflected `data-state` attribute. Bytes are ingested through the worker
+//! `POST …/blob` route (relayed by the guest's `window.fetch`), and a
+//! successful upload dispatches a bubbling `tonk-upload` CustomEvent carrying
+//! the resulting `blob:<hash>`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use wasm_bindgen::JsCast;
+use web_sys::{Element, HtmlElement, ShadowRoot};
+
+/// Per-instance state: the shadow root and the live preview/status nodes, plus
+/// the change-listener closure kept alive for the element's lifetime.
+#[derive(Default)]
+struct Inner {
+    shadow: Option<ShadowRoot>,
+    // Closures are stored to keep them alive; filled in Task 4.
+    listeners: Vec<wasm_bindgen::closure::Closure<dyn FnMut(web_sys::Event)>>,
+}
+
+type Shared = Rc<RefCell<Inner>>;
+
+#[derive(Default)]
+pub struct TonkUploadElement {
+    state: Shared,
+}
+
+impl CustomElement for TonkUploadElement {
+    fn shadow() -> bool {
+        // We attach our own shadow root so we control build timing.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &["with", "accept"]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        set_state(this, "idle");
+        build_shadow(this, &self.state);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        *self.state.borrow_mut() = Inner::default();
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if old == new {
+            return;
+        }
+        // `accept` propagates to the input; `with` only affects the next upload.
+        if name == "accept" {
+            if let Some(root) = self.state.borrow().shadow.as_ref() {
+                if let Ok(Some(input)) = root.query_selector("input[type=file]") {
+                    let _ = input.set_attribute("accept", new.as_deref().unwrap_or(""));
+                }
+            }
+        }
+    }
+}
+
+/// Reflect the state machine onto the host for `data-state` CSS.
+fn set_state(this: &HtmlElement, state: &str) {
+    let _ = this.set_attribute("data-state", state);
+}
+
+fn ensure_shadow(this: &HtmlElement) -> ShadowRoot {
+    if let Some(root) = this.shadow_root() {
+        return root;
+    }
+    let init = web_sys::ShadowRootInit::new(web_sys::ShadowRootMode::Open);
+    this.attach_shadow(&init).unwrap()
+}
+
+fn doc() -> web_sys::Document {
+    web_sys::window().unwrap().document().unwrap()
+}
+fn el(tag: &str) -> Element {
+    doc().create_element(tag).unwrap()
+}
+
+/// Build the default shadow UI once. Wiring of the file input is added in Task 4.
+fn build_shadow(this: &HtmlElement, state: &Shared) {
+    let root = ensure_shadow(this);
+    // style
+    let style = el("style");
+    style.set_text_content(Some(STYLE));
+    let _ = root.append_child(&style);
+
+    // container
+    let base = el("div");
+    let _ = base.set_attribute("part", "base");
+
+    // hidden real input
+    let input = el("input");
+    let _ = input.set_attribute("type", "file");
+    let _ = input.set_attribute("hidden", "");
+    if let Some(accept) = this.get_attribute("accept") {
+        let _ = input.set_attribute("accept", &accept);
+    }
+    let _ = base.append_child(&input);
+
+    // trigger slot (fallback = default button)
+    let slot = el("slot");
+    let _ = slot.set_attribute("name", "trigger");
+    let button = el("button");
+    let _ = button.set_attribute("part", "button");
+    let _ = button.set_attribute("type", "button");
+    button.set_text_content(Some("Choose file…"));
+    let _ = slot.append_child(&button);
+    let _ = base.append_child(&slot);
+
+    // preview (element-owned part; hidden until an upload)
+    let preview = el("img");
+    let _ = preview.set_attribute("part", "preview");
+    let _ = preview.set_attribute("hidden", "");
+    let _ = base.append_child(&preview);
+
+    // status (element-owned part)
+    let status = el("span");
+    let _ = status.set_attribute("part", "status");
+    let _ = base.append_child(&status);
+
+    let _ = root.append_child(&base);
+    state.borrow_mut().shadow = Some(root);
+    // Task 4 wires the trigger-slot click → input.click() and the input change
+    // → the upload flow here, pushing closures into state.listeners.
+}
+
+const STYLE: &str = r#"
+:host { display: inline-flex; }
+[part=base] {
+  display: inline-flex; align-items: center; gap: var(--tonk-upload-gap, 8px);
+  font-family: var(--wa-font-family-body, system-ui, sans-serif);
+}
+[part=button] {
+  padding: 6px 12px; border-radius: var(--tonk-upload-radius, 6px);
+  border: 1px solid var(--wa-color-neutral-fill-loud, #ccc);
+  background: var(--tonk-upload-accent, var(--wa-color-brand-fill-loud, #2563eb));
+  color: var(--wa-color-brand-on-loud, #fff); cursor: pointer; font: inherit;
+}
+[part=button]:hover { filter: brightness(1.05); }
+[part=preview] { max-width: 96px; max-height: 96px; border-radius: 4px; }
+[part=preview][hidden] { display: none; }
+[part=status] { font-size: 12px; color: var(--wa-color-text-quiet, #666); }
+:host([data-state=error]) [part=status] { color: var(--wa-color-danger-fill-loud, #dc2626); }
+"#;
+
+/// Register the `<tonk-upload>` element. Idempotent.
+pub fn register() {
+    if already_registered() {
+        return;
+    }
+    TonkUploadElement::define("tonk-upload");
+}
+
+fn already_registered() -> bool {
+    doc()
+        .default_view()
+        .map(|w| !w.custom_elements().get("tonk-upload").is_undefined())
+        .unwrap_or(false)
+}
+```
+
+Then in `rust/tonk-display/src/lib.rs`: add `mod upload;` and add `upload::register();` to the `#[cfg(target_arch = "wasm32")] pub fn register()` fan-out (the one calling `view::register()`, `element::register()`, etc.). Confirm `custom-elements = { workspace = true }` and the needed `web-sys` features (`ShadowRoot`, `ShadowRootInit`, `ShadowRootMode`, `HtmlInputElement`, `File`, `FileList`, `Blob`, `Headers`, `RequestInit`, `Request`, `Response`, `Url`, `CustomEvent`, `CustomEventInit`) are enabled for `tonk-display` in `Cargo.toml` — add any missing ones.
+
+- [ ] **Step 4: Run the test — confirm pass**
+
+Run: `nix develop .#ci -c bash -c 'cargo nextest run -p tonk-display -E "test(it_builds_a_default_shadow_ui)" 2>&1 | tail -20'`
+Expected: PASS (browser). If it can't find Chrome, use the repo's `test:web:debug` path.
+
+- [ ] **Step 5: Lint + commit**
+
+`nix develop .#ci -c cargo clippy -p tonk-display --all-targets --all-features -- -D warnings` (clean), then:
+
+```bash
+git add rust/tonk-display/src/upload.rs rust/tonk-display/src/lib.rs rust/tonk-display/Cargo.toml
+git commit -m "feat(tonk-display): <tonk-upload> element skeleton + default shadow UI"
+```
+
+---
+
+### Task 4: `<tonk-upload>` — pick → read → upload → preview → emit
+
+Wire the behavior: clicking the trigger opens the picker; a picked file is read to bytes, uploaded via the relayed `window.fetch`, the preview swaps to the read route, and a `tonk-upload` event fires. Errors set `data-state=error` and emit nothing. Missing `with` disables the trigger.
+
+**Files:** Modify `rust/tonk-display/src/upload.rs`.
+
+**Interfaces:**
+- Consumes: `crate::blob_url::branch_repo` (Task 2); `web-sys` (`File`, `FileList`, `HtmlInputElement`, `Headers`, `RequestInit`, `Response`, `Url`, `CustomEvent`, `CustomEventInit`); `js_sys::Uint8Array`; `wasm_bindgen_futures::{spawn_local, JsFuture}`.
+- Produces: the `tonk-upload` event contract (`detail = { blob, contentType, name, size }`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `upload.rs`'s test module. Stub the relayed `window.fetch` so no real network is needed, then drive the input and assert the event + preview swap + state.
+
+```rust
+#[dialog_common::test]
+async fn it_uploads_and_emits_on_pick() {
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsValue;
+
+    super::register();
+
+    // Stub window.fetch → a Response with the canned JSON, so the element's
+    // POST resolves deterministically. (Restore is unnecessary in the test realm.)
+    let stub = Closure::wrap(Box::new(move |_url: JsValue, _init: JsValue| {
+        let json = r#"{"entity":"blob:zH","contentType":"image/png","name":"a.png","size":3}"#;
+        let init = web_sys::ResponseInit::new();
+        init.set_status(200);
+        let resp = web_sys::Response::new_with_opt_str_and_init(Some(json), &init).unwrap();
+        js_sys::Promise::resolve(&resp.into())
+    }) as Box<dyn FnMut(JsValue, JsValue) -> js_sys::Promise>);
+    js_sys::Reflect::set(
+        &web_sys::window().unwrap(),
+        &"fetch".into(),
+        stub.as_ref().unchecked_ref(),
+    )
+    .unwrap();
+    stub.forget();
+
+    let el = document().create_element("tonk-upload").unwrap();
+    el.set_attribute("with", "main@repo").unwrap();
+    document().body().unwrap().append_child(&el).unwrap();
+    let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+
+    // Listen for the success event.
+    let got: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    {
+        let got = got.clone();
+        let cb = Closure::wrap(Box::new(move |ev: web_sys::CustomEvent| {
+            let detail = ev.detail();
+            let blob = js_sys::Reflect::get(&detail, &"blob".into())
+                .ok()
+                .and_then(|v| v.as_string());
+            *got.borrow_mut() = blob;
+        }) as Box<dyn FnMut(web_sys::CustomEvent)>);
+        host.add_event_listener_with_callback("tonk-upload", cb.as_ref().unchecked_ref())
+            .unwrap();
+        cb.forget();
+    }
+
+    // Wait for the shadow, then drive a synthetic file through the flow.
+    // (Helper `dispatch_test_file` is added to the element in Step 3 so tests can
+    // inject a File without a real OS picker.)
+    let mut input = None;
+    for _ in 0..200 {
+        if let Some(r) = host.shadow_root() {
+            if let Ok(Some(i)) = r.query_selector("input[type=file]") {
+                input = Some(i);
+                break;
+            }
+        }
+        sleep(5).await;
+    }
+    let input: web_sys::HtmlInputElement = input.unwrap().dyn_into().unwrap();
+
+    // Build a File and hand it to the element's test hook.
+    let parts = js_sys::Array::new();
+    parts.push(&js_sys::Uint8Array::from(&b"abc"[..]).into());
+    let opts = web_sys::FilePropertyBag::new();
+    opts.set_type("image/png");
+    let file =
+        web_sys::File::new_with_u8_array_sequence_and_options(&parts, "a.png", &opts).unwrap();
+    super::__test_ingest(&host, &file);
+
+    // The event fires, preview swaps to the read route, state is done.
+    for _ in 0..200 {
+        if got.borrow().is_some() {
+            break;
+        }
+        sleep(5).await;
+    }
+    assert_eq!(got.borrow().as_deref(), Some("blob:zH"));
+    assert_eq!(host.get_attribute("data-state").as_deref(), Some("done"));
+    let preview = host
+        .shadow_root()
+        .unwrap()
+        .query_selector("[part=preview]")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        preview.get_attribute("src").as_deref(),
+        Some("/api/repository/repo/branch/main/blob/blob:zH"),
+    );
+    let _ = input; // silence unused
+}
+```
+
+- [ ] **Step 2: Run it — confirm it fails**
+
+Run: `nix develop .#ci -c bash -c 'cargo build -p tonk-display 2>&1 | tail'`
+Expected: FAIL — `__test_ingest` and the upload flow don't exist.
+
+- [ ] **Step 3: Implement the flow**
+
+In `upload.rs`, wire the trigger + input in `build_shadow` and add the ingest function. Add these pieces:
+
+In `build_shadow`, after building the nodes, before storing state — wire the trigger-slot click and the input change:
+
+```rust
+    // Clicking anywhere on the trigger slot (default button or author-slotted
+    // content) opens the native picker — unless `with` is missing.
+    let with_ok = crate::blob_url::branch_repo(&this.get_attribute("with").unwrap_or_default())
+        .is_some();
+    if !with_ok {
+        let _ = button.set_attribute("disabled", "");
+        status.set_text_content(Some("no space context"));
+    }
+    {
+        let input_for_click = input.clone();
+        let click = wasm_bindgen::closure::Closure::wrap(Box::new(move |_e: web_sys::Event| {
+            if with_ok {
+                let _ = input_for_click.unchecked_ref::<web_sys::HtmlElement>().click();
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = slot.add_event_listener_with_callback("click", click.as_ref().unchecked_ref());
+        state.borrow_mut().listeners.push(click);
+    }
+    {
+        let host = this.clone();
+        let change = wasm_bindgen::closure::Closure::wrap(Box::new(move |e: web_sys::Event| {
+            if let Some(target) = e.target() {
+                if let Ok(input) = target.dyn_into::<web_sys::HtmlInputElement>() {
+                    if let Some(file) = input.files().and_then(|l| l.get(0)) {
+                        ingest(&host, &file);
+                    }
+                }
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = input.add_event_listener_with_callback("change", change.as_ref().unchecked_ref());
+        state.borrow_mut().listeners.push(change);
+    }
+```
+
+Add the ingest function + a test hook:
+
+```rust
+/// Read `file` to bytes, POST it to the ingest route, swap the preview to the
+/// read route, and emit `tonk-upload` on success. All async; drives `data-state`.
+fn ingest(host: &HtmlElement, file: &web_sys::File) {
+    let host = host.clone();
+    let file = file.clone();
+    wasm_bindgen_futures::spawn_local(async move {
+        let with = host.get_attribute("with").unwrap_or_default();
+        let Some((branch, repo)) = crate::blob_url::branch_repo(&with) else {
+            fail(&host, "no space context");
+            return;
+        };
+        let name = file.name();
+        let mime = {
+            let t = file.type_();
+            if t.is_empty() { "application/octet-stream".to_string() } else { t }
+        };
+
+        set_state(&host, "reading");
+        // Instant local preview.
+        if mime.starts_with("image/") {
+            if let Ok(url) = web_sys::Url::create_object_url_with_blob(&file) {
+                show_preview(&host, &url);
+            }
+        }
+
+        // Read bytes.
+        let buf = match wasm_bindgen_futures::JsFuture::from(file.array_buffer()).await {
+            Ok(b) => b,
+            Err(_) => return fail(&host, "could not read file"),
+        };
+        let bytes = js_sys::Uint8Array::new(&buf);
+
+        set_state(&host, "uploading");
+        // POST via the relayed window.fetch (string URL, binary init.body).
+        let url = format!("/api/repository/{repo}/branch/{branch}/blob");
+        let headers = web_sys::Headers::new().unwrap();
+        let _ = headers.append("content-type", &mime);
+        let _ = headers.append("x-tonk-blob-name", &name);
+        let init = web_sys::RequestInit::new();
+        init.set_method("POST");
+        init.set_headers(&headers);
+        init.set_body(&bytes.into());
+        let win = web_sys::window().unwrap();
+        let resp_val = match wasm_bindgen_futures::JsFuture::from(
+            win.fetch_with_str_and_init(&url, &init),
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(_) => return fail(&host, "upload failed"),
+        };
+        let resp: web_sys::Response = resp_val.dyn_into().unwrap();
+        if !resp.ok() {
+            return fail(&host, &format!("upload failed ({})", resp.status()));
+        }
+        let text = match wasm_bindgen_futures::JsFuture::from(resp.text().unwrap()).await {
+            Ok(t) => t.as_string().unwrap_or_default(),
+            Err(_) => return fail(&host, "bad response"),
+        };
+        let json: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(j) => j,
+            Err(_) => return fail(&host, "bad response"),
+        };
+        let entity = json["entity"].as_str().unwrap_or_default().to_string();
+        let content_type = json["contentType"].as_str().unwrap_or(&mime).to_string();
+        let size = json["size"].as_u64().unwrap_or(0);
+
+        // Swap preview to the read route (proves storage). Non-image → name+size.
+        if content_type.starts_with("image/") {
+            if let Some(read) = crate::blob_url::blob_read_url(&with, &entity) {
+                show_preview(&host, &read);
+            }
+        } else {
+            set_status(&host, &format!("{name} · {size} bytes"));
+        }
+
+        set_state(&host, "done");
+        emit(&host, &entity, &content_type, &name, size);
+    });
+}
+
+fn show_preview(host: &HtmlElement, src: &str) {
+    if let Some(root) = host.shadow_root() {
+        if let Ok(Some(img)) = root.query_selector("[part=preview]") {
+            let _ = img.set_attribute("src", src);
+            let _ = img.remove_attribute("hidden");
+        }
+    }
+}
+fn set_status(host: &HtmlElement, msg: &str) {
+    if let Some(root) = host.shadow_root() {
+        if let Ok(Some(s)) = root.query_selector("[part=status]") {
+            s.set_text_content(Some(msg));
+        }
+    }
+}
+fn fail(host: &HtmlElement, msg: &str) {
+    set_state(host, "error");
+    set_status(host, msg);
+    if let Some(root) = host.shadow_root() {
+        if let Ok(Some(img)) = root.query_selector("[part=preview]") {
+            let _ = img.set_attribute("hidden", "");
+        }
+    }
+}
+fn emit(host: &HtmlElement, blob: &str, content_type: &str, name: &str, size: u64) {
+    let detail = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(&detail, &"blob".into(), &blob.into());
+    let _ = js_sys::Reflect::set(&detail, &"contentType".into(), &content_type.into());
+    let _ = js_sys::Reflect::set(&detail, &"name".into(), &name.into());
+    let _ = js_sys::Reflect::set(&detail, &"size".into(), &(size as f64).into());
+    let init = web_sys::CustomEventInit::new();
+    init.set_bubbles(true);
+    init.set_composed(true);
+    init.set_detail(&detail);
+    if let Ok(ev) = web_sys::CustomEvent::new_with_event_init_dict("tonk-upload", &init) {
+        let _ = host.dispatch_event(&ev);
+    }
+}
+
+/// Test-only hook: inject a `File` as if the user had picked it (browsers don't
+/// let script set `input.files`, and there's no real OS picker in tests).
+#[cfg(all(test, target_arch = "wasm32"))]
+pub(crate) fn __test_ingest(host: &HtmlElement, file: &web_sys::File) {
+    ingest(host, file);
+}
+```
+
+> **Implementer note:** the exact `web-sys` setter shapes (`RequestInit`/`ResponseInit`/`CustomEventInit`/`FilePropertyBag` — builder methods vs fields) depend on the pinned `web-sys` version; follow the shapes in `rust/tonk-tree/src/model.rs:91-126` (RequestInit/Headers/fetch) and `rust/tonk-guest/src/bin/guest.rs:75-99` (Blob/Url) — adapt setter calls to whatever compiles against the workspace `web-sys`. The `#[cfg(test)]`-gated `__test_ingest` keeps the hook out of release builds.
+
+- [ ] **Step 4: Run tests — confirm pass**
+
+Run: `nix develop .#ci -c bash -c 'cargo nextest run -p tonk-display -E "test(it_uploads_and_emits_on_pick) + test(it_builds_a_default_shadow_ui)" 2>&1 | tail -30'`
+Expected: both PASS.
+
+- [ ] **Step 5: Add the failure + slot-override tests**
+
+Add two more `#[dialog_common::test]`s to `upload.rs`: (a) stub `window.fetch` to resolve a `500` Response → assert `data-state=error`, no `tonk-upload` event, preview hidden; (b) mount `<tonk-upload with="main@repo"><button slot="trigger">Pick</button></tonk-upload>`, assert the slotted `[slot=trigger]` button is present as an assigned node and the default `[part=button]` is the slot fallback (still uploads via `__test_ingest`). Run them; expect PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+`nix develop .#ci -c cargo clippy -p tonk-display --all-targets --all-features -- -D warnings` (clean), `cargo fmt` check, then:
+
+```bash
+git add rust/tonk-display/src/upload.rs
+git commit -m "feat(tonk-display): <tonk-upload> pick/read/upload/preview/emit + errors"
+```
+
+---
+
+### Task 5: Register in the guest bundle + demo view
+
+Make `<tonk-upload>` available in the sealed guest, and add a demo for manual e2e.
+
+**Files:**
+- Modify: `rust/tonk-guest/src/bin/guest.rs` (confirm `tonk_display::register()` is called — it already is, and it now fans out to `upload::register()` from Task 3, so `<tonk-upload>` is registered automatically; add a direct call only if it's a separate crate). Verify no separate wiring is needed.
+- Modify: `rust/tonk-core/assets/library/demo.yaml` (a demo view mounting `<tonk-upload>` that logs/handles the event).
+
+- [ ] **Step 1: Confirm guest registration**
+
+Read `rust/tonk-guest/src/bin/guest.rs:21-56`. Since Task 3 added `upload::register()` to `tonk_display::register()`'s fan-out (`lib.rs:78-85`), and `guest.rs` already calls `tonk_display::register()`, `<tonk-upload>` is registered in the guest with no further change. Confirm this by reading the fan-out; if `<tonk-upload>` were its own crate it would need an explicit `tonk_upload::register();` line — it is not.
+
+- [ ] **Step 2: Add a demo view**
+
+In `rust/tonk-core/assets/library/demo.yaml`, add a small view that mounts the element inside a route context that forwards `with`, e.g. a concept + `view!` whose `display` is:
+
+```
+<tonk-upload with="{branch}@{repo}" accept="image/*"></tonk-upload>
+```
+
+(Match the surrounding demo.yaml conventions for how a view gets its `{branch}`/`{repo}` — mirror an existing route/demo view that already forwards `with`, e.g. the artifact route view.) This is manual-e2e only; no automated assertion.
+
+- [ ] **Step 3: Validate the library still loads**
+
+Run the tonk-core seed/analyze validation the way the repo does (mirror how other `*.yaml` library changes are validated — check `rust/tonk-core` for the analyze/seed test harness). Expected: the demo library parses/validates.
+
+- [ ] **Step 4: Manual e2e (document, don't automate)**
+
+In `dev:web` (now backed by a local blob-aware access service): open the demo view, pick an image, confirm (a) the preview renders, (b) the Network tab shows `POST …/blob` → 200 then `GET …/blob/blob:<hash>` → 200 `image/png`, (c) a `tonk-upload` event is observable (console log in the demo). Record the steps in the PR description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-core/assets/library/demo.yaml
+git commit -m "docs(demo): <tonk-upload> demo view for manual e2e"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Task 1 = the POST route (asserts content-type/name via `X-Tonk-Blob-Name`, JSON response, idempotent, empty→400). Tasks 3–4 = the headless element (shadow default UI, `with`/`accept`, pick→read→POST→preview-swap→emit, `data-state`, error path, slot trigger). Task 2 = the shared URL helper the spec calls for. Task 5 = guest registration + demo. ✔
+- **Deviation from spec (flagged):** the spec listed `preview`/`status` as slots; this plan makes them element-owned `::part()`s (the element writes their content) and keeps only `trigger` as a slot. Rationale: the element drives preview/status content, so slotting them cleanly is a follow-up. Restyling via `::part()` + `data-state` + CSS vars is preserved. **This is a real spec deviation — confirm it's acceptable at review, or promote preview/status to slots.**
+- **Placeholder scan:** each code step is complete; two "Implementer note" blocks flag where the exact reactor-commit path (Task 1) and `web-sys` builder shapes (Task 4) must be matched to the pinned APIs rather than trusted verbatim — these are grounding instructions, not TODOs.
+- **Type consistency:** the ingest URL (`…/blob`) and read URL (`…/blob/{entity}`) match Task 1's routes and the shared helper; the `tonk-upload` `detail` keys (`blob`/`contentType`/`name`/`size`) are identical across the element, the emit fn, and the tests.
+- **Risk:** the biggest execution risk is Task 4's `web-sys` builder-API shapes drifting from the pinned version — mitigated by pointing at `tonk-tree/model.rs` and `guest.rs` as compile-checked references. Element tests need the browser harness (chromedriver) — same as the display tests already in CI.

--- a/docs/superpowers/specs/2026-07-09-blob-upload-design.md
+++ b/docs/superpowers/specs/2026-07-09-blob-upload-design.md
@@ -1,0 +1,81 @@
+# `<tonk-upload>` — Web-UI Blob Upload Design
+
+**Status:** approved (2026-07-09)
+**Depends on:** the blob feature on `feat/tonk-blobs` (PR #561) — the `tonk:blob` concept, the read route `GET …/blob/{entity}` (`router/blob.rs::serve`), and the `<tonk-display model=tonk:blob>` `<img>` renderer. This feature branches off `feat/tonk-blobs`.
+
+## Goal
+
+A native, reusable web-UI primitive that ingests a user-picked file into the current branch's content-addressed blob store and surfaces the resulting `blob:<hash>` reference. The primitive is **blob-agnostic**: it ingests and emits; it does not know what the blob is "for." Views compose it and decide what to do with the ref.
+
+Non-goal (v1): binding the upload to a specific entity/field. That layers on later by wiring the emitted event into a `/transact` — no change to this element.
+
+## Why native, not a yaml component
+
+A file picker needs asynchronous JS (`FileReader`/`file.arrayBuffer()`), which declarative `<tonk-display>` views cannot run (views never execute scripts). The two homes that *can* run it are a yaml `component!:` (branch data, hot-swappable) or a native custom element. We chose **native**: it's available in every space with no per-space seeding, it's a trusted first-party primitive on par with `<tonk-display>`, and it's consistent with the native `tonk:blob` `<img>` renderer shipped in #561. Cost accepted: a Rust rebuild to change it (not hot-swappable).
+
+## Architecture — two parts
+
+### Part 1 — Worker ingest route
+
+`POST /api/repository/{repo}/branch/{branch}/blob` — a new handler in `rust/tonk-worker/src/router/blob.rs`, registered next to the existing `get(blob::serve)` at `router.rs`.
+
+- **Extractors:** `State(AppState)`, `Path { repo, branch }`, `headers: HeaderMap`, `body: Bytes` (the buffered file bytes — the established body-read pattern used by `transfer::import`, `claim::assert_claim`, `transact::transact`).
+- **MIME:** taken from the request `Content-Type` header. Absent/empty → `application/octet-stream`.
+- **Filename:** taken from an `X-Tonk-Blob-Name` request header. Absent → no name fact. *(Decision: a header, not a `?name=` query param or `multipart/form-data` — keeps the body a raw byte stream matching the CLI's streaming ingest, and avoids a multipart parser. The relay passes headers through.)*
+- **Ingest:** `Blob::import(stream::once(async move { Ok::<_, dialog_effects::blob::BlobError>(body.to_vec()) })).write(branch.blobs()).perform(&tonk.operator)` → `blob:<hash>` `Entity`. Branch is opened exactly as `serve` does (`profile.repository(repo).load()` → `repo.branch(branch).open()`). Idempotent by content address.
+- **Facts:** the route **asserts** `xyz.tonk.blob/content-type` (always) and `xyz.tonk.blob/name` (when the header is present) on the blob entity, in one reactor transaction, then broadcasts the new revision. *(Decision: the route asserts, rather than returning a bare entity for the caller to assert — this matches `tonk blob add` exactly, so the read route and `<tonk-display model=tonk:blob>` work immediately, and it's one round-trip instead of two.)* The commit path mirrors `transfer::import` (commit a body, then broadcast so subscriptions re-poll).
+- **Empty body:** rejected with `400`.
+- **Response:** `200` with JSON `{ "entity": "blob:<hash>", "contentType": "<mime>", "name": "<name-or-null>", "size": <bytes> }`.
+- **Errors:** mirror `serve`'s mapping — malformed input → `Router`(400), branch/repo failures → `NotFound`/`Internal`, using the same `TonkWorkerError` variants.
+- **Buffered, not streamed** in v1 — the same explicit limitation as the read route (`blob.rs` buffers the whole blob on read). A `BodyStream` refinement is a later pass.
+
+### Part 2 — Native `<tonk-upload>` element
+
+New module `rust/tonk-display/src/upload.rs`, `register()`ed into the guest bundle alongside `<tonk-display>` (via `tonk_display::register()` → guest).
+
+- **Attributes:**
+  - `with="{branch}@{repo}"` — the branch context, forwarded by the embedding view exactly like `<tonk-display>`. The element builds the ingest/read URLs from it, reusing the same `{branch}@{repo}` split logic as `blob_image_src` (factor that helper so both share it). If `with` is missing or an unsubstituted `{…}` template, the element renders a disabled state with a status note (it can't know where to POST).
+  - `accept` (optional) — passed straight to the file input's `accept` attribute (e.g. `image/*`).
+- **DOM:** renders a real `<input type="file">` (plus a small status/preview area). Native-element DOM runs, unlike inert view templates.
+- **On pick (single file):**
+  1. Read bytes: `await file.arrayBuffer()`.
+  2. Show an **instant local preview** via `URL.createObjectURL(file)` (revoked after swap) so the user sees the image immediately.
+  3. POST: `fetch('/api/repository/{repo}/branch/{branch}/blob', { method:'POST', body: <ArrayBuffer>, headers:{ 'Content-Type': file.type || 'application/octet-stream', 'X-Tonk-Blob-Name': file.name } })`. From a sealed guest this is relayed through the portal bridge — binary bodies survive the `postMessage` structured clone, and the request **must** use `init.body` (not a `Request` object, which the guest normalizer would `.text()`).
+  4. On `2xx`: parse `{ entity, contentType, name, size }`. Swap the preview to the **read-route** URL `/api/repository/{repo}/branch/{branch}/blob/<entity>` — proving the bytes were actually stored and are retrievable (not just a local file). For non-image `contentType`, show name + size instead of an `<img>`.
+  5. **Emit:** dispatch a bubbling, composed `CustomEvent('tonk-upload')` with `detail = { blob: entity, contentType, name, size }`.
+- **Status line:** idle → "reading…" → "uploading…" → done / error text.
+
+### Data flow
+
+```
+pick file
+  → read bytes (arrayBuffer)
+  → instant local preview (object URL)
+  → POST /…/blob  (relayed through the bridge for a sealed guest)
+    → worker: Blob::import → assert content-type[+name] facts → broadcast
+    → 200 { entity, contentType, name, size }
+  → element: swap preview to read-route URL, emit `tonk-upload` {detail}
+  → (view author, LATER) binds `tonk-upload` → /transact to record the ref on some entity
+```
+
+## Error handling
+
+- **Worker:** empty body → 400; unreadable/failed ingest → 500 JSON error; malformed repo/branch/headers → 400, matching `serve`.
+- **Element:** `arrayBuffer()`/read failure, fetch rejection, or non-2xx → status line shows the message, the local preview is cleared, and **no `tonk-upload` event is emitted** (a consumer never sees a phantom ref). Missing/unsubstituted `with` → disabled input + status note.
+
+## Testing
+
+- **Worker route** (`#[dialog_common::test]`, wasm service-worker, in `router/blob.rs`): POST bytes with a `Content-Type` and `X-Tonk-Blob-Name` → assert `200` + a `blob:` entity in the JSON; then `GET …/blob/<entity>` through `serve` and assert the bytes round-trip and the `Content-Type` came back from the asserted fact. A second POST of the same bytes returns the same entity (idempotence). An empty-body POST → 400.
+- **Element** (`#[dialog_common::test]`, browser, in `upload.rs`): mount `<tonk-upload with="main@repo">`, drive a synthetic `File` through the input, stub the relayed fetch to return a canned `{entity,…}`, and assert (a) the `tonk-upload` event fires once with the expected `detail`, (b) the preview `<img>` `src` becomes the read-route URL, (c) a failed fetch emits **no** event and shows an error status.
+- **Manual e2e:** a small demo view (e.g. in `demo.yaml`) mounting `<tonk-upload>` and capturing the event, exercised in `dev:web` (which now runs a local blob-aware access service).
+
+## Out of scope (v1)
+
+Drag-and-drop, multi-file selection, upload progress, streaming ingest, and upload-bound-to-an-entity/field. The last one is the natural next layer: a view binds the emitted `tonk-upload` event to a `/transact` that writes `blob:<hash>` onto a target entity's attribute.
+
+## File-level plan (informs the implementation plan)
+
+- `rust/tonk-worker/src/router/blob.rs` — add the `POST` handler + its test; register the route in `router.rs`.
+- `rust/tonk-display/src/upload.rs` — new element + test; `register()` from the crate's `register()` and the guest bundle.
+- `rust/tonk-display/src/element.rs` (or a shared helper module) — factor the `{branch}@{repo}` → URL logic out of `blob_image_src` so `<tonk-upload>` reuses it.
+- `rust/tonk-core/assets/library/demo.yaml` — a demo view mounting `<tonk-upload>` (manual e2e only).

--- a/docs/superpowers/specs/2026-07-09-blob-upload-design.md
+++ b/docs/superpowers/specs/2026-07-09-blob-upload-design.md
@@ -7,43 +7,58 @@
 
 A native, reusable web-UI primitive that ingests a user-picked file into the current branch's content-addressed blob store and surfaces the resulting `blob:<hash>` reference. The primitive is **blob-agnostic**: it ingests and emits; it does not know what the blob is "for." Views compose it and decide what to do with the ref.
 
+It is a **headless primitive with a nice default UI**: it ships a clean, usable appearance so it works out of the box with zero authoring, and every visible piece is overridable by the view author (slots, `::part()`, CSS custom properties, state) with no Rust changes.
+
 Non-goal (v1): binding the upload to a specific entity/field. That layers on later by wiring the emitted event into a `/transact` — no change to this element.
 
-## Why native, not a yaml component
+## Why a native headless element (not a yaml component)
 
-A file picker needs asynchronous JS (`FileReader`/`file.arrayBuffer()`), which declarative `<tonk-display>` views cannot run (views never execute scripts). The two homes that *can* run it are a yaml `component!:` (branch data, hot-swappable) or a native custom element. We chose **native**: it's available in every space with no per-space seeding, it's a trusted first-party primitive on par with `<tonk-display>`, and it's consistent with the native `tonk:blob` `<img>` renderer shipped in #561. Cost accepted: a Rust rebuild to change it (not hot-swappable).
+A file picker needs asynchronous JS (`FileReader`/`file.arrayBuffer()`), which declarative `<tonk-display>` views cannot run. The two homes that can are a yaml `component!:` (branch data) or a native custom element. We chose **native** because the user wants a strong primitive available in every space out of the box, with no per-space seeding, on par with `<tonk-display>` and consistent with the native `tonk:blob` `<img>` renderer shipped in #561.
+
+The usual objection to native — "you lose author control over the UI" — is answered by making it **headless**: the mechanism lives in Shadow DOM, and presentation is exposed through the standard web-component customization surface. Shadow DOM is the hinge — `<tonk-display>` reconciles light DOM, not shadow DOM, so the element can hold live UI inside a view without being clobbered. This is exactly how the library's `wa-*` (WebAwesome) components already work: shadow-DOM primitives restyled from view CSS via `::part()` (e.g. `wa-button::part(base)`, `.fab__invite::part(button)`). The security boundary is unaffected either way: bytes only enter the store through the UCAN-authorized worker route; the UI just calls it.
 
 ## Architecture — two parts
 
 ### Part 1 — Worker ingest route
 
-`POST /api/repository/{repo}/branch/{branch}/blob` — a new handler in `rust/tonk-worker/src/router/blob.rs`, registered next to the existing `get(blob::serve)` at `router.rs`.
+`POST /api/repository/{repo}/branch/{branch}/blob` — a new handler in `rust/tonk-worker/src/router/blob.rs`, registered alongside the existing `get(blob::serve)` in `router.rs`. (Distinct path from the read route `GET …/blob/{entity}`.)
 
-- **Extractors:** `State(AppState)`, `Path { repo, branch }`, `headers: HeaderMap`, `body: Bytes` (the buffered file bytes — the established body-read pattern used by `transfer::import`, `claim::assert_claim`, `transact::transact`).
-- **MIME:** taken from the request `Content-Type` header. Absent/empty → `application/octet-stream`.
-- **Filename:** taken from an `X-Tonk-Blob-Name` request header. Absent → no name fact. *(Decision: a header, not a `?name=` query param or `multipart/form-data` — keeps the body a raw byte stream matching the CLI's streaming ingest, and avoids a multipart parser. The relay passes headers through.)*
-- **Ingest:** `Blob::import(stream::once(async move { Ok::<_, dialog_effects::blob::BlobError>(body.to_vec()) })).write(branch.blobs()).perform(&tonk.operator)` → `blob:<hash>` `Entity`. Branch is opened exactly as `serve` does (`profile.repository(repo).load()` → `repo.branch(branch).open()`). Idempotent by content address.
-- **Facts:** the route **asserts** `xyz.tonk.blob/content-type` (always) and `xyz.tonk.blob/name` (when the header is present) on the blob entity, in one reactor transaction, then broadcasts the new revision. *(Decision: the route asserts, rather than returning a bare entity for the caller to assert — this matches `tonk blob add` exactly, so the read route and `<tonk-display model=tonk:blob>` work immediately, and it's one round-trip instead of two.)* The commit path mirrors `transfer::import` (commit a body, then broadcast so subscriptions re-poll).
+- **Extractors:** `State(AppState)`, `Path { repo, branch }`, `headers: HeaderMap`, `body: Bytes` — the established body-read pattern (`transfer::import`, `claim::assert_claim`, `transact::transact`).
+- **MIME:** from the request `Content-Type` header; absent/empty → `application/octet-stream`.
+- **Filename:** from an `X-Tonk-Blob-Name` request header; absent → no name fact. *(Decision: a header, not a `?name=` query param or `multipart/form-data` — keeps the body a raw byte stream matching the CLI's streaming ingest and avoids a multipart parser; the relay passes headers through.)*
+- **Ingest:** `Blob::import(stream::once(async move { Ok::<_, dialog_effects::blob::BlobError>(body.to_vec()) })).write(branch.blobs()).perform(&tonk.operator)` → `blob:<hash>` `Entity`. Branch opened exactly as `serve` does. Idempotent by content address.
+- **Facts:** the route **asserts** `xyz.tonk.blob/content-type` (always) and `xyz.tonk.blob/name` (when the header is present) on the blob entity in one reactor transaction, then broadcasts the new revision. *(Decision: the route asserts rather than returning a bare entity — matches `tonk blob add`, so the read route and `<tonk-display model=tonk:blob>` work immediately, in one round-trip.)* Commit + broadcast mirror `transfer::import`.
 - **Empty body:** rejected with `400`.
 - **Response:** `200` with JSON `{ "entity": "blob:<hash>", "contentType": "<mime>", "name": "<name-or-null>", "size": <bytes> }`.
-- **Errors:** mirror `serve`'s mapping — malformed input → `Router`(400), branch/repo failures → `NotFound`/`Internal`, using the same `TonkWorkerError` variants.
-- **Buffered, not streamed** in v1 — the same explicit limitation as the read route (`blob.rs` buffers the whole blob on read). A `BodyStream` refinement is a later pass.
+- **Errors:** mirror `serve`'s `TonkWorkerError` mapping (malformed → `Router`/400, repo/branch failures → `NotFound`/`Internal`).
+- **Buffered, not streamed** in v1 — same explicit limitation as the read route; a `BodyStream` refinement is a later pass.
 
-### Part 2 — Native `<tonk-upload>` element
+### Part 2 — Native headless `<tonk-upload>` element
 
-New module `rust/tonk-display/src/upload.rs`, `register()`ed into the guest bundle alongside `<tonk-display>` (via `tonk_display::register()` → guest).
+New module `rust/tonk-display/src/upload.rs`, `register()`ed into the guest bundle alongside `<tonk-display>` (via `tonk_display::register()`). The mechanism (file input, ingest fetch, state machine, preview management) lives in **Shadow DOM**; the presentation is author-overridable.
 
-- **Attributes:**
-  - `with="{branch}@{repo}"` — the branch context, forwarded by the embedding view exactly like `<tonk-display>`. The element builds the ingest/read URLs from it, reusing the same `{branch}@{repo}` split logic as `blob_image_src` (factor that helper so both share it). If `with` is missing or an unsubstituted `{…}` template, the element renders a disabled state with a status note (it can't know where to POST).
-  - `accept` (optional) — passed straight to the file input's `accept` attribute (e.g. `image/*`).
-- **DOM:** renders a real `<input type="file">` (plus a small status/preview area). Native-element DOM runs, unlike inert view templates.
-- **On pick (single file):**
-  1. Read bytes: `await file.arrayBuffer()`.
-  2. Show an **instant local preview** via `URL.createObjectURL(file)` (revoked after swap) so the user sees the image immediately.
-  3. POST: `fetch('/api/repository/{repo}/branch/{branch}/blob', { method:'POST', body: <ArrayBuffer>, headers:{ 'Content-Type': file.type || 'application/octet-stream', 'X-Tonk-Blob-Name': file.name } })`. From a sealed guest this is relayed through the portal bridge — binary bodies survive the `postMessage` structured clone, and the request **must** use `init.body` (not a `Request` object, which the guest normalizer would `.text()`).
-  4. On `2xx`: parse `{ entity, contentType, name, size }`. Swap the preview to the **read-route** URL `/api/repository/{repo}/branch/{branch}/blob/<entity>` — proving the bytes were actually stored and are retrievable (not just a local file). For non-image `contentType`, show name + size instead of an `<img>`.
-  5. **Emit:** dispatch a bubbling, composed `CustomEvent('tonk-upload')` with `detail = { blob: entity, contentType, name, size }`.
-- **Status line:** idle → "reading…" → "uploading…" → done / error text.
+**Default UI (works with zero authoring):** a cleanly-styled trigger button ("Choose file…"), an inline preview thumbnail, and a status line — styled with the shell's WebAwesome design tokens (`--wa-color-*`, radius/spacing tokens) so the default is cohesive and theme-aware. Every piece is overridable.
+
+**Attributes:**
+- `with="{branch}@{repo}"` — branch context, forwarded by the view like `<tonk-display>`. The element builds ingest/read URLs from it, via a `{branch}@{repo}`→URL helper factored out of `blob_image_src` so both elements share it. Missing/unsubstituted `{…}` → the element disables the trigger and shows a status note (it can't know where to POST).
+- `accept` (optional) — passed to the internal `<input type="file">`.
+
+**Behavior (Shadow DOM):** on pick of a single file →
+1. `await file.arrayBuffer()`.
+2. Instant local `URL.createObjectURL(file)` preview (revoked after swap).
+3. `fetch('/api/repository/{repo}/branch/{branch}/blob', { method:'POST', body: <ArrayBuffer>, headers:{ 'Content-Type': file.type || 'application/octet-stream', 'X-Tonk-Blob-Name': file.name } })` — relayed through the bridge for a sealed guest (binary bodies survive the `postMessage` structured clone; must use `init.body`, not a `Request` object).
+4. On 2xx: parse `{ entity, contentType, name, size }`, swap the preview to the **read-route** URL `/api/repository/{repo}/branch/{branch}/blob/<entity>` (proving the bytes are stored and retrievable). Non-image `contentType` → show name + size instead of an `<img>`.
+5. Emit the event (below).
+
+State machine reflected on the host: `idle → reading → uploading → done | error`.
+
+**Customization surface (author drives from the view template + CSS, no Rust):**
+- **Slots:** `trigger` (the clickable that opens the picker — default: the styled button), `preview` (default: the element-managed `<img>`/thumb), `status` (default: the status text). Slot nothing → the default UI renders.
+- **`::part()`:** `base` (container), `button`, `preview`, `status` — styleable from view CSS exactly like `wa-button::part(base)`.
+- **CSS custom properties:** a small `--tonk-upload-*` set for the common knobs (accent color, radius, gap), each defaulting to a shell token.
+- **State:** the host reflects `data-state="idle|reading|uploading|done|error"` for per-state CSS.
+
+**Emit:** on success, a bubbling composed `CustomEvent('tonk-upload')` with `detail = { blob, contentType, name, size }` — the data hook a view wires into `/transact`. No event on failure.
 
 ### Data flow
 
@@ -54,28 +69,28 @@ pick file
   → POST /…/blob  (relayed through the bridge for a sealed guest)
     → worker: Blob::import → assert content-type[+name] facts → broadcast
     → 200 { entity, contentType, name, size }
-  → element: swap preview to read-route URL, emit `tonk-upload` {detail}
+  → element: swap preview to read-route URL, set data-state=done, emit `tonk-upload` {detail}
   → (view author, LATER) binds `tonk-upload` → /transact to record the ref on some entity
 ```
 
 ## Error handling
 
-- **Worker:** empty body → 400; unreadable/failed ingest → 500 JSON error; malformed repo/branch/headers → 400, matching `serve`.
-- **Element:** `arrayBuffer()`/read failure, fetch rejection, or non-2xx → status line shows the message, the local preview is cleared, and **no `tonk-upload` event is emitted** (a consumer never sees a phantom ref). Missing/unsubstituted `with` → disabled input + status note.
+- **Worker:** empty body → 400; failed ingest → 500 JSON error; malformed repo/branch/headers → 400, matching `serve`.
+- **Element:** `arrayBuffer()`/read failure, fetch rejection, or non-2xx → `data-state=error`, the status slot shows the message, the local preview is cleared, and **no `tonk-upload` event is emitted** (a consumer never sees a phantom ref). Missing/unsubstituted `with` → disabled trigger + status note.
 
 ## Testing
 
-- **Worker route** (`#[dialog_common::test]`, wasm service-worker, in `router/blob.rs`): POST bytes with a `Content-Type` and `X-Tonk-Blob-Name` → assert `200` + a `blob:` entity in the JSON; then `GET …/blob/<entity>` through `serve` and assert the bytes round-trip and the `Content-Type` came back from the asserted fact. A second POST of the same bytes returns the same entity (idempotence). An empty-body POST → 400.
-- **Element** (`#[dialog_common::test]`, browser, in `upload.rs`): mount `<tonk-upload with="main@repo">`, drive a synthetic `File` through the input, stub the relayed fetch to return a canned `{entity,…}`, and assert (a) the `tonk-upload` event fires once with the expected `detail`, (b) the preview `<img>` `src` becomes the read-route URL, (c) a failed fetch emits **no** event and shows an error status.
-- **Manual e2e:** a small demo view (e.g. in `demo.yaml`) mounting `<tonk-upload>` and capturing the event, exercised in `dev:web` (which now runs a local blob-aware access service).
+- **Worker route** (`#[dialog_common::test]`, wasm service-worker, in `router/blob.rs`): POST bytes with a `Content-Type` and `X-Tonk-Blob-Name` → assert `200` + a `blob:` entity; then `GET …/blob/<entity>` through `serve` and assert the bytes round-trip and the `Content-Type` came back from the asserted fact. Re-POST the same bytes → same entity (idempotence). Empty-body POST → 400.
+- **Element** (`#[dialog_common::test]`, browser, in `upload.rs`): mount `<tonk-upload with="main@repo">`; assert (1) the **default UI** renders in the shadow root (a trigger `::part(button)`, a `::part(preview)`, a `::part(status)`) and `data-state=idle`; (2) driving a synthetic `File` through the input with a stubbed relayed fetch emits `tonk-upload` once with the expected `detail`, swaps the preview `src` to the read-route URL, and sets `data-state=done`; (3) a failed fetch → `data-state=error`, no event; (4) an **author override** — mounting `<tonk-upload><button slot="trigger">Pick</button></tonk-upload>` — projects the author's trigger into the slot (default button not used) and still uploads.
+- **Manual e2e:** a small demo view (in `demo.yaml`) mounting `<tonk-upload>` and capturing the event, exercised in `dev:web` (which now runs a local blob-aware access service).
 
 ## Out of scope (v1)
 
-Drag-and-drop, multi-file selection, upload progress, streaming ingest, and upload-bound-to-an-entity/field. The last one is the natural next layer: a view binds the emitted `tonk-upload` event to a `/transact` that writes `blob:<hash>` onto a target entity's attribute.
+Drag-and-drop, multi-file selection, upload progress bars, streaming ingest, and upload-bound-to-an-entity/field. The last is the natural next layer: a view binds the emitted `tonk-upload` event to a `/transact` that writes `blob:<hash>` onto a target entity's attribute.
 
 ## File-level plan (informs the implementation plan)
 
 - `rust/tonk-worker/src/router/blob.rs` — add the `POST` handler + its test; register the route in `router.rs`.
-- `rust/tonk-display/src/upload.rs` — new element + test; `register()` from the crate's `register()` and the guest bundle.
-- `rust/tonk-display/src/element.rs` (or a shared helper module) — factor the `{branch}@{repo}` → URL logic out of `blob_image_src` so `<tonk-upload>` reuses it.
+- `rust/tonk-display/src/upload.rs` — new headless element (shadow DOM, default UI, slots/parts/state) + tests; `register()` from the crate and the guest bundle.
+- `rust/tonk-display/src/element.rs` (or a small shared module) — factor the `{branch}@{repo}`→URL logic out of `blob_image_src` so `<tonk-upload>` reuses it.
 - `rust/tonk-core/assets/library/demo.yaml` — a demo view mounting `<tonk-upload>` (manual e2e only).

--- a/rust/tonk-display/Cargo.toml
+++ b/rust/tonk-display/Cargo.toml
@@ -51,6 +51,20 @@ web-sys = { workspace = true, features = [
     "NodeList",
     "Text",
     "Window",
+    "Blob",
+    "File",
+    "FileList",
+    "FilePropertyBag",
+    "Headers",
+    "HtmlInputElement",
+    "Request",
+    "RequestInit",
+    "Response",
+    "ResponseInit",
+    "ShadowRoot",
+    "ShadowRootInit",
+    "ShadowRootMode",
+    "Url",
 ] }
 
 [dev-dependencies]

--- a/rust/tonk-display/src/blob_url.rs
+++ b/rust/tonk-display/src/blob_url.rs
@@ -1,0 +1,58 @@
+//! Shared helpers for building blob route URLs from a `<tonk-display>`/
+//! `<tonk-upload>` `with="{branch}@{repo}"` context attribute.
+
+/// Parse a `with="{branch}@{repo}"` context into `(branch, repo)`. Returns
+/// `None` if `with` is empty or still an unsubstituted `{…}` template. A bare
+/// token with no `@` is a repo on the default branch `main`.
+pub(crate) fn branch_repo(with: &str) -> Option<(String, String)> {
+    if with.is_empty() || with.contains('{') {
+        return None;
+    }
+    // `with` is `branch@repo`; a bare token (no `@`) is a repo on `main`.
+    let (branch, repo) = match with.split_once('@') {
+        Some((branch, repo)) => (branch, repo),
+        None => ("main", with),
+    };
+    if repo.is_empty() {
+        return None;
+    }
+    Some((branch.to_string(), repo.to_string()))
+}
+
+/// The read URL for a blob entity, scoped by `with`. `None` if `with` is unusable.
+pub(crate) fn blob_read_url(with: &str, entity: &str) -> Option<String> {
+    let (branch, repo) = branch_repo(with)?;
+    Some(format!("/api/repository/{repo}/branch/{branch}/blob/{entity}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_parses_branch_and_repo() {
+        assert_eq!(
+            branch_repo("main@did:key:zX"),
+            Some(("main".into(), "did:key:zX".into()))
+        );
+        assert_eq!(
+            branch_repo("did:key:zX"),
+            Some(("main".into(), "did:key:zX".into()))
+        );
+        assert_eq!(branch_repo(""), None);
+        assert_eq!(branch_repo("{branch}@{repo}"), None);
+    }
+
+    #[dialog_common::test]
+    fn it_builds_the_read_url() {
+        assert_eq!(
+            blob_read_url("main@repo", "blob:zH").as_deref(),
+            Some("/api/repository/repo/branch/main/blob/blob:zH"),
+        );
+        assert_eq!(blob_read_url("{x}", "blob:zH"), None);
+    }
+}

--- a/rust/tonk-display/src/blob_url.rs
+++ b/rust/tonk-display/src/blob_url.rs
@@ -27,6 +27,33 @@ pub(crate) fn blob_read_url(with: &str, entity: &str) -> Option<String> {
     ))
 }
 
+/// Fetch a worker blob URL through the (relayed) `window.fetch` and wrap the
+/// bytes in an object URL.
+///
+/// Blob content renders inside the sealed guest (`about:srcdoc`), whose native
+/// `<img src>` loads bypass the relayed fetch and the service worker and hit
+/// the dev server's SPA fallback. So the bytes have to arrive via `fetch`
+/// (which IS relayed) and be handed to the `<img>` as a `blob:` object URL.
+/// Returns `None` on any transport/decode failure. The caller owns the URL and
+/// should `Url::revoke_object_url` it once it's no longer referenced.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn fetch_object_url(url: &str) -> Option<String> {
+    use wasm_bindgen::JsCast as _;
+    let win = web_sys::window()?;
+    let resp = wasm_bindgen_futures::JsFuture::from(win.fetch_with_str(url))
+        .await
+        .ok()?;
+    let resp: web_sys::Response = resp.dyn_into().ok()?;
+    if !resp.ok() {
+        return None;
+    }
+    let blob = wasm_bindgen_futures::JsFuture::from(resp.blob().ok()?)
+        .await
+        .ok()?;
+    let blob: web_sys::Blob = blob.dyn_into().ok()?;
+    web_sys::Url::create_object_url_with_blob(&blob).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tonk-display/src/blob_url.rs
+++ b/rust/tonk-display/src/blob_url.rs
@@ -22,7 +22,9 @@ pub(crate) fn branch_repo(with: &str) -> Option<(String, String)> {
 /// The read URL for a blob entity, scoped by `with`. `None` if `with` is unusable.
 pub(crate) fn blob_read_url(with: &str, entity: &str) -> Option<String> {
     let (branch, repo) = branch_repo(with)?;
-    Some(format!("/api/repository/{repo}/branch/{branch}/blob/{entity}"))
+    Some(format!(
+        "/api/repository/{repo}/branch/{branch}/blob/{entity}"
+    ))
 }
 
 #[cfg(test)]

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1540,7 +1540,7 @@ fn mount_portal_slide(host: &Element, inner: &Inner, display: &str) -> Option<Sl
 /// the `src` is stable for a given `(with, entity)`, so re-running on a
 /// later frame is a no-op once the element exists.
 fn handle_blob_image_frame(host: &Element) {
-    let Some(src) = blob_image_src(host) else {
+    let Some(url) = blob_image_src(host) else {
         return;
     };
     let Some(document) = window().and_then(|w| w.document()) else {
@@ -1556,9 +1556,33 @@ fn handle_blob_image_frame(host: &Element) {
             created
         }
     };
-    if img.get_attribute("src").as_deref() != Some(src.as_str()) {
-        let _ = img.set_attribute("src", &src);
+    // Idempotent per `(with, entity)`: the worker URL is stable, so once we've
+    // fetched the bytes for it, later frames are a no-op. `data-blob-url`
+    // records the route we last fetched — the `src` itself becomes an opaque
+    // object URL, so it can't double as the dedupe key.
+    if img.get_attribute("data-blob-url").as_deref() == Some(url.as_str()) {
+        return;
     }
+    let _ = img.set_attribute("data-blob-url", &url);
+
+    // Fetch the bytes *through* the relay and hand the `<img>` an object URL
+    // instead of the worker route: inside the sealed guest a native `<img src>`
+    // load of `/api/…/blob/…` bypasses the relay + service worker.
+    let img = img.clone();
+    spawn_local(async move {
+        let Some(object_url) = crate::blob_url::fetch_object_url(&url).await else {
+            return;
+        };
+        // Revoke the object URL we're replacing (if any): once the new `src`
+        // is set, the previous frame's bytes are no longer referenced.
+        if let Some(old) = img.get_attribute("src")
+            && old.starts_with("blob:")
+        {
+            let _ = web_sys::Url::revoke_object_url(&old);
+        }
+        let _ = img.set_attribute("src", &object_url);
+    });
+
     state::set(host, State::Ready);
 }
 
@@ -2977,6 +3001,30 @@ mod tests {
             serde_wasm_bindgen::to_value(&conclusions).unwrap()
         }
 
+        /// Replace `window.fetch` with a stub that records the requested URL
+        /// and returns a 200 with a small body — enough for `.blob()` +
+        /// `createObjectURL`. Mirrors the sealed-guest relay: the code under
+        /// test fetches bytes through `window.fetch`, not a native `<img>`
+        /// resource load.
+        fn stub_fetch_bytes(captured: Rc<RefCell<Option<String>>>) {
+            let stub = Closure::wrap(Box::new(move |url: JsValue, _init: JsValue| {
+                *captured.borrow_mut() = url.as_string();
+                let init = web_sys::ResponseInit::new();
+                init.set_status(200);
+                let resp =
+                    web_sys::Response::new_with_opt_str_and_init(Some("fakepng"), &init).unwrap();
+                Promise::resolve(&resp.into())
+            })
+                as Box<dyn FnMut(JsValue, JsValue) -> Promise>);
+            Reflect::set(
+                &window().unwrap(),
+                &"fetch".into(),
+                stub.as_ref().unchecked_ref(),
+            )
+            .unwrap();
+            stub.forget();
+        }
+
         struct FakeHost {
             container: Element,
             state: Rc<RefCell<FakeState>>,
@@ -3269,12 +3317,18 @@ mod tests {
             );
         }
 
-        /// A display whose `model` is `tonk:blob` renders a single
-        /// `<img>` pointing at the worker's blob-bytes route, with the
-        /// repo/branch taken from the host's `with` attribute and the
-        /// blob entity from `entity`. No inline template, no iframe.
+        /// A display whose `model` is `tonk:blob` fetches the bytes through
+        /// the (relayed) `window.fetch` and points its single `<img>` at an
+        /// object URL — never at the worker route directly. Inside the sealed
+        /// guest (`about:srcdoc`) a native `<img src>` load bypasses the
+        /// relayed fetch and the service worker, hitting the dev server's SPA
+        /// fallback, so the URL must be a `blob:` object URL built from bytes
+        /// fetched through the relay.
         #[dialog_common::test]
-        async fn it_mounts_an_img_for_a_blob_model() {
+        async fn it_fetches_blob_bytes_and_mounts_an_object_url_img() {
+            let requested: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+            stub_fetch_bytes(requested.clone());
+
             // `model = "tonk:blob"` already looks like a URI (it contains
             // `:`), so — unlike the bare `"counter"` model name the other
             // fixtures use — `resolve_model_query` skips the Name-concept
@@ -3315,9 +3369,26 @@ mod tests {
             let img = await_selector(&display, "img")
                 .await
                 .expect("a tonk:blob model should mount an <img>");
+            // The object URL lands after the async fetch resolves.
+            let mut src = None;
+            for _ in 0..200 {
+                match img.get_attribute("src") {
+                    Some(s) => {
+                        src = Some(s);
+                        break;
+                    }
+                    None => sleep(5).await,
+                }
+            }
+            let src = src.expect("img src is set once the blob fetch resolves");
+            assert!(
+                src.starts_with("blob:") && src.contains('/'),
+                "src is an object URL, not the worker route or the raw entity: {src}",
+            );
             assert_eq!(
-                img.get_attribute("src").as_deref(),
+                requested.borrow().as_deref(),
                 Some("/api/repository/myrepo/branch/main/blob/blob:zHASH"),
+                "the bytes were fetched from the worker blob route through the relay",
             );
         }
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1569,17 +1569,7 @@ fn handle_blob_image_frame(host: &Element) {
 fn blob_image_src(host: &Element) -> Option<String> {
     let entity = host.get_attribute("entity")?;
     let with = host.get_attribute("with")?;
-    if with.contains('{') {
-        return None; // unsubstituted `{branch}@{repo}` template
-    }
-    // `with` is `branch@repo`; a bare token (no `@`) is a repo on `main`.
-    let (branch, repo) = match with.split_once('@') {
-        Some((branch, repo)) => (branch, repo),
-        None => ("main", with.as_str()),
-    };
-    Some(format!(
-        "/api/repository/{repo}/branch/{branch}/blob/{entity}"
-    ))
+    crate::blob_url::blob_read_url(&with, &entity)
 }
 
 /// Marker attribute stamped on a `<tonk-display>` host once its event

--- a/rust/tonk-display/src/lib.rs
+++ b/rust/tonk-display/src/lib.rs
@@ -61,6 +61,8 @@ mod fallback;
 mod notation;
 #[cfg(target_arch = "wasm32")]
 mod render;
+#[cfg(target_arch = "wasm32")]
+mod upload;
 // `state::State` and its `as_str` mapping are target-independent
 // — DOM-touching helpers in this module are individually gated
 // to wasm32 so native test builds can still exercise the enum.
@@ -84,4 +86,5 @@ pub fn register() {
     element::register();
     fallback::register();
     component::register();
+    upload::register();
 }

--- a/rust/tonk-display/src/lib.rs
+++ b/rust/tonk-display/src/lib.rs
@@ -49,6 +49,8 @@ pub mod notation_format;
 #[cfg(any(target_arch = "wasm32", test))]
 mod notation_tokens;
 
+#[cfg(any(target_arch = "wasm32", test))]
+mod blob_url;
 #[cfg(target_arch = "wasm32")]
 mod component;
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-display/src/upload.rs
+++ b/rust/tonk-display/src/upload.rs
@@ -248,9 +248,17 @@ fn ingest(host: &HtmlElement, file: &web_sys::File) {
         let content_type = json["contentType"].as_str().unwrap_or(&mime).to_string();
         let size = json["size"].as_u64().unwrap_or(0);
 
+        // Read the image back FROM THE DB and preview those bytes — the whole
+        // round-trip in one go. Fetch the worker blob route through the relayed
+        // `window.fetch` and swap the preview to that object URL (a native
+        // `<img src>` load of the route would bypass the relay + service worker
+        // inside the sealed guest). On failure the reading-phase local preview
+        // stays put. Non-images get a status line instead.
         if content_type.starts_with("image/") {
-            if let Some(read) = crate::blob_url::blob_read_url(&with, &entity) {
-                show_preview(&host, &read);
+            if let Some(read) = crate::blob_url::blob_read_url(&with, &entity)
+                && let Some(obj) = crate::blob_url::fetch_object_url(&read).await
+            {
+                show_preview(&host, &obj);
             }
         } else {
             set_status(&host, &format!("{name} · {size} bytes"));
@@ -265,8 +273,17 @@ fn show_preview(host: &HtmlElement, src: &str) {
     if let Some(root) = host.shadow_root()
         && let Ok(Some(img)) = root.query_selector("[part=preview]")
     {
+        let prior = img.get_attribute("src");
         let _ = img.set_attribute("src", src);
         let _ = img.remove_attribute("hidden");
+        // Free the object URL we just replaced (the reading-phase local
+        // preview when swapping to the DB read-back), once nothing references it.
+        if let Some(prior) = prior
+            && prior.starts_with("blob:")
+            && prior != src
+        {
+            let _ = web_sys::Url::revoke_object_url(&prior);
+        }
     }
 }
 
@@ -391,7 +408,16 @@ mod tests {
 
     /// Replace `window.fetch` with a stub returning `status` + `json`.
     fn stub_fetch(status: u16, json: &'static str) {
-        let stub = Closure::wrap(Box::new(move |_url: JsValue, _init: JsValue| {
+        stub_fetch_capturing(status, json, Rc::new(RefCell::new(Vec::new())));
+    }
+
+    /// Like [`stub_fetch`], but records every requested URL into `urls` — so a
+    /// test can assert which routes were hit (e.g. the read-back GET).
+    fn stub_fetch_capturing(status: u16, json: &'static str, urls: Rc<RefCell<Vec<String>>>) {
+        let stub = Closure::wrap(Box::new(move |url: JsValue, _init: JsValue| {
+            if let Some(u) = url.as_string() {
+                urls.borrow_mut().push(u);
+            }
             let init = web_sys::ResponseInit::new();
             init.set_status(status);
             let resp = web_sys::Response::new_with_opt_str_and_init(Some(json), &init).unwrap();
@@ -424,9 +450,11 @@ mod tests {
     #[dialog_common::test]
     async fn it_uploads_and_emits_on_pick() {
         super::register();
-        stub_fetch(
+        let urls: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        stub_fetch_capturing(
             200,
             r#"{"entity":"blob:zH","contentType":"image/png","name":"a.png","size":3}"#,
+            urls.clone(),
         );
 
         let el = document().create_element("tonk-upload").unwrap();
@@ -465,9 +493,21 @@ mod tests {
             .query_selector("[part=preview]")
             .unwrap()
             .unwrap();
-        assert_eq!(
-            preview.get_attribute("src").as_deref(),
-            Some("/api/repository/repo/branch/main/blob/blob:zH"),
+        // After upload the preview is read back FROM THE DB: the bytes are
+        // fetched from the worker blob route through the relayed `window.fetch`
+        // and shown as an object URL (a native `<img src>` load of the route
+        // would bypass the relay + service worker inside the sealed guest).
+        let src = preview.get_attribute("src").expect("preview has a src");
+        assert!(
+            src.starts_with("blob:") && src.contains('/'),
+            "preview src is an object URL: {src}",
+        );
+        assert!(
+            urls.borrow()
+                .iter()
+                .any(|u| u == "/api/repository/repo/branch/main/blob/blob:zH"),
+            "the preview was read back from the DB via the blob route, got: {:?}",
+            urls.borrow(),
         );
     }
 

--- a/rust/tonk-display/src/upload.rs
+++ b/rust/tonk-display/src/upload.rs
@@ -330,21 +330,48 @@ pub(crate) fn __test_ingest(host: &HtmlElement, file: &web_sys::File) {
 const STYLE: &str = r#"
 :host { display: inline-flex; }
 [part=base] {
-  display: inline-flex; align-items: center; gap: var(--tonk-upload-gap, 8px);
+  display: inline-flex; align-items: center; gap: var(--tonk-upload-gap, var(--wa-space-s, 8px));
   font-family: var(--wa-font-family-body, system-ui, sans-serif);
+  color: var(--wa-color-text-normal, #1a1a1a);
 }
+/* A neutral bordered control matching the sheets/board/wiki templates:
+   a surface fill with a subtle border that brightens on hover — no loud
+   brand accent. `--tonk-upload-accent` still lets an author tint the
+   border. */
 [part=button] {
-  padding: 6px 12px; border-radius: var(--tonk-upload-radius, 6px);
-  border: 1px solid var(--wa-color-neutral-fill-loud, #ccc);
-  background: var(--tonk-upload-accent, var(--wa-color-brand-fill-loud, #2563eb));
-  color: var(--wa-color-brand-on-loud, #fff); cursor: pointer; font: inherit;
+  display: inline-flex; align-items: center; gap: var(--wa-space-xs, 6px);
+  padding: var(--wa-space-xs, 6px) var(--wa-space-m, 12px);
+  font: inherit; font-size: var(--wa-font-size-s, 14px);
+  color: var(--wa-color-text-normal, #1a1a1a);
+  background: var(--wa-color-surface-raised, #fff);
+  border: var(--wa-border-width-s, 1px) solid
+    var(--tonk-upload-accent, var(--wa-color-surface-border, #d4d4d4));
+  border-radius: var(--tonk-upload-radius, var(--wa-border-radius-s, 4px));
+  cursor: pointer;
+  transition-property: color, background-color, border-color;
+  transition-duration: 120ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
-[part=button]:hover { filter: brightness(1.05); }
+[part=button]:hover {
+  border-color: var(--wa-color-text-normal, #1a1a1a);
+  background: var(--wa-color-neutral-fill-quiet, #f4f4f4);
+}
 [part=button][disabled] { opacity: 0.5; cursor: not-allowed; }
-[part=preview] { max-width: 96px; max-height: 96px; border-radius: 4px; }
+[part=button][disabled]:hover {
+  border-color: var(--wa-color-surface-border, #d4d4d4);
+  background: var(--wa-color-surface-raised, #fff);
+}
+[part=preview] {
+  max-width: 96px; max-height: 96px;
+  border-radius: var(--wa-border-radius-s, 4px);
+  border: var(--wa-border-width-s, 1px) solid var(--wa-color-surface-border, #d4d4d4);
+}
 [part=preview][hidden] { display: none; }
-[part=status] { font-size: 12px; color: var(--wa-color-text-quiet, #666); }
-:host([data-state=error]) [part=status] { color: var(--wa-color-danger-fill-loud, #dc2626); }
+[part=status] {
+  font-size: var(--wa-font-size-s, 13px);
+  color: var(--wa-color-text-quiet, #666);
+}
+:host([data-state=error]) [part=status] { color: var(--wa-color-danger-on-quiet, #dc2626); }
 "#;
 
 /// Register the `<tonk-upload>` element. Idempotent.

--- a/rust/tonk-display/src/upload.rs
+++ b/rust/tonk-display/src/upload.rs
@@ -1,0 +1,528 @@
+//! `<tonk-upload>` — a headless native blob-upload primitive.
+//!
+//! The mechanism (file input, ingest fetch, state machine, preview) lives in
+//! Shadow DOM; the author restyles it via the `trigger` slot, `::part()`
+//! (`base`/`button`/`preview`/`status`), `--tonk-upload-*` CSS vars, and the
+//! reflected `data-state` attribute. Bytes are ingested through the worker
+//! `POST …/blob` route (relayed by the guest's `window.fetch`), and a
+//! successful upload dispatches a bubbling `tonk-upload` CustomEvent carrying
+//! the resulting `blob:<hash>`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use web_sys::{Element, HtmlElement, ShadowRoot};
+
+/// Per-instance state: the shadow root plus the change/click listener closures,
+/// kept alive for the element's lifetime.
+#[derive(Default)]
+struct Inner {
+    shadow: Option<ShadowRoot>,
+    listeners: Vec<Closure<dyn FnMut(web_sys::Event)>>,
+}
+
+type Shared = Rc<RefCell<Inner>>;
+
+#[derive(Default)]
+pub struct TonkUploadElement {
+    state: Shared,
+}
+
+impl CustomElement for TonkUploadElement {
+    fn shadow() -> bool {
+        // We attach our own shadow root so we control build timing.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &["with", "accept"]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        set_state(this, "idle");
+        build_shadow(this, &self.state);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        *self.state.borrow_mut() = Inner::default();
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        _this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if old == new {
+            return;
+        }
+        // `accept` propagates to the input; `with` only affects the next upload.
+        if name == "accept"
+            && let Some(root) = self.state.borrow().shadow.as_ref()
+            && let Ok(Some(input)) = root.query_selector("input[type=file]")
+        {
+            let _ = input.set_attribute("accept", new.as_deref().unwrap_or(""));
+        }
+    }
+}
+
+/// Reflect the state machine onto the host for `data-state` CSS.
+fn set_state(this: &HtmlElement, state: &str) {
+    let _ = this.set_attribute("data-state", state);
+}
+
+fn ensure_shadow(this: &HtmlElement) -> ShadowRoot {
+    if let Some(root) = this.shadow_root() {
+        return root;
+    }
+    let init = web_sys::ShadowRootInit::new(web_sys::ShadowRootMode::Open);
+    this.attach_shadow(&init).unwrap()
+}
+
+fn doc() -> web_sys::Document {
+    web_sys::window().unwrap().document().unwrap()
+}
+
+fn el(tag: &str) -> Element {
+    doc().create_element(tag).unwrap()
+}
+
+/// Build the default shadow UI once, and wire the trigger + file input.
+fn build_shadow(this: &HtmlElement, state: &Shared) {
+    let root = ensure_shadow(this);
+
+    let style = el("style");
+    style.set_text_content(Some(STYLE));
+    let _ = root.append_child(&style);
+
+    let base = el("div");
+    let _ = base.set_attribute("part", "base");
+
+    // Hidden real input.
+    let input = el("input");
+    let _ = input.set_attribute("type", "file");
+    let _ = input.set_attribute("hidden", "");
+    if let Some(accept) = this.get_attribute("accept") {
+        let _ = input.set_attribute("accept", &accept);
+    }
+    let _ = base.append_child(&input);
+
+    // Trigger slot (fallback = default button).
+    let slot = el("slot");
+    let _ = slot.set_attribute("name", "trigger");
+    let button = el("button");
+    let _ = button.set_attribute("part", "button");
+    let _ = button.set_attribute("type", "button");
+    button.set_text_content(Some("Choose file…"));
+    let _ = slot.append_child(&button);
+    let _ = base.append_child(&slot);
+
+    // Preview (element-owned part; hidden until an upload).
+    let preview = el("img");
+    let _ = preview.set_attribute("part", "preview");
+    let _ = preview.set_attribute("hidden", "");
+    let _ = base.append_child(&preview);
+
+    // Status (element-owned part).
+    let status = el("span");
+    let _ = status.set_attribute("part", "status");
+    let _ = base.append_child(&status);
+
+    let _ = root.append_child(&base);
+    state.borrow_mut().shadow = Some(root);
+
+    // Disable the trigger when there is no usable space context.
+    let with_ok =
+        crate::blob_url::branch_repo(&this.get_attribute("with").unwrap_or_default()).is_some();
+    if !with_ok {
+        let _ = button.set_attribute("disabled", "");
+        status.set_text_content(Some("no space context"));
+    }
+
+    // Clicking anywhere on the trigger slot (default button or author-slotted
+    // content) opens the native picker — unless `with` is missing.
+    {
+        let input_for_click = input.clone();
+        let click = Closure::wrap(Box::new(move |_e: web_sys::Event| {
+            if with_ok {
+                input_for_click.unchecked_ref::<HtmlElement>().click();
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = slot.add_event_listener_with_callback("click", click.as_ref().unchecked_ref());
+        state.borrow_mut().listeners.push(click);
+    }
+
+    // A picked file drives the upload flow.
+    {
+        let host = this.clone();
+        let change = Closure::wrap(Box::new(move |e: web_sys::Event| {
+            if let Some(target) = e.target()
+                && let Ok(input) = target.dyn_into::<web_sys::HtmlInputElement>()
+                && let Some(file) = input.files().and_then(|l| l.get(0))
+            {
+                ingest(&host, &file);
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = input.add_event_listener_with_callback("change", change.as_ref().unchecked_ref());
+        state.borrow_mut().listeners.push(change);
+    }
+}
+
+/// Read `file` to bytes, POST it to the ingest route, swap the preview to the
+/// read route, and emit `tonk-upload` on success. All async; drives `data-state`.
+fn ingest(host: &HtmlElement, file: &web_sys::File) {
+    let host = host.clone();
+    let file = file.clone();
+    spawn_local(async move {
+        let with = host.get_attribute("with").unwrap_or_default();
+        let Some((branch, repo)) = crate::blob_url::branch_repo(&with) else {
+            fail(&host, "no space context");
+            return;
+        };
+        let name = file.name();
+        let mime = {
+            let t = file.type_();
+            if t.is_empty() {
+                "application/octet-stream".to_string()
+            } else {
+                t
+            }
+        };
+
+        set_state(&host, "reading");
+        if mime.starts_with("image/")
+            && let Ok(url) = web_sys::Url::create_object_url_with_blob(&file)
+        {
+            show_preview(&host, &url);
+        }
+
+        let buf = match JsFuture::from(file.array_buffer()).await {
+            Ok(b) => b,
+            Err(_) => return fail(&host, "could not read file"),
+        };
+        let bytes = js_sys::Uint8Array::new(&buf);
+
+        set_state(&host, "uploading");
+        let url = format!("/api/repository/{repo}/branch/{branch}/blob");
+        let headers = web_sys::Headers::new().unwrap();
+        let _ = headers.append("content-type", &mime);
+        let _ = headers.append("x-tonk-blob-name", &name);
+        let init = web_sys::RequestInit::new();
+        init.set_method("POST");
+        init.set_headers(&headers);
+        init.set_body(&bytes.into());
+        let win = web_sys::window().unwrap();
+        let resp_val = match JsFuture::from(win.fetch_with_str_and_init(&url, &init)).await {
+            Ok(v) => v,
+            Err(_) => return fail(&host, "upload failed"),
+        };
+        let resp: web_sys::Response = match resp_val.dyn_into() {
+            Ok(r) => r,
+            Err(_) => return fail(&host, "upload failed"),
+        };
+        if !resp.ok() {
+            return fail(&host, &format!("upload failed ({})", resp.status()));
+        }
+        let text = match resp.text() {
+            Ok(p) => match JsFuture::from(p).await {
+                Ok(t) => t.as_string().unwrap_or_default(),
+                Err(_) => return fail(&host, "bad response"),
+            },
+            Err(_) => return fail(&host, "bad response"),
+        };
+        let json: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(j) => j,
+            Err(_) => return fail(&host, "bad response"),
+        };
+        let entity = json["entity"].as_str().unwrap_or_default().to_string();
+        if entity.is_empty() {
+            return fail(&host, "bad response");
+        }
+        let content_type = json["contentType"].as_str().unwrap_or(&mime).to_string();
+        let size = json["size"].as_u64().unwrap_or(0);
+
+        if content_type.starts_with("image/") {
+            if let Some(read) = crate::blob_url::blob_read_url(&with, &entity) {
+                show_preview(&host, &read);
+            }
+        } else {
+            set_status(&host, &format!("{name} · {size} bytes"));
+        }
+
+        set_state(&host, "done");
+        emit(&host, &entity, &content_type, &name, size);
+    });
+}
+
+fn show_preview(host: &HtmlElement, src: &str) {
+    if let Some(root) = host.shadow_root()
+        && let Ok(Some(img)) = root.query_selector("[part=preview]")
+    {
+        let _ = img.set_attribute("src", src);
+        let _ = img.remove_attribute("hidden");
+    }
+}
+
+fn set_status(host: &HtmlElement, msg: &str) {
+    if let Some(root) = host.shadow_root()
+        && let Ok(Some(s)) = root.query_selector("[part=status]")
+    {
+        s.set_text_content(Some(msg));
+    }
+}
+
+fn fail(host: &HtmlElement, msg: &str) {
+    set_state(host, "error");
+    set_status(host, msg);
+    if let Some(root) = host.shadow_root()
+        && let Ok(Some(img)) = root.query_selector("[part=preview]")
+    {
+        let _ = img.set_attribute("hidden", "");
+    }
+}
+
+fn emit(host: &HtmlElement, blob: &str, content_type: &str, name: &str, size: u64) {
+    let detail = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(&detail, &"blob".into(), &blob.into());
+    let _ = js_sys::Reflect::set(&detail, &"contentType".into(), &content_type.into());
+    let _ = js_sys::Reflect::set(&detail, &"name".into(), &name.into());
+    let _ = js_sys::Reflect::set(&detail, &"size".into(), &JsValue::from_f64(size as f64));
+    let init = web_sys::CustomEventInit::new();
+    init.set_bubbles(true);
+    init.set_composed(true);
+    init.set_detail(&detail);
+    if let Ok(ev) = web_sys::CustomEvent::new_with_event_init_dict("tonk-upload", &init) {
+        let _ = host.dispatch_event(&ev);
+    }
+}
+
+/// Test-only hook: inject a `File` as if the user had picked it (browsers don't
+/// let script set `input.files`, and there's no real OS picker in tests).
+#[cfg(all(test, target_arch = "wasm32"))]
+pub(crate) fn __test_ingest(host: &HtmlElement, file: &web_sys::File) {
+    ingest(host, file);
+}
+
+const STYLE: &str = r#"
+:host { display: inline-flex; }
+[part=base] {
+  display: inline-flex; align-items: center; gap: var(--tonk-upload-gap, 8px);
+  font-family: var(--wa-font-family-body, system-ui, sans-serif);
+}
+[part=button] {
+  padding: 6px 12px; border-radius: var(--tonk-upload-radius, 6px);
+  border: 1px solid var(--wa-color-neutral-fill-loud, #ccc);
+  background: var(--tonk-upload-accent, var(--wa-color-brand-fill-loud, #2563eb));
+  color: var(--wa-color-brand-on-loud, #fff); cursor: pointer; font: inherit;
+}
+[part=button]:hover { filter: brightness(1.05); }
+[part=button][disabled] { opacity: 0.5; cursor: not-allowed; }
+[part=preview] { max-width: 96px; max-height: 96px; border-radius: 4px; }
+[part=preview][hidden] { display: none; }
+[part=status] { font-size: 12px; color: var(--wa-color-text-quiet, #666); }
+:host([data-state=error]) [part=status] { color: var(--wa-color-danger-fill-loud, #dc2626); }
+"#;
+
+/// Register the `<tonk-upload>` element. Idempotent.
+pub fn register() {
+    if already_registered() {
+        return;
+    }
+    TonkUploadElement::define("tonk-upload");
+}
+
+fn already_registered() -> bool {
+    doc()
+        .default_view()
+        .map(|w| !w.custom_elements().get("tonk-upload").is_undefined())
+        .unwrap_or(false)
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_futures::JsFuture;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn document() -> web_sys::Document {
+        web_sys::window().unwrap().document().unwrap()
+    }
+
+    async fn sleep(ms: i32) {
+        let p = js_sys::Promise::new(&mut |res, _| {
+            let _ = web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&res, ms);
+        });
+        let _ = JsFuture::from(p).await;
+    }
+
+    async fn await_input(host: &web_sys::HtmlElement) -> web_sys::ShadowRoot {
+        for _ in 0..200 {
+            if let Some(r) = host.shadow_root() {
+                if r.query_selector("input[type=file]").unwrap().is_some() {
+                    return r;
+                }
+            }
+            sleep(5).await;
+        }
+        panic!("shadow input never appeared");
+    }
+
+    fn make_file(bytes: &[u8], name: &str, mime: &str) -> web_sys::File {
+        let parts = js_sys::Array::new();
+        parts.push(&js_sys::Uint8Array::from(bytes).into());
+        let opts = web_sys::FilePropertyBag::new();
+        opts.set_type(mime);
+        web_sys::File::new_with_u8_array_sequence_and_options(&parts, name, &opts).unwrap()
+    }
+
+    /// Replace `window.fetch` with a stub returning `status` + `json`.
+    fn stub_fetch(status: u16, json: &'static str) {
+        let stub = Closure::wrap(Box::new(move |_url: JsValue, _init: JsValue| {
+            let init = web_sys::ResponseInit::new();
+            init.set_status(status);
+            let resp = web_sys::Response::new_with_opt_str_and_init(Some(json), &init).unwrap();
+            js_sys::Promise::resolve(&resp.into())
+        })
+            as Box<dyn FnMut(JsValue, JsValue) -> js_sys::Promise>);
+        js_sys::Reflect::set(
+            &web_sys::window().unwrap(),
+            &"fetch".into(),
+            stub.as_ref().unchecked_ref(),
+        )
+        .unwrap();
+        stub.forget();
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_default_shadow_ui() {
+        super::register();
+        let el = document().create_element("tonk-upload").unwrap();
+        el.set_attribute("with", "main@did:key:zSpace").unwrap();
+        document().body().unwrap().append_child(&el).unwrap();
+        let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+        let root = await_input(&host).await;
+        assert!(root.query_selector("[part=button]").unwrap().is_some());
+        assert!(root.query_selector("[part=preview]").unwrap().is_some());
+        assert!(root.query_selector("[part=status]").unwrap().is_some());
+        assert_eq!(host.get_attribute("data-state").as_deref(), Some("idle"));
+    }
+
+    #[dialog_common::test]
+    async fn it_uploads_and_emits_on_pick() {
+        super::register();
+        stub_fetch(
+            200,
+            r#"{"entity":"blob:zH","contentType":"image/png","name":"a.png","size":3}"#,
+        );
+
+        let el = document().create_element("tonk-upload").unwrap();
+        el.set_attribute("with", "main@repo").unwrap();
+        document().body().unwrap().append_child(&el).unwrap();
+        let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+
+        let got: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        {
+            let got = got.clone();
+            let cb = Closure::wrap(Box::new(move |ev: web_sys::CustomEvent| {
+                let blob = js_sys::Reflect::get(&ev.detail(), &"blob".into())
+                    .ok()
+                    .and_then(|v| v.as_string());
+                *got.borrow_mut() = blob;
+            }) as Box<dyn FnMut(web_sys::CustomEvent)>);
+            host.add_event_listener_with_callback("tonk-upload", cb.as_ref().unchecked_ref())
+                .unwrap();
+            cb.forget();
+        }
+
+        let _ = await_input(&host).await;
+        super::__test_ingest(&host, &make_file(b"abc", "a.png", "image/png"));
+
+        for _ in 0..200 {
+            if got.borrow().is_some() {
+                break;
+            }
+            sleep(5).await;
+        }
+        assert_eq!(got.borrow().as_deref(), Some("blob:zH"));
+        assert_eq!(host.get_attribute("data-state").as_deref(), Some("done"));
+        let preview = host
+            .shadow_root()
+            .unwrap()
+            .query_selector("[part=preview]")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            preview.get_attribute("src").as_deref(),
+            Some("/api/repository/repo/branch/main/blob/blob:zH"),
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_without_emitting_on_failure() {
+        super::register();
+        stub_fetch(500, r#"{"error":"boom"}"#);
+
+        let el = document().create_element("tonk-upload").unwrap();
+        el.set_attribute("with", "main@repo").unwrap();
+        document().body().unwrap().append_child(&el).unwrap();
+        let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+
+        let fired = Rc::new(RefCell::new(false));
+        {
+            let fired = fired.clone();
+            let cb = Closure::wrap(Box::new(move |_ev: web_sys::CustomEvent| {
+                *fired.borrow_mut() = true;
+            }) as Box<dyn FnMut(web_sys::CustomEvent)>);
+            host.add_event_listener_with_callback("tonk-upload", cb.as_ref().unchecked_ref())
+                .unwrap();
+            cb.forget();
+        }
+
+        let _ = await_input(&host).await;
+        super::__test_ingest(&host, &make_file(b"abc", "a.png", "image/png"));
+
+        for _ in 0..200 {
+            if host.get_attribute("data-state").as_deref() == Some("error") {
+                break;
+            }
+            sleep(5).await;
+        }
+        assert_eq!(host.get_attribute("data-state").as_deref(), Some("error"));
+        assert!(!*fired.borrow(), "no tonk-upload event on failure");
+    }
+
+    #[dialog_common::test]
+    async fn it_projects_a_slotted_trigger() {
+        super::register();
+        let el = document().create_element("tonk-upload").unwrap();
+        el.set_attribute("with", "main@repo").unwrap();
+        let btn = document().create_element("button").unwrap();
+        btn.set_attribute("slot", "trigger").unwrap();
+        btn.set_text_content(Some("Pick"));
+        el.append_child(&btn).unwrap();
+        document().body().unwrap().append_child(&el).unwrap();
+        let host: web_sys::HtmlElement = el.dyn_into().unwrap();
+        let _ = await_input(&host).await;
+
+        // The author's light-DOM trigger is present and assigned to the slot.
+        let slotted = host
+            .query_selector("button[slot=trigger]")
+            .unwrap()
+            .unwrap();
+        assert_eq!(slotted.text_content().as_deref(), Some("Pick"));
+    }
+}

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -268,10 +268,15 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
             "/api/repository/{repo}/branch/{branch}/host/{host}/{entity}",
             get(host::guest),
         )
-        // Content-addressed blob bytes. Serves a `blob:<hash>` entity's
-        // bytes from the branch's blob store, with `Content-Type` from
-        // the blob's `xyz.tonk.blob/content-type` fact. `<tonk-display>`
-        // points `<img src>` here for `tonk:blob` models.
+        // Content-addressed blob bytes: GET serves an entity's bytes; POST
+        // ingests a new blob into the branch store and returns its ref.
+        // `<tonk-display>` points `<img src>` at the GET form for
+        // `tonk:blob` models; `Content-Type` there comes from the blob's
+        // `xyz.tonk.blob/content-type` fact, which POST asserts.
+        .route(
+            "/api/repository/{repo}/branch/{branch}/blob",
+            post(blob::upload),
+        )
         .route(
             "/api/repository/{repo}/branch/{branch}/blob/{entity}",
             get(blob::serve),

--- a/rust/tonk-worker/src/router/blob.rs
+++ b/rust/tonk-worker/src/router/blob.rs
@@ -4,20 +4,22 @@
 use ::axum::{
     body::Body,
     extract::{Path, State},
-    http::{HeaderValue, StatusCode, header},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_artifacts::{ArtifactSelector, Attribute, Entity};
+use dialog_artifacts::{ArtifactSelector, Attribute, Entity, Value};
 use dialog_effects::blob::BlobError;
 use dialog_repository::{Blob, CommitError, RepositoryExt as _};
-use futures_util::StreamExt as _;
-use serde::Deserialize;
+use futures_util::{StreamExt as _, stream};
+use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
 
 use super::AppState;
+use super::claim::RawClaim;
+use super::evaluate::EvaluatePath;
 use crate::TonkWorkerError;
 
 /// Path parameters for the blob route.
@@ -124,6 +126,144 @@ pub async fn serve(
     Ok(response)
 }
 
+/// JSON body of a successful `POST …/blob`.
+#[derive(Debug, Serialize)]
+pub struct BlobUploadResponse {
+    /// The content-addressed `blob:<hash>` entity the bytes were stored under.
+    pub entity: String,
+    /// MIME type recorded for the blob (from the request `Content-Type`).
+    #[serde(rename = "contentType")]
+    pub content_type: String,
+    /// File name recorded for the blob, if the `X-Tonk-Blob-Name` header was set.
+    pub name: Option<String>,
+    /// Size of the stored bytes.
+    pub size: usize,
+}
+
+/// Handler for `POST /api/repository/{repo}/branch/{branch}/blob`.
+///
+/// Buffers the request body, writes it into the branch's content-addressed
+/// blob store, and asserts the blob's `xyz.tonk.blob/content-type` (and
+/// `xyz.tonk.blob/name`, when the `X-Tonk-Blob-Name` header is present)
+/// facts — so the read route (`serve`, above) and
+/// `<tonk-display model=tonk:blob>` work immediately. Idempotent by content
+/// address: re-uploading the same bytes returns the same entity and
+/// re-asserts the same (cardinality-one) facts.
+///
+/// The blob bytes are written directly to the branch's blob store (as
+/// `serve`, above, reads them back), which needs no reactor involvement —
+/// it's raw content-addressed storage, not a claim. The metadata facts,
+/// though, go through the *reactor's* transaction (`tonk.reactor.repository
+/// (..).branch(..).transaction()`), matching `claim::assert_claim`'s commit
+/// path, not a bare `Repository::branch(..).open()` handle's — that's the
+/// path with subscription re-polling, so following up the commit with
+/// `run_scheduled_polls` makes the new facts visible to subscribers
+/// immediately, the same as every other write route in this file's crate.
+#[wasm_compat]
+pub async fn upload(
+    State(state): State<AppState>,
+    Path(path): Path<EvaluatePath>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<Response, TonkWorkerError> {
+    if body.is_empty() {
+        return Err(TonkWorkerError::Router("empty upload body".to_string()));
+    }
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let name = headers
+        .get("x-tonk-blob-name")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let size = body.len();
+
+    let tonk = state.write().await;
+
+    // Ingest bytes into the content-addressed store. Direct branch access
+    // (as `serve` reads from) — the blob store isn't part of the claim/fact
+    // graph, so it doesn't go through the reactor.
+    let repository = tonk
+        .profile
+        .repository(&path.repo)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::NotFound(format!("Repository '{}' not found: {e}", path.repo))
+        })?;
+    let branch_handle = repository
+        .branch(path.branch.as_str())
+        .open()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("Failed to open branch '{}': {e}", path.branch))
+        })?;
+
+    let chunks = vec![Ok::<_, BlobError>(body.to_vec())];
+    let entity = Blob::import(stream::iter(chunks))
+        .write(branch_handle.blobs())
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("write blob: {e}")))?;
+
+    // Assert extrinsic metadata as ordinary facts on the blob entity,
+    // mirroring `tonk blob add`. Committed through the reactor (like
+    // `claim::assert_claim`), then drain the scheduled poll so subscribers
+    // on this branch see the new facts.
+    let ct_attr: Attribute = "xyz.tonk.blob/content-type"
+        .parse()
+        .map_err(|e| TonkWorkerError::Internal(format!("bad attribute: {e}")))?;
+    let mut tx = tonk
+        .reactor
+        .repository(&path.repo)
+        .branch(&path.branch)
+        .transaction()
+        .assert(RawClaim {
+            the: ct_attr,
+            of: entity.clone(),
+            is: Value::String(content_type.clone()),
+            unique: true,
+        });
+    if let Some(n) = &name {
+        let name_attr: Attribute = "xyz.tonk.blob/name"
+            .parse()
+            .map_err(|e| TonkWorkerError::Internal(format!("bad attribute: {e}")))?;
+        tx = tx.assert(RawClaim {
+            the: name_attr,
+            of: entity.clone(),
+            is: Value::String(n.clone()),
+            unique: true,
+        });
+    }
+    tx.commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("assert metadata: {e}")))?;
+
+    tonk.reactor.run_scheduled_polls(&tonk.operator).await;
+
+    let payload = BlobUploadResponse {
+        entity: entity.to_string(),
+        content_type,
+        name,
+        size,
+    };
+    let json = serde_json::to_string(&payload)
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize: {e}")))?;
+    let mut response = (StatusCode::OK, json).into_response();
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    Ok(response)
+}
+
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -212,6 +352,98 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(body.as_ref(), payload.as_slice());
+    }
+
+    #[dialog_common::test]
+    async fn it_uploads_bytes_and_serves_them_back() {
+        let tonk = test_state().await;
+        let app_state = Arc::new(RwLock::new(tonk));
+        let (app, _lsp) = api_router_from_state(app_state.clone());
+        let repo = put_repo(&app, "blob-upload").await;
+
+        let payload = b"\x89PNG\r\n\x1a\nupload".to_vec();
+
+        // Upload via the new POST route.
+        let up = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                    .method("POST")
+                    .header("content-type", "image/png")
+                    .header("x-tonk-blob-name", "shot.png")
+                    .body(Body::from(payload.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(up.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(up.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entity = json["entity"].as_str().unwrap().to_string();
+        assert!(
+            entity.starts_with("blob:"),
+            "entity is a blob ref: {entity}"
+        );
+        assert_eq!(json["contentType"], "image/png");
+        assert_eq!(json["name"], "shot.png");
+        assert_eq!(json["size"], payload.len());
+
+        // The GET route serves the same bytes + Content-Type from the asserted fact.
+        let got = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/blob/{entity}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.status(), StatusCode::OK);
+        assert_eq!(got.headers().get("content-type").unwrap(), "image/png");
+        let got_body = axum::body::to_bytes(got.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(got_body.as_ref(), payload.as_slice());
+
+        // Idempotent: same bytes → same entity.
+        let up2 = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                    .method("POST")
+                    .header("content-type", "image/png")
+                    .body(Body::from(payload.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body2 = axum::body::to_bytes(up2.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json2: serde_json::Value = serde_json::from_slice(&body2).unwrap();
+        assert_eq!(
+            json2["entity"], entity,
+            "content-addressed: re-upload yields same entity"
+        );
+
+        // Empty body → 400.
+        let empty = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/branch/main/blob"))
+                    .method("POST")
+                    .header("content-type", "image/png")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## What

Adds a web-UI path to ingest a file into the branch's content-addressed blob store, complementing the read/render path in #561.

- **Worker `POST /api/repository/{repo}/branch/{branch}/blob`** — buffers the body, writes it via `Blob::import`, asserts the `xyz.tonk.blob/content-type` (+ `xyz.tonk.blob/name` from an `X-Tonk-Blob-Name` header) facts through the reactor (so subscriptions re-poll), and returns `{ entity, contentType, name, size }`. Idempotent by content address; empty body → 400.
- **Native `<tonk-upload>` element** — a headless shadow-DOM primitive: ships a clean default UI (Choose-file button + preview + status) and is fully author-restylable via the `trigger` slot, `::part(base|button|preview|status)`, `--tonk-upload-*` CSS vars, and the reflected `data-state`. On pick it reads the file, POSTs via the relayed `window.fetch`, swaps its preview to the read route (proving storage), and dispatches a bubbling `tonk-upload` CustomEvent (`detail = { blob, contentType, name, size }`) — the hook a view wires into `/transact`. Registered through `tonk_display::register()`, so the sealed guest picks it up automatically.

## Design

Headless native primitive: mechanism in shadow DOM (which `<tonk-display>` reconciliation leaves alone, same as the library's `wa-*` components), presentation fully author-controlled. The security boundary is the UCAN-authorized worker route, not the UI. Spec: `docs/superpowers/specs/2026-07-09-blob-upload-design.md`; plan: `docs/superpowers/plans/2026-07-09-blob-upload.md`.

## Tests

- Worker: `it_uploads_bytes_and_serves_them_back` (wasm service-worker) — POST → GET round-trip, Content-Type from the asserted fact, idempotence, empty→400.
- Element: 4 browser tests — default shadow UI, upload+emit, failure-emits-nothing, slotted-trigger override. Clippy (`--all-features`) + rustfmt clean.

## Manual test

`<tonk-upload>` is registered in the guest. Mount it where `with` resolves — e.g. drop `<tonk-upload with="{branch}@{repo}">` into a route view, or a literal `with="main@<repo-did>"`. In `dev:web` (now backed by a local blob-aware access service), pick an image: the preview renders, the Network tab shows `POST …/blob` → 200 then `GET …/blob/blob:<hash>` → 200, and a `tonk-upload` event fires.

## Notes

- **Stacked on #561** (needs the `tonk:blob` concept, the read route, and the display renderer). Base is `feat/tonk-blobs`; retarget to staging once #561 merges.
- **Deferred (follow-ups):** a seeded demo view in `demo.yaml`; `preview`/`status` as author-overridable slots (currently element-owned `::part()`s — `trigger` is a slot); drag-and-drop, multi-file, progress, streaming ingest; and the "attach upload to a specific entity/field" layer (wire the `tonk-upload` event to a `/transact`).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `POST` route for uploading files to a branch's blob store and adds a headless `<tonk-upload>` web component for file uploads. It enhances the existing blob handling capabilities and improves the overall UI experience for file ingestion.

### Detailed summary
- Added `POST /api/repository/{repo}/branch/{branch}/blob` route for file uploads.
- Introduced `BlobUploadResponse` struct for JSON responses.
- Created `upload` handler to ingest files and assert metadata.
- Implemented `<tonk-upload>` component for user file uploads with a default UI.
- Refactored URL generation logic for blob routes into `blob_url.rs`.
- Updated tests to cover new upload functionality and component behavior.

> The following files were skipped due to too many changes: `docs/superpowers/plans/2026-07-09-blob-upload.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->