### PR TITLE
fix(ci): drive cli-npm publish from tags and resolve local dirs

### DIFF
--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -1,27 +1,54 @@
 name: 'CLI npm'
 
-# Manual-trigger only: builds the per-platform tonk binaries and
-# publishes @tonk/cli (plus its platform packages) to npm. Nothing
-# publishes on a normal push.
+# Tag-driven: pushing a `v*` tag builds the per-platform tonk binaries
+# and publishes @tonk/cli (plus its platform packages) to npm. The
+# version comes from the tag and must match the Cargo workspace version;
+# nothing publishes on a normal push.
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'npm version to publish (e.g. 0.4.0)'
-        required: true
-        default: '0.4.0'
-      dist-tag:
-        description: 'npm dist-tag'
-        required: true
-        default: 'latest'
+  push:
+    tags:
+      - 'v*'
 
 concurrency:
   group: cli-npm-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: 'Resolve version'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      dist-tag: ${{ steps.resolve.outputs.dist-tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Derive and validate version
+        id: resolve
+        run: |
+          set -euo pipefail
+          # Tag `v0.4.0` -> version `0.4.0`.
+          version="${GITHUB_REF_NAME#v}"
+          # Single source of truth: the Cargo workspace version must match the tag.
+          cargo_version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
+            | grep -m1 '^version' \
+            | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [[ "$version" != "$cargo_version" ]]; then
+            echo "::error::tag v$version does not match Cargo workspace version $cargo_version"
+            exit 1
+          fi
+          # Prereleases (e.g. 0.4.1-rc.1) publish under `next`, releases under `latest`.
+          if [[ "$version" == *-* ]]; then
+            dist_tag="next"
+          else
+            dist_tag="latest"
+          fi
+          echo "version=$version"   >> "$GITHUB_OUTPUT"
+          echo "dist-tag=$dist_tag" >> "$GITHUB_OUTPUT"
+          echo "Publishing $version to npm dist-tag '$dist_tag'"
+
   build:
     name: 'Build ${{ matrix.artifact-name }}'
+    needs: ['prepare']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -50,7 +77,7 @@ jobs:
 
   publish:
     name: 'Publish to npm'
-    needs: ['build']
+    needs: ['prepare', 'build']
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -77,7 +104,7 @@ jobs:
       - name: Stamp version
         working-directory: rust/tonk-cli/npm
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
           for dir in darwin-arm64 linux-x64 cli; do
@@ -98,11 +125,13 @@ jobs:
         working-directory: rust/tonk-cli/npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          TAG: ${{ inputs.dist-tag }}
+          TAG: ${{ needs.prepare.outputs.dist-tag }}
         run: |
           set -euo pipefail
           # Platform packages first: the wrapper's optionalDependencies
           # point at them, so they must exist before it resolves.
-          npm publish darwin-arm64 --access public --tag "$TAG"
-          npm publish linux-x64   --access public --tag "$TAG"
-          npm publish cli         --access public --tag "$TAG"
+          # The `./` prefix is required — a bare name like `darwin-arm64`
+          # is parsed as a registry package spec, not a local directory.
+          npm publish ./darwin-arm64 --access public --tag "$TAG"
+          npm publish ./linux-x64    --access public --tag "$TAG"
+          npm publish ./cli          --access public --tag "$TAG"


### PR DESCRIPTION
## What

Two independent fixes to `.github/workflows/cli-npm.yml`.

### 1. Publish resolved the wrong packages
The publish step used bare directory names:

```
npm publish darwin-arm64 --access public --tag "$TAG"
```

npm only treats an argument as a local directory if it looks like a path (`./`, `/`, `~/`, drive letter). A bare `darwin-arm64` is parsed as a **registry package spec**, so npm went to npmjs instead of the local folder:

- `darwin-arm64` → the real-but-empty public `darwin-arm64` package → `ENOVERSIONS` (the failure that surfaced).
- `cli` → an unrelated third-party `cli@1.0.1` package, which `npm publish cli --dry-run` packs instead of `@tonk/cli`.

Fix: prefix the paths with `./` so npm packs the local packages. Verified with `npm publish ./cli --dry-run` → `@tonk/cli@0.4.0`.

### 2. Tag-driven releases instead of manual dispatch
Switched the trigger from `workflow_dispatch` (free-text version input, tied to nothing) to `push` on `v*` tags. A new `prepare` job:

- derives the npm version from the tag (`v0.4.0` → `0.4.0`),
- asserts it matches `[workspace.package] version` in the root `Cargo.toml` — a mismatched tag fails **before** any binary is built,
- routes prereleases (`v0.4.1-rc.1`) to the `next` dist-tag, releases to `latest`.

`build` and `publish` consume the resolved version/dist-tag as job outputs.

## Releasing after this

```
# bump the workspace version in Cargo.toml, commit, then:
git tag v0.4.1
git push origin v0.4.1
```

Re-run a failed publish via GitHub's "Re-run jobs" — no tag churn needed.

## Verification
- Version derive/validate logic exercised locally against the real `Cargo.toml` (match → publish; mismatch → fail; prerelease → `next`).
- `npm publish ./cli --dry-run` packs `@tonk/cli@0.4.0`; bare `cli` packs an unrelated registry package.
- YAML parses cleanly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow for publishing the `@tonk/cli` package to npm. It changes the trigger from manual to tag-driven, ensuring that the version from the tag matches the Cargo workspace version, and modifies the process for determining the distribution tag.

### Detailed summary
- Changed trigger from `workflow_dispatch` to `push` with `v*` tags.
- Added a `prepare` job to resolve version and distribution tag.
- Updated version and dist-tag references in the `publish` job.
- Modified npm publish commands to include `./` prefix for local directories.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->