### PR TITLE
docs(cli): datalog mental-model priming and hard-won event/view gotchas

### DIFF
--- a/rust/tonk-cli/src/guide-events.md
+++ b/rust/tonk-cli/src/guide-events.md
@@ -265,6 +265,18 @@ kebab `name="note-body"` won't resolve, since the path looks up
 `noteBody`. `preventDefault` fires synchronously so the page
 doesn't reload.
 
+**The prevent-default trap: an action field makes a command
+rule-proof.** A `dom.event.do/*` field projects as a side effect and
+stores **no value**, but a rule's `assert: <command>` premise
+requires every declared field present — so the premise matches zero
+rows and the rule never fires, even though the command transacts
+successfully. A form-submit command like `save` above is only for
+**handler-consumed** commands (typed Rust handlers). A command a
+`rule!:` consumes must NOT declare a `dom.event.do/*` field: fire it
+from a `<button type="button" onclick=…>` instead (no native submit
+exists, so nothing needs preventing) and read the form's controls
+via `dom.event.current-target.form.elements.<name>/value`.
+
 ### `rule!:` — the reactive layer
 
 A rule has a head with one polarity and a body of premises:
@@ -329,13 +341,15 @@ row disappear.
 A rule head needs every field bound, **including `this`** — there is
 no formula that generates a fresh entity. To create durable state
 from an event (a "new post" form), bind the transient command's own
-content-derived entity as the new fact's identity:
+content-derived entity as the new fact's identity. Fire the command
+from a plain `type="button"` (NOT a form submit — see the
+prevent-default trap below) and reach the form controls through
+`current-target.form`:
 
 ```yaml
 command!: &publish
   with:
-    body:    { the: dom.event.current-target.elements.body/value, as: text }
-    prevent: { the: dom.event.do/prevent-default }
+    body: { the: dom.event.current-target.form.elements.body/value, as: text }
 
 rule!:
   assert!: post
@@ -343,6 +357,20 @@ rule!:
     - assert: publish
       where: { this: ?this, body: ?body }   # the transient's own entity
 ```
+
+```yaml
+view!: &composer
+  model: board
+  display: !text/html |
+    <form>
+      <textarea name="body"></textarea>
+      <button type="button" onclick=publish>Post</button>
+    </form>
+```
+
+`type="button"` means there is no native submit to prevent, so the
+command needs no `dom.event.do/prevent-default` field — which is what
+keeps it rule-consumable.
 
 One durable entity per event, carrying the command's identity. The
 caveat: a command's entity is content-derived, so two events with
@@ -370,16 +398,23 @@ The failure modes, from loud to silent:
    blank (`""`/`null`), so the field was omitted and the posted
    command doesn't satisfy the rule's premise. See the blank-leaf
    bullet above.
-3. **The wrong rule fired (or two did)** — commands match
+3. **The command transacts (POST 200) but the rule never fires** —
+   the command declares a `dom.event.do/*` field. Action fields
+   store no value, so a rule premise over that command matches zero
+   rows, always. See "the prevent-default trap"; fire the command
+   from a `type="button"` click instead.
+4. **The wrong rule fired (or two did)** — commands match
    structurally, not by name; see "One command, one shape".
-4. **The form reloaded the page** — the command failed to build
+5. **The form reloaded the page** — the command failed to build
    (case 1), so its queued `prevent-default` never ran and the
    native submit won.
 
 To isolate a rule from the DOM wiring, assert the command's shape
-directly with `tonk eval` (transients evaluate like any concept) and
-check the rule's output fact appears; if it does, the bug is in the
-event binding, not the rule.
+directly with `tonk eval` and check the rule's output fact appears.
+Caveat: notation forces a value into every field — including ones the
+real DOM event can't produce (a blank input, an action field) — so a
+rule that fires under eval can still be unreachable from the DOM;
+cases 2 and 3 are exactly that false positive.
 
 ### Opening the view in tonk-ui
 

--- a/rust/tonk-cli/src/guide-events.md
+++ b/rust/tonk-cli/src/guide-events.md
@@ -136,11 +136,14 @@ Rules of the translation:
   posted and the event falls through to the next matching
   binding. Only a `the:` that doesn't address the event at all
   is silently dropped.
