### PR TITLE
refactor(cli): slim the visible surface from 27 commands to 20

### DIFF
--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -13,7 +13,8 @@ Run commands from a directory at or below the one containing `.tonk/`.
 tonk guide            # one-screen index of the agent reference
 tonk schema           # every concept + attribute on the branch, as notation
 tonk schema <concept> # one concept's subset, same format
-tonk concepts         # name<TAB>description, one row per user concept
+tonk concept ls       # name<TAB>description, one row per user concept
+tonk view ls          # renderable entities (text/html claim carriers)
 tonk status           # synced | ahead | behind | diverged | no-upstream
 ```
 
@@ -27,7 +28,7 @@ required. Errors enumerate the valid options.
 tonk assert <concept> --<field> <value> …            # mint a new instance (all non-optional fields required)
 tonk assert <concept> <entity> --<field> <value> …   # supersede fields on an existing instance
 tonk query <concept> [--json]                        # every instance, every field bound
-tonk get <concept> <entity> [--json]                 # one instance
+tonk query <concept> <entity> [--json]               # one instance
 tonk retract <concept> <entity> --field <f>          # retract one field (a many-cardinality field loses every value)
 tonk retract <concept> <entity>                      # retract the whole instance
 ```
@@ -76,8 +77,8 @@ tonk eval -c '…' --dry-run    # preview without committing
 
 ```bash
 tonk push | tonk pull                       # sync main with its upstream
-tonk remote add <name> <url>                # register an access-service remote
-tonk remote set-upstream <name>             # track <name>/main
+tonk remote add <name> <url>                # register a remote; the first one becomes main's upstream
+tonk remote set-upstream <name>             # re-point which remote main tracks
 tonk invite [--remote <name>]               # mint a paste-able invite URL (pushes first)
 tonk join '<invite-url>'                    # claim an invite into a fresh .tonk/
 tonk share concept <name>                   # launcher URL onto a live concept view

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -33,7 +33,7 @@ use tonk_cli::{ExitCode, guide, identity, schema, site};
     about = "Headless CLI for a datalog-flavoured, syncable fact store: define concepts, assert facts, query them, render views",
     version,
     propagate_version = true,
-    after_help = "The loop: orient, define concepts, assert facts, give them a view, share.\n\n  orient   guide · schema · concepts · views · status\n  author   concept add · view add · home\n  data     assert · query · get · retract\n  power    eval (asserted-notation) · render\n  collab   share · invite · join · push · pull · remote\n  setup    init · identity · blob · export · import · migrate · telemetry\n\nStart with `tonk guide`; every command's --help carries examples."
+    after_help = "The loop: orient, define concepts, assert facts, give them a view, share.\n\n  orient   guide · schema · concept ls · view ls · status\n  author   concept add · view add · home\n  data     assert · query · retract\n  power    eval (asserted-notation) · render\n  collab   share · invite · join · push · pull · remote\n  setup    init · blob · telemetry\n\nStart with `tonk guide`; every command's --help carries examples."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -75,22 +75,6 @@ enum Command {
         #[arg(value_name = "CONCEPT")]
         concept: Option<String>,
     },
-
-    /// List user-defined concepts on the branch
-    ///
-    /// One row per concept, tab-separated `name<TAB>description`.
-    /// Built-in concepts (`attribute`, `concept`, …) are omitted —
-    /// they're resolvable everywhere and would just be noise.
-    #[command(after_help = "Examples:\n  tonk concepts")]
-    Concepts,
-
-    /// List renderable entities (those carrying a text/html claim)
-    ///
-    /// One row per entity, tab-separated `name<TAB>entity<TAB>bytes`.
-    /// Claim-driven: surfaces anything the host route would serve,
-    /// regardless of how the claim was asserted.
-    #[command(after_help = "Examples:\n  tonk views")]
-    Views,
 
     /// Report how local main relates to its upstream
     ///
@@ -159,32 +143,23 @@ enum Command {
         rest: Vec<String>,
     },
 
-    /// Read every instance of a concept, every field bound
+    /// Read instances of a concept, every field bound
     ///
-    /// Reads are queries in dialog. Read-only; nothing commits.
-    /// Filter flags (e.g. `--where`) are the intended future
-    /// direction; today the whole concept is returned.
-    #[command(after_help = "Examples:\n  tonk query task\n  tonk query task --json")]
+    /// With no entity, every instance; with an entity, just that
+    /// one. Reads are queries in dialog — read-only, nothing
+    /// commits. Filter flags (e.g. `--where`) are the intended
+    /// future direction; today the whole concept is returned.
+    #[command(
+        after_help = "Examples:\n  tonk query task\n  tonk query task alice\n  tonk query task --json"
+    )]
     Query {
         /// Name of the concept to query.
         #[arg(value_name = "CONCEPT")]
         concept: String,
-        /// Emit `EvaluateResponse` as pretty JSON instead of notation.
-        #[arg(long)]
-        json: bool,
-    },
-
-    /// Read one instance of a concept by entity
-    ///
-    /// Every field bound. Read-only — the query commits nothing.
-    #[command(after_help = "Examples:\n  tonk get task alice\n  tonk get task alice --json")]
-    Get {
-        /// Name of the concept to fetch from.
-        #[arg(value_name = "CONCEPT")]
-        concept: String,
-        /// Bookmark name or `did:key:…` entity URI of the instance.
+        /// Optional bookmark name or `did:key:…` entity URI —
+        /// fetch just this instance.
         #[arg(value_name = "ENTITY")]
-        entity: String,
+        entity: Option<String>,
         /// Emit `EvaluateResponse` as pretty JSON instead of notation.
         #[arg(long)]
         json: bool,
@@ -302,8 +277,12 @@ enum Command {
     /// Show (or reset) the local profile DID
     ///
     /// With `--reset`, deletes the on-disk profile and creates a
-    /// fresh identity.
-    #[command(after_help = "Examples:\n  tonk identity\n  tonk identity --reset")]
+    /// fresh identity. Hidden from the command list: needed once,
+    /// ever, mostly when debugging delegation.
+    #[command(
+        hide = true,
+        after_help = "Examples:\n  tonk identity\n  tonk identity --reset"
+    )]
     Identity {
         /// Wipe the on-disk profile and create a new one. This removes
         /// access to existing repos without re-delegation.
@@ -319,8 +298,12 @@ enum Command {
 
     /// Export local main's artifacts as CSV
     ///
-    /// Writes to stdout unless `--out <file>` is given.
-    #[command(after_help = "Examples:\n  tonk export\n  tonk export --out data.csv")]
+    /// Writes to stdout unless `--out <file>` is given. Hidden
+    /// from the command list: bulk-transfer plumbing.
+    #[command(
+        hide = true,
+        after_help = "Examples:\n  tonk export\n  tonk export --out data.csv"
+    )]
     Export {
         /// Write the CSV to this file instead of stdout.
         #[arg(long, value_name = "PATH")]
@@ -329,8 +312,9 @@ enum Command {
 
     /// Import artifacts from a CSV file onto local main
     ///
-    /// Commits each row as an assertion.
-    #[command(after_help = "Examples:\n  tonk import data.csv")]
+    /// Commits each row as an assertion. Hidden from the command
+    /// list: bulk-transfer plumbing.
+    #[command(hide = true, after_help = "Examples:\n  tonk import data.csv")]
     Import {
         /// The CSV file to read (`the,of,as,is,cause` columns).
         #[arg(value_name = "PATH")]
@@ -341,8 +325,12 @@ enum Command {
     ///
     /// Walks up from `$PWD` to find the source unless `--from` is
     /// supplied; the destination is always a sibling `.tonk/` of
-    /// the source.
-    #[command(after_help = "Examples:\n  tonk migrate\n  tonk migrate --from ../old --move")]
+    /// the source. Hidden from the command list: a one-time
+    /// converter for pre-tonk carry sites.
+    #[command(
+        hide = true,
+        after_help = "Examples:\n  tonk migrate\n  tonk migrate --from ../old --move"
+    )]
     Migrate {
         /// Explicit source `.carry/` directory. Default: walk up
         /// from `$PWD`.
@@ -401,10 +389,13 @@ enum ShareCommand {
     /// `/space/<space-name>/branch/main/view/<entity>` with the body
     /// served from the entity's `text/html` claim. Events don't fire
     /// there — for interactive, data-bound views use `share display`.
-    #[command(after_help = "Examples:\n  tonk share view my-page")]
+    /// Hidden from the command list for exactly that reason: it's a
+    /// trap next to `share display`, which is what you almost always
+    /// want.
+    #[command(hide = true, after_help = "Examples:\n  tonk share view my-page")]
     View {
         /// Bookmark name or `did:key:…` entity URI for the view.
-        /// `tonk views` lists what's available.
+        /// `tonk view ls` lists what's available.
         #[arg(value_name = "NAME_OR_ENTITY")]
         target: String,
         /// Override the URL prefix the launcher is built against.
@@ -467,7 +458,9 @@ enum RemoteCommand {
     /// Register a UCAN-S3 access-service remote
     ///
     /// Writes the dialog remote handle and the meta-branch
-    /// `Remote` concept browsers read.
+    /// `Remote` concept browsers read. When no upstream is wired
+    /// yet, the new remote becomes `main`'s upstream (an existing
+    /// upstream is never touched — re-point with `set-upstream`).
     #[command(after_help = "Examples:\n  tonk remote add prod https://access.example.com")]
     Add {
         /// Local name for the remote.
@@ -546,6 +539,14 @@ enum ConceptCommand {
         #[arg(long, value_name = "TEXT")]
         description: Option<String>,
     },
+
+    /// List user-defined concepts on the branch
+    ///
+    /// One row per concept, tab-separated `name<TAB>description`.
+    /// Built-in concepts (`attribute`, `concept`, …) are omitted —
+    /// they're resolvable everywhere and would just be noise.
+    #[command(after_help = "Examples:\n  tonk concept ls")]
+    Ls,
 }
 
 #[derive(Subcommand, Debug)]
@@ -576,6 +577,14 @@ enum ViewCommand {
         #[arg(long, value_name = "NAME")]
         name: Option<String>,
     },
+
+    /// List renderable entities (those carrying a text/html claim)
+    ///
+    /// One row per entity, tab-separated `name<TAB>entity<TAB>bytes`.
+    /// Claim-driven: surfaces anything the host route would serve,
+    /// regardless of how the claim was asserted.
+    #[command(after_help = "Examples:\n  tonk view ls")]
+    Ls,
 }
 
 #[derive(Args, Debug)]
@@ -650,12 +659,9 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
         Command::Eval(_) => ("eval", None),
         Command::Guide { .. } => ("guide", None),
         Command::Schema { .. } => ("schema", None),
-        Command::Concepts => ("concepts", None),
         Command::Query { .. } => ("query", None),
-        Command::Get { .. } => ("get", None),
         Command::Assert { .. } => ("assert", None),
         Command::Retract { .. } => ("retract", None),
-        Command::Views => ("views", None),
         Command::Migrate { .. } => ("migrate", None),
         Command::Export { .. } => ("export", None),
         Command::Render { .. } => ("render", None),
@@ -685,12 +691,14 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
             "concept",
             Some(match command {
                 ConceptCommand::Add { .. } => "add",
+                ConceptCommand::Ls => "ls",
             }),
         ),
         Command::View { command } => (
             "view",
             Some(match command {
                 ViewCommand::Add { .. } => "add",
+                ViewCommand::Ls => "ls",
             }),
         ),
         Command::Home { .. } => ("home", None),
@@ -741,20 +749,20 @@ async fn main() {
         Command::Eval(args) => eval(args).await,
         Command::Guide { topic } => print_guide(topic.as_deref()),
         Command::Schema { concept } => print_schema(concept).await,
-        Command::Concepts => print_concepts().await,
-        Command::Query { concept, json } => query_op(concept, json).await,
-        Command::Get {
+        Command::Query {
             concept,
             entity,
             json,
-        } => get_op(concept, entity, json).await,
+        } => match entity {
+            Some(entity) => get_op(concept, entity, json).await,
+            None => query_op(concept, json).await,
+        },
         Command::Assert { concept, rest } => assert_cmd(concept, rest).await,
         Command::Retract {
             concept,
             entity,
             field,
         } => retract_op(concept, entity, field).await,
-        Command::Views => print_views().await,
         Command::Migrate { from, do_move } => migrate(from, do_move).await,
         Command::Export { out } => export_op(out).await,
         Command::Render { route, out } => render_op(route, out).await,
@@ -1107,7 +1115,35 @@ async fn remote_op(command: RemoteCommand) -> ExitCode {
             match remote::add(&site, &name, &url, subject).await {
                 Ok(outcome) => {
                     print_remote_add_outcome(&outcome);
-                    ExitCode::Success
+                    // A first remote with no upstream wired is a
+                    // foot-gun (writes only auto-sync once an
+                    // upstream exists), and add-then-set-upstream is
+                    // nearly always performed together — so the
+                    // first remote becomes the upstream by default.
+                    // An existing upstream is never touched.
+                    match remote::upstream_configured(&site).await {
+                        Ok(true) => ExitCode::Success,
+                        Ok(false) => match remote::set_upstream(&site, &name).await {
+                            Ok(upstream) => {
+                                print_set_upstream_outcome(&upstream);
+                                ExitCode::Success
+                            }
+                            Err(err) => {
+                                eprintln!(
+                                    "error: remote added, but wiring it as the upstream \
+                                     failed: {err}\nretry with `tonk remote set-upstream {name}`"
+                                );
+                                err.exit_code()
+                            }
+                        },
+                        Err(err) => {
+                            eprintln!(
+                                "error: remote added, but checking the upstream failed: {err}\n\
+                                 wire it manually with `tonk remote set-upstream {name}`"
+                            );
+                            err.exit_code()
+                        }
+                    }
                 }
                 Err(err) => {
                     eprintln!("error: {err}");
@@ -1477,16 +1513,10 @@ async fn migrate(from: Option<PathBuf>, do_move: bool) -> ExitCode {
     }
 }
 
-async fn print_concepts() -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
-    };
-    let concepts = match schema::list_concepts(&site).await {
+/// List user-defined concepts (`tonk concept ls`), one
+/// tab-separated `name<TAB>description` row per concept.
+async fn list_concepts_op(site: &site::TonkSite) -> ExitCode {
+    let concepts = match schema::list_concepts(site).await {
         Ok(c) => c,
         Err(err) => return print_error(err.to_string()),
     };
@@ -1645,6 +1675,7 @@ async fn concept_op(command: ConceptCommand) -> ExitCode {
                 err.exit_code()
             }
         },
+        ConceptCommand::Ls => list_concepts_op(&site).await,
     }
 }
 
@@ -1701,6 +1732,7 @@ async fn view_op(command: ViewCommand) -> ExitCode {
                 }
             }
         }
+        ViewCommand::Ls => list_views_op(&site).await,
     }
 }
 
@@ -1731,16 +1763,10 @@ async fn home_op(models: Vec<String>) -> ExitCode {
     }
 }
 
-async fn print_views() -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
-    };
-    let listed = match views::list(&site).await {
+/// List renderable entities (`tonk view ls`), one tab-separated
+/// `name<TAB>entity<TAB>bytes` row per `text/html` claim carrier.
+async fn list_views_op(site: &site::TonkSite) -> ExitCode {
+    let listed = match views::list(site).await {
         Ok(v) => v,
         Err(err) => return print_error(err.to_string()),
     };

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -31,15 +31,15 @@ quote every string literal (`name: "alice"`, not `name: alice`).
 
 1. Discover what's already on the branch — don't guess or memorize:
    - `tonk schema [<concept>]` — attributes and concepts, as re-submittable notation
-   - `tonk concepts` — user-defined concepts (name + description)
-   - `tonk views`    — entities carrying a renderable claim
+   - `tonk concept ls` — user-defined concepts (name + description)
+   - `tonk view ls`    — entities carrying a renderable claim
 2. Define schema: `tonk concept add <name> --attr <field>:<type>:<card> …`
    (types enumerate on a miss; `one`/`many` cardinality). The concept is
    immediately usable: `tonk assert <name> --help` shows its typed flags.
 3. Work the data with the argument verbs (each write auto-syncs):
    - `tonk assert <concept> --<field> <value> …`          — mint an instance
    - `tonk assert <concept> <entity> --<field> <value> …` — supersede fields
-   - `tonk query <concept>` / `tonk get <concept> <entity>` — read (`--json`)
+   - `tonk query <concept> [<entity>]` — read all or one (`--json`)
    - `tonk retract <concept> <entity> [--field <f>]`      — retract claims
 4. Give it a view and put it on the space home — a build nobody can see
    isn't done:

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -200,7 +200,7 @@ page!: &about
     <h1>About</h1>
 ```
 
