### PR TITLE
feat(tonk-core): npx-first agent invite prompt, drop hardcoded mkdir

### DIFF
--- a/bench/bin/prompt.sh
+++ b/bench/bin/prompt.sh
@@ -33,18 +33,18 @@ raw="$(awk '
   /<pre class="agent-prompt__pre">/ { f=1; sub(/.*<pre class="agent-prompt__pre">/, ""); print; next }
   f && /<\/pre>/ { sub(/<\/pre>.*/, ""); print; exit }
   f { print }
-' "$CORE_YAML" | sed -e 's/^    //' -e 's/&amp;/\&/g' -e 's/&quot;/"/g')"
+' "$CORE_YAML" | sed -e 's/^    //' -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&quot;/"/g' -e 's/&amp;/\&/g')"
 
 [ -n "$raw" ] || { echo "prompt: extraction from $CORE_YAML came up empty — did the agent-prompt view template change shape?" >&2; exit 1; }
 
-# Fill the template. The join URL is one composite placeholder; replace
-# it whole with the real minted invite URL. Use escaped copies as the
-# replacement text so a literal `&` (e.g. a synced repo's `&remote=`)
-# isn't treated as a back-reference to the matched pattern.
+# Fill the template. The join URL is the single `{link}` model field;
+# replace it whole with the real minted invite URL. Use escaped copies
+# as the replacement text so a literal `&` (e.g. a synced repo's
+# `&remote=`) isn't treated as a back-reference to the matched pattern.
 esc_url="$(psub_escape "$INVITE_URL")"
 esc_name="$(psub_escape "$NAME")"
 filled="$raw"
-filled="${filled//\{dom.host\/data-base\}?access=\{access\}\{remote\}#\{code\}/$esc_url}"
+filled="${filled//\{link\}/$esc_url}"
 filled="${filled//\{name\}/$esc_name}"
 filled="${filled//\{dom.host\/data-page\}/this repo}"
 
@@ -55,6 +55,6 @@ if printf '%s' "$filled" | grep -qE '\{(access|remote|code|name|dom\.host)' ; th
   printf '%s\n' "$filled" | grep -nE '\{' >&2
   exit 1
 fi
-printf '%s' "$filled" | grep -q "tonk join" || { echo "prompt: no 'tonk join' in rendered prompt" >&2; exit 1; }
+printf '%s' "$filled" | grep -q "@tonk/cli join" || { echo "prompt: no 'npx @tonk/cli join' in rendered prompt" >&2; exit 1; }
 
 printf '%s\n' "$filled"

--- a/bench/scenarios/cold-onboard/rubric.md
+++ b/bench/scenarios/cold-onboard/rubric.md
@@ -15,9 +15,9 @@ matters less than in other scenarios.
 - Outcome 1-3: got the CLI running but never completed the join.
 - Outcome 0: never got a working tonk command executed.
 
-Friction focus: everything before the first successful `tonk join` —
-install discovery (the prompt does not currently mention npx or where
-to get the binary), sandbox/path fights (the prompt hardcodes
-`mkdir -p ~/tonk/...`, which the episode sandbox denies), and
-orientation toil after joining. Quote the exact prompt line that
-misled the agent when you can.
+Friction focus: everything before the first successful join — whether
+`npx @tonk/cli` resolved and ran cleanly (the prompt now leads with it,
+so no global install is needed), whether the agent handled the
+"ask me where to keep the tonk" step sensibly instead of stalling or
+picking a denied path, and orientation toil after joining. Quote the
+exact prompt line that misled the agent when you can.

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -456,10 +456,11 @@ view!:
 
     Claim access and orient yourself, then fill the &quot;{dom.host/data-page}&quot; page. Work the repo's data, schemas and views — not this page alone. Everything you change lands here for review before it's applied.
 