-- An **empty string** reads as "blank = omit" (like an empty form
-  field), so a required field that resolves to `""` also drops the
-  whole command, silently. If a field can legitimately be empty,
-  send a sentinel from the component (e.g. `<br>` for empty rich
-  text) rather than `""`.
+- A **blank** leaf (`""` from an empty text input, `null` from a
+  blank `<wa-input>`) is "not provided": the field is **omitted** and
+  the command still posts without it. No error is logged — but a rule
+  premise that names the missing field then matches nothing, so the
+  event silently does nothing. Read as little as possible from the
+  form and derive the rest in the rule from branch data; if a field
+  can legitimately be empty, send a sentinel from the component
+  (e.g. `<br>` for empty rich text) rather than `""`.
 - The `as:` type drives coercion: `text` → string, `entity` →
   string parsed as a URI (rejected if it has no `:`),
   `unsigned-integer` / `signed-integer` / `float` → number,
@@ -320,6 +323,63 @@ rule!:
 The rule fires on the click-derived `complete` transient and
 retracts the matched `todo`. The view's subscription sees the
 row disappear.
+
+### Minting a new entity from a rule (create forms)
+
+A rule head needs every field bound, **including `this`** — there is
+no formula that generates a fresh entity. To create durable state
+from an event (a "new post" form), bind the transient command's own
+content-derived entity as the new fact's identity:
+
+```yaml
+command!: &publish
+  with:
+    body:    { the: dom.event.current-target.elements.body/value, as: text }
+    prevent: { the: dom.event.do/prevent-default }
+
+rule!:
+  assert!: post
+  when:
+    - assert: publish
+      where: { this: ?this, body: ?body }   # the transient's own entity
+```
+
+One durable entity per event, carrying the command's identity. The
+caveat: a command's entity is content-derived, so two events with
+identical parameters collide on the same entity. If duplicates must
+stay distinct, add a per-event nonce field to the command (e.g.
+`time: { the: dom.event/time-stamp, as: float }`) so each event's
+body — and therefore its entity — differs.
+
+Everything the head asserts must be bound in the body: read what the
+user typed from the form, and pull the rest (author, defaults) from
+persistent facts joined in additional `when:` premises, or bind
+constants with `==` / formula premises.
+
+### Debugging: the click did nothing
+
+The failure modes, from loud to silent:
+
+1. **Console warn "field … did not resolve against the event"** —
+   the path itself is wrong: a missing property step, a kebab-case
+   control name (each path segment camelCases, so `name="like-seed"`
+   is looked up as `likeSeed` — prefer single-word lowercase
+   `name=`s), or a value that won't coerce to `as:` (an `entity`
+   needs a `:`). The whole binding aborts; nothing posts.
+2. **No warn, but the rule didn't fire** — a form control resolved
+   blank (`""`/`null`), so the field was omitted and the posted
+   command doesn't satisfy the rule's premise. See the blank-leaf
+   bullet above.
+3. **The wrong rule fired (or two did)** — commands match
+   structurally, not by name; see "One command, one shape".
+4. **The form reloaded the page** — the command failed to build
+   (case 1), so its queued `prevent-default` never ran and the
+   native submit won.
+
+To isolate a rule from the DOM wiring, assert the command's shape
+directly with `tonk eval` (transients evaluate like any concept) and
+check the rule's output fact appears; if it does, the bug is in the
+event binding, not the rule.
 
 ### Opening the view in tonk-ui
 

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -4,6 +4,29 @@ Headless CLI for reading and writing tonk data and views as
 asserted-notation. You define concepts (schemas), assert facts against
 them, and publish views that render those facts.
 
