### PR TITLE
fix: nested-guest origin + pull upstream on join

### DIFF
--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1433,6 +1433,11 @@ fn print_claim_outcome(parent: &std::path::Path, outcome: &ClaimOutcome) {
         && let Some(url) = &outcome.remote_url
     {
         println!("remote:  {name} -> {url}");
+        if outcome.synced {
+            println!("synced:  pulled current state from {name}");
+        } else {
+            println!("synced:  no (run `tonk pull` before making changes)");
+        }
     }
 }
 

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -65,10 +65,17 @@ pub struct ClaimOutcome {
     pub remote_url: Option<Url>,
     /// Local name of the auto-registered remote (always
     /// [`crate::remote::DEFAULT_REMOTE`] when set), or `None` if
-    /// the invite carried no `remote=` URL. Tonk's normal
-    /// post-join `tonk pull` resolves this remote implicitly
-    /// because it's the only one configured.
+    /// the invite carried no `remote=` URL. When set, [`claim`]
+    /// also performs an initial pull from it (see [`synced`]).
+    ///
+    /// [`synced`]: Self::synced
     pub auto_configured_remote: Option<String>,
+    /// Whether the initial post-join pull from the auto-configured
+    /// remote succeeded and brought upstream state into the fresh
+    /// local `main`. `false` when the invite carried no remote, or
+    /// when the pull failed (e.g. the endpoint was unreachable) —
+    /// join still succeeds, and the user can retry with `tonk pull`.
+    pub synced: bool,
 }
 
 /// Failure modes for [`mint`] / [`claim`].
