### PR TITLE
Load-time fixes: stop SW state accumulating across reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "base58",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "base58",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "base58",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "async-trait",
  "base58",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?branch=feat%2Finductive-self-negation#09bddcc1bc3f1c5fdc83b76d17f2b110cf019699"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,22 +164,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", branch = "feat/inductive-self-negation" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
 
 # NOTE — incremental subscriptions (plan/incremental-subscriptions.md): the
 # dialog deps above are pinned to the `feat/inductive-self-negation` BRANCH (not
@@ -207,5 +207,6 @@ opt-level = "s"
 debug = 0
 inherits = "release"
 strip = "debuginfo"
+
 
 

--- a/rust/dialog-reactor/src/branch/session.rs
+++ b/rust/dialog-reactor/src/branch/session.rs
@@ -46,11 +46,17 @@ impl BranchSession {
         self.state.poll(env)
     }
 
-    /// Register a fresh subscriber for `query`. Returns a
+    /// Register a fresh subscriber for `query`, optionally tagged
+    /// with the client it serves (see
+    /// [`BranchState::retain_subscribers`]). Returns a
     /// [`Subscriber`] carrying the subscription's hash and the
     /// receiver to read broadcast bytes from.
-    pub fn subscribe(&self, query: ConceptQuery) -> Result<Subscriber, ReactorError> {
-        self.state.subscribe(query)
+    pub fn subscribe(
+        &self,
+        query: ConceptQuery,
+        client: Option<String>,
+    ) -> Result<Subscriber, ReactorError> {
+        self.state.subscribe(query, client)
     }
 
     /// Reference a single subscription on this branch by its

--- a/rust/dialog-reactor/src/branch/session.rs
+++ b/rust/dialog-reactor/src/branch/session.rs
@@ -46,17 +46,11 @@ impl BranchSession {
         self.state.poll(env)
     }
 
-    /// Register a fresh subscriber for `query`, optionally tagged
-    /// with the client it serves (see
-    /// [`BranchState::retain_subscribers`]). Returns a
+    /// Register a fresh subscriber for `query`. Returns a
     /// [`Subscriber`] carrying the subscription's hash and the
     /// receiver to read broadcast bytes from.
-    pub fn subscribe(
-        &self,
-        query: ConceptQuery,
-        client: Option<String>,
-    ) -> Result<Subscriber, ReactorError> {
-        self.state.subscribe(query, client)
+    pub fn subscribe(&self, query: ConceptQuery) -> Result<Subscriber, ReactorError> {
+        self.state.subscribe(query)
     }
 
     /// Reference a single subscription on this branch by its

--- a/rust/dialog-reactor/src/branch/state.rs
+++ b/rust/dialog-reactor/src/branch/state.rs
@@ -142,7 +142,11 @@ impl BranchState {
     /// the hash is the right move here. Track the upstream fix
     /// in dialog-db (make `NamedAttributes::PartialEq`
     /// order-insensitive, or serialize in sorted order).
-    pub fn subscribe(&self, query: ConceptQuery) -> Result<Subscriber, ReactorError> {
+    pub fn subscribe(
+        &self,
+        query: ConceptQuery,
+        client: Option<String>,
+    ) -> Result<Subscriber, ReactorError> {
         let hash = QueryHash::from(&query);
         let (sender, receiver) = mpsc::unbounded_channel();
 
@@ -165,9 +169,40 @@ impl BranchState {
         subscription.subscribers.push(SubscriberSession {
             sender,
             status: Status::Pending,
+            client,
         });
 
         Ok(Subscriber { hash, receiver })
+    }
+
+    /// Drop every subscriber whose `client` tag fails `keep`; an
+    /// untagged subscriber (`None`) is always kept. A subscription
+    /// left with no subscribers is removed with its engine.
+    ///
+    /// This is the liveness-driven prune: send-failure pruning in
+    /// `fan_out` only fires once the receiver is actually dropped,
+    /// which a vanished client may never trigger — its stale
+    /// subscription would re-evaluate on every poll forever.
+    pub fn retain_subscribers<F: Fn(&str) -> bool>(&self, keep: F) {
+        let mut subs = self.subscriptions.lock();
+        subs.retain(|_, subscription| {
+            subscription
+                .subscribers
+                .retain(|s| s.client.as_deref().is_none_or(&keep));
+            !subscription.subscribers.is_empty()
+        });
+    }
+
+    /// Drop every session-overlay fact recorded for entities that
+    /// fail `keep` — the branch-level surface of
+    /// [`Overlay::retain_entities`](dialog_repository::Overlay).
+    /// Returns whether anything was removed; the caller schedules a
+    /// poll when it was, so live subscribers observe the removal.
+    pub fn retain_overlay_entities<F: FnMut(&dialog_artifacts::Entity) -> bool>(
+        &self,
+        keep: F,
+    ) -> bool {
+        self.branch.overlay().retain_entities(keep)
     }
 
     /// Re-poll every subscription on this branch. Mutating leaf

--- a/rust/dialog-reactor/src/branch/state.rs
+++ b/rust/dialog-reactor/src/branch/state.rs
@@ -142,11 +142,7 @@ impl BranchState {
     /// the hash is the right move here. Track the upstream fix
     /// in dialog-db (make `NamedAttributes::PartialEq`
     /// order-insensitive, or serialize in sorted order).
-    pub fn subscribe(
-        &self,
-        query: ConceptQuery,
-        client: Option<String>,
-    ) -> Result<Subscriber, ReactorError> {
+    pub fn subscribe(&self, query: ConceptQuery) -> Result<Subscriber, ReactorError> {
         let hash = QueryHash::from(&query);
         let (sender, receiver) = mpsc::unbounded_channel();
 
@@ -169,40 +165,9 @@ impl BranchState {
         subscription.subscribers.push(SubscriberSession {
             sender,
             status: Status::Pending,
-            client,
         });
 
         Ok(Subscriber { hash, receiver })
-    }
-
-    /// Drop every subscriber whose `client` tag fails `keep`; an
-    /// untagged subscriber (`None`) is always kept. A subscription
-    /// left with no subscribers is removed with its engine.
-    ///
-    /// This is the liveness-driven prune: send-failure pruning in
-    /// `fan_out` only fires once the receiver is actually dropped,
-    /// which a vanished client may never trigger — its stale
-    /// subscription would re-evaluate on every poll forever.
-    pub fn retain_subscribers<F: Fn(&str) -> bool>(&self, keep: F) {
-        let mut subs = self.subscriptions.lock();
-        subs.retain(|_, subscription| {
-            subscription
-                .subscribers
-                .retain(|s| s.client.as_deref().is_none_or(&keep));
-            !subscription.subscribers.is_empty()
-        });
-    }
-
-    /// Drop every session-overlay fact recorded for entities that
-    /// fail `keep` — the branch-level surface of
-    /// [`Overlay::retain_entities`](dialog_repository::Overlay).
-    /// Returns whether anything was removed; the caller schedules a
-    /// poll when it was, so live subscribers observe the removal.
-    pub fn retain_overlay_entities<F: FnMut(&dialog_artifacts::Entity) -> bool>(
-        &self,
-        keep: F,
-    ) -> bool {
-        self.branch.overlay().retain_entities(keep)
     }
 
     /// Re-poll every subscription on this branch. Mutating leaf

--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -247,27 +247,6 @@ impl Reactor {
         Ok(())
     }
 
-    /// Snapshot every cached branch state, across named repositories
-    /// and the profile-as-repository. Used by liveness sweeps that
-    /// reconcile per-client state (overlay facts, tagged subscribers)
-    /// against the set of live clients — only cached branches can
-    /// hold any, since both live on the in-memory [`BranchState`].
-    pub fn cached_branch_states(&self) -> Vec<Arc<BranchState>> {
-        let repos: Vec<Arc<RepositoryState>> = {
-            let map = self.repos.read();
-            map.values().cloned().collect()
-        };
-        let profile = self.profile_repo.read().clone();
-        repos
-            .into_iter()
-            .chain(profile)
-            .flat_map(|repo| {
-                let branches = repo.branches().read();
-                branches.values().cloned().collect::<Vec<_>>()
-            })
-            .collect()
-    }
-
     /// Begin a chain scoped to the named repository.
     pub fn repository<'a>(&'a self, name: &'a str) -> RepositoryReference<'a> {
         RepositoryReference::Named {

--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -247,6 +247,27 @@ impl Reactor {
         Ok(())
     }
 
+    /// Snapshot every cached branch state, across named repositories
+    /// and the profile-as-repository. Used by liveness sweeps that
+    /// reconcile per-client state (overlay facts, tagged subscribers)
+    /// against the set of live clients — only cached branches can
+    /// hold any, since both live on the in-memory [`BranchState`].
+    pub fn cached_branch_states(&self) -> Vec<Arc<BranchState>> {
+        let repos: Vec<Arc<RepositoryState>> = {
+            let map = self.repos.read();
+            map.values().cloned().collect()
+        };
+        let profile = self.profile_repo.read().clone();
+        repos
+            .into_iter()
+            .chain(profile)
+            .flat_map(|repo| {
+                let branches = repo.branches().read();
+                branches.values().cloned().collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     /// Begin a chain scoped to the named repository.
     pub fn repository<'a>(&'a self, name: &'a str) -> RepositoryReference<'a> {
         RepositoryReference::Named {

--- a/rust/dialog-reactor/src/subscribe.rs
+++ b/rust/dialog-reactor/src/subscribe.rs
@@ -16,26 +16,12 @@ pub struct Subscribe<'a> {
     pub branch: BranchReference<'a>,
     /// The query the subscription re-evaluates on every change.
     pub query: ConceptQuery,
-    /// The client this subscriber serves, when known — see
-    /// [`BranchState::retain_subscribers`](crate::BranchState::retain_subscribers).
-    pub client: Option<String>,
 }
 
 impl<'a> Subscribe<'a> {
     /// Build a new `Subscribe` effect.
     pub fn new(branch: BranchReference<'a>, query: ConceptQuery) -> Self {
-        Self {
-            branch,
-            query,
-            client: None,
-        }
-    }
-
-    /// Tag the subscriber with the client it serves, so the owner
-    /// can prune it once that client is no longer alive.
-    pub fn client(mut self, client: impl Into<String>) -> Self {
-        self.client = Some(client.into());
-        self
+        Self { branch, query }
     }
 
     /// Resolve the branch (opening it if needed), attach a
@@ -46,7 +32,7 @@ impl<'a> Subscribe<'a> {
         Env: LoadProvider + BranchOpenProvider + SelectProvider,
     {
         let session = self.branch.acquire(env).await?;
-        let subscriber = session.subscribe(self.query, self.client)?;
+        let subscriber = session.subscribe(self.query)?;
         session
             .subscription(subscriber.hash.clone())
             .poll()

--- a/rust/dialog-reactor/src/subscribe.rs
+++ b/rust/dialog-reactor/src/subscribe.rs
@@ -16,12 +16,26 @@ pub struct Subscribe<'a> {
     pub branch: BranchReference<'a>,
     /// The query the subscription re-evaluates on every change.
     pub query: ConceptQuery,
+    /// The client this subscriber serves, when known — see
+    /// [`BranchState::retain_subscribers`](crate::BranchState::retain_subscribers).
+    pub client: Option<String>,
 }
 
 impl<'a> Subscribe<'a> {
     /// Build a new `Subscribe` effect.
     pub fn new(branch: BranchReference<'a>, query: ConceptQuery) -> Self {
-        Self { branch, query }
+        Self {
+            branch,
+            query,
+            client: None,
+        }
+    }
+
+    /// Tag the subscriber with the client it serves, so the owner
+    /// can prune it once that client is no longer alive.
+    pub fn client(mut self, client: impl Into<String>) -> Self {
+        self.client = Some(client.into());
+        self
     }
 
     /// Resolve the branch (opening it if needed), attach a
@@ -32,7 +46,7 @@ impl<'a> Subscribe<'a> {
         Env: LoadProvider + BranchOpenProvider + SelectProvider,
     {
         let session = self.branch.acquire(env).await?;
-        let subscriber = session.subscribe(self.query)?;
+        let subscriber = session.subscribe(self.query, self.client)?;
         session
             .subscription(subscriber.hash.clone())
             .poll()

--- a/rust/dialog-reactor/src/subscription/reference.rs
+++ b/rust/dialog-reactor/src/subscription/reference.rs
@@ -17,7 +17,7 @@ use crate::BranchState;
 use crate::env::SelectProvider;
 use crate::{Conclusion, Frame};
 
-use super::state::{QueryHash, Status};
+use super::state::QueryHash;
 
 /// Names a subscription within a branch. Built from
 /// [`BranchSession::subscription`].
@@ -79,22 +79,17 @@ impl SubscriptionPoll<'_> {
         Self: 'a,
     {
         // Snapshot what we need out of the map lock: the engine
-        // handle, the projection terms, and whether any subscriber is
-        // Pending (needs a full snapshot rather than a delta).
-        let (slot, terms, any_pending) = {
+        // handle and the projection terms. Whether a subscriber needs
+        // a full snapshot is decided at fan-out time (under the lock),
+        // NOT here: a subscriber can attach while the engine poll below
+        // awaits, so a flag captured now would miss it and leave it
+        // hung on `loading` forever (the stuck-spinner race).
+        let (slot, terms) = {
             let subs = self.state.subscriptions().lock();
             let Some(subscription) = subs.get(&self.hash) else {
                 return;
             };
-            let any_pending = subscription
-                .subscribers
-                .iter()
-                .any(|s| s.status == Status::Pending);
-            (
-                Arc::clone(&subscription.engine),
-                subscription.terms.clone(),
-                any_pending,
-            )
+            (Arc::clone(&subscription.engine), subscription.terms.clone())
         };
 
         // Take the engine out of its slot so the poll runs without a
@@ -135,19 +130,19 @@ impl SubscriptionPoll<'_> {
         // tree) still re-evaluates on this poll — no re-seed here.
         let poll_result = engine.poll(env).await;
 
-        // Snapshot for Pending subscribers — projected from the
-        // engine's retained results, consistent with the poll we just
-        // ran. Built only when some subscriber needs it.
-        let snapshot_bytes = if any_pending {
-            let conclusions: Vec<Conclusion> = engine
-                .results()
-                .iter()
-                .map(|c| Conclusion::project(c, &terms))
-                .collect();
-            serialize(&Frame::Snapshot { conclusions })
-        } else {
-            None
-        };
+        // Project the engine's retained results while we still hold the
+        // engine — the snapshot any Pending subscriber will need. Kept as
+        // projected conclusions (not yet serialized) so the fan-out below
+        // can decide, under the map lock, whether a snapshot is actually
+        // needed. Serializing eagerly here would waste work on the common
+        // no-Pending poll; deferring it to fan-out is what lets us serve a
+        // subscriber that attached during the poll `await` above without
+        // paying for a snapshot when there is none.
+        let snapshot_conclusions: Vec<Conclusion> = engine
+            .results()
+            .iter()
+            .map(|c| Conclusion::project(c, &terms))
+            .collect();
 
         // Put the engine back before handling the poll outcome so the
         // slot is never left empty on an early return.
@@ -185,35 +180,17 @@ impl SubscriptionPoll<'_> {
             })
         });
 
-        // Fan out under the map lock.
+        // Fan out under the map lock. The delivery decision (snapshot to
+        // Pending, delta to Established) lives on `Subscription::deliver`
+        // so it re-checks the subscriber set HERE, under the lock, rather
+        // than off a flag captured before the poll `await` — a subscriber
+        // that attached during the poll is served its first snapshot now
+        // instead of hanging until some later write schedules another poll.
         let mut subs = self.state.subscriptions().lock();
         let Some(subscription) = subs.get_mut(&self.hash) else {
             return;
         };
-
-        subscription.subscribers.retain_mut(|subscriber| {
-            let bytes = match subscriber.status {
-                // A fresh (or reconnected) subscriber needs the full
-                // set, not a delta it has no base for.
-                Status::Pending => snapshot_bytes.clone(),
-                // An established subscriber only hears about changes.
-                Status::Established => delta_bytes.clone(),
-            };
-            let Some(bytes) = bytes else {
-                // Nothing to send this subscriber this round (an
-                // Established subscriber on a no-change poll, or a
-                // frame that failed to serialize) — keep it.
-                return true;
-            };
-            match subscriber.sender.send(bytes) {
-                Ok(()) => {
-                    subscriber.status = Status::Established;
-                    true
-                }
-                Err(_) => false,
-            }
-        });
-
+        subscription.deliver(&snapshot_conclusions, delta_bytes.as_ref());
         if subscription.subscribers.is_empty() {
             subs.remove(&self.hash);
         }

--- a/rust/dialog-reactor/src/subscription/state.rs
+++ b/rust/dialog-reactor/src/subscription/state.rs
@@ -16,8 +16,9 @@ use dialog_query::Parameters;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::Query;
+use crate::{Conclusion, Frame, Query};
 use bytes::Bytes;
+use dialog_common::log;
 
 /// The dialog engine backing one reactor subscription.
 ///
@@ -123,4 +124,208 @@ pub struct Subscription {
     pub terms: Parameters,
     /// Open downstream channels with their delivery status.
     pub subscribers: Vec<SubscriberSession>,
+}
+
+impl Subscription {
+    /// Fan a poll's result out to every subscriber, advancing each to
+    /// [`Established`](Status::Established) once served.
+    ///
+    /// - A [`Pending`](Status::Pending) subscriber gets a full
+    ///   [`Frame::Snapshot`] built from `snapshot_conclusions` (the
+    ///   engine's retained results, projected to wire rows). This is the
+    ///   race-safe half: the Pending set is read HERE, at delivery, not
+    ///   from a flag captured before the poll's `await` — so a subscriber
+    ///   that attached while the poll ran is still served its first frame
+    ///   now rather than left hung on `loading` until an unrelated write
+    ///   happens to schedule another poll (which, on a quiescent branch,
+    ///   may never come).
+    /// - An [`Established`](Status::Established) subscriber gets
+    ///   `delta_bytes` when the poll reported a non-empty change, and
+    ///   nothing otherwise.
+    ///
+    /// The snapshot is serialized lazily and at most once, only when a
+    /// Pending subscriber is actually present. A subscriber whose channel
+    /// has closed is dropped.
+    pub fn deliver(&mut self, snapshot_conclusions: &[Conclusion], delta_bytes: Option<&Bytes>) {
+        fan_out(&mut self.subscribers, snapshot_conclusions, delta_bytes);
+    }
+}
+
+/// Deliver a poll's result to a subscriber set (see
+/// [`Subscription::deliver`]). Split out from the `Subscription` method so
+/// the delivery logic — the race-sensitive part — is exercised directly by
+/// tests without fabricating a dialog engine.
+fn fan_out(
+    subscribers: &mut Vec<SubscriberSession>,
+    snapshot_conclusions: &[Conclusion],
+    delta_bytes: Option<&Bytes>,
+) {
+    // Memoized snapshot bytes: `None` = not built yet, `Some(inner)` =
+    // built (`inner` may itself be `None` if serialization failed).
+    let mut snapshot_bytes: Option<Option<Bytes>> = None;
+
+    subscribers.retain_mut(|subscriber| {
+        let bytes = match subscriber.status {
+            Status::Pending => snapshot_bytes
+                .get_or_insert_with(|| serialize_snapshot(snapshot_conclusions.to_vec()))
+                .clone(),
+            Status::Established => delta_bytes.cloned(),
+        };
+        let Some(bytes) = bytes else {
+            // Nothing to send this subscriber this round (an Established
+            // subscriber on a no-change poll, or a frame that failed to
+            // serialize) — keep it.
+            return true;
+        };
+        match subscriber.sender.send(bytes) {
+            Ok(()) => {
+                subscriber.status = Status::Established;
+                true
+            }
+            Err(_) => false,
+        }
+    });
+}
+
+/// Serialize a [`Frame::Snapshot`] to wire bytes, logging and dropping on
+/// failure (a serialization error is not worth killing the fan-out).
+fn serialize_snapshot(conclusions: Vec<Conclusion>) -> Option<Bytes> {
+    match serde_json::to_vec(&Frame::Snapshot { conclusions }) {
+        Ok(bytes) => Some(Bytes::from(bytes)),
+        Err(err) => {
+            log!("[reactor] failed to serialize snapshot frame: {err}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(missing_docs)]
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use std::collections::BTreeMap;
+
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    use super::*;
+
+    /// One row of a snapshot.
+    fn conclusion(this: &str) -> Conclusion {
+        Conclusion {
+            this: this.to_owned(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    /// A subscriber in the given delivery state, paired with its receiver.
+    fn subscriber(status: Status) -> (SubscriberSession, UnboundedReceiver<Bytes>) {
+        let (sender, receiver) = unbounded_channel();
+        (SubscriberSession { sender, status }, receiver)
+    }
+
+    /// Decode a delivered frame off a receiver.
+    fn recv(receiver: &mut UnboundedReceiver<Bytes>) -> Option<Frame> {
+        receiver
+            .try_recv()
+            .ok()
+            .map(|bytes| serde_json::from_slice(&bytes).expect("frame decodes"))
+    }
+
+    /// A Pending subscriber must receive its snapshot on the next fan-out —
+    /// even when it is the ONLY pending subscriber and every other is
+    /// Established. The regression: the snapshot used to be built off a flag
+    /// captured before the engine poll, so a subscriber that attached during
+    /// the poll (or after that flag was read) was silently kept unserved and
+    /// its `<tonk-display>` hung on `loading` forever. Delivery now decides
+    /// per-subscriber at fan-out, so this can't happen.
+    #[dialog_common::test]
+    fn it_snapshots_a_pending_subscriber_even_beside_established_ones() {
+        let (established, mut established_rx) = subscriber(Status::Established);
+        let (pending, mut pending_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![established, pending];
+
+        // A no-change poll: no delta for the Established subscriber, but the
+        // Pending one still needs its first snapshot.
+        fan_out(&mut subscribers, &[conclusion("id:one")], None);
+
+        // The Pending subscriber got a Snapshot and is now Established.
+        match recv(&mut pending_rx) {
+            Some(Frame::Snapshot { conclusions }) => {
+                assert_eq!(conclusions, vec![conclusion("id:one")]);
+            }
+            other => panic!("pending subscriber must get a Snapshot, got {other:?}"),
+        }
+        assert_eq!(subscribers[1].status, Status::Established);
+
+        // The Established subscriber got nothing on a no-change poll.
+        assert!(
+            recv(&mut established_rx).is_none(),
+            "established subscriber gets no frame when the delta is empty"
+        );
+    }
+
+    /// The snapshot is serialized at most once regardless of how many
+    /// Pending subscribers there are, and every one of them receives it.
+    #[dialog_common::test]
+    fn it_serves_every_pending_subscriber_one_snapshot() {
+        let (a, mut a_rx) = subscriber(Status::Pending);
+        let (b, mut b_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![a, b];
+
+        fan_out(&mut subscribers, &[conclusion("id:x")], None);
+
+        for rx in [&mut a_rx, &mut b_rx] {
+            assert!(
+                matches!(recv(rx), Some(Frame::Snapshot { .. })),
+                "each pending subscriber receives the snapshot"
+            );
+        }
+        assert!(subscribers.iter().all(|s| s.status == Status::Established));
+    }
+
+    /// An Established subscriber receives a non-empty delta; a Pending one
+    /// added in the same round still gets a full snapshot, not the delta.
+    #[dialog_common::test]
+    fn it_sends_deltas_to_established_and_snapshots_to_pending() {
+        let (established, mut established_rx) = subscriber(Status::Established);
+        let (pending, mut pending_rx) = subscriber(Status::Pending);
+        let mut subscribers = vec![established, pending];
+
+        let delta = Bytes::from(
+            serde_json::to_vec(&Frame::Delta {
+                asserted: vec![],
+                retracted: vec![],
+            })
+            .unwrap(),
+        );
+        fan_out(&mut subscribers, &[conclusion("id:one")], Some(&delta));
+
+        assert!(
+            matches!(recv(&mut established_rx), Some(Frame::Delta { .. })),
+            "established subscriber gets the delta"
+        );
+        assert!(
+            matches!(recv(&mut pending_rx), Some(Frame::Snapshot { .. })),
+            "pending subscriber gets a snapshot, not the delta"
+        );
+    }
+
+    /// A subscriber whose receiver has been dropped is pruned from the set.
+    #[dialog_common::test]
+    fn it_drops_a_subscriber_whose_channel_closed() {
+        let (live, mut live_rx) = subscriber(Status::Pending);
+        let (dead, dead_rx) = subscriber(Status::Pending);
+        drop(dead_rx);
+        let mut subscribers = vec![live, dead];
+
+        fan_out(&mut subscribers, &[conclusion("id:one")], None);
+
+        assert_eq!(subscribers.len(), 1, "the closed subscriber is pruned");
+        assert!(matches!(recv(&mut live_rx), Some(Frame::Snapshot { .. })));
+    }
 }

--- a/rust/dialog-reactor/src/subscription/state.rs
+++ b/rust/dialog-reactor/src/subscription/state.rs
@@ -99,6 +99,13 @@ pub struct SubscriberSession {
     pub sender: UnboundedSender<Bytes>,
     /// Whether the subscriber has received its initial snapshot.
     pub status: Status,
+    /// The client (e.g. a service-worker client id) this subscriber
+    /// serves, when known. Lets the owner reconcile subscribers
+    /// against its live-client set and drop the dead ones — channel
+    /// closure alone can't be relied on: a client that vanishes
+    /// without cancelling its response stream leaves the receiver
+    /// alive, so the send-failure prune never fires.
+    pub client: Option<String>,
 }
 
 /// One subscription, shared by every subscriber that opened the
@@ -225,7 +232,14 @@ mod tests {
     /// A subscriber in the given delivery state, paired with its receiver.
     fn subscriber(status: Status) -> (SubscriberSession, UnboundedReceiver<Bytes>) {
         let (sender, receiver) = unbounded_channel();
-        (SubscriberSession { sender, status }, receiver)
+        (
+            SubscriberSession {
+                sender,
+                status,
+                client: None,
+            },
+            receiver,
+        )
     }
 
     /// Decode a delivered frame off a receiver.

--- a/rust/dialog-reactor/src/subscription/state.rs
+++ b/rust/dialog-reactor/src/subscription/state.rs
@@ -99,13 +99,6 @@ pub struct SubscriberSession {
     pub sender: UnboundedSender<Bytes>,
     /// Whether the subscriber has received its initial snapshot.
     pub status: Status,
-    /// The client (e.g. a service-worker client id) this subscriber
-    /// serves, when known. Lets the owner reconcile subscribers
-    /// against its live-client set and drop the dead ones — channel
-    /// closure alone can't be relied on: a client that vanishes
-    /// without cancelling its response stream leaves the receiver
-    /// alive, so the send-failure prune never fires.
-    pub client: Option<String>,
 }
 
 /// One subscription, shared by every subscriber that opened the
@@ -232,14 +225,7 @@ mod tests {
     /// A subscriber in the given delivery state, paired with its receiver.
     fn subscriber(status: Status) -> (SubscriberSession, UnboundedReceiver<Bytes>) {
         let (sender, receiver) = unbounded_channel();
-        (
-            SubscriberSession {
-                sender,
-                status,
-                client: None,
-            },
-            receiver,
-        )
+        (SubscriberSession { sender, status }, receiver)
     }
 
     /// Decode a delivered frame off a receiver.

--- a/rust/tonk-host/Cargo.toml
+++ b/rust/tonk-host/Cargo.toml
@@ -44,6 +44,7 @@ web-sys = { workspace = true, features = [
   "MutationObserverInit",
   "MutationRecord",
   "Navigator",
+  "Url",
   "Node",
   "ReadableStream",
   "ReadableStreamDefaultReader",

--- a/rust/tonk-host/src/navigate.rs
+++ b/rust/tonk-host/src/navigate.rs
@@ -100,6 +100,20 @@ pub fn navigate_to(href: &str) {
     let Some(win) = window() else {
         return;
     };
+
+    // Navigating to where we already are is a no-op, not a navigation. Without
+    // this guard every such call pushed a DUPLICATE history entry and fired a
+    // `popstate` that re-routed the site and re-stamped it for no change — and
+    // the duplicates then had to be walked back through one by one on Back.
+    // Resolved against the current document so a relative `href` compares
+    // correctly with `location`.
+    if let Ok(current) = win.location().href()
+        && let Ok(target) = web_sys::Url::new_with_base(href, &current)
+        && target.href() == current
+    {
+        return;
+    }
+
     let pushed = win
         .history()
         .ok()

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -906,13 +906,20 @@ async fn fetch_tonk_code_bundles() -> Vec<(String, String)> {
         if files.iter().any(|(n, _)| n == &name) {
             continue;
         }
-        // `reload` cache mode: unlike the guest-manifest assets, the tonk-code
-        // bundles are served under STABLE (unhashed) names, so the SW's
-        // stale-while-revalidate shell cache would otherwise serve a previous
-        // build's editor — a content change must reach the guest. `reload`
-        // bypasses the cache for the request but still writes the response back,
-        // so a later offline load is still served.
-        let src = match fetch_text_reload(&format!("/tonk-code/{name}")).await {
+        // Cache-first, like every other guest-boot asset. This used to
+        // `reload` (force a network fetch, bypassing the cache) because the
+        // two entry points have STABLE names and a rebuilt editor must reach
+        // the guest. But forcing the network made a cached load on a slow
+        // connection pay the full download every time — the editor graph is
+        // ~3 MB, so a 3G reload took seconds to fetch bytes it already had
+        // cached, while an offline reload (which can't reach the network) was
+        // instant. The SW's stale-while-revalidate serves the cached copy
+        // immediately and refreshes in the background, so a content change
+        // reaches the guest on the NEXT load — acceptable: the chunks are
+        // content-hashed (immutable), only the two entry points can change,
+        // and dev hot-reload already does a full page reload on a real code
+        // change.
+        let src = match fetch_text(&format!("/tonk-code/{name}")).await {
             Ok(src) => src,
             Err(e) => {
                 web_sys::console::warn_1(&JsValue::from_str(&format!(
@@ -1003,24 +1010,6 @@ async fn fetch_array_buffer(url: &str) -> Result<JsValue, String> {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// Fetch `url` as text with `cache: "reload"` — bypass the cache for the request
-/// but still update it. For stable-named assets (the tonk-code bundles) whose
-/// content changes across builds, so a stale shell-cache copy isn't served.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn fetch_text_reload(url: &str) -> Result<String, String> {
-    use web_sys::{RequestCache, RequestInit};
-    let win = window().ok_or("no window")?;
-    let init = RequestInit::new();
-    init.set_cache(RequestCache::Reload);
-    let resp_value = wasm_bindgen_futures::JsFuture::from(win.fetch_with_str_and_init(url, &init))
-        .await
-        .map_err(|e| format!("fetch {url}: {e:?}"))?;
-    let resp: web_sys::Response = resp_value
-        .dyn_into()
-        .map_err(|_| format!("fetch {url}: not a Response"))?;
-    resp_text(resp).await
-}
-
 async fn fetch(url: &str) -> Result<web_sys::Response, String> {
     let win = window().ok_or("no window")?;
     // Default cache mode (no override): these URLs are content-hashed (named

--- a/rust/tonk-portal/src/element.rs
+++ b/rust/tonk-portal/src/element.rs
@@ -94,8 +94,15 @@ impl CustomElement for TonkPortal {
                 // element a tick later — synchronous destruction of a live
                 // guest is the pattern the browser process crashes under
                 // (see `site::teardown`).
+                //
+                // Unload via the frame's own `location.replace()`, never by
+                // setting `src`: setting `src` NAVIGATES the frame, and a
+                // frame navigation appends an entry to the joint session
+                // history, so each teardown left an extra Back step behind.
                 let _ = iframe.remove_attribute("srcdoc");
-                let _ = iframe.set_attribute("src", "about:blank");
+                if let Some(frame_window) = iframe.content_window() {
+                    let _ = frame_window.location().replace("about:blank");
+                }
                 wasm_bindgen_futures::spawn_local(async move {
                     let promise = js_sys::Promise::new(&mut |resolve, _reject| {
                         if let Some(win) = web_sys::window() {

--- a/rust/tonk-portal/src/element.rs
+++ b/rust/tonk-portal/src/element.rs
@@ -274,10 +274,18 @@ mod tests {
         );
     }
 
-    /// Teardown is TWO-PHASE: on disconnect the guest realm is pointed at
-    /// `about:blank` immediately (comms already severed), and the element
-    /// itself is removed a tick later — synchronous destruction of a live
-    /// guest is the pattern the browser process crashed under.
+    /// Teardown is TWO-PHASE: on disconnect the guest realm is unloaded
+    /// immediately (comms already severed), and the element itself is removed
+    /// a tick later — synchronous destruction of a live guest is the pattern
+    /// the browser process crashed under.
+    ///
+    /// Phase one asserts the guest CONTENT is gone, not the mechanism that
+    /// removed it. The unload goes through the frame's own
+    /// `location.replace()` rather than `iframe.src = "about:blank"`, because
+    /// setting `src` navigates the frame and a frame navigation appends an
+    /// entry to the joint session history (Back then needed an extra press per
+    /// teardown). `location.replace()` leaves the `src` attribute untouched,
+    /// so asserting on it would only pin the old mechanism in place.
     #[dialog_common::test]
     async fn it_removes_the_iframe_on_disconnect() {
         let host = mount(Some("<p>hi</p>"));
@@ -285,12 +293,20 @@ mod tests {
 
         host.remove();
 
-        // Phase one, immediate: the frame is unloading, not yet detached.
+        // Phase one, immediate: the frame is unloading, not yet detached — and
+        // it must NOT have been navigated via its `src` attribute, which is
+        // what used to grow the history.
         if let Some(iframe) = host.query_selector("iframe").unwrap() {
             assert_eq!(
-                iframe.get_attribute("src").as_deref(),
-                Some("about:blank"),
+                iframe.get_attribute("srcdoc"),
+                None,
                 "disconnect must unload the guest realm first",
+            );
+            assert_eq!(
+                iframe.get_attribute("src"),
+                None,
+                "the unload must not navigate the frame via `src` — that appends \
+                 a joint-session-history entry",
             );
         }
 

--- a/rust/tonk-portal/src/site.rs
+++ b/rust/tonk-portal/src/site.rs
@@ -119,11 +119,18 @@ impl CustomElement for TonkSite {
 /// Tear down the portal iframe held by `cell`, if any.
 ///
 /// TWO-PHASE: sever the comms (aborts + port closes via `clear_subs`),
-/// point the frame at `about:blank` so the guest realm unloads on its own
-/// schedule, and only remove the element a tick later. Synchronously
-/// destroying a live nested guest (running wasm, brokered ports, its own
-/// nested frames) from inside a render pass is the pattern the browser
-/// process has crashed under — give the unload a turn to settle first.
+/// unload the guest realm so it tears down on its own schedule, and only
+/// remove the element a tick later. Synchronously destroying a live nested
+/// guest (running wasm, brokered ports, its own nested frames) from inside a
+/// render pass is the pattern the browser process has crashed under — give
+/// the unload a turn to settle first.
+///
+/// The unload goes through the frame's own `location.replace()`, NOT through
+/// `iframe.src = "about:blank"`. Setting `src` *navigates* the frame, and a
+/// frame navigation appends an entry to the JOINT session history — so every
+/// teardown left a Back step behind, and the user had to press Back several
+/// times to leave a page they had navigated to once. `location.replace()`
+/// unloads the realm while replacing the current entry rather than adding one.
 fn teardown(cell: &StateCell) {
     if let Some(state) = cell.borrow_mut().take() {
         let mut s = state.borrow_mut();
@@ -132,7 +139,12 @@ fn teardown(cell: &StateCell) {
         if let Some(iframe) = s.iframe.take() {
             crate::bridge::unregister_portal(&iframe);
             let _ = iframe.remove_attribute("srcdoc");
-            let _ = iframe.set_attribute("src", "about:blank");
+            // Replace (don't push) the frame's entry. If the content window is
+            // unreachable (already detached), the frame is on its way out
+            // anyway and the element removal below finishes the job.
+            if let Some(frame_window) = iframe.content_window() {
+                let _ = frame_window.location().replace("about:blank");
+            }
             spawn_local(async move {
                 let promise = js_sys::Promise::new(&mut |resolve, _reject| {
                     if let Some(win) = window() {

--- a/rust/tonk-portal/src/site.rs
+++ b/rust/tonk-portal/src/site.rs
@@ -93,12 +93,24 @@ impl CustomElement for TonkSite {
         // changes (e.g. `/space/{id}/inspector` → `/space/{id}` removes it), and
         // a template re-stamp can rewrite `with`/`allow`. The `<tonk-site>`
         // re-asserts `tonk:load` against the same site entity so the live
-        // subscription re-renders. The initial values are handled by
-        // `connected_callback`, so skip the first-set callback — NOTE the
-        // `custom-elements` JS shim coerces a null `oldValue` to `""`, so a
-        // first set arrives as `Some("")`, never `None`.
+        // subscription re-renders.
+        //
+        // `with`/`allow` skip the first-set callback (the initial values are
+        // handled by `connected_callback`) — NOTE the `custom-elements` JS shim
+        // coerces a null `oldValue` to `""`, so a first set arrives as
+        // `Some("")`, never `None`. `path` must NOT apply that skip: an absent
+        // path is a routed state (`/`), so the empty → value transition IS a
+        // navigation (the bare space route gaining a `{rest}` sub-path), not
+        // mount noise. Pre-connect callbacks are already no-ops inside
+        // `resolve_and_render` (`is_connected` gate), and a mount-time double
+        // resolve is absorbed by the same-route iframe reuse.
         let first_set = old.as_deref().is_none_or(str::is_empty);
-        if matches!(name.as_str(), "path" | "with" | "allow") && !first_set && old != new {
+        let re_route = match name.as_str() {
+            "path" => old != new,
+            "with" | "allow" => !first_set && old != new,
+            _ => false,
+        };
+        if re_route {
             resolve_and_render(this, self.inner.clone());
         }
     }

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -85,23 +85,17 @@ self.registration.addEventListener?.("updatefound", async () => {
     }
 });
 
-// Connectivity transitions, observed by the worker itself. An offline
-// page stops polling, so no fetch would ever wake the Rust side to
-// stamp `sync:offline` — the SW's own `offline` event is the reliable
-// signal; `online` runs a drain so statuses reconcile the moment
-// connectivity returns. The wasm boot (`activateWorker`) can outlive a
-// flapping transition, so dispatch on the CURRENT `navigator.onLine`,
-// not on which event happened to fire.
+// Connectivity transitions. The Rust side reads `navigator.onLine` itself
+// (reliable in the SW scope) and reconciles — an offline reading stamps
+// `sync:offline`, an online one runs a drain. We only need to POKE it on a
+// transition; the decision is the worker's. The SW's own `offline`/`online`
+// events fire the poke, and so does a `{type:"connectivity"}` message from the
+// active page (belt-and-suspenders — the page's events are the ones guaranteed
+// to fire, and it forwards them here).
 const onConnectivityChange = async () => {
     try {
         const worker = await activateWorker();
-        if (navigator.onLine) {
-            log("Online — reconciling");
-            await worker.ononline?.();
-        } else {
-            log("Offline — stamping sync:offline");
-            await worker.onoffline?.();
-        }
+        await worker.onconnectivity?.();
     } catch (err) {
         log("Failed to handle connectivity change:", err);
     }
@@ -137,46 +131,126 @@ async function serveNavigation(event) {
     const cache = await caches.open(SHELL_CACHE);
     const cached = await cache.match("/");
 
-    const revalidate = (async () => {
+    // Background refresh. Only ever mutates the cache with a fresh shell
+    // ALREADY IN HAND — never deletes before it can replace, so an offline
+    // or failed fetch leaves the cached shell untouched (the app must stay
+    // loadable offline). On a build change it replaces `/` and prunes the
+    // OLD build's hashed assets so the shell and its assets never cross
+    // builds; `/` itself is rewritten in the same pass, so the cache is
+    // never without a shell.
+    const revalidate = async () => {
+        let fresh;
         try {
-            const fresh = await fetch("/");
-            if (!fresh.ok || fresh.type === "opaque") return;
-            // Compare against the copy we served to detect a build change.
-            const freshText = await fresh.clone().text();
-            const cachedText = cached ? await cached.clone().text() : null;
-            if (cachedText !== null && cachedText !== freshText) {
-                // New build: flush the whole shell cache so the old
-                // build's hashed assets can't mix with the new shell,
-                // then seed the fresh shell into the clean cache.
-                await caches.delete(SHELL_CACHE);
-                const clean = await caches.open(SHELL_CACHE);
-                await clean.put("/", fresh);
-            } else {
-                await cache.put("/", fresh);
-            }
+            fresh = await fetch("/");
         } catch {
-            // Offline / fetch failed — keep the cached shell as-is.
+            return; // offline / network error — keep what we have
         }
-    })();
+        if (!fresh.ok || fresh.type === "opaque") return;
+
+        const freshText = await fresh.clone().text();
+        const cachedText = cached ? await cached.clone().text() : null;
+
+        if (cachedText !== null && cachedText !== freshText) {
+            // New build. Prune every OTHER entry (the previous build's
+            // hashed assets) but keep `/` continuously populated by
+            // overwriting it with the fresh shell in the same cache.
+            const keys = await cache.keys();
+            await Promise.all(
+                keys
+                    .filter((req) => new URL(req.url).pathname !== "/")
+                    .map((req) => cache.delete(req)),
+            );
+            await cache.put("/", fresh);
+        } else {
+            await cache.put("/", fresh);
+        }
+    };
 
     if (cached) {
-        // Don't block the response on the refresh, but keep the worker
-        // alive until it settles so the cache updates for next time.
-        event?.waitUntil?.(revalidate);
+        // Serve the cached shell immediately; refresh in the background.
+        event?.waitUntil?.(revalidate());
         return cached;
     }
-    // Cold cache (first visit, or just flushed): the refresh IS the
-    // response — wait for it and serve the fetched shell.
-    await revalidate;
-    return (await cache.match("/")) || fetch("/");
+    // Cold cache: no shell to serve yet. Fetch it (this is the only path
+    // that can hard-fail offline, and only when nothing was ever cached —
+    // `oninstall` precaches `/`, so this is the rare first-visit race).
+    try {
+        const fresh = await fetch("/");
+        if (fresh.ok && fresh.type !== "opaque") {
+            cache.put("/", fresh.clone()).catch(() => {});
+        }
+        return fresh;
+    } catch {
+        // Offline with an empty cache — nothing we can do but surface it.
+        return Response.error();
+    }
+}
+
+// Whether a request can be served from the shell cache by the JS shim
+// WITHOUT booting the wasm worker. Same-origin GETs that aren't the data
+// plane (`/api/*`) and don't ask for fresh content. Mirrors `cache.rs`'s
+// `is_cacheable`, but lives here so a cached asset is served straight from
+// the Cache API — the wasm worker's own bundle can be multiple MB, and
+// booting it to serve a static file made every subresource wait on that
+// download (fatal on 3G). The Rust worker still owns the SAME cache for
+// misses and for guest-iframe path rewrites.
+function isShellCacheable(request, path) {
+    if (request.method !== "GET") return false;
+    if (request.mode === "navigate") return false;
+    if (path.startsWith("/api/")) return false;
+    // A guest-iframe subresource is rewritten to a branch-scoped `/api/...`
+    // path by the Rust worker; those must not be served as top-level assets.
+    // They carry a client id the shim can't see, so exclude by the one
+    // shared-asset exception the worker passes through unchanged.
+    const cache = request.cache;
+    if (cache === "no-store" || cache === "reload" || cache === "no-cache") {
+        return false;
+    }
+    return true;
+}
+
+// Serve a static asset cache-first, revalidating in the background. Returns
+// the cached response immediately when present (no network, no worker boot —
+// instant on any connection); on a miss, falls through to the wasm worker,
+// which fetches, caches, and applies any guest rewrite.
+async function serveAsset(event) {
+    const cache = await caches.open(SHELL_CACHE);
+    // Match ONLY what the Rust worker itself cached (it writes the top-level
+    // resource graph under the request URL). A guest-iframe subresource is
+    // rewritten to a branch-scoped `/api/...` path by the worker and cached
+    // under THAT key, so it can never match here — no cross-serving a guest
+    // asset from the top-level cache.
+    const cached = await cache.match(event.request);
+    if (cached) {
+        // Background refresh for next time; never blocks this response.
+        event.waitUntil?.(
+            (async () => {
+                try {
+                    const fresh = await fetch(event.request);
+                    if (fresh.ok && fresh.type !== "opaque") {
+                        await cache.put(event.request, fresh.clone());
+                    }
+                } catch {
+                    // offline / blip — keep the cached copy
+                }
+            })(),
+        );
+        return cached;
+    }
+    // Cache miss: let the wasm worker fetch + cache (it owns the guest
+    // rewrite and the resource cache write). This is the only path that
+    // pays the worker-boot cost, and only for assets not yet cached.
+    return (await activateWorker()).onfetch(event);
 }
 
 // Route navigations straight to the cached shell (bypassing the
 // Rust worker boot, so TTFB doesn't wait on dialog-repository /
-// axum / IndexedDB init); everything else — `/api/*` and static
-// assets — goes through the Rust worker, which owns the guest
-// rewrite and the resource cache.
+// axum / IndexedDB init); cached static assets are served from the
+// Cache API directly (also bypassing the boot); everything else —
+// `/api/*` and cache-missed assets — goes through the Rust worker,
+// which owns the guest rewrite and the resource cache.
 self.onfetch = event => {
+    const path = new URL(event.request.url).pathname;
     if (event.request.mode === "navigate") {
         // `/api/*` navigations are real data-plane requests, not SPA
         // routes — a user visiting e.g. `/api/migrate/...` directly, or
@@ -185,11 +259,15 @@ self.onfetch = event => {
         // instead of handing back the shell HTML (which would boot the
         // SPA and 404 in the client router). Everything else is a
         // navigation to an app route: serve the cached shell.
-        const path = new URL(event.request.url).pathname;
         if (!path.startsWith("/api/")) {
             event.respondWith(serveNavigation(event));
             return;
         }
+    } else if (isShellCacheable(event.request, path)) {
+        // A cached static asset is served WITHOUT booting the wasm worker,
+        // so a slow connection never waits on the worker's own bundle.
+        event.respondWith(serveAsset(event));
+        return;
     }
     event.respondWith(
         (async () => (await activateWorker()).onfetch(event))(),
@@ -213,6 +291,22 @@ self.onfetch = event => {
 self.onmessage = event => {
     if (event.data && event.data.type === "claim") {
         event.waitUntil?.(self.clients.claim());
+        return;
+    }
+    // Connectivity nudge from the active page on an `online`/`offline`
+    // transition. The worker re-reads `navigator.onLine` itself and reconciles;
+    // this just wakes it so the overlay updates without waiting for a fetch.
+    if (event.data && event.data.type === "connectivity") {
+        event.waitUntil?.(
+            (async () => {
+                try {
+                    const worker = await activateWorker();
+                    await worker.onconnectivity?.();
+                } catch (err) {
+                    log("connectivity dispatch failed:", err);
+                }
+            })(),
+        );
         return;
     }
     event.waitUntil?.(

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -138,6 +138,16 @@ async function serveNavigation(event) {
     // OLD build's hashed assets so the shell and its assets never cross
     // builds; `/` itself is rewritten in the same pass, so the cache is
     // never without a shell.
+    // Snapshot the cached shell's body NOW, while we still own it. Below we
+    // hand `cached` itself to the browser, which consumes its body to render
+    // the page — and a Response whose body is being consumed can no longer be
+    // cloned. Cloning inside `revalidate` (which runs concurrently under
+    // `waitUntil`) therefore raced the page and threw
+    // "Response body is already used", so the `cache.put` below it never ran:
+    // the shell cache was never refreshed, and every navigation paid a `/`
+    // fetch whose result was thrown away on the exception.
+    const cachedTextPromise = cached ? cached.clone().text() : null;
+
     const revalidate = async () => {
         let fresh;
         try {
@@ -148,7 +158,7 @@ async function serveNavigation(event) {
         if (!fresh.ok || fresh.type === "opaque") return;
 
         const freshText = await fresh.clone().text();
-        const cachedText = cached ? await cached.clone().text() : null;
+        const cachedText = cachedTextPromise ? await cachedTextPromise : null;
 
         if (cachedText !== null && cachedText !== freshText) {
             // New build. Prune every OTHER entry (the previous build's

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -118,20 +118,57 @@ self.addEventListener("online", onConnectivityChange);
 //
 // Keyed on `/`, where the origin serves the shell HTML (200).
 // `/index.html` is a 307 redirect to `/`, so it can't be cached
-// or served as the shell. The shell is seeded by `oninstall` and
-// re-seeded on every new worker install, so a deploy refreshes
-// it. The rare miss (first visit racing the install, or a purged
-// cache) fetches it once.
-async function serveNavigation() {
+// or served as the shell.
+//
+// Stale-while-revalidate: serve the cached shell IMMEDIATELY (a
+// navigation never waits on the network, so a repeat load on a slow
+// or flaky connection is instant and works offline), and in the
+// background fetch `/` to refresh the cached copy for NEXT time. But
+// a plain SWR on the shell alone poisons the cache: the shell names
+// content-hashed assets, so refreshing `/` to a newer build leaves
+// the cache holding the new shell beside the OLD build's assets (and
+// missing the new ones) — exactly the mix that makes a later load
+// reference assets that aren't cached and hard-fail. So when the
+// refreshed shell DIFFERS from the cached one (a new build), drop
+// every cached asset: the new shell then re-populates its own assets
+// on the next load, and the two never cross builds. The current
+// load keeps serving the coherent build it already had.
+async function serveNavigation(event) {
     const cache = await caches.open(SHELL_CACHE);
     const cached = await cache.match("/");
-    if (cached) return cached;
 
-    const response = await fetch("/");
-    if (response.ok && response.type !== "opaque") {
-        cache.put("/", response.clone()).catch(() => {});
+    const revalidate = (async () => {
+        try {
+            const fresh = await fetch("/");
+            if (!fresh.ok || fresh.type === "opaque") return;
+            // Compare against the copy we served to detect a build change.
+            const freshText = await fresh.clone().text();
+            const cachedText = cached ? await cached.clone().text() : null;
+            if (cachedText !== null && cachedText !== freshText) {
+                // New build: flush the whole shell cache so the old
+                // build's hashed assets can't mix with the new shell,
+                // then seed the fresh shell into the clean cache.
+                await caches.delete(SHELL_CACHE);
+                const clean = await caches.open(SHELL_CACHE);
+                await clean.put("/", fresh);
+            } else {
+                await cache.put("/", fresh);
+            }
+        } catch {
+            // Offline / fetch failed — keep the cached shell as-is.
+        }
+    })();
+
+    if (cached) {
+        // Don't block the response on the refresh, but keep the worker
+        // alive until it settles so the cache updates for next time.
+        event?.waitUntil?.(revalidate);
+        return cached;
     }
-    return response;
+    // Cold cache (first visit, or just flushed): the refresh IS the
+    // response — wait for it and serve the fetched shell.
+    await revalidate;
+    return (await cache.match("/")) || fetch("/");
 }
 
 // Route navigations straight to the cached shell (bypassing the
@@ -150,7 +187,7 @@ self.onfetch = event => {
         // navigation to an app route: serve the cached shell.
         const path = new URL(event.request.url).pathname;
         if (!path.startsWith("/api/")) {
-            event.respondWith(serveNavigation());
+            event.respondWith(serveNavigation(event));
             return;
         }
     }

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -312,13 +312,29 @@
             //
             // No reloads, no timeouts: the claim path is deterministic
             // once the SW has a `message` handler that honors `claim`.
+            // Poke the worker to re-check connectivity. Sent BEFORE the app's
+            // first data-plane call (this runs inside `serviceWorkerActivates`,
+            // which the shell awaits at boot), so on a reload while offline the
+            // worker reconciles the offline status before it would otherwise
+            // drain — which was resetting the indicator to "online" on reload.
+            // The worker reads `navigator.onLine` itself; this only wakes it.
+            const sendConnectivity = async () => {
+                const reg = await navigator.serviceWorker.ready;
+                reg.active?.postMessage({ type: "connectivity" });
+            };
+
             self.serviceWorkerActivates = async () => {
                 if (!("serviceWorker" in navigator)) {
                     throw new Error(
                         "Service workers not supported; Tonk will not work!",
                     );
                 }
-                if (navigator.serviceWorker.controller) return;
+                if (navigator.serviceWorker.controller) {
+                    // Warm reload: already controlled. Still poke so a reload
+                    // while offline reconciles the offline state.
+                    await sendConnectivity();
+                    return;
+                }
 
                 const controlled = new Promise((resolve) => {
                     navigator.serviceWorker.addEventListener(
@@ -334,6 +350,7 @@
                 });
 
                 await controlled;
+                await sendConnectivity();
             };
 
             // Register a one-shot background sync under `tag` so a
@@ -354,6 +371,15 @@
                 const registration = await navigator.serviceWorker.ready;
                 await registration.sync.register(tag);
             };
+
+            // Poke the worker on connectivity TRANSITIONS so the sync indicator
+            // updates immediately instead of waiting for the next fetch. The
+            // active page's `online`/`offline` events are the dependable
+            // trigger; the worker itself decides online-vs-offline from
+            // `navigator.onLine`. The INITIAL poke is sent from
+            // `serviceWorkerActivates` above (before the first data-plane call).
+            self.addEventListener("online", () => sendConnectivity().catch(() => {}));
+            self.addEventListener("offline", () => sendConnectivity().catch(() => {}));
         </script>
         <!-- The following are load-bearing configuration for the Trunk build tool
          (https://trunkrs.dev/assets/); if you need to add build steps or copy

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -227,17 +227,35 @@
             type="font/ttf"
             crossorigin
         />
-        <!-- Preload the loader so it starts compiling alongside the
-       Wasm bundle instead of after the HTML has finished parsing.
-       The loader itself dynamically imports per-component chunks
-       on demand, so preloading the loader is the highest-leverage
-       step we can take without enumerating every chunk. -->
-        <link rel="modulepreload" href="/webawesome/webawesome.loader.js" />
-        <script
-            type="module"
-            src="/webawesome/webawesome.loader.js"
-            data-webawesome="/webawesome"
-        ></script>
+        <!-- Web Awesome loader — injected when the browser goes idle, NOT
+       eagerly. The loader module statically imports ~16 runtime chunks
+       (discover/startLoader/icon+translation registries/base-path utils),
+       so importing it eagerly downloads all of them at once. On a slow
+       connection that flood saturates the pipe and starves the boot data
+       plane: the wasm + the first `/api/*` fetches queue behind it, and
+       first paint waits. Nothing on the TOP page uses a `<wa-*>` COMPONENT
+       — the theme is pure CSS (loaded above), and every `<wa-*>` element
+       renders inside the sealed guest, which ships its own Web Awesome. So
+       the top-level loader isn't on the critical path; defer it to
+       `requestIdleCallback` (with a timeout fallback) so the wasm and data
+       plane win the bandwidth first. `data-webawesome` is carried onto the
+       injected script so the loader still resolves its base path. -->
+        <script>
+            (() => {
+                const inject = () => {
+                    const s = document.createElement("script");
+                    s.type = "module";
+                    s.src = "/webawesome/webawesome.loader.js";
+                    s.dataset.webawesome = "/webawesome";
+                    document.head.appendChild(s);
+                };
+                if ("requestIdleCallback" in window) {
+                    requestIdleCallback(inject, { timeout: 3000 });
+                } else {
+                    setTimeout(inject, 1000);
+                }
+            })();
+        </script>
 
         <!-- PostHog analytics, self-hosted (no external CDN, matching
        the font policy above). The bundle only defines window.posthog;

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -6,6 +6,8 @@
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::prelude::*;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_futures::spawn_local;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[wasm_bindgen(main)]
@@ -23,14 +25,12 @@ async fn main() {
     // `route!` table decides what to render.
     tonk_portal::register_site();
 
-    // Ensure the default repository + profile exist before routing.
-    let _ = tonk_ui::api::init().await;
-
-    // Install the host AFTER init: init awaits service-worker readiness, so
-    // everything the host wires up runs against a controlling SW. Nothing
-    // dispatches consumer events before `mount_root` below, so the late
-    // install loses no operations. (Sync cadence is SW-owned — the page
-    // runs no heartbeat.)
+    // Install the host IO surface and mount `<tonk-site>` right away —
+    // first paint no longer waits on any data round-trip. Every `/api/*`
+    // fetch the host issues self-gates on service-worker readiness
+    // (`tonk_host::ready::wait`, memoized), so mounting before the SW is
+    // controlling loses nothing: the site's own routing fetches block
+    // themselves until the worker is up.
     tonk_host::install();
 
     // Dev-only hot reload client. `debug_assertions` is on under `trunk serve`
@@ -39,6 +39,17 @@ async fn main() {
     inject_hot_swap();
 
     mount_root();
+
+    // Ensure the profile has at least one space, off the critical path.
+    // `init` awaits SW readiness then a `GET /api/profile` (a ~1.6s
+    // first-touch main-branch transact) and, on a fresh profile, a space
+    // create — none of which the first paint needs. The Hub renders its
+    // space directory through a LIVE `<tonk-display>` subscription, so a
+    // space created here populates it reactively with no reload. The
+    // returned client id is unused, so the result is discarded.
+    spawn_local(async {
+        let _ = tonk_ui::api::init().await;
+    });
 }
 
 /// Mount the single `<tonk-site>` root into `<body>` — the top-level router.

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -72,7 +72,6 @@ web-sys = { workspace = true, features = [
     "Cache",
     "CacheStorage",
     "Client",
-    "ClientQueryOptions",
     "Clients",
     "CryptoKey",
     "ExtendableEvent",

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -72,6 +72,7 @@ web-sys = { workspace = true, features = [
     "Cache",
     "CacheStorage",
     "Client",
+    "ClientQueryOptions",
     "Clients",
     "CryptoKey",
     "ExtendableEvent",

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -60,7 +60,7 @@ pub use query::QueryPath;
 pub use tonk_schema::{DEFAULT_BRANCH, SpaceRef, parse_space};
 
 mod session;
-pub use session::SiteResponse;
+pub use session::{SiteRegistry, SiteResponse};
 
 mod transact;
 pub use transact::{ProfileTransactPath, TransactPath, TransactResponse};
@@ -350,6 +350,7 @@ pub mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: super::command_registry(),
+            sites: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -60,7 +60,7 @@ pub use query::QueryPath;
 pub use tonk_schema::{DEFAULT_BRANCH, SpaceRef, parse_space};
 
 mod session;
-pub use session::{SiteRegistry, SiteResponse};
+pub use session::SiteResponse;
 
 mod transact;
 pub use transact::{ProfileTransactPath, TransactPath, TransactResponse};
@@ -352,7 +352,6 @@ pub mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: super::command_registry(),
-            sites: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -60,7 +60,7 @@ pub use query::QueryPath;
 pub use tonk_schema::{DEFAULT_BRANCH, SpaceRef, parse_space};
 
 mod session;
-pub use session::SiteResponse;
+pub use session::{ClientRegistry, ClientState, SiteResponse};
 
 mod transact;
 pub use transact::{ProfileTransactPath, TransactPath, TransactResponse};
@@ -352,6 +352,7 @@ pub mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: super::command_registry(),
+            clients: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -466,6 +466,7 @@ async fn handle_subscribe(
             .repository(&binding.repo)
             .branch(&binding.branch)
             .subscribe(query)
+            .client(client.0.clone())
             .perform(&tonk.operator)
             .await
         {
@@ -627,7 +628,12 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
             return;
         }
     };
-    let live_promise = global.clients().match_all();
+    // Include uncontrolled clients: a document mid-navigation (or one the
+    // SW hasn't claimed yet) is absent from the default set, and treating
+    // it as dead would sweep state it registered moments earlier.
+    let options = web_sys::ClientQueryOptions::new();
+    options.set_include_uncontrolled(true);
+    let live_promise = global.clients().match_all_with_options(&options);
     let live_value = match wasm_bindgen_futures::JsFuture::from(live_promise).await {
         Ok(v) => v,
         Err(e) => {
@@ -640,6 +646,8 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         .iter()
         .filter_map(|v| v.dyn_into::<web_sys::Client>().ok().map(|c| c.id()))
         .collect();
+
+    sweep_reactor_state(state, &live_ids).await;
 
     let (stale_bridges, stale_views) = {
         let snap = state.read().await;
@@ -698,6 +706,56 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         stale_bridges.len(),
         stale_views.len(),
     );
+}
+
+/// Reconcile per-client **reactor** state against the live-client set:
+/// drop dead clients' tagged SSE subscribers and prune their stamped
+/// site facts from the branch overlays.
+///
+/// Both accumulate unboundedly without this — a reload assigns the page
+/// a fresh client id, so the old id's subscriptions keep re-evaluating
+/// on every poll (a vanished client's stream may never cancel, so the
+/// send-failure prune never fires) and its `site:` overlay facts grow
+/// the fold every read pays. This is the GC the `site:<client-id>`
+/// keying was designed for (see `session::SiteRegistry`).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn sweep_reactor_state(
+    state: &crate::router::AppState,
+    live_ids: &std::collections::HashSet<String>,
+) {
+    let snap = state.read().await;
+
+    // Dead site entities: registry entries whose client is gone.
+    // Removed from the registry here; their overlay facts below.
+    let dead_sites: std::collections::HashSet<String> = {
+        let mut registry = snap.sites.write().await;
+        let dead: std::collections::HashSet<String> = registry
+            .iter()
+            .filter(|(_, client)| !live_ids.contains(&client.0))
+            .map(|(site, _)| site.clone())
+            .collect();
+        registry.retain(|_, client| live_ids.contains(&client.0));
+        dead
+    };
+
+    for branch in snap.reactor.cached_branch_states() {
+        branch.retain_subscribers(|client| live_ids.contains(client));
+        if !dead_sites.is_empty()
+            && branch.retain_overlay_entities(|entity| !dead_sites.contains(entity.as_str()))
+        {
+            // The overlay changed under live subscribers — schedule a
+            // poll so they observe the removal; the request dispatcher
+            // drains it once this turn.
+            snap.reactor.schedule_poll(branch);
+        }
+    }
+
+    if !dead_sites.is_empty() {
+        log!(
+            "sweep: pruned {} dead site(s) from overlays",
+            dead_sites.len()
+        );
+    }
 }
 
 /// Post an error envelope back to the client.

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -466,6 +466,7 @@ async fn handle_subscribe(
             .repository(&binding.repo)
             .branch(&binding.branch)
             .subscribe(query)
+            .client(client.0.clone())
             .perform(&tonk.operator)
             .await
         {
@@ -641,6 +642,17 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         .filter_map(|v| v.dyn_into::<web_sys::Client>().ok().map(|c| c.id()))
         .collect();
 
+    // ONE verdict, used by every consumer below: which clients are provably
+    // dead. See `reap_dead_clients` — bare absence from `matchAll()` is not
+    // death, because a booting page (whose id is the navigation's
+    // `resultingClientId`) is absent for its entire boot.
+    let dead = reap_dead_clients(state, &live_ids).await;
+    if dead.clients.is_empty() {
+        return;
+    }
+
+    sweep_reactor_state(state, &dead).await;
+
     let (stale_bridges, stale_views) = {
         let snap = state.read().await;
         let bridges_arc = snap.bridges.clone();
@@ -651,7 +663,7 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
             let guard = bridges_arc.read().await;
             guard
                 .keys()
-                .filter(|c| !live_ids.contains(&c.0))
+                .filter(|c| dead.clients.contains(c))
                 .cloned()
                 .collect()
         };
@@ -659,7 +671,7 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
             let guard = views_arc.read().await;
             guard
                 .keys()
-                .filter(|c| !live_ids.contains(&c.0))
+                .filter(|c| dead.clients.contains(c))
                 .cloned()
                 .collect()
         };
@@ -697,6 +709,117 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         "sweep: dropped {} bridge sessions, {} view bindings",
         stale_bridges.len(),
         stale_views.len(),
+    );
+}
+
+/// The clients this sweep proved dead, and the site entities they had
+/// stamped (carried out of the ledger, since the site URI is not a
+/// function of the client id — see [`crate::router::ClientState`]).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[derive(Default)]
+struct Dead {
+    clients: std::collections::HashSet<ClientId>,
+    sites: std::collections::HashSet<String>,
+}
+
+/// Reconcile the liveness ledger against this poll's live set and return
+/// the clients that are **provably dead**: ones we previously observed
+/// alive in `clients.matchAll()` that are now gone. Reaped entries are
+/// removed from the ledger.
+///
+/// This is the ONLY place death is decided, so no two consumers of the
+/// sweep can disagree about it.
+///
+/// Absence from `matchAll()` is not death on its own. A navigation's
+/// client id is the `FetchEvent`'s `resultingClientId` — the id the
+/// *future* document will get — so a booting page is legitimately absent
+/// (with or without `includeUncontrolled`) for its whole boot, which is
+/// exactly when it stamps its site, registers its bridge, and opens its
+/// subscriptions. Reaping on bare absence deletes the live page's own
+/// session out from under it, and its display then waits forever on a
+/// subscription nobody will ever feed. So a client must be seen ALIVE
+/// once before its later absence counts as death.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn reap_dead_clients(
+    state: &crate::router::AppState,
+    live_ids: &std::collections::HashSet<String>,
+) -> Dead {
+    let (clients, bridges, views) = {
+        let snap = state.read().await;
+        (
+            snap.clients.clone(),
+            snap.bridges.clone(),
+            snap.view_bindings.clone(),
+        )
+    };
+
+    // Enroll every client the worker holds state for, not just those that
+    // stamped a site: a sealed guest registers a bridge and a view binding
+    // but no site, and a client absent from the ledger could never be
+    // judged dead — its state would leak for the worker's lifetime.
+    // Enrolled as NOT-seen-live, so enrollment alone can never condemn a
+    // client; only a later poll that actually sees it alive can.
+    let held: Vec<ClientId> = {
+        let bridges = bridges.read().await;
+        let views = views.read().await;
+        bridges.keys().chain(views.keys()).cloned().collect()
+    };
+
+    let mut ledger = clients.write().await;
+    for client in held {
+        ledger.entry(client).or_default();
+    }
+
+    let mut dead = Dead::default();
+    ledger.retain(|client, entry| {
+        if live_ids.contains(&client.0) {
+            // Observed alive. From here on, absence means death.
+            entry.seen_live = true;
+            return true;
+        }
+        if !entry.seen_live {
+            // Never yet seen alive: presumed booting, not dead. Keep.
+            return true;
+        }
+        // Born, then died.
+        dead.sites.extend(entry.sites.iter().cloned());
+        dead.clients.insert(client.clone());
+        false
+    });
+    dead
+}
+
+/// Drop dead clients' reactor state: their SSE subscribers and the site
+/// facts they stamped into branch overlays.
+///
+/// Both accumulate without this. A reload assigns the page a fresh client
+/// id, so the old id's subscriptions keep re-evaluating on every poll (a
+/// vanished client's response stream may never cancel, so the
+/// send-failure prune never fires) and its `site:` overlay facts grow the
+/// fold that every read of the branch pays.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn sweep_reactor_state(state: &crate::router::AppState, dead: &Dead) {
+    let dead_ids: std::collections::HashSet<&str> =
+        dead.clients.iter().map(|c| c.0.as_str()).collect();
+    let snap = state.read().await;
+
+    for branch in snap.reactor.cached_branch_states() {
+        branch.retain_subscribers(|client| !dead_ids.contains(client));
+        // Deliberately NO `schedule_poll` here. This sweep runs from
+        // `on_fetch` for EVERY request, including static assets — and those
+        // have no dispatcher to drain the reactor's scheduled-poll set, so a
+        // poll scheduled here would sit in `pending_polls` until some
+        // unrelated request happened to drain it, with every sweep piling on
+        // another. Nor is a poll needed: the facts removed belonged to a
+        // client that is gone, so no live subscriber was reading them and
+        // their removal changes nothing anyone can observe.
+        branch.retain_overlay_entities(|entity| !dead.sites.contains(entity.as_str()));
+    }
+
+    log!(
+        "sweep: reaped {} dead client(s), {} site(s)",
+        dead.clients.len(),
+        dead.sites.len()
     );
 }
 

--- a/rust/tonk-worker/src/router/bridge.rs
+++ b/rust/tonk-worker/src/router/bridge.rs
@@ -466,7 +466,6 @@ async fn handle_subscribe(
             .repository(&binding.repo)
             .branch(&binding.branch)
             .subscribe(query)
-            .client(client.0.clone())
             .perform(&tonk.operator)
             .await
         {
@@ -628,12 +627,7 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
             return;
         }
     };
-    // Include uncontrolled clients: a document mid-navigation (or one the
-    // SW hasn't claimed yet) is absent from the default set, and treating
-    // it as dead would sweep state it registered moments earlier.
-    let options = web_sys::ClientQueryOptions::new();
-    options.set_include_uncontrolled(true);
-    let live_promise = global.clients().match_all_with_options(&options);
+    let live_promise = global.clients().match_all();
     let live_value = match wasm_bindgen_futures::JsFuture::from(live_promise).await {
         Ok(v) => v,
         Err(e) => {
@@ -646,8 +640,6 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         .iter()
         .filter_map(|v| v.dyn_into::<web_sys::Client>().ok().map(|c| c.id()))
         .collect();
-
-    sweep_reactor_state(state, &live_ids).await;
 
     let (stale_bridges, stale_views) = {
         let snap = state.read().await;
@@ -706,56 +698,6 @@ pub async fn sweep_stale_clients(state: &crate::router::AppState) {
         stale_bridges.len(),
         stale_views.len(),
     );
-}
-
-/// Reconcile per-client **reactor** state against the live-client set:
-/// drop dead clients' tagged SSE subscribers and prune their stamped
-/// site facts from the branch overlays.
-///
-/// Both accumulate unboundedly without this — a reload assigns the page
-/// a fresh client id, so the old id's subscriptions keep re-evaluating
-/// on every poll (a vanished client's stream may never cancel, so the
-/// send-failure prune never fires) and its `site:` overlay facts grow
-/// the fold every read pays. This is the GC the `site:<client-id>`
-/// keying was designed for (see `session::SiteRegistry`).
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn sweep_reactor_state(
-    state: &crate::router::AppState,
-    live_ids: &std::collections::HashSet<String>,
-) {
-    let snap = state.read().await;
-
-    // Dead site entities: registry entries whose client is gone.
-    // Removed from the registry here; their overlay facts below.
-    let dead_sites: std::collections::HashSet<String> = {
-        let mut registry = snap.sites.write().await;
-        let dead: std::collections::HashSet<String> = registry
-            .iter()
-            .filter(|(_, client)| !live_ids.contains(&client.0))
-            .map(|(site, _)| site.clone())
-            .collect();
-        registry.retain(|_, client| live_ids.contains(&client.0));
-        dead
-    };
-
-    for branch in snap.reactor.cached_branch_states() {
-        branch.retain_subscribers(|client| live_ids.contains(client));
-        if !dead_sites.is_empty()
-            && branch.retain_overlay_entities(|entity| !dead_sites.contains(entity.as_str()))
-        {
-            // The overlay changed under live subscribers — schedule a
-            // poll so they observe the removal; the request dispatcher
-            // drains it once this turn.
-            snap.reactor.schedule_poll(branch);
-        }
-    }
-
-    if !dead_sites.is_empty() {
-        log!(
-            "sweep: pruned {} dead site(s) from overlays",
-            dead_sites.len()
-        );
-    }
 }
 
 /// Post an error envelope back to the client.

--- a/rust/tonk-worker/src/router/evaluate.rs
+++ b/rust/tonk-worker/src/router/evaluate.rs
@@ -132,7 +132,14 @@ pub async fn evaluate(
     body: Bytes,
 ) -> Result<Json<EvaluateResponse>, TonkWorkerError> {
     log!("evaluate repo={}, branch={}", path.repo, path.branch);
-    let tonk_state = state.write().await;
+    // A READ lock, not a write lock. `tokio`'s `RwLock` is write-preferring, so
+    // a single write-lock holder stalls every new reader — a boot-time evaluate
+    // (or the editor's auto-evaluate) blocked every concurrent `query` for its
+    // whole duration. `evaluate_on_branch` reaches the branch through the reactor
+    // (its own per-branch locks) and never mutates `TonkState`, so shared access
+    // suffices — same as `query`/`transact`/`sync`. The committing path serializes
+    // on the branch transactor itself (see `evaluate_on_branch`).
+    let tonk_state = state.read().await;
     let tonk_branch = tonk_state
         .reactor
         .repository(&path.repo)
@@ -193,7 +200,9 @@ pub async fn evaluate_profile(
     body: Bytes,
 ) -> Result<Json<EvaluateResponse>, TonkWorkerError> {
     log!("evaluate profile branch={}", path.branch);
-    let tonk_state = state.write().await;
+    // Read lock — see [`evaluate`] for why a write lock here serialized every
+    // concurrent request behind a commit.
+    let tonk_state = state.read().await;
     let tonk_branch = tonk_state.reactor.profile_repository().branch(&path.branch);
     let result = evaluate_on_branch(&tonk_state, tonk_branch, body, query).await;
 
@@ -247,106 +256,182 @@ async fn evaluate_on_branch<'a>(
         .acquire(&tonk_state.operator)
         .await
         .map_err(|e| TonkWorkerError::NotFound(e.to_string()))?;
-    let branch = session.handle();
-    let revision_before = branch.revision();
 
-    // Fold the branch's session overlay (ephemeral facts kept out of
-    // storage, e.g. an invite's private seed) into the evaluation
-    // transaction so every evaluation — the inspector running
-    // `invitation:`, preview or explicit — sees the same facts a
-    // `query`/`subscribe` does. Folding it here (not gated on
-    // `transact`) is what keeps the read paths consistent; the overlay
-    // is read-only and gets `induce`-swept on commit (below) so it never
-    // lands durably.
-    // The branch folds its session overlay into every read — the
-    // transaction's as-if-committed view included — so the dry-run
-    // preview sees the same ephemeral facts a `query`/`subscribe` does
-    // with no explicit integrate here, and they never reach the durable
-    // write (the overlay is session-only). The evaluation's match queries
-    // resolve stored `db.rule/*` rules automatically via the branch
-    // query's layer stack.
-    let txn = branch.transaction();
+    // A document commits when it writes anything. `rule!:` is a mutation (the
+    // `!` says so) and the analyzer lifts it into a `Statement::InstallEffect`,
+    // so a planned statement is the single commit signal. We can only know this
+    // after evaluating, but the WILL-commit decision also governs locking, so a
+    // committing document runs its whole evaluate+commit under the branch
+    // transactor while a dry run takes no lock — hence the two arms below share
+    // the evaluation via a closure rather than a pre-check.
 
-    let t_eval = web_time::Instant::now();
-    let evaluated = syntax
-        .evaluate(txn)
-        .perform(&tonk_state.operator)
-        .await
-        .map_err(map_evaluate_error)?;
-    let eval_ms = t_eval.elapsed().as_millis();
-
-    // Compute the post-evaluation matches before any commit
-    // decision: the txn's overlay already reflects every mutation
-    // and induce-pass derivation, so this is the same answer a
-    // post-commit branch query would give.
-    let t_matches = web_time::Instant::now();
-    let matches_after = evaluated
-        .matches_after(&tonk_state.operator)
-        .await
-        .map_err(map_evaluate_error)?;
-    let matches_ms = t_matches.elapsed().as_millis();
-
-    // A document commits when it writes anything. `rule!:` is a
-    // mutation (the `!` says so) and the analyzer lifts it into a
-    // `Statement::InstallEffect`, so a document with any planned
-    // statement is the single commit signal.
-    let response = if query.transact && evaluated.analysis.analysis.has_statements() {
-        let t_commit = web_time::Instant::now();
-        // The session overlay is folded in for reads but is never part of
-        // the durable write (dialog keeps it session-only), so the commit
-        // lands only the document's own statements — no overlay sweep here.
-        let revision_after = evaluated
-            .txn
-            .commit()
+    // Evaluate against the current head. Kept as a closure so the committing
+    // path can replay it after a refresh (the evaluated transaction borrows the
+    // pre-refresh tree, so a moved head means re-evaluating, not just
+    // re-committing). Evaluation is pure over (document, head) and the
+    // document's statements are idempotent asserts/retracts, so replay is safe.
+    let evaluate_once = || async {
+        let branch = session.handle();
+        let revision_before = branch.revision();
+        // The branch folds its session overlay into every read — the
+        // transaction's as-if-committed view included — so the dry-run preview
+        // sees the same ephemeral facts a `query`/`subscribe` does with no
+        // explicit integrate here, and they never reach the durable write (the
+        // overlay is session-only). Match queries resolve stored `db.rule/*`
+        // rules automatically via the branch query's layer stack.
+        let txn = branch.transaction();
+        let t_eval = web_time::Instant::now();
+        let evaluated = syntax
+            .evaluate(txn)
             .perform(&tonk_state.operator)
             .await
-            .map_err(|e| map_evaluate_error(EvaluateError::Query(format!("commit: {e}"))))?;
-        let commit_ms = t_commit.elapsed().as_millis();
-        // Re-poll subscriptions so SSE clients see the new state.
-        // The chain commits via dialog directly; the reactor's
-        // subscription registry is the worker's responsibility.
-        let t_poll = web_time::Instant::now();
-        session.poll(&tonk_state.operator).await;
-        let poll_ms = t_poll.elapsed().as_millis();
-        let timing = format!(
-            "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | matches {matches_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
-        );
-        log!("{timing}");
-        // Tee timing onto a BroadcastChannel so a page (or DevTools
-        // listener) can read seed numbers without the SW console — the
-        // seed runs background in the SW, so its logs never reach the
-        // page console.
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-        if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
-            let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
-        }
-        EvaluateResponse {
+            .map_err(map_evaluate_error)?;
+        let eval_ms = t_eval.elapsed().as_millis();
+        // Post-evaluation matches: the txn's overlay already reflects every
+        // mutation and induce-pass derivation, so this is the same answer a
+        // post-commit branch query would give.
+        let t_matches = web_time::Instant::now();
+        let matches_after = evaluated
+            .matches_after(&tonk_state.operator)
+            .await
+            .map_err(map_evaluate_error)?;
+        let matches_ms = t_matches.elapsed().as_millis();
+        Ok::<_, TonkWorkerError>((
+            evaluated,
             revision_before,
-            revision_after: Some(revision_after),
-            matches_before: evaluated.matches,
             matches_after,
-            commits: evaluated.commits,
-        }
-    } else {
-        // Pure-query or dry-run: drop the transaction without
-        // committing. The pre-mutation matches double as "after"
-        // because no mutations actually landed. Zero out
-        // `claims` so the response reflects what *did* commit
-        // (nothing), not what *would* have committed — auto-
-        // evaluate from the editor relies on this to know the
-        // branch is untouched.
+            eval_ms,
+            matches_ms,
+        ))
+    };
+
+    // Dry-run fast path: evaluate once, take NO lock, drop the transaction.
+    // This is the editor's per-keystroke auto-evaluate — it must never contend
+    // with a committing writer, which is the whole point of dropping the write
+    // lock. We can't know it's a dry run until after evaluating, so a peek: if
+    // the first (lock-free) evaluation shows no commit, return it directly; only
+    // a committing document re-enters under the transactor lock.
+    let (evaluated, revision_before, matches_after, ..) = evaluate_once().await?;
+    if !(query.transact && evaluated.analysis.analysis.has_statements()) {
+        // Pure-query or dry-run: drop the transaction without committing. The
+        // pre-mutation matches double as "after". Zero out `claims` so the
+        // response reflects what *did* commit (nothing) — the editor's
+        // auto-evaluate relies on this to know the branch is untouched.
+        let _ = matches_after;
         let mut commits = evaluated.commits;
         commits.claims = 0;
-        EvaluateResponse {
+        return Ok(Json(EvaluateResponse {
             revision_before: revision_before.clone(),
             revision_after: revision_before,
             matches_before: evaluated.matches.clone(),
             matches_after: evaluated.matches,
             commits,
+        }));
+    }
+    drop(evaluated);
+
+    // Committing path. Serialize on the branch transactor — the same lock the
+    // reactor's `Commit::perform` takes for `/transact`. This document's commit
+    // is a *dialog* `Transaction::commit()` (it threads the raw transaction
+    // through the evaluator), which CASes against the head snapshot but never
+    // retries. The lock excludes the common racer — another committer — so those
+    // line up here instead of one losing the CAS. A sync is the exception the
+    // lock can't cover: it advances the head while holding this lock only for
+    // its microsecond cell write, releasing it across its network fetch, so it
+    // can still land in our snapshot→publish window. The retry loop below
+    // handles that residual case by refreshing and re-evaluating, exactly as
+    // `Commit::perform` does for `/transact`.
+    let _committing = session.transactor().lock().await;
+
+    // Evaluate under the lock and commit, refreshing and re-evaluating on a
+    // `Version mismatch` (a sync landed between our head snapshot and the
+    // publish). Each iteration re-evaluates because `Transaction` isn't `Clone`
+    // and the commit consumes it — and after a refresh the evaluation must run
+    // against the new head anyway. Bounded so a flapping head can't spin.
+    const EVALUATE_RETRY_LIMIT: usize = 4;
+    let (
+        revision_before,
+        revision_after,
+        matches_after,
+        matches_before,
+        commits,
+        eval_ms,
+        matches_ms,
+        commit_ms,
+    ) = {
+        let mut attempt = 0;
+        loop {
+            let (evaluated, revision_before, matches_after, eval_ms, matches_ms) =
+                evaluate_once().await?;
+            // Extract what the response needs before the commit consumes the
+            // transaction (`Transaction` isn't `Clone`, and `commit()` takes it
+            // by value).
+            let matches_before = evaluated.matches;
+            let commits = evaluated.commits;
+            let t_commit = web_time::Instant::now();
+            match evaluated.txn.commit().perform(&tonk_state.operator).await {
+                Ok(revision_after) => {
+                    break (
+                        revision_before,
+                        revision_after,
+                        matches_after,
+                        matches_before,
+                        commits,
+                        eval_ms,
+                        matches_ms,
+                        t_commit.elapsed().as_millis(),
+                    );
+                }
+                Err(e)
+                    if e.to_string().contains("Version mismatch")
+                        && attempt + 1 < EVALUATE_RETRY_LIMIT =>
+                {
+                    attempt += 1;
+                    log!(
+                        "evaluate commit raced a sync (attempt {attempt}); refreshing and retrying"
+                    );
+                    session
+                        .handle()
+                        .refresh(&tonk_state.operator)
+                        .await
+                        .map_err(|e| {
+                            map_evaluate_error(EvaluateError::Query(format!("refresh: {e}")))
+                        })?;
+                }
+                Err(e) => {
+                    return Err(map_evaluate_error(EvaluateError::Query(format!(
+                        "commit: {e}"
+                    ))));
+                }
+            }
         }
     };
 
-    Ok(Json(response))
+    // Re-poll subscriptions so SSE clients see the new state. The chain commits
+    // via dialog directly; the reactor's subscription registry is the worker's
+    // responsibility.
+    let t_poll = web_time::Instant::now();
+    session.poll(&tonk_state.operator).await;
+    let poll_ms = t_poll.elapsed().as_millis();
+    let timing = format!(
+        "evaluate timing: {exprs} exprs | parse {parse_ms}ms | analyze+eval {eval_ms}ms | matches {matches_ms}ms | commit {commit_ms}ms | poll {poll_ms}ms"
+    );
+    log!("{timing}");
+    // Tee timing onto a BroadcastChannel so a page (or DevTools listener) can
+    // read seed numbers without the SW console — the seed runs background in the
+    // SW, so its logs never reach the page console.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    if let Ok(channel) = web_sys::BroadcastChannel::new("tonk-timing") {
+        let _ = channel.post_message(&wasm_bindgen::JsValue::from_str(&timing));
+    }
+
+    Ok(Json(EvaluateResponse {
+        revision_before,
+        revision_after: Some(revision_after),
+        matches_before,
+        matches_after,
+        commits,
+    }))
 }
 
 /// Bridge-callable wrapper around the evaluate pipeline. Runs

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -284,6 +284,7 @@ mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: crate::router::command_registry(),
+            sites: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -284,7 +284,6 @@ mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: crate::router::command_registry(),
-            sites: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -284,6 +284,7 @@ mod tests {
             bridges: Default::default(),
             sync_queue: Default::default(),
             commands: crate::router::command_registry(),
+            clients: Default::default(),
         }
     }
 

--- a/rust/tonk-worker/src/router/query.rs
+++ b/rust/tonk-worker/src/router/query.rs
@@ -53,10 +53,9 @@ pub async fn query(
     headers: HeaderMap,
     request: Request,
 ) -> Result<Response, TonkWorkerError> {
-    let client = request_client(&request);
     let tonk = state.read().await;
     let branch = tonk.reactor.repository(&path.repo).branch(&path.branch);
-    query_on_branch(&tonk, branch, headers, request, client).await
+    query_on_branch(&tonk, branch, headers, request).await
 }
 
 /// `POST /api/profile/branch/{branch}/query`
@@ -74,22 +73,9 @@ pub async fn query_profile(
     headers: HeaderMap,
     request: Request,
 ) -> Result<Response, TonkWorkerError> {
-    let client = request_client(&request);
     let tonk = state.read().await;
     let branch = tonk.reactor.profile_repository().branch(&path.branch);
-    query_on_branch(&tonk, branch, headers, request, client).await
-}
-
-/// The requesting SW client's id, when the fetch handler stamped one.
-/// Tags SSE subscribers so the stale-client sweep can prune the ones
-/// whose page is gone (a dead client's stream may never cancel, so
-/// send-failure pruning alone can't be relied on).
-fn request_client(request: &Request) -> Option<String> {
-    request
-        .extensions()
-        .get::<crate::router::ClientId>()
-        .map(|c| c.0.clone())
-        .filter(|id| !id.is_empty())
+    query_on_branch(&tonk, branch, headers, request).await
 }
 
 /// Shared body for [`query`] and [`query_profile`]. Takes a
@@ -100,7 +86,6 @@ async fn query_on_branch<'a>(
     branch: crate::reactor::BranchReference<'a>,
     headers: HeaderMap,
     request: Request,
-    client: Option<String>,
 ) -> Result<Response, TonkWorkerError> {
     let bytes = request
         .into_body()
@@ -171,11 +156,8 @@ async fn query_on_branch<'a>(
                 .expect("response builder failed"));
         }
 
-        let mut subscribe = branch.subscribe(query);
-        if let Some(client) = client {
-            subscribe = subscribe.client(client);
-        }
-        let subscriber = subscribe
+        let subscriber = branch
+            .subscribe(query)
             .perform(&tonk.operator)
             .await
             .map_err(reactor_to_error)?;

--- a/rust/tonk-worker/src/router/query.rs
+++ b/rust/tonk-worker/src/router/query.rs
@@ -53,9 +53,10 @@ pub async fn query(
     headers: HeaderMap,
     request: Request,
 ) -> Result<Response, TonkWorkerError> {
+    let client = request_client(&request);
     let tonk = state.read().await;
     let branch = tonk.reactor.repository(&path.repo).branch(&path.branch);
-    query_on_branch(&tonk, branch, headers, request).await
+    query_on_branch(&tonk, branch, headers, request, client).await
 }
 
 /// `POST /api/profile/branch/{branch}/query`
@@ -73,9 +74,22 @@ pub async fn query_profile(
     headers: HeaderMap,
     request: Request,
 ) -> Result<Response, TonkWorkerError> {
+    let client = request_client(&request);
     let tonk = state.read().await;
     let branch = tonk.reactor.profile_repository().branch(&path.branch);
-    query_on_branch(&tonk, branch, headers, request).await
+    query_on_branch(&tonk, branch, headers, request, client).await
+}
+
+/// The requesting SW client's id, when the fetch handler stamped one.
+/// Tags SSE subscribers so the stale-client sweep can prune the ones
+/// whose page is gone (a dead client's stream may never cancel, so
+/// send-failure pruning alone can't be relied on).
+fn request_client(request: &Request) -> Option<String> {
+    request
+        .extensions()
+        .get::<crate::router::ClientId>()
+        .map(|c| c.0.clone())
+        .filter(|id| !id.is_empty())
 }
 
 /// Shared body for [`query`] and [`query_profile`]. Takes a
@@ -86,6 +100,7 @@ async fn query_on_branch<'a>(
     branch: crate::reactor::BranchReference<'a>,
     headers: HeaderMap,
     request: Request,
+    client: Option<String>,
 ) -> Result<Response, TonkWorkerError> {
     let bytes = request
         .into_body()
@@ -156,8 +171,11 @@ async fn query_on_branch<'a>(
                 .expect("response builder failed"));
         }
 
-        let subscriber = branch
-            .subscribe(query)
+        let mut subscribe = branch.subscribe(query);
+        if let Some(client) = client {
+            subscribe = subscribe.client(client);
+        }
+        let subscriber = subscribe
             .perform(&tonk.operator)
             .await
             .map_err(reactor_to_error)?;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -4225,7 +4225,7 @@ mod tests {
                 .await
                 .expect("acquire cached main");
             subscriber = session
-                .subscribe(ConceptQuery::from(Query::<Name>::default()))
+                .subscribe(ConceptQuery::from(Query::<Name>::default()), None)
                 .expect("subscribe");
             before_ptr = Arc::as_ptr(&session.state);
         }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -4225,7 +4225,7 @@ mod tests {
                 .await
                 .expect("acquire cached main");
             subscriber = session
-                .subscribe(ConceptQuery::from(Query::<Name>::default()), None)
+                .subscribe(ConceptQuery::from(Query::<Name>::default()))
                 .expect("subscribe");
             before_ptr = Arc::as_ptr(&session.state);
         }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -4019,7 +4019,7 @@ mod tests {
                 .await
                 .expect("acquire cached main");
             subscriber = session
-                .subscribe(ConceptQuery::from(Query::<Name>::default()))
+                .subscribe(ConceptQuery::from(Query::<Name>::default()), None)
                 .expect("subscribe");
             before_ptr = Arc::as_ptr(&session.state);
         }

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -305,6 +305,19 @@ async fn stamp_site_on(
         return;
     };
 
+    // A re-stamp REPLACES this site's overlay facts, not merges into them:
+    // params the new route does not capture must not survive the previous
+    // navigation as stale cardinality-one values. The bare space route
+    // (`/space/{id}`) captures no `{rest}`, so after visiting
+    // `/space/{id}/inspector` a merge would leave `rest="inspector"` on the
+    // site and the nested `<tonk-site path={rest}>` would keep routing the
+    // old sub-path. Pruned only once the route matched (above), so a
+    // no-match navigation still keeps the previous stamp; the write below
+    // schedules the poll that lets subscribers observe the swap atomically.
+    state
+        .state
+        .retain_overlay_entities(|overlaid| overlaid.as_str() != site);
+
     // Write through the overlay builder: it asserts into the session overlay and
     // schedules a poll so subscribers are notified — the request dispatcher
     // drains the poll once. Cardinality-one fields supersede in place, so a

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -33,6 +33,17 @@ pub struct SiteResponse {
     pub site: String,
 }
 
+/// Shared map of stamped site entity URI → the SW client the stamp
+/// serves. Every [`stamp_site_on`] records its entry here; the
+/// stale-client sweep reconciles it against `clients.matchAll()` and
+/// prunes dead clients' site facts from the branch overlays — the GC
+/// the `site:<client-id>` keying was designed for. Covers both site
+/// keyings: `site:<client-id>` (the `/site` endpoints) and
+/// `site:<uuid>` (the `tonk:load` command, whose entity is minted by
+/// the page but whose commit origin names the client).
+pub type SiteRegistry =
+    std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<String, super::ClientId>>>;
+
 /// Read a header as a `&str`, empty when absent or non-ASCII.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn header<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
@@ -68,7 +79,7 @@ pub async fn register_site(
         let path = header(&headers, "x-tonk-path").to_owned();
         let anchor = header(&headers, "x-tonk-hash").to_owned();
         let tonk = state.read().await;
-        stamp_site(&tonk, &site, &path, anchor).await;
+        stamp_site(&tonk, &site, ClientId(client_id), &path, anchor).await;
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
@@ -105,7 +116,7 @@ pub async fn register_site_on_repo(
     ::axum::extract::Path(path): ::axum::extract::Path<crate::router::transact::TransactPath>,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let site = client_site(&request)?;
+    let (site, client) = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -113,6 +124,7 @@ pub async fn register_site_on_repo(
         stamp_site_on(
             &tonk,
             &site,
+            client,
             &path.repo,
             &path.branch,
             false,
@@ -124,7 +136,7 @@ pub async fn register_site_on_repo(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request);
+        let _ = (&state, &path, &request, &client);
     }
     Ok(Json(SiteResponse { site }))
 }
@@ -140,7 +152,7 @@ pub async fn register_site_on_profile(
     >,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let site = client_site(&request)?;
+    let (site, client) = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -149,6 +161,7 @@ pub async fn register_site_on_profile(
         stamp_site_on(
             &tonk,
             &site,
+            client,
             &repo,
             &path.branch,
             true,
@@ -160,14 +173,14 @@ pub async fn register_site_on_profile(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request);
+        let _ = (&state, &path, &request, &client);
     }
     Ok(Json(SiteResponse { site }))
 }
 
 /// Derive the `site:<client-id>` entity for a request, erroring if the SW set no
 /// client id (the per-tab key the site is stamped under).
-fn client_site(request: &Request) -> Result<String, TonkWorkerError> {
+fn client_site(request: &Request) -> Result<(String, ClientId), TonkWorkerError> {
     let client_id = request
         .extensions()
         .get::<ClientId>()
@@ -176,7 +189,7 @@ fn client_site(request: &Request) -> Result<String, TonkWorkerError> {
     if client_id.is_empty() {
         return Err(TonkWorkerError::Router("no client id on /site".into()));
     }
-    Ok(format!("site:{client_id}"))
+    Ok((format!("site:{client_id}"), ClientId(client_id)))
 }
 
 /// Read and decode the [`SiteRequest`] body, defaulting to an empty path when
@@ -209,7 +222,13 @@ async fn read_site_request(request: Request) -> Result<SiteRequest, TonkWorkerEr
 /// per-branch `/site` endpoint, which calls [`stamp_site_on`] directly with the
 /// branch named in the request URL.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anchor: String) {
+async fn stamp_site(
+    tonk: &crate::worker::TonkState,
+    site: &str,
+    client: ClientId,
+    path: &str,
+    anchor: String,
+) {
     use tonk_schema::{RouteTarget, resolve_path};
 
     let Some(RouteTarget::Space { space, rest }) = resolve_path(path) else {
@@ -218,6 +237,7 @@ async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anc
     stamp_site_on(
         tonk,
         site,
+        client,
         &space.name,
         &space.branch,
         false,
@@ -243,6 +263,7 @@ async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anc
 async fn stamp_site_on(
     tonk: &crate::worker::TonkState,
     site: &str,
+    client: ClientId,
     repo: &str,
     branch_name: &str,
     profile: bool,
@@ -332,6 +353,13 @@ async fn stamp_site_on(
     if let Err(e) = overlay.write().perform(&tonk.operator).await {
         tonk_common::log!("register_site: overlay write failed for {path}: {e}");
     } else {
+        // Record which client this site serves, so the stale-client
+        // sweep can prune the overlay facts once the client is gone.
+        // An unknown client (empty id) is not registered — better to
+        // leak its facts than sweep a live page's site.
+        if !client.0.is_empty() {
+            tonk.sites.write().await.insert(site.to_owned(), client);
+        }
         tonk_common::log!("[stamp] {site} WROTE path={path}");
     }
 }
@@ -455,6 +483,17 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             let repo = env.origin().repo.clone();
             let branch = env.origin().branch.clone();
             let profile = repo.is_empty();
+            // The site entity is page-minted (`site:<uuid>`), but the commit
+            // origin names the client — the sweep key. A missing origin
+            // client (shouldn't happen for a page commit) stamps under an
+            // empty id; `stamp_site_on` skips registering those, so the
+            // facts outlive the client (the pre-sweep behaviour) instead of
+            // being wrongly swept out from under a live page.
+            let client = env
+                .origin()
+                .client
+                .clone()
+                .unwrap_or(crate::router::ClientId(String::new()));
             dialog_common::log!(
                 "command Load site={} path={} repo={} branch={} profile={}",
                 site,
@@ -471,6 +510,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             stamp_site_on(
                 &tonk,
                 &site,
+                client,
                 &repo,
                 &branch,
                 profile,

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -33,17 +33,6 @@ pub struct SiteResponse {
     pub site: String,
 }
 
-/// Shared map of stamped site entity URI → the SW client the stamp
-/// serves. Every [`stamp_site_on`] records its entry here; the
-/// stale-client sweep reconciles it against `clients.matchAll()` and
-/// prunes dead clients' site facts from the branch overlays — the GC
-/// the `site:<client-id>` keying was designed for. Covers both site
-/// keyings: `site:<client-id>` (the `/site` endpoints) and
-/// `site:<uuid>` (the `tonk:load` command, whose entity is minted by
-/// the page but whose commit origin names the client).
-pub type SiteRegistry =
-    std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<String, super::ClientId>>>;
-
 /// Read a header as a `&str`, empty when absent or non-ASCII.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn header<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
@@ -79,7 +68,7 @@ pub async fn register_site(
         let path = header(&headers, "x-tonk-path").to_owned();
         let anchor = header(&headers, "x-tonk-hash").to_owned();
         let tonk = state.read().await;
-        stamp_site(&tonk, &site, ClientId(client_id), &path, anchor).await;
+        stamp_site(&tonk, &site, &path, anchor).await;
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
@@ -116,7 +105,7 @@ pub async fn register_site_on_repo(
     ::axum::extract::Path(path): ::axum::extract::Path<crate::router::transact::TransactPath>,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let (site, client) = client_site(&request)?;
+    let site = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -124,7 +113,6 @@ pub async fn register_site_on_repo(
         stamp_site_on(
             &tonk,
             &site,
-            client,
             &path.repo,
             &path.branch,
             false,
@@ -136,7 +124,7 @@ pub async fn register_site_on_repo(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request, &client);
+        let _ = (&state, &path, &request);
     }
     Ok(Json(SiteResponse { site }))
 }
@@ -152,7 +140,7 @@ pub async fn register_site_on_profile(
     >,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let (site, client) = client_site(&request)?;
+    let site = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -161,7 +149,6 @@ pub async fn register_site_on_profile(
         stamp_site_on(
             &tonk,
             &site,
-            client,
             &repo,
             &path.branch,
             true,
@@ -173,14 +160,14 @@ pub async fn register_site_on_profile(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request, &client);
+        let _ = (&state, &path, &request);
     }
     Ok(Json(SiteResponse { site }))
 }
 
 /// Derive the `site:<client-id>` entity for a request, erroring if the SW set no
 /// client id (the per-tab key the site is stamped under).
-fn client_site(request: &Request) -> Result<(String, ClientId), TonkWorkerError> {
+fn client_site(request: &Request) -> Result<String, TonkWorkerError> {
     let client_id = request
         .extensions()
         .get::<ClientId>()
@@ -189,7 +176,7 @@ fn client_site(request: &Request) -> Result<(String, ClientId), TonkWorkerError>
     if client_id.is_empty() {
         return Err(TonkWorkerError::Router("no client id on /site".into()));
     }
-    Ok((format!("site:{client_id}"), ClientId(client_id)))
+    Ok(format!("site:{client_id}"))
 }
 
 /// Read and decode the [`SiteRequest`] body, defaulting to an empty path when
@@ -222,13 +209,7 @@ async fn read_site_request(request: Request) -> Result<SiteRequest, TonkWorkerEr
 /// per-branch `/site` endpoint, which calls [`stamp_site_on`] directly with the
 /// branch named in the request URL.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn stamp_site(
-    tonk: &crate::worker::TonkState,
-    site: &str,
-    client: ClientId,
-    path: &str,
-    anchor: String,
-) {
+async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anchor: String) {
     use tonk_schema::{RouteTarget, resolve_path};
 
     let Some(RouteTarget::Space { space, rest }) = resolve_path(path) else {
@@ -237,7 +218,6 @@ async fn stamp_site(
     stamp_site_on(
         tonk,
         site,
-        client,
         &space.name,
         &space.branch,
         false,
@@ -263,7 +243,6 @@ async fn stamp_site(
 async fn stamp_site_on(
     tonk: &crate::worker::TonkState,
     site: &str,
-    client: ClientId,
     repo: &str,
     branch_name: &str,
     profile: bool,
@@ -366,13 +345,6 @@ async fn stamp_site_on(
     if let Err(e) = overlay.write().perform(&tonk.operator).await {
         tonk_common::log!("register_site: overlay write failed for {path}: {e}");
     } else {
-        // Record which client this site serves, so the stale-client
-        // sweep can prune the overlay facts once the client is gone.
-        // An unknown client (empty id) is not registered — better to
-        // leak its facts than sweep a live page's site.
-        if !client.0.is_empty() {
-            tonk.sites.write().await.insert(site.to_owned(), client);
-        }
         tonk_common::log!("[stamp] {site} WROTE path={path}");
     }
 }
@@ -496,17 +468,6 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             let repo = env.origin().repo.clone();
             let branch = env.origin().branch.clone();
             let profile = repo.is_empty();
-            // The site entity is page-minted (`site:<uuid>`), but the commit
-            // origin names the client — the sweep key. A missing origin
-            // client (shouldn't happen for a page commit) stamps under an
-            // empty id; `stamp_site_on` skips registering those, so the
-            // facts outlive the client (the pre-sweep behaviour) instead of
-            // being wrongly swept out from under a live page.
-            let client = env
-                .origin()
-                .client
-                .clone()
-                .unwrap_or(crate::router::ClientId(String::new()));
             dialog_common::log!(
                 "command Load site={} path={} repo={} branch={} profile={}",
                 site,
@@ -523,7 +484,6 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             stamp_site_on(
                 &tonk,
                 &site,
-                client,
                 &repo,
                 &branch,
                 profile,

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -33,6 +33,43 @@ pub struct SiteResponse {
     pub site: String,
 }
 
+/// What one SW client has registered with the worker, plus whether we
+/// have ever *observed it alive* in `clients.matchAll()`.
+///
+/// The liveness latch is the load-bearing part. Absence from
+/// `matchAll()` proves a client is dead ONLY for a client we have
+/// previously seen alive; for a brand-new one it equally means
+/// not-born-yet. A navigation's client id is the `FetchEvent`'s
+/// `resultingClientId` — the id the *future* document will get — so a
+/// booting page is legitimately absent from `matchAll()` (with or
+/// without `includeUncontrolled`) for its entire boot, which is exactly
+/// when it stamps its site and opens its subscriptions. Sweeping on bare
+/// absence therefore deletes the live page's own session out from under
+/// it: its `site:` facts vanish, its subscribers are dropped, and its
+/// display waits forever on a subscription nobody will ever feed.
+///
+/// So the sweep only ever reaps **born-then-died**: `seen_live` latched
+/// true, and the client has since disappeared.
+#[derive(Debug, Default, Clone)]
+pub struct ClientState {
+    /// Site entities this client has stamped. Tracked per client (not as
+    /// a `site → client` map) because the site URI is not a function of
+    /// the client: the `/site` endpoints key it `site:<client-id>`, but
+    /// the page-minted `tonk:load` command keys it `site:<uuid>`.
+    pub sites: std::collections::HashSet<String>,
+    /// Latched once this client appeared in `clients.matchAll()`. Until
+    /// then the client is presumed to be booting, never dead.
+    pub seen_live: bool,
+}
+
+/// Shared ledger of SW client → what it registered. The stale-client
+/// sweep reconciles this against `clients.matchAll()` and reaps the
+/// clients that were born and have since died, dropping their site
+/// overlay facts and SSE subscriptions — the GC the `site:<client-id>`
+/// keying was designed for but never got.
+pub type ClientRegistry =
+    std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<super::ClientId, ClientState>>>;
+
 /// Read a header as a `&str`, empty when absent or non-ASCII.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn header<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
@@ -68,7 +105,7 @@ pub async fn register_site(
         let path = header(&headers, "x-tonk-path").to_owned();
         let anchor = header(&headers, "x-tonk-hash").to_owned();
         let tonk = state.read().await;
-        stamp_site(&tonk, &site, &path, anchor).await;
+        stamp_site(&tonk, &site, ClientId(client_id), &path, anchor).await;
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
@@ -105,7 +142,7 @@ pub async fn register_site_on_repo(
     ::axum::extract::Path(path): ::axum::extract::Path<crate::router::transact::TransactPath>,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let site = client_site(&request)?;
+    let (site, client) = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -113,6 +150,7 @@ pub async fn register_site_on_repo(
         stamp_site_on(
             &tonk,
             &site,
+            client,
             &path.repo,
             &path.branch,
             false,
@@ -124,7 +162,7 @@ pub async fn register_site_on_repo(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request);
+        let _ = (&state, &path, &request, &client);
     }
     Ok(Json(SiteResponse { site }))
 }
@@ -140,7 +178,7 @@ pub async fn register_site_on_profile(
     >,
     request: Request,
 ) -> Result<Json<SiteResponse>, TonkWorkerError> {
-    let site = client_site(&request)?;
+    let (site, client) = client_site(&request)?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         let body = read_site_request(request).await?;
@@ -149,6 +187,7 @@ pub async fn register_site_on_profile(
         stamp_site_on(
             &tonk,
             &site,
+            client,
             &repo,
             &path.branch,
             true,
@@ -160,14 +199,14 @@ pub async fn register_site_on_profile(
     }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
-        let _ = (&state, &path, &request);
+        let _ = (&state, &path, &request, &client);
     }
     Ok(Json(SiteResponse { site }))
 }
 
 /// Derive the `site:<client-id>` entity for a request, erroring if the SW set no
 /// client id (the per-tab key the site is stamped under).
-fn client_site(request: &Request) -> Result<String, TonkWorkerError> {
+fn client_site(request: &Request) -> Result<(String, ClientId), TonkWorkerError> {
     let client_id = request
         .extensions()
         .get::<ClientId>()
@@ -176,7 +215,7 @@ fn client_site(request: &Request) -> Result<String, TonkWorkerError> {
     if client_id.is_empty() {
         return Err(TonkWorkerError::Router("no client id on /site".into()));
     }
-    Ok(format!("site:{client_id}"))
+    Ok((format!("site:{client_id}"), ClientId(client_id)))
 }
 
 /// Read and decode the [`SiteRequest`] body, defaulting to an empty path when
@@ -209,7 +248,13 @@ async fn read_site_request(request: Request) -> Result<SiteRequest, TonkWorkerEr
 /// per-branch `/site` endpoint, which calls [`stamp_site_on`] directly with the
 /// branch named in the request URL.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anchor: String) {
+async fn stamp_site(
+    tonk: &crate::worker::TonkState,
+    site: &str,
+    client: ClientId,
+    path: &str,
+    anchor: String,
+) {
     use tonk_schema::{RouteTarget, resolve_path};
 
     let Some(RouteTarget::Space { space, rest }) = resolve_path(path) else {
@@ -218,6 +263,7 @@ async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anc
     stamp_site_on(
         tonk,
         site,
+        client,
         &space.name,
         &space.branch,
         false,
@@ -243,6 +289,7 @@ async fn stamp_site(tonk: &crate::worker::TonkState, site: &str, path: &str, anc
 async fn stamp_site_on(
     tonk: &crate::worker::TonkState,
     site: &str,
+    client: ClientId,
     repo: &str,
     branch_name: &str,
     profile: bool,
@@ -345,6 +392,21 @@ async fn stamp_site_on(
     if let Err(e) = overlay.write().perform(&tonk.operator).await {
         tonk_common::log!("register_site: overlay write failed for {path}: {e}");
     } else {
+        // Record the site against its client so the stale-client sweep can
+        // drop these overlay facts once the client is provably gone. The
+        // entry is created NOT-seen-live: this stamp lands while the page is
+        // still booting (its client is not yet in `clients.matchAll()`), and
+        // registering it as live-then-absent would let the very next sweep
+        // reap the page that just announced itself.
+        if !client.0.is_empty() {
+            tonk.clients
+                .write()
+                .await
+                .entry(client)
+                .or_default()
+                .sites
+                .insert(site.to_owned());
+        }
         tonk_common::log!("[stamp] {site} WROTE path={path}");
     }
 }
@@ -468,6 +530,16 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             let repo = env.origin().repo.clone();
             let branch = env.origin().branch.clone();
             let profile = repo.is_empty();
+            // The site entity here is page-minted (`site:<uuid>`), so the
+            // commit's origin is what names the client the stamp serves.
+            // An absent client leaves the site unregistered — its facts then
+            // outlive the client (the pre-sweep behaviour) rather than being
+            // attributed to the wrong one.
+            let client = env
+                .origin()
+                .client
+                .clone()
+                .unwrap_or(crate::router::ClientId(String::new()));
             dialog_common::log!(
                 "command Load site={} path={} repo={} branch={} profile={}",
                 site,
@@ -484,6 +556,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
             stamp_site_on(
                 &tonk,
                 &site,
+                client,
                 &repo,
                 &branch,
                 profile,

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -689,6 +689,36 @@ pub async fn sync(
         params.branch
     );
 
+    // Don't touch the network while offline. This is the single chokepoint every
+    // sync path flows through (the per-fetch drain, the self-scheduled loop,
+    // `POST /api/sync`, an SSE reconnect), so gating here stops ALL of them from
+    // hammering an unreachable upstream — an offline branch would otherwise
+    // retry `handle.fetch()` on every tick, re-queue on failure, and retry
+    // again. Stamp `offline` so the chip reflects the disconnect and report
+    // success (nothing to reconcile until connectivity returns; any traffic or
+    // the page's `online` event restarts real syncing).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    if crate::worker::offline() {
+        // Read lock — the overlay stamp goes through the reactor (its own
+        // locks); a write lock here would block concurrent reads, same as
+        // `mark_offline`, which stamps the identical status under `read()`.
+        let tonk_state = state.read().await;
+        publish_sync_status_attr(
+            &tonk_state,
+            &params.repo,
+            &params.branch,
+            tonk_schema::Replica::offline_status(),
+        )
+        .await;
+        log!("sync of {}/{} skipped: offline", params.repo, params.branch);
+        return Ok(Json(SyncResponse {
+            success: true,
+            before: None,
+            after: None,
+            error: None,
+        }));
+    }
+
     // Honor the durable pause preference at the single chokepoint every sync
     // path flows through (the in-page interval coordinator, the background
     // sweep, a manual sync all call `/sync`). A paused replica neither pulls

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -84,11 +84,19 @@ pub async fn transact(
             .branch(&path.branch);
         transact_on_branch(&tonk_state, tonk_branch, body).await?
     };
-    // Mark the repo dirty so the next sync drain pushes its new commits. The
-    // SW owns the sync work-queue (the page only pokes `POST /api/sync` on a
-    // heartbeat); a commit here is the authoritative "this repo has un-pushed
-    // changes" signal. A no-op transact (empty claims) re-marks harmlessly —
-    // the drain just finds nothing ahead and pushes nothing.
+    // Mark the repo dirty so the next sync drain pushes its new commits — but
+    // ONLY if the commit actually moved the tree. The SW owns the sync
+    // work-queue (the page only pokes `POST /api/sync` on a heartbeat); a
+    // commit here is the authoritative "this repo has un-pushed changes"
+    // signal, and a transact whose data didn't change has none.
+    //
+    // This is not hypothetical: every page load fires the transient
+    // `tonk:load` site stamp through this route. Transients are retracted
+    // before the durable write, so the commit lands with an IDENTICAL tree
+    // hash (only the revision's `moment` ticks) — yet it used to enqueue the
+    // repo, so every single reload scheduled a push of nothing.
+    if response.0.revision_before.as_ref().map(|r| &r.tree)
+        != response.0.revision_after.as_ref().map(|r| &r.tree)
     {
         let tonk_state = state.read().await;
         tonk_state.sync_queue.mark_dirty(&path.repo, now_millis());

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -333,6 +333,10 @@ pub struct TonkState {
     /// `POST /api/sync` (the page heartbeat) and the post-commit push drain
     /// reconcile it. See `router::sync::SyncQueue`.
     pub sync_queue: crate::router::SyncQueue,
+    /// Liveness ledger: SW client → what it registered (site stamps) and
+    /// whether we have observed it alive. The stale-client sweep reaps
+    /// born-then-died clients from here. See [`crate::router::ClientRegistry`].
+    pub clients: crate::router::ClientRegistry,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -612,6 +616,19 @@ struct SyncScheduler {
     /// it — later requests just ride the debounce. Taken (and logged) by the
     /// ticket that actually drains.
     cause: std::rc::Rc<std::cell::RefCell<Option<String>>>,
+    /// Wall-clock ms when the last drain FINISHED, so the next one can be
+    /// held off for [`SYNC_COOLDOWN_MS`]. The debounce measures from the
+    /// triggering request, which says nothing about how long the previous
+    /// drain ran: on a slow link a drain can outlast the loop's interval, so
+    /// without a completion-relative gap the next drain starts the moment the
+    /// last one lands and sync runs back-to-back forever.
+    last_drain_end: std::rc::Rc<std::cell::Cell<f64>>,
+    /// Set once the worker is being replaced. A dying worker must not start
+    /// new sync work: the SW spec keeps it alive until every `waitUntil`
+    /// settles and every fetch completes, so a drain scheduled (or a loop
+    /// tick fired) after `updatefound` pins the outgoing worker in `waiting`
+    /// — which is why it "won't go away".
+    stopped: std::rc::Rc<std::cell::Cell<bool>>,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -654,12 +671,7 @@ impl SyncScheduler {
     /// past [`SYNC_MAX_WAIT_MS`] (the cap, so continuous traffic can't starve
     /// the drain).
     fn should_drain(&self, ticket: u64, now: f64) -> bool {
-        if self.in_flight.get() {
-            return false;
-        }
-        // Yield to an actively-loading page — a boot burst (this tab or another)
-        // finishes before sync competes for the SW thread and branch locks.
-        if self.is_loading(now) {
+        if !self.may_drain(now) {
             return false;
         }
         let is_latest = self.generation.get() == ticket;
@@ -670,6 +682,35 @@ impl SyncScheduler {
         is_latest || capped
     }
 
+    /// The gate EVERY drain entrypoint passes through — the debounced
+    /// per-fetch drain, the self-scheduled loop, and Background Sync's
+    /// `onsync`. Previously only the per-fetch path consulted `in_flight`,
+    /// so a loop tick could start a second drain on top of a running one and
+    /// they would contend for the SW thread and the branch locks.
+    ///
+    /// Refuses when: the worker is being replaced (a dying worker must start
+    /// no new work — see `stopped`), a drain is already running, a page is
+    /// actively loading, or the previous drain finished less than
+    /// [`SYNC_COOLDOWN_MS`] ago.
+    fn may_drain(&self, now: f64) -> bool {
+        if self.stopped.get() {
+            return false;
+        }
+        if self.in_flight.get() {
+            return false;
+        }
+        // Yield to an actively-loading page — a boot burst (this tab or another)
+        // finishes before sync competes for the SW thread and branch locks.
+        if self.is_loading(now) {
+            return false;
+        }
+        // Quiet period measured from the LAST DRAIN'S COMPLETION, not from the
+        // request that triggered this one. Without it, a drain that outlasts
+        // the loop interval (easy on a slow link) is followed immediately by
+        // the next, and sync runs continuously.
+        now - self.last_drain_end.get() >= SYNC_COOLDOWN_MS as f64
+    }
+
     /// Mark a drain as started: take the `in_flight` guard and clear the burst
     /// clock so the max-wait cap restarts from the next request.
     fn begin_drain(&self) {
@@ -677,9 +718,21 @@ impl SyncScheduler {
         self.pending_since.set(None);
     }
 
-    /// Release the `in_flight` guard once a drain finishes.
+    /// Release the `in_flight` guard once a drain finishes, and stamp the
+    /// completion time so the cooldown measures from here.
     fn end_drain(&self) {
         self.in_flight.set(false);
+        self.last_drain_end.set(js_sys::Date::now());
+    }
+
+    /// Stop all sync work: the worker is being replaced. Idempotent.
+    fn stop(&self) {
+        self.stopped.set(true);
+    }
+
+    /// Whether the worker has been told to stop.
+    fn stopped(&self) -> bool {
+        self.stopped.get()
     }
 
     /// Record the burst-opening request: the first call after a drain wins,
@@ -732,6 +785,15 @@ const SYNC_DEBOUNCE_MS: i32 = 500;
 /// the drain never runs. Measured from the first request after the last drain.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const SYNC_MAX_WAIT_MS: i32 = 3_000;
+
+/// Minimum quiet period between the END of one sync drain and the start of
+/// the next. The debounce measures from the triggering request, which says
+/// nothing about how long the previous drain ran — on a slow link a drain can
+/// outlast the loop's interval, and without a completion-relative gap the next
+/// one starts the instant the last lands, so sync runs continuously and starves
+/// the queries it shares the single SW thread with.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const SYNC_COOLDOWN_MS: i32 = 2_000;
 
 /// The main Tonk service worker that handles browser fetch events.
 ///
@@ -817,6 +879,7 @@ impl TonkServiceWorker {
             bridges: Default::default(),
             commands: crate::router::command_registry(),
             sync_queue: Default::default(),
+            clients: Default::default(),
         };
         bootstrap_profile(&state)
             .await
@@ -856,6 +919,16 @@ impl TonkServiceWorker {
     #[wasm_bindgen(js_name = "onupdatefound")]
     pub fn on_update_found(&self) -> Promise {
         log!("Update found — releasing in-flight streams");
+        // Stop all sync work FIRST. The spec keeps this worker alive until
+        // every in-flight fetch and every `waitUntil` promise settles; a drain
+        // scheduled on a fetch's `waitUntil`, or the self-scheduled loop's next
+        // tick, would keep re-arming that condition and pin the outgoing worker
+        // in `waiting` indefinitely — the "SW won't go away" symptom.
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        {
+            self.sync_scheduler.stop();
+            self.sync_loop.set(false);
+        }
         let lsp = self.lsp.clone();
         let state = self.state.clone();
         future_to_promise(async move {
@@ -1031,8 +1104,23 @@ impl TonkServiceWorker {
     pub fn sync(&self, tag: String) -> Promise {
         let state = self.state.clone();
 
+        // Same gate as every other drain entrypoint: never overlap a running
+        // drain, never run on a worker that is being replaced, and honor the
+        // completion-relative cooldown.
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        let scheduler = self.sync_scheduler.clone();
         future_to_promise(async move {
             log!("Background sync triggered ({tag:?})");
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            {
+                if !scheduler.may_drain(js_sys::Date::now()) {
+                    return Ok(JsValue::UNDEFINED);
+                }
+                scheduler.begin_drain();
+                crate::router::drain_sync(&state).await;
+                scheduler.end_drain();
+            }
+            #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
             crate::router::drain_sync(&state).await;
             Ok(JsValue::UNDEFINED)
         })
@@ -1057,11 +1145,14 @@ impl TonkServiceWorker {
             self.ensure_sync_loop();
         }
         let state = self.state.clone();
+        let scheduler = self.sync_scheduler.clone();
         future_to_promise(async move {
             if offline {
                 crate::router::mark_offline(&state).await;
-            } else {
+            } else if scheduler.may_drain(js_sys::Date::now()) {
+                scheduler.begin_drain();
                 crate::router::drain_sync(&state).await;
+                scheduler.end_drain();
             }
             Ok(JsValue::UNDEFINED)
         })
@@ -1077,15 +1168,23 @@ impl TonkServiceWorker {
     /// it. This replaces the page-side `POST /api/sync` heartbeat.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     fn ensure_sync_loop(&self) {
-        if self.sync_loop.get() {
+        // A worker being replaced starts no new work — its loop would keep
+        // waking up and pinning it in `waiting`.
+        if self.sync_scheduler.stopped() || self.sync_loop.get() {
             return;
         }
         self.sync_loop.set(true);
         let running = self.sync_loop.clone();
         let state = self.state.clone();
+        let scheduler = self.sync_scheduler.clone();
         wasm_bindgen_futures::spawn_local(async move {
             loop {
                 let _ = crate::sleep(web_time::Duration::from_millis(SYNC_LOOP_MS)).await;
+                // The worker is being replaced (or `onupdatefound` cleared the
+                // running flag): exit so this worker can be released.
+                if scheduler.stopped() || !running.get() {
+                    break;
+                }
                 if offline() {
                     // Reflect the disconnect, then stop — `ononline`
                     // restarts the loop and reconciles immediately.
@@ -1102,7 +1201,19 @@ impl TonkServiceWorker {
                     log!("sync loop parked: every open space is paused");
                     break;
                 }
+                // Through the SAME gate as the per-fetch drain: a loop tick used
+                // to call `drain_sync` directly, so it could start a second
+                // drain on top of one already running (they only consulted
+                // `in_flight` on the per-fetch path) and the two then contended
+                // for the single SW thread and the branch locks. The gate also
+                // enforces the cooldown, so a drain that outlasts this interval
+                // is not immediately followed by another.
+                if !scheduler.may_drain(js_sys::Date::now()) {
+                    continue;
+                }
+                scheduler.begin_drain();
                 crate::router::drain_sync(&state).await;
+                scheduler.end_drain();
             }
             running.set(false);
         });

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -480,7 +480,7 @@ mod route_for_tests {
         // Drain at the trailing edge, which clears the burst clock.
         assert!(s.should_drain(t1, SYNC_DEBOUNCE_MS as f64));
         s.begin_drain();
-        s.end_drain();
+        s.end_drain(SYNC_DEBOUNCE_MS as f64);
         // A fresh burst after the drain starts a NEW cap clock at t=10_000. Use a
         // superseded ticket (t2, then t3 bumps the generation) so `is_latest` is
         // false and only the cap can trigger a drain — that's what proves the
@@ -508,7 +508,7 @@ mod route_for_tests {
             !s.should_drain(t1, SYNC_MAX_WAIT_MS as f64 * 10.0),
             "in_flight guard must block a second concurrent drain",
         );
-        s.end_drain();
+        s.end_drain(SYNC_MAX_WAIT_MS as f64 * 10.0);
     }
 
     #[dialog_common::test]
@@ -622,7 +622,9 @@ struct SyncScheduler {
     /// drain ran: on a slow link a drain can outlast the loop's interval, so
     /// without a completion-relative gap the next drain starts the moment the
     /// last one lands and sync runs back-to-back forever.
-    last_drain_end: std::rc::Rc<std::cell::Cell<f64>>,
+    /// `None` until the first drain completes: with no previous drain there is
+    /// nothing to cool down from, so the first one runs immediately.
+    last_drain_end: std::rc::Rc<std::cell::Cell<Option<f64>>>,
     /// Set once the worker is being replaced. A dying worker must not start
     /// new sync work: the SW spec keeps it alive until every `waitUntil`
     /// settles and every fetch completes, so a drain scheduled (or a loop
@@ -708,7 +710,9 @@ impl SyncScheduler {
         // request that triggered this one. Without it, a drain that outlasts
         // the loop interval (easy on a slow link) is followed immediately by
         // the next, and sync runs continuously.
-        now - self.last_drain_end.get() >= SYNC_COOLDOWN_MS as f64
+        self.last_drain_end
+            .get()
+            .is_none_or(|end| now - end >= SYNC_COOLDOWN_MS as f64)
     }
 
     /// Mark a drain as started: take the `in_flight` guard and clear the burst
@@ -718,11 +722,13 @@ impl SyncScheduler {
         self.pending_since.set(None);
     }
 
-    /// Release the `in_flight` guard once a drain finishes, and stamp the
-    /// completion time so the cooldown measures from here.
-    fn end_drain(&self) {
+    /// Release the `in_flight` guard once a drain finishes, stamping `now` as
+    /// the completion time so the cooldown measures from here. The clock is
+    /// passed in rather than read internally so the gate is testable against a
+    /// synthetic one.
+    fn end_drain(&self, now: f64) {
         self.in_flight.set(false);
-        self.last_drain_end.set(js_sys::Date::now());
+        self.last_drain_end.set(Some(now));
     }
 
     /// Stop all sync work: the worker is being replaced. Idempotent.
@@ -1118,7 +1124,7 @@ impl TonkServiceWorker {
                 }
                 scheduler.begin_drain();
                 crate::router::drain_sync(&state).await;
-                scheduler.end_drain();
+                scheduler.end_drain(js_sys::Date::now());
             }
             #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
             crate::router::drain_sync(&state).await;
@@ -1152,7 +1158,7 @@ impl TonkServiceWorker {
             } else if scheduler.may_drain(js_sys::Date::now()) {
                 scheduler.begin_drain();
                 crate::router::drain_sync(&state).await;
-                scheduler.end_drain();
+                scheduler.end_drain(js_sys::Date::now());
             }
             Ok(JsValue::UNDEFINED)
         })
@@ -1213,7 +1219,7 @@ impl TonkServiceWorker {
                 }
                 scheduler.begin_drain();
                 crate::router::drain_sync(&state).await;
-                scheduler.end_drain();
+                scheduler.end_drain(js_sys::Date::now());
             }
             running.set(false);
         });
@@ -1315,7 +1321,7 @@ fn schedule_sync_drain(event: &FetchEvent, scheduler: &SyncScheduler, state: &Ap
         if offline() {
             scheduler.begin_drain();
             crate::router::mark_offline(&state).await;
-            scheduler.end_drain();
+            scheduler.end_drain(js_sys::Date::now());
             return Ok(JsValue::UNDEFINED);
         }
         scheduler.begin_drain();
@@ -1323,7 +1329,7 @@ fn schedule_sync_drain(event: &FetchEvent, scheduler: &SyncScheduler, state: &Ap
             log!("sync drain, caused by: {cause}");
         }
         crate::router::drain_sync(&state).await;
-        scheduler.end_drain();
+        scheduler.end_drain(js_sys::Date::now());
         Ok(JsValue::UNDEFINED)
     });
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -333,6 +333,10 @@ pub struct TonkState {
     /// `POST /api/sync` (the page heartbeat) and the post-commit push drain
     /// reconcile it. See `router::sync::SyncQueue`.
     pub sync_queue: crate::router::SyncQueue,
+    /// Stamped site entities keyed to the SW client each serves, so
+    /// the stale-client sweep can prune dead clients' site facts
+    /// from the branch overlays. See [`crate::router::SiteRegistry`].
+    pub sites: crate::router::SiteRegistry,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -817,6 +821,7 @@ impl TonkServiceWorker {
             bridges: Default::default(),
             commands: crate::router::command_registry(),
             sync_queue: Default::default(),
+            sites: Default::default(),
         };
         bootstrap_profile(&state)
             .await

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1038,31 +1038,31 @@ impl TonkServiceWorker {
         })
     }
 
-    /// Connectivity lost — the SW's own `offline` event. Stamp
-    /// `sync:offline` on every open repo so the chips/discs reflect the
-    /// disconnect. This is the reliable signal: an offline page stops
-    /// polling, so no fetch would otherwise wake this worker.
+    /// Connectivity changed. Re-read `navigator.onLine` (reliable in the SW
+    /// scope) and reconcile: offline stamps `sync:offline` on every open repo
+    /// so the chips/discs reflect the disconnect; online runs a drain and
+    /// restarts the self-scheduled sync loop the offline transition stopped.
+    ///
+    /// Fired both by the SW's own `offline`/`online` events and by a
+    /// `{type:"connectivity"}` nudge from the active page (whose events fire
+    /// even when the SW's don't). Either way the decision is made from
+    /// `navigator.onLine`, not from who fired — a flapping transition settles
+    /// on the current reading.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    #[wasm_bindgen(js_name = "onoffline")]
-    pub fn on_offline(&self) -> Promise {
+    #[wasm_bindgen(js_name = "onconnectivity")]
+    pub fn on_connectivity(&self) -> Promise {
+        let offline = offline();
+        if !offline {
+            // Restart the self-scheduled loop the offline transition stopped.
+            self.ensure_sync_loop();
+        }
         let state = self.state.clone();
         future_to_promise(async move {
-            crate::router::mark_offline(&state).await;
-            Ok(JsValue::UNDEFINED)
-        })
-    }
-
-    /// Connectivity restored — the SW's own `online` event. Run a drain
-    /// directly (like Background Sync's `onsync`) so statuses reconcile
-    /// immediately, and restart the self-scheduled sync loop the offline
-    /// transition stopped.
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    #[wasm_bindgen(js_name = "ononline")]
-    pub fn on_online(&self) -> Promise {
-        self.ensure_sync_loop();
-        let state = self.state.clone();
-        future_to_promise(async move {
-            crate::router::drain_sync(&state).await;
+            if offline {
+                crate::router::mark_offline(&state).await;
+            } else {
+                crate::router::drain_sync(&state).await;
+            }
             Ok(JsValue::UNDEFINED)
         })
     }
@@ -1222,11 +1222,13 @@ fn schedule_sync_drain(event: &FetchEvent, scheduler: &SyncScheduler, state: &Ap
     let _ = extendable.wait_until(&promise);
 }
 
-/// Whether the worker reports no network connectivity. Unknown (no worker
-/// global) counts as online — a wrongly skipped drain is worse than a
-/// failed fetch.
+/// Whether the worker reports no network connectivity, read straight from
+/// `navigator.onLine` in the service-worker scope (which does update under
+/// DevTools offline emulation and reflects the real connection in the wild).
+/// A failure to read the scope counts as online — a wrongly skipped drain is
+/// worse than a failed fetch (which itself stamps `sync:offline`).
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn offline() -> bool {
+pub(crate) fn offline() -> bool {
     use wasm_bindgen::JsCast;
     js_sys::global()
         .dyn_into::<web_sys::WorkerGlobalScope>()

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -506,6 +506,68 @@ mod route_for_tests {
         );
         s.end_drain();
     }
+
+    #[dialog_common::test]
+    fn it_defers_a_drain_while_a_page_is_loading() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        // A data-plane request is in flight (a page booting): even the latest
+        // ticket at its debounce edge must NOT drain — sync yields the thread.
+        let _guard = s.enter_loading(0.0);
+        assert!(
+            !s.should_drain(t1, SYNC_DEBOUNCE_MS as f64),
+            "an in-flight data-plane request defers the drain",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_drains_once_the_load_settles() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        {
+            let _guard = s.enter_loading(0.0);
+            assert!(!s.should_drain(t1, SYNC_DEBOUNCE_MS as f64));
+        }
+        // Guard dropped — the request completed, so the drain proceeds.
+        assert!(
+            s.should_drain(t1, SYNC_DEBOUNCE_MS as f64),
+            "the drain runs once the in-flight request completes",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_stops_deferring_past_the_load_cap() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        // A request that never completes (held guard) must not defer sync
+        // forever: past SYNC_LOAD_DEFER_MS from its start, the drain proceeds.
+        let _guard = s.enter_loading(0.0);
+        assert!(
+            !s.should_drain(t1, SYNC_LOAD_DEFER_MS as f64 - 1.0),
+            "within the cap, an in-flight request still defers",
+        );
+        assert!(
+            s.should_drain(t1, SYNC_LOAD_DEFER_MS as f64),
+            "past the cap, a stuck request no longer defers the drain",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_counts_concurrent_loads() {
+        let s = SyncScheduler::default();
+        let t1 = s.next(0.0);
+        let g1 = s.enter_loading(0.0);
+        let g2 = s.enter_loading(0.0);
+        drop(g1);
+        // One of two concurrent requests finished; the other still defers
+        // (e.g. a second tab still booting).
+        assert!(
+            !s.should_drain(t1, SYNC_DEBOUNCE_MS as f64),
+            "a drain waits while any data-plane request is still in flight",
+        );
+        drop(g2);
+        assert!(s.should_drain(t1, SYNC_DEBOUNCE_MS as f64));
+    }
 }
 
 /// Trailing-edge debounce coordinator for the background sync drain, with a
@@ -532,6 +594,16 @@ mod route_for_tests {
 struct SyncScheduler {
     generation: std::rc::Rc<std::cell::Cell<u64>>,
     in_flight: std::rc::Rc<std::cell::Cell<bool>>,
+    /// Count of outstanding data-plane (`/api/*`) requests. A sync drain
+    /// competes with these for the single SW thread and the reactor's branch
+    /// locks, so it holds off while any are in flight — a page actively loading
+    /// (this tab or another) finishes its boot before sync does network work.
+    /// Bounded by [`SYNC_LOAD_DEFER_MS`] so a hung request can't defer sync
+    /// forever.
+    loading: std::rc::Rc<std::cell::Cell<u32>>,
+    /// Wall-clock ms of the last data-plane request start, used with `loading`
+    /// to cap how long an in-flight request may defer a drain.
+    last_request_at: std::rc::Rc<std::cell::Cell<f64>>,
     /// Wall-clock ms when the current un-drained burst began, or `None` when the
     /// last drain cleared it. The max-wait cap measures from here.
     pending_since: std::rc::Rc<std::cell::Cell<Option<f64>>>,
@@ -557,12 +629,37 @@ impl SyncScheduler {
         next
     }
 
+    /// Mark a data-plane (`/api/*`) request as started — a drain defers while
+    /// any are outstanding. Returns a guard that decrements on drop, so the
+    /// count is released on any request outcome (success, error, or panic).
+    fn enter_loading(&self, now: f64) -> LoadingGuard {
+        self.loading.set(self.loading.get().saturating_add(1));
+        self.last_request_at.set(now);
+        LoadingGuard {
+            loading: self.loading.clone(),
+        }
+    }
+
+    /// Whether a page is actively loading: at least one data-plane request is
+    /// in flight AND the most recent one started within [`SYNC_LOAD_DEFER_MS`].
+    /// The time bound caps how long a single stuck request can defer sync — past
+    /// it, the drain proceeds even with the counter non-zero.
+    fn is_loading(&self, now: f64) -> bool {
+        self.loading.get() > 0 && now - self.last_request_at.get() < SYNC_LOAD_DEFER_MS as f64
+    }
+
     /// Whether a woken ticket should drain now. True when no drain is already
-    /// running AND either the ticket is still the latest (normal trailing edge)
-    /// or the current burst has been pending past [`SYNC_MAX_WAIT_MS`] (the cap,
-    /// so continuous traffic can't starve the drain).
+    /// running AND no page is actively loading AND either the ticket is still
+    /// the latest (normal trailing edge) or the current burst has been pending
+    /// past [`SYNC_MAX_WAIT_MS`] (the cap, so continuous traffic can't starve
+    /// the drain).
     fn should_drain(&self, ticket: u64, now: f64) -> bool {
         if self.in_flight.get() {
+            return false;
+        }
+        // Yield to an actively-loading page — a boot burst (this tab or another)
+        // finishes before sync competes for the SW thread and branch locks.
+        if self.is_loading(now) {
             return false;
         }
         let is_latest = self.generation.get() == ticket;
@@ -599,6 +696,28 @@ impl SyncScheduler {
         self.cause.borrow_mut().take()
     }
 }
+
+/// Decrements the scheduler's in-flight data-plane count on drop, so a request
+/// releases its "loading" hold on the sync drain regardless of how it finishes.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+struct LoadingGuard {
+    loading: std::rc::Rc<std::cell::Cell<u32>>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl Drop for LoadingGuard {
+    fn drop(&mut self) {
+        self.loading.set(self.loading.get().saturating_sub(1));
+    }
+}
+
+/// How long an in-flight data-plane request may defer the sync drain. Past this,
+/// a stuck or slow request no longer holds sync off — the drain proceeds even
+/// with requests still counted as in flight. Comfortably longer than a normal
+/// page load (sub-500ms measured) so a real boot always completes first, but
+/// short enough that a genuinely hung request doesn't stall sync for long.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+const SYNC_LOAD_DEFER_MS: i32 = 2_000;
 
 /// Quiet window before a request's scheduled sync drain fires. A burst of boot
 /// queries collapses into one drain at the trailing edge. Kept short so a
@@ -831,7 +950,21 @@ impl TonkServiceWorker {
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         self.ensure_sync_loop();
 
+        // Count data-plane (`/api/*`) requests as in-flight for the duration of
+        // this fetch: they contend with the sync drain for the SW thread and the
+        // reactor's branch locks, so the drain holds off while any are running.
+        // A page actively booting (this tab or another) thus finishes before
+        // sync does network work. Static-asset fetches don't count — they never
+        // touch the reactor. The guard rides into the future below and drops when
+        // the request completes.
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        let loading_guard = path
+            .starts_with("/api/")
+            .then(|| self.sync_scheduler.enter_loading(js_sys::Date::now()));
+
         future_to_promise(async move {
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            let _loading_guard = loading_guard;
             // Opportunistic cleanup of stale bridge sessions and view
             // bindings. Cheap enough to run on every fetch.
             #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -333,10 +333,6 @@ pub struct TonkState {
     /// `POST /api/sync` (the page heartbeat) and the post-commit push drain
     /// reconcile it. See `router::sync::SyncQueue`.
     pub sync_queue: crate::router::SyncQueue,
-    /// Stamped site entities keyed to the SW client each serves, so
-    /// the stale-client sweep can prune dead clients' site facts
-    /// from the branch overlays. See [`crate::router::SiteRegistry`].
-    pub sites: crate::router::SiteRegistry,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -821,7 +817,6 @@ impl TonkServiceWorker {
             bridges: Default::default(),
             commands: crate::router::command_registry(),
             sync_queue: Default::default(),
-            sites: Default::default(),
         };
         bootstrap_profile(&state)
             .await


### PR DESCRIPTION
Space loads were slow and got slower with every reload (7.5s settling time growing past 11s), resetting only when the service worker restarted. Chasing that surfaced four more defects in the same area; this branch fixes all of them.

**Per-client state accumulated in the SW.** Every reload assigns the page a fresh client id, and nothing reconciled the old one, so `site:` overlay facts (folded into every read of the branch) and SSE subscriptions (re-evaluated on every poll) grew without bound. The sweep now reaps them — but only for clients it can *prove* are dead.

That proof is the subtle part. Absence from `clients.matchAll()` is **not** death: a navigation's client id is the `FetchEvent`'s `resultingClientId`, the id the *future* document will get, so a booting page is legitimately absent for its entire boot — which is exactly when it stamps its site and opens its subscriptions. Reaping on bare absence deleted the live page's own session out from under it, and its display then waited forever on a subscription nobody would feed (a stuck query on every second reload). A client is now reaped only once it has been **seen alive and has since vanished**.

**Sync had no cross-mechanism single-flight.** Only the per-fetch drain consulted `in_flight`; the self-scheduled loop and Background Sync's `onsync` called `drain_sync()` directly, so a loop tick could stack a second drain on top of a running one and the two contended for the single SW thread and the branch locks. Every entrypoint now passes one gate, with a quiet period measured from the previous drain's **completion** (the debounce measures from the triggering request, which says nothing about how long the last drain ran — on a slow link it can outlast the loop interval, and sync then runs continuously).

**The worker would not go away.** The SW spec keeps a worker alive until every in-flight fetch and `waitUntil` settles. Sync drains ride `waitUntil`, and the self-scheduled loop kept re-arming, so the outgoing worker never reached the quiet state needed to release it. A worker being replaced now starts no new sync work.

**Every reload queued a push of nothing.** The transient `tonk:load` site stamp is retracted before the durable write, so its commit lands with an identical tree hash — yet the repo was marked dirty unconditionally, so each reload scheduled a push with nothing to push.

**Back needed several presses.** Guest-iframe teardown set `src="about:blank"`, which *navigates* the frame — and a frame navigation appends an entry to the joint session history. History grew three entries per reload. The unload now goes through the frame's own `location.replace()`, which replaces the entry instead of appending one. Measured: history length held flat across reloads (was 4 → 7 per reload).

**Shell revalidation was dead.** `revalidate()` cloned the cached `Response` *after* `serveNavigation` had handed that same object to the browser, so the clone raced the page consuming the body and threw "Response body is already used" — the `cache.put` below it never ran, and every navigation paid a `/` fetch whose result was discarded on the exception.

Reload settle time is flat at ~1s, and offline / Slow 3G reloads match online speed (offline was previously *faster* than 3G, because offline short-circuits sync before it can do any of the wasted work above).

Depends on `Overlay::retain_entities` from dialog-db#390 (pinned via the `tonk-2026-07-12-2` tag): the overlay needed a remove-by-entity primitive, since retracting would only grow it with tombstones and clearing would take unrelated sessions' facts along with the dead ones.

Also on this branch: a same-document navigation fix (the nested `<tonk-site>` now re-routes when its path changes; a site re-stamp replaces its overlay facts so params the new route does not capture cannot go stale), cache-first asset serving without booting the wasm worker, offline detection in SW scope, and /evaluate read-lock + per-branch commit serialization.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of client subscriptions and state management in a service worker context, including improvements to client tracking, subscription delivery, and site registration.

### Detailed summary
- Added `client` tracking in subscriptions.
- Improved client state management for dead clients.
- Enhanced site registration with client ID.
- Updated subscription logic to ensure correct delivery to clients.
- Refined handling of network connectivity and offline states.
- Adjusted site stamping to replace existing overlay facts.

> The following files were skipped due to too many changes: `rust/tonk-ui/assets/service_worker.js`, `rust/tonk-worker/src/router/evaluate.rs`, `rust/tonk-worker/src/worker.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->