### PR TITLE
feat(hub): create spots as Untitled and navigate into them

### DIFF
--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -273,8 +273,6 @@ view/directory!:
         .onb-nav--close { right: 20px; }
         .onb-nav--back { left: 20px; }
         .onb-head { text-align: center; max-width: 560px; }
-        .onb-kick { font-family: var(--spot-font-mono); font-size: 11.5px; letter-spacing: .13em;
-          text-transform: uppercase; color: var(--wa-color-text-quiet); margin-bottom: 10px; }
         .onb-head h3 { font-family: var(--spot-font-display); font-weight: 300; font-size: 38px;
           letter-spacing: -1.3px; margin: 0 0 12px; color: var(--wa-color-text-normal);
           /* opt out of the global heading "headline-cover" dark box */
@@ -388,8 +386,10 @@ view/directory!:
         .onb-agent-note { display: none; text-align: center; }
         #wiz-agent:checked ~ .spot-overlay .onb-agent-note { display: block; }
         /* Details-screen heading follows the chosen path (same trick as the
-           note/grid above). */
-        .onb-h { display: none; }
+           note/grid above). `.onb-head .onb-h` (0,2,0) so the hide out-ranks
+           the `.onb-head h3 { display: block }` headline-cover opt-out above;
+           the checked-radio reveals carry an id and out-rank both. */
+        .onb-head .onb-h { display: none; }
         #wiz-tmpl:checked ~ .spot-overlay .onb-h--tmpl { display: block; }
         #wiz-agent:checked ~ .spot-overlay .onb-h--agent { display: block; }
         .onb-fields { display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 620px; }
@@ -457,7 +457,6 @@ view/directory!:
               <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
             </label>
             <div class="onb-head">
-              <div class="onb-kick">new spot</div>
               <h3>How do you want to start?</h3>
               <p class="onb-lede">Seed a ready-made layout, or start blank and hand the spot to an agent.</p>
             </div>
@@ -501,7 +500,6 @@ view/directory!:
               <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
             </label>
             <div class="onb-head">
-              <div class="onb-kick">new spot</div>
               <h3 class="onb-h onb-h--tmpl">Pick a template</h3>
               <h3 class="onb-h onb-h--agent">Build with an agent</h3>
             </div>
@@ -820,7 +818,9 @@ view/directory!: &profile/fab/view
            `<tonk-default-remote>` resolves the default sync URL on this same
            profile/meta branch.
            Mirrors the Hub's create dialog (the directory view above). -->