-`tonk views` lists every entity carrying a `text/html` claim;
+`tonk view ls` lists every entity carrying a `text/html` claim;
 `tonk share view <name>` opens it in the iframe viewer. The viewer
 shell does not register `<tonk-display>`, so events won't fire there —
 use `tonk share display` for interactive, data-bound views.
@@ -208,5 +208,5 @@ use `tonk share display` for interactive, data-bound views.
 ---
 
 For interactivity (clicks, forms) see `tonk guide events`. Don't
-memorize built-ins — run `tonk schema` / `tonk concepts` /
-`tonk views` to see what's on the branch.
+memorize built-ins — run `tonk schema` / `tonk concept ls` /
+`tonk view ls` to see what's on the branch.

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -146,6 +146,20 @@ pub async fn add(
     })
 }
 
+/// True when the local `main` branch already tracks an upstream.
+/// `tonk remote add` consults this to decide whether the remote it
+/// just registered should become the upstream by default — the
+/// add-then-set-upstream pair is nearly always performed together,
+/// and a first remote with no upstream wired is a foot-gun (writes
+/// auto-sync only once an upstream exists).
+pub async fn upstream_configured(site: &TonkSite) -> Result<bool, RemoteError> {
+    let session = site
+        .branch()
+        .await
+        .map_err(|e| RemoteError::Io(format!("failed to acquire branch: {e}")))?;
+    Ok(session.handle().upstream().is_some())
+}
+
 /// Set the local `main` branch's upstream to `<remote>/main`,
 /// writing the corresponding `TrackingBranch` and remote-side
 /// `Branch` concepts on the meta branch.

