### PR TITLE
perf(ui): defer the Web Awesome loader off the boot critical path

### DIFF
--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -227,17 +227,35 @@
             type="font/ttf"
             crossorigin
         />
-        <!-- Preload the loader so it starts compiling alongside the
-       Wasm bundle instead of after the HTML has finished parsing.
-       The loader itself dynamically imports per-component chunks
-       on demand, so preloading the loader is the highest-leverage
-       step we can take without enumerating every chunk. -->
-        <link rel="modulepreload" href="/webawesome/webawesome.loader.js" />
-        <script
-            type="module"
-            src="/webawesome/webawesome.loader.js"
-            data-webawesome="/webawesome"
-        ></script>
+        <!-- Web Awesome loader — injected when the browser goes idle, NOT
+       eagerly. The loader module statically imports ~16 runtime chunks
+       (discover/startLoader/icon+translation registries/base-path utils),
+       so importing it eagerly downloads all of them at once. On a slow
+       connection that flood saturates the pipe and starves the boot data
+       plane: the wasm + the first `/api/*` fetches queue behind it, and
+       first paint waits. Nothing on the TOP page uses a `<wa-*>` COMPONENT
+       — the theme is pure CSS (loaded above), and every `<wa-*>` element
+       renders inside the sealed guest, which ships its own Web Awesome. So
+       the top-level loader isn't on the critical path; defer it to
+       `requestIdleCallback` (with a timeout fallback) so the wasm and data
+       plane win the bandwidth first. `data-webawesome` is carried onto the
+       injected script so the loader still resolves its base path. -->
+        <script>
+            (() => {
+                const inject = () => {
+                    const s = document.createElement("script");
+                    s.type = "module";
+                    s.src = "/webawesome/webawesome.loader.js";
+                    s.dataset.webawesome = "/webawesome";
+                    document.head.appendChild(s);
+                };
+                if ("requestIdleCallback" in window) {
+                    requestIdleCallback(inject, { timeout: 3000 });
+                } else {
+                    setTimeout(inject, 1000);
+                }
+            })();
+        </script>
 
         <!-- PostHog analytics, self-hosted (no external CDN, matching
        the font policy above). The bundle only defines window.posthog;


### PR DESCRIPTION
## Why

On a slow connection the cold load is dominated by the Web Awesome loader, not by our own code. The top-level loader was module-preloaded and run eagerly; its module statically imports ~16 runtime chunks (discover / startLoader / icon + translation registries / base-path utils), so importing it downloads all of them at once.

Measured on emulated Slow 3G (cold, caches cleared): the page wasm finishes at ~4.6s, then the 16 Web Awesome chunks flood the connection from ~4.3s to ~6.7s, and `/api/profile` — the first data-plane request — can't get bandwidth until ~7.2s. The component library starves the boot data plane; "everything awaits on it."

Nothing on the top page needs it: there are zero `<wa-*>` **component** elements in the top-level DOM (the 16 `wa-*` references are CSS theme classes like `wa-dark`, served by the flattened stylesheet). Every `<wa-*>` element renders inside the sealed guest, which ships and injects its **own** Web Awesome (`manifest.wa_js` / `wa_css`, loaded as a blob into the iframe). So the top-level loader is off the critical path.

## How

Inject the loader on `requestIdleCallback` (with a `setTimeout` fallback) instead of eagerly, carrying `data-webawesome` onto the injected script so it still resolves its base path. The wasm and the data plane now win the bandwidth first; Web Awesome loads once the browser is idle.

Verified against a real nix build: the loader now starts well after boot (idle) instead of flooding the pipe mid-load, the boot shell renders unchanged (it's pure CSS), and there are no console errors. The theme CSS (`webawesome-flat.css`) is untouched — it already loads async via `media="print"`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the way the Web Awesome loader is injected into the `index.html` file. It changes from an eager preload to a deferred injection using `requestIdleCallback`, improving performance by allowing the WebAssembly and API fetches to complete first.

### Detailed summary
- Removed eager preloading of the Web Awesome loader script.
- Added a deferred injection method using an IIFE (Immediately Invoked Function Expression).
- Utilized `requestIdleCallback` for injecting the loader when the browser is idle, with a fallback to `setTimeout`.
- Maintained the `data-webawesome` attribute for base path resolution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->