-      <wa-dialog id="fab-space-create" label="New spot" class="fab__dialog">
+      <!-- `--width` is the wa-dialog sizing hook; the default (~31rem) is
+           too narrow for the 2x2 template grid. -->
+      <wa-dialog id="fab-space-create" label="New spot" class="fab__dialog" style="--width: 40rem">
         <form id="fab-space-create-form" class="fab__form wizard" onsubmit=space/create data-close-dialog>
           <style>
             /* CSS-paged wizard: a hidden radio per screen drives which
@@ -832,6 +832,14 @@ view/directory!: &profile/fab/view
             #wiz-start:checked    ~ .wizard__screen--start    { display: flex; }
             #wiz-template:checked ~ .wizard__screen--template { display: flex; }
             .wizard__cards { display: flex; gap: var(--wa-space-m); }
+            /* Screen 2 holds FOUR template cards. A flex row can't shrink
+               them below their longest word, so it overflowed the dialog
+               edge; a 2x2 grid with minmax(0,1fr) tracks keeps every card
+               inside the dialog at its natural width. Screen 1's two
+               chooser cards stay a flex row. */
+            .wizard__screen--template .wizard__cards {
+              display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
             .wizard__card {
               flex: 1; display: block; padding: var(--wa-space-l);
               border: var(--wa-border-width-s) solid var(--wa-color-surface-border);

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -393,6 +393,10 @@ view/directory!:
         #wiz-tmpl:checked ~ .spot-overlay .onb-h--tmpl { display: block; }
         #wiz-agent:checked ~ .spot-overlay .onb-h--agent { display: block; }
         .onb-fields { display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 620px; }
+        /* The submit shouldn't span the whole column — shrink it to its
+           content (the flex column would otherwise stretch it) with a
+           floor for a comfortable hit target. */
+        .onb-fields wa-button { align-self: center; min-width: 220px; }
       </style>
 
       <!-- wizard state radio group: closed by default; each open state is a
@@ -839,6 +843,12 @@ view/directory!: &profile/fab/view
                chooser cards stay a flex row. */
             .wizard__screen--template .wizard__cards {
               display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+            /* Shrink the submit to its content (the screen's flex column
+               would otherwise stretch it full-width), with a floor for a
+               comfortable hit target. */
+            .wizard__screen--template > wa-button[type="submit"] {
+              align-self: center; min-width: 220px;
             }
             .wizard__card {
               flex: 1; display: block; padding: var(--wa-space-l);

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -61,8 +61,9 @@ concept!: &space
 # The Add Space command. Submitting the Hub's form asserts this
 # transient command; the worker's `create_space` handler decodes it and
 # does the work (record the replica, create + seed the repository, flip
-# the status). `name` reads from the form on submit:
-# `event.currentTarget.elements.name.value` — the `<wa-input name="name">`
+# the status, navigate the creator into the new spot). `name` reads from
+# the form on submit: `event.currentTarget.elements.name.value` — the
+# hidden `<input name="name" value="Untitled">`
 # inside `<form onsubmit=space/create>`. `prevent-default` stops the page
 # from reloading: `method="dialog"` does NOT work here because the form is
 # slotted into `<wa-dialog>` and the native `<dialog>` lives across the
@@ -71,10 +72,18 @@ concept!: &space
 # transient: it fires the handler once and is swept before the durable
 # commit.
 command!: &space/create
-  description: A request to create a new space by the name typed into the form.
+  description: A request to create a new space from the wizard form.
   with:
     name:
-      description: The space name, read from the form's `name` input on submit
+      description: >
+        The space name, read from the form's `name` input on submit. The
+        wizard no longer asks for one: a hidden input carries the
+        "Untitled" sentinel, which the worker's CreateSpaceHandler
+        uniquifies against the existing space labels ("Untitled",
+        "Untitled 2", …); the user renames the spot later. The sentinel
+        must be non-empty — the event extractor omits blank fields, and
+        with no `name` fact the transient would never trigger the
+        handler.
       the: dom.event.current-target.elements.name/value
       as: text
     remote:
@@ -378,6 +387,11 @@ view/directory!:
           border-bottom: var(--wa-border-width-s) solid var(--wa-color-neutral-fill-normal); }
         .onb-agent-note { display: none; text-align: center; }
         #wiz-agent:checked ~ .spot-overlay .onb-agent-note { display: block; }
+        /* Details-screen heading follows the chosen path (same trick as the
+           note/grid above). */
+        .onb-h { display: none; }
+        #wiz-tmpl:checked ~ .spot-overlay .onb-h--tmpl { display: block; }
+        #wiz-agent:checked ~ .spot-overlay .onb-h--agent { display: block; }
         .onb-fields { display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 620px; }
       </style>
 
@@ -429,6 +443,11 @@ view/directory!:
 
       <div class="spot-overlay">
         <form class="onb-overlay-body" onsubmit=space/create data-close-radio="wiz-closed">
+          <!-- No name up front: the hidden sentinel becomes "Untitled" /
+               "Untitled 2" (worker-uniquified); the user renames later.
+               Must be non-empty or the extractor omits the field and the
+               command never fires. -->
+          <input type="hidden" name="name" value="Untitled">
           <input type="hidden" name="remote" value="">
           <tonk-default-remote field="remote" auto></tonk-default-remote>
 
@@ -461,14 +480,17 @@ view/directory!:
                   </div>
                   <div class="onb-card__name">Build with an agent</div>
                   <div class="onb-card__desc">Start blank; hand the spot to an agent from inside it.</div>
-                  <div class="onb-card__cta">name it &rsaquo;</div>
+                  <div class="onb-card__cta">start blank &rsaquo;</div>
                 </wa-card>
               </label>
             </div>
           </div>
 
-          <!-- Screen 2: details — the only submit. Name (required, visible)
-               + template picker (template path) or agent note (agent path). -->
+          <!-- Screen 2: details — the only submit. Template picker
+               (template path) or agent note (agent path); no name field —
+               the spot starts "Untitled" and is renamed in place. The
+               heading follows the path via the same checked-radio sibling
+               selectors that page the screens. -->
           <div class="onb-screen onb-screen--details">
             <label class="onb-nav onb-nav--back" for="wiz-start">
               <wa-button variant="neutral" appearance="plain" size="small">
@@ -480,7 +502,8 @@ view/directory!:
             </label>
             <div class="onb-head">
               <div class="onb-kick">new spot</div>
-              <h3>Name your spot</h3>
+              <h3 class="onb-h onb-h--tmpl">Pick a template</h3>
+              <h3 class="onb-h onb-h--agent">Build with an agent</h3>
             </div>
             <!-- Template picker. Native radios drive a 3-up grid of card
                  <label>s (reliable side-by-side layout, matching the
@@ -520,7 +543,6 @@ view/directory!:
             </div>
             <p class="onb-agent-note onb-lede">An agent will build this spot from a blank canvas.</p>
             <div class="onb-fields">
-              <wa-input name="name" label="Spot name" placeholder="e.g. pictures" autocomplete="off" required></wa-input>
               <wa-button type="submit" variant="brand">Create spot</wa-button>
             </div>
           </div>
@@ -803,8 +825,8 @@ view/directory!: &profile/fab/view
           <style>
             /* CSS-paged wizard: a hidden radio per screen drives which
                .wizard__screen shows. The form submits once at the end, so
-               every control (name, template, hidden remote) is in the same form
-               and read via dom.event.current-target.elements.* . */
+               every control (hidden name, template, hidden remote) is in the
+               same form and read via dom.event.current-target.elements.* . */
             .wizard__nav { position: absolute; opacity: 0; pointer-events: none; }
             .wizard__screen { display: none; flex-direction: column; gap: var(--wa-space-m); }
             #wiz-start:checked    ~ .wizard__screen--start    { display: flex; }
@@ -875,12 +897,16 @@ view/directory!: &profile/fab/view
           <input class="wizard__template" type="radio" name="template" value="sheets" id="tpl-sheets">
           <input class="wizard__template" type="radio" name="template" value="wiki" id="tpl-wiki">
           <input class="wizard__template" type="radio" name="template" value="board" id="tpl-board">
+          <!-- No name up front: the hidden sentinel becomes "Untitled" /
+               "Untitled 2" (worker-uniquified); the user renames later.
+               Must be non-empty or the extractor omits the field and the
+               command never fires. -->
+          <input type="hidden" name="name" value="Untitled">
           <input type="hidden" name="remote" value="">
           <tonk-default-remote field="remote" auto></tonk-default-remote>
 
-          <!-- Screen 1: name + how to start -->
+          <!-- Screen 1: how to start -->
           <div class="wizard__screen wizard__screen--start">
-            <wa-input name="name" label="Spot name" placeholder="e.g. pictures" autocomplete="off" autofocus required></wa-input>
             <div class="wizard__cards">
               <label class="wizard__card" for="wiz-template">
                 <h3>Start from a template</h3>

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -59,6 +59,10 @@ pub struct CreateSpace {
     /// worker from the predicate + payload).
     pub this: Entity,
     /// Local name for the new space, read from the form's `name` input.
+    /// The create wizard supplies it from a hidden input carrying the
+    /// `Untitled` sentinel (the user no longer types a name up front);
+    /// the worker's handler uniquifies that to "Untitled N" against the
+    /// existing space labels, and the user renames later.
     pub name: SpaceName,
 }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -76,6 +76,8 @@ pub use host::{ClientId, ViewBinding, ViewBindings};
 
 mod migration;
 
+mod navigate;
+
 mod command;
 pub use command::{CommandEnv, CommandOrigin, command_registry, dispatch};
 

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -609,7 +609,7 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
             tonk.reactor.schedule_poll(Arc::clone(&session.state));
             tonk.reactor.run_scheduled_polls(&tonk.operator).await;
             let href = format!("/space/{key}", key = outcome.key);
-            notify_navigate(env.client(), &href);
+            crate::router::navigate::notify_navigate(env.client(), &href);
             log!(
                 "join: succeeded (subject {}, key {})",
                 outcome.subject,
@@ -678,74 +678,6 @@ async fn pull_joined_content(tonk: &TonkState, key: &str) {
     }
 }
 
-/// Post a `{ type: "navigate", href }` message to the originating client so
-/// it redirects there. This is how a worker-side command performs a page
-/// capability: the service worker has no `window`, and the command is
-/// transient (it never lands in a branch a subscription could observe), so
-/// the originating client is the only path back to the page that asked.
-///
-/// No-ops (with a log) when the client is unknown or its handle can't be
-/// resolved — the join still succeeded; only the convenience redirect is
-/// lost, and the recipient can navigate from the Hub.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn notify_navigate(client: Option<&crate::router::ClientId>, href: &str) {
-    use wasm_bindgen::{JsCast, JsValue};
-    use wasm_bindgen_futures::{JsFuture, spawn_local};
-
-    let Some(client) = client else {
-        log!("join: no originating client to navigate; skipping redirect");
-        return;
-    };
-    let client_id = client.0.clone();
-    let href = href.to_owned();
-
-    let global: web_sys::ServiceWorkerGlobalScope = match js_sys::global().dyn_into() {
-        Ok(g) => g,
-        Err(_) => {
-            log!("join: not in a service worker scope; skipping redirect");
-            return;
-        }
-    };
-
-    // `clients.get(id)` resolves the live `Client` handle; post the message
-    // on it. Done on a spawned task so the caller isn't blocked on the
-    // round-trip (the navigate is fire-and-forget).
-    spawn_local(async move {
-        let client_value = match JsFuture::from(global.clients().get(&client_id)).await {
-            Ok(value) if !value.is_undefined() && !value.is_null() => value,
-            Ok(_) => {
-                log!("join: originating client {client_id} is gone; skipping redirect");
-                return;
-            }
-            Err(e) => {
-                log!("join: clients.get failed: {e:?}");
-                return;
-            }
-        };
-        let Ok(client) = client_value.dyn_into::<web_sys::Client>() else {
-            log!("join: clients.get did not yield a Client; skipping redirect");
-            return;
-        };
-
-        // `{ type: "navigate", href }` — the page's `<tonk-host>` listens
-        // for `navigate` messages and assigns `window.location`.
-        let message = js_sys::Object::new();
-        let _ = js_sys::Reflect::set(
-            &message,
-            &JsValue::from_str("type"),
-            &JsValue::from_str("navigate"),
-        );
-        let _ = js_sys::Reflect::set(
-            &message,
-            &JsValue::from_str("href"),
-            &JsValue::from_str(&href),
-        );
-        if let Err(e) = client.post_message(&message) {
-            log!("join: post_message(navigate) failed: {e:?}");
-        }
-    });
-}
-
 /// Post a `{ type: "sync" }` message to the originating client so it
 /// dispatches a `tonk:committed` window event, prompting the sync
 /// controller to push immediately instead of waiting for the heartbeat.
@@ -753,6 +685,8 @@ fn notify_navigate(client: Option<&crate::router::ClientId>, href: &str) {
 /// Mirrors [`notify_navigate`] exactly — fire-and-forget on a spawned
 /// task, no `TonkState` access, so the caller's held read lock is
 /// irrelevant.
+///
+/// [`notify_navigate`]: crate::router::navigate::notify_navigate
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) fn notify_sync(client: Option<&crate::router::ClientId>) {
     use wasm_bindgen::{JsCast, JsValue};

--- a/rust/tonk-worker/src/router/navigate.rs
+++ b/rust/tonk-worker/src/router/navigate.rs
@@ -1,0 +1,79 @@
+//! Redirecting the page that asked — the worker side of a navigation.
+//!
+//! A command handler whose effect is a page capability (loading a new
+//! location) can't perform it itself: the service worker has no
+//! `window`, and a transient command never lands in a branch a
+//! subscription could observe. The only channel back to the page that
+//! asked is a `postMessage` to its originating client; the page's
+//! `<tonk-host>` listens for `navigate` messages and assigns
+//! `window.location`. Used by the join handler (redirect into the
+//! joined space) and the create handler (drop the creator into the
+//! fresh spot).
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tonk_common::log;
+
+/// Post a `{ type: "navigate", href }` message to the originating client so
+/// it redirects there.
+///
+/// No-ops (with a log) when the client is unknown or its handle can't be
+/// resolved — the triggering command still succeeded; only the convenience
+/// redirect is lost, and the user can navigate from the Hub.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn notify_navigate(client: Option<&crate::router::ClientId>, href: &str) {
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_futures::{JsFuture, spawn_local};
+
+    let Some(client) = client else {
+        log!("navigate: no originating client; skipping redirect");
+        return;
+    };
+    let client_id = client.0.clone();
+    let href = href.to_owned();
+
+    let global: web_sys::ServiceWorkerGlobalScope = match js_sys::global().dyn_into() {
+        Ok(g) => g,
+        Err(_) => {
+            log!("navigate: not in a service worker scope; skipping redirect");
+            return;
+        }
+    };
+
+    // `clients.get(id)` resolves the live `Client` handle; post the message
+    // on it. Done on a spawned task so the caller isn't blocked on the
+    // round-trip (the navigate is fire-and-forget).
+    spawn_local(async move {
+        let client_value = match JsFuture::from(global.clients().get(&client_id)).await {
+            Ok(value) if !value.is_undefined() && !value.is_null() => value,
+            Ok(_) => {
+                log!("navigate: originating client {client_id} is gone; skipping redirect");
+                return;
+            }
+            Err(e) => {
+                log!("navigate: clients.get failed: {e:?}");
+                return;
+            }
+        };
+        let Ok(client) = client_value.dyn_into::<web_sys::Client>() else {
+            log!("navigate: clients.get did not yield a Client; skipping redirect");
+            return;
+        };
+
+        // `{ type: "navigate", href }` — the page's `<tonk-host>` listens
+        // for `navigate` messages and assigns `window.location`.
+        let message = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &message,
+            &JsValue::from_str("type"),
+            &JsValue::from_str("navigate"),
+        );
+        let _ = js_sys::Reflect::set(
+            &message,
+            &JsValue::from_str("href"),
+            &JsValue::from_str(&href),
+        );
+        if let Err(e) = client.post_message(&message) {
+            log!("navigate: post_message(navigate) failed: {e:?}");
+        }
+    });
+}

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -321,6 +321,115 @@ fn template_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
         .filter(|name| !name.is_empty())
 }
 
+/// The default display label for a space created without a user-typed
+/// name. The create forms carry it in a hidden `name` input (the wizard
+/// no longer asks for a name up front); the handler uniquifies it
+/// against the existing space labels via [`next_untitled_label`], and
+/// the user renames the spot later (the FAB's inline editable /
+/// `tonk/rename-repository`).
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const UNTITLED: &str = "Untitled";
+
+/// Pick the first free untitled label: `Untitled`, then `Untitled 2`,
+/// `Untitled 3`, … — the smallest ordinal no existing label already
+/// uses. Only exact `Untitled` / `Untitled <n>` labels count as taken;
+/// anything else (user-typed names, key fallbacks) is ignored.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn next_untitled_label<I>(existing: I) -> String
+where
+    I: IntoIterator<Item = String>,
+{
+    let taken: std::collections::HashSet<u64> = existing
+        .into_iter()
+        .filter_map(|label| {
+            let label = label.trim();
+            if label == UNTITLED {
+                return Some(1);
+            }
+            label
+                .strip_prefix(UNTITLED)
+                .and_then(|rest| rest.strip_prefix(' '))
+                .and_then(|ordinal| ordinal.parse::<u64>().ok())
+                .filter(|ordinal| *ordinal >= 2)
+        })
+        .collect();
+    let mut ordinal = 1;
+    while taken.contains(&ordinal) {
+        ordinal += 1;
+    }
+    if ordinal == 1 {
+        UNTITLED.to_string()
+    } else {
+        format!("{UNTITLED} {ordinal}")
+    }
+}
+
+/// The display labels of every space the profile owns, read from each
+/// repository's own `tonk/repository` concept (the same source the Hub
+/// renders). Used by the create handler to uniquify the untitled label.
+///
+/// Best-effort: a replica whose repo can't be loaded is skipped (its
+/// [`repository_label`] key fallback wouldn't match the untitled
+/// pattern anyway), so a single broken space never blocks a create.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn existing_space_labels(state: &AppState) -> Vec<String> {
+    use tonk_schema::domain::replica::Profile as ProfileEntity;
+
+    let tonk = state.read().await;
+    let profile_entity = tonk.profile.did().this();
+
+    let meta = match tonk
+        .reactor
+        .profile_repository()
+        .branch(PROFILE_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+    {
+        Ok(meta) => meta,
+        Err(e) => {
+            log!("existing_space_labels: profile meta acquire failed: {e}");
+            return Vec::new();
+        }
+    };
+
+    let rows: Vec<Replica> = meta
+        .handle()
+        .query()
+        .select(Query::<Replica> {
+            this: Term::var("this"),
+            subject: Term::var("subject"),
+            profile: Term::from(ProfileEntity(profile_entity.clone())),
+            kind: Term::var("kind"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .unwrap_or_default();
+
+    let mut labels = Vec::new();
+    for replica in rows {
+        // The profile's self-replica is not a space.
+        if replica.subject.0 == profile_entity {
+            continue;
+        }
+        let Ok(did) = replica.subject.0.to_string().parse::<Did>() else {
+            continue;
+        };
+        let key = did.repo_key().to_owned();
+        match tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+        {
+            Ok(repository) => labels.push(repository_label(&tonk, &repository, &key).await),
+            Err(e) => log!("existing_space_labels: repository '{key}' not loadable: {e}"),
+        }
+    }
+    labels
+}
+
 /// Command handler for the "New space" form (`space/create`) and the
 /// topbar's "Enable sync" form (`space/enable-sync`).
 ///
@@ -338,7 +447,13 @@ fn template_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
 /// the same handler serves both forms: the Hub "New space" form and the
 /// topbar "Enable sync" form — both post the same `name`(+`remote`)
 /// shape, and the handler keys on the shared `name` attribute. The
-/// user-typed `name` is only a display label; two spaces may share it. A
+/// `name` is only a display label; two spaces may share it. The create
+/// wizard doesn't ask for one — its hidden input carries the
+/// [`UNTITLED`] sentinel, which the handler uniquifies against the
+/// existing space labels ([`next_untitled_label`]) so consecutive
+/// creates read "Untitled", "Untitled 2", …. Once the space is created
+/// and seeded, the handler posts a `navigate` message back to the
+/// originating client so the creator lands inside the new spot. A
 /// remote/auth failure leaves a working local space, retryable from the
 /// topbar.
 ///
@@ -403,6 +518,17 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHa
             let Some(name) = name else {
                 return;
             };
+
+            // The create wizard no longer asks for a name: its hidden
+            // `name` input carries the `Untitled` sentinel (a blank name
+            // from an older form gets the same treatment). Uniquify it
+            // against the existing space labels so consecutive creates
+            // read "Untitled", "Untitled 2", … — the user renames later.
+            let name = if name.trim().is_empty() || name.trim() == UNTITLED {
+                next_untitled_label(existing_space_labels(env.state()).await)
+            } else {
+                name
+            };
             log!("command CreateSpace name={} remote={:?}", name, remote);
 
             // 1. Always create local-only first, so the space appears
@@ -417,7 +543,16 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHa
                 }
             };
 
-            // 2. If the form carried a remote, attach it best-effort to
+            // 2. The space is created and seeded — drop the creator into
+            //    it. Same page-capability channel as the join redirect: a
+            //    `{ type: "navigate", href }` posted to the originating
+            //    client. Fired before the remote attach so the navigation
+            //    doesn't wait on the network; the attach continues in the
+            //    worker regardless.
+            let href = format!("/space/{key}");
+            crate::router::navigate::notify_navigate(env.client(), &href);
+
+            // 3. If the form carried a remote, attach it best-effort to
             //    the identity just created. A failure here just leaves it
             //    local-only — retryable from the topbar's Enable sync.
             //    (`remote_from_facts` already dropped empty/blank URLs.)
@@ -3262,6 +3397,77 @@ mod template_from_facts_tests {
             .is("   ".to_string())
             .assert(&mut changes);
         assert!(template_from_facts(&artifacts(changes)).is_none());
+    }
+}
+
+/// The pure untitled-label picker the create handler uses. Native.
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+mod next_untitled_label_tests {
+    use super::next_untitled_label;
+
+    fn labels(labels: &[&str]) -> Vec<String> {
+        labels.iter().map(|label| label.to_string()).collect()
+    }
+
+    #[test]
+    fn it_starts_at_bare_untitled() {
+        assert_eq!(next_untitled_label(labels(&[])), "Untitled");
+    }
+
+    #[test]
+    fn it_ignores_named_spaces() {
+        assert_eq!(
+            next_untitled_label(labels(&["pictures", "notes"])),
+            "Untitled",
+        );
+    }
+
+    #[test]
+    fn it_numbers_from_two_after_the_bare_label() {
+        assert_eq!(
+            next_untitled_label(labels(&["Untitled", "pictures"])),
+            "Untitled 2",
+        );
+    }
+
+    #[test]
+    fn it_fills_the_smallest_gap() {
+        assert_eq!(
+            next_untitled_label(labels(&["Untitled", "Untitled 3"])),
+            "Untitled 2",
+        );
+        assert_eq!(
+            next_untitled_label(labels(&["Untitled 2", "Untitled 3"])),
+            "Untitled",
+        );
+    }
+
+    #[test]
+    fn it_counts_past_a_dense_run() {
+        assert_eq!(
+            next_untitled_label(labels(&["Untitled", "Untitled 2", "Untitled 3"])),
+            "Untitled 4",
+        );
+    }
+
+    #[test]
+    fn it_ignores_near_misses() {
+        // Prefixes without the ` <n>` shape, or with a non-ordinal
+        // suffix, are user-typed names — not part of the sequence.
+        assert_eq!(
+            next_untitled_label(labels(&[
+                "Untitled draft",
+                "Untitled2",
+                "Untitled 0",
+                "untitled",
+            ])),
+            "Untitled",
+        );
+    }
+
+    #[test]
+    fn it_trims_surrounding_whitespace() {
+        assert_eq!(next_untitled_label(labels(&["  Untitled  "])), "Untitled 2");
     }
 }
 


### PR DESCRIPTION
## What

Spot creation no longer asks for a name up front, and the creator is dropped straight into the new spot.

- **No name prompt.** Both create wizards (the FAB "New spot" dialog and the Hub onboarding overlay) lose the required `Spot name` input. A hidden `name` input carries an `Untitled` sentinel — it must be non-empty because the event extractor omits blank fields, and with no `name` fact the transient would never trigger the handler.
- **Worker-side uniquifying.** `CreateSpaceHandler` maps a blank or `Untitled` name to the smallest free untitled label — "Untitled", "Untitled 2", … — by reading every existing space's display label from its own `tonk/repository` concept (the same source the Hub renders). A user-typed name from an older seeded form passes through untouched, so frozen profile descriptors keep working. Renaming stays the existing editable title (`tonk/rename-repository`).
- **Post-create navigation.** Once the space is created and seeded, the handler posts `{type: "navigate", href: "/space/<key>"}` to the originating client — the same worker→page channel the join redirect uses, factored out of `join.rs` into a shared `router/navigate.rs`. Guest-originated transacts relay through the host page, so the top page performs the (client-side, pushState) route change. The navigate fires before the best-effort remote attach so it never waits on the network.
- The overlay's details screen, formerly "Name your spot", now shows a per-path heading ("Pick a template" / "Build with an agent") via the same checked-radio CSS that pages the screens.

## Behavior note

"Build with an agent" in the FAB now creates immediately on click — the required name field used to block that submit.

## Testing

- `next_untitled_label` has 7 native unit tests (gap filling, near-miss names, dense runs).
- `standard_library` suite passes (profile.yaml still lowers).
- `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --all --check`, and a `wasm32-unknown-unknown` check of `tonk-worker` (the target that compiles the handler) are all clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `navigate` module for handling page redirection in the service worker context, updates the way untitled space names are generated, and refines the create space wizard to manage naming without user input.

### Detailed summary
- Added a new `navigate` module in `rust/tonk-worker/src/router`.
- Refactored `notify_navigate` to handle page redirection via `postMessage`.
- Updated `name` handling in the `CreateSpaceHandler` to use a hidden input for untitled names.
- Introduced `next_untitled_label` function to generate unique untitled names.
- Enhanced tests for `next_untitled_label`.
- Updated documentation and comments for clarity regarding the new naming scheme.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->