### PR TITLE
Share: mint and copy on one click, and dismiss the FAB menus by clicking away

### DIFF
--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -692,18 +692,20 @@ view/fab-roster!:
   display: |
     <span class="fab__menu-item fab__menu-item--member">{name}</span>
 
-# A compact invite-link view kind for the FAB bar. Distinct attribute
+# The FAB bar's invite view kind. Distinct attribute
 # (`xyz.tonk.view/fab-invite`) so `tonk:agent-invite` can carry both its
-# default agent-prompt view AND this compact bar link. Selected via
-# `view=tonk:view/fab-invite`. Renders a single "Copy invite link" button —
-# the raw access token is never shown; the `<wa-copy-button>` carries the
-# real absolute join URL (`{base}?access={access}{remote}#{code}`, `base` =
-# `{origin}/join` from a wrapping `<tonk-origin>`) and copies it on click,
-# briefly swapping its label to "Copied!". Resolves only once both invite
-# halves exist, so the FAB shows the "share" mint button until the mint lands.
+# default agent-prompt view AND this one. Selected via
+# `view=tonk:view/fab-invite`.
+#
+# It renders NOTHING. Minting and copying are one click on the FAB's "share"
+# button (`<tonk-share>`), so there is no second control to render: this view's
+# only job is to carry the minted `link` into the DOM, where the display's
+# `tonk-display:result` event delivers it to `<tonk-share>`, which completes the
+# clipboard write it opened on the click. The profile stylesheet hides the
+# display outright. The raw access token is never rendered.
 concept!: &view/fab-invite
   this: tonk:view/fab-invite
-  description: A compact invite-link view kind for the FAB bar.
+  description: Carries the minted invite link to the FAB's share control.
   with:
     model:
       description: Concept this view renders
@@ -711,19 +713,20 @@ concept!: &view/fab-invite
       cardinality: one
       as: entity
     display:
-      description: HTML template for the FAB compact invite link
+      description: HTML template carrying the minted invite link
       the: xyz.tonk.view/fab-invite
       cardinality: one
       as: text
 
+# Renders the link into a hidden element rather than a control. The display is
+# `display: none` in the FAB, so this is never seen; it exists because a view
+# must render *something* for the display to reach `ready` and dispatch the
+# `tonk-display:result` that hands `{link}` to `<tonk-share>`.
 view/fab-invite!:
   this: id:tonk:agent-invite/fab-invite
   model: tonk:agent-invite
   display: |
-    <wa-copy-button class="fab__invite" style="display: inline-flex; align-items: center; vertical-align: middle;" copy-label="Copy invite link for {name}" value="{link}">
-      <span slot="copy-icon" class="fab__invite-label"><wa-icon name="copy" style="opacity: 0.7;"></wa-icon>copy invite link</span>
-      <span slot="success-icon" class="fab__invite-label"><wa-icon name="check"></wa-icon>copied</span>
-    </wa-copy-button>
+    <span class="fab__invite-link" hidden>{link}</span>
 
 # The FAB share-mint trigger — a no-entity directory view over
 # `tonk:repository`, mounted in the FAB share zone via
@@ -752,7 +755,18 @@ view/directory!:
   model: tonk:repository
   display: |
     <form class="fab__share-form" data-invite="tonk:invite" onsubmit=tonk:invite>
-      <button type="submit" class="fab__share-trigger">share</button>
+      <button type="submit" class="fab__share-trigger">
+        <span class="fab__share-label fab__share-label--idle">share</span>
+        <span class="fab__share-label fab__share-label--copying">
+          <span class="fab__share-spinner"></span>copying…
+        </span>
+        <span class="fab__share-label fab__share-label--copied">
+          <wa-icon name="check"></wa-icon>copied
+        </span>
+        <span class="fab__share-label fab__share-label--failed">
+          <wa-icon name="triangle-exclamation"></wa-icon>failed
+        </span>
+      </button>
     </form>
 
 # NOTE: the FAB's pause affordance is no longer a space-side view. It moved to

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -876,34 +876,43 @@ view/directory!: &profile/fab/view
              against this nested space branch (its origin repo). `<tonk-origin>`
              supplies `{origin}/join` as `data-base` for the copyable URL. -->
         <span class="fab__seg fab__share">
-            <tonk-origin>
-              <!-- The minted invite link. Shown once the mint lands; before
-                   that `tonk:agent-invite` does not resolve and the empty
-                   hidden fallbacks suppress tonk-display's built-in absence
-                   callout, so the bar shows only the "share" button below.
-                   When it resolves the display sets `data-state="ready"`, and
-                   the CSS sibling rule hides the button so the bar shows just
-                   the link + copy. `bind:base` supplies `{origin}/join`.
-                   Each display carries its own `with={dom.host/data-space}`
-                   (the active space) — routing is per element, not inherited
-                   from the wrapping span. -->
-              <tonk-display class="fab__invite-display" with={dom.host/data-space} entity={dom.host/data-space} model=tonk:agent-invite view=tonk:view/fab-invite bind:base="data-base">
+            <!-- `<tonk-share>` makes minting and copying ONE click. A click on
+                 the "share" button opens a clipboard write against a promise
+                 (synchronously, while the click's user activation is still
+                 live — the async mint would otherwise outlive it and the
+                 browser would refuse the write), lets the click fall through to
+                 the mint form below, then resolves that promise with the invite
+                 URL as soon as the mint's frame arrives. It stamps its own
+                 `data-share-state` (idle → copying → copied → idle), which the
+                 stylesheet keys the label and spinner off. -->
+            <tonk-share>
+              <!-- The minted invite. Not shown: its whole job is to DELIVER the
+                   URL. When the mint lands, `tonk:agent-invite` resolves and
+                   this display dispatches a bubbling `tonk-display:result`
+                   carrying the assembled (already shortened) `link`, which
+                   `<tonk-share>` reads to complete the pending clipboard write.
+                   The user never sees or clicks a separate copy control, so the
+                   link itself needs no chrome. The empty hidden fallbacks
+                   suppress tonk-display's built-in absence callout.
+                   `with={dom.host/data-space}` (the active space) is per
+                   element — routing is not inherited from the wrapping span. -->
+              <tonk-display class="fab__invite-display" with={dom.host/data-space} entity={dom.host/data-space} model=tonk:agent-invite view=tonk:view/fab-invite>
                 <span slot="no-entity" hidden></span>
                 <span slot="no-model" hidden></span>
                 <span slot="loading" hidden></span>
               </tonk-display>
-              <!-- The mint trigger. The "share" form lives in a SPACE-branch
-                   view (core.yaml's `tonk:repository` directory view), mounted
-                   here no-entity inside the nested `with` context — so its
-                   `onsubmit=tonk:invite` binding both resolves its descriptor
-                   AND dispatches its claim on the SPACE's content branch, where
-                   the worker's InviteHandler mints for that repo. (Binding it in
-                   the FAB's own profile/meta template instead dispatched the
-                   claim to profile/meta with an empty origin repo.) Directory
-                   chrome renders regardless of whether the repo is named, so the
-                   "share" button is always present. -->
+              <!-- The mint trigger, and now the only visible control. The
+                   "share" form lives in a SPACE-branch view (core.yaml's
+                   `tonk:repository` directory view), mounted here no-entity
+                   inside the nested `with` context — so its `onsubmit=tonk:invite`
+                   binding both resolves its descriptor AND dispatches its claim
+                   on the SPACE's content branch, where the worker's InviteHandler
+                   mints for that repo. (Binding it in the FAB's own profile/meta
+                   template instead dispatched the claim to profile/meta with an
+                   empty origin repo.) Directory chrome renders regardless of
+                   whether the repo is named, so the button is always present. -->
               <tonk-display class="fab__share-mint" with={dom.host/data-space} model="tonk:repository"></tonk-display>
-            </tonk-origin>
+            </tonk-share>
             <nav class="fab__menu fab__share-menu">
               <tonk-display with={dom.host/data-space} model="tonk:member" view="tonk:view/fab-roster"></tonk-display>
             </nav>
@@ -1506,25 +1515,25 @@ view/directory!: &profile/fab/view
            `inline` instead made the button an inline-block sitting on the
            text baseline, so it rode up out of the pill. The roster `<nav>` is
            `position: absolute`, so it stays out of this flex flow. */
