### PR TITLE
feat(tonk-fab): adaptive compact pill and touch drag fixes

### DIFF
--- a/docs/superpowers/plans/2026-07-17-fab-compact-pill.md
+++ b/docs/superpowers/plans/2026-07-17-fab-compact-pill.md
@@ -1,0 +1,1138 @@
+# FAB Compact Pill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `<tonk-fab>` usable on small screens and touch devices: an adaptive compact pill (scroll-snap pages + chevron vertical menu) plus repaired touch dragging and viewport clamping.
+
+**Architecture:** One DOM, no new components. Compact mode is a measured layout state (`fab--compact` on `.fab`): the existing segments move inside a horizontal scroll-snap strip grouped into pages, a chevron cap toggles a CSS-restacked vertical menu (`fab--menu`). Wide viewports render pixel-identically to today via `display: contents` wrappers + flex `order`. All new geometry is pure functions in `logic.rs` (native-tested); DOM wiring lives in `element.rs`; markup in `markup.rs`; styling in `fab.css`.
+
+**Tech Stack:** Rust/WASM (`custom-elements` crate), web-sys pointer events, CSS scroll-snap. Spec: `docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md`.
+
+## Global Constraints
+
+- No emojis in code, commits, or output.
+- Conventional Commits: `type(tonk-fab): subject`, imperative, lowercase, no trailing period.
+- Native tests: plain `#[test]` in behaviour-named `#[cfg(test)] mod`s with `it_does_x` / descriptive-sentence names, matching `logic.rs`'s existing style.
+- `logic.rs` must stay DOM-free (compiles and tests on the native target).
+- Wide-viewport rendering must not change: same visual order (circle, account, repo, share, end cap), same telescope behaviour, same dock persistence.
+- The lint gate is workspace-wide: `cargo clippy --workspace --all-targets --all-features` (native) plus `cargo fmt --check` must pass at the end.
+- Wasm tests run in a browser: `cargo test -p tonk-fab --target wasm32-unknown-unknown` with a major-version-matched chromedriver on PATH and Chrome at the default `/Applications` path (or the safaridriver route). If neither driver is available locally, note it in the final report rather than skipping silently.
+
+## File Structure
+
+No new files. All work lands in `rust/tonk-fab/src/`:
+
+- `logic.rs` — new pure functions: `DOCK_INSET_PX`, `is_compact`, `clamp_position` (+ tests).
+- `element.rs` — clamping in `track_position`; touch-aware drag arming; `telescope_tiles` re-scoped and visually ranked; `update_compact_mode` / `expanded_bar_width` / resize listener; chevron + strip-scroll gestures; `close_menus` extension; wasm tests.
+- `markup.rs` — bar restructure: `.fab__strip` > `.fab__page`s, tile modifier classes, chevron button (+ tests).
+- `fab.css` — touch-action + coarse-pointer hit target; wide-mode parity (`display: contents`, `order`); compact strip/pages/chevron; vertical-menu restack; drag scroll lock.
+
+---
+
+### Task 1: Pure geometry — `is_compact` and `clamp_position`
+
+**Files:**
+- Modify: `rust/tonk-fab/src/logic.rs` (add after `mirrored`, around line 200)
+
+**Interfaces:**
+- Produces: `pub const DOCK_INSET_PX: f64`, `pub fn is_compact(expanded_width: f64, viewport_width: f64) -> bool`, `pub fn clamp_position(left: f64, top: f64, width: f64, height: f64, vw: f64, vh: f64) -> (f64, f64)`. Tasks 2 and 5 consume these from `crate::logic`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `logic.rs` alongside the existing test modules:
+
+```rust
+#[cfg(test)]
+mod compact {
+    use super::*;
+
+    #[test]
+    fn a_bar_that_fits_with_both_insets_is_not_compact() {
+        assert!(!is_compact(300.0, 400.0));
+    }
+
+    #[test]
+    fn a_bar_wider_than_the_viewport_minus_insets_is_compact() {
+        assert!(is_compact(380.0, 400.0));
+    }
+
+    #[test]
+    fn the_exact_fit_is_not_compact() {
+        // 368 + 2*16 == 400: still fits; only strictly-greater flips it, so
+        // the threshold is identical in both directions and cannot flap.
+        assert!(!is_compact(368.0, 400.0));
+    }
+}
+
+#[cfg(test)]
+mod clamp {
+    use super::*;
+
+    #[test]
+    fn an_inside_position_is_untouched() {
+        assert_eq!(
+            clamp_position(100.0, 50.0, 300.0, 36.0, 1000.0, 800.0),
+            (100.0, 50.0)
+        );
+    }
+
+    #[test]
+    fn it_clamps_every_edge() {
+        // Past the origin pins to 0.
+        assert_eq!(
+            clamp_position(-20.0, -5.0, 300.0, 36.0, 1000.0, 800.0),
+            (0.0, 0.0)
+        );
+        // Right/bottom overflow pins to viewport minus the bar.
+        assert_eq!(
+            clamp_position(900.0, 790.0, 300.0, 36.0, 1000.0, 800.0),
+            (700.0, 764.0)
+        );
+    }
+
+    #[test]
+    fn a_bar_wider_than_the_viewport_pins_to_the_origin() {
+        // vw - width is negative; the origin wins (max runs last) so the
+        // bar's left edge — and the circle cap on it — stays reachable.
+        assert_eq!(
+            clamp_position(50.0, 10.0, 500.0, 36.0, 400.0, 800.0),
+            (0.0, 10.0)
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p tonk-fab compact clamp` (from the repo root; native target)
+Expected: FAIL to compile — `is_compact` / `clamp_position` / `DOCK_INSET_PX` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `logic.rs` after `mirrored` (before the telescope constants):
+
+```rust
+/// The stylesheet's dock inset — `tonk-fab.fab-dock-* { …: 16px }` in
+/// `fab.css`. The compact-mode fit test must account for it on both sides.
+pub const DOCK_INSET_PX: f64 = 16.0;
+
+/// Whether the bar must render compact: the fully EXPANDED bar plus both
+/// dock insets no longer fits the viewport width. Keyed on the would-be
+/// expanded width (not the current rendered width), so the threshold is the
+/// same entering and leaving compact and cannot oscillate.
+pub fn is_compact(expanded_width: f64, viewport_width: f64) -> bool {
+    expanded_width + 2.0 * DOCK_INSET_PX > viewport_width
+}
+
+/// Clamp a dragged bar's top-left corner so the bar stays fully inside the
+/// viewport. The origin clamp runs LAST: a bar wider or taller than the
+/// viewport pins to the left/top edge, keeping the grab handle reachable.
+pub fn clamp_position(
+    left: f64,
+    top: f64,
+    width: f64,
+    height: f64,
+    vw: f64,
+    vh: f64,
+) -> (f64, f64) {
+    (
+        left.min(vw - width).max(0.0),
+        top.min(vh - height).max(0.0),
+    )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p tonk-fab`
+Expected: PASS (all existing modules plus `compact` and `clamp`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-fab/src/logic.rs
+git commit -m "feat(tonk-fab): add compact-fit and viewport-clamp geometry"
+```
+
+---
+
+### Task 2: Clamp the drag to the viewport
+
+**Files:**
+- Modify: `rust/tonk-fab/src/element.rs` (imports around line 37; `track_position` around line 1072)
+
+**Interfaces:**
+- Consumes: `logic::clamp_position` from Task 1.
+- Produces: `track_position` now clamps internally; no signature change, no caller changes.
+
+- [ ] **Step 1: Update the import**
+
+In the `use crate::logic::{…}` list at the top of `element.rs`, add `clamp_position`:
+
+```rust
+use crate::logic::{
+    DOCK_CLASSES, Dock, clamp_position, corrected_min_width, create_space_claim_json,
+    dock_claim_json, dock_from_conclusions, mirrored, nearest_dock, pause_claim_json,
+    profile_rename_claim_json, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+};
+```
+
+- [ ] **Step 2: Clamp inside `track_position`**
+
+Replace the existing `track_position`:
+
+```rust
+/// Track the FAB at `(left, top)` (viewport top-left) with plain `left`/`top`
+/// during a drag — no corner anchoring, so it follows the cursor 1:1 without
+/// jumping as it crosses the viewport midlines. Clamped so the bar can never
+/// leave the viewport, whatever the pointer does. (The mirror-flip
+/// compensation in `apply_mirror_from_handle` writes `left` directly and is
+/// not clamped — the very next pointer move re-clamps, so any excursion
+/// lasts one frame at most.)
+fn track_position(el: &HtmlElement, left: f64, top: f64) {
+    let rect = el.get_bounding_client_rect();
+    let (left, top) = clamp_position(
+        left,
+        top,
+        rect.width(),
+        rect.height(),
+        viewport_width(),
+        viewport_height(),
+    );
+    let style = el.style();
+    let _ = style.remove_property("right");
+    let _ = style.remove_property("bottom");
+    let _ = style.set_property("left", &format!("{}px", left));
+    let _ = style.set_property("top", &format!("{}px", top));
+}
+```
+
+- [ ] **Step 3: Verify it builds and existing tests pass**
+
+Run: `cargo check -p tonk-fab --target wasm32-unknown-unknown && cargo test -p tonk-fab`
+Expected: clean check, all native tests PASS (the clamp function itself is covered by Task 1's tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-fab/src/element.rs
+git commit -m "fix(tonk-fab): clamp the drag so the bar cannot leave the viewport"
+```
+
+---
+
+### Task 3: Repair touch dragging
+
+**Files:**
+- Modify: `rust/tonk-fab/src/element.rs` (`DRAG_THRESHOLD_PX` around line 96; `attach_drag` around line 883; `finish_drag` around line 1025; `disconnected_callback` around line 164)
+- Modify: `rust/tonk-fab/src/fab.css` (the `.fab__cap-l` block around line 193)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: touch presses arm with `data-fab-touch`, capture immediately on the cap, and use an 8px threshold. No API changes.
+
+- [ ] **Step 1: Add the touch threshold constant**
+
+Below `DRAG_THRESHOLD_PX` in `element.rs`:
+
+```rust
+/// The drag threshold for TOUCH pointers. Wider than the mouse threshold: a
+/// finger wobbles a few px during a plain tap, and promoting that to a drag
+/// would eat the tap-to-toggle gesture.
+const TOUCH_DRAG_THRESHOLD_PX: f64 = 8.0;
+```
+
+- [ ] **Step 2: Arm touch presses with immediate capture**
+
+In `attach_drag`'s `on_down` closure, after the `if !on_circle { return; }` check and before the rect bookkeeping, the cap element is needed — restructure the circle check to keep it:
+
+Replace:
+
+```rust
+        let on_circle = e
+            .target()
+            .and_then(|t| t.dyn_into::<Element>().ok())
+            .and_then(|el| el.closest(".fab__cap-l").ok().flatten())
+            .is_some();
+        if !on_circle {
+            return;
+        }
+```
+
+with:
+
+```rust
+        let Some(cap) = e
+            .target()
+            .and_then(|t| t.dyn_into::<Element>().ok())
+            .and_then(|el| el.closest(".fab__cap-l").ok().flatten())
+        else {
+            return;
+        };
+        // TOUCH presses capture IMMEDIATELY, and on the CAP (not the host):
+        // a fast flick outruns even the window listeners' first delivery on
+        // some mobile browsers, and deferred capture is the desktop
+        // compromise that lets a stationary mouse press click — a touch tap
+        // still clicks with capture held, because capture retargets pointer
+        // events to the cap, which is exactly where the tap's click routes
+        // anyway. Capturing on the host instead would retarget the click to
+        // the host and break tap-to-toggle (`attach_gestures` walks
+        // `closest(".fab__cap-l")` from the click target).
+        if e.pointer_type() == "touch" {
+            el_down.dataset().set("fabTouch", "1").ok();
+            cap.set_pointer_capture(e.pointer_id()).ok();
+        } else {
+            el_down.dataset().delete("fabTouch");
+        }
+```
+
+- [ ] **Step 3: Use the touch threshold and skip re-capture in `on_move`**
+
+In the promotion block of `on_move`, replace:
+
+```rust
+        if el_move.dataset().get("fabMoved").is_none() {
+            if dx.hypot(dy) < DRAG_THRESHOLD_PX {
+                return;
+            }
+            el_move.dataset().set("fabMoved", "1").ok();
+            el_move.set_pointer_capture(e.pointer_id()).ok();
+```
+
+with:
+
+```rust
+        if el_move.dataset().get("fabMoved").is_none() {
+            let touch = el_move.dataset().get("fabTouch").is_some();
+            let threshold = if touch {
+                TOUCH_DRAG_THRESHOLD_PX
+            } else {
+                DRAG_THRESHOLD_PX
+            };
+            if dx.hypot(dy) < threshold {
+                return;
+            }
+            el_move.dataset().set("fabMoved", "1").ok();
+            // A touch press already holds capture on the cap (see
+            // `on_down`); re-capturing on the host would retarget the
+            // post-drag click mid-gesture.
+            if !touch {
+                el_move.set_pointer_capture(e.pointer_id()).ok();
+            }
+```
+
+- [ ] **Step 4: Release the cap's capture and clear the flag in `finish_drag` and `disconnected_callback`**
+
+In `finish_drag`, after `el.dataset().delete("fabPressing");` add:
+
+```rust
+    let touch = el.dataset().get("fabTouch").is_some();
+    el.dataset().delete("fabTouch");
+```
+
+and replace `el.release_pointer_capture(pointer_id).ok();` with:
+
+```rust
+    if touch {
+        // Touch capture lives on the cap (see `attach_drag`). Explicit
+        // release is belt-and-braces — pointerup implicitly releases — but
+        // pointercancel paths keep it honest.
+        if let Some(cap) = el.query_selector(".fab__cap-l").ok().flatten() {
+            cap.release_pointer_capture(pointer_id).ok();
+        }
+    } else {
+        el.release_pointer_capture(pointer_id).ok();
+    }
+```
+
+In `disconnected_callback`, alongside the `fabPressing`/`fabMoved` deletes add:
+
+```rust
+        this.dataset().delete("fabTouch");
+```
+
+- [ ] **Step 5: CSS — stop the browser competing, widen the touch target**
+
+In `fab.css`, extend the grab-handle cap block (the `.fab__cap-l { flex: none; … }` rule around line 193) by adding one declaration to it:
+
+```css
+  /* The browser must not race us for touch gestures on the drag handle —
+     without this, mobile scroll/zoom recognizers usually win and the drag
+     stutters or dies. Scoped to the cap so touch behaviour anywhere else
+     on the bar (and the compact strip's own pan) is untouched. */
+  touch-action: none;
+```
+
+and add after that rule:
+
+```css
+/* On coarse pointers the 36px cap grows an invisible 52px hit area
+   (>=44px Apple/Android guidance) without visual change. The cap is
+   `position: relative` via `.fab__seg`, so the inset anchors to it; the
+   pseudo-element is part of the cap for hit-testing, so both the drag
+   arming and the tap gesture route through `closest(".fab__cap-l")`
+   exactly as before. */
+@media (pointer: coarse) {
+  .fab__cap-l::after {
+    content: "";
+    position: absolute;
+    inset: -8px;
+  }
+}
+```
+
+- [ ] **Step 6: Verify it builds; native tests pass**
+
+Run: `cargo check -p tonk-fab --target wasm32-unknown-unknown && cargo test -p tonk-fab`
+Expected: clean check, tests PASS. (`pointer_type()` is part of web-sys's `PointerEvent`, already a dependency feature.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-fab/src/element.rs rust/tonk-fab/src/fab.css
+git commit -m "fix(tonk-fab): make touch dragging reliable"
+```
+
+---
+
+### Task 4: Restructure the markup — strip, pages, chevron (wide mode pixel-identical)
+
+**Files:**
+- Modify: `rust/tonk-fab/src/markup.rs` (`fab_html`, lines 75–181, and its tests)
+- Modify: `rust/tonk-fab/src/element.rs` (`telescope_tiles` around line 800; wasm `fab_host` fixture around line 1259)
+- Modify: `rust/tonk-fab/src/fab.css` (wide-mode parity rules; stylesheet test selector)
+- Modify: `rust/tonk-fab/src/logic.rs` (stylesheet test around line 1307)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: DOM contract used by Tasks 5–6 — `.fab__strip` (direct child of `.fab`) containing `.fab__page.fab__page--main` (repo tile) and `.fab__page.fab__page--more` (share, then account tiles); tiles carry `fab__tele--account` / `--repo` / `--share` / `--end` modifiers; the end tile (outside the strip) holds both the decorative `.fab__end` nub and a `<button class="fab__seg fab__cap-r fab__more">`.
+
+- [ ] **Step 1: Write the failing markup tests**
+
+Add to `markup.rs`'s test module:
+
+```rust
+    #[test]
+    fn it_groups_the_tiles_into_compact_pages() {
+        let html = fab_html("did:key:z6Mk");
+        // Page 1 holds the space name + switcher; page 2 share then account.
+        // The strip and pages are `display: contents` on wide viewports, so
+        // this grouping is invisible there; compact mode makes them the
+        // scroll-snap pager.
+        let strip = html.find("fab__strip").expect("strip present");
+        let main = html.find("fab__page--main").expect("main page present");
+        let more = html.find("fab__page--more").expect("more page present");
+        let repo = html.find("fab__tele--repo").expect("repo tile present");
+        let share = html.find("fab__tele--share").expect("share tile present");
+        let account = html.find("fab__tele--account").expect("account tile present");
+        assert!(strip < main && main < more, "strip wraps the pages in order");
+        assert!(main < repo && repo < more, "the repo tile is page 1's content");
+        assert!(more < share && share < account, "page 2 is share, then account");
+    }
+
+    #[test]
+    fn it_authors_the_chevron_beside_the_end_nub() {
+        let html = fab_html("did:key:z6Mk");
+        // Both live in the end tile, OUTSIDE the strip: the chevron is a
+        // fixed right cap (like the circle on the left), never scrolled away
+        // with the pages. CSS shows exactly one of the pair per mode.
+        let end_tile = html.find("fab__tele--end").expect("end tile present");
+        let nub = html.find("fab__end").expect("nub present");
+        let more = html.find("fab__more").expect("chevron present");
+        assert!(end_tile < nub && end_tile < more);
+        assert!(html.contains(r#"<button type="button" class="fab__seg fab__cap-r fab__more""#));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p tonk-fab --lib markup`
+Expected: FAIL — `fab__strip` etc. not found in the HTML.
+
+- [ ] **Step 3: Rewrite the bar portion of `fab_html`**
+
+Replace the bar `<div class="fab …">…</div>` portion of the format string in `fab_html` (everything from `<div class="fab fab--anim fab--settled">` through its closing `</div>`, leaving the scrim line and the whole `<wa-dialog>` unchanged):
+
+```html
+<div class="fab fab--anim fab--settled">
+  <span class="fab__seg fab__cap-l fab__circle"><ui-sync-status with="main@{space}" onpause="tonk:pause-sync"></ui-sync-status></span>
+  <div class="fab__strip">
+    <div class="fab__page fab__page--main">
+      <div class="fab__tele fab__tele--repo">
+        <span class="fab__seg fab__repo">
+          <span class="fab__space"><ui-space-name space="{space}"></ui-space-name></span>
+          <ui-dropdown class="fab__menu" exclude="{space}">
+            <ui-space-switcher exclude="{space}"></ui-space-switcher>
+          </ui-dropdown>
+        </span>
+      </div>
+    </div>
+    <div class="fab__page fab__page--more">
+      <div class="fab__tele fab__tele--share">
+        <span class="fab__seg fab__share">
+          <tonk-share space="{space}">
+            <form class="fab__share-form">
+              <button type="submit" class="fab__share-trigger">
+                <span class="fab__share-label fab__share-label--idle">share</span>
+                <span class="fab__share-label fab__share-label--copying">
+                  <span class="fab__share-spinner"></span>copying…
+                </span>
+                <span class="fab__share-label fab__share-label--copied">
+                  <wa-icon name="check"></wa-icon>copied
+                </span>
+                <span class="fab__share-label fab__share-label--failed">
+                  <wa-icon name="triangle-exclamation"></wa-icon>failed
+                </span>
+              </button>
+            </form>
+          </tonk-share>
+          <nav class="fab__menu fab__share-menu">
+            <ui-member-roster space="{space}"></ui-member-roster>
+          </nav>
+        </span>
+      </div>
+      <div class="fab__tele fab__tele--account">
+        <span class="fab__seg fab__account">
+          <span class="fab__name"><ui-profile-name></ui-profile-name></span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div class="fab__tele fab__tele--end">
+    <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
+    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="More controls"><wa-icon name="chevron-right"></wa-icon></button>
+  </div>
+</div>
+```
+
+Also update the module doc's "Structure is authored, not inferred" section with one sentence noting the strip/page grouping exists for the compact pager and is `display: contents` on wide viewports.
+
+- [ ] **Step 4: Wide-mode parity CSS**
+
+In `fab.css`, after the `.fab { … }` block, add:
+
+```css
+/* ── Compact grouping (inert on wide viewports) ───────────────────
+   The strip and pages exist for the compact pager (see `.fab--compact`
+   below). On wide viewports they generate NO boxes, so the tiles are
+   direct flex items of `.fab` exactly as before — and flex `order`
+   restores the wide bar's visual order (account, repo, share, end),
+   which the DOM gives up to group page 2 (share, account) together.
+   The circle cap keeps default order 0, so it stays first. */
+.fab__strip,
+.fab__page { display: contents; }
+.fab__tele--account { order: 1; }
+.fab__tele--repo    { order: 2; }
+.fab__tele--share   { order: 3; }
+.fab__tele--end     { order: 4; }
+/* The chevron cap is compact-only; wide mode shows the decorative nub. */
+.fab__more { display: none; }
+```
+
+- [ ] **Step 5: Re-scope and rank `telescope_tiles`**
+
+In `element.rs`, replace `telescope_tiles`:
+
+```rust
+/// Collect the `.fab__tele` wrapper tiles, sorted into VISUAL order. The
+/// DOM groups tiles by compact page (repo before share/account) while CSS
+/// `order` restores the wide bar's visual order — the telescope stagger
+/// must follow what the eye sees, not the DOM. A child scan no longer
+/// works: the tiles live inside `.fab__strip` > `.fab__page` wrappers.
+fn telescope_tiles(fab: &Element) -> Vec<Element> {
+    let mut out = Vec::new();
+    if let Ok(list) = fab.query_selector_all(".fab__tele") {
+        for i in 0..list.length() {
+            if let Some(node) = list.item(i)
+                && let Ok(el) = node.dyn_into::<Element>()
+            {
+                out.push(el);
+            }
+        }
+    }
+    out.sort_by_key(tile_rank);
+    out
+}
+
+/// The wide bar's visual position of a tile — must match the CSS `order`
+/// values in `fab.css` (account 1, repo 2, share 3, end 4).
+fn tile_rank(tile: &Element) -> u8 {
+    let cl = tile.class_list();
+    if cl.contains("fab__tele--account") {
+        0
+    } else if cl.contains("fab__tele--repo") {
+        1
+    } else if cl.contains("fab__tele--share") {
+        2
+    } else {
+        3
+    }
+}
+```
+
+- [ ] **Step 6: Update the wasm fixture and the stylesheet test**
+
+In `element.rs`'s wasm test module, update `fab_host` to the new shape (the drag/gesture tests walk this structure):
+
+```rust
+        host.set_inner_html(
+            r#"<div class="fab__scrim"></div>
+               <div class="fab">
+                 <span class="fab__seg fab__cap-l"></span>
+                 <div class="fab__strip">
+                   <div class="fab__page fab__page--main">
+                     <div class="fab__tele fab__tele--repo"><span class="fab__seg fab__repo"></span></div>
+                   </div>
+                   <div class="fab__page fab__page--more">
+                     <div class="fab__tele fab__tele--share"><span class="fab__seg fab__share"></span></div>
+                     <div class="fab__tele fab__tele--account"><span class="fab__seg fab__account"></span></div>
+                   </div>
+                 </div>
+                 <div class="fab__tele fab__tele--end">
+                   <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
+                   <button type="button" class="fab__seg fab__cap-r fab__more"></button>
+                 </div>
+               </div>"#,
+        );
+```
+
+In `logic.rs`'s `mod stylesheet` test, add one line so a stale CSS copy fails:
+
+```rust
+        assert!(css.contains(".fab__strip"));
+```
+
+- [ ] **Step 7: Run all native tests**
+
+Run: `cargo test -p tonk-fab && cargo check -p tonk-fab --target wasm32-unknown-unknown`
+Expected: PASS — new markup tests, existing markup tests (space stamping, telescope wrappers, no tonk-display), stylesheet test.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add rust/tonk-fab/src/markup.rs rust/tonk-fab/src/element.rs rust/tonk-fab/src/fab.css rust/tonk-fab/src/logic.rs
+git commit -m "refactor(tonk-fab): group bar tiles into compact pages behind display:contents"
+```
+
+---
+
+### Task 5: Compact mode — activation and the scroll-snap pager
+
+**Files:**
+- Modify: `rust/tonk-fab/src/element.rs` (new `update_compact_mode`, `expanded_bar_width`, `attach_resize`, `attach_strip_scroll`; `connected_callback` around line 125; `set_telescope` around line 732; `schedule_settle` around line 839)
+- Modify: `rust/tonk-fab/src/fab.css` (compact layout rules)
+
+**Interfaces:**
+- Consumes: `logic::is_compact` (Task 1), DOM contract (Task 4).
+- Produces: `fn update_compact_mode(element: &HtmlElement)` — Task 6's tests may call it; the `fab--compact` class on `.fab` that all compact CSS keys off.
+
+- [ ] **Step 1: Implement mode evaluation in `element.rs`**
+
+Add `is_compact` to the `crate::logic` import list, then add:
+
+```rust
+/// Re-evaluate compact mode from the WOULD-BE expanded bar width — the same
+/// input whichever mode we are in, so the threshold cannot flap. Called on
+/// connect, on guest-window resize, and when the telescope settles (content
+/// like a minted invite link can widen the bar without a resize).
+fn update_compact_mode(element: &HtmlElement) {
+    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+        return;
+    };
+    let compact = is_compact(expanded_bar_width(&fab), viewport_width());
+    if fab.class_list().contains("fab--compact") == compact {
+        return;
+    }
+    // Crossing modes resets transient UI state: menus close (their anchors
+    // change shape entirely) and the telescope re-opens expanded with no
+    // stale per-tile clamps — a wide-mode collapse leaves inline
+    // `max-width: 0` on every tile, which would zero out the compact pages.
+    close_menus(element);
+    fab.class_list().remove_1("fab--collapsed").ok();
+    fab.class_list().add_1("fab--settled").ok();
+    for tile in telescope_tiles(&fab) {
+        let style = tile.unchecked_ref::<HtmlElement>().style();
+        let _ = style.remove_property("max-width");
+        let _ = style.remove_property("margin-left");
+        let _ = style.remove_property("transition-delay");
+        tile.class_list().remove_1("fab__tele--hidden").ok();
+    }
+    fab.class_list()
+        .toggle_with_force("fab--compact", compact)
+        .ok();
+}
+
+/// The bar's expanded width. Measured directly when expanded; a compact bar
+/// is momentarily unclamped within one task — no paint can happen before the
+/// classes are restored — the same trick `menu_natural_width` uses on closed
+/// menus. Known gap, accepted: a WIDE bar collapsed to its circle
+/// under-reports here (its tiles hold inline `max-width: 0` that no class
+/// removal lifts), so shrinking the viewport while collapsed-wide defers the
+/// flip to compact until the next expand's settle pass re-evaluates — and a
+/// collapsed circle always fits anyway.
+fn expanded_bar_width(fab: &Element) -> f64 {
+    let cl = fab.class_list();
+    let was_compact = cl.contains("fab--compact");
+    if was_compact {
+        cl.remove_1("fab--compact").ok();
+    }
+    let width = fab.get_bounding_client_rect().width();
+    if was_compact {
+        cl.add_1("fab--compact").ok();
+    }
+    width
+}
+
+/// Re-evaluate compact mode whenever the guest window resizes. The overlay
+/// iframe is pinned full-viewport, so its window size IS the app viewport.
+fn attach_resize(element: &HtmlElement) {
+    let el = element.clone();
+    let on_resize = Closure::<dyn FnMut()>::new(move || update_compact_mode(&el));
+    if let Some(win) = window() {
+        let target: &web_sys::EventTarget = win.unchecked_ref();
+        let _ = target
+            .add_event_listener_with_callback("resize", on_resize.as_ref().unchecked_ref());
+    }
+    on_resize.forget();
+}
+
+/// A swipe on the compact strip moves the segments out from under their
+/// anchored dropdowns — dismiss them rather than drag them along.
+fn attach_strip_scroll(element: &HtmlElement) {
+    let Some(strip) = element.query_selector(".fab__strip").ok().flatten() else {
+        return;
+    };
+    let el = element.clone();
+    let on_scroll = Closure::<dyn FnMut()>::new(move || close_menus(&el));
+    let target: &web_sys::EventTarget = strip.unchecked_ref();
+    let _ = target.add_event_listener_with_callback("scroll", on_scroll.as_ref().unchecked_ref());
+    on_scroll.forget();
+}
+```
+
+- [ ] **Step 2: Wire the calls**
+
+In `connected_callback`'s bind block, after `preload_menu_widths(this);` add:
+
+```rust
+            attach_resize(this);
+            attach_strip_scroll(this);
+            update_compact_mode(this);
+```
+
+In `schedule_settle`, the settle closure needs the host element for the mode pass. Change its signature and body:
+
+```rust
+fn schedule_settle(element: &HtmlElement, fab: &Element, count: usize) {
+    let fab_for_settle = fab.clone();
+    let el_for_settle = element.clone();
+    let settle_once = Closure::<dyn Fn()>::new(move || {
+        fab_for_settle.class_list().add_1("fab--settled").ok();
+        for tile in telescope_tiles(&fab_for_settle) {
+            if tile.class_list().contains("fab__tele--hidden") {
+                continue;
+            }
+            let style = tile.unchecked_ref::<HtmlElement>().style();
+            let _ = style.set_property("max-width", "none");
+        }
+        // Content settling is the moment the bar reaches its true width —
+        // the one growth path (invite link, long rename) a resize never
+        // sees. Re-check the fit here.
+        update_compact_mode(&el_for_settle);
+    });
+    let settle_fn = settle_once
+        .as_ref()
+        .unchecked_ref::<js_sys::Function>()
+        .clone();
+    settle_once.forget();
+    let id = set_timeout(&settle_fn, telescope_settle_ms(count) as i32);
+    element.dataset().set("settleTimer", &id.to_string()).ok();
+}
+```
+
+(The existing per-tile unclamp comment block stays; only the `el_for_settle` capture and the trailing call are new.)
+
+- [ ] **Step 3: Compact collapse is CSS-driven — guard `set_telescope`**
+
+At the top of `set_telescope`, before the settle-timer clearing:
+
+```rust
+    // Compact collapse is CSS-driven: the strip and the chevron cap
+    // transition their own max-width (see `.fab--compact.fab--collapsed`
+    // in fab.css). Driving per-tile inline max-widths here would zero out
+    // the pages the strip lays out.
+    if fab.class_list().contains("fab--compact") {
+        fab.class_list()
+            .toggle_with_force("fab--collapsed", collapsing)
+            .ok();
+        return;
+    }
+```
+
+- [ ] **Step 4: Compact layout CSS**
+
+Add to `fab.css` after the wide-mode parity block from Task 4:
+
+```css
+/* ── Compact mode ─────────────────────────────────────────────────
+   `fab--compact` is set on `.fab` by element.rs when the EXPANDED bar
+   plus both 16px dock insets would overflow the viewport (measured, not
+   device-sniffed — a narrow desktop window compacts too). Layout: the
+   circle cap stays the fixed left cap, the chevron replaces the end nub
+   as the fixed right cap, and the segments page horizontally between
+   them in a native scroll-snap strip — swipe momentum for free, and no
+   gesture code to fight the drag (which arms only on the circle cap). */
+.fab--compact { max-inline-size: calc(100vw - 32px); }
+.fab--compact .fab__strip {
+  display: flex;
+  gap: 2px;
+  flex: 0 1 auto;
+  min-width: 0;
+  /* Numeric so the collapse transition below can interpolate to 0:
+     viewport minus circle cap (36) + chevron cap (36) + insets (32) +
+     two 2px bar gaps. */
+  max-width: calc(100vw - 108px);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  transition: max-width 0.4s ease;
+}
+.fab--compact .fab__strip::-webkit-scrollbar { display: none; }
+.fab--compact .fab__page {
+  display: flex;
+  gap: 2px;
+  flex: 0 0 auto;
+  /* Just under the strip width: the next page's leading edge peeks
+     ~24px, signalling there is more to swipe to (no page dots). */
+  min-width: calc(100% - 24px);
+  scroll-snap-align: start;
+}
+/* Pages own the sizing now; tiles and segments shrink into them.
+   Scoped to `.fab__page` descendants: the circle cap and the chevron
+   cap are `.fab__seg`s OUTSIDE the strip and must keep their fixed
+   36px sizing — an unscoped `.fab--compact .fab__seg` outranks their
+   single-class rules and breaks both caps. */
+.fab--compact .fab__page .fab__tele { flex: 1 1 auto; min-width: 0; }
+.fab--compact .fab__page .fab__seg { min-width: 0; flex: 1 1 auto; padding: 0 14px; }
+/* Order is DOM order inside the strip (page 1 first); clear the
+   wide-mode reordering. */
+.fab--compact .fab__tele--account,
+.fab--compact .fab__tele--repo,
+.fab--compact .fab__tele--share { order: 0; }
+/* The right cap swaps: nub out, chevron in. */
+.fab--compact .fab__end { display: none; }
+.fab--compact .fab__more {
+  display: inline-flex;
+  flex: none;
+  inline-size: 36px;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+.fab--compact .fab__more wa-icon { transition: transform 0.2s ease; }
+/* Collapse in compact: the strip and chevron retract into the circle
+   (CSS transitions, not per-tile inline styles — see set_telescope). */
+.fab--compact .fab__tele--end {
+  transition: max-width 0.4s ease, margin-left 0.4s ease;
+  max-width: 40px;
+}
+.fab--compact.fab--collapsed .fab__strip,
+.fab--compact.fab--collapsed .fab__tele--end {
+  max-width: 0;
+  margin-left: -2px;
+  overflow: hidden;
+}
+/* Dragging locks the pager so paging and dragging cannot interleave. */
+.fab.dragging .fab__strip { overflow: hidden; }
+@media (prefers-reduced-motion: reduce) {
+  .fab--compact .fab__strip,
+  .fab--compact .fab__tele--end,
+  .fab--compact .fab__more wa-icon { transition: none; }
+}
+```
+
+- [ ] **Step 5: Wasm test — compact activation is measured**
+
+Add to `element.rs`'s wasm test module. The test browser's viewport can't be resized from inside the test, so drive the OTHER input: an oversized segment makes the measured expanded width exceed any real viewport (no stylesheet is injected in the fixture, so the class itself changes no geometry and the measurement is deterministic).
+
+```rust
+    #[wasm_bindgen_test]
+    fn it_compacts_when_the_expanded_bar_cannot_fit() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        document.body().expect("body").append_child(&host).expect("mount");
+        let wide = host
+            .query_selector(".fab__repo")
+            .ok()
+            .flatten()
+            .expect("repo segment")
+            .unchecked_into::<HtmlElement>();
+        let _ = wide
+            .style()
+            .set_property("cssText", "display:inline-block;width:9999px");
+
+        update_compact_mode(&host);
+        let fab = host.query_selector(".fab").ok().flatten().expect("bar");
+        assert!(
+            fab.class_list().contains("fab--compact"),
+            "a bar wider than any viewport must compact"
+        );
+
+        let _ = wide.style().set_property("cssText", "display:inline-block;width:10px");
+        update_compact_mode(&host);
+        assert!(
+            !fab.class_list().contains("fab--compact"),
+            "a bar that fits again must leave compact mode"
+        );
+        host.remove();
+    }
+```
+
+- [ ] **Step 6: Build, run tests**
+
+Run: `cargo test -p tonk-fab && cargo test -p tonk-fab --target wasm32-unknown-unknown`
+Expected: native PASS; wasm PASS including the new activation test (chromedriver route — if no driver is available locally, flag it in the final report).
+
+- [ ] **Step 7: Manual smoke check (responsive mode)**
+
+Build and serve the app the usual way for this branch, open the browser dev tools responsive mode:
+- Wide viewport: bar renders exactly as before (order: circle, account, repo, share, nub); telescope and dropdowns unchanged.
+- Narrow (~390px phone width): bar compacts — circle + space name + chevron; swiping the middle pages to share/profile with snap; next page edge peeks.
+- Resize across the threshold both ways: mode flips, no flapping, menus closed on the flip.
+Record any visual rough edges to iterate on after Task 6 (padding, peek width, snap feel are tuning knobs, not plan changes).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add rust/tonk-fab/src/element.rs rust/tonk-fab/src/fab.css
+git commit -m "feat(tonk-fab): adaptive compact mode with a scroll-snap pager"
+```
+
+---
+
+### Task 6: The chevron's vertical menu
+
+**Files:**
+- Modify: `rust/tonk-fab/src/element.rs` (`attach_gestures` around line 219; `close_menus` around line 648; new `toggle_more_menu`; wasm tests)
+- Modify: `rust/tonk-fab/src/fab.css` (menu restack rules; scrim `:has` rule around line 658)
+
+**Interfaces:**
+- Consumes: `fab--compact` (Task 5), DOM contract (Task 4).
+- Produces: `fab--menu` class on `.fab`; `close_menus` now also clears it (drag promotion and the scrim get dismissal for free).
+
+- [ ] **Step 1: Write the failing wasm tests**
+
+Add to `element.rs`'s wasm test module (the fixture already has `.fab__more` from Task 4):
+
+```rust
+    fn has_menu(host: &HtmlElement) -> bool {
+        host.query_selector(".fab")
+            .ok()
+            .flatten()
+            .map(|fab| fab.class_list().contains("fab--menu"))
+            .unwrap_or(false)
+    }
+
+    fn bubbling_click() -> web_sys::MouseEvent {
+        let init = web_sys::MouseEventInit::new();
+        init.set_bubbles(true);
+        web_sys::MouseEvent::new_with_mouse_event_init_dict("click", &init).expect("click event")
+    }
+
+    #[wasm_bindgen_test]
+    fn it_toggles_the_vertical_menu_from_the_chevron() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document.body().expect("body").append_child(&host).expect("mount");
+
+        let chevron = host.query_selector(".fab__more").ok().flatten().expect("chevron");
+        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(has_menu(&host), "a chevron click opens the vertical menu");
+
+        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(!has_menu(&host), "a second click closes it again");
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_dismisses_the_vertical_menu_from_the_curtain() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document.body().expect("body").append_child(&host).expect("mount");
+
+        host.query_selector(".fab")
+            .ok()
+            .flatten()
+            .expect("bar")
+            .class_list()
+            .add_1("fab--menu")
+            .expect("open");
+        let scrim = host.query_selector(".fab__scrim").ok().flatten().expect("curtain");
+        scrim.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(!has_menu(&host), "the click-away curtain closes the vertical menu");
+        host.remove();
+    }
+```
+
+- [ ] **Step 2: Run wasm tests to verify the new ones fail**
+
+Run: `cargo test -p tonk-fab --target wasm32-unknown-unknown`
+(Chromedriver/Chrome route; if no driver is available locally, proceed and flag it in the final report — the native suite still gates.)
+Expected: the two new tests FAIL (no `fab--menu` handling yet); the three existing wasm tests PASS.
+
+- [ ] **Step 3: Implement the gesture and dismissal**
+
+In `attach_gestures`'s click closure, insert a chevron branch right after the scrim branch (before the `.fab__cap-l` branch):
+
+```rust
+        } else if t.closest(".fab__more").ok().flatten().is_some() {
+            toggle_more_menu(&el_click);
+```
+
+Add the function near `toggle_menu`:
+
+```rust
+/// Toggle the compact vertical menu (`fab--menu` on `.fab`): every control
+/// stacked full-width, anchored to the bar like the dropdowns. Opening it
+/// first closes any open dropdown — the vertical menu owns the whole field,
+/// and the dropdowns re-open INSIDE it as inline accordions (CSS).
+fn toggle_more_menu(element: &HtmlElement) {
+    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+        return;
+    };
+    let opening = !fab.class_list().contains("fab--menu");
+    close_menus(element);
+    fab.class_list()
+        .toggle_with_force("fab--menu", opening)
+        .ok();
+}
+```
+
+Extend `close_menus` (this gives the scrim, drag promotion, mode switches, and strip scrolls dismissal of the vertical menu for free — every existing caller wants it):
+
+```rust
+fn close_menus(el: &HtmlElement) {
+    for sel in MENU_SEGMENTS {
+        if let Some(seg) = el.query_selector(sel).ok().flatten() {
+            seg.class_list().remove_1("is-open").ok();
+        }
+    }
+    if let Some(fab) = el.query_selector(".fab").ok().flatten() {
+        fab.class_list().remove_1("fab--menu").ok();
+    }
+}
+```
+
+- [ ] **Step 4: Menu restack CSS**
+
+Add to `fab.css` after the compact block, and extend the scrim rule:
+
+```css
+/* ── The chevron's vertical menu (compact only in practice) ───────
+   `fab--menu` pops the strip out of the bar as an absolutely-anchored
+   vertical stack — the same anchoring the dropdowns use (away from the
+   docked edge, dock-keyed), so it always unfolds into view. The bar
+   itself shrinks to its two caps while the menu is up, iOS-style. */
+.fab--menu .fab__strip {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  max-width: none;
+  overflow: visible;
+  z-index: 100;
+}
+.fab-dock-top .fab--menu .fab__strip { top: 100%; margin-top: 7px; }
+.fab-dock-bottom .fab--menu .fab__strip { bottom: 100%; margin-bottom: 7px; }
+/* Pages dissolve; every tile is its own full-width row. Scoped to the
+   strip: the end tile (chevron cap) sits outside it and keeps its bar
+   styling while the menu is up. */
+.fab--menu .fab__page { display: contents; }
+.fab--menu .fab__strip .fab__tele {
+  max-width: none !important;
+  overflow: visible;
+  min-width: 0;
+}
+.fab--menu .fab__strip .fab__seg {
+  width: 100%;
+  box-sizing: border-box;
+  block-size: 36px;
+  border-radius: 2px;
+  flex: none;
+}
+/* An open dropdown renders INLINE as an accordion row under its
+   segment instead of floating: the segment's tile stacks them. */
+.fab--menu .fab__tele--repo,
+.fab--menu .fab__tele--share { display: flex; flex-direction: column; gap: 7px; }
+.fab--menu .fab__repo.is-open .fab__menu,
+.fab--menu .fab__share.is-open .fab__share-menu {
+  position: static;
+  margin: 7px 0 0;
+  width: 100%;
+}
+/* The chevron flips while the menu is up. */
+.fab--menu .fab__more wa-icon { transform: rotate(90deg); }
+```
+
+And extend the existing scrim activation rule:
+
+```css
+tonk-fab:has(.is-open) .fab__scrim,
+tonk-fab:has(.fab--menu) .fab__scrim { pointer-events: auto; }
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test -p tonk-fab && cargo test -p tonk-fab --target wasm32-unknown-unknown`
+Expected: native PASS; all five wasm tests PASS.
+
+- [ ] **Step 6: Manual smoke check**
+
+In responsive mode at phone width: chevron tap opens the vertical stack (rows: space name, share, profile), chevron rotates; tapping the space-name row unfolds the switcher inline; tap-away on the page closes everything; dragging the circle still works with the menu auto-closing. Note polish items for the iteration pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-fab/src/element.rs rust/tonk-fab/src/fab.css
+git commit -m "feat(tonk-fab): chevron-toggled vertical menu for the compact pill"
+```
+
+---
+
+### Task 7: Gate and device pass
+
+**Files:**
+- None expected (fixes only if the gate finds issues).
+
+- [ ] **Step 1: Run the full lint gate**
+
+Run: `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check` (both native, from the repo root).
+Expected: clean. Fix any findings in place (the `--all-features` gate compiles integration tests that per-crate clippy misses).
+
+- [ ] **Step 2: Full test sweep**
+
+Run: `cargo test -p tonk-fab && cargo test -p tonk-fab --target wasm32-unknown-unknown`
+Expected: PASS.
+
+- [ ] **Step 3: Manual verification checklist**
+
+Serve the app; verify and record results honestly:
+- Desktop wide: pixel parity with `main` behaviour (order, telescope, dropdowns, drag + corner snap, dock persistence across reload).
+- Desktop narrow window: compact activates; drag cannot push the bar off-screen; corners still snap and persist.
+- Phone (real device or touch emulation): drag from the circle is reliable (no scroll fights, ≥44px target, taps still toggle); swipe pages with momentum; chevron menu opens/dismisses; reduced-motion honoured.
+
+- [ ] **Step 4: Commit any gate fixes**
+
+```bash
+git add -u
+git commit -m "chore(tonk-fab): appease the workspace lint gate"
+```
+
+(Skip if the gate was already clean.)

--- a/docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md
+++ b/docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md
@@ -1,0 +1,119 @@
+# FAB compact pill — design
+
+2026-07-17
+
+## Problem
+
+The FAB (`<tonk-fab>`, `rust/tonk-fab`) is designed for desktop and breaks down elsewhere:
+
+- **Low resolution**: the bar is fixed-width with pixel sizing and no responsive
+  layout. Docked to a corner with a 16px inset, a bar wider than the viewport
+  overflows it, so some segments cannot be reached.
+- **Mobile**: dragging uses pointer events but has no `touch-action` handling,
+  defers pointer capture until a 4px threshold, and only the small circle cap is
+  draggable. The browser's own touch gestures win the race, making finger drag
+  unreliable and cross-screen drags nearly impossible. There is also no viewport
+  clamping mid-drag.
+
+Inspiration: the iOS text-selection popup — a pill with a fixed chevron that
+pages horizontally on swipe and expands into a vertical menu showing everything.
+
+## Decisions
+
+- **Adaptive, not universal**: wide viewports keep the current expanded bar and
+  telescope unchanged. The compact pill only activates when the bar would not
+  fit.
+- **Free drag stays** on all screen sizes, repaired for touch (not reduced to
+  dock-only or removed).
+- **Overflow mechanics**: swipe to page horizontally + chevron opens a vertical
+  menu. No chevron-tap-to-page.
+- **Page 1 contents**: sync circle (fixed cap) + space name/switcher. Share and
+  profile name go to page 2 and the vertical menu.
+- **Architecture**: scroll-snap pager + CSS restack (approach A). One DOM, no
+  new child components, no markup duplication; gesture handling is native
+  browser scrolling. Rejected: a Rust-driven pager (re-implements browser
+  scrolling inside already-subtle pointer handlers) and a separate
+  `<tonk-fab-mini>` element (two components sharing seven children and one
+  persistence model).
+
+## Compact mode
+
+A new `fab--compact` class, decided by measurement, not device detection:
+
+- `logic.rs` gains a pure function `is_compact(expanded_width, viewport_width)`
+  returning true when the fully expanded bar plus the two 16px insets exceeds
+  the viewport width. `expanded_width` comes from the tile widths already
+  measured for the telescope.
+- Evaluated on connect, on guest-window resize, and after content settles
+  (invite links and long names widen the bar).
+- Crossing the threshold swaps the class; any open menus close on a mode switch
+  so dropdown geometry is never stranded.
+
+A phone and a small desktop window behave identically.
+
+## Compact layout
+
+Left to right:
+
+1. **Left cap — sync circle**, unchanged. Still the drag handle and the
+   telescope toggle. Telescope works in compact mode: the pill can collapse to
+   just the circle.
+2. **Middle — scroll strip.** The existing segments sit inside a horizontal
+   `overflow-x` container with CSS `scroll-snap-type: x mandatory`. `markup.rs`
+   wraps segments in page groups:
+   - Page 1: space name + switcher (`.fab__repo`).
+   - Page 2: share (`.fab__share`), then profile name (`.fab__account`).
+   Swiping is native scroll (momentum, rubber-banding); snap points land on
+   page boundaries. No page-indicator dots — the chevron plus a slight peek of
+   the next segment's edge signal there is more. An open dropdown closes when a
+   swipe starts.
+3. **Right cap — chevron.** Tapping toggles `fab--menu`: the strip restacks
+   vertically, each segment on its own full-width row, chevron rotates. The
+   space switcher and member roster — dropdowns today — render inline as
+   accordion rows via CSS repositioning of the same elements. The existing
+   `.fab__scrim` handles tap-away dismissal.
+
+Wide viewports see zero change.
+
+## Drag fixes (all modes)
+
+- **`touch-action: none` on the circle cap** so the browser stops competing for
+  touch gestures. Scoped to the cap; touch scrolling elsewhere is unaffected.
+- **Immediate pointer capture for touch pointers** at `pointerdown`. Mouse keeps
+  the current deferred-capture behavior (capture at the drag threshold) so a
+  stationary press still clicks; capture does not break tap-to-toggle on touch.
+- **Bigger touch target**: an invisible pseudo-element pads the cap's hit area
+  to ≥44px without visual change. Drag threshold for touch pointers rises to
+  ≈8px so taps don't misregister as drags.
+- **Viewport clamping**: a pure `logic.rs` function clamps `left/top` during
+  drag so the bar can never leave the viewport, in any mode.
+- **Drag/paging exclusivity**: while `.dragging` is set, the scroll strip locks
+  (`overflow: hidden`).
+
+Corner docking, mirror flip, and the durable `xyz.tonk.fab/dock` claim are
+untouched; compact mode docks and persists identically. Page and menu state are
+ephemeral (not persisted).
+
+## Error handling / edge cases
+
+- `prefers-reduced-motion` continues to suppress transitions, including the
+  menu restack.
+- Mode re-evaluation after settle handles content growth (e.g. minted invite
+  link) pushing a previously fitting bar past the viewport.
+- Stale-press guard (`buttons == 0` on move) and pointercancel handling remain.
+
+## Testing
+
+- Native tests for the new pure functions in `logic.rs` (`is_compact`,
+  `clamp_position`), alongside the existing dock and telescope-timing tests.
+- wasm tests (safaridriver locally) for class toggling: compact activation on
+  narrow viewports, chevron toggling `fab--menu`, menus closing on mode switch.
+- Manual pass for feel (swipe momentum, drag responsiveness) in responsive mode
+  and on a phone.
+
+## Non-goals
+
+- No change to wide-viewport behavior, dock persistence, or child elements'
+  internals.
+- No page-indicator dots, no chevron-tap paging.
+- No device detection; all adaptation is measurement-driven.

--- a/docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md
+++ b/docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md
@@ -25,10 +25,25 @@ pages horizontally on swipe and expands into a vertical menu showing everything.
   fit.
 - **Free drag stays** on all screen sizes, repaired for touch (not reduced to
   dock-only or removed).
-- **Overflow mechanics**: swipe to page horizontally + chevron opens a vertical
-  menu. No chevron-tap-to-page.
+- **Overflow mechanics** (revised 2026-07-17 after device testing): swipe to
+  page horizontally + chevron-tap advances one page, wrapping to the start at
+  the end. The vertical menu of the first design was cut — buggy on device
+  and it added little over the pager. The chevron is nub-sized (a rounded
+  terminator that meshes with the pill, with an invisible >=44px coarse-pointer
+  hit area) and retracts with the strip when the bar collapses.
 - **Page 1 contents**: sync circle (fixed cap) + space name/switcher. Share and
-  profile name go to page 2 and the vertical menu.
+  profile name go to page 2.
+- **Compact dropdowns float**: the switcher and roster open over the bar in
+  compact mode (`position: fixed`; the bar's drop-shadow filter makes `.fab`
+  the containing block, lifting the menu out of the scroll strip's clip),
+  spanning the full bar width. Same `is-open` mechanics as desktop.
+- **Strip is horizontal-only**: `touch-action: pan-x` + `overscroll-behavior:
+  contain`, so a vertical finger on the strip cannot pan the overlay page and
+  ride the pill off-screen.
+- **Async content re-measures the fit**: the names arrive from live
+  subscriptions after connect, so a MutationObserver on the bar (child-list +
+  text) and a `document.fonts.ready` pass re-run the compact-fit evaluation —
+  without them a phone sits in wide mode measuring the empty bar.
 - **Architecture**: scroll-snap pager + CSS restack (approach A). One DOM, no
   new child components, no markup duplication; gesture handling is native
   browser scrolling. Rejected: a Rust-driven pager (re-implements browser
@@ -67,11 +82,11 @@ Left to right:
    page boundaries. No page-indicator dots — the chevron plus a slight peek of
    the next segment's edge signal there is more. An open dropdown closes when a
    swipe starts.
-3. **Right cap — chevron.** Tapping toggles `fab--menu`: the strip restacks
-   vertically, each segment on its own full-width row, chevron rotates. The
-   space switcher and member roster — dropdowns today — render inline as
-   accordion rows via CSS repositioning of the same elements. The existing
-   `.fab__scrim` handles tap-away dismissal.
+3. **Right cap — chevron** (revised): a nub-sized paging button. Tapping
+   advances the strip one page (smooth scroll), wrapping to the start at the
+   end — `strip_page_target` in `logic.rs` owns the arithmetic. The
+   dropdowns float over the bar (see Decisions); `.fab__scrim` handles
+   tap-away dismissal as on desktop.
 
 Wide viewports see zero change.
 
@@ -106,8 +121,11 @@ ephemeral (not persisted).
 
 - Native tests for the new pure functions in `logic.rs` (`is_compact`,
   `clamp_position`), alongside the existing dock and telescope-timing tests.
-- wasm tests (safaridriver locally) for class toggling: compact activation on
-  narrow viewports, chevron toggling `fab--menu`, menus closing on mode switch.
+- wasm tests (safaridriver or chromedriver locally) for: compact activation
+  on narrow viewports, compact segment taps opening the floating dropdowns,
+  collapse dismissing dropdowns and dropping `fab--settled`, and
+  computed-style pins with the real stylesheet (chevron hidden in wide mode,
+  chevron tile clamped away when collapsed).
 - Manual pass for feel (swipe momentum, drag responsiveness) in responsive mode
   and on a phone.
 

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -45,6 +45,8 @@ web-sys = { workspace = true, features = [
     "NodeList",
     "PointerEvent",
     "ResizeObserver",
+    "ScrollBehavior",
+    "ScrollToOptions",
     "Text",
     "Window",
 ] }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -803,18 +803,39 @@ fn set_telescope(element: &HtmlElement, fab: &Element, collapsing: bool) {
     }
 }
 
-/// Collect the `.fab__tele` wrapper tiles in DOM order.
+/// Collect the `.fab__tele` wrapper tiles, sorted into VISUAL order. The
+/// DOM groups tiles by compact page (repo before share/account) while CSS
+/// `order` restores the wide bar's visual order — the telescope stagger
+/// must follow what the eye sees, not the DOM. A child scan no longer
+/// works: the tiles live inside `.fab__strip` > `.fab__page` wrappers.
 fn telescope_tiles(fab: &Element) -> Vec<Element> {
     let mut out = Vec::new();
-    let children = fab.children();
-    for i in 0..children.length() {
-        if let Some(child) = children.item(i)
-            && child.class_list().contains("fab__tele")
-        {
-            out.push(child);
+    if let Ok(list) = fab.query_selector_all(".fab__tele") {
+        for i in 0..list.length() {
+            if let Some(node) = list.item(i)
+                && let Ok(el) = node.dyn_into::<Element>()
+            {
+                out.push(el);
+            }
         }
     }
+    out.sort_by_key(tile_rank);
     out
+}
+
+/// The wide bar's visual position of a tile — must match the CSS `order`
+/// values in `fab.css` (account 1, repo 2, share 3, end 4).
+fn tile_rank(tile: &Element) -> u8 {
+    let cl = tile.class_list();
+    if cl.contains("fab__tele--account") {
+        0
+    } else if cl.contains("fab__tele--repo") {
+        1
+    } else if cl.contains("fab__tele--share") {
+        2
+    } else {
+        3
+    }
 }
 
 /// Measure each tile's natural width by momentarily unclamping it (max-width
@@ -1322,8 +1343,19 @@ mod tests {
             r#"<div class="fab__scrim"></div>
                <div class="fab">
                  <span class="fab__seg fab__cap-l"></span>
-                 <span class="fab__seg fab__repo"></span>
-                 <span class="fab__seg fab__share"></span>
+                 <div class="fab__strip">
+                   <div class="fab__page fab__page--main">
+                     <div class="fab__tele fab__tele--repo"><span class="fab__seg fab__repo"></span></div>
+                   </div>
+                   <div class="fab__page fab__page--more">
+                     <div class="fab__tele fab__tele--share"><span class="fab__seg fab__share"></span></div>
+                     <div class="fab__tele fab__tele--account"><span class="fab__seg fab__account"></span></div>
+                   </div>
+                 </div>
+                 <div class="fab__tele fab__tele--end">
+                   <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
+                   <button type="button" class="fab__seg fab__cap-r fab__more"></button>
+                 </div>
                </div>"#,
         );
         host

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -1535,6 +1535,25 @@ mod tests {
     #[wasm_bindgen_test]
     fn it_compacts_when_the_expanded_bar_cannot_fit() {
         let document = window().expect("window").document().expect("document");
+        // `expanded_bar_width` only measures correctly because it removes
+        // `fab--compact` before reading the rect (then restores it) — a
+        // naive measurement while the class is still applied would read the
+        // clamped-down size instead of the bar's true would-be-expanded
+        // size. The fixture otherwise loads no stylesheet, so nothing here
+        // would catch a regression that measured before unclamping. Inject
+        // the one rule that actually exercises that: a real `.fab--compact`
+        // clamp, matching fab.css's compact-mode intent, that would corrupt
+        // a naive measurement if `expanded_bar_width` didn't remove the
+        // class first.
+        const CLAMP_STYLE_ID: &str = "it-compacts-when-the-expanded-bar-cannot-fit-clamp";
+        let clamp_style = document.create_element("style").expect("create style");
+        let _ = clamp_style.set_attribute("id", CLAMP_STYLE_ID);
+        clamp_style.set_text_content(Some(
+            ".fab--compact { max-inline-size: 50px; overflow: hidden; }",
+        ));
+        if let Some(head) = document.head() {
+            head.append_child(&clamp_style).expect("mount clamp style");
+        }
         let host = fab_host();
         document
             .body()
@@ -1604,6 +1623,19 @@ mod tests {
             "a bar wider than any viewport must compact"
         );
 
+        // The bar is still oversized and now genuinely carries
+        // `fab--compact` (with the clamp rule above in effect). Re-evaluate
+        // while clamped: a correct `expanded_bar_width` removes the class
+        // before measuring, so it still sees the true oversized width and
+        // stays compact. A regression that measured before removing the
+        // class would read the clamped ~50px, decide the bar fits, and
+        // wrongly drop the class here.
+        update_compact_mode(&host);
+        assert!(
+            fab.class_list().contains("fab--compact"),
+            "re-evaluating while clamped must measure the unclamped width"
+        );
+
         let _ = wide.style().set_property("width", "10px");
         update_compact_mode(&host);
         assert!(
@@ -1611,5 +1643,6 @@ mod tests {
             "a bar that fits again must leave compact mode"
         );
         host.remove();
+        clamp_style.remove();
     }
 }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -95,7 +95,8 @@ fn ensure_stylesheet() {
 
 /// How far (CSS px) the pointer must travel from the press origin before it
 /// counts as a drag rather than a click. Below this the press toggles the
-/// telescope; above it the FAB moves and the click is suppressed.
+/// telescope; above it the FAB moves and the click is suppressed. Touch pointers
+/// use `TOUCH_DRAG_THRESHOLD_PX` instead.
 const DRAG_THRESHOLD_PX: f64 = 4.0;
 
 /// The drag threshold for TOUCH pointers. Wider than the mouse threshold: a
@@ -1055,12 +1056,12 @@ fn attach_drag(element: &HtmlElement) {
 /// guard in `pointermove`.
 fn finish_drag(el: &HtmlElement, pointer_id: i32) {
     el.dataset().delete("fabPressing");
+    let touch = el.dataset().get("fabTouch").is_some();
+    el.dataset().delete("fabTouch");
     let moved = el.dataset().get("fabMoved").is_some();
     if !moved {
         return;
     }
-    let touch = el.dataset().get("fabTouch").is_some();
-    el.dataset().delete("fabTouch");
     if touch {
         // Touch capture lives on the cap (see `attach_drag`). Explicit
         // release is belt-and-braces — pointerup implicitly releases — but

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -666,12 +666,11 @@ fn apply_mirror_from_handle(el: &HtmlElement) {
     }
 }
 
-/// Close both dropdowns (the ratcheted widths stay). Two callers:
-///
-/// - A drag: it drops the `fab-dock-*` classes that give an open menu its
-///   vertical anchor, so an open menu would float mid-bar; dragging with a menu
-///   open isn't a state the chrome supports.
-/// - The click-away curtain: a click outside every menu dismisses both.
+/// Dismiss all transient overlays — both dropdowns and the compact vertical
+/// menu (ratcheted widths stay). Called by any interaction that invalidates
+/// an open overlay's anchoring: a drag (which drops the `fab-dock-*` classes
+/// anchoring the menu to the bar, so an open menu would float unanchored
+/// mid-bar), mode switches, pager swipes, or click-away.
 fn close_menus(el: &HtmlElement) {
     for sel in MENU_SEGMENTS {
         if let Some(seg) = el.query_selector(sel).ok().flatten() {

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -37,8 +37,8 @@
 use crate::logic::{
     DOCK_CLASSES, Dock, clamp_position, corrected_min_width, create_space_claim_json,
     dock_claim_json, dock_from_conclusions, is_compact, mirrored, nearest_dock, pause_claim_json,
-    profile_rename_claim_json, ratchet_min_width, strip_page_target, telescope_delay_ms,
-    telescope_settle_ms,
+    profile_rename_claim_json, ratchet_min_width, strip_at_end, strip_page_target,
+    telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -1021,6 +1021,8 @@ fn update_compact_mode(element: &HtmlElement) {
     fab.class_list()
         .toggle_with_force("fab--compact", compact)
         .ok();
+    // A fresh mode starts the pager at page 1 with a forward arrow.
+    sync_pager_arrow(element);
 }
 
 /// The bar's expanded width. Measured directly when expanded; a compact bar
@@ -1064,10 +1066,34 @@ fn attach_strip_scroll(element: &HtmlElement) {
         return;
     };
     let el = element.clone();
-    let on_scroll = Closure::<dyn FnMut()>::new(move || close_menus(&el));
+    let on_scroll = Closure::<dyn FnMut()>::new(move || {
+        close_menus(&el);
+        sync_pager_arrow(&el);
+    });
     let target: &web_sys::EventTarget = strip.unchecked_ref();
     let _ = target.add_event_listener_with_callback("scroll", on_scroll.as_ref().unchecked_ref());
     on_scroll.forget();
+}
+
+/// Point the pager arrow at what its next tap DOES: forward mid-strip,
+/// back (`fab__more--back`, a 180° glyph flip) once the strip rests at its
+/// end and the next tap wraps to the start. Driven from the strip's scroll
+/// events and from mode changes, so swipes and taps both keep it honest.
+fn sync_pager_arrow(element: &HtmlElement) {
+    let Some(strip) = element.query_selector(".fab__strip").ok().flatten() else {
+        return;
+    };
+    let Some(more) = element.query_selector(".fab__more").ok().flatten() else {
+        return;
+    };
+    let at_end = strip_at_end(
+        strip.scroll_left() as f64,
+        strip.client_width() as f64,
+        strip.scroll_width() as f64,
+    );
+    more.class_list()
+        .toggle_with_force("fab__more--back", at_end)
+        .ok();
 }
 
 /// Attach pointer event listeners for free drag-and-drop. The element moves

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -36,7 +36,7 @@
 
 use crate::logic::{
     DOCK_CLASSES, Dock, clamp_position, corrected_min_width, create_space_claim_json,
-    dock_claim_json, dock_from_conclusions, mirrored, nearest_dock, pause_claim_json,
+    dock_claim_json, dock_from_conclusions, is_compact, mirrored, nearest_dock, pause_claim_json,
     profile_rename_claim_json, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
@@ -162,6 +162,9 @@ impl CustomElement for TonkFab {
             attach_create_space_form(this);
             attach_profile_name_commit(this);
             preload_menu_widths(this);
+            attach_resize(this);
+            attach_strip_scroll(this);
+            update_compact_mode(this);
         }
         // Restore the persisted position and apply it to our own style.
         restore_position(this);
@@ -737,6 +740,17 @@ fn toggle_telescope(element: &HtmlElement) {
 /// Drive the telescope to the given state. `collapsing = true` retracts the
 /// tiles into the circle; `false` unfolds them to their measured widths.
 fn set_telescope(element: &HtmlElement, fab: &Element, collapsing: bool) {
+    // Compact collapse is CSS-driven: the strip and the chevron cap
+    // transition their own max-width (see `.fab--compact.fab--collapsed`
+    // in fab.css). Driving per-tile inline max-widths here would zero out
+    // the pages the strip lays out.
+    if fab.class_list().contains("fab--compact") {
+        fab.class_list()
+            .toggle_with_force("fab--collapsed", collapsing)
+            .ok();
+        return;
+    }
+
     let tiles = telescope_tiles(fab);
     let count = tiles.len();
 
@@ -866,6 +880,7 @@ fn measure_tile_widths(tiles: &[Element]) -> Vec<f64> {
 /// measured width. Stashes the timer id so a re-toggle (or disconnect) cancels it.
 fn schedule_settle(element: &HtmlElement, fab: &Element, count: usize) {
     let fab_for_settle = fab.clone();
+    let el_for_settle = element.clone();
     let settle_once = Closure::<dyn Fn()>::new(move || {
         fab_for_settle.class_list().add_1("fab--settled").ok();
         // Unclamp shown tiles: drop the inline `max-width` pinned during the
@@ -882,6 +897,10 @@ fn schedule_settle(element: &HtmlElement, fab: &Element, count: usize) {
             let style = tile.unchecked_ref::<HtmlElement>().style();
             let _ = style.set_property("max-width", "none");
         }
+        // Content settling is the moment the bar reaches its true width —
+        // the one growth path (invite link, long rename) a resize never
+        // sees. Re-check the fit here.
+        update_compact_mode(&el_for_settle);
     });
     let settle_fn = settle_once
         .as_ref()
@@ -890,6 +909,84 @@ fn schedule_settle(element: &HtmlElement, fab: &Element, count: usize) {
     settle_once.forget();
     let id = set_timeout(&settle_fn, telescope_settle_ms(count) as i32);
     element.dataset().set("settleTimer", &id.to_string()).ok();
+}
+
+/// Re-evaluate compact mode from the WOULD-BE expanded bar width — the same
+/// input whichever mode we are in, so the threshold cannot flap. Called on
+/// connect, on guest-window resize, and when the telescope settles (content
+/// like a minted invite link can widen the bar without a resize).
+fn update_compact_mode(element: &HtmlElement) {
+    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+        return;
+    };
+    let compact = is_compact(expanded_bar_width(&fab), viewport_width());
+    if fab.class_list().contains("fab--compact") == compact {
+        return;
+    }
+    // Crossing modes resets transient UI state: menus close (their anchors
+    // change shape entirely) and the telescope re-opens expanded with no
+    // stale per-tile clamps — a wide-mode collapse leaves inline
+    // `max-width: 0` on every tile, which would zero out the compact pages.
+    close_menus(element);
+    fab.class_list().remove_1("fab--collapsed").ok();
+    fab.class_list().add_1("fab--settled").ok();
+    for tile in telescope_tiles(&fab) {
+        let style = tile.unchecked_ref::<HtmlElement>().style();
+        let _ = style.remove_property("max-width");
+        let _ = style.remove_property("margin-left");
+        let _ = style.remove_property("transition-delay");
+        tile.class_list().remove_1("fab__tele--hidden").ok();
+    }
+    fab.class_list()
+        .toggle_with_force("fab--compact", compact)
+        .ok();
+}
+
+/// The bar's expanded width. Measured directly when expanded; a compact bar
+/// is momentarily unclamped within one task — no paint can happen before the
+/// classes are restored — the same trick `menu_natural_width` uses on closed
+/// menus. Known gap, accepted: a WIDE bar collapsed to its circle
+/// under-reports here (its tiles hold inline `max-width: 0` that no class
+/// removal lifts), so shrinking the viewport while collapsed-wide defers the
+/// flip to compact until the next expand's settle pass re-evaluates — and a
+/// collapsed circle always fits anyway.
+fn expanded_bar_width(fab: &Element) -> f64 {
+    let cl = fab.class_list();
+    let was_compact = cl.contains("fab--compact");
+    if was_compact {
+        cl.remove_1("fab--compact").ok();
+    }
+    let width = fab.get_bounding_client_rect().width();
+    if was_compact {
+        cl.add_1("fab--compact").ok();
+    }
+    width
+}
+
+/// Re-evaluate compact mode whenever the guest window resizes. The overlay
+/// iframe is pinned full-viewport, so its window size IS the app viewport.
+fn attach_resize(element: &HtmlElement) {
+    let el = element.clone();
+    let on_resize = Closure::<dyn FnMut()>::new(move || update_compact_mode(&el));
+    if let Some(win) = window() {
+        let target: &web_sys::EventTarget = win.unchecked_ref();
+        let _ =
+            target.add_event_listener_with_callback("resize", on_resize.as_ref().unchecked_ref());
+    }
+    on_resize.forget();
+}
+
+/// A swipe on the compact strip moves the segments out from under their
+/// anchored dropdowns — dismiss them rather than drag them along.
+fn attach_strip_scroll(element: &HtmlElement) {
+    let Some(strip) = element.query_selector(".fab__strip").ok().flatten() else {
+        return;
+    };
+    let el = element.clone();
+    let on_scroll = Closure::<dyn FnMut()>::new(move || close_menus(&el));
+    let target: &web_sys::EventTarget = strip.unchecked_ref();
+    let _ = target.add_event_listener_with_callback("scroll", on_scroll.as_ref().unchecked_ref());
+    on_scroll.forget();
 }
 
 /// Attach pointer event listeners for free drag-and-drop. The element moves
@@ -1433,5 +1530,86 @@ mod tests {
         close_menus(&fab);
         assert!(!is_open(&fab, ".fab__repo"));
         assert!(!is_open(&fab, ".fab__share"));
+    }
+
+    #[wasm_bindgen_test]
+    fn it_compacts_when_the_expanded_bar_cannot_fit() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+        let fab = host
+            .query_selector(".fab")
+            .ok()
+            .flatten()
+            .expect("bar")
+            .unchecked_into::<HtmlElement>();
+        // The fixture loads no stylesheet, so every element here is plain
+        // block/inline layout. `.fab`'s own rect would otherwise just fill
+        // its container regardless of content (a block `<div>`'s `width:
+        // auto` fills its containing block; it does not shrink-to-fit or
+        // grow with an overflowing child) — insensitive to the oversized
+        // segment below and unable to exercise `expanded_bar_width` at all.
+        // Reproduce the three fab.css facts the measurement actually
+        // depends on: `.fab` itself is `inline-flex` (shrink-to-fit, so an
+        // unshrinkable child can push its rect past the viewport);
+        // `.fab__strip`/`.fab__page` are `display: contents` (they
+        // disappear from the box tree, so their `.fab__tele` descendants
+        // become direct flex items of `.fab`, exactly as fab.css flattens
+        // them); and `.fab__tele` is `flex: 0 0 auto` (no shrink, so an
+        // oversized tile isn't compressed back down by the flex algorithm).
+        let _ = fab.style().set_property("display", "inline-flex");
+        for sel in [".fab__strip", ".fab__page"] {
+            if let Ok(list) = host.query_selector_all(sel) {
+                for i in 0..list.length() {
+                    if let Some(node) = list.item(i) {
+                        let _ = node
+                            .unchecked_into::<HtmlElement>()
+                            .style()
+                            .set_property("display", "contents");
+                    }
+                }
+            }
+        }
+        if let Ok(list) = host.query_selector_all(".fab__tele") {
+            for i in 0..list.length() {
+                if let Some(node) = list.item(i) {
+                    let _ = node
+                        .unchecked_into::<HtmlElement>()
+                        .style()
+                        .set_property("flex", "0 0 auto");
+                }
+            }
+        }
+        let wide = host
+            .query_selector(".fab__repo")
+            .ok()
+            .flatten()
+            .expect("repo segment")
+            .unchecked_into::<HtmlElement>();
+        // Per-property, not a `cssText` blob: `CSSStyleDeclaration.setProperty
+        // ("cssText", …)` is a Blink/Gecko-only quirk that WebKit/Safari does
+        // not honor (confirmed empirically — the style attribute never gets
+        // created), which would silently leave this element at its default
+        // zero size under Safari's local wasm-test route.
+        let _ = wide.style().set_property("display", "inline-block");
+        let _ = wide.style().set_property("width", "9999px");
+
+        update_compact_mode(&host);
+        assert!(
+            fab.class_list().contains("fab--compact"),
+            "a bar wider than any viewport must compact"
+        );
+
+        let _ = wide.style().set_property("width", "10px");
+        update_compact_mode(&host);
+        assert!(
+            !fab.class_list().contains("fab--compact"),
+            "a bar that fits again must leave compact mode"
+        );
+        host.remove();
     }
 }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -98,6 +98,11 @@ fn ensure_stylesheet() {
 /// telescope; above it the FAB moves and the click is suppressed.
 const DRAG_THRESHOLD_PX: f64 = 4.0;
 
+/// The drag threshold for TOUCH pointers. Wider than the mouse threshold: a
+/// finger wobbles a few px during a plain tap, and promoting that to a drag
+/// would eat the tap-to-toggle gesture.
+const TOUCH_DRAG_THRESHOLD_PX: f64 = 8.0;
+
 /// The `<tonk-fab>` custom element.
 #[derive(Default)]
 pub struct TonkFab;
@@ -177,6 +182,7 @@ impl CustomElement for TonkFab {
         // buttons-up move.
         this.dataset().delete("fabPressing");
         this.dataset().delete("fabMoved");
+        this.dataset().delete("fabTouch");
     }
 
     fn attribute_changed_callback(
@@ -889,13 +895,27 @@ fn attach_drag(element: &HtmlElement) {
         if e.button() != 0 {
             return;
         }
-        let on_circle = e
+        let Some(cap) = e
             .target()
             .and_then(|t| t.dyn_into::<Element>().ok())
             .and_then(|el| el.closest(".fab__cap-l").ok().flatten())
-            .is_some();
-        if !on_circle {
+        else {
             return;
+        };
+        // TOUCH presses capture IMMEDIATELY, and on the CAP (not the host):
+        // a fast flick outruns even the window listeners' first delivery on
+        // some mobile browsers, and deferred capture is the desktop
+        // compromise that lets a stationary mouse press click — a touch tap
+        // still clicks with capture held, because capture retargets pointer
+        // events to the cap, which is exactly where the tap's click routes
+        // anyway. Capturing on the host instead would retarget the click to
+        // the host and break tap-to-toggle (`attach_gestures` walks
+        // `closest(".fab__cap-l")` from the click target).
+        if e.pointer_type() == "touch" {
+            el_down.dataset().set("fabTouch", "1").ok();
+            cap.set_pointer_capture(e.pointer_id()).ok();
+        } else {
+            el_down.dataset().delete("fabTouch");
         }
         // DELTA-based drag: remember the pointer's start AND the element's start
         // `left`/`top`, then translate by the pointer delta. No grab-offset or
@@ -941,11 +961,22 @@ fn attach_drag(element: &HtmlElement) {
         // Promote to a DRAG once past the dead zone; take capture only then, so a
         // stationary press stays a plain native click.
         if el_move.dataset().get("fabMoved").is_none() {
-            if dx.hypot(dy) < DRAG_THRESHOLD_PX {
+            let touch = el_move.dataset().get("fabTouch").is_some();
+            let threshold = if touch {
+                TOUCH_DRAG_THRESHOLD_PX
+            } else {
+                DRAG_THRESHOLD_PX
+            };
+            if dx.hypot(dy) < threshold {
                 return;
             }
             el_move.dataset().set("fabMoved", "1").ok();
-            el_move.set_pointer_capture(e.pointer_id()).ok();
+            // A touch press already holds capture on the cap (see
+            // `on_down`); re-capturing on the host would retarget the
+            // post-drag click mid-gesture.
+            if !touch {
+                el_move.set_pointer_capture(e.pointer_id()).ok();
+            }
             if let Some(fab) = el_move.query_selector(".fab").ok().flatten() {
                 fab.class_list().add_1("dragging").ok();
             }
@@ -1028,7 +1059,18 @@ fn finish_drag(el: &HtmlElement, pointer_id: i32) {
     if !moved {
         return;
     }
-    el.release_pointer_capture(pointer_id).ok();
+    let touch = el.dataset().get("fabTouch").is_some();
+    el.dataset().delete("fabTouch");
+    if touch {
+        // Touch capture lives on the cap (see `attach_drag`). Explicit
+        // release is belt-and-braces — pointerup implicitly releases — but
+        // pointercancel paths keep it honest.
+        if let Some(cap) = el.query_selector(".fab__cap-l").ok().flatten() {
+            cap.release_pointer_capture(pointer_id).ok();
+        }
+    } else {
+        el.release_pointer_capture(pointer_id).ok();
+    }
     if let Some(fab) = el.query_selector(".fab").ok().flatten() {
         fab.class_list().remove_1("dragging").ok();
     }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -271,9 +271,17 @@ fn attach_gestures(element: &HtmlElement) {
                 let _ = seg.class_list().remove_1("is-open");
             }
         } else if let Some(seg) = t.closest(".fab__repo").ok().flatten() {
-            toggle_menu(&el_click, &seg, ".fab__share");
+            if compact_without_menu(&el_click) {
+                toggle_more_menu(&el_click);
+            } else {
+                toggle_menu(&el_click, &seg, ".fab__share");
+            }
         } else if let Some(seg) = t.closest(".fab__share").ok().flatten() {
-            toggle_menu(&el_click, &seg, ".fab__repo");
+            if compact_without_menu(&el_click) {
+                toggle_more_menu(&el_click);
+            } else {
+                toggle_menu(&el_click, &seg, ".fab__repo");
+            }
         }
     });
 
@@ -520,6 +528,19 @@ fn toggle_more_menu(element: &HtmlElement) {
         .ok();
 }
 
+/// Whether the bar is compact with the vertical menu closed — the state in
+/// which a floating dropdown must not open: the scroll strip's `overflow`
+/// clips an absolutely-positioned menu to the bar's own height, so the
+/// segment tap routes to the vertical menu instead (where the same menus
+/// render as inline accordions).
+fn compact_without_menu(element: &HtmlElement) -> bool {
+    element
+        .query_selector(".fab.fab--compact:not(.fab--menu)")
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 /// Measure the menu's natural (max-content) width — momentarily overriding
 /// the stylesheet's `width: 100%`, reading the box, restoring — and stamp the
 /// segment's inline `min-width` to the RATCHETED target (never below a prior
@@ -764,6 +785,11 @@ fn set_telescope(element: &HtmlElement, fab: &Element, collapsing: bool) {
     // in fab.css). Driving per-tile inline max-widths here would zero out
     // the pages the strip lays out.
     if fab.class_list().contains("fab--compact") {
+        // A collapse retracts EVERYTHING, including the vertical menu:
+        // `.fab--compact.fab--collapsed .fab__strip` out-specifies
+        // `.fab--menu .fab__strip`, so an open menu left standing here would
+        // be clipped to nothing with its scrim still armed.
+        close_menus(element);
         fab.class_list()
             .toggle_with_force("fab--collapsed", collapsing)
             .ok();
@@ -1730,6 +1756,82 @@ mod tests {
         assert!(
             !has_menu(&host),
             "the click-away curtain closes the vertical menu"
+        );
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_routes_a_compact_segment_tap_to_the_vertical_menu() {
+        // In compact mode the floating dropdown would be clipped to the
+        // ~36px scroll strip (`overflow-x: auto` forces `overflow-y: auto`
+        // too), so a segment tap must open the vertical menu instead — the
+        // menus render as inline accordions there. Through the real gesture
+        // path, like the other tests here.
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+
+        host.query_selector(".fab")
+            .ok()
+            .flatten()
+            .expect("bar")
+            .class_list()
+            .add_1("fab--compact")
+            .expect("compact");
+
+        let repo = host
+            .query_selector(".fab__repo")
+            .ok()
+            .flatten()
+            .expect("repo segment");
+        repo.dispatch_event(&bubbling_click()).expect("dispatch");
+
+        assert!(
+            has_menu(&host),
+            "a compact segment tap must open the vertical menu"
+        );
+        assert!(
+            !is_open(&host, ".fab__repo"),
+            "a compact segment tap must not open the floating dropdown"
+        );
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_closes_the_vertical_menu_when_the_compact_bar_collapses() {
+        // `.fab--compact.fab--collapsed .fab__strip` out-specifies
+        // `.fab--menu .fab__strip`, so collapsing while the vertical menu is
+        // open would clip it to nothing with its scrim still armed. A
+        // collapse must retract the menu first.
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+
+        let fab = host.query_selector(".fab").ok().flatten().expect("bar");
+        fab.class_list().add_1("fab--compact").expect("compact");
+        fab.class_list().add_1("fab--menu").expect("menu open");
+
+        let cap = host
+            .query_selector(".fab__cap-l")
+            .ok()
+            .flatten()
+            .expect("cap");
+        // A plain bubbling click — not the alt-click pause gesture.
+        cap.dispatch_event(&bubbling_click()).expect("dispatch");
+
+        assert!(
+            !has_menu(&host),
+            "collapsing the compact bar must close the vertical menu"
         );
         host.remove();
     }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -35,9 +35,9 @@
 //! The element does NOT use Shadow DOM — it is a transparent wrapper.
 
 use crate::logic::{
-    DOCK_CLASSES, Dock, corrected_min_width, create_space_claim_json, dock_claim_json,
-    dock_from_conclusions, mirrored, nearest_dock, pause_claim_json, profile_rename_claim_json,
-    ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+    DOCK_CLASSES, Dock, clamp_position, corrected_min_width, create_space_claim_json,
+    dock_claim_json, dock_from_conclusions, mirrored, nearest_dock, pause_claim_json,
+    profile_rename_claim_json, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -1068,8 +1068,21 @@ fn read_data_f64(el: &HtmlElement, key: &str) -> f64 {
 
 /// Track the FAB at `(left, top)` (viewport top-left) with plain `left`/`top`
 /// during a drag — no corner anchoring, so it follows the cursor 1:1 without
-/// jumping as it crosses the viewport midlines.
+/// jumping as it crosses the viewport midlines. Clamped so the bar can never
+/// leave the viewport, whatever the pointer does. (The mirror-flip
+/// compensation in `apply_mirror_from_handle` writes `left` directly and is
+/// not clamped — the very next pointer move re-clamps, so any excursion
+/// lasts one frame at most.)
 fn track_position(el: &HtmlElement, left: f64, top: f64) {
+    let rect = el.get_bounding_client_rect();
+    let (left, top) = clamp_position(
+        left,
+        top,
+        rect.width(),
+        rect.height(),
+        viewport_width(),
+        viewport_height(),
+    );
     let style = el.style();
     let _ = style.remove_property("right");
     let _ = style.remove_property("bottom");

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -239,6 +239,8 @@ fn attach_gestures(element: &HtmlElement) {
             // curtain lies behind the bar, so this never fires for a click on
             // the bar itself or on a menu row.
             close_menus(&el_click);
+        } else if t.closest(".fab__more").ok().flatten().is_some() {
+            toggle_more_menu(&el_click);
         } else if let Some(cap) = t.closest(".fab__cap-l").ok().flatten() {
             // Alt/option-click toggles sync pause; a plain click folds/expands.
             // Pause is dispatched here (on the FAB, which reliably receives the
@@ -503,6 +505,21 @@ fn toggle_menu(element: &HtmlElement, seg: &Element, other_sel: &str) {
     }
 }
 
+/// Toggle the compact vertical menu (`fab--menu` on `.fab`): every control
+/// stacked full-width, anchored to the bar like the dropdowns. Opening it
+/// first closes any open dropdown — the vertical menu owns the whole field,
+/// and the dropdowns re-open INSIDE it as inline accordions (CSS).
+fn toggle_more_menu(element: &HtmlElement) {
+    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+        return;
+    };
+    let opening = !fab.class_list().contains("fab--menu");
+    close_menus(element);
+    fab.class_list()
+        .toggle_with_force("fab--menu", opening)
+        .ok();
+}
+
 /// Measure the menu's natural (max-content) width — momentarily overriding
 /// the stylesheet's `width: 100%`, reading the box, restoring — and stamp the
 /// segment's inline `min-width` to the RATCHETED target (never below a prior
@@ -660,6 +677,9 @@ fn close_menus(el: &HtmlElement) {
         if let Some(seg) = el.query_selector(sel).ok().flatten() {
             seg.class_list().remove_1("is-open").ok();
         }
+    }
+    if let Some(fab) = el.query_selector(".fab").ok().flatten() {
+        fab.class_list().remove_1("fab--menu").ok();
     }
 }
 
@@ -1644,5 +1664,74 @@ mod tests {
         );
         host.remove();
         clamp_style.remove();
+    }
+
+    fn has_menu(host: &HtmlElement) -> bool {
+        host.query_selector(".fab")
+            .ok()
+            .flatten()
+            .map(|fab| fab.class_list().contains("fab--menu"))
+            .unwrap_or(false)
+    }
+
+    fn bubbling_click() -> web_sys::MouseEvent {
+        let init = web_sys::MouseEventInit::new();
+        init.set_bubbles(true);
+        web_sys::MouseEvent::new_with_mouse_event_init_dict("click", &init).expect("click event")
+    }
+
+    #[wasm_bindgen_test]
+    fn it_toggles_the_vertical_menu_from_the_chevron() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+
+        let chevron = host
+            .query_selector(".fab__more")
+            .ok()
+            .flatten()
+            .expect("chevron");
+        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(has_menu(&host), "a chevron click opens the vertical menu");
+
+        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(!has_menu(&host), "a second click closes it again");
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_dismisses_the_vertical_menu_from_the_curtain() {
+        let document = window().expect("window").document().expect("document");
+        let host = fab_host();
+        attach_gestures(&host);
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("mount");
+
+        host.query_selector(".fab")
+            .ok()
+            .flatten()
+            .expect("bar")
+            .class_list()
+            .add_1("fab--menu")
+            .expect("open");
+        let scrim = host
+            .query_selector(".fab__scrim")
+            .ok()
+            .flatten()
+            .expect("curtain");
+        scrim.dispatch_event(&bubbling_click()).expect("dispatch");
+        assert!(
+            !has_menu(&host),
+            "the click-away curtain closes the vertical menu"
+        );
+        host.remove();
     }
 }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -37,7 +37,8 @@
 use crate::logic::{
     DOCK_CLASSES, Dock, clamp_position, corrected_min_width, create_space_claim_json,
     dock_claim_json, dock_from_conclusions, is_compact, mirrored, nearest_dock, pause_claim_json,
-    profile_rename_claim_json, ratchet_min_width, telescope_delay_ms, telescope_settle_ms,
+    profile_rename_claim_json, ratchet_min_width, strip_page_target, telescope_delay_ms,
+    telescope_settle_ms,
 };
 use custom_elements::CustomElement;
 use js_sys::Promise;
@@ -164,6 +165,7 @@ impl CustomElement for TonkFab {
             preload_menu_widths(this);
             attach_resize(this);
             attach_strip_scroll(this);
+            observe_bar_content(this);
             update_compact_mode(this);
         }
         // Restore the persisted position and apply it to our own style.
@@ -240,7 +242,7 @@ fn attach_gestures(element: &HtmlElement) {
             // the bar itself or on a menu row.
             close_menus(&el_click);
         } else if t.closest(".fab__more").ok().flatten().is_some() {
-            toggle_more_menu(&el_click);
+            advance_strip(&el_click);
         } else if let Some(cap) = t.closest(".fab__cap-l").ok().flatten() {
             // Alt/option-click toggles sync pause; a plain click folds/expands.
             // Pause is dispatched here (on the FAB, which reliably receives the
@@ -271,17 +273,9 @@ fn attach_gestures(element: &HtmlElement) {
                 let _ = seg.class_list().remove_1("is-open");
             }
         } else if let Some(seg) = t.closest(".fab__repo").ok().flatten() {
-            if compact_without_menu(&el_click) {
-                toggle_more_menu(&el_click);
-            } else {
-                toggle_menu(&el_click, &seg, ".fab__share");
-            }
+            toggle_menu(&el_click, &seg, ".fab__share");
         } else if let Some(seg) = t.closest(".fab__share").ok().flatten() {
-            if compact_without_menu(&el_click) {
-                toggle_more_menu(&el_click);
-            } else {
-                toggle_menu(&el_click, &seg, ".fab__repo");
-            }
+            toggle_menu(&el_click, &seg, ".fab__repo");
         }
     });
 
@@ -513,35 +507,24 @@ fn toggle_menu(element: &HtmlElement, seg: &Element, other_sel: &str) {
     }
 }
 
-/// Toggle the compact vertical menu (`fab--menu` on `.fab`): every control
-/// stacked full-width, anchored to the bar like the dropdowns. Opening it
-/// first closes any open dropdown — the vertical menu owns the whole field,
-/// and the dropdowns re-open INSIDE it as inline accordions (CSS).
-fn toggle_more_menu(element: &HtmlElement) {
-    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+/// Advance the compact pager one page, wrapping to the start at the end —
+/// the tap alternative to swiping the strip (the compact bar's only other
+/// horizontal gesture). Smooth so the slide reads as paging, not a jump;
+/// the strip's own `scroll` listener dismisses any open dropdown as the
+/// segments move out from under it.
+fn advance_strip(element: &HtmlElement) {
+    let Some(strip) = element.query_selector(".fab__strip").ok().flatten() else {
         return;
     };
-    let opening = !fab.class_list().contains("fab--menu");
-    close_menus(element);
-    fab.class_list()
-        .toggle_with_force("fab--menu", opening)
-        .ok();
-    if let Some(chevron) = element.query_selector(".fab__more").ok().flatten() {
-        let _ = chevron.set_attribute("aria-expanded", &opening.to_string());
-    }
-}
-
-/// Whether the bar is compact with the vertical menu closed — the state in
-/// which a floating dropdown must not open: the scroll strip's `overflow`
-/// clips an absolutely-positioned menu to the bar's own height, so the
-/// segment tap routes to the vertical menu instead (where the same menus
-/// render as inline accordions).
-fn compact_without_menu(element: &HtmlElement) -> bool {
-    element
-        .query_selector(".fab.fab--compact:not(.fab--menu)")
-        .ok()
-        .flatten()
-        .is_some()
+    let target = strip_page_target(
+        strip.scroll_left() as f64,
+        strip.client_width() as f64,
+        strip.scroll_width() as f64,
+    );
+    let options = web_sys::ScrollToOptions::new();
+    options.set_left(target);
+    options.set_behavior(web_sys::ScrollBehavior::Smooth);
+    strip.scroll_to_with_scroll_to_options(&options);
 }
 
 /// Measure the menu's natural (max-content) width — momentarily overriding
@@ -557,6 +540,16 @@ fn compact_without_menu(element: &HtmlElement) -> bool {
 /// layout before the target, so the 0.2s `min-width` ease has a numeric start
 /// instead of animating from the unanimatable `auto`.
 fn equalize_menu_width(seg: &Element) {
+    // Not while compact: the compact dropdown is bar-width by rule, not
+    // rung-equalized, so a stamp buys nothing there — and mid-compact the
+    // segment rect under-reports, making any ratchet taken here junk. The
+    // stamps that already exist stay (the pager CSS neutralizes them with
+    // `min-width: 0 !important`), so the wide layout — and the compact-fit
+    // measurement, which unclamps to the wide layout — is identical before
+    // and after a trip through compact.
+    if seg.closest(".fab--compact").ok().flatten().is_some() {
+        return;
+    }
     let Some(menu) = seg.query_selector(".fab__menu").ok().flatten() else {
         return;
     };
@@ -615,6 +608,11 @@ fn menu_natural_width(seg: &Element, menu: &Element) -> f64 {
 /// against fallback-font metrics before the Plex face landed. The min-width
 /// transition eases the correction, riding the font swap's own reflow.
 fn restamp_menu_width(seg: &Element) {
+    // Same compact suspension as `equalize_menu_width`, and for the same
+    // reason: inline stamps must not fight the pager's `min-width: 0`.
+    if seg.closest(".fab--compact").ok().flatten().is_some() {
+        return;
+    }
     let Some(menu) = seg.query_selector(".fab__menu").ok().flatten() else {
         return;
     };
@@ -690,22 +688,16 @@ fn apply_mirror_from_handle(el: &HtmlElement) {
     }
 }
 
-/// Dismiss all transient overlays — both dropdowns and the compact vertical
-/// menu (ratcheted widths stay). Called by any interaction that invalidates
-/// an open overlay's anchoring: a drag (which drops the `fab-dock-*` classes
-/// anchoring the menu to the bar, so an open menu would float unanchored
-/// mid-bar), mode switches, pager swipes, or click-away.
+/// Dismiss both dropdowns (the ratcheted widths stay). The single dismissal
+/// point, called by any interaction that invalidates an open menu's
+/// anchoring: a drag (which drops the `fab-dock-*` classes anchoring the
+/// menu to the bar, so an open menu would float unanchored mid-bar), mode
+/// switches, pager swipes and taps, or click-away.
 fn close_menus(el: &HtmlElement) {
     for sel in MENU_SEGMENTS {
         if let Some(seg) = el.query_selector(sel).ok().flatten() {
             seg.class_list().remove_1("is-open").ok();
         }
-    }
-    if let Some(fab) = el.query_selector(".fab").ok().flatten() {
-        fab.class_list().remove_1("fab--menu").ok();
-    }
-    if let Some(chevron) = el.query_selector(".fab__more").ok().flatten() {
-        let _ = chevron.set_attribute("aria-expanded", "false");
     }
 }
 
@@ -768,7 +760,37 @@ fn refresh_on_fonts_ready(element: &HtmlElement) {
                 restamp_menu_width(&seg);
             }
         }
+        // The face swap changes every label's metrics — the same reflow
+        // that invalidates the stamps invalidates the compact-fit call.
+        update_compact_mode(&el);
     });
+}
+
+/// Re-evaluate compact mode whenever the bar's CONTENT changes: the profile
+/// and space names arrive asynchronously from live subscriptions, so the
+/// width measured at connect is the EMPTY bar's — without this, a phone
+/// sits in wide mode until some unrelated trigger (a resize, a telescope
+/// settle) happens to re-measure. Child-list/text mutations only: the
+/// class flips `update_compact_mode` itself performs are attribute
+/// mutations and cannot re-fire the observer.
+fn observe_bar_content(element: &HtmlElement) {
+    let Some(fab) = element.query_selector(".fab").ok().flatten() else {
+        return;
+    };
+    let el = element.clone();
+    let cb = Closure::<dyn FnMut(js_sys::Array, MutationObserver)>::new(
+        move |_records: js_sys::Array, _obs: MutationObserver| {
+            update_compact_mode(&el);
+        },
+    );
+    if let Ok(observer) = MutationObserver::new(cb.as_ref().unchecked_ref()) {
+        let init = MutationObserverInit::new();
+        init.set_child_list(true);
+        init.set_subtree(true);
+        init.set_character_data(true);
+        observer.observe_with_options(&fab, &init).ok();
+    }
+    cb.forget();
 }
 
 /// Toggle the telescope open/closed: flip `fab--collapsed` on `.fab` and drive
@@ -791,11 +813,18 @@ fn set_telescope(element: &HtmlElement, fab: &Element, collapsing: bool) {
     // in fab.css). Driving per-tile inline max-widths here would zero out
     // the pages the strip lays out.
     if fab.class_list().contains("fab--compact") {
-        // A collapse retracts EVERYTHING, including the vertical menu:
-        // `.fab--compact.fab--collapsed .fab__strip` out-specifies
-        // `.fab--menu .fab__strip`, so an open menu left standing here would
-        // be clipped to nothing with its scrim still armed.
+        // A collapse retracts everything: a floating dropdown left standing
+        // would hover over a bar that is shrinking to a bare circle, with
+        // its scrim still armed.
         close_menus(element);
+        // Collapsed and settled are mutually exclusive, exactly as in the
+        // wide branch below: `fab--settled`'s unclamp (`max-width: none` on
+        // every shown tile, and a higher-specificity rule than the collapse
+        // clamp) would hold the chevron's tile open while the strip
+        // retracts — the collapsed pill kept its arrow.
+        fab.class_list()
+            .toggle_with_force("fab--settled", !collapsing)
+            .ok();
         fab.class_list()
             .toggle_with_force("fab--collapsed", collapsing)
             .ok();
@@ -1698,14 +1727,6 @@ mod tests {
         clamp_style.remove();
     }
 
-    fn has_menu(host: &HtmlElement) -> bool {
-        host.query_selector(".fab")
-            .ok()
-            .flatten()
-            .map(|fab| fab.class_list().contains("fab--menu"))
-            .unwrap_or(false)
-    }
-
     fn bubbling_click() -> web_sys::MouseEvent {
         let init = web_sys::MouseEventInit::new();
         init.set_bubbles(true);
@@ -1713,67 +1734,10 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn it_toggles_the_vertical_menu_from_the_chevron() {
-        let document = window().expect("window").document().expect("document");
-        let host = fab_host();
-        attach_gestures(&host);
-        document
-            .body()
-            .expect("body")
-            .append_child(&host)
-            .expect("mount");
-
-        let chevron = host
-            .query_selector(".fab__more")
-            .ok()
-            .flatten()
-            .expect("chevron");
-        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
-        assert!(has_menu(&host), "a chevron click opens the vertical menu");
-
-        chevron.dispatch_event(&bubbling_click()).expect("dispatch");
-        assert!(!has_menu(&host), "a second click closes it again");
-        host.remove();
-    }
-
-    #[wasm_bindgen_test]
-    fn it_dismisses_the_vertical_menu_from_the_curtain() {
-        let document = window().expect("window").document().expect("document");
-        let host = fab_host();
-        attach_gestures(&host);
-        document
-            .body()
-            .expect("body")
-            .append_child(&host)
-            .expect("mount");
-
-        host.query_selector(".fab")
-            .ok()
-            .flatten()
-            .expect("bar")
-            .class_list()
-            .add_1("fab--menu")
-            .expect("open");
-        let scrim = host
-            .query_selector(".fab__scrim")
-            .ok()
-            .flatten()
-            .expect("curtain");
-        scrim.dispatch_event(&bubbling_click()).expect("dispatch");
-        assert!(
-            !has_menu(&host),
-            "the click-away curtain closes the vertical menu"
-        );
-        host.remove();
-    }
-
-    #[wasm_bindgen_test]
-    fn it_routes_a_compact_segment_tap_to_the_vertical_menu() {
-        // In compact mode the floating dropdown would be clipped to the
-        // ~36px scroll strip (`overflow-x: auto` forces `overflow-y: auto`
-        // too), so a segment tap must open the vertical menu instead — the
-        // menus render as inline accordions there. Through the real gesture
-        // path, like the other tests here.
+    fn it_opens_the_floating_dropdown_from_a_compact_segment_tap() {
+        // Compact segment taps open the SAME dropdown as desktop — floated
+        // over the bar by CSS (position: fixed escapes the strip's clip) —
+        // not a separate mobile menu. Through the real gesture path.
         let document = window().expect("window").document().expect("document");
         let host = fab_host();
         attach_gestures(&host);
@@ -1799,22 +1763,17 @@ mod tests {
         repo.dispatch_event(&bubbling_click()).expect("dispatch");
 
         assert!(
-            has_menu(&host),
-            "a compact segment tap must open the vertical menu"
-        );
-        assert!(
-            !is_open(&host, ".fab__repo"),
-            "a compact segment tap must not open the floating dropdown"
+            is_open(&host, ".fab__repo"),
+            "a compact segment tap must open its dropdown, same as desktop"
         );
         host.remove();
     }
 
     #[wasm_bindgen_test]
-    fn it_closes_the_vertical_menu_when_the_compact_bar_collapses() {
-        // `.fab--compact.fab--collapsed .fab__strip` out-specifies
-        // `.fab--menu .fab__strip`, so collapsing while the vertical menu is
-        // open would clip it to nothing with its scrim still armed. A
-        // collapse must retract the menu first.
+    fn it_collapses_the_compact_bar_with_a_dropdown_open() {
+        // A collapse retracts everything: the strip clamps to nothing, so a
+        // floating dropdown left standing would hover over a bare circle
+        // with its scrim still armed. The cap click must dismiss it.
         let document = window().expect("window").document().expect("document");
         let host = fab_host();
         attach_gestures(&host);
@@ -1826,7 +1785,14 @@ mod tests {
 
         let fab = host.query_selector(".fab").ok().flatten().expect("bar");
         fab.class_list().add_1("fab--compact").expect("compact");
-        fab.class_list().add_1("fab--menu").expect("menu open");
+        fab.class_list().add_1("fab--settled").expect("settled");
+        host.query_selector(".fab__repo")
+            .ok()
+            .flatten()
+            .expect("repo segment")
+            .class_list()
+            .add_1("is-open")
+            .expect("open dropdown");
 
         let cap = host
             .query_selector(".fab__cap-l")
@@ -1837,8 +1803,17 @@ mod tests {
         cap.dispatch_event(&bubbling_click()).expect("dispatch");
 
         assert!(
-            !has_menu(&host),
-            "collapsing the compact bar must close the vertical menu"
+            fab.class_list().contains("fab--collapsed"),
+            "the cap click must collapse the compact bar"
+        );
+        assert!(
+            !fab.class_list().contains("fab--settled"),
+            "collapsing must drop fab--settled — its unclamp rule outranks \
+             the collapse clamp and would keep the chevron's tile open"
+        );
+        assert!(
+            !is_open(&host, ".fab__repo"),
+            "collapsing must dismiss the open dropdown"
         );
         host.remove();
     }

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -526,6 +526,9 @@ fn toggle_more_menu(element: &HtmlElement) {
     fab.class_list()
         .toggle_with_force("fab--menu", opening)
         .ok();
+    if let Some(chevron) = element.query_selector(".fab__more").ok().flatten() {
+        let _ = chevron.set_attribute("aria-expanded", &opening.to_string());
+    }
 }
 
 /// Whether the bar is compact with the vertical menu closed — the state in
@@ -700,6 +703,9 @@ fn close_menus(el: &HtmlElement) {
     }
     if let Some(fab) = el.query_selector(".fab").ok().flatten() {
         fab.class_list().remove_1("fab--menu").ok();
+    }
+    if let Some(chevron) = el.query_selector(".fab__more").ok().flatten() {
+        let _ = chevron.set_attribute("aria-expanded", "false");
     }
 }
 
@@ -882,8 +888,9 @@ fn telescope_tiles(fab: &Element) -> Vec<Element> {
     out
 }
 
-/// The wide bar's visual position of a tile — must match the CSS `order`
-/// values in `fab.css` (account 1, repo 2, share 3, end 4).
+/// The wide bar's visual position of a tile, RELATIVE to the others — must
+/// mirror the visual order the CSS `order` rules in `fab.css` establish
+/// (account, then repo, then share, then end).
 fn tile_rank(tile: &Element) -> u8 {
     let cl = tile.class_list();
     if cl.contains("fab__tele--account") {

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -239,6 +239,52 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
   .fab--compact .fab__tele--end,
   .fab--compact .fab__more wa-icon { transition: none; }
 }
+/* ── The chevron's vertical menu (compact only in practice) ───────
+   `fab--menu` pops the strip out of the bar as an absolutely-anchored
+   vertical stack — the same anchoring the dropdowns use (away from the
+   docked edge, dock-keyed), so it always unfolds into view. The bar
+   itself shrinks to its two caps while the menu is up, iOS-style. */
+.fab--menu .fab__strip {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  max-width: none;
+  overflow: visible;
+  z-index: 100;
+}
+.fab-dock-top .fab--menu .fab__strip { top: 100%; margin-top: 7px; }
+.fab-dock-bottom .fab--menu .fab__strip { bottom: 100%; margin-bottom: 7px; }
+/* Pages dissolve; every tile is its own full-width row. Scoped to the
+   strip: the end tile (chevron cap) sits outside it and keeps its bar
+   styling while the menu is up. */
+.fab--menu .fab__page { display: contents; }
+.fab--menu .fab__strip .fab__tele {
+  max-width: none !important;
+  overflow: visible;
+  min-width: 0;
+}
+.fab--menu .fab__strip .fab__seg {
+  width: 100%;
+  box-sizing: border-box;
+  block-size: 36px;
+  border-radius: 2px;
+  flex: none;
+}
+/* An open dropdown renders INLINE as an accordion row under its
+   segment instead of floating: the segment's tile stacks them. */
+.fab--menu .fab__tele--repo,
+.fab--menu .fab__tele--share { display: flex; flex-direction: column; gap: 7px; }
+.fab--menu .fab__repo.is-open .fab__menu,
+.fab--menu .fab__share.is-open .fab__share-menu {
+  position: static;
+  margin: 7px 0 0;
+  width: 100%;
+}
+/* The chevron flips while the menu is up. */
+.fab--menu .fab__more wa-icon { transform: rotate(90deg); }
 /* A segment: its own cream surface + ink, an inset highlight/shadow that
    reads like the wireframe's pressed-plastic pill. Middle segments are
    square; the caps below round their outer edge. */
@@ -766,7 +812,8 @@ tonk-share[data-share-state="failed"] .fab__share-trigger {
    handles the hit). It sits below the bar's own stacking context, so
    the bar and its menus stay clickable through it. */
 .fab__scrim { position: fixed; inset: 0; pointer-events: none; }
-tonk-fab:has(.is-open) .fab__scrim { pointer-events: auto; }
+tonk-fab:has(.is-open) .fab__scrim,
+tonk-fab:has(.fab--menu) .fab__scrim { pointer-events: auto; }
 /* Mirrored: the bar is row-reversed, so the share zone is the LEFT
    end — its roster flips to anchor left (the repo switcher already
    re-anchors right via `.fab-mirror .fab__menu`). Row alignment

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -174,7 +174,15 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
    as the fixed right cap, and the segments page horizontally between
    them in a native scroll-snap strip — swipe momentum for free, and no
    gesture code to fight the drag (which arms only on the circle cap). */
-.fab--compact { max-inline-size: calc(100vw - 32px); }
+.fab--compact {
+  max-inline-size: calc(100vw - 32px);
+  /* Horizontal-only for the WHOLE compact bar, not just the strip: a
+     swipe starting on the chevron, a cap, or a between-segment gap could
+     otherwise pan the page vertically and ride the pill off-screen. The
+     circle cap's own `touch-action: none` still wins for drags (the
+     effective action is the intersection down the touched chain). */
+  touch-action: pan-x;
+}
 .fab--compact .fab__strip {
   display: flex;
   gap: 2px;
@@ -232,23 +240,37 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 .fab--compact .fab__more {
   display: inline-flex;
   flex: none;
-  inline-size: 22px;
+  /* The nub's exact geometry (`.fab__end` is 18px) so the arrow reads as
+     the pill's terminator, not a separate button; `appearance`/`margin`
+     zeroed because iOS Safari's UA button styling otherwise floats the
+     button off the bar's axis. */
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  inline-size: 18px;
+  block-size: 100%;
+  align-self: stretch;
   padding: 0;
   align-items: center;
   justify-content: center;
   border: 0;
   cursor: pointer;
   font: inherit;
-  font-size: 11px;
+  font-size: 10px;
 }
-/* On coarse pointers the 22px chevron grows an invisible >=44px hit area,
+/* The arrow points at what the next tap does: forward mid-strip, back
+   once the strip rests at the end and the tap wraps to the start
+   (element.rs toggles the class from the strip's scroll position). */
+.fab--compact .fab__more wa-icon { transition: transform 0.2s ease; }
+.fab__more--back wa-icon { transform: rotate(180deg); }
+/* On coarse pointers the 18px chevron grows an invisible >=44px hit area,
    mirroring the circle cap's treatment (`.fab__seg` supplies the
    `position: relative` anchor). */
 @media (pointer: coarse) {
   .fab__more::after {
     content: "";
     position: absolute;
-    inset: -11px;
+    inset: -13px;
   }
 }
 /* Collapse in compact: the strip and chevron retract into the circle
@@ -284,7 +306,8 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 }
 @media (prefers-reduced-motion: reduce) {
   .fab--compact .fab__strip,
-  .fab--compact .fab__tele--end { transition: none; }
+  .fab--compact .fab__tele--end,
+  .fab--compact .fab__more wa-icon { transition: none; }
 }
 /* A segment: its own cream surface + ink, an inset highlight/shadow that
    reads like the wireframe's pressed-plastic pill. Middle segments are

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -234,6 +234,12 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 }
 /* Dragging locks the pager so paging and dragging cannot interleave. */
 .fab.dragging .fab__strip { overflow: hidden; }
+/* A floating dropdown cannot render inside the compact scroll strip —
+   its overflow clips an absolutely-positioned menu to the bar's height.
+   Compact taps route to the vertical menu instead (element.rs); this
+   guard covers any other path that sets `is-open` outside menu mode. */
+.fab--compact:not(.fab--menu) .fab__repo.is-open .fab__menu,
+.fab--compact:not(.fab--menu) .fab__share.is-open .fab__share-menu { display: none; }
 @media (prefers-reduced-motion: reduce) {
   .fab--compact .fab__strip,
   .fab--compact .fab__tele--end,

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -146,6 +146,21 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
     drop-shadow(0 1px 2px rgba(20, 22, 8, 0.22))
     drop-shadow(0 8px 22px rgba(20, 22, 8, 0.20));
 }
+/* ── Compact grouping (inert on wide viewports) ───────────────────
+   The strip and pages exist for the compact pager (see `.fab--compact`
+   below). On wide viewports they generate NO boxes, so the tiles are
+   direct flex items of `.fab` exactly as before — and flex `order`
+   restores the wide bar's visual order (account, repo, share, end),
+   which the DOM gives up to group page 2 (share, account) together.
+   The circle cap keeps default order 0, so it stays first. */
+.fab__strip,
+.fab__page { display: contents; }
+.fab__tele--account { order: 1; }
+.fab__tele--repo    { order: 2; }
+.fab__tele--share   { order: 3; }
+.fab__tele--end     { order: 4; }
+/* The chevron cap is compact-only; wide mode shows the decorative nub. */
+.fab__more { display: none; }
 /* A segment: its own cream surface + ink, an inset highlight/shadow that
    reads like the wireframe's pressed-plastic pill. Middle segments are
    square; the caps below round their outer edge. */

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -161,6 +161,84 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 .fab__tele--end     { order: 4; }
 /* The chevron cap is compact-only; wide mode shows the decorative nub. */
 .fab__more { display: none; }
+/* ── Compact mode ─────────────────────────────────────────────────
+   `fab--compact` is set on `.fab` by element.rs when the EXPANDED bar
+   plus both 16px dock insets would overflow the viewport (measured, not
+   device-sniffed — a narrow desktop window compacts too). Layout: the
+   circle cap stays the fixed left cap, the chevron replaces the end nub
+   as the fixed right cap, and the segments page horizontally between
+   them in a native scroll-snap strip — swipe momentum for free, and no
+   gesture code to fight the drag (which arms only on the circle cap). */
+.fab--compact { max-inline-size: calc(100vw - 32px); }
+.fab--compact .fab__strip {
+  display: flex;
+  gap: 2px;
+  flex: 0 1 auto;
+  min-width: 0;
+  /* Numeric so the collapse transition below can interpolate to 0:
+     viewport minus circle cap (36) + chevron cap (36) + insets (32) +
+     two 2px bar gaps. */
+  max-width: calc(100vw - 108px);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  transition: max-width 0.4s ease;
+}
+.fab--compact .fab__strip::-webkit-scrollbar { display: none; }
+.fab--compact .fab__page {
+  display: flex;
+  gap: 2px;
+  flex: 0 0 auto;
+  /* Just under the strip width: the next page's leading edge peeks
+     ~24px, signalling there is more to swipe to (no page dots). */
+  min-width: calc(100% - 24px);
+  scroll-snap-align: start;
+}
+/* Pages own the sizing now; tiles and segments shrink into them.
+   Scoped to `.fab__page` descendants: the circle cap and the chevron
+   cap are `.fab__seg`s OUTSIDE the strip and must keep their fixed
+   36px sizing — an unscoped `.fab--compact .fab__seg` outranks their
+   single-class rules and breaks both caps. */
+.fab--compact .fab__page .fab__tele { flex: 1 1 auto; min-width: 0; }
+.fab--compact .fab__page .fab__seg { min-width: 0; flex: 1 1 auto; padding: 0 14px; }
+/* Order is DOM order inside the strip (page 1 first); clear the
+   wide-mode reordering. */
+.fab--compact .fab__tele--account,
+.fab--compact .fab__tele--repo,
+.fab--compact .fab__tele--share { order: 0; }
+/* The right cap swaps: nub out, chevron in. */
+.fab--compact .fab__end { display: none; }
+.fab--compact .fab__more {
+  display: inline-flex;
+  flex: none;
+  inline-size: 36px;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+.fab--compact .fab__more wa-icon { transition: transform 0.2s ease; }
+/* Collapse in compact: the strip and chevron retract into the circle
+   (CSS transitions, not per-tile inline styles — see set_telescope). */
+.fab--compact .fab__tele--end {
+  transition: max-width 0.4s ease, margin-left 0.4s ease;
+  max-width: 40px;
+}
+.fab--compact.fab--collapsed .fab__strip,
+.fab--compact.fab--collapsed .fab__tele--end {
+  max-width: 0;
+  margin-left: -2px;
+  overflow: hidden;
+}
+/* Dragging locks the pager so paging and dragging cannot interleave. */
+.fab.dragging .fab__strip { overflow: hidden; }
+@media (prefers-reduced-motion: reduce) {
+  .fab--compact .fab__strip,
+  .fab--compact .fab__tele--end,
+  .fab--compact .fab__more wa-icon { transition: none; }
+}
 /* A segment: its own cream surface + ink, an inset highlight/shadow that
    reads like the wireframe's pressed-plastic pill. Middle segments are
    square; the caps below round their outer edge. */

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -159,8 +159,13 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 .fab__tele--repo    { order: 2; }
 .fab__tele--share   { order: 3; }
 .fab__tele--end     { order: 4; }
-/* The chevron cap is compact-only; wide mode shows the decorative nub. */
-.fab__more { display: none; }
+/* The chevron cap is compact-only; wide mode shows the decorative nub.
+   The hide rule must OUTRANK `.fab__seg`'s `display: inline-flex` (the
+   chevron carries both classes, and `.fab__seg` sits later in this sheet,
+   so a bare same-specificity `.fab__more` loses the tie and the chevron
+   leaks into the wide bar). `:not(.fab--compact)` both raises specificity
+   and scopes the rule so it can never fight the compact show rule. */
+.fab:not(.fab--compact) .fab__more { display: none; }
 /* ── Compact mode ─────────────────────────────────────────────────
    `fab--compact` is set on `.fab` by element.rs when the EXPANDED bar
    plus both 16px dock insets would overflow the viewport (measured, not

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -187,6 +187,12 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   scrollbar-width: none;
+  /* Horizontal ONLY: without pan-x, a vertical finger on the strip pans
+     the guest page instead (iOS bounces the overlay's body and the whole
+     pill rides off-screen with it); contain stops the rubber-band from
+     chaining out of the strip at either end. */
+  touch-action: pan-x;
+  overscroll-behavior: contain;
   transition: max-width 0.4s ease;
 }
 .fab--compact .fab__strip::-webkit-scrollbar { display: none; }
@@ -205,26 +211,46 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
    36px sizing — an unscoped `.fab--compact .fab__seg` outranks their
    single-class rules and breaks both caps. */
 .fab--compact .fab__page .fab__tele { flex: 1 1 auto; min-width: 0; }
-.fab--compact .fab__page .fab__seg { min-width: 0; flex: 1 1 auto; padding: 0 14px; }
+/* `!important` on min-width: the wide-mode menu/rung equalizer stamps an
+   INLINE `min-width` on the dropdown segments (element.rs ratchet), and a
+   plain declaration loses to it — freezing the segments at their wide
+   column widths so they cannot shrink into their pages. The stamps must
+   survive (wide mode reuses them on return), so they are overridden here
+   rather than cleared. */
+.fab--compact .fab__page .fab__seg { min-width: 0 !important; flex: 1 1 auto; padding: 0 14px; }
 /* Order is DOM order inside the strip (page 1 first); clear the
    wide-mode reordering. */
 .fab--compact .fab__tele--account,
 .fab--compact .fab__tele--repo,
 .fab--compact .fab__tele--share { order: 0; }
-/* The right cap swaps: nub out, chevron in. */
+/* The right cap swaps: nub out, chevron in. Sized like the nub it
+   replaces (a rounded terminator, not a full segment) so it meshes with
+   the pill instead of reading as its own button; the icon shrinks with
+   it. The tap target stays honest via the coarse-pointer hit-area
+   below. */
 .fab--compact .fab__end { display: none; }
 .fab--compact .fab__more {
   display: inline-flex;
   flex: none;
-  inline-size: 36px;
+  inline-size: 22px;
   padding: 0;
   align-items: center;
   justify-content: center;
   border: 0;
   cursor: pointer;
   font: inherit;
+  font-size: 11px;
 }
-.fab--compact .fab__more wa-icon { transition: transform 0.2s ease; }
+/* On coarse pointers the 22px chevron grows an invisible >=44px hit area,
+   mirroring the circle cap's treatment (`.fab__seg` supplies the
+   `position: relative` anchor). */
+@media (pointer: coarse) {
+  .fab__more::after {
+    content: "";
+    position: absolute;
+    inset: -11px;
+  }
+}
 /* Collapse in compact: the strip and chevron retract into the circle
    (CSS transitions, not per-tile inline styles — see set_telescope). */
 .fab--compact .fab__tele--end {
@@ -239,63 +265,27 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
 }
 /* Dragging locks the pager so paging and dragging cannot interleave. */
 .fab.dragging .fab__strip { overflow: hidden; }
-/* A floating dropdown cannot render inside the compact scroll strip —
-   its overflow clips an absolutely-positioned menu to the bar's height.
-   Compact taps route to the vertical menu instead (element.rs); this
-   guard covers any other path that sets `is-open` outside menu mode. */
-.fab--compact:not(.fab--menu) .fab__repo.is-open .fab__menu,
-.fab--compact:not(.fab--menu) .fab__share.is-open .fab__share-menu { display: none; }
-@media (prefers-reduced-motion: reduce) {
-  .fab--compact .fab__strip,
-  .fab--compact .fab__tele--end,
-  .fab--compact .fab__more wa-icon { transition: none; }
-}
-/* ── The chevron's vertical menu (compact only in practice) ───────
-   `fab--menu` pops the strip out of the bar as an absolutely-anchored
-   vertical stack — the same anchoring the dropdowns use (away from the
-   docked edge, dock-keyed), so it always unfolds into view. The bar
-   itself shrinks to its two caps while the menu is up, iOS-style. */
-.fab--menu .fab__strip {
-  position: absolute;
+/* Compact dropdowns FLOAT over the bar. The strip's overflow would clip
+   an absolutely-positioned descendant to the bar's own height, so the
+   open menu switches to `position: fixed`: the bar's drop-shadow
+   `filter` makes `.fab` the containing block for fixed descendants,
+   which lifts the menu out of the strip's clip (its containing-block
+   chain no longer passes through the scroller) while the dock-keyed
+   `top`/`bottom` offsets below still resolve against the bar's own box —
+   the same away-from-the-docked-edge anchoring as at rest. `left`/
+   `right` span the whole bar: the dropdown is bar-width on a phone, not
+   rung-width. */
+.fab--compact .fab__repo.is-open .fab__menu,
+.fab--compact .fab__share.is-open .fab__share-menu {
+  position: fixed;
   left: 0;
   right: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  max-width: none;
-  overflow: visible;
-  z-index: 100;
+  width: auto;
 }
-.fab-dock-top .fab--menu .fab__strip { top: 100%; margin-top: 7px; }
-.fab-dock-bottom .fab--menu .fab__strip { bottom: 100%; margin-bottom: 7px; }
-/* Pages dissolve; every tile is its own full-width row. Scoped to the
-   strip: the end tile (chevron cap) sits outside it and keeps its bar
-   styling while the menu is up. */
-.fab--menu .fab__page { display: contents; }
-.fab--menu .fab__strip .fab__tele {
-  max-width: none !important;
-  overflow: visible;
-  min-width: 0;
+@media (prefers-reduced-motion: reduce) {
+  .fab--compact .fab__strip,
+  .fab--compact .fab__tele--end { transition: none; }
 }
-.fab--menu .fab__strip .fab__seg {
-  width: 100%;
-  box-sizing: border-box;
-  block-size: 36px;
-  border-radius: 2px;
-  flex: none;
-}
-/* An open dropdown renders INLINE as an accordion row under its
-   segment instead of floating: the segment's tile stacks them. */
-.fab--menu .fab__tele--repo,
-.fab--menu .fab__tele--share { display: flex; flex-direction: column; gap: 7px; }
-.fab--menu .fab__repo.is-open .fab__menu,
-.fab--menu .fab__share.is-open .fab__share-menu {
-  position: static;
-  margin: 7px 0 0;
-  width: 100%;
-}
-/* The chevron flips while the menu is up. */
-.fab--menu .fab__more wa-icon { transform: rotate(90deg); }
 /* A segment: its own cream surface + ink, an inset highlight/shadow that
    reads like the wireframe's pressed-plastic pill. Middle segments are
    square; the caps below round their outer edge. */
@@ -823,8 +813,7 @@ tonk-share[data-share-state="failed"] .fab__share-trigger {
    handles the hit). It sits below the bar's own stacking context, so
    the bar and its menus stay clickable through it. */
 .fab__scrim { position: fixed; inset: 0; pointer-events: none; }
-tonk-fab:has(.is-open) .fab__scrim,
-tonk-fab:has(.fab--menu) .fab__scrim { pointer-events: auto; }
+tonk-fab:has(.is-open) .fab__scrim { pointer-events: auto; }
 /* Mirrored: the bar is row-reversed, so the share zone is the LEFT
    end — its roster flips to anchor left (the repo switcher already
    re-anchors right via `.fab-mirror .fab__menu`). Row alignment

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -196,6 +196,24 @@ tonk-fab.fab-dock-right  { left: auto; right: 16px; }
   padding: 0;
   justify-content: center;
   cursor: grab;
+  /* The browser must not race us for touch gestures on the drag handle —
+     without this, mobile scroll/zoom recognizers usually win and the drag
+     stutters or dies. Scoped to the cap so touch behaviour anywhere else
+     on the bar (and the compact strip's own pan) is untouched. */
+  touch-action: none;
+}
+/* On coarse pointers the 36px cap grows an invisible 52px hit area
+   (>=44px Apple/Android guidance) without visual change. The cap is
+   `position: relative` via `.fab__seg`, so the inset anchors to it; the
+   pseudo-element is part of the cap for hit-testing, so both the drag
+   arming and the tap gesture route through `closest(".fab__cap-l")`
+   exactly as before. */
+@media (pointer: coarse) {
+  .fab__cap-l::after {
+    content: "";
+    position: absolute;
+    inset: -8px;
+  }
 }
 /* The far end cap: a fixed 18px round-right nub that finishes the bar
    (the wireframe's `cp-cap-r` without its toggle glyph). Half the

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -199,6 +199,32 @@ pub fn mirrored(center_x: f64, vw: f64) -> bool {
     center_x >= vw / 2.0
 }
 
+/// The stylesheet's dock inset — `tonk-fab.fab-dock-* { …: 16px }` in
+/// `fab.css`. The compact-mode fit test must account for it on both sides.
+pub const DOCK_INSET_PX: f64 = 16.0;
+
+/// Whether the bar must render compact: the fully EXPANDED bar plus both
+/// dock insets no longer fits the viewport width. Keyed on the would-be
+/// expanded width (not the current rendered width), so the threshold is the
+/// same entering and leaving compact and cannot oscillate.
+pub fn is_compact(expanded_width: f64, viewport_width: f64) -> bool {
+    expanded_width + 2.0 * DOCK_INSET_PX > viewport_width
+}
+
+/// Clamp a dragged bar's top-left corner so the bar stays fully inside the
+/// viewport. The origin clamp runs LAST: a bar wider or taller than the
+/// viewport pins to the left/top edge, keeping the grab handle reachable.
+pub fn clamp_position(
+    left: f64,
+    top: f64,
+    width: f64,
+    height: f64,
+    vw: f64,
+    vh: f64,
+) -> (f64, f64) {
+    (left.min(vw - width).max(0.0), top.min(vh - height).max(0.0))
+}
+
 /// The telescope animation duration, in milliseconds — each tile's
 /// `max-width` transition (wireframe `--dur: .4s`).
 pub const TELESCOPE_MS: u64 = 400;
@@ -353,6 +379,65 @@ mod mirror {
     fn the_midline_mirrors_like_nearest_dock_falls_right() {
         // Consistent with `nearest_dock`, whose exact midline docks right.
         assert!(mirrored(500.0, 1000.0));
+    }
+}
+
+#[cfg(test)]
+mod compact {
+    use super::*;
+
+    #[test]
+    fn a_bar_that_fits_with_both_insets_is_not_compact() {
+        assert!(!is_compact(300.0, 400.0));
+    }
+
+    #[test]
+    fn a_bar_wider_than_the_viewport_minus_insets_is_compact() {
+        assert!(is_compact(380.0, 400.0));
+    }
+
+    #[test]
+    fn the_exact_fit_is_not_compact() {
+        // 368 + 2*16 == 400: still fits; only strictly-greater flips it, so
+        // the threshold is identical in both directions and cannot flap.
+        assert!(!is_compact(368.0, 400.0));
+    }
+}
+
+#[cfg(test)]
+mod clamp {
+    use super::*;
+
+    #[test]
+    fn an_inside_position_is_untouched() {
+        assert_eq!(
+            clamp_position(100.0, 50.0, 300.0, 36.0, 1000.0, 800.0),
+            (100.0, 50.0)
+        );
+    }
+
+    #[test]
+    fn it_clamps_every_edge() {
+        // Past the origin pins to 0.
+        assert_eq!(
+            clamp_position(-20.0, -5.0, 300.0, 36.0, 1000.0, 800.0),
+            (0.0, 0.0)
+        );
+        // Right/bottom overflow pins to viewport minus the bar.
+        assert_eq!(
+            clamp_position(900.0, 790.0, 300.0, 36.0, 1000.0, 800.0),
+            (700.0, 764.0)
+        );
+    }
+
+    #[test]
+    fn a_bar_wider_than_the_viewport_pins_to_the_origin() {
+        // vw - width is negative; the origin wins (max runs last) so the
+        // bar's left edge — and the circle cap on it — stays reachable.
+        assert_eq!(
+            clamp_position(50.0, 10.0, 500.0, 36.0, 400.0, 800.0),
+            (0.0, 10.0)
+        );
     }
 }
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1399,6 +1399,7 @@ mod stylesheet {
         assert!(css.contains(".fab__menu-item"));
         assert!(css.contains(".fab__share-label"));
         assert!(css.contains(".wizard__card"));
+        assert!(css.contains(".fab__strip"));
     }
 }
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -225,14 +225,23 @@ pub fn clamp_position(
     (left.min(vw - width).max(0.0), top.min(vh - height).max(0.0))
 }
 
+/// Whether the compact pager's strip rests at its scroll end — the state in
+/// which the arrow's next tap wraps to the start, and the glyph flips to
+/// point back so the wrap is announced rather than silent. Tolerates a small
+/// epsilon (browsers report fractional scroll positions), and a strip with
+/// nothing to scroll is NOT "at the end": its arrow keeps pointing forward
+/// and its tap is a harmless no-op.
+pub fn strip_at_end(scroll_left: f64, client_width: f64, scroll_width: f64) -> bool {
+    let max = scroll_width - client_width;
+    max > 0.0 && scroll_left >= max - 2.0
+}
+
 /// The scroll offset the compact pager's arrow advances the strip to: one
-/// page-width forward per tap, wrapping back to the start once the end is
-/// reached. "At the end" tolerates a small epsilon — browsers report
-/// fractional scroll positions, and a strip resting within a couple of px
-/// of its maximum must wrap rather than dead-end the arrow.
+/// page-width forward per tap, wrapping back to the start from the end
+/// ([`strip_at_end`]).
 pub fn strip_page_target(scroll_left: f64, client_width: f64, scroll_width: f64) -> f64 {
     let max = (scroll_width - client_width).max(0.0);
-    if scroll_left >= max - 2.0 {
+    if strip_at_end(scroll_left, client_width, scroll_width) {
         0.0
     } else {
         (scroll_left + client_width).min(max)
@@ -567,6 +576,23 @@ mod pager {
     fn a_strip_with_nothing_to_scroll_stays_at_the_start() {
         assert_eq!(strip_page_target(0.0, 300.0, 300.0), 0.0);
         assert_eq!(strip_page_target(0.0, 300.0, 250.0), 0.0);
+    }
+
+    #[test]
+    fn the_end_state_drives_the_arrow_flip() {
+        assert!(!strip_at_end(0.0, 300.0, 800.0));
+        assert!(!strip_at_end(300.0, 300.0, 800.0));
+        assert!(strip_at_end(500.0, 300.0, 800.0));
+        // Fractionally shy of the end still counts as the end.
+        assert!(strip_at_end(498.5, 300.0, 800.0));
+    }
+
+    #[test]
+    fn a_strip_with_nothing_to_scroll_is_not_at_the_end() {
+        // The arrow must keep pointing forward when there is nothing to
+        // page — a back-arrow on a strip that never moved reads as broken.
+        assert!(!strip_at_end(0.0, 300.0, 300.0));
+        assert!(!strip_at_end(0.0, 300.0, 250.0));
     }
 }
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -225,6 +225,20 @@ pub fn clamp_position(
     (left.min(vw - width).max(0.0), top.min(vh - height).max(0.0))
 }
 
+/// The scroll offset the compact pager's arrow advances the strip to: one
+/// page-width forward per tap, wrapping back to the start once the end is
+/// reached. "At the end" tolerates a small epsilon — browsers report
+/// fractional scroll positions, and a strip resting within a couple of px
+/// of its maximum must wrap rather than dead-end the arrow.
+pub fn strip_page_target(scroll_left: f64, client_width: f64, scroll_width: f64) -> f64 {
+    let max = (scroll_width - client_width).max(0.0);
+    if scroll_left >= max - 2.0 {
+        0.0
+    } else {
+        (scroll_left + client_width).min(max)
+    }
+}
+
 /// The telescope animation duration, in milliseconds — each tile's
 /// `max-width` transition (wireframe `--dur: .4s`).
 pub const TELESCOPE_MS: u64 = 400;
@@ -524,6 +538,35 @@ mod dock {
     fn an_unknown_symbol_has_no_dock() {
         assert_eq!(Dock::from_symbol("tonk:middle"), None);
         assert_eq!(Dock::from_symbol(""), None);
+    }
+}
+
+#[cfg(test)]
+mod pager {
+    use super::*;
+
+    #[test]
+    fn a_mid_strip_tap_advances_one_page_width() {
+        assert_eq!(strip_page_target(0.0, 300.0, 800.0), 300.0);
+    }
+
+    #[test]
+    fn the_last_advance_clamps_to_the_end() {
+        // 800 - 300 = 500 is the max offset; 300 + 300 = 600 overshoots it.
+        assert_eq!(strip_page_target(300.0, 300.0, 800.0), 500.0);
+    }
+
+    #[test]
+    fn a_tap_at_the_end_wraps_to_the_start() {
+        assert_eq!(strip_page_target(500.0, 300.0, 800.0), 0.0);
+        // Fractional resting positions a couple px shy of the end wrap too.
+        assert_eq!(strip_page_target(498.5, 300.0, 800.0), 0.0);
+    }
+
+    #[test]
+    fn a_strip_with_nothing_to_scroll_stays_at_the_start() {
+        assert_eq!(strip_page_target(0.0, 300.0, 300.0), 0.0);
+        assert_eq!(strip_page_target(0.0, 300.0, 250.0), 0.0);
     }
 }
 

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -124,7 +124,7 @@ pub fn fab_html(space_did: &str) -> String {
   </div>
   <div class="fab__tele fab__tele--end">
     <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
-    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="More controls" aria-haspopup="true" aria-expanded="false"><wa-icon name="chevron-right"></wa-icon></button>
+    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="Show more controls"><wa-icon name="chevron-right"></wa-icon></button>
   </div>
 </div>
 <wa-dialog id="fab-space-create" label="New spot" class="fab__dialog" style="--width: 40rem">

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -36,7 +36,10 @@
 //! this module owns the whole subtree, both are authored directly: the
 //! `.fab__scrim` div is a literal sibling of `.fab`, and every collapsible
 //! segment is already inside its own `.fab__tele` wrapper with the resting
-//! `fab--anim fab--settled` classes stamped on `.fab` itself.
+//! `fab--anim fab--settled` classes stamped on `.fab` itself. The tele tiles
+//! are further grouped into `.fab__strip` > `.fab__page` pages (repo alone,
+//! then share + account) for the compact scroll-snap pager — `display:
+//! contents` on wide viewports, so that grouping renders no boxes there.
 //!
 //! ## The wizard's `onsubmit` cannot fire yet
 //!
@@ -77,44 +80,51 @@ pub fn fab_html(space_did: &str) -> String {
         r#"<div class="fab__scrim"></div>
 <div class="fab fab--anim fab--settled">
   <span class="fab__seg fab__cap-l fab__circle"><ui-sync-status with="main@{space}" onpause="tonk:pause-sync"></ui-sync-status></span>
-  <div class="fab__tele">
-    <span class="fab__seg fab__account">
-      <span class="fab__name"><ui-profile-name></ui-profile-name></span>
-    </span>
+  <div class="fab__strip">
+    <div class="fab__page fab__page--main">
+      <div class="fab__tele fab__tele--repo">
+        <span class="fab__seg fab__repo">
+          <span class="fab__space"><ui-space-name space="{space}"></ui-space-name></span>
+          <ui-dropdown class="fab__menu" exclude="{space}">
+            <ui-space-switcher exclude="{space}"></ui-space-switcher>
+          </ui-dropdown>
+        </span>
+      </div>
+    </div>
+    <div class="fab__page fab__page--more">
+      <div class="fab__tele fab__tele--share">
+        <span class="fab__seg fab__share">
+          <tonk-share space="{space}">
+            <form class="fab__share-form">
+              <button type="submit" class="fab__share-trigger">
+                <span class="fab__share-label fab__share-label--idle">share</span>
+                <span class="fab__share-label fab__share-label--copying">
+                  <span class="fab__share-spinner"></span>copying…
+                </span>
+                <span class="fab__share-label fab__share-label--copied">
+                  <wa-icon name="check"></wa-icon>copied
+                </span>
+                <span class="fab__share-label fab__share-label--failed">
+                  <wa-icon name="triangle-exclamation"></wa-icon>failed
+                </span>
+              </button>
+            </form>
+          </tonk-share>
+          <nav class="fab__menu fab__share-menu">
+            <ui-member-roster space="{space}"></ui-member-roster>
+          </nav>
+        </span>
+      </div>
+      <div class="fab__tele fab__tele--account">
+        <span class="fab__seg fab__account">
+          <span class="fab__name"><ui-profile-name></ui-profile-name></span>
+        </span>
+      </div>
+    </div>
   </div>
-  <div class="fab__tele">
-    <span class="fab__seg fab__repo">
-      <span class="fab__space"><ui-space-name space="{space}"></ui-space-name></span>
-      <ui-dropdown class="fab__menu" exclude="{space}">
-        <ui-space-switcher exclude="{space}"></ui-space-switcher>
-      </ui-dropdown>
-    </span>
-  </div>
-  <div class="fab__tele">
-    <span class="fab__seg fab__share">
-      <tonk-share space="{space}">
-        <form class="fab__share-form">
-          <button type="submit" class="fab__share-trigger">
-            <span class="fab__share-label fab__share-label--idle">share</span>
-            <span class="fab__share-label fab__share-label--copying">
-              <span class="fab__share-spinner"></span>copying…
-            </span>
-            <span class="fab__share-label fab__share-label--copied">
-              <wa-icon name="check"></wa-icon>copied
-            </span>
-            <span class="fab__share-label fab__share-label--failed">
-              <wa-icon name="triangle-exclamation"></wa-icon>failed
-            </span>
-          </button>
-        </form>
-      </tonk-share>
-      <nav class="fab__menu fab__share-menu">
-        <ui-member-roster space="{space}"></ui-member-roster>
-      </nav>
-    </span>
-  </div>
-  <div class="fab__tele">
+  <div class="fab__tele fab__tele--end">
     <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
+    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="More controls"><wa-icon name="chevron-right"></wa-icon></button>
   </div>
 </div>
 <wa-dialog id="fab-space-create" label="New spot" class="fab__dialog" style="--width: 40rem">
@@ -231,6 +241,48 @@ mod tests {
         assert!(!html.contains("tonk:profile/name"));
         assert!(!html.contains("tonk:view/fab-invite"));
         assert!(!html.contains(r#"model="tonk:repository""#));
+    }
+
+    #[test]
+    fn it_groups_the_tiles_into_compact_pages() {
+        let html = fab_html("did:key:z6Mk");
+        // Page 1 holds the space name + switcher; page 2 share then account.
+        // The strip and pages are `display: contents` on wide viewports, so
+        // this grouping is invisible there; compact mode makes them the
+        // scroll-snap pager.
+        let strip = html.find("fab__strip").expect("strip present");
+        let main = html.find("fab__page--main").expect("main page present");
+        let more = html.find("fab__page--more").expect("more page present");
+        let repo = html.find("fab__tele--repo").expect("repo tile present");
+        let share = html.find("fab__tele--share").expect("share tile present");
+        let account = html
+            .find("fab__tele--account")
+            .expect("account tile present");
+        assert!(
+            strip < main && main < more,
+            "strip wraps the pages in order"
+        );
+        assert!(
+            main < repo && repo < more,
+            "the repo tile is page 1's content"
+        );
+        assert!(
+            more < share && share < account,
+            "page 2 is share, then account"
+        );
+    }
+
+    #[test]
+    fn it_authors_the_chevron_beside_the_end_nub() {
+        let html = fab_html("did:key:z6Mk");
+        // Both live in the end tile, OUTSIDE the strip: the chevron is a
+        // fixed right cap (like the circle on the left), never scrolled away
+        // with the pages. CSS shows exactly one of the pair per mode.
+        let end_tile = html.find("fab__tele--end").expect("end tile present");
+        let nub = html.find("fab__end").expect("nub present");
+        let more = html.find("fab__more").expect("chevron present");
+        assert!(end_tile < nub && end_tile < more);
+        assert!(html.contains(r#"<button type="button" class="fab__seg fab__cap-r fab__more""#));
     }
 
     #[test]

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -124,7 +124,7 @@ pub fn fab_html(space_did: &str) -> String {
   </div>
   <div class="fab__tele fab__tele--end">
     <span class="fab__seg fab__cap-r fab__end" aria-hidden="true"></span>
-    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="More controls"><wa-icon name="chevron-right"></wa-icon></button>
+    <button type="button" class="fab__seg fab__cap-r fab__more" aria-label="More controls" aria-haspopup="true" aria-expanded="false"><wa-icon name="chevron-right"></wa-icon></button>
   </div>
 </div>
 <wa-dialog id="fab-space-create" label="New spot" class="fab__dialog" style="--width: 40rem">

--- a/rust/tonk-fab/tests/fab_stylesheet.rs
+++ b/rust/tonk-fab/tests/fab_stylesheet.rs
@@ -81,3 +81,52 @@ async fn it_injects_the_stylesheet_exactly_once_across_multiple_mounts() {
     second.remove();
     first.remove();
 }
+
+/// The chevron cap is a compact-only control, but it carries `fab__seg`
+/// alongside `fab__more` — and `.fab__seg { display: inline-flex }` sits
+/// LATER in the stylesheet than a bare `.fab__more { display: none }`, so a
+/// same-specificity hide rule loses the tie and the chevron leaks into the
+/// wide bar (where clicking it opens the vertical menu on desktop). This
+/// pins the COMPUTED style with the real injected stylesheet, in both modes
+/// — exactly what the class-toggle unit tests cannot see.
+#[dialog_common::test]
+async fn it_hides_the_chevron_cap_outside_compact_mode() {
+    let host = mount();
+    let more = host
+        .query_selector(".fab__more")
+        .expect("query")
+        .expect("chevron authored");
+    let display = |el: &web_sys::Element| {
+        window()
+            .expect("window")
+            .get_computed_style(el)
+            .expect("computed style")
+            .expect("style declaration")
+            .get_property_value("display")
+            .expect("display value")
+    };
+
+    assert_eq!(
+        display(&more),
+        "none",
+        "the wide bar must not render the compact chevron cap"
+    );
+
+    let fab = host
+        .query_selector(".fab")
+        .expect("query")
+        .expect("bar authored");
+    fab.class_list()
+        .add_1("fab--compact")
+        .expect("enter compact");
+    // Not a literal `inline-flex` check: the chevron is a flex ITEM (its
+    // tile is `display: flex`), so browsers blockify the computed value to
+    // plain `flex`. What matters is that compact mode shows it at all.
+    assert_ne!(
+        display(&more),
+        "none",
+        "compact mode must show the chevron cap"
+    );
+
+    host.remove();
+}

--- a/rust/tonk-fab/tests/fab_stylesheet.rs
+++ b/rust/tonk-fab/tests/fab_stylesheet.rs
@@ -86,9 +86,9 @@ async fn it_injects_the_stylesheet_exactly_once_across_multiple_mounts() {
 /// alongside `fab__more` — and `.fab__seg { display: inline-flex }` sits
 /// LATER in the stylesheet than a bare `.fab__more { display: none }`, so a
 /// same-specificity hide rule loses the tie and the chevron leaks into the
-/// wide bar (where clicking it opens the vertical menu on desktop). This
-/// pins the COMPUTED style with the real injected stylesheet, in both modes
-/// — exactly what the class-toggle unit tests cannot see.
+/// wide bar as a clickable stray control. This pins the COMPUTED style with
+/// the real injected stylesheet, in both modes — exactly what the
+/// class-toggle unit tests cannot see.
 #[dialog_common::test]
 async fn it_hides_the_chevron_cap_outside_compact_mode() {
     let host = mount();

--- a/rust/tonk-fab/tests/fab_stylesheet.rs
+++ b/rust/tonk-fab/tests/fab_stylesheet.rs
@@ -119,6 +119,32 @@ async fn it_hides_the_chevron_cap_outside_compact_mode() {
     fab.class_list()
         .add_1("fab--compact")
         .expect("enter compact");
+    // Collapsed-compact retracts the chevron with the strip: the end tile
+    // clamps to zero width (a transitionable clamp, not display:none). This
+    // is the "button hides when the fab is collapsed" contract.
+    // `fab--settled` comes off with the collapse — its unclamp rule
+    // (`max-width: none` on shown tiles) outranks the collapse clamp, and
+    // set_telescope enforces the exclusivity (pinned by the element test
+    // `it_collapses_the_compact_bar_with_a_dropdown_open`).
+    fab.class_list().remove_1("fab--settled").expect("unsettle");
+    fab.class_list().add_1("fab--collapsed").expect("collapse");
+    let end_tile = host
+        .query_selector(".fab__tele--end")
+        .expect("query")
+        .expect("end tile authored");
+    assert_eq!(
+        window()
+            .expect("window")
+            .get_computed_style(&end_tile)
+            .expect("computed style")
+            .expect("style declaration")
+            .get_property_value("max-width")
+            .expect("max-width value"),
+        "0px",
+        "collapsing the compact bar must clamp the chevron's tile away"
+    );
+    fab.class_list().remove_1("fab--collapsed").expect("expand");
+    fab.class_list().add_1("fab--settled").expect("resettle");
     // Not a literal `inline-flex` check: the chevron is a flex ITEM (its
     // tile is `display: flex`), so browsers blockify the computed value to
     // plain `flex`. What matters is that compact mode shows it at all.


### PR DESCRIPTION
The FAB was desktop-only: on small viewports the fixed-width bar overflowed the screen (unreachable segments), and touch dragging lost the race against the browser's own gestures. This PR makes the pill adapt by measurement and repairs touch interaction end to end.

Spec: `docs/superpowers/specs/2026-07-17-fab-compact-pill-design.md` (revised after on-device testing; plan in `docs/superpowers/plans/`).

## Compact mode (measured, not device-sniffed)

- `fab--compact` activates when the fully expanded bar plus the 16px dock insets would not fit the viewport — evaluated on connect, resize, telescope settle, bar-content mutations (names arrive async from subscriptions), and `fonts.ready`. The threshold uses the would-be expanded width in both directions, so it cannot flap.
- The segments move into a horizontal scroll-snap strip grouped into pages (page 1: space name + switcher; page 2: share + profile), with a peek of the next page. Swiping is native scroll; `touch-action: pan-x` + `overscroll-behavior: contain` on the bar keep the gesture horizontal-only.
- The end nub swaps for an 18px chevron pager: tap advances one page, wrapping at the end — the glyph flips to point back when the next tap wraps (`strip_at_end`/`strip_page_target`, natively tested). It retracts with the strip when the pill collapses to the circle.
- Dropdowns float over the bar in compact (`position: fixed` escapes the strip's overflow clip via the bar's drop-shadow filter containing block), bar-width.
- Wide viewports render pixel-identically: the strip/page wrappers are `display: contents` and flex `order` restores the visual order.

## Touch drag

- `touch-action: none` on the circle cap plus immediate pointer capture (on the cap, so tap-to-toggle still routes) for touch pointers; 8px touch threshold; invisible >=44px coarse-pointer hit areas on both caps.
- Drag position clamps to the viewport in every mode.

## Notable bugs found on device (each pinned by a test)

- The compact collapse never dropped `fab--settled`, whose unclamp rule out-specifies the collapse clamp — the collapsed pill kept its arrow (computed-style test with the real stylesheet).
- A bare `.fab__more { display: none }` lost a specificity tie to `.fab__seg` by source order, leaking the chevron into the desktop bar.
- The menu/rung equalizer's inline `min-width` stamps froze compact segments at wide-column widths (neutralized with `!important`; the stamps survive for the return to wide).
- Phones sat in wide mode measuring the empty bar before names streamed in (fixed by the mutation/fonts re-measure above).

An earlier iteration shipped a chevron-opened vertical menu; it was cut after device testing in favour of the pager (see the spec's revision notes).

## Testing

- Native: 75/75 (`cargo test -p tonk-fab`) — dock/telescope/pager/clamp geometry all pure functions in `logic.rs`.
- Wasm: 39/39 ran in real browsers locally (safaridriver and chromedriver routes), including gesture-path tests via dispatched bubbling clicks and computed-style pins against the injected stylesheet.
- Workspace gate: `cargo clippy --workspace --all-targets --all-features` + `cargo fmt --check` clean.
- On-device (iPhone via tunnel): drag, swipe, paging, collapse verified through two feedback rounds.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk-fab` component by implementing a compact mode for smaller screens, improving touch dragging, and ensuring viewport clamping during interactions. It introduces new geometry functions and modifies the layout structure for better usability.

### Detailed summary
- Added `DOCK_INSET_PX`, `is_compact`, and `clamp_position` functions in `logic.rs`.
- Restructured the markup in `markup.rs` to include `.fab__strip` and `.fab__page` for compact mode.
- Implemented compact mode styling in `fab.css`.
- Enhanced drag functionality in `element.rs`, including viewport clamping.
- Added tests for compact mode functionality and geometry calculations.

> The following files were skipped due to too many changes: `docs/superpowers/plans/2026-07-17-fab-compact-pill.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->