+## Mental model: it's a datalog
+
+Everything on a branch is a **fact** — entity, attribute, value — as
+in datalog or Datomic. Nothing updates in place: you assert new claims,
+and a cardinality-one attribute supersedes its old value while a
+cardinality-many one accumulates. "Retract" is itself a claim that
+invalidates an earlier one.
+
+- **attribute** — a typed predicate (`the:` URI, `as:` type, cardinality)
+- **concept** — a named schema over attributes (its `with:` map);
+  a concept query matches entities carrying every required attribute
+- **query** — pattern matching with unification: the same `?x` across
+  expressions must take the same value, like datalog body clauses
+- **view** — an HTML template rendered over a concept's instances
+- **rule** — a datalog rule whose trigger premise is a transient
+  command fact produced by a DOM event; its head asserts/retracts facts
+
+Two consequences worth internalizing early: entity identity is
+content-addressed (re-asserting an identical body is a no-op; changing
+any field mints a NEW entity unless you bind the old one with `this:`),
+and bare lowercase tokens are symbols resolved through the name table —
+quote every string literal (`name: "alice"`, not `name: alice`).
+
 ## The loop
 
 1. Discover what's already on the branch — don't guess or memorize:

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -31,6 +31,12 @@ in place and never leave duplicate rows.
 `<tonk-display entity=<uri> model=<concept> view=<view-concept>>`
 renders a single entity. The resolution that trips people up:
 
+- `entity` must be an entity **URI** — something containing `:`
+  (`did:key:…`, `id:foo`, or `{this}`, which interpolates one). The
+  browser shell rejects a bare name (`entity=alice`) with
+  "`entity` must be an entity URI"; headless `tonk render` is more
+  lenient, so a template that SSRs fine can still break live. Always
+  write `{this}` or a URI.
 - `model` is the entity's concept; it projects the entity's fields.
 - `view` is a **view concept** (e.g. the built-in `tonk:view`), NOT a
   specific view instance. `<tonk-display>` resolves the view concept,

--- a/rust/tonk-notation/guide.md
+++ b/rust/tonk-notation/guide.md
@@ -11,6 +11,14 @@ The examples below can be pasted into the editor and evaluated
 against a branch; the worked example near the top runs against an
 empty branch.
 
+If you know datalog or Datomic, map it directly: a branch is a set
+of entity–attribute–value facts; an assertion adds facts; `?x` is a
+logic variable; multiple expressions in one document join by
+unification, like the body clauses of a datalog rule; a concept is a
+named schema over a set of attributes. There is no update-in-place —
+a cardinality-one attribute supersedes on re-assertion, and
+retraction is itself a claim invalidating an earlier one.
+
 ## Two flavours of expression
 
 Every top-level entry in a document is one of two things,


### PR DESCRIPTION
## What

Reworks the baked-in guide to prime agents with the right mental model and the failure modes a real from-scratch build hit live:

- **Datalog priming**: `tonk guide` and the notation guide open with the datalog/Datomic mapping (facts, unification, content-addressed identity, symbols-vs-strings) before any syntax
- **Views**: `<tonk-display entity=…>` must be a URI in the browser shell even though headless render resolves bare names
- **Events**: corrected blank-field semantics — blanks are *omitted* and the command still posts (the old text wrongly said the whole command drops); a rule premise naming the field then silently mismatches
- **Events**: the **prevent-default trap** — a `dom.event.do/*` field stores no value, so a rule premise over that command matches zero rows, always; the command transacts (POST 200) and the rule never fires, and eval-testing false-positives because notation forces a value into every field
- **Events**: a "minting a new entity from a rule" section using the working shape (`type="button"` onclick, controls read via `current-target.form.elements.<name>/value`, transient's own entity as the new fact's identity, nonce caveat)
- **Events**: a loud-to-silent debugging checklist for "the click did nothing"

## Why

The twitter session burned ~30 minutes across the blank-field black hole and the prevent-default trap; every composer iteration (post-tweet → compose → publish) kept the form-submit + prevent-default shape, so none could ever fire its rule.

## Verification

- guide files are `include_str!`-embedded; `cargo test -p tonk-cli` green, output of `tonk guide` / `tonk guide events` reviewed by hand

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances documentation related to the `tonk` framework, focusing on datalog concepts, command handling, and entity creation. It clarifies rules and best practices for binding fields and managing state in reactive applications.

### Detailed summary
- Added explanations of datalog concepts and their application in `tonk`.
- Clarified the requirement for `entity` to be a URI.
- Explained the handling of blank fields in commands.
- Introduced rules for minting new entities from commands.
- Provided debugging tips for common command issues.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->