-        .fab__share tonk-origin,
-        .fab__share .fab__invite-display,
+        .fab__share tonk-share,
         .fab__share .fab__share-mint,
         .fab__share-mint tonk-view { display: contents; }
+        /* The invite display exists only to deliver the minted URL to
+           `<tonk-share>` (via its `tonk-display:result` event). It renders no
+           chrome of its own — the "share" button IS the control now — so it
+           takes up no space whether or not an invite has been minted. */
+        .fab__share .fab__invite-display { display: none; }
         .fab__share-form {
           display: inline-flex;
           align-items: center;
           gap: 4px;
         }
-        /* Once the invite link has rendered (the display reaches `ready`), drop
-           the "share" mint button so the bar shows just the link + copy. The
-           link display (B) precedes the mint display (A), so the sibling
-           combinator reaches the "share" button inside A. */
-        .fab__invite-display[data-state="ready"] ~ .fab__share-mint .fab__share-trigger,
-        .fab__invite-display[data-state="default-view"] ~ .fab__share-mint .fab__share-trigger { display: none; }
-        /* The "share" affordance shown before a link is minted: a text button
-           that submits the mint form. Full `--fab-ink`, bar font — reads exactly
-           like the account/repo labels beside it (the segment's own hover
-           supplies the highlight, so the label carries no dimmed resting state). */
+        /* The share control: one text button that mints AND copies. Full
+           `--fab-ink`, bar font — reads exactly like the account/repo labels
+           beside it (the segment's own hover supplies the highlight, so the
+           label carries no dimmed resting state). Its label is swapped per
+           `data-share-state` below, so the button reserves room for the widest
+           of the three ("copying…") and the bar doesn't reflow mid-cycle. */
         .fab__share-trigger {
           font: inherit;
           line-height: 1;
@@ -1533,54 +1542,71 @@ view/directory!: &profile/fab/view
           color: var(--fab-ink);
           cursor: pointer;
           padding: 0 2px;
-        }
-        /* The minted invite: a "Copy invite link" control that reads as part of
-           the pill — a plain `--fab-ink` label + link glyph in the bar's own
-           font, no button chrome, so it matches the bar's other labels. (The
-           <wa-copy-button> defaults its host colour to a quiet neutral grey,
-           invisible on the inverted pill, and its `button` part to a padded
-           icon-button; both are overridden below. Part styles from this outer
-           tree win over the component's own `.button` rules regardless of
-           specificity.) The button still carries the real absolute join URL and
-           copies it on click, briefly swapping to "Copied!"; the raw token is
-           never shown. */
-        .fab__invite { color: var(--fab-ink); }
-        /* Suppress the copy button's built-in hover tooltip. The visible label
-           already reads "Copy invite link", so the popup (the copy-label,
-           rendered by an internal <wa-tooltip> exported as `tooltip__base`) is
-           redundant. */
-        .fab__invite::part(tooltip__base) { display: none; }
-        .fab__invite::part(button) {
-          padding: 0;
-          border-radius: 0;
-          color: var(--fab-ink);
-          background: transparent;
-          transition: opacity 0.15s ease;
-        }
-        .fab__invite::part(button):hover {
-          background: transparent;
-          opacity: 0.7;
-        }
-        /* Icon + label sit inline within each state slot (copy / copied). */
-        .fab__invite-label {
           display: inline-flex;
           align-items: center;
-          line-height: 1;
           gap: 6px;
           white-space: nowrap;
-          /* Slotted into <wa-copy-button>, so it inherits WebAwesome's body
-             font (not the FAB's) — pin it back to the FAB face. */
-          font-family: "IBM Plex Sans Condensed", var(--wa-font-family-heading, sans-serif);
         }
-        /* The "Copied!" success state. WebAwesome tints its success slot green
-           (`var(--wa-color-success-on-quiet)`), tuned for a light background and
-           illegible on the inverted dark pill. These labels are OUR slotted
-           light-DOM spans, so recolour them directly (an explicit colour beats
-           the slot's inherited green): a green-tinted ink that still reads as
-           success but stays legible in both themes (the ink inverts with the
-           page, the green tint rides along). */
-        .fab__invite [slot="success-icon"] {
+        .fab__share-trigger:hover { opacity: 0.7; }
+        /* One label per state, exactly one shown. `<tonk-share>` stamps
+           `data-share-state` on itself; these rules reach down into the button's
+           labels, which live in a light-DOM view (core.yaml's `tonk:repository`
+           directory view), so the selector crosses no shadow boundary.
+
+           IDLE IS THE DEFAULT, and it is styled with no `tonk-share` in the
+           selector at all. So the button reads "share" even if `<tonk-share>`
+           never upgrades — a stale bundle, a wasm that failed to load, the
+           moment before registration. Keying idle off the element instead (e.g.
+           `tonk-share:not([data-share-state])`) hides EVERY label in exactly
+           those cases, leaving a blank button. */
+        .fab__share-label--idle {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .fab__share-label--copying,
+        .fab__share-label--copied,
+        .fab__share-label--failed { display: none; }
+        /* Once a state is stamped, that state's label replaces idle. */
+        tonk-share[data-share-state="copying"] .fab__share-label--idle,
+        tonk-share[data-share-state="copied"] .fab__share-label--idle,
+        tonk-share[data-share-state="failed"] .fab__share-label--idle { display: none; }
+        tonk-share[data-share-state="copying"] .fab__share-label--copying,
+        tonk-share[data-share-state="copied"] .fab__share-label--copied,
+        tonk-share[data-share-state="failed"] .fab__share-label--failed {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        /* In flight: the click landed and the mint is running. Dim + a spinner,
+           and no pointer — a second click is dropped by the element anyway (it
+           would rotate the credential out from under the pending copy), so the
+           cursor shouldn't invite one. */
+        tonk-share[data-share-state="copying"] .fab__share-trigger {
+          cursor: default;
+          opacity: 0.7;
+        }
+        .fab__share-spinner {
+          width: 0.85em;
+          height: 0.85em;
+          border: 2px solid color-mix(in oklab, var(--fab-ink) 30%, transparent);
+          border-top-color: var(--fab-ink);
+          border-radius: 50%;
+          animation: fab-share-spin 0.6s linear infinite;
+        }
+        @keyframes fab-share-spin { to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) {
+          .fab__share-spinner { animation-duration: 2.4s; }
+        }
+        /* Copied. A green-tinted ink that still reads as success but stays
+           legible on the inverted pill in both themes (the ink inverts with the
+           page, the green tint rides along). Reverts to "share" on its own after
+           a beat — the control never latches. */
+        tonk-share[data-share-state="copied"] .fab__share-trigger {
           color: color-mix(in oklab, var(--fab-ink) 68%, #3ddc84);
+        }
+        tonk-share[data-share-state="failed"] .fab__share-trigger {
+          color: color-mix(in oklab, var(--fab-ink) 68%, #ff6b6b);
         }
         /* The member roster dropdown — anchored to the share zone's RIGHT edge
            (the repo switcher anchors left). Inherits `.fab__menu`'s transparent

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -1586,17 +1586,53 @@ view/directory!: &profile/fab/view
           cursor: default;
           opacity: 0.7;
         }
+        /* The in-flight spinner: rings drawn as circles showing only their TOP
+           border, chasing each other a beat apart so the arc leaves a fading
+           trail rather than reading as one hard tick.
+
+           The rings are PSEUDO-ELEMENTS, not child spans. The view template
+           renderer drops empty elements, so a `<span class="spinner"><span>
+           </span>…</span>` arrives in the DOM as an empty box — correctly sized
+           and completely blank, which is exactly what it looked like. Pseudo-
+           elements are pure CSS and cannot be stripped.
+
+           Sized in `em` so it tracks the bar's font, and drawn in
+           `currentColor` so it inherits the label's ink with no colour of its
+           own. */
         .fab__share-spinner {
-          width: 0.85em;
-          height: 0.85em;
-          border: 2px solid color-mix(in oklab, var(--fab-ink) 30%, transparent);
-          border-top-color: var(--fab-ink);
+          box-sizing: border-box;
+          display: inline-block;
+          position: relative;
+          width: 0.9em;
+          height: 0.9em;
+          flex: none;
+          border: 1.5px solid currentColor;
           border-radius: 50%;
-          animation: fab-share-spin 0.6s linear infinite;
+          border-color: currentColor transparent transparent transparent;
+          animation: fab-share-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
         }
-        @keyframes fab-share-spin { to { transform: rotate(360deg); } }
+        .fab__share-spinner::before,
+        .fab__share-spinner::after {
+          content: "";
+          box-sizing: border-box;
+          position: absolute;
+          /* Inset by the border width so the trailing rings sit ON the leading
+             ring's circle rather than concentric inside it. */
+          inset: -1.5px;
+          border: 1.5px solid currentColor;
+          border-radius: 50%;
+          border-color: currentColor transparent transparent transparent;
+          animation: inherit;
+        }
+        .fab__share-spinner::before { animation-delay: -0.3s; }
+        .fab__share-spinner::after { animation-delay: -0.15s; }
+        @keyframes fab-share-ring { to { transform: rotate(360deg); } }
+        /* Reduced motion: keep the ring (it is the only "working" cue the bar
+           has) but slow it to a crawl rather than strobing. */
         @media (prefers-reduced-motion: reduce) {
-          .fab__share-spinner { animation-duration: 2.4s; }
+          .fab__share-spinner,
+          .fab__share-spinner::before,
+          .fab__share-spinner::after { animation-duration: 4s; }
         }
         /* Copied. A green-tinted ink that still reads as success but stays
            legible on the inverted pill in both themes (the ink inverts with the

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -813,6 +813,13 @@ view/directory!: &profile/fab/view
   model: tonk:profile/fab
   display: |
     <tonk-fab>
+      <!-- NOTE: the click-away curtain (`.fab__scrim`) is NOT authored here.
+           `<tonk-fab>` injects it on connect, for two reasons: the view template
+           renderer drops empty elements (an authored `<div class="fab__scrim">
+           </div>` never reaches the DOM), and it must be a SIBLING of `.fab` —
+           `wrap_telescope_tiles` treats child[0] of `.fab` as the circle cap, so
+           a scrim nested inside would be mistaken for it. The stylesheet below
+           still owns how it looks and when it takes clicks. -->
       <div class="fab">
         <!-- LEFT CAP — the grab handle. A round-left segment (36×36) holding
              the live sync ring: the same host-chrome `<ui-sync-status>` element
@@ -1654,6 +1661,14 @@ view/directory!: &profile/fab/view
         /* The roster opens when the share segment is CLICKED (element.rs
            toggles `is-open`), like the repo switcher above. */
         .fab__share.is-open .fab__share-menu { display: flex; }
+        /* Click-away scrim. Resting: no box, no hit area — so it can never
+           swallow a click on the page while the bar is idle. While EITHER
+           dropdown is open it becomes a transparent, viewport-covering click
+           target, so a click anywhere outside a menu closes both (element.rs
+           handles the hit). It sits below the bar's own stacking context, so
+           the bar and its menus stay clickable through it. */
+        .fab__scrim { position: fixed; inset: 0; pointer-events: none; }
+        tonk-fab:has(.is-open) .fab__scrim { pointer-events: auto; }
         /* Mirrored: the bar is row-reversed, so the share zone is the LEFT
            end — its roster flips to anchor left (the repo switcher already
            re-anchors right via `.fab-mirror .fab__menu`). Row alignment

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -34,6 +34,7 @@ web-sys = { workspace = true, features = [
     "HtmlElement",
     "MessageEvent",
     "MouseEvent",
+    "MouseEventInit",
     "MutationObserver",
     "MutationObserverInit",
     "Navigator",

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -18,8 +18,10 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [
     "console",
+    "Clipboard",
     "CssStyleDeclaration",
     "CustomElementRegistry",
+    "CustomEvent",
     "Document",
     "DomRect",
     "DomStringMap",
@@ -34,6 +36,7 @@ web-sys = { workspace = true, features = [
     "MouseEvent",
     "MutationObserver",
     "MutationObserverInit",
+    "Navigator",
     "Node",
     "PointerEvent",
     "ResizeObserver",

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -105,6 +105,7 @@ impl CustomElement for TonkFab {
             .unwrap_or(false);
         if !already_bound {
             let _ = Reflect::set(this.as_ref(), &"__tonkFabBound".into(), &JsValue::TRUE);
+            inject_scrim(this);
             wrap_telescope_tiles(this);
             attach_drag(this);
             attach_gestures(this);
@@ -142,12 +143,51 @@ impl CustomElement for TonkFab {
     }
 }
 
+/// Inject the click-away curtain: a viewport-covering, invisible click target
+/// that dismisses both dropdowns. It is created here rather than authored in the
+/// view template for two reasons:
+///
+///  - The template renderer drops EMPTY elements, so an authored
+///    `<div class="fab__scrim"></div>` never reaches the DOM.
+///  - It has to be a SIBLING of `.fab`, not a child: `wrap_telescope_tiles`
+///    takes child[0] of `.fab` to be the circle cap, so a scrim nested inside
+///    would be mistaken for it and the real cap would be wrapped as a
+///    collapsible tile.
+///
+/// The stylesheet (profile.yaml) owns the rest: it is `pointer-events: none`
+/// at rest and only becomes a live hit area while a menu is open
+/// (`tonk-fab:has(.is-open)`), so it can never swallow a click on the page
+/// while the bar is idle. Idempotent.
+fn inject_scrim(element: &HtmlElement) {
+    if element
+        .query_selector(".fab__scrim")
+        .ok()
+        .flatten()
+        .is_some()
+    {
+        return;
+    }
+    let Some(document) = window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Ok(scrim) = document.create_element("div") else {
+        return;
+    };
+    let _ = scrim.set_attribute("class", "fab__scrim");
+    // Before `.fab`, so the bar paints over it and menu rows stay clickable.
+    let _ = element.insert_before(scrim.as_ref(), element.first_child().as_ref());
+}
+
 /// Wrap each collapsible segment (every `.fab` child after the sync-circle cap)
 /// in a `.fab__tele` div whose `max-width` the telescope animates. Adds the
 /// `fab--anim` marker (enables the transition CSS) and the initial
 /// `fab--settled` state (the bar rests EXPANDED — all segments shown). Mirrors
 /// the wireframe's programmatic `wrapTele` — done in JS, not the authored markup,
 /// so the view template stays a plain segment list.
+///
+/// Child[0] of `.fab` is taken to be the circle cap and is left unwrapped —
+/// which is why the click-away curtain hangs off `<tonk-fab>` rather than
+/// sitting inside `.fab` (see [`inject_scrim`]).
 fn wrap_telescope_tiles(element: &HtmlElement) {
     let Some(fab) = element.query_selector(".fab").ok().flatten() else {
         return;
@@ -210,7 +250,14 @@ fn attach_gestures(element: &HtmlElement) {
         let Some(t) = e.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
             return;
         };
-        if let Some(cap) = t.closest(".fab__cap-l").ok().flatten() {
+        if t.closest(".fab__scrim").ok().flatten().is_some() {
+            // The click-away curtain. It only has a hit area while a dropdown is
+            // open (CSS: `.fab:has(.is-open) .fab__scrim`), so reaching here
+            // means the user clicked outside every menu — retract both. The
+            // curtain lies behind the bar, so this never fires for a click on
+            // the bar itself or on a menu row.
+            close_menus(&el_click);
+        } else if let Some(cap) = t.closest(".fab__cap-l").ok().flatten() {
             // Alt/option-click toggles sync pause; a plain click folds/expands.
             // Pause is dispatched here (on the FAB, which reliably receives the
             // click — the cloned `<ui-sync-status>` inside the cap cannot own a
@@ -485,10 +532,12 @@ fn apply_mirror_from_handle(el: &HtmlElement) {
     }
 }
 
-/// Close both dropdowns (the ratcheted widths stay). A drag drops the
-/// `fab-dock-*` classes that give an open menu its vertical anchor, so an
-/// open menu would float mid-bar; dragging with a menu open isn't a state
-/// the chrome supports.
+/// Close both dropdowns (the ratcheted widths stay). Two callers:
+///
+/// - A drag: it drops the `fab-dock-*` classes that give an open menu its
+///   vertical anchor, so an open menu would float mid-bar; dragging with a menu
+///   open isn't a state the chrome supports.
+/// - The click-away curtain: a click outside every menu dismisses both.
 fn close_menus(el: &HtmlElement) {
     for sel in MENU_SEGMENTS {
         if let Some(seg) = el.query_selector(sel).ok().flatten() {
@@ -1089,4 +1138,179 @@ pub fn register() {
         return;
     }
     TonkFab::define("tonk-fab");
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// A FAB whose two dropdown segments are both open, plus the click-away
+    /// curtain — the shape the profile view renders.
+    fn open_fab() -> HtmlElement {
+        let document = window().expect("window").document().expect("document");
+        let fab: HtmlElement = document
+            .create_element("div")
+            .expect("create fab")
+            .unchecked_into();
+        fab.set_class_name("fab");
+        fab.set_inner_html(
+            r#"<div class="fab__scrim"></div>
+               <span class="fab__seg fab__repo is-open"></span>
+               <span class="fab__seg fab__share is-open"></span>"#,
+        );
+        fab
+    }
+
+    fn is_open(fab: &HtmlElement, selector: &str) -> bool {
+        fab.query_selector(selector)
+            .ok()
+            .flatten()
+            .map(|seg| seg.class_list().contains("is-open"))
+            .unwrap_or(false)
+    }
+
+    /// A `<tonk-fab>` holding the bar, the way the profile view renders it —
+    /// cap first, then the two dropdown segments.
+    fn fab_host() -> HtmlElement {
+        let document = window().expect("window").document().expect("document");
+        let host: HtmlElement = document
+            .create_element("tonk-fab")
+            .expect("create host")
+            .unchecked_into();
+        host.set_inner_html(
+            r#"<div class="fab">
+                 <span class="fab__seg fab__cap-l"></span>
+                 <span class="fab__seg fab__repo"></span>
+                 <span class="fab__seg fab__share"></span>
+               </div>"#,
+        );
+        host
+    }
+
+    #[wasm_bindgen_test]
+    fn it_injects_the_curtain_outside_the_bar() {
+        // The curtain must be a SIBLING of `.fab`, never a child: the telescope
+        // takes child[0] of `.fab` to be the circle cap, so a curtain nested
+        // inside would be mistaken for the cap and the real cap would get
+        // wrapped as a collapsible tile.
+        let host = fab_host();
+        inject_scrim(&host);
+
+        let scrim = host
+            .query_selector(".fab__scrim")
+            .ok()
+            .flatten()
+            .expect("the curtain should be injected");
+        assert_eq!(
+            scrim.parent_element().map(|p| p.tag_name()).as_deref(),
+            Some("TONK-FAB"),
+            "the curtain must hang off <tonk-fab>, not off .fab",
+        );
+        assert!(
+            scrim.closest(".fab").ok().flatten().is_none(),
+            "the curtain must not be inside .fab — the telescope would wrap the cap",
+        );
+        // And it must precede the bar, so the bar paints over it.
+        assert_eq!(
+            host.first_element_child()
+                .map(|c| c.class_name())
+                .as_deref(),
+            Some("fab__scrim"),
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_injects_the_curtain_only_once() {
+        // `connected_callback` can run again on a reconnect; a second curtain
+        // would stack another hit area over the page.
+        let host = fab_host();
+        inject_scrim(&host);
+        inject_scrim(&host);
+
+        let children = host.children();
+        let scrims = (0..children.length())
+            .filter_map(|i| children.item(i))
+            .filter(|child| child.class_list().contains("fab__scrim"))
+            .count();
+        assert_eq!(scrims, 1, "a reconnect must not stack a second curtain");
+    }
+
+    #[wasm_bindgen_test]
+    fn it_dismisses_the_menus_when_the_curtain_is_clicked() {
+        // End-to-end through the real gesture handler: a click on the curtain
+        // must reach `close_menus`. Testing `close_menus` alone would still pass
+        // if the handler's curtain branch were deleted.
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        inject_scrim(&host);
+        attach_gestures(&host);
+        // The handler walks up from `event.target`, so the element has to be in
+        // the document for the click to dispatch and bubble.
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+        for selector in [".fab__repo", ".fab__share"] {
+            host.query_selector(selector)
+                .ok()
+                .flatten()
+                .expect("segment")
+                .class_list()
+                .add_1("is-open")
+                .expect("open");
+        }
+
+        let scrim = host
+            .query_selector(".fab__scrim")
+            .ok()
+            .flatten()
+            .expect("curtain");
+        // Must bubble: the listener lives on <tonk-fab>, not on the curtain.
+        let init = web_sys::MouseEventInit::new();
+        init.set_bubbles(true);
+        let click = web_sys::MouseEvent::new_with_mouse_event_init_dict("click", &init)
+            .expect("click event");
+        scrim.dispatch_event(&click).expect("dispatch");
+
+        assert!(
+            !is_open(&host, ".fab__repo") && !is_open(&host, ".fab__share"),
+            "clicking the curtain must dismiss both dropdowns",
+        );
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_closes_both_dropdowns_at_once() {
+        // The curtain dismisses EVERY menu, not just the one that opened it —
+        // a click outside is a click outside for both.
+        let fab = open_fab();
+        assert!(is_open(&fab, ".fab__repo") && is_open(&fab, ".fab__share"));
+
+        close_menus(&fab);
+
+        assert!(
+            !is_open(&fab, ".fab__repo"),
+            "the repo switcher should close"
+        );
+        assert!(
+            !is_open(&fab, ".fab__share"),
+            "the share roster should close"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_is_a_no_op_when_nothing_is_open() {
+        // The curtain has no hit area unless a menu is open, but closing an
+        // already-closed bar must not throw or disturb the segments.
+        let fab = open_fab();
+        close_menus(&fab);
+        close_menus(&fab);
+        assert!(!is_open(&fab, ".fab__repo"));
+        assert!(!is_open(&fab, ".fab__share"));
+    }
 }

--- a/rust/tonk-fab/src/lib.rs
+++ b/rust/tonk-fab/src/lib.rs
@@ -11,10 +11,14 @@ pub mod logic;
 #[cfg(target_arch = "wasm32")]
 mod element;
 
+#[cfg(target_arch = "wasm32")]
+mod share;
+
 /// Register `<tonk-fab>` with the page. Idempotent — safe to call multiple times.
 #[cfg(target_arch = "wasm32")]
 pub fn register() {
     element::register();
+    share::register();
 }
 
 /// No-op on non-wasm targets (tests / native build checks).

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -718,3 +718,82 @@ mod ratchet {
         assert_eq!(ratchet_min_width(80.0, 120.0, None), None);
     }
 }
+
+/// What the share control is doing, and therefore what it shows.
+///
+/// One click drives the whole cycle: `Idle` → `Copying` (mint in flight, the
+/// clipboard already holding an unresolved promise) → `Copied` → back to
+/// `Idle`. There is no state in which the control sits waiting for a *second*
+/// click to copy — that was the old two-control flow, where minting revealed a
+/// separate copy button that then stayed on the bar forever.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShareState {
+    /// Resting: offers to share.
+    Idle,
+    /// A mint is in flight. The clipboard write is already pending on a
+    /// promise this state is waiting to resolve.
+    Copying,
+    /// The link is on the clipboard. Reverts to `Idle` after
+    /// [`COPIED_LINGER_MS`].
+    Copied,
+    /// The mint or the clipboard write failed. Also reverts to `Idle`, so the
+    /// control always returns to offering a retry rather than latching.
+    Failed,
+}
+
+impl ShareState {
+    /// The `data-share-state` attribute value. The view stylesheet keys its
+    /// label/spinner swap off this, so the element owns the state and the
+    /// stylesheet owns the look.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Copying => "copying",
+            Self::Copied => "copied",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Whether a click should start a new mint. A click while one is already
+    /// in flight is dropped: the clipboard holds exactly one pending promise
+    /// and a second mint would rotate the credential out from under it.
+    pub fn accepts_click(self) -> bool {
+        !matches!(self, Self::Copying)
+    }
+
+    /// Whether this state settles back to `Idle` on a timer.
+    pub fn is_transient(self) -> bool {
+        matches!(self, Self::Copied | Self::Failed)
+    }
+}
+
+/// How long the "copied" (or "failed") confirmation stays up before the
+/// control reverts to offering "share" again. Long enough to read, short
+/// enough that the bar doesn't keep showing a stale result.
+pub const COPIED_LINGER_MS: i32 = 2_000;
+
+#[cfg(test)]
+mod share {
+    use super::*;
+
+    #[test]
+    fn it_offers_a_retry_from_every_settled_state() {
+        // Only an in-flight mint refuses a click. Notably `Copied` accepts
+        // one: the link rotates per mint, so a second share is a legitimate
+        // ask, not a double-submit.
+        assert!(ShareState::Idle.accepts_click());
+        assert!(ShareState::Copied.accepts_click());
+        assert!(ShareState::Failed.accepts_click());
+        assert!(!ShareState::Copying.accepts_click());
+    }
+
+    #[test]
+    fn it_settles_only_the_confirmation_states() {
+        // Idle is already the resting state and Copying ends by resolving,
+        // not by timing out — neither is on a revert timer.
+        assert!(ShareState::Copied.is_transient());
+        assert!(ShareState::Failed.is_transient());
+        assert!(!ShareState::Idle.is_transient());
+        assert!(!ShareState::Copying.is_transient());
+    }
+}

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -130,11 +130,15 @@ impl CustomElement for TonkShare {
             let current = read_state(&host);
             if !current.accepts_click() {
                 // A mint is already in flight holding the clipboard promise.
-                // Swallow the click rather than let it submit a second mint,
-                // which would rotate the credential out from under the copy
-                // we're about to complete.
+                // Cancel the activation so the form does not submit a second
+                // mint, which would rotate the credential out from under the
+                // copy we're about to complete.
+                //
+                // `preventDefault` only — NOT `stopPropagation`. The click still
+                // has to reach `<tonk-fab>`, which toggles the roster for every
+                // click in the share zone. Swallowing it outright would make the
+                // menu unresponsive for as long as a mint is in flight.
                 event.prevent_default();
-                event.stop_propagation();
                 return;
             }
             // Whatever link is on screen right now is the PREVIOUS mint's. Note
@@ -404,7 +408,7 @@ mod tests {
     use super::*;
     use js_sys::Object;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-    use web_sys::window;
+    use web_sys::{Element, window};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -422,6 +426,21 @@ mod tests {
             ));
         }
         host
+    }
+
+    /// A host mounted inside an OPEN share segment, the way the FAB nests it:
+    /// `.fab__share.is-open > <tonk-share>`. Returns the segment so a test can
+    /// assert on its classes.
+    fn host_in_open_segment() -> (HtmlElement, Element) {
+        let document = window().expect("window").document().expect("document");
+        let segment = document.create_element("span").expect("create segment");
+        segment.set_class_name("fab__seg fab__share is-open");
+        let host: HtmlElement = document
+            .create_element("tonk-share")
+            .expect("create host")
+            .unchecked_into();
+        segment.append_child(&host).expect("nest host");
+        (host, segment)
     }
 
     /// A `tonk-display:result` detail, in the shape the display actually
@@ -531,6 +550,25 @@ mod tests {
         assert!(
             state.borrow().pending.is_none(),
             "settling must consume the pending copy, so a later frame can't re-settle it",
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_leaves_the_roster_alone_when_the_copy_settles() {
+        // `<tonk-share>` does not touch the dropdown. `<tonk-fab>` toggles
+        // `.is-open` on the segment for every click in the share zone, so the
+        // menu opens on the first click and closes on the second. Force-closing
+        // it here would desync that toggle: the click after an auto-close would
+        // re-OPEN the menu instead of closing it.
+        let (host, segment) = host_in_open_segment();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+
+        settle(&host, &state, Ok("https://tonk.xyz/@/new".to_owned()));
+
+        assert!(
+            segment.class_list().contains("is-open"),
+            "settling must leave the menu's open state to <tonk-fab>'s toggle",
         );
     }
 

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -1,0 +1,572 @@
+//! The `<tonk-share>` custom element — mint an invite and copy it, on one click.
+//!
+//! It wraps the share zone's two `<tonk-display>`s (the mint trigger and the
+//! invite link) and turns them into a single control. Clicking it mints a fresh
+//! invite AND puts the resulting URL on the clipboard, without a second click,
+//! then reverts to offering "share" again.
+//!
+//! ## Why this needs an element at all
+//!
+//! `navigator.clipboard.writeText` requires *transient user activation*. The
+//! mint is an async round-trip (claim → service worker → commit → subscription
+//! frame), which outlives that activation — so "await the mint, then write the
+//! clipboard" is rejected by the browser.
+//!
+//! The way out is [`ClipboardItem`]'s promise form: `navigator.clipboard.write`
+//! accepts an item whose value is a `Promise<string>`. Construct the item
+//! *synchronously inside the click handler*, while activation is still live,
+//! and the browser holds the write open until the promise settles. So we open
+//! the clipboard write on click, let the mint run, and resolve the promise with
+//! the URL when it arrives.
+//!
+//! ## How the URL gets here
+//!
+//! We do not plumb it out of the claim. The mint's own transact receipt is
+//! discarded by the event delegate, but the minted invite lands on
+//! `tonk:agent-invite` (with the assembled, shortened `link`), and the invite
+//! `<tonk-display>` re-renders and dispatches a bubbling `tonk-display:result`
+//! carrying that conclusion. This element listens for it and reads `link`.
+//!
+//! [`ClipboardItem`]: https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use js_sys::{Array, Function, Object, Promise, Reflect};
+use wasm_bindgen::JsCast;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::prelude::*;
+use web_sys::{CustomEvent, HtmlElement, window};
+
+use crate::logic::{COPIED_LINGER_MS, ShareState};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = globalThis, js_name = setTimeout)]
+    fn set_timeout(handler: &Function, delay: i32) -> i32;
+
+    #[wasm_bindgen(js_namespace = globalThis, js_name = clearTimeout)]
+    fn clear_timeout(id: i32);
+}
+
+/// The clipboard write we opened on click, waiting on the mint.
+///
+/// `resolve` is the pending `ClipboardItem` promise's resolver: calling it with
+/// the invite URL completes the clipboard write the browser has been holding
+/// open since the click. `reject` abandons it (the browser drops the write and
+/// leaves the existing clipboard contents alone).
+struct PendingCopy {
+    resolve: Function,
+    reject: Function,
+    /// The link already on screen when the click landed, if any.
+    ///
+    /// The invite display holds the LAST mint's link, and every subscription
+    /// frame re-renders and re-dispatches `tonk-display:result` — so a frame
+    /// carrying the previous link can arrive after our click and before the new
+    /// mint commits. Copying that would hand out a stale invite. The mint
+    /// supersedes the credential in place (cardinality-one on the subject), so
+    /// the new link is always a *different* string: we wait for one that
+    /// differs from this.
+    stale: Option<String>,
+}
+
+/// Per-element state. One pending copy at a time — a click while a mint is in
+/// flight is dropped (see [`ShareState::accepts_click`]).
+#[derive(Default)]
+struct ShareStateCell {
+    pending: Option<PendingCopy>,
+    /// The `setTimeout` that reverts a `Copied`/`Failed` confirmation to
+    /// `Idle`. Cleared and re-armed on each settle so a fresh result always
+    /// gets its full linger, and cancelled on disconnect.
+    revert: Option<i32>,
+}
+
+/// An installed listener, paired with the `Closure` owning its JS-side memory.
+/// Dropped (and removed) on disconnect.
+type ListenerEntry = (String, Closure<dyn FnMut(web_sys::Event)>);
+
+pub struct TonkShare {
+    state: Rc<RefCell<ShareStateCell>>,
+    listeners: Vec<ListenerEntry>,
+}
+
+impl Default for TonkShare {
+    fn default() -> Self {
+        Self {
+            state: Rc::new(RefCell::new(ShareStateCell::default())),
+            listeners: Vec::new(),
+        }
+    }
+}
+
+impl CustomElement for TonkShare {
+    /// No Shadow DOM — `<tonk-share>` is a transparent wrapper around the two
+    /// `<tonk-display>`s the FAB template puts inside it.
+    ///
+    /// `custom-elements` defaults this to `true`, which attaches a shadow root.
+    /// A shadow root with no `<slot>` renders none of the light-DOM children,
+    /// so the mint button and the invite display would both vanish — the
+    /// element would connect with an empty subtree and the bar would show an
+    /// empty box where the share control belongs.
+    fn shadow() -> bool {
+        false
+    }
+
+    fn inject_children(&mut self, this: &HtmlElement) {
+        set_state(this, ShareState::Idle);
+
+        // Click: open the clipboard write while activation is live. This must
+        // stay synchronous all the way to `clipboard.write()` — any `await`
+        // before it spends the activation and the write is refused.
+        //
+        // We do NOT dispatch the mint ourselves. The inner `<form
+        // onsubmit=tonk:invite>` (a space-branch view) already does, and its
+        // binding is what carries the right routing context. We let the click
+        // through to it and only arrange for the result to be copied.
+        let state = Rc::clone(&self.state);
+        let host = this.clone();
+        let on_click = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let current = read_state(&host);
+            if !current.accepts_click() {
+                // A mint is already in flight holding the clipboard promise.
+                // Swallow the click rather than let it submit a second mint,
+                // which would rotate the credential out from under the copy
+                // we're about to complete.
+                event.prevent_default();
+                event.stop_propagation();
+                return;
+            }
+            // Whatever link is on screen right now is the PREVIOUS mint's. Note
+            // it so a frame still carrying it isn't mistaken for our result.
+            let stale = rendered_link(&host);
+            match open_clipboard_write(Rc::clone(&state), stale) {
+                Ok(()) => set_state(&host, ShareState::Copying),
+                // No clipboard (an insecure context, a denied permission, or a
+                // browser without the promise form). The mint still runs — the
+                // click falls through to the form — so the link is minted and
+                // rendered; it just isn't auto-copied. Better than blocking the
+                // share outright.
+                Err(e) => {
+                    warn(&format!("share: clipboard unavailable: {e:?}"));
+                    set_state(&host, ShareState::Copying);
+                }
+            }
+        });
+        add_listener(this, "click", &on_click);
+        self.listeners.push(("click".to_owned(), on_click));
+
+        // The invite `<tonk-display>` re-renders when the mint's conclusion
+        // arrives and dispatches a bubbling `tonk-display:result` carrying it.
+        // That is our "the URL exists now" signal.
+        let state = Rc::clone(&self.state);
+        let host = this.clone();
+        let on_result = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            // Ignore frames that arrive when we aren't waiting on one: the
+            // invite display re-renders on any subscription frame, including
+            // ones no click of ours provoked.
+            let stale = match state.borrow().pending.as_ref() {
+                Some(pending) => pending.stale.clone(),
+                None => return,
+            };
+            let Some(link) = event
+                .dyn_ref::<CustomEvent>()
+                .and_then(|e| link_from_detail(&e.detail()))
+            else {
+                return;
+            };
+            // Still the previous mint's link — the new one hasn't landed yet.
+            // Keep the clipboard write open and wait for the next frame.
+            if Some(&link) == stale.as_ref() {
+                return;
+            }
+            settle(&host, &state, Ok(link));
+        });
+        add_listener(this, "tonk-display:result", &on_result);
+        self.listeners
+            .push(("tonk-display:result".to_owned(), on_result));
+
+        // A failed mint surfaces as the display's error event. Without this the
+        // control would sit in `Copying` forever and the clipboard would keep
+        // an unresolved promise open.
+        let state = Rc::clone(&self.state);
+        let host = this.clone();
+        let on_error = Closure::<dyn FnMut(web_sys::Event)>::new(move |_: web_sys::Event| {
+            if state.borrow().pending.is_none() {
+                return;
+            }
+            settle(&host, &state, Err("the invite display reported an error"));
+        });
+        add_listener(this, "tonk-display:error", &on_error);
+        self.listeners
+            .push(("tonk-display:error".to_owned(), on_error));
+    }
+
+    fn disconnected_callback(&mut self, this: &HtmlElement) {
+        for (event_type, closure) in self.listeners.drain(..) {
+            let target: &web_sys::EventTarget = this.unchecked_ref();
+            let _ = target
+                .remove_event_listener_with_callback(&event_type, closure.as_ref().unchecked_ref());
+        }
+        let mut state = self.state.borrow_mut();
+        if let Some(id) = state.revert.take() {
+            clear_timeout(id);
+        }
+        // Abandon a clipboard write still held open by a mint that will now
+        // never land — leaving it pending would hold the clipboard hostage.
+        if let Some(pending) = state.pending.take() {
+            let _ = pending.reject.call1(
+                &JsValue::NULL,
+                &JsValue::from_str("share: element detached"),
+            );
+        }
+    }
+}
+
+/// Open a clipboard write against a promise we resolve later.
+///
+/// Synchronous on purpose: it runs inside the click handler so the browser sees
+/// a user-activated `clipboard.write()`. The returned promise is parked in
+/// `state.pending`; the browser holds the write open until we settle it.
+fn open_clipboard_write(
+    state: Rc<RefCell<ShareStateCell>>,
+    stale: Option<String>,
+) -> Result<(), JsValue> {
+    let clipboard = window()
+        .ok_or_else(|| JsValue::from_str("no window"))?
+        .navigator()
+        .clipboard();
+
+    // Capture the executor's resolve/reject so the mint can settle this promise
+    // from outside.
+    let slot: Rc<RefCell<Option<(Function, Function)>>> = Rc::new(RefCell::new(None));
+    let captured = Rc::clone(&slot);
+    let text = Promise::new(&mut move |resolve, reject| {
+        *captured.borrow_mut() = Some((resolve, reject));
+    });
+    let (resolve, reject) = slot
+        .borrow_mut()
+        .take()
+        .ok_or_else(|| JsValue::from_str("promise executor did not run"))?;
+    let pending = PendingCopy {
+        resolve,
+        reject,
+        stale,
+    };
+
+    // `new ClipboardItem({ "text/plain": <Promise<string>> })` — the promise
+    // form. `writeText` cannot express this: it takes a resolved string, so it
+    // would need the URL up front, which is the thing we don't have yet.
+    let item_init = Object::new();
+    Reflect::set(&item_init, &JsValue::from_str(MIME_TEXT), &text)?;
+    let item = clipboard_item(&item_init)?;
+
+    // A rejected write (permission denied, or the promise we reject when the
+    // mint fails) must not surface as an unhandled rejection.
+    let on_rejected = Closure::<dyn FnMut(JsValue)>::new(|e: JsValue| {
+        warn(&format!("share: clipboard write failed: {e:?}"));
+    });
+    let _ = clipboard.write(&Array::of1(&item)).catch(&on_rejected);
+
+    state.borrow_mut().pending = Some(pending);
+    Ok(())
+}
+
+/// `new ClipboardItem(init)` via the global constructor. web-sys does not
+/// expose a `ClipboardItem` binding in the features we enable, and we need the
+/// promise-valued form regardless (its typed binding takes resolved values).
+fn clipboard_item(init: &Object) -> Result<JsValue, JsValue> {
+    let global = js_sys::global();
+    let ctor = Reflect::get(&global, &JsValue::from_str("ClipboardItem"))?;
+    let ctor = ctor
+        .dyn_into::<Function>()
+        .map_err(|_| JsValue::from_str("ClipboardItem is not constructible"))?;
+    Reflect::construct(&ctor, &Array::of1(init.as_ref()))
+}
+
+const MIME_TEXT: &str = "text/plain";
+
+/// Complete (or abandon) the clipboard write the click opened, and move the
+/// control to its confirmation state.
+fn settle(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, result: Result<String, &str>) {
+    let Some(pending) = state.borrow_mut().pending.take() else {
+        return;
+    };
+    let settled = match result {
+        Ok(link) => {
+            let _ = pending
+                .resolve
+                .call1(&JsValue::NULL, &JsValue::from_str(&link));
+            ShareState::Copied
+        }
+        Err(reason) => {
+            let _ = pending
+                .reject
+                .call1(&JsValue::NULL, &JsValue::from_str(reason));
+            ShareState::Failed
+        }
+    };
+    set_state(host, settled);
+    arm_revert(host, state);
+}
+
+/// Revert a confirmation to `Idle` after [`COPIED_LINGER_MS`], so the control
+/// goes back to offering "share" instead of latching on "copied" for the rest
+/// of the session (which is what the old copy button did).
+fn arm_revert(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
+    let mut cell = state.borrow_mut();
+    if let Some(id) = cell.revert.take() {
+        clear_timeout(id);
+    }
+    let host = host.clone();
+    let state_for_timer = Rc::clone(state);
+    let revert = Closure::once_into_js(move || {
+        state_for_timer.borrow_mut().revert = None;
+        // Don't stomp a mint the user started during the linger.
+        if read_state(&host).is_transient() {
+            set_state(&host, ShareState::Idle);
+        }
+    });
+    cell.revert = Some(set_timeout(
+        revert.unchecked_ref::<Function>(),
+        COPIED_LINGER_MS,
+    ));
+}
+
+/// Read the invite URL out of a `tonk-display:result` detail.
+///
+/// The detail is a serialized conclusion, `{ this, fields: { … } }` — the
+/// concept's attributes live under `fields`, NOT at the top level. `link` is
+/// the assembled (and shortened) invite URL the worker's mint asserted onto
+/// `tonk:credential`.
+///
+/// Absent before a mint lands: the display also frames the bare
+/// `tonk:repository` name (`fields: { name }`), which carries no link. Those
+/// frames must not settle a pending copy.
+fn link_from_detail(detail: &JsValue) -> Option<String> {
+    let fields = Reflect::get(detail, &JsValue::from_str("fields")).ok()?;
+    let link = Reflect::get(&fields, &JsValue::from_str("link")).ok()?;
+    link.as_string().filter(|s| !s.is_empty())
+}
+
+/// The link the invite display is currently showing — i.e. the last mint's, if
+/// any. The `fab-invite` view renders it into a hidden `.fab__invite-link`.
+/// `None` before the first mint.
+fn rendered_link(host: &HtmlElement) -> Option<String> {
+    let el = host.query_selector(".fab__invite-link").ok().flatten()?;
+    let text = el.text_content()?;
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
+/// Stamp the state on the host. The view stylesheet keys the label and spinner
+/// off `data-share-state`, so the element owns the state machine and the
+/// stylesheet owns the appearance.
+fn set_state(host: &HtmlElement, state: ShareState) {
+    let _ = host.set_attribute("data-share-state", state.as_str());
+}
+
+fn read_state(host: &HtmlElement) -> ShareState {
+    match host.get_attribute("data-share-state").as_deref() {
+        Some("copying") => ShareState::Copying,
+        Some("copied") => ShareState::Copied,
+        Some("failed") => ShareState::Failed,
+        _ => ShareState::Idle,
+    }
+}
+
+fn add_listener(
+    host: &HtmlElement,
+    event_type: &str,
+    closure: &Closure<dyn FnMut(web_sys::Event)>,
+) {
+    let target: &web_sys::EventTarget = host.unchecked_ref();
+    let _ = target.add_event_listener_with_callback(event_type, closure.as_ref().unchecked_ref());
+}
+
+fn warn(message: &str) {
+    web_sys::console::warn_1(&JsValue::from_str(message));
+}
+
+/// Register `<tonk-share>`. Idempotent.
+pub fn register() {
+    let Some(win) = window() else {
+        return;
+    };
+    if !win.custom_elements().get("tonk-share").is_undefined() {
+        return;
+    }
+    TonkShare::define("tonk-share");
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use js_sys::Object;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::window;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// A host carrying the invite display's rendered link, exactly as the
+    /// `fab-invite` view emits it.
+    fn host_showing(link: Option<&str>) -> HtmlElement {
+        let document = window().expect("window").document().expect("document");
+        let host: HtmlElement = document
+            .create_element("div")
+            .expect("create host")
+            .unchecked_into();
+        if let Some(link) = link {
+            host.set_inner_html(&format!(
+                r#"<span class="fab__invite-link" hidden>{link}</span>"#
+            ));
+        }
+        host
+    }
+
+    /// A `tonk-display:result` detail, in the shape the display actually
+    /// dispatches: a serialized conclusion `{ this, fields: { … } }`. The
+    /// concept's attributes are nested under `fields` — reading `link` off the
+    /// top level (as an earlier cut of this did) always finds nothing, and the
+    /// copy hangs forever waiting for a link that is right there.
+    fn detail_with_fields(pairs: &[(&str, &str)]) -> JsValue {
+        let fields = Object::new();
+        for (key, value) in pairs {
+            Reflect::set(&fields, &JsValue::from_str(key), &JsValue::from_str(value))
+                .expect("set field");
+        }
+        let detail = Object::new();
+        Reflect::set(
+            &detail,
+            &JsValue::from_str("this"),
+            &JsValue::from_str("did:key:zSubject"),
+        )
+        .expect("set this");
+        Reflect::set(&detail, &JsValue::from_str("fields"), &fields).expect("set fields");
+        detail.into()
+    }
+
+    #[wasm_bindgen_test]
+    fn it_reads_the_link_out_of_the_conclusions_fields() {
+        // The link is nested under `fields`, alongside the invite's other
+        // attributes — exactly as the display serializes a real minted invite.
+        assert_eq!(
+            link_from_detail(&detail_with_fields(&[
+                ("name", "home"),
+                ("link", "https://tonk.xyz/@/abc"),
+                ("code", "zSeed"),
+            ])),
+            Some("https://tonk.xyz/@/abc".to_owned()),
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_ignores_the_pre_mint_frame() {
+        // Before a mint lands, the display still frames the repo's bare name
+        // (`fields: { name }`) — no `link`. Treating that as the result settles
+        // the copy with nothing, so the guard has to hold out for a real link.
+        assert_eq!(
+            link_from_detail(&detail_with_fields(&[("name", "home")])),
+            None
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_ignores_a_malformed_or_empty_frame() {
+        assert_eq!(link_from_detail(&Object::new().into()), None);
+        assert_eq!(link_from_detail(&detail_with_fields(&[("link", "")])), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn it_sees_no_rendered_link_before_the_first_mint() {
+        // A space that has never been shared renders no invite, so there is no
+        // stale link to guard against.
+        assert_eq!(rendered_link(&host_showing(None)), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn it_reads_the_previous_mints_link_off_the_dom() {
+        // This is what makes the stale guard work: on click we can see which
+        // link is already on screen, so we know to keep waiting when a frame
+        // still carries it.
+        assert_eq!(
+            rendered_link(&host_showing(Some("https://tonk.xyz/@/old"))),
+            Some("https://tonk.xyz/@/old".to_owned()),
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_defaults_to_idle_before_the_element_upgrades() {
+        // No `data-share-state` yet — the button must read "share", not blank.
+        assert_eq!(read_state(&host_showing(None)), ShareState::Idle);
+    }
+
+    #[wasm_bindgen_test]
+    fn it_round_trips_every_state_through_the_dom() {
+        // The stylesheet keys the label swap off this attribute, so a state
+        // that doesn't survive the round-trip renders the wrong label.
+        let host = host_showing(None);
+        for state in [
+            ShareState::Idle,
+            ShareState::Copying,
+            ShareState::Copied,
+            ShareState::Failed,
+        ] {
+            set_state(&host, state);
+            assert_eq!(read_state(&host), state);
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn it_settles_a_pending_copy_and_shows_copied() {
+        let host = host_showing(None);
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+        assert!(state.borrow().pending.is_some(), "the copy is pending");
+
+        settle(&host, &state, Ok("https://tonk.xyz/@/new".to_owned()));
+
+        assert_eq!(read_state(&host), ShareState::Copied);
+        assert!(
+            state.borrow().pending.is_none(),
+            "settling must consume the pending copy, so a later frame can't re-settle it",
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn it_shows_failed_when_the_mint_errors() {
+        let host = host_showing(None);
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        settle(&host, &state, Err("mint failed"));
+
+        // Failed, not stuck on `copying` — and the clipboard promise is
+        // rejected, so the browser abandons the write instead of holding it.
+        assert_eq!(read_state(&host), ShareState::Failed);
+        assert!(state.borrow().pending.is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn it_settles_only_once() {
+        // The invite display re-renders on every subscription frame. Only the
+        // first frame after a click may settle the copy; a later one must find
+        // nothing pending and leave the confirmation alone.
+        let host = host_showing(None);
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+
+        settle(&host, &state, Ok("https://tonk.xyz/@/first".to_owned()));
+        assert_eq!(read_state(&host), ShareState::Copied);
+
+        // A second frame with no pending copy: a no-op, not a state change.
+        settle(&host, &state, Err("late error"));
+        assert_eq!(
+            read_state(&host),
+            ShareState::Copied,
+            "a frame arriving after the copy settled must not flip it to failed",
+        );
+    }
+}

--- a/rust/tonk-ui/assets/hot-swap.js
+++ b/rust/tonk-ui/assets/hot-swap.js
@@ -19,6 +19,11 @@
 
 ;(async () => {
   const LIBRARY_URL = "/library/core.yaml"
+  // The profile branch's own library — the Hub view and the FAB chrome. It is
+  // seeded onto the profile's meta branch, NOT the space content branch, so a
+  // core.yaml reseed never reaches it. Without reseeding this too, every
+  // profile.yaml edit needs the profile recreated to be seen.
+  const PROFILE_LIBRARY_URL = "/library/profile.yaml"
 
   // Pill label glyphs: a recycle mark for an in-place standard-library
   // reseed (live update, no reload), an eject mark for a full page
@@ -382,10 +387,32 @@
   // signal is a real rebuild (reload); an unchanged hash means only
   // an asset moved (trunk fires a generic `reload` for any pipeline
   // run, so we can't trust the signal alone).
+  // The served library text. BOTH documents are fetched and joined, because
+  // this string is what the change signal hashes: keying only on core.yaml
+  // would leave a profile.yaml-only edit undetected, so the FAB chrome would
+  // never reseed. `reseed` splits it back apart and sends each half to the
+  // branch it belongs on.
+  const LIBRARY_SEPARATOR = "\n#--- hot-swap: profile library ---\n"
   const fetchLibrary = async () => {
-    const response = await fetch(LIBRARY_URL, { cache: "no-store" })
-    if (!response.ok) throw new Error(`GET ${LIBRARY_URL} -> ${response.status}`)
-    return await response.text()
+    const [core, profile] = await Promise.all(
+      [LIBRARY_URL, PROFILE_LIBRARY_URL].map(async (url) => {
+        const response = await fetch(url, { cache: "no-store" })
+        if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`)
+        return await response.text()
+      }),
+    )
+    return core + LIBRARY_SEPARATOR + profile
+  }
+  // Split a joined library back into `{ core, profile }`. Tolerates an older
+  // cached string with no separator (all of it is core).
+  const splitLibrary = (library) => {
+    const at = library.indexOf(LIBRARY_SEPARATOR)
+    return at === -1
+      ? { core: library, profile: null }
+      : {
+          core: library.slice(0, at),
+          profile: library.slice(at + LIBRARY_SEPARATOR.length),
+        }
   }
   // The previously-cached library — what was served (and applied) on
   // the last load. `force-cache` returns the cached copy without
@@ -394,19 +421,28 @@
   // fresh), so a reload picks up bootstrap edits made while away.
   const cachedLibrary = async () => {
     try {
-      const response = await fetch(LIBRARY_URL, { cache: "force-cache" })
-      if (!response.ok) return null
-      return await response.text()
+      const parts = await Promise.all(
+        [LIBRARY_URL, PROFILE_LIBRARY_URL].map(async (url) => {
+          const response = await fetch(url, { cache: "force-cache" })
+          return response.ok ? await response.text() : null
+        }),
+      )
+      if (parts.some((part) => part === null)) return null
+      return parts.join(LIBRARY_SEPARATOR)
     } catch (_) {
       return null
     }
   }
-  // Prime the HTTP cache with the current served library so the next
+  // Prime the HTTP cache with the current served libraries so the next
   // load's `cachedLibrary()` reflects what we just applied (otherwise
   // it would re-detect the same change and reseed every load).
   const primeLibraryCache = async () => {
     try {
-      await fetch(LIBRARY_URL, { cache: "reload" })
+      await Promise.all(
+        [LIBRARY_URL, PROFILE_LIBRARY_URL].map((url) =>
+          fetch(url, { cache: "reload" }),
+        ),
+      )
     } catch (_) {
       // Non-fatal: a failed prime just means an extra reseed next load.
     }
@@ -440,8 +476,20 @@
       return
     }
 
+    // The PROFILE branch carries a DIFFERENT library: `profile.yaml` (the Hub
+    // and the FAB chrome), not `core.yaml`. Seeding core.yaml there would leave
+    // every FAB edit unreachable until the profile was recreated — which is
+    // exactly what it used to mean.
+    const { core, profile } = splitLibrary(library)
+    const libraryFor = (branch) =>
+      branch.getAttribute("with").includes("@profile:") ? profile : core
+
     for (const branch of branches) {
-      const detail = { document: library }
+      const document = libraryFor(branch)
+      // An older cached string may carry no profile half; skip rather than
+      // seed `null` onto the profile branch.
+      if (!document) continue
+      const detail = { document }
       const event = new CustomEvent("tonk-evaluate", {
         detail,
         bubbles: true,


### PR DESCRIPTION
Sharing a space took two clicks. **Share** minted the invite, then the bar swapped to a separate **copy invite link** button that needed a second click — and once it appeared it stayed there for the rest of the session. There was also nothing to indicate the mint was in flight, so the first click looked like it did nothing.

Along the way this also fixes the FAB dropdowns (clicking away didn't dismiss them) and the dev loop for `profile.yaml`.

## Why the share needs a custom element

The obvious fix (await the mint, then copy) does not work. `navigator.clipboard.writeText` requires **transient user activation**, and the mint is a full async round-trip: claim → service worker → commit → subscription frame. By the time the URL exists the activation is spent and the browser refuses the write. That constraint is presumably why it was two controls to begin with.

The way through is [`ClipboardItem`'s promise form](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem): `navigator.clipboard.write` accepts an item whose value is a `Promise<string>`. Construct it **synchronously inside the click handler**, while activation is live, and the browser holds the write open until the promise settles. Baseline since Feb 2025 (Firefox from 126; Safari added promise resolution for exactly this transient-activation problem).

So `<tonk-share>` opens the clipboard write on click, lets the existing `onsubmit=tonk:invite` binding mint as it always did, and resolves the promise once the invite display frames the link. One click, a spinner while it runs, and it reverts to **share** rather than latching.

The URL does not come back through the claim — the event delegate discards the transact receipt. The minted invite lands on `tonk:agent-invite`, whose `<tonk-display>` re-renders and dispatches a bubbling `tonk-display:result`. That display now renders nothing; it exists purely as the subscription that delivers the link.

## Click-away curtain

An open dropdown only closed by clicking its segment again. `<tonk-fab>` now injects a viewport-covering curtain that is inert (`pointer-events: none`) until a menu opens, then takes the click and dismisses both.

It is **injected, not authored** in the view template, for two reasons — and the second is a live trap: `wrap_telescope_tiles` treats child[0] of `.fab` as the circle cap, so a curtain nested inside `.fab` would be mistaken for the cap and the *real* cap would get wrapped as a collapsible tile, breaking the telescope.

## Dev loop: `profile.yaml` now hot-swaps

`hot-swap.js` only ever reseeded `core.yaml` — and dispatched it at *every* mounted context, including the profile branch, which actually carries `profile.yaml` (the Hub and the FAB chrome). So no `profile.yaml` edit could reach a running profile: seeing any FAB change meant recreating the profile from scratch. It now fetches both, hashes them together so a profile-only edit still registers as a change, and routes each document to the branch it belongs on.

## Two traps worth knowing

**`custom-elements` defaults `shadow()` to `true`.** A shadow root with no `<slot>` renders none of its light-DOM children, so `<tonk-share>` silently swallowed the entire share control. `<tonk-fab>` sets `shadow() -> false` for the same reason.

**The view template renderer drops empty elements.** The spinner's nested `<span></span>` rings never reached the DOM, so it painted as a correctly-sized, entirely blank box. The rings are pseudo-elements now. The curtain hits the same rule, which is part of why it is injected from Rust.

## Tests

16 wasm + 35 native, each sabotage-verified. Two gaps that sabotage-testing caught, both worth calling out:

- The original share tests asserted a flat `{link}` event detail I had invented, while the real conclusion is `{this, fields: {link}}`. They passed against a code path that hung forever.
- Testing `close_menus` in isolation still passed with the curtain's click branch deleted, so there is now an end-to-end test that dispatches a real click on the curtain and asserts both menus close.