--- a/rust/tonk-cli/tests/sync.rs
+++ b/rust/tonk-cli/tests/sync.rs
@@ -44,6 +44,26 @@ async fn upstream_revision(test: &TestSite) -> Result<Option<Revision>> {
     Ok(upstream.revision())
 }
 
+mod when_checking_for_an_upstream {
+    use super::*;
+    use tonk_cli::remote;
+
+    #[dialog_common::test]
+    async fn it_reports_whether_main_tracks_an_upstream() -> Result<()> {
+        let test = TestSite::new().await?;
+        assert!(
+            !remote::upstream_configured(&test.site).await?,
+            "a fresh site has no upstream"
+        );
+        wire_sibling_upstream(&test).await?;
+        assert!(
+            remote::upstream_configured(&test.site).await?,
+            "wiring an upstream flips the check"
+        );
+        Ok(())
+    }
+}
+
 mod when_evaluating_with_an_upstream {
     use super::*;
 


### PR DESCRIPTION
## What

Follow-up to #603: instead of just tidying the 27-command list, shrink it.

**Merged (breaking spellings, no capability lost):**
- `tonk get <concept> <entity>` → `tonk query <concept> [<entity>]` — one read verb, optional entity
- `tonk concepts` → `tonk concept ls`, `tonk views` → `tonk view ls` — both nouns now read add/ls; clap's built-in tip suggests `concept` when someone types the old `concepts`

**Hidden from `-h` (still fully functional):**
- `export`, `import` — bulk-transfer plumbing
- `migrate` — one-time carry→tonk converter
- `identity` — needed once, ever
- `share view` — the iframe viewer where events never fire; a documented trap sitting next to `share display`, which is what callers almost always want

**Behavioral merge:** the first `tonk remote add` now wires that remote as `main`'s upstream by default (an existing upstream is never touched). The add-then-set-upstream pair was always performed together, and a first remote with no upstream silently disables auto-sync on writes.

Visible surface: 27 → 20 commands. Guide index, views guide, and the repo tonk skill updated to the new spellings.

## Verification

- `cargo test -p tonk-cli` green, including a new test for `remote::upstream_configured` (false on a fresh site, true after wiring)
- e2e against a scratch site: `concept ls` / `view ls` list, `query tweet` returns all instances, `query tweet <did>` returns one, `tonk concepts` errors with the `concept` suggestion, hidden commands still respond to `--help`
- clippy `--all-targets --all-features` clean, `cargo fmt --check` clean

## Breaking

`tonk get` / `tonk concepts` / `tonk views` no longer parse. Grep says nothing in-repo (bench, docs, scripts) calls them; the guide and skill are updated in this PR. External muscle memory gets clap's did-you-mean tip.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces tests for upstream configuration in the `tonk-cli`, updates command documentation, and refines various command functionalities for clarity and consistency. It also modifies how concepts and views are listed and improves the handling of remote branches.

### Detailed summary
- Added a new test module `when_checking_for_an_upstream` to verify upstream tracking.
- Updated command documentation to reflect changes from `tonk views` to `tonk view ls`.
- Refined the `upstream_configured` function in `remote.rs` for better clarity.
- Modified command structures to replace `Get` with optional entity handling in `Query`.
- Removed deprecated commands and updated associated help text.
- Enhanced error handling for remote operations during upstream configuration.
- Introduced new functions for listing concepts and views with clear documentation.
- Adjusted command help outputs for better user guidance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->