### PR TITLE
build(deps): repoint dialog to a non-orphaned tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "base58",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "base58",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "base58",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "async-trait",
  "base58",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-12-2#baa5d57e8ca2b64af01883a1b10397094444f41c"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-13#e86f42a2332b16bb548b6111a6da57e61b4e57f4"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,22 +164,22 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-12-2" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-13" }
 
 # NOTE — incremental subscriptions (plan/incremental-subscriptions.md): the
 # dialog deps above are pinned to the `feat/inductive-self-negation` BRANCH (not


### PR DESCRIPTION
`staging` pins dialog at `tonk-2026-07-12-2`, which points at an **orphaned commit**. That tag was cut before dialog-db#390 was rebased, so the commit it names is reachable from no branch — if it is ever garbage-collected, the build stops resolving.

`tonk-2026-07-13` tags that PR's live head. It carries the identical `retain_entities` change and actually sits on `feat/overlay-retain-entities`, so it cannot be collected out from under us.

Note this does not remove the underlying dependency: `staging` still builds against an **unmerged** dialog PR (dialog-db#390). Once that merges we should repoint again at a tag on the merged base. This is the safe interim step.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Cargo.toml` and `Cargo.lock` files to change the Git tags for various `dialog` dependencies from `tonk-2026-07-12-2` to `tonk-2026-07-13`, ensuring that the project uses the latest versions of these dependencies.

### Detailed summary
- Updated `Cargo.toml` to change all `dialog` dependencies' tags to `tonk-2026-07-13`.
- Updated `Cargo.lock` to reflect the new source tags for:
  - `dialog-artifacts`
  - `dialog-capability`
  - `dialog-common`
  - `dialog-credentials`
  - `dialog-csv`
  - `dialog-effects`
  - `dialog-operator`
  - `dialog-query`
  - `dialog-remote-s3`
  - `dialog-remote-ucan-s3`
  - `dialog-repository`
  - `dialog-search-tree`
  - `dialog-storage`
  - `dialog-ucan`
  - `dialog-ucan-core`
  - `dialog-varsig`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->