### PR TITLE
feat(cli): publish tonk to npm as @tonk/cli (0.4.0)

### DIFF
--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -1,0 +1,108 @@
+name: 'CLI npm'
+
+# Manual-trigger only: builds the per-platform tonk binaries and
+# publishes @tonk/cli (plus its platform packages) to npm. Nothing
+# publishes on a normal push.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'npm version to publish (e.g. 0.4.0)'
+        required: true
+        default: '0.4.0'
+      dist-tag:
+        description: 'npm dist-tag'
+        required: true
+        default: 'latest'
+
+concurrency:
+  group: cli-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: 'Build ${{ matrix.artifact-name }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-name: tonk-linux-x86_64
+          - os: macos-latest
+            artifact-name: tonk-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wimpysworld/nothing-but-nix@main
+        if: runner.os == 'Linux'
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: 'Build tonk'
+        run: nix build --accept-flake-config .#tonk-cli
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: result/bin/tonk
+
+  publish:
+    name: 'Publish to npm'
+    needs: ['build']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v4
+        with:
+          name: tonk-macos-arm64
+          path: artifacts/darwin-arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: tonk-linux-x86_64
+          path: artifacts/linux-x64
+      - name: Assemble platform packages
+        working-directory: rust/tonk-cli/npm
+        run: |
+          set -euo pipefail
+          install -Dm0755 "$GITHUB_WORKSPACE/artifacts/darwin-arm64/tonk" darwin-arm64/bin/tonk
+          install -Dm0755 "$GITHUB_WORKSPACE/artifacts/linux-x64/tonk"   linux-x64/bin/tonk
+      - name: Stamp version
+        working-directory: rust/tonk-cli/npm
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for dir in darwin-arm64 linux-x64 cli; do
+            (cd "$dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version)
+          done
+          # Pin the wrapper's optionalDependencies to the same version.
+          node -e '
+            const fs = require("fs");
+            const v = process.env.VERSION;
+            const p = "cli/package.json";
+            const j = JSON.parse(fs.readFileSync(p, "utf8"));
+            for (const k of Object.keys(j.optionalDependencies || {})) {
+              j.optionalDependencies[k] = v;
+            }
+            fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+          '
+      - name: Publish
+        working-directory: rust/tonk-cli/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ inputs.dist-tag }}
+        run: |
+          set -euo pipefail
+          # Platform packages first: the wrapper's optionalDependencies
+          # point at them, so they must exist before it resolves.
+          npm publish darwin-arm64 --access public --tag "$TAG"
+          npm publish linux-x64   --access public --tag "$TAG"
+          npm publish cli         --access public --tag "$TAG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4599,7 +4599,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "bs58",
@@ -4611,7 +4611,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dialog-capability",
  "dialog-common",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Tonk Labs"]
 license = "MIT"
 edition = "2024"

--- a/rust/tonk-cli/npm/.gitignore
+++ b/rust/tonk-cli/npm/.gitignore
@@ -1,0 +1,5 @@
+# Native binaries are build artifacts injected by release CI (or a local
+# pack test); never commit them.
+darwin-arm64/bin/
+linux-x64/bin/
+*.tgz