@@ -208,6 +215,11 @@ pub async fn mint(
 ///    matching the layout `tonk init` produces (so all the
 ///    later read paths work uniformly across init- and
 ///    join-bootstrapped sites).
+/// 6. If the invite carried a `remote=` URL, register it, set it
+///    as the local `main`'s upstream, and pull once — a clean
+///    fast-forward into the freshly-created branch, so the joiner
+///    starts from the upstream's state rather than an empty branch
+///    that would diverge on the first local write.
 pub async fn claim(
     parent: &Path,
     invite_url: &str,
@@ -319,6 +331,7 @@ pub async fn claim(
     // surfaces; the remote's subject is the inviter's DID
     // (carried through on the claim chain), not the joiner's.
     let mut auto_configured_remote: Option<String> = None;
+    let mut synced = false;
     if let Some(url) = &remote_url {
         remote::add(&joined, DEFAULT_REMOTE, url.as_str(), Some(subject.clone()))
             .await
@@ -329,12 +342,28 @@ pub async fn claim(
             .await
             .map_err(|e| InviteError::Io(format!("failed to wire upstream from invite: {e}")))?;
         auto_configured_remote = Some(DEFAULT_REMOTE.to_owned());
+
+        // Pull upstream state into the just-created local `main`. The join
+        // provisioned `main` fresh and hasn't written to it, so this is a
+        // clean fast-forward — the joiner ends up with a faithful copy of the
+        // upstream, not an empty branch that silently diverges the moment they
+        // (or their agent) start asserting. Best-effort: an unreachable remote
+        // shouldn't fail an otherwise-complete join — the user can retry with
+        // `tonk pull` — but a real sync error is worth surfacing.
+        match sync::pull(&joined).await {
+            Ok(_) => synced = true,
+            Err(e) => eprintln!(
+                "warning: joined, but the initial pull from '{DEFAULT_REMOTE}' failed: {e}\n\
+                 run `tonk pull` before making changes so you don't diverge from upstream"
+            ),
+        }
     }
 
     Ok(ClaimOutcome {
         subject,
         remote_url,
         auto_configured_remote,
+        synced,
     })
 }
 

--- a/rust/tonk-host/src/bridge.rs
+++ b/rust/tonk-host/src/bridge.rs
@@ -38,7 +38,10 @@ pub fn context_field(name: &str) -> Option<String> {
 /// bridge context the host supplies. Falls back to `window.location.origin`
 /// when there is no bridge (the element running in the real top document).
 pub fn context_origin() -> Option<String> {
-    if let Some(origin) = context_field("origin") {
+    // Reject a forwarded `"null"` as well as an empty one: a nested host whose
+    // own location is `about:srcdoc` could forward the opaque `"null"`, and a
+    // literal `null` origin must never reach a same-origin URL.
+    if let Some(origin) = context_field("origin").filter(|o| o != "null") {
         return Some(origin);
     }
     window()?
@@ -167,4 +170,58 @@ pub async fn host_fetch_text(path: &str) -> Result<String, ErrorDetail> {
     .map_err(|e| ErrorDetail::new(ErrorKind::Network, format!("await text: {e:?}")))?;
     text.as_string()
         .ok_or_else(|| ErrorDetail::new(ErrorKind::Parse, "fetch body not a string"))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use js_sys::Object;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Install `window.tonk.context.origin = value` so the reader sees a
+    /// host-forwarded origin, mirroring what a parent portal's `ready`
+    /// envelope sets on a sealed guest.
+    fn set_context_origin(value: &str) {
+        let win = window().unwrap();
+        let tonk = Object::new();
+        let context = Object::new();
+        let _ = Reflect::set(&context, &"origin".into(), &JsValue::from_str(value));
+        let _ = Reflect::set(&tonk, &"context".into(), &context);
+        let _ = Reflect::set(&win, &"tonk".into(), &tonk);
+    }
+
+    /// Clear `window.tonk` so a later test sees no bridge context (the
+    /// top-document state). `context_field` treats an undefined `tonk` as
+    /// absent, so setting it back to `undefined` is enough.
+    fn clear_context() {
+        let win = window().unwrap();
+        let _ = Reflect::set(&win, &"tonk".into(), &JsValue::UNDEFINED);
+    }
+
+    /// A real forwarded origin is returned verbatim — this is the value a
+    /// nested portal forwards down so a sealed guest can build a same-origin
+    /// invite link without reading its `about:srcdoc` location.
+    #[dialog_common::test]
+    async fn it_prefers_the_forwarded_context_origin() {
+        set_context_origin("https://example.test");
+        assert_eq!(context_origin().as_deref(), Some("https://example.test"));
+        clear_context();
+    }
+
+    /// A forwarded `"null"` (a nested host whose own location was
+    /// `about:srcdoc`) is treated as absent, so it never surfaces as a
+    /// literal `null` origin in an invite URL. It falls through to the real
+    /// harness location, which is never `"null"`.
+    #[dialog_common::test]
+    async fn it_treats_a_null_forwarded_origin_as_absent() {
+        set_context_origin("null");
+        assert_ne!(
+            context_origin().as_deref(),
+            Some("null"),
+            "a forwarded \"null\" must not surface as the origin",
+        );
+        clear_context();
+    }
 }

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -1934,10 +1934,15 @@ fn build_context(host: &Element, state: &Rc<RefCell<PortalState>>) -> Object {
     let this = host.get_attribute("entity").unwrap_or_default();
     let model = host.get_attribute("model").unwrap_or_default();
     let location = window().map(|w| w.location());
-    let origin = location
-        .as_ref()
-        .and_then(|l| l.origin().ok())
-        .unwrap_or_default();
+    // The host's real origin. Read it via `context_origin()`, not
+    // `location.origin()` directly: when THIS portal is itself inside a sealed
+    // guest (a NESTED `<tonk-site>`), the host document is `about:srcdoc` and
+    // `location.origin()` is the opaque string `"null"`. `context_origin()`
+    // prefers the origin the parent portal already forwarded in
+    // `window.tonk.context.origin`, so the real origin propagates down every
+    // nesting level; it falls back to `location.origin` at the top document
+    // (no parent portal, so `window.tonk` is absent).
+    let origin = tonk_host::bridge::context_origin().unwrap_or_default();
     // The guest's own `window.location` is `about:srcdoc`; its REAL location is
     // the parent's. Pass the parent's path + search + hash so the guest stamps
     // them on its requests (the SW reads them to route/contain) and so a
@@ -2583,6 +2588,40 @@ mod tests {
         assert!(
             get_str(&context, "search").is_some(),
             "context carries a `search` field forwarded from the host location",
+        );
+    }
+
+    /// When THIS portal is itself a nested guest, its host document is
+    /// `about:srcdoc` and `location.origin` is `"null"`; the real origin lives
+    /// in the parent-forwarded `window.tonk.context.origin`. The ready envelope
+    /// must carry that forwarded origin (not `"null"`), so a further-nested
+    /// guest can build a same-origin invite link. Simulated by installing a
+    /// `window.tonk.context.origin` before bind.
+    #[dialog_common::test]
+    async fn it_forwards_the_parent_context_origin() {
+        let win = window().expect("window");
+        let tonk = Object::new();
+        let ctx = Object::new();
+        let _ = Reflect::set(&ctx, &"origin".into(), &"https://forwarded.test".into());
+        let _ = Reflect::set(&tonk, &"context".into(), &ctx);
+        let _ = Reflect::set(&win, &"tonk".into(), &tonk);
+
+        let host = FakeHost::install();
+        let consumer = relay_consumer(&host, Some("id:demo-counter"), Some("counter"), None);
+        let state = Rc::new(RefCell::new(PortalState::new()));
+        let (listener, _port) = bind(&consumer, &state);
+
+        let ready = listener.wait_for("ready").await;
+        let context = Reflect::get(&ready, &"context".into()).expect("context");
+
+        // Restore before asserting so a failure doesn't leak `window.tonk`
+        // into a later test running in the same page.
+        let _ = Reflect::set(&win, &"tonk".into(), &JsValue::UNDEFINED);
+
+        assert_eq!(
+            get_str(&context, "origin").as_deref(),
+            Some("https://forwarded.test"),
+            "a nested portal forwards the parent context origin, not `about:srcdoc`'s null",
         );
     }
 


### PR DESCRIPTION
Two independent fixes stacked on `feat/agent-build`, each its own commit.

## 1. `fix(portal): forward the host origin to nested guests`

The agent-link join URL rendered as `tonk join 'null/join?...'`. A space's chrome runs a second `<tonk-site>` inside the level-1 guest, so that nested portal's `build_context` read `window.location.origin` from an `about:srcdoc` document — the opaque string `"null"` — and forwarded it verbatim. `<tonk-origin>` then built `{origin}/join` from it.

`build_context` now reads the origin via `tonk_host::bridge::context_origin()`, which prefers the parent-forwarded `window.tonk.context.origin` (so the real origin propagates down every nesting level) and falls back to `location.origin` only at the top document. `context_origin` also filters a forwarded `"null"` as defense-in-depth.

Tests (headless Chrome): `it_prefers_the_forwarded_context_origin`, `it_treats_a_null_forwarded_origin_as_absent` (tonk-host), `it_forwards_the_parent_context_origin` (tonk-portal); existing `it_posts_ready_with_context_on_bind` still green.

## 2. `fix(cli): pull upstream on join so the joiner doesn't diverge`

`tonk join` only wired the remote and `set_upstream` — it never pulled, leaving local `main` empty. A joiner (especially an agent following the agent-link prompt) would then assert onto an empty branch that silently diverged from upstream, surfacing later as a `NonFastForward` push.

`claim` now does a best-effort `sync::pull` after `set_upstream`. Local `main` has no commits at that point (join goes through `open_with`, not `init_with`, so no `core.yaml` seed), so it's a clean fast-forward — the joiner ends up with a faithful clone of upstream. An unreachable remote warns and points at `tonk pull` rather than failing the join. `ClaimOutcome` gains a `synced` flag, surfaced in the join output.

Not verified: a live mint→join→pull round-trip against a real remote endpoint (no in-process URL-remote harness in tonk-cli tests). Build, clippy `--all-targets --all-features`, fmt, and existing `tests/sync.rs` (8) are green.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` application by improving the handling of remote synchronization. It adds checks for successful state pulling and updates relevant documentation to clarify the behavior of remote invites.

### Detailed summary
- Added logging for sync status in `tonk.rs`.
- Updated `context_origin` in `bridge.rs` to reject "null" origins.
- Introduced tests for context origin handling in `bridge.rs`.
- Changed origin retrieval logic in `tonk-portal/src/bridge.rs`.
- Updated documentation for `auto_configured_remote` and `synced` in `invite.rs`.
- Implemented initial pull logic in the `claim` function and added error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->