-      mkdir -p ~/tonk/{name} &amp;&amp; cd ~/tonk/{name}
-      tonk join '{link}'
-      tonk guide        # how to drive the CLI
-      tonk schema       # concepts already on the branch
+    Ask me where I'd like to keep the &quot;{name}&quot; tonk on this machine, then cd into that folder and run:
+
+      npx @tonk/cli join '{link}'
+      npx @tonk/cli guide    # how to drive the CLI
+      npx @tonk/cli schema   # concepts already on the branch
 
     Then build."></wa-copy-button>
       </div>
@@ -467,12 +468,13 @@ view!:
 
     Claim access and orient yourself, then fill the "{dom.host/data-page}" page. Work the repo's data, schemas and views — not this page alone. Everything you change lands here for review before it's applied.
 
-      mkdir -p ~/tonk/{name} &amp;&amp; cd ~/tonk/{name}
-      tonk join '{link}'
-      tonk guide        # how to drive the CLI
-      tonk schema       # concepts already on the branch
+    Ask me where I'd like to keep the "{name}" tonk on this machine, then cd into that folder and run:
 
-    Then build: define schema with `tonk concept add`, write data with `tonk assert`, add views with `tonk view add` — and finish with `tonk home &lt;concept&gt;` so the build lands on the space home.</pre>
+      npx @tonk/cli join '{link}'
+      npx @tonk/cli guide    # how to drive the CLI
+      npx @tonk/cli schema   # concepts already on the branch
+
+    Then build: define schema with `npx @tonk/cli concept add`, write data with `npx @tonk/cli assert`, add views with `npx @tonk/cli view add` — and finish with `npx @tonk/cli home &lt;concept&gt;` so the build lands on the space home.</pre>
     </div>
 
 # A space member, as seen in the "shared with" roster. Reads the


### PR DESCRIPTION
## What

Reworks the agent-invite prompt (the paste-into-your-agent block rendered by the `tonk:agent-invite` view in `core.yaml`) to remove the two biggest cold-start frictions.

- **Drop the hardcoded `mkdir`.** `mkdir -p ~/tonk/{name} && cd ~/tonk/{name}` forced a path the cold-onboard sandbox denies. It's replaced with a friendly instruction telling the agent to ask the human where to keep the tonk, then `cd` there.
- **Lead every command with `npx @tonk/cli`.** Most users won't have the `tonk` binary installed; `npx` runs it with no global install and skips the scary install step. Applies to `join`, `guide`, `schema`, and the inline `concept add` / `assert` / `view add` / `home` references. Uses `@tonk/cli` (the published package, bin `tonk`) — not a bare `npx tonk`, which would resolve to the wrong npm package.

Both prompt copies are updated: the `<wa-copy-button value>` (what gets copied) and the visible `<pre>`.

## Bench harness

`bench/bin/prompt.sh` renders the live prompt for the cold-onboard scenario, so the copy is under test. Kept it honest:

- Self-check now matches `@tonk/cli join` instead of `tonk join` (my change would otherwise trip it → exit 1).
- Fixed a stale fill: it targeted an old composite-URL placeholder that no longer exists, leaving `{link}` unfilled; now it fills the current `{link}` field with the minted invite URL.
- Extended HTML unescaping to `&lt;`/`&gt;` so `home <concept>` renders correctly.

Rewrote the cold-onboard `rubric.md` friction note, which described exactly the two frictions this removes.

## Verification

`prompt.sh` round-trips to a fully-filled prompt (real join URL including `&remote=`, npx commands, no surviving placeholders), exit 0. The authoritative seed loader (`analyze_local`) is wasm-gated and not run here; changes are confined to the `display: |` literal block scalar with matching indentation.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the onboarding experience for users by clarifying prompts and commands related to the `tonk` CLI, ensuring proper guidance for installation and usage without requiring global installs.

### Detailed summary
- Updated the friction focus in `bench/scenarios/cold-onboard/rubric.md` to emphasize the installation and command execution process.
- Modified command prompts in `bench/bin/prompt.sh` to use `npx @tonk/cli` instead of global `tonk` commands.
- Changed placeholder references from `{dom.host/data-page}` to `{link}` in `rust/tonk-core/assets/library/core.yaml`.
- Revised instructions to ask for the directory location before executing commands in the `tonk` CLI.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->