--- a/rust/tonk-cli/npm/README.md
+++ b/rust/tonk-cli/npm/README.md
@@ -1,0 +1,53 @@
+# npm distribution for the tonk CLI
+
+This directory packages the native `tonk` binary (built from
+`rust/tonk-cli`) for npm, so `npx @tonk/cli` and `npm i -g @tonk/cli`
+work with no Rust toolchain.
+
+## Layout
+
+- `cli/` — the published wrapper package **`@tonk/cli`**. Its
+  `bin/tonk.js` launcher resolves the matching platform package and
+  execs the native binary. It declares the platform packages as
+  `optionalDependencies`, so npm downloads only the one for the host.
+- `darwin-arm64/` — **`@tonk/cli-darwin-arm64`** (`os: darwin`,
+  `cpu: arm64`).
+- `linux-x64/` — **`@tonk/cli-linux-x64`** (`os: linux`, `cpu: x64`).
+
+The platform packages' `bin/tonk` binaries are **build artifacts**, not
+committed (`.gitignore`d). Release CI (or the local pack test below)
+injects them before publishing.
+
+Adding a platform later = one nix build matrix row in
+`.github/workflows/cli-npm.yml`, a new `<platform>/package.json` here,
+and an entry in the wrapper's `optionalDependencies`.
+
+## Publishing (maintainers)
+
+Publishing runs in CI so every platform binary is built reproducibly —
+you cannot build the Linux binary from a Mac. It is **manual-trigger
+only**; nothing publishes on a normal push.
+
+1. One-time: add an `NPM_TOKEN` repository secret (an npm automation
+   token for the `@tonk` scope with publish rights).
+2. Run the **CLI npm** workflow (`.github/workflows/cli-npm.yml`) via
+   *Actions → CLI npm → Run workflow*, setting `version` (e.g. `0.4.0`)
+   and `dist-tag` (`latest`). It builds both binaries, stamps the
+   version across all three package.jsons, and publishes the platform
+   packages first, then the wrapper.
+
+To verify locally without publishing, from `rust/tonk-cli/npm`:
+
+```sh
+# darwin-arm64 only (the binary you can build on a Mac)
+nix build --accept-flake-config ../../..#tonk-cli
+install -Dm0755 ../../../result/bin/tonk darwin-arm64/bin/tonk
+npm pack ./darwin-arm64 ./cli            # produces .tgz tarballs
+# smoke-test the launcher against the packed tarballs:
+tmp=$(mktemp -d) && npm --prefix "$tmp" install ./tonk-cli-darwin-arm64-*.tgz ./tonk-cli-0.4.0.tgz
+"$tmp/node_modules/.bin/tonk" --help
+```
+
+The npm package version tracks the Rust workspace version
+(`version.workspace` in the root `Cargo.toml`), so `tonk --version`
+matches the published `@tonk/cli` version. Bump both together.

--- a/rust/tonk-cli/npm/cli/README.md
+++ b/rust/tonk-cli/npm/cli/README.md
@@ -1,0 +1,23 @@
+# @tonk/cli
+
+The Tonk stack command line utility — `tonk`.
+
+```sh
+npx @tonk/cli --help
+# or install globally
+npm install -g @tonk/cli
+tonk --help
+```
+
+`@tonk/cli` is a thin launcher. The actual `tonk` program is a native
+binary shipped in a per-platform package that npm installs automatically
+for your OS and CPU:
+
+| Platform      | Package                   |
+| ------------- | ------------------------- |
+| macOS (arm64) | `@tonk/cli-darwin-arm64`  |
+| Linux (x64)   | `@tonk/cli-linux-x64`     |
+
+More platforms coming soon.
+
+Source: [`rust/tonk-cli`](https://github.com/tonk-labs/tonk/tree/main/rust/tonk-cli).

--- a/rust/tonk-cli/npm/cli/bin/tonk.js
+++ b/rust/tonk-cli/npm/cli/bin/tonk.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+// Thin launcher for the tonk CLI. The real program is a native Rust
+// binary shipped in a per-platform package (@tonk/cli-<platform>-<arch>).
+// npm installs only the package whose `os`/`cpu` match this host, so we
+// resolve that one binary and exec it. esbuild, turbo, and swc all
+// distribute their native binaries with this same require.resolve pattern.
+const { spawnSync } = require("node:child_process");
+
+function resolveBinary() {
+  const { platform, arch } = process;
+  const pkg = `@tonk/cli-${platform}-${arch}`;
+  const exe = platform === "win32" ? "tonk.exe" : "tonk";
+  try {
+    return require.resolve(`${pkg}/bin/${exe}`);
+  } catch {
+    return null;
+  }
+}
+
+const bin = resolveBinary();
+if (bin === null) {
+  console.error(
+    `@tonk/cli: no prebuilt tonk binary for ${process.platform}-${process.arch} yet.\n` +
+      "Supported today: darwin-arm64 and linux-x64. More platforms coming soon.",
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+// spawnSync sets `status` to null when the child was killed by a signal;
+// map that to a non-zero exit so callers see the failure.
+process.exit(typeof result.status === "number" ? result.status : 1);

--- a/rust/tonk-cli/npm/cli/package.json
+++ b/rust/tonk-cli/npm/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tonk/cli",
+  "version": "0.4.0",
+  "description": "The Tonk stack command line utility.",
+  "license": "MIT",
+  "homepage": "https://github.com/tonk-labs/tonk#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tonk-labs/tonk.git",
+    "directory": "rust/tonk-cli"
+  },
+  "bugs": {
+    "url": "https://github.com/tonk-labs/tonk/issues"
+  },
+  "keywords": [
+    "cli",
+    "ai",
+    "crdt",
+    "local-first",
+    "tonk"
+  ],
+  "bin": {
+    "tonk": "bin/tonk.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@tonk/cli-darwin-arm64": "0.4.0",
+    "@tonk/cli-linux-x64": "0.4.0"
+  }
+}

--- a/rust/tonk-cli/npm/darwin-arm64/package.json
+++ b/rust/tonk-cli/npm/darwin-arm64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tonk/cli-darwin-arm64",
+  "version": "0.4.0",
+  "description": "darwin-arm64 binary for @tonk/cli.",
+  "license": "MIT",
+  "homepage": "https://github.com/tonk-labs/tonk#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tonk-labs/tonk.git",
+    "directory": "rust/tonk-cli"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/rust/tonk-cli/npm/linux-x64/package.json
+++ b/rust/tonk-cli/npm/linux-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tonk/cli-linux-x64",
+  "version": "0.4.0",
+  "description": "linux-x64 binary for @tonk/cli.",
+  "license": "MIT",
+  "homepage": "https://github.com/tonk-labs/tonk#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tonk-labs/tonk.git",
+    "directory": "rust/tonk-cli"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ]
+}


### PR DESCRIPTION
## What

Ships the native `tonk` CLI to npm so `npx @tonk/cli` and `npm i -g @tonk/cli` work with no Rust toolchain, and aligns every version at **0.4.0**.

`@tonk/cli` is a thin JS launcher that resolves a per-platform binary package via `optionalDependencies` and execs it — the esbuild/turbo pattern:

| Platform | Package |
| --- | --- |
| macOS arm64 | `@tonk/cli-darwin-arm64` |
| Linux x64 | `@tonk/cli-linux-x64` |

npm installs only the package whose `os`/`cpu` match the host. Unsupported platforms get a clear "coming soon" message. Platforms match what `cli.yml` already builds via `nix build .#tonk-cli`; adding more is one matrix row + one platform package + one `optionalDependencies` entry.

## Release CI

`.github/workflows/cli-npm.yml` — **manual-trigger only** (`workflow_dispatch`). Builds both binaries, stamps the version across all three `package.json`s, and publishes the platform packages first, then the wrapper. Nothing publishes on push. Requires a one-time `NPM_TOKEN` repo secret.

## Version alignment

The old `@tonk/cli@0.3.x` on npm is the retired Node/TypeScript CLI; **0.4.0 is a fresh line for the Rust binary** (deliberate supersession). The Rust workspace is bumped `0.1.0 → 0.4.0` too, so `tonk --version` matches the published package.

## Verified locally (darwin-arm64)

`npm pack` → install both tarballs into a clean dir → `tonk --help` runs the native binary (exit 0); bogus subcommand exits 1; npm installed only the matching platform package.

## To publish (maintainer, after merge)

1. Add an `NPM_TOKEN` repo secret (npm automation token, publish rights on `@tonk`).
2. Actions → **CLI npm** → Run workflow, `version=0.4.0`, `dist-tag=latest`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `tonk` CLI and its related packages to `0.4.0`, along with adding platform-specific binaries for `darwin-arm64` and `linux-x64`. It also enhances the documentation for the CLI and its npm distribution.

### Detailed summary
- Updated version in `Cargo.toml` and `Cargo.lock` to `0.4.0`.
- Added `.gitignore` entries for build artifacts.
- Created `package.json` for `@tonk/cli-linux-x64` and `@tonk/cli-darwin-arm64`.
- Enhanced `README.md` for `tonk` CLI with usage instructions.
- Added a thin launcher script in `bin/tonk.js`.
- Updated `cli/package.json` with new version and dependencies.
- Added detailed publishing instructions in `README.md`.
- Updated GitHub Actions workflow in `.github/workflows/cli-npm.yml` for manual publishing process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->