### PR TITLE
fix: Add 'ucan/*' to run_worker_first paths

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,7 @@ command = "nix build .#tonk-cloudflare-artifacts"
 directory = "./result/tonk-ui"
 not_found_handling = "single-page-application"
 binding = "ASSETS"
-run_worker_first = ["/@", "/@/*", "/ucan"]
+run_worker_first = ["/@", "/@/*", "/ucan", "/ucan/*"]
 
 [[r2_buckets]]
 binding = "BUCKET"


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- closes [Linear ID, e.g. TON-123]

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `wrangler.toml` configuration file to enhance the routing for the worker.

### Detailed summary
- Updated `run_worker_first` to include the path `"/ucan/*"` in addition to existing paths. This change allows the worker to handle all requests under the `"/ucan"` prefix.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->