### PR TITLE
feat(cli): canonical spot dir

### DIFF
--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -1,7 +1,7 @@
 # tonk CLI — Agent Reference
 
-tonk is a headless CLI for reading and writing data and views in a local
-`.tonk/` site (a dialog repository). Data lives as claims: you **assert**
+tonk is a headless CLI for reading and writing data and views in a spot
+(a named local dialog repository). Data lives as claims: you **assert**
 claims and **retract** them — a retraction is itself an assertion that
 invalidates an old claim, not a deletion.
 

--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -5,7 +5,10 @@ tonk is a headless CLI for reading and writing data and views in a local
 claims and **retract** them — a retraction is itself an assertion that
 invalidates an old claim, not a deletion.
 
-Run commands from a directory at or below the one containing `.tonk/`.
+Commands run from anywhere, against whichever spot is selected —
+resolution is `--spot` > `TONK_SPOT` > `tonk use`. Automation (agents,
+CI) should set `TONK_SPOT` or pass `--spot` rather than relying on the
+global `tonk use` selection.
 
 ## Orientation
 
@@ -80,7 +83,7 @@ tonk push | tonk pull                       # sync main with its upstream
 tonk remote add <name> <url>                # register a remote; the first one becomes main's upstream
 tonk remote set-upstream <name>             # re-point which remote main tracks
 tonk invite [--remote <name>]               # mint a paste-able invite URL (pushes first)
-tonk join '<invite-url>'                    # claim an invite into a fresh .tonk/
+tonk join '<invite-url>' --name <spot>      # claim an invite into a fresh spot
 tonk share concept <name>                   # launcher URL onto a live concept view
 tonk share display <subject> --view <name>  # launcher URL onto a <tonk-display> render
 tonk render <route>                         # headless HTML render (e.g. alice@person!card)
@@ -89,7 +92,10 @@ tonk render <route>                         # headless HTML render (e.g. alice@p
 ## Setup
 
 ```bash
-tonk init            # create .tonk/ in the current directory
-tonk identity        # show the local profile DID
-tonk migrate         # convert a .carry/ site to .tonk/
+tonk spot new <name>              # create a spot (site) and select it
+tonk spot new <name> --site <path>  # adopt an existing .tonk directory as a spot
+tonk spot list                    # registered spots, with the resolved current
+tonk use <name>                   # set the global current spot
+tonk identity                     # show the local profile DID
+tonk migrate                      # convert a .carry/ site to .tonk/
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "bs58",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dialog-capability",
  "dialog-common",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tonk Labs"]
 license = "MIT"
 edition = "2024"

--- a/docs/superpowers/plans/2026-07-20-cli-canonical-spots.md
+++ b/docs/superpowers/plans/2026-07-20-cli-canonical-spots.md
@@ -1,0 +1,1558 @@
+# CLI Canonical Spots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace cwd-based `.tonk/` discovery with a platform-canonical spot store plus a name registry, so `tonk` works from anywhere against a selected spot.
+
+**Architecture:** A new `spot` module owns a JSON registry (`spots.json`, name → site path + `current` selection) under `dirs::data_dir()/tonk/`. Every data command resolves `--spot` > `TONK_SPOT` > registry `current` and opens the site at the registered path; `discover_and_open` is deleted. New commands `tonk use` and `tonk spot new|list|rm` manage the registry; `tonk join` lands in a canonical site; `tonk init` is removed. Spec: `docs/superpowers/specs/2026-07-20-cli-canonical-spots-design.md`.
+
+**Tech Stack:** Rust (tonk-cli crate), clap, serde_json, dirs, tempfile-based tests.
+
+## Global Constraints
+
+- Work on branch `feat/cli-canonical-dir` in `/Users/jackdouglas/tonk/tonk/.wt/cli`. All paths below are relative to `rust/tonk-cli/` unless they start with `docs/` or `rust/`.
+- Lint gate (matches CI): `cargo clippy --all-targets --all-features -- -D warnings` natively, plus `cargo fmt --check`.
+- Tests use `#[dialog_common::test]` for async, plain `#[test]` for pure sync logic; names are `it_does_x`, grouped in behaviour modules.
+- No `mod.rs`. New integration test files need a `[[test]]` entry in `Cargo.toml` (`autotests = false`).
+- Commit messages: Conventional Commits, imperative, lowercase, no trailing period, no emojis. End the body with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Doc comments are load-bearing in this repo: every new pub item gets one in the style of the neighboring code. The doc comments in the code blocks below are part of the deliverable.
+- Vocabulary: a **spot** is the named registry entry; a **site** is the physical directory backing it. Never say "workspace" (collides with the tonk-ui tab surface).
+- Registry semantics (from the spec): absolute expanded paths in `spots.json`; atomic temp-file + rename writes; corrupt registry is a hard error naming the file, never silently recreated; spot names match `[a-z0-9][a-z0-9-_]*`.
+
+---
+
+### Task 1: `spot` module — store, registry, resolution
+
+**Files:**
+- Create: `src/spot.rs`
+- Modify: `src/lib.rs` (add `pub mod spot;` to the module list and a one-line entry in the crate doc's module inventory, alongside the `site` entry)
+
+**Interfaces:**
+- Produces: `spot::SpotStore` (`open()`, `at(dir)`, `registry_path()`, `canonical_site(name)`, `load()`, `save(&Registry)`, `resolve(flag, env)`), `spot::Registry { current, spots }`, `spot::SpotEntry { site }`, `spot::Resolved { name, site, source }`, `spot::Source` (Display: `flag`/`env`/`global`), `spot::SpotError`, `spot::validate_name(&str)`, consts `spot::SPOT_ENV = "TONK_SPOT"`, `spot::STATE_ENV = "TONK_SPOTS_STATE"`. Tasks 3–5 consume all of these.
+
+- [ ] **Step 1: Write `src/spot.rs` with failing-to-compile consumers in mind — module plus unit tests in one pass**
+
+```rust
+//! Spot registry: named spots, canonical storage, selection.
+//!
+//! A *spot* is a named entry in `spots.json` mapping to the *site*
+//! directory that backs it (see [`crate::site`]). The registry and
+//! the canonical site directories live under the platform data dir
+//! (`~/Library/Application Support/tonk/` on macOS), next to
+//! `telemetry.json` / `update.json`:
+//!
+//! ```text
+//! tonk/
+//!   spots.json      registry: name → site path, plus `current`
+//!   spots/<name>/   canonical site dirs
+//! ```
+//!
+//! Selection resolves `--spot` > `TONK_SPOT` > the registry's
+//! `current`. The flag and env forms are per-invocation /
+//! per-process, so concurrent sessions pinning their own spot can
+//! never mix regardless of who rewrites the shared `current`.
+//!
+//! `spots.json` stores absolute, expanded paths so applications
+//! built on tonk can resolve a name with zero path logic. Writes
+//! go through a temp file + atomic rename. A corrupt registry is a
+//! hard error naming the file — never silently recreated.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Environment variable naming the spot to use, beaten only by the
+/// `--spot` flag. Automation (agents, bench, CI) should always set
+/// this (or pass `--spot`) and never rely on `tonk use`.
+pub const SPOT_ENV: &str = "TONK_SPOT";
+
+/// Environment variable overriding the directory that holds
+/// `spots.json` and the canonical `spots/` root, so tests can
+/// isolate state (same pattern as `TONK_TELEMETRY_STATE`).
+pub const STATE_ENV: &str = "TONK_SPOTS_STATE";
+
+/// File name of the registry inside the store directory.
+const REGISTRY_FILE: &str = "spots.json";
+
+/// Directory name (inside the store) holding canonical site dirs.
+const SPOTS_DIRNAME: &str = "spots";
+
+/// On-disk registry: the shared `current` selection plus one entry
+/// per spot. `BTreeMap` keeps listing and serialization order
+/// stable.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Registry {
+    /// The globally selected spot, if any. A convenience for the
+    /// human at the keyboard; concurrent sessions pin their spot
+    /// via [`SPOT_ENV`] or `--spot` instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<String>,
+    /// Name → entry. Paths inside are absolute and expanded.
+    #[serde(default)]
+    pub spots: BTreeMap<String, SpotEntry>,
+}
+
+/// One registered spot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpotEntry {
+    /// Absolute path to the site directory backing this spot.
+    pub site: PathBuf,
+}
+
+/// Where a resolution's spot name came from. Surfaced in status
+/// and error output so a session can always tell what it is about
+/// to touch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `--spot` flag.
+    Flag,
+    /// [`SPOT_ENV`] environment variable.
+    Env,
+    /// The registry's `current` field.
+    Global,
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Source::Flag => "flag",
+            Source::Env => "env",
+            Source::Global => "global",
+        })
+    }
+}
+
+/// A successful resolution: which spot, where its site lives, and
+/// which selection mechanism picked it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Resolved {
+    /// The spot's registry name.
+    pub name: String,
+    /// Absolute path to the site directory.
+    pub site: PathBuf,
+    /// Which selection mechanism named it.
+    pub source: Source,
+}
+
+/// Failure modes for registry access and resolution.
+#[derive(Debug, Error)]
+pub enum SpotError {
+    /// Spots exist but nothing is selected anywhere.
+    #[error("no spot selected; run `tonk use <name>`, pass --spot, or set TONK_SPOT")]
+    NoSelection,
+    /// The registry has zero spots — selection is moot; the fix is
+    /// creating one.
+    #[error("no spots registered; create one with `tonk spot new <name>`")]
+    NothingRegistered,
+    /// A name that isn't in the registry.
+    #[error("unknown spot '{name}'{}", unknown_hint(.available))]
+    Unknown {
+        /// The name that failed to resolve.
+        name: String,
+        /// Every registered name, for the error hint.
+        available: Vec<String>,
+    },
+    /// `spot new` against a name that already exists. Re-pointing
+    /// is an explicit `rm` + `new`, never an overwrite.
+    #[error("spot '{0}' already exists; run `tonk spot rm {0}` first to re-point it")]
+    Exists(String),
+    /// The registry file exists but doesn't parse. Deliberately
+    /// not self-healing: silently recreating it would orphan every
+    /// registered spot.
+    #[error("corrupt spot registry at {path}: {detail}")]
+    Corrupt {
+        /// Path to the offending `spots.json`.
+        path: PathBuf,
+        /// The serde error text.
+        detail: String,
+    },
+    /// A name outside the allowed slug. Canonical names become
+    /// directory names, so the alphabet is conservative.
+    #[error("invalid spot name '{0}': use [a-z0-9][a-z0-9-_]*")]
+    InvalidName(String),
+    /// The platform reports no data directory (no home).
+    #[error("could not determine the platform data directory")]
+    NoDataDir,
+    /// Site bootstrap (`spot new`) failed inside the site layer.
+    #[error("failed to initialize site: {0}")]
+    Init(String),
+    /// Registry or site-directory I/O.
+    #[error("{0}")]
+    Io(String),
+}
+
+/// Hint suffix for [`SpotError::Unknown`]: list what is
+/// registered, or point at `spot new` when nothing is.
+fn unknown_hint(available: &[String]) -> String {
+    if available.is_empty() {
+        "; none registered (create one with `tonk spot new <name>`)".to_string()
+    } else {
+        format!("; registered: {}", available.join(", "))
+    }
+}
+
+/// Handle on the spot state directory. All registry reads and
+/// writes go through one of these; tests construct it with
+/// [`SpotStore::at`] over a tempdir so nothing touches the user's
+/// real data dir and no test ever mutates process-global env.
+#[derive(Debug, Clone)]
+pub struct SpotStore {
+    dir: PathBuf,
+}
+
+impl SpotStore {
+    /// The real store: [`STATE_ENV`] override, else the platform
+    /// data dir (`dirs::data_dir()/tonk`, the same base telemetry
+    /// and update state use).
+    pub fn open() -> Result<Self, SpotError> {
+        if let Ok(dir) = std::env::var(STATE_ENV)
+            && !dir.is_empty()
+        {
+            return Ok(Self { dir: dir.into() });
+        }
+        let base = dirs::data_dir().ok_or(SpotError::NoDataDir)?;
+        Ok(Self {
+            dir: base.join("tonk"),
+        })
+    }
+
+    /// A store rooted at an explicit directory (tests).
+    pub fn at(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Path to `spots.json` inside this store.
+    pub fn registry_path(&self) -> PathBuf {
+        self.dir.join(REGISTRY_FILE)
+    }
+
+    /// Canonical site directory for `name` inside this store.
+    /// Purely a path computation — nothing is created.
+    pub fn canonical_site(&self, name: &str) -> PathBuf {
+        self.dir.join(SPOTS_DIRNAME).join(name)
+    }
+
+    /// Load the registry. A missing file is an empty registry (the
+    /// pre-first-use state); an unparseable one is
+    /// [`SpotError::Corrupt`].
+    pub fn load(&self) -> Result<Registry, SpotError> {
+        let path = self.registry_path();
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Registry::default());
+            }
+            Err(e) => {
+                return Err(SpotError::Io(format!(
+                    "could not read {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        serde_json::from_str(&text).map_err(|e| SpotError::Corrupt {
+            path,
+            detail: e.to_string(),
+        })
+    }
+
+    /// Persist the registry atomically: write a sibling temp file,
+    /// then rename over `spots.json` so concurrent readers never
+    /// observe a torn write.
+    pub fn save(&self, registry: &Registry) -> Result<(), SpotError> {
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| SpotError::Io(format!("could not create {}: {e}", self.dir.display())))?;
+        let path = self.registry_path();
+        let tmp = self.dir.join(format!("{REGISTRY_FILE}.tmp"));
+        let text = serde_json::to_string_pretty(registry)
+            .map_err(|e| SpotError::Io(format!("could not serialize registry: {e}")))?;
+        std::fs::write(&tmp, text)
+            .map_err(|e| SpotError::Io(format!("could not write {}: {e}", tmp.display())))?;
+        std::fs::rename(&tmp, &path).map_err(|e| {
+            SpotError::Io(format!(
+                "could not move {} into place: {e}",
+                tmp.display()
+            ))
+        })
+    }
+
+    /// Resolve the spot a command should operate on.
+    ///
+    /// Strict precedence: `flag` (`--spot`) > `env` ([`SPOT_ENV`],
+    /// already read and empty-filtered by the caller) > the
+    /// registry's `current`. The cwd is never consulted.
+    pub fn resolve(&self, flag: Option<&str>, env: Option<&str>) -> Result<Resolved, SpotError> {
+        let registry = self.load()?;
+        let (name, source) = if let Some(name) = flag {
+            (name.to_owned(), Source::Flag)
+        } else if let Some(name) = env {
+            (name.to_owned(), Source::Env)
+        } else if let Some(name) = registry.current.clone() {
+            (name, Source::Global)
+        } else if registry.spots.is_empty() {
+            return Err(SpotError::NothingRegistered);
+        } else {
+            return Err(SpotError::NoSelection);
+        };
+        match registry.spots.get(&name) {
+            Some(entry) => Ok(Resolved {
+                name,
+                site: entry.site.clone(),
+                source,
+            }),
+            None => Err(SpotError::Unknown {
+                name,
+                available: registry.spots.keys().cloned().collect(),
+            }),
+        }
+    }
+}
+
+/// Validate a spot name against the canonical slug:
+/// `[a-z0-9][a-z0-9-_]*`. Names become directory names under
+/// `spots/`, so the alphabet stays conservative.
+pub fn validate_name(name: &str) -> Result<(), SpotError> {
+    let mut chars = name.chars();
+    let head_ok = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    let tail_ok = chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_');
+    if head_ok && tail_ok {
+        Ok(())
+    } else {
+        Err(SpotError::InvalidName(name.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, SpotStore) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = SpotStore::at(tmp.path());
+        (tmp, store)
+    }
+
+    fn registry_with(names: &[(&str, &str)], current: Option<&str>) -> Registry {
+        Registry {
+            current: current.map(str::to_owned),
+            spots: names
+                .iter()
+                .map(|(name, site)| {
+                    (
+                        (*name).to_owned(),
+                        SpotEntry {
+                            site: PathBuf::from(site),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    mod loading_and_saving {
+        use super::*;
+
+        #[test]
+        fn it_treats_a_missing_registry_as_empty() {
+            let (_tmp, store) = store();
+            let registry = store.load().expect("load");
+            assert_eq!(registry, Registry::default());
+        }
+
+        #[test]
+        fn it_round_trips_the_registry() {
+            let (_tmp, store) = store();
+            let registry = registry_with(&[("garden", "/tmp/garden")], Some("garden"));
+            store.save(&registry).expect("save");
+            assert_eq!(store.load().expect("load"), registry);
+        }
+
+        #[test]
+        fn it_errors_on_a_corrupt_registry_instead_of_recreating() {
+            let (_tmp, store) = store();
+            std::fs::create_dir_all(store.registry_path().parent().unwrap()).unwrap();
+            std::fs::write(store.registry_path(), "not json").unwrap();
+            let err = store.load().expect_err("corrupt must not load");
+            assert!(matches!(err, SpotError::Corrupt { .. }), "{err}");
+            // Still corrupt afterwards — load must not have healed it.
+            assert_eq!(
+                std::fs::read_to_string(store.registry_path()).unwrap(),
+                "not json"
+            );
+        }
+
+        #[test]
+        fn it_leaves_no_temp_file_behind_after_save() {
+            let (_tmp, store) = store();
+            store.save(&Registry::default()).expect("save");
+            let leftovers: Vec<_> = std::fs::read_dir(store.registry_path().parent().unwrap())
+                .unwrap()
+                .map(|e| e.unwrap().file_name())
+                .filter(|n| n.to_string_lossy().ends_with(".tmp"))
+                .collect();
+            assert!(leftovers.is_empty(), "{leftovers:?}");
+        }
+    }
+
+    mod resolving {
+        use super::*;
+
+        #[test]
+        fn it_prefers_flag_over_env_over_global() {
+            let (_tmp, store) = store();
+            let registry = registry_with(
+                &[("a", "/s/a"), ("b", "/s/b"), ("c", "/s/c")],
+                Some("c"),
+            );
+            store.save(&registry).expect("save");
+
+            let flag = store.resolve(Some("a"), Some("b")).expect("flag");
+            assert_eq!((flag.name.as_str(), flag.source), ("a", Source::Flag));
+
+            let env = store.resolve(None, Some("b")).expect("env");
+            assert_eq!((env.name.as_str(), env.source), ("b", Source::Env));
+
+            let global = store.resolve(None, None).expect("global");
+            assert_eq!((global.name.as_str(), global.source), ("c", Source::Global));
+            assert_eq!(global.site, PathBuf::from("/s/c"));
+        }
+
+        #[test]
+        fn it_errors_when_nothing_is_selected() {
+            let (_tmp, store) = store();
+            store
+                .save(&registry_with(&[("a", "/s/a")], None))
+                .expect("save");
+            let err = store.resolve(None, None).expect_err("no selection");
+            assert!(matches!(err, SpotError::NoSelection), "{err}");
+        }
+
+        #[test]
+        fn it_hints_spot_new_when_the_registry_is_empty() {
+            let (_tmp, store) = store();
+            let err = store.resolve(None, None).expect_err("empty");
+            assert!(matches!(err, SpotError::NothingRegistered), "{err}");
+            assert!(err.to_string().contains("tonk spot new"), "{err}");
+        }
+
+        #[test]
+        fn it_errors_on_an_unknown_name_listing_available() {
+            let (_tmp, store) = store();
+            store
+                .save(&registry_with(&[("a", "/s/a")], None))
+                .expect("save");
+            let err = store.resolve(Some("nope"), None).expect_err("unknown");
+            assert!(err.to_string().contains("registered: a"), "{err}");
+        }
+    }
+
+    mod naming {
+        use super::*;
+
+        #[test]
+        fn it_accepts_conservative_slugs() {
+            for name in ["a", "garden", "work-2", "a_b", "0day"] {
+                assert!(validate_name(name).is_ok(), "{name}");
+            }
+        }
+
+        #[test]
+        fn it_rejects_everything_else() {
+            for name in ["", "Garden", "-lead", "_lead", "sp ace", "dot.", "sl/ash", "über"] {
+                assert!(validate_name(name).is_err(), "{name}");
+            }
+        }
+    }
+}
+```
+
+In `src/lib.rs`, add `pub mod spot;` in alphabetical position among the existing `pub mod` declarations, and add one line to the crate-doc module inventory near the `site` line:
+
+```rust
+//! - [`spot`] — spot registry: named spots, canonical storage, selection.
+```
+
+- [ ] **Step 2: Run the module tests, expect all green**
+
+Run: `cargo test -p tonk-cli --lib spot::`
+Expected: all `it_*` tests PASS (10 tests).
+
+- [ ] **Step 3: Lint**
+
+Run: `cargo clippy -p tonk-cli --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean. (Full `--all-features` gate runs in Task 7.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-cli/src/spot.rs rust/tonk-cli/src/lib.rs
+git commit -m "feat(tonk-cli): spot registry store and resolution"
+```
+
+---
+
+### Task 2: `TonkSite::init_at_with` — root-directly site init
+
+**Files:**
+- Modify: `src/site.rs` (around `init_with`, line ~136)
+- Test: `tests/site.rs` (new behaviour module at the end)
+
+**Interfaces:**
+- Consumes: existing `TonkSite::init_with(parent, config)` body.
+- Produces: `TonkSite::init_at_with(root: &Path, config: SiteConfig) -> Result<Self>` — treats `root` itself as the site directory (creates it, no `.tonk` nesting). Tasks 4 and 5 call this. `init_with` keeps its parent+`.tonk` semantics for existing tests by delegating.
+
+- [ ] **Step 1: Write the failing test**
+
+At the end of `tests/site.rs`:
+
+```rust
+mod when_initializing_at_an_explicit_root {
+    use anyhow::Result;
+    use tonk_cli::site::TonkSite;
+
+    use crate::common;
+
+    /// Canonical spots put repo blocks directly in the registered
+    /// site directory — no `.tonk/` nesting. `init_at_with` must
+    /// root the site at exactly the path it is given.
+    #[dialog_common::test]
+    async fn it_roots_the_site_at_the_given_directory() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let parent = tmp.path().canonicalize()?;
+        let config = common::isolated_config(&parent)?;
+        let root = parent.join("spots").join("garden");
+
+        let site = TonkSite::init_at_with(&root, config.clone()).await?;
+        assert_eq!(site.root, root.canonicalize()?);
+        assert!(!root.join(".tonk").exists(), "no nested .tonk");
+
+        // Idempotent: a second init at the same root adopts the
+        // existing repo instead of erroring or re-seeding.
+        let reopened = TonkSite::init_at_with(&root, config.clone()).await?;
+        assert_eq!(reopened.repository.did(), site.repository.did());
+
+        // And a plain open works against it.
+        let opened = TonkSite::open_with(&root, config).await?;
+        assert_eq!(opened.repository.did(), site.repository.did());
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: Run it, expect compile failure**
+
+Run: `cargo test -p tonk-cli --test site when_initializing_at_an_explicit_root`
+Expected: FAIL — `no function or associated item named 'init_at_with'`.
+
+- [ ] **Step 3: Implement by refactoring `init_with`**
+
+In `src/site.rs`, replace the current `init_with` (lines 135–187) with a thin delegator plus the new root-direct form. The body after the `root` binding is the existing code, moved verbatim:
+
+```rust
+    /// [`Self::init`] with caller-supplied [`SiteConfig`].
+    ///
+    /// Historical parent-relative form: the site lands at
+    /// `parent/.tonk/`. Kept for the test fixtures that model the
+    /// pre-registry layout; new callers go through
+    /// [`Self::init_at_with`].
+    pub async fn init_with(parent: &Path, config: SiteConfig) -> Result<Self> {
+        let parent = parent
+            .canonicalize()
+            .with_context(|| format!("could not canonicalize {}", parent.display()))?;
+        Self::init_at_with(&parent.join(SITE_DIRNAME), config).await
+    }
+
+    /// Initialize (or adopt) a site whose directory is exactly
+    /// `root` — no `.tonk/` nesting. This is what canonical spot
+    /// storage uses: the registry maps a spot name to this
+    /// directory. Idempotent: an existing repository at `root` is
+    /// loaded, not clobbered, which is also how `tonk spot new
+    /// --site <path>` adopts pre-existing storage.
+    pub async fn init_at_with(root: &Path, config: SiteConfig) -> Result<Self> {
+        std::fs::create_dir_all(root)
+            .with_context(|| format!("failed to create {}", root.display()))?;
+        let root = root
+            .canonicalize()
+            .with_context(|| format!("could not canonicalize {}", root.display()))?;
+
+        let (profile, operator) = build_profile_and_operator(&root, &config).await?;
+
+        // ... existing body from `init_with` continues unchanged from the
+        // "Try to load first" comment through returning `Ok(site)`,
+        // with `root` used directly instead of `parent.join(SITE_DIRNAME)`.
+    }
+```
+
+Concretely: the existing lines from `// Try to load first.` down to `Ok(site)` move into `init_at_with` unmodified (they already operate on `root`).
+
+- [ ] **Step 4: Run the test again, expect pass; run the whole site suite**
+
+Run: `cargo test -p tonk-cli --test site`
+Expected: new test PASSES, all existing site tests still pass (they use `init_with`, whose observable behaviour is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-cli/src/site.rs rust/tonk-cli/tests/site.rs
+git commit -m "feat(tonk-cli): init a site directly at an explicit root"
+```
+
+---
+
+### Task 3: Registry resolution in the binary — `--spot`, delete discovery, remove `init`
+
+**Files:**
+- Modify: `src/bin/tonk.rs`
+- Modify: `src/site.rs` (delete `discover_and_open` at line 81 and `find_site_root` at line 305; delete `TonkSite::init` at line 98 — its only caller was the removed `init` handler; keep `TonkSite::open`, `open_with`, `init_with`, `init_at_with`, `SITE_DIRNAME`)
+- Modify: `src/migrate.rs` doc/print only if it references discovery (check with `rg -n "discover" src/migrate.rs`; expected: no hits, no change)
+
+**Interfaces:**
+- Consumes: `spot::SpotStore`, `spot::Resolved`, `spot::SPOT_ENV` (Task 1).
+- Produces: `open_selected(flag: Option<&str>) -> Result<(spot::Resolved, site::TonkSite), ExitCode>` in `bin/tonk.rs` — every site-using handler goes through it. Handlers gain a trailing `spot: Option<&str>` parameter. Task 4 and 5 reuse `open_selected` untouched.
+
+- [ ] **Step 1: Add the global flag and the helper**
+
+In the `Cli` struct (line 38):
+
+```rust
+struct Cli {
+    /// Operate on this spot instead of the selected one.
+    /// Precedence: --spot > TONK_SPOT > `tonk use` selection.
+    #[arg(long, global = true, value_name = "NAME")]
+    spot: Option<String>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+```
+
+Below `print_error` (line ~1910), add:
+
+```rust
+/// Resolve the selected spot (--spot > TONK_SPOT > `tonk use`) and
+/// open its site. Every failure path names the spot and the
+/// selection source so a wrong-spot mistake is visible in the
+/// error itself. The cwd is never consulted.
+async fn open_selected(
+    flag: Option<&str>,
+) -> Result<(tonk_cli::spot::Resolved, site::TonkSite), ExitCode> {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return Err(print_error(err.to_string())),
+    };
+    let env = std::env::var(tonk_cli::spot::SPOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty());
+    let resolved = match store.resolve(flag, env.as_deref()) {
+        Ok(resolved) => resolved,
+        Err(err) => return Err(print_error(err.to_string())),
+    };
+    match site::TonkSite::open(&resolved.site).await {
+        Ok(site) => Ok((resolved, site)),
+        Err(err) => Err(print_error(format!(
+            "spot '{name}' (via {source}, site {site}): {err:#}",
+            name = resolved.name,
+            source = resolved.source,
+            site = resolved.site.display(),
+        ))),
+    }
+}
+```
+
+- [ ] **Step 2: Swap every discovery call site**
+
+Each of these handlers currently opens with the same block:
+
+```rust
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+    };
+    let site = match site::TonkSite::discover_and_open(&cwd).await {
+        Ok(s) => s,
+        Err(err) => return print_error(err.to_string()),
+    };
+```
+
+Replace it in every case with:
+
+```rust
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
+    };
+```
+
+and add a trailing `spot: Option<&str>` parameter to the handler. The full list (current line of the `cwd` block): `eval` (872), `sync_op` (959), `export_op` (986), `render_op` (1022), `import_op` (1050), `status_op` (1095), `remote_op` (1137), `blob_op` (1241), `share_op` (1306), `mint_invite` (1443), `query_op` (1576), `get_op` (1603), `assert_cmd` (1638), `retract_op` (1665), `concept_op` (1691), `view_op` (1728), `home_op` (1782), `print_schema` (1829).
+
+`status_op` is the one non-uniform case — it keeps the `Resolved` and prints it (spec: status output names the resolved spot):
+
+```rust
+async fn status_op(spot: Option<&str>) -> ExitCode {
+    let (resolved, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
+    };
+    println!(
+        "spot: {name} ({source})",
+        name = resolved.name,
+        source = resolved.source,
+    );
+
+    match sync::status(&site).await {
+        // ... existing body unchanged
+    }
+}
+```
+
+In `main`'s dispatch (line 763), bind the flag before the `match` and thread it: `let spot = cli.spot;` then e.g. `Command::Eval(args) => eval(args, spot.as_deref()).await,` for every handler in the list. `claim_invite` (join) and `migrate` stay as they are until Task 5 / stay cwd-based respectively.
+
+- [ ] **Step 3: Remove `tonk init`**
+
+- Delete the `Command::Init` variant (line ~267) and the `init` handler (line ~830).
+- Delete `Command::Init { .. } => ("init", None),` from `descriptor` (line 671).
+- Delete the dispatch arm `Command::Init { label } => init(label).await,`.
+- In `src/site.rs`: delete `TonkSite::init` (line 98), `TonkSite::discover_and_open` (line 81), and `find_site_root` (line 305). Update the module doc header (lines 1–11) to say a site is a directory holding the repo, located via the spot registry rather than cwd discovery, and update the `lib.rs` crate-doc line for `site` (line 10: currently "`.tonk/` discovery, repo+branch open/init") to match.
+- Update the binary's help copy: the crate doc comment at the top of `bin/tonk.rs` (lines 1–8, mentions `init` and "local `.tonk/` site") and the `after_help` on `Cli` (line 36): change the setup line to `setup    spot · use · blob · telemetry` and reword "against the local `.tonk/` site" to "against the selected spot".
+
+- [ ] **Step 4: Build and test**
+
+Run: `cargo build -p tonk-cli && cargo test -p tonk-cli`
+Expected: compiles; all tests pass (integration tests drive `TonkSite` directly and never used discovery).
+
+Smoke check the no-selection error:
+
+```bash
+TONK_SPOTS_STATE=$(mktemp -d) cargo run -p tonk-cli --bin tonk -- status
+```
+Expected stderr: `error: no spots registered; create one with `tonk spot new <name>`` and non-zero exit.
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `cargo clippy -p tonk-cli --all-targets -- -D warnings && cargo fmt --check`
+
+```bash
+git add rust/tonk-cli/src/bin/tonk.rs rust/tonk-cli/src/site.rs rust/tonk-cli/src/lib.rs
+git commit -m "feat(tonk-cli): resolve every command through the spot registry"
+```
+
+---
+
+### Task 4: Spot management commands — `use`, `spot new|list|rm`
+
+**Files:**
+- Modify: `src/spot.rs` (append the ops section below)
+- Modify: `src/bin/tonk.rs` (new commands + printing)
+- Create: `tests/spot.rs`
+- Modify: `Cargo.toml` (add the `[[test]]` entry)
+
+**Interfaces:**
+- Consumes: `SpotStore`, `Registry`, `SpotEntry`, `validate_name`, `SpotError` (Task 1); `TonkSite::init_at_with`, `SiteConfig` (Task 2).
+- Produces: `spot::create(&SpotStore, name, site_override: Option<&Path>, config: SiteConfig) -> Result<CreateOutcome, SpotError>` with `CreateOutcome { name, site, did }`; `spot::select(&SpotStore, name) -> Result<Resolved, SpotError>` (source always `Global`); `spot::listing(&SpotStore, flag, env) -> Result<Listing, SpotError>` with `Listing { rows: Vec<(String, PathBuf)>, current: Option<Resolved> }`; `spot::remove(&SpotStore, name, delete: bool) -> Result<RemoveOutcome, SpotError>` with `RemoveOutcome { name, site, deleted }`. Task 5 reuses `create`'s register-and-select tail pattern via `register` below.
+
+- [ ] **Step 1: Write the failing integration test**
+
+`tests/spot.rs`:
+
+```rust
+//! Spot management ops: create/register/select/list/remove against
+//! an isolated store. These exercise the `spot` module's ops layer
+//! the way the `tonk use` / `tonk spot *` commands drive it —
+//! nothing here touches process env or the user's data dir.
+
+mod common;
+
+use anyhow::Result;
+use tonk_cli::site::TonkSite;
+use tonk_cli::spot::{self, SpotStore};
+
+mod when_creating_a_spot {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_creates_registers_and_selects_in_the_canonical_dir() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        let outcome = spot::create(&store, "garden", None, config.clone()).await?;
+        assert_eq!(outcome.site, store.canonical_site("garden").canonicalize()?);
+
+        // Registered and selected: a bare resolve now finds it.
+        let resolved = store.resolve(None, None)?;
+        assert_eq!(resolved.name, "garden");
+        assert_eq!(resolved.site, outcome.site);
+
+        // And the site actually opens.
+        let opened = TonkSite::open_with(&resolved.site, config).await?;
+        assert_eq!(opened.repository.did().to_string(), outcome.did);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adopts_an_existing_site_via_site_override() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let parent = tmp.path().canonicalize()?;
+        let config = common::isolated_config(&parent)?;
+
+        // A pre-existing site (the old cwd-`.tonk` migration case).
+        let legacy_root = parent.join("proj").join(".tonk");
+        let legacy = TonkSite::init_at_with(&legacy_root, config.clone()).await?;
+
+        let outcome =
+            spot::create(&store, "proj", Some(&legacy_root), config.clone()).await?;
+        assert_eq!(outcome.did, legacy.repository.did().to_string());
+        assert_eq!(outcome.site, legacy_root.canonicalize()?);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_duplicate_name() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        spot::create(&store, "garden", None, config.clone()).await?;
+        let err = spot::create(&store, "garden", None, config)
+            .await
+            .expect_err("duplicate");
+        assert!(matches!(err, spot::SpotError::Exists(_)), "{err}");
+        Ok(())
+    }
+}
+
+mod when_removing_a_spot {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_unregisters_but_keeps_data_by_default() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, config).await?;
+
+        let outcome = spot::remove(&store, "garden", false)?;
+        assert!(!outcome.deleted);
+        assert!(created.site.exists(), "data kept");
+        // Entry and selection are gone.
+        assert!(store.load()?.spots.is_empty());
+        assert!(store.load()?.current.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_the_site_dir_with_delete() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, config).await?;
+
+        let outcome = spot::remove(&store, "garden", true)?;
+        assert!(outcome.deleted);
+        assert!(!created.site.exists(), "data removed");
+        Ok(())
+    }
+}
+
+mod when_selecting_and_listing {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_selects_by_name_and_lists_with_the_resolved_current() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        spot::create(&store, "a", None, config.clone()).await?;
+        spot::create(&store, "b", None, config).await?; // create selects b
+
+        let selected = spot::select(&store, "a")?;
+        assert_eq!(selected.name, "a");
+        assert_eq!(store.load()?.current.as_deref(), Some("a"));
+
+        let listing = spot::listing(&store, None, None)?;
+        assert_eq!(
+            listing.rows.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert_eq!(listing.current.as_ref().map(|c| c.name.as_str()), Some("a"));
+
+        let err = spot::select(&store, "nope").expect_err("unknown");
+        assert!(matches!(err, spot::SpotError::Unknown { .. }), "{err}");
+        Ok(())
+    }
+}
+```
+
+In `Cargo.toml`, after the `authoring` entry:
+
+```toml
+[[test]]
+name = "spot"
+path = "tests/spot.rs"
+```
+
+- [ ] **Step 2: Run it, expect compile failure**
+
+Run: `cargo test -p tonk-cli --test spot`
+Expected: FAIL — `cannot find function 'create' in module 'spot'` (and friends).
+
+- [ ] **Step 3: Implement the ops in `src/spot.rs`**
+
+Append after `validate_name` (before `mod tests`):
+
+```rust
+/// Outcome of [`create`]: the registered spot and the DID of the
+/// repository backing it.
+#[derive(Debug, Clone)]
+pub struct CreateOutcome {
+    /// Registry name.
+    pub name: String,
+    /// Absolute site directory.
+    pub site: PathBuf,
+    /// The site repository's DID.
+    pub did: String,
+}
+
+/// Outcome of [`remove`].
+#[derive(Debug, Clone)]
+pub struct RemoveOutcome {
+    /// The removed registry name.
+    pub name: String,
+    /// Where the site lived (still lives, unless `deleted`).
+    pub site: PathBuf,
+    /// Whether the site directory was deleted from disk.
+    pub deleted: bool,
+}
+
+/// Rows for `tonk spot list` plus the resolved current selection
+/// (None when nothing resolves — empty registry or dangling name).
+#[derive(Debug, Clone)]
+pub struct Listing {
+    /// `(name, site)` per registered spot, in name order.
+    pub rows: Vec<(String, PathBuf)>,
+    /// The spot a bare command would hit right now, with source.
+    pub current: Option<Resolved>,
+}
+
+/// Create (or adopt) a spot: initialize the site, register the
+/// name, and select it. The site lands in the store's canonical
+/// `spots/<name>/` unless `site_override` names another directory;
+/// because [`crate::site::TonkSite::init_at_with`] is idempotent,
+/// an override pointing at existing site storage adopts it — the
+/// migration path for pre-registry `.tonk/` dirs.
+pub async fn create(
+    store: &SpotStore,
+    name: &str,
+    site_override: Option<&Path>,
+    config: crate::site::SiteConfig,
+) -> Result<CreateOutcome, SpotError> {
+    validate_name(name)?;
+    let mut registry = store.load()?;
+    if registry.spots.contains_key(name) {
+        return Err(SpotError::Exists(name.to_owned()));
+    }
+
+    let target = site_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| store.canonical_site(name));
+    let site = crate::site::TonkSite::init_at_with(&target, config)
+        .await
+        .map_err(|e| SpotError::Init(format!("{e:#}")))?;
+
+    let outcome = CreateOutcome {
+        name: name.to_owned(),
+        site: site.root.clone(),
+        did: site.repository.did().to_string(),
+    };
+    registry.spots.insert(
+        name.to_owned(),
+        SpotEntry {
+            site: outcome.site.clone(),
+        },
+    );
+    registry.current = Some(name.to_owned());
+    store.save(&registry)?;
+    Ok(outcome)
+}
+
+/// Set the registry's `current` to `name`. This is the human
+/// selection path (`tonk use`); automation pins spots per-process
+/// via [`SPOT_ENV`] / `--spot` instead.
+pub fn select(store: &SpotStore, name: &str) -> Result<Resolved, SpotError> {
+    let mut registry = store.load()?;
+    let Some(entry) = registry.spots.get(name) else {
+        return Err(SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+        });
+    };
+    let resolved = Resolved {
+        name: name.to_owned(),
+        site: entry.site.clone(),
+        source: Source::Global,
+    };
+    registry.current = Some(name.to_owned());
+    store.save(&registry)?;
+    Ok(resolved)
+}
+
+/// Everything `tonk spot list` needs in one read: the rows plus
+/// what a bare command would currently resolve to (honouring the
+/// same `flag`/`env` precedence, so `tonk --spot x spot list`
+/// marks `x`).
+pub fn listing(
+    store: &SpotStore,
+    flag: Option<&str>,
+    env: Option<&str>,
+) -> Result<Listing, SpotError> {
+    let registry = store.load()?;
+    let rows = registry
+        .spots
+        .iter()
+        .map(|(name, entry)| (name.clone(), entry.site.clone()))
+        .collect();
+    Ok(Listing {
+        rows,
+        current: store.resolve(flag, env).ok(),
+    })
+}
+
+/// Remove `name` from the registry, clearing `current` if it
+/// pointed there. Site data stays on disk unless `delete` — the
+/// registry is the authority on names, not a lifecycle manager
+/// for storage it didn't necessarily create.
+pub fn remove(store: &SpotStore, name: &str, delete: bool) -> Result<RemoveOutcome, SpotError> {
+    let mut registry = store.load()?;
+    let Some(entry) = registry.spots.remove(name) else {
+        return Err(SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+        });
+    };
+    if registry.current.as_deref() == Some(name) {
+        registry.current = None;
+    }
+    store.save(&registry)?;
+    let deleted = if delete {
+        std::fs::remove_dir_all(&entry.site).map_err(|e| {
+            SpotError::Io(format!(
+                "entry removed, but deleting {} failed: {e}",
+                entry.site.display()
+            ))
+        })?;
+        true
+    } else {
+        false
+    };
+    Ok(RemoveOutcome {
+        name: name.to_owned(),
+        site: entry.site,
+        deleted,
+    })
+}
+```
+
+- [ ] **Step 4: Run the integration test, expect pass**
+
+Run: `cargo test -p tonk-cli --test spot`
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Wire the CLI commands**
+
+In `bin/tonk.rs`, add to the `Command` enum (in the `-- setup --` section where `Init` used to be):
+
+```rust
+    /// Select the current spot (used by every command from anywhere)
+    ///
+    /// The selection is global to this machine. Concurrent sessions
+    /// (agents, CI) should pin their spot per-process with --spot or
+    /// TONK_SPOT instead of relying on it.
+    #[command(after_help = "Examples:\n  tonk use garden")]
+    Use {
+        /// A registered spot name (see `tonk spot list`).
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+
+    /// Manage spots: named, centrally registered fact stores
+    Spot {
+        #[command(subcommand)]
+        command: SpotCommand,
+    },
+```
+
+and the subcommand enum next to `RemoteCommand`:
+
+```rust
+#[derive(Subcommand, Debug)]
+enum SpotCommand {
+    /// Create (or adopt) a spot, register it, and select it
+    ///
+    /// The site lands in the canonical store
+    /// (`~/Library/Application Support/tonk/spots/<name>` on macOS)
+    /// unless --site points elsewhere. --site aimed at an existing
+    /// site directory adopts it instead of creating fresh — the
+    /// migration path for pre-registry `.tonk/` dirs.
+    #[command(
+        after_help = "Examples:\n  tonk spot new garden\n  tonk spot new work --site ~/work/site\n  tonk spot new proj --site ~/proj/.tonk"
+    )]
+    New {
+        /// Spot name ([a-z0-9][a-z0-9-_]*).
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Store the site at this directory instead of the
+        /// canonical location.
+        #[arg(long, value_name = "PATH")]
+        site: Option<PathBuf>,
+    },
+
+    /// List registered spots and the current selection
+    #[command(after_help = "Examples:\n  tonk spot list")]
+    List,
+
+    /// Remove a spot from the registry (data stays unless --delete)
+    #[command(after_help = "Examples:\n  tonk spot rm garden\n  tonk spot rm garden --delete")]
+    Rm {
+        /// Spot name to unregister.
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Also delete the site directory from disk.
+        #[arg(long)]
+        delete: bool,
+    },
+}
+```
+
+`descriptor` additions:
+
+```rust
+        Command::Use { .. } => ("use", None),
+        Command::Spot { command } => (
+            "spot",
+            Some(match command {
+                SpotCommand::New { .. } => "new",
+                SpotCommand::List => "list",
+                SpotCommand::Rm { .. } => "rm",
+            }),
+        ),
+```
+
+Dispatch arms:
+
+```rust
+        Command::Use { name } => use_op(name).await,
+        Command::Spot { command } => spot_op(command, spot.as_deref()).await,
+```
+
+Handlers (near the other setup handlers; `use_op` is async only for signature uniformity in the dispatch — the ops are sync):
+
+```rust
+/// `tonk use` — set the global current spot.
+async fn use_op(name: String) -> ExitCode {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
+    };
+    match tonk_cli::spot::select(&store, &name) {
+        Ok(resolved) => {
+            println!(
+                "current spot: {name} ({site})",
+                name = resolved.name,
+                site = resolved.site.display(),
+            );
+            ExitCode::Success
+        }
+        Err(err) => print_error(err.to_string()),
+    }
+}
+
+/// `tonk spot new|list|rm` — registry management.
+async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
+    };
+    match command {
+        SpotCommand::New { name, site } => {
+            match tonk_cli::spot::create(&store, &name, site.as_deref(), site::default_config())
+                .await
+            {
+                Ok(outcome) => {
+                    println!("Registered spot '{}'", outcome.name);
+                    println!("site: {}", outcome.site.display());
+                    println!("DID: {}", outcome.did);
+                    println!("current spot: {}", outcome.name);
+                    ExitCode::Success
+                }
+                Err(err) => print_error(err.to_string()),
+            }
+        }
+        SpotCommand::List => {
+            let env = std::env::var(tonk_cli::spot::SPOT_ENV)
+                .ok()
+                .filter(|value| !value.is_empty());
+            match tonk_cli::spot::listing(&store, flag, env.as_deref()) {
+                Ok(listing) => {
+                    if listing.rows.is_empty() {
+                        println!("(no spots registered; create one with `tonk spot new <name>`)");
+                        return ExitCode::Success;
+                    }
+                    let current = listing.current.as_ref().map(|c| c.name.as_str());
+                    for (name, site) in &listing.rows {
+                        let marker = if Some(name.as_str()) == current { '*' } else { ' ' };
+                        println!("{marker} {name}\t{site}", site = site.display());
+                    }
+                    if let Some(resolved) = &listing.current {
+                        println!(
+                            "current: {name} ({source})",
+                            name = resolved.name,
+                            source = resolved.source,
+                        );
+                    }
+                    ExitCode::Success
+                }
+                Err(err) => print_error(err.to_string()),
+            }
+        }
+        SpotCommand::Rm { name, delete } => {
+            match tonk_cli::spot::remove(&store, &name, delete) {
+                Ok(outcome) => {
+                    println!("Removed spot '{}' from the registry", outcome.name);
+                    if outcome.deleted {
+                        println!("site deleted: {}", outcome.site.display());
+                    } else {
+                        println!("site kept at {}", outcome.site.display());
+                    }
+                    ExitCode::Success
+                }
+                Err(err) => print_error(err.to_string()),
+            }
+        }
+    }
+}
+```
+
+Note `spot_op` receives the global `--spot` flag value purely so `list` can mark what a bare command would resolve to.
+
+- [ ] **Step 6: End-to-end smoke against an isolated store**
+
+```bash
+STATE=$(mktemp -d)
+t() { env TONK_SPOTS_STATE="$STATE" cargo run -q -p tonk-cli --bin tonk -- "$@"; }
+t spot new garden          # Registered spot 'garden' ... current spot: garden
+t spot list                # * garden  <path>  /  current: garden (global)
+t status                   # spot: garden (global) + no-upstream
+t spot rm garden           # Removed ... site kept at <path>
+t status                   # error: no spot selected... (registry has 0 spots → spot new hint)
+```
+Expected: as annotated. (`t status` after `rm` reports the empty-registry hint.)
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `cargo clippy -p tonk-cli --all-targets -- -D warnings && cargo fmt --check && cargo test -p tonk-cli`
+
+```bash
+git add rust/tonk-cli/src/spot.rs rust/tonk-cli/src/bin/tonk.rs rust/tonk-cli/tests/spot.rs rust/tonk-cli/Cargo.toml
+git commit -m "feat(tonk-cli): tonk use and tonk spot new/list/rm"
+```
+
+---
+
+### Task 5: `tonk join` lands in a canonical spot
+
+**Files:**
+- Modify: `src/invite.rs` (`claim`, line 224; `InviteError::SiteAlreadyExists`, line 93)
+- Modify: `src/bin/tonk.rs` (`Join` command, line ~243; `claim_invite`, line 1493; `print_claim_outcome`, line 1512)
+- Modify: `tests/site.rs` (the four `invite::claim` call sites at lines 162, 193, 229, 289, 359, 382, 397 — see step 4)
+
+**Interfaces:**
+- Consumes: `spot::{SpotStore, SpotEntry, validate_name, SpotError}` (Tasks 1/4).
+- Produces: `invite::claim(root: &Path, invite_url: &str, config: SiteConfig)` — `root` is now the site directory itself, not the parent that gets `.tonk/` appended.
+
+- [ ] **Step 1: Change `claim` to take the site root directly**
+
+In `src/invite.rs`, replace the head of `claim` (lines 224–235):
+
+```rust
+/// Claim an invite, bootstrapping a fresh site at `root` (the
+/// site directory itself — the caller picks it, typically the
+/// canonical `spots/<name>/` dir) whose repository targets the
+/// invited subject DID.
+///
+/// Steps:
+///
+/// 1. Refuse if `root` already exists — the join must never
+///    clobber existing site storage.
+/// 2. Parse the URL via [`Invite::parse_url`]; reject malformed
+///    invites before touching disk.
+/// 3. Stand up the on-disk site directory and build a tonk
+///    operator rooted there, opening (or creating) the local
+///    profile.
+/// ... (steps 4–6 of the existing doc comment unchanged)
+pub async fn claim(
+    root: &Path,
+    invite_url: &str,
+    config: SiteConfig,
+) -> Result<ClaimOutcome, InviteError> {
+    if root.exists() {
+        return Err(InviteError::SiteAlreadyExists(root.to_path_buf()));
+    }
+```
+
+Then, where the old body did `let root = parent.join(SITE_DIRNAME);` + existence check: delete those lines. Move the existing `std::fs::create_dir_all(&root)` (line 254) up as-is, and canonicalize after creation so the operator gets an absolute root (the old code canonicalized `parent` up front):
+
+```rust
+    std::fs::create_dir_all(root)
+        .map_err(|e| InviteError::Io(format!("failed to create {}: {e}", root.display())))?;
+    let root = root.canonicalize().map_err(|e| {
+        InviteError::Io(format!("could not canonicalize {}: {e}", root.display()))
+    })?;
+```
+
+(The shortcut-resolution and parse block between the guard and `create_dir_all` stays where it is — parse before touching disk.) The rest of the body already uses `&root`. Update the error text at line 93:
+
+```rust
+    /// `claim` was asked to bootstrap a site directory that
+    /// already exists. The join must never clobber existing site
+    /// storage; the user removes it (or picks another spot name)
+    /// first.
+    #[error("a site already exists at {0}; remove it or pick another spot name")]
+    SiteAlreadyExists(PathBuf),
+```
+
+Remove the now-unused `SITE_DIRNAME` import from `src/invite.rs` (line 30).
+
+- [ ] **Step 2: Rework the `Join` command**
+
+Command definition (line ~243) gains a required `--name`:
+
+```rust
+    /// Join a shared repo from an invite URL into a new spot
+    #[command(after_help = "Examples:\n  tonk join 'https://...#invite' --name garden")]
+    Join {
+        /// The invite URL (quote it - the #fragment matters).
+        #[arg(value_name = "URL")]
+        url: String,
+        /// Spot name to register the joined repo under.
+        #[arg(long, value_name = "NAME")]
+        name: String,
+    },
+```
+
+Dispatch: `Command::Join { url, name } => claim_invite(url, name).await,`.
+
+Replace `claim_invite` and `print_claim_outcome` (lines 1493–1525):
+
+```rust
+/// `tonk join` — claim an invite into a fresh canonical spot:
+/// site at `spots/<name>/`, registered and selected on success.
+/// Registration happens only after the claim succeeds, so a
+/// failed join never leaves a dangling registry entry (a partial
+/// site dir may remain; re-running with the same name reports it).
+async fn claim_invite(url: String, name: String) -> ExitCode {
+    if let Err(err) = tonk_cli::spot::validate_name(&name) {
+        return print_error(err.to_string());
+    }
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
+    };
+    let mut registry = match store.load() {
+        Ok(registry) => registry,
+        Err(err) => return print_error(err.to_string()),
+    };
+    if registry.spots.contains_key(&name) {
+        return print_error(tonk_cli::spot::SpotError::Exists(name).to_string());
+    }
+    let root = store.canonical_site(&name);
+
+    // Same default site config `tonk spot new` writes against, so
+    // the joined site picks up the user's normal profile.
+    match invite::claim(&root, &url, site::default_config()).await {
+        Ok(outcome) => {
+            registry.spots.insert(
+                name.clone(),
+                tonk_cli::spot::SpotEntry { site: root.clone() },
+            );
+            registry.current = Some(name.clone());
+            if let Err(err) = store.save(&registry) {
+                return print_error(format!(
+                    "joined, but registering spot '{name}' failed: {err}\n\
+                     re-register with `tonk spot new {name} --site {root}`",
+                    root = root.display(),
+                ));
+            }
+            print_claim_outcome(&name, &root, &outcome);
+            ExitCode::Success
+        }
+        Err(err) => {
+            eprintln!("error: {err}");
+            err.exit_code()
+        }
+    }
+}
+
+fn print_claim_outcome(name: &str, root: &std::path::Path, outcome: &ClaimOutcome) {
+    println!("Joined spot '{name}' ({})", root.display());
+    println!("subject: {}", outcome.subject);
+    if let Some(remote) = &outcome.auto_configured_remote
+        && let Some(url) = &outcome.remote_url
+    {
+        println!("remote:  {remote} -> {url}");
+        if outcome.synced {
+            println!("synced:  pulled current state from {remote}");
+        } else {
+            println!("synced:  no (run `tonk pull` before making changes)");
+        }
+    }
+    println!("current spot: {name}");
+}
+```
+
+- [ ] **Step 3: Point `tonk migrate` output at the registry**
+
+In `bin/tonk.rs`'s `migrate` handler (line ~1527), after the existing `println!("DID: ...")`, add:
+
+```rust
+            println!(
+                "register it as a spot: `tonk spot new <name> --site {}`",
+                outcome.destination.display()
+            );
+```
+
+(`migrate` keeps its explicit cwd destination — it is a legacy, path-explicit import; the registry hint closes the loop.)
+
+- [ ] **Step 4: Update the claim call sites in `tests/site.rs`**
+
+Every `invite::claim(&claimer_parent, ...)` call passes a parent today and then opens `claimer_parent.join(SITE_DIRNAME)`. Switch each to an explicit root. Pattern (apply at lines 162, 193, 229, 289, 359, 382, 397, adjusting variable names in context):
+
+```rust
+        let claimer_tmp = tempfile::tempdir()?;
+        let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
+        let claimer_config = common::isolated_config(&claimer_parent)?;
+        let claim_outcome =
+            invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
+```
+
+and each later `TonkSite::open_with(&claimer_parent.join(SITE_DIRNAME), ...)` becomes `TonkSite::open_with(&claimer_root, ...)`. The double-claim test (line ~382) claims twice against the same root and must now assert the `SiteAlreadyExists` error text `"a site already exists"`. Drop the `SITE_DIRNAME` import from the test file if it becomes unused.
+
+- [ ] **Step 5: Run the affected suites**
+
+Run: `cargo test -p tonk-cli --test site && cargo test -p tonk-cli`
+Expected: all pass. (The `integration-tests`-gated shortcut test compiles against the new signature; if the feature isn't runnable locally, `cargo check -p tonk-cli --tests --features integration-tests` must still pass.)
+
+- [ ] **Step 6: Lint and commit**
+
+Run: `cargo clippy -p tonk-cli --all-targets --all-features -- -D warnings && cargo fmt --check`
+
+```bash
+git add rust/tonk-cli/src/invite.rs rust/tonk-cli/src/bin/tonk.rs rust/tonk-cli/tests/site.rs
+git commit -m "feat(tonk-cli): join claims into a registered canonical spot"
+```
+
+---
+
+### Task 6: Docs and agent guidance
+
+**Files:**
+- Modify: `README.md`
+- Modify: `src/guide-index.md`
+
+**Interfaces:** none — copy only.
+
+- [ ] **Step 1: README**
+
+- Line 5: replace "it operates on a `.tonk/` site" framing with: `tonk` operates on the selected **spot** — a named fact store resolved through a central registry, so the CLI works from any directory.
+- Lines 16–17 (quickstart): replace
+
+  ```bash
+  # Initialize a .tonk/ repo in the current directory.
+  tonk init
+  ```
+
+  with
+
+  ```bash
+  # Create a spot (stored canonically, e.g. ~/Library/Application Support/tonk/spots/garden).
+  tonk spot new garden
+  # Later, from anywhere:
+  tonk use garden
+  ```
+
+- Section "### The `.tonk/` site" (line 77): retitle to "### Spots and sites" and rewrite the body: a **spot** is a named entry in `spots.json` under the platform data dir; its **site** is the directory holding the dialog repository (canonical `spots/<name>/`, or anywhere via `tonk spot new --site <path>`); resolution is `--spot` > `TONK_SPOT` > `tonk use` selection; the registry file is plain JSON any application can read. Mention adopting a legacy `.tonk/` dir with `tonk spot new proj --site ~/proj/.tonk`.
+- Line 112: update "`tonk join` claims one into a fresh `.tonk/`" to "claims one into a fresh spot (`tonk join <url> --name <spot>`)".
+
+- [ ] **Step 2: Guide (agent-facing)**
+
+In `src/guide-index.md`, add a short section (near the orient material) titled `## Spots`:
+
+```markdown
+## Spots
+
+Commands run against the selected *spot* (a named fact store), not
+the cwd. Resolution order: `--spot <name>` > `TONK_SPOT` env >
+`tonk use <name>` selection. In automation, always pin the spot
+per-process (`TONK_SPOT=x tonk ...` or `--spot x`) — never rely on
+`tonk use`, which is shared global state another session can change.
+`tonk spot list` shows what's registered and what is current.
+```
+
+- [ ] **Step 3: Verify the guide still ships and commit**
+
+Run: `cargo test -p tonk-cli && cargo run -q -p tonk-cli --bin tonk -- guide | head -40`
+Expected: tests pass; the guide index prints and includes the Spots section.
+
+```bash
+git add rust/tonk-cli/README.md rust/tonk-cli/src/guide-index.md
+git commit -m "docs(tonk-cli): document spots, registry, and automation pinning"
+```
+
+---
+
+### Task 7: Full gate and final smoke
+
+**Files:** none new.
+
+- [ ] **Step 1: Workspace lint gate (matches CI)**
+
+Run, from the workspace root:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+Expected: both clean. Fix anything surfaced (wasm-gated helpers, dead code from the deleted discovery path) before proceeding.
+
+- [ ] **Step 2: Full native test run**
+
+Run: `cargo nextest run -p tonk-cli` (or `cargo test -p tonk-cli`)
+Expected: all suites pass, including the new `spot` binary.
+
+- [ ] **Step 3: Cold-start smoke, isolated store**
+
+```bash
+STATE=$(mktemp -d)
+t() { env TONK_SPOTS_STATE="$STATE" cargo run -q -p tonk-cli --bin tonk -- "$@"; }
+t query task                      # error: no spots registered → spot new hint
+t spot new garden
+t concept add task title:text     # works from any cwd
+t assert task --title "hello"
+t query task                      # one row
+TONK_SPOT=garden t status         # spot: garden (env)
+t --spot garden status            # spot: garden (flag)
+t spot rm garden --delete
+```
+Expected: annotated behaviour; `rm --delete` leaves `$STATE/spots` empty.
+
+- [ ] **Step 4: Commit any gate fixes**
+
+```bash
+git add -u
+git commit -m "chore(tonk-cli): satisfy workspace lint gate for spot registry"
+```
+(Skip the commit if the gate was already clean.)

--- a/docs/superpowers/specs/2026-07-20-cli-canonical-spots-design.md
+++ b/docs/superpowers/specs/2026-07-20-cli-canonical-spots-design.md
@@ -1,0 +1,176 @@
+# CLI canonical spot storage + registry
+
+**Date:** 2026-07-20
+**Status:** approved design, pending implementation
+**Branch:** `feat/cli-canonical-dir`
+
+## Problem
+
+`tonk` today roots everything at a `.tonk/` directory discovered by
+walking up from the cwd (`rust/tonk-cli/src/site.rs`). That forces
+users to `cd` into the right directory before every command, forces
+applications built on tonk to track where sites live themselves, and
+lets the same spot end up replicated across scattered filesystem
+locations.
+
+## Design
+
+Tonk becomes opinionated about where spot data lives, the way docker,
+ollama, and postgres manage their resources: a platform-canonical
+storage directory, a name registry, and a selected "current" spot so
+the CLI works from anywhere.
+
+### Vocabulary
+
+- **spot** — the named logical unit in the registry. What users
+  select and what applications resolve by name.
+- **site** — the physical directory backing a spot (what `.tonk/`
+  holds today: the dialog repo blocks). `TonkSite` and the whole site
+  layer are unchanged; everything new is a resolution layer above it.
+
+### Layout
+
+macOS shown; `dirs::data_dir()` supplies the platform equivalent on
+Linux/Windows, matching the existing `telemetry.json` / `update.json`
+placement:
+
+```
+~/Library/Application Support/tonk/
+  spots.json          # registry: name → site path, plus current selection
+  spots/<name>/       # canonical site dirs (repo blocks directly inside, no .tonk nesting)
+  telemetry.json      # existing
+  update.json         # existing
+```
+
+### Registry
+
+`spots.json` is the single source of truth mapping spot names to site
+paths. Paths are stored absolute and expanded so any application can
+read the file and resolve a name with zero path logic:
+
+```json
+{
+  "current": "garden",
+  "spots": {
+    "garden": { "site": "/Users/jack/Library/Application Support/tonk/spots/garden" },
+    "work":   { "site": "/Users/jack/work/site" }
+  }
+}
+```
+
+- Writes go through temp-file + atomic rename in the same directory.
+- A corrupt or unparseable registry is a hard error naming the file.
+  It is never silently recreated or repaired.
+- Spot names are validated to a conservative slug
+  (`[a-z0-9][a-z0-9-_]*`) because canonical names become directory
+  names.
+
+### Resolution
+
+Every data command resolves its spot in strict precedence order:
+
+1. `--spot <name>` — new global CLI flag
+2. `TONK_SPOT` — environment variable
+3. `current` — the registry's global selection
+
+The cwd is never consulted. `discover_and_open` and `find_site_root`
+are deleted. Failure modes:
+
+- No selection anywhere → error with a hint: `tonk use <name>`, or
+  `tonk spot new <name>` when the registry is empty.
+- Unknown name → error listing the registered spots.
+
+Resolution reports its **source** (`flag`, `env`, or `global`)
+alongside the name, and command surfaces expose it (see Concurrency).
+
+### Commands
+
+- `tonk use <name>` — set the registry's `current`. Errors on unknown
+  name.
+- `tonk spot new <name> [--site <path>]` — create the site (canonical
+  `spots/<name>/` by default, `--site` overrides the storage
+  location), register it, and select it. `TonkSite::init` is
+  idempotent, so `--site` pointing at an existing site directory
+  adopts it — this is also the migration path for pre-existing
+  `.tonk/` dirs: `tonk spot new myproj --site ~/proj/.tonk`.
+- `tonk spot list` — one row per spot: name, site path, a marker on
+  the current spot, and the source the current selection resolved
+  from.
+- `tonk spot rm <name>` — remove the registry entry (clearing
+  `current` if it pointed there). Data stays on disk and the site
+  path is printed. `--delete` also removes the site directory.
+- `tonk join <url> --name <name>` — join into a canonical site under
+  `<name>`, register, select. The name is required; nothing is
+  derived from the invite.
+- `tonk init` — removed. `tonk spot new` replaces it.
+
+### Concurrency
+
+The global `current` is a convenience for the human at the keyboard.
+Concurrent sessions (parallel agents, bench runs, CI) must pin their
+spot explicitly; the precedence order makes that safe because `--spot`
+and `TONK_SPOT` are per-invocation / per-process and always beat the
+shared `current`. Two sessions each launched with their own
+`TONK_SPOT` cannot mix, regardless of who runs `tonk use` meanwhile.
+
+Two guardrails make the contract visible:
+
+1. **Visibility** — resolution carries its source everywhere. `tonk
+   spot list` shows which spot is current and whether that came from
+   `flag`, `env`, or `global`; errors and status output name the
+   resolved spot. A session can always verify what it is about to
+   touch.
+2. **Agent guidance** — the `tonk` skill and the agent-facing guide
+   state the rule: automation always sets `TONK_SPOT` (or passes
+   `--spot`) and never relies on `tonk use`. Same contract CI has
+   with `DOCKER_CONTEXT`.
+
+A `TONK_REQUIRE_SPOT` hard-mode guard (bare fallthrough to `global`
+becomes an error) was considered and deferred — no immediate use.
+
+### Code shape
+
+- New module `rust/tonk-cli/src/spot.rs`: registry types
+  (`Registry`, entry struct), load/save with atomic rename,
+  `resolve(override) -> resolved {name, site path, source}`,
+  canonical-root helper, error types.
+- `bin/tonk.rs`: add the global `--spot` arg; replace every
+  `current_dir()` + `discover_and_open` pair with resolve-then-
+  `TonkSite::open`.
+- `invite.rs`: the join path roots at the canonical site (or is
+  handed a site path) instead of `cwd/.tonk`; the
+  "site already exists" guard keys off the registry name and target
+  directory instead of `parent/.tonk`.
+- `TONK_SPOTS_STATE` environment variable overrides the directory
+  holding `spots.json` and the canonical `spots/` root (same pattern
+  as `TONK_TELEMETRY_STATE` / the update state override) so tests run
+  against temp dirs.
+
+### Error handling
+
+- Missing/unknown spot: actionable errors as described under
+  Resolution.
+- Corrupt registry: hard error with the file path.
+- `spot new` with a name that already exists: error; re-pointing a
+  name is an explicit `rm` + `new`.
+- `--site` paths are canonicalized at registration; a non-UTF-8 or
+  uncreatable path errors up front.
+
+### Testing
+
+- Registry unit tests: precedence order (flag > env > global), atomic
+  write, slug validation, adopt-existing via `--site`, `rm` with and
+  without `--delete`, corrupt-file error.
+- Site-layer tests are untouched (`init_with`/`open_with` on temp
+  dirs still work).
+- CLI-level tests pin `TONK_SPOT` plus the registry-path env
+  override.
+
+## Out of scope / follow-ups
+
+- Updating the `tonk` skill, bench scenarios, and docs that assume
+  cwd discovery ("cd into the project"). They break until they pass
+  `--spot` or set `TONK_SPOT`; tracked as follow-up work.
+- `TONK_REQUIRE_SPOT` hard mode.
+- Any change to profile/identity storage (already canonical under
+  `~/Library/Application Support/dialog/`).

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -65,6 +65,10 @@ path = "tests/authoring.rs"
 name = "spot"
 path = "tests/spot.rs"
 
+[[test]]
+name = "cli_spot"
+path = "tests/cli_spot.rs"
+
 [features]
 integration-tests = []
 

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -61,6 +61,10 @@ path = "tests/data_verbs.rs"
 name = "authoring"
 path = "tests/authoring.rs"
 
+[[test]]
+name = "spot"
+path = "tests/spot.rs"
+
 [features]
 integration-tests = []
 

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -2,19 +2,22 @@
 
 A local-only CLI for reading and writing tonk facts via asserted-notation.
 
-`tonk` is the headless companion to tonk-ui: it operates on a `.tonk/` site
-(a single dialog repository named `main`, working on the `main` branch) without
-a browser. The mutating verb is `eval`, which runs a notation document through
-the analyze → query → plan → commit pipeline. The other subcommands are
-read-only introspection, one-shot setup, sync, and sharing helpers. The crate
-also exposes a small library surface (`tonk::eval`, `tonk::site`, …) so
-integration tests and SDK consumers can drive the same code paths as the binary.
+`tonk` is the headless companion to tonk-ui, without a browser: it operates on
+the selected **spot** — a named fact store resolved through a central
+registry, so the CLI works from any directory. The mutating verb is `eval`,
+which runs a notation document through the analyze → query → plan → commit
+pipeline. The other subcommands are read-only introspection, one-shot setup,
+sync, and sharing helpers. The crate also exposes a small library surface
+(`tonk::eval`, `tonk::site`, …) so integration tests and SDK consumers can
+drive the same code paths as the binary.
 
 ## Usage
 
 ```sh
-# Initialize a .tonk/ repo in the current directory.
-tonk init
+# Create a spot (stored canonically, e.g. ~/Library/Application Support/tonk/spots/garden).
+tonk spot new garden
+# Later, from anywhere:
+tonk use garden
 
 # Evaluate a notation document: inline, from a file, or piped.
 tonk eval -c 'person:'
@@ -74,16 +77,23 @@ nothing. Full inventory: [`docs/telemetry.md`](../../docs/telemetry.md).
 
 ## How it works
 
-### The `.tonk/` site
+### Spots and sites
 
-A site is a working directory containing a `.tonk/` sub-directory that holds one
-dialog repository (`main`), opened on the `main` branch. Multi-branch and
-multi-repo workflows are intentionally not exposed. Most commands call
-`TonkSite::discover_and_open`, which walks up from the current directory to find
-`.tonk/` and assembles the working context: the user's profile, an operator
-rooted at `.tonk/`, the repository handle, and the opened branch. The local
-identity is a shared profile (`tonk identity` prints its DID; `--reset` mints a
-fresh one).
+A **spot** is a named entry in `spots.json`, a registry kept under the
+platform data dir (`~/Library/Application Support/tonk/` on macOS). Each
+entry points at a **site**: the working directory holding the actual dialog
+repository (`main`, opened on the `main` branch — multi-branch and multi-repo
+workflows are intentionally not exposed). Sites live canonically under
+`spots/<name>/`, or anywhere you like via `tonk spot new --site <path>`.
+Commands resolve which spot to use as `--spot` > `TONK_SPOT` > the `tonk use`
+selection, then open its site. `spots.json` is plain JSON, so any application
+can read the registry without going through the CLI.
+
+To adopt an existing `.tonk/` directory (from a pre-spots checkout, or
+somewhere you keep data outside the canonical store) as a spot, point
+`--site` at it: `tonk spot new proj --site ~/proj/.tonk`. The local identity
+is a shared profile (`tonk identity` prints its DID; `--reset` mints a fresh
+one).
 
 ### The eval pipeline
 
@@ -109,11 +119,12 @@ with errors that name the upstream-not-configured and non-fast-forward cases.
 Remotes are UCAN-S3 access services registered on the repository's meta branch.
 `tonk invite` mints a UCAN delegation chain over the repo and prints an
 audience-open invite URL (anyone holding it can claim by redelegating from the
-embedded ephemeral key); `tonk join` claims one into a fresh `.tonk/`. The
-`share` subcommands push to the upstream, mint an invite that embeds the
-upstream URL, and append a launcher URL that lands the recipient on a live view
-of the data: an auto-rendered concept route (`share concept`), the iframe HTML
-viewer (`share view`), or a `<tonk-display>` declarative view (`share display`).
+embedded ephemeral key); `tonk join` claims one into a fresh spot
+(`tonk join <url> --name <spot>`). The `share` subcommands push to the
+upstream, mint an invite that embeds the upstream URL, and append a launcher
+URL that lands the recipient on a live view of the data: an auto-rendered
+concept route (`share concept`), the iframe HTML viewer (`share view`), or a
+`<tonk-display>` declarative view (`share display`).
 
 ## Built on
 

--- a/rust/tonk-cli/npm/cli/package.json
+++ b/rust/tonk-cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The Tonk stack command line utility.",
   "license": "MIT",
   "homepage": "https://github.com/tonk-labs/tonk#readme",
@@ -30,7 +30,7 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@tonk/cli-darwin-arm64": "0.5.0",
-    "@tonk/cli-linux-x64": "0.5.0"
+    "@tonk/cli-darwin-arm64": "0.6.0",
+    "@tonk/cli-linux-x64": "0.6.0"
   }
 }

--- a/rust/tonk-cli/npm/darwin-arm64/package.json
+++ b/rust/tonk-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "darwin-arm64 binary for @tonk/cli.",
   "license": "MIT",
   "homepage": "https://github.com/tonk-labs/tonk#readme",

--- a/rust/tonk-cli/npm/linux-x64/package.json
+++ b/rust/tonk-cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonk/cli-linux-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "linux-x64 binary for @tonk/cli.",
   "license": "MIT",
   "homepage": "https://github.com/tonk-labs/tonk#readme",

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -242,15 +242,15 @@ enum Command {
         remote: Option<String>,
     },
 
-    /// Claim an invite URL into a fresh .tonk/ here
-    ///
-    /// Refuses if a site already exists under the current directory.
-    #[command(after_help = "Examples:\n  tonk join 'https://...#invite'")]
+    /// Join a shared repo from an invite URL into a new spot
+    #[command(after_help = "Examples:\n  tonk join 'https://...#invite' --name garden")]
     Join {
-        /// Invite URL produced by `tonk invite` or
-        /// tonk-ui's invite flow.
+        /// The invite URL (quote it - the #fragment matters).
         #[arg(value_name = "URL")]
         url: String,
+        /// Spot name to register the joined repo under.
+        #[arg(long, value_name = "NAME")]
+        name: String,
     },
 
     /// Push local main to its upstream
@@ -850,7 +850,7 @@ async fn main() {
         Command::Invite { base_url, remote } => {
             mint_invite(base_url, remote, spot.as_deref()).await
         }
-        Command::Join { url } => claim_invite(url).await,
+        Command::Join { url, name } => claim_invite(url, name).await,
         Command::Remote { command } => remote_op(command, spot.as_deref()).await,
         Command::Blob { command } => blob_op(command, spot.as_deref()).await,
         Command::Share { command } => share_op(command, spot.as_deref()).await,
@@ -1585,16 +1585,45 @@ fn print_invite_outcome(outcome: &InviteOutcome) {
     eprintln!("audience: {} (ephemeral)", outcome.audience);
 }
 
-async fn claim_invite(url: String) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+/// `tonk join` — claim an invite into a fresh canonical spot:
+/// site at `spots/<name>/`, registered and selected on success.
+/// Registration happens only after the claim succeeds, so a
+/// failed join never leaves a dangling registry entry (a partial
+/// site dir may remain; re-running with the same name reports it).
+async fn claim_invite(url: String, name: String) -> ExitCode {
+    if let Err(err) = tonk_cli::spot::validate_name(&name) {
+        return print_error(err.to_string());
+    }
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
     };
-    // Use the same default site config tonk init writes against,
-    // so the joined site picks up the user's normal profile.
-    match invite::claim(&cwd, &url, site::default_config()).await {
+    let mut registry = match store.load() {
+        Ok(registry) => registry,
+        Err(err) => return print_error(err.to_string()),
+    };
+    if registry.spots.contains_key(&name) {
+        return print_error(tonk_cli::spot::SpotError::Exists(name).to_string());
+    }
+    let root = store.canonical_site(&name);
+
+    // Same default site config `tonk spot new` writes against, so
+    // the joined site picks up the user's normal profile.
+    match invite::claim(&root, &url, site::default_config()).await {
         Ok(outcome) => {
-            print_claim_outcome(&cwd, &outcome);
+            registry.spots.insert(
+                name.clone(),
+                tonk_cli::spot::SpotEntry { site: root.clone() },
+            );
+            registry.current = Some(name.clone());
+            if let Err(err) = store.save(&registry) {
+                return print_error(format!(
+                    "joined, but registering spot '{name}' failed: {err}\n\
+                     re-register with `tonk spot new {name} --site {root}`",
+                    root = root.display(),
+                ));
+            }
+            print_claim_outcome(&name, &root, &outcome);
             ExitCode::Success
         }
         Err(err) => {
@@ -1604,19 +1633,20 @@ async fn claim_invite(url: String) -> ExitCode {
     }
 }
 
-fn print_claim_outcome(parent: &std::path::Path, outcome: &ClaimOutcome) {
-    println!("Joined .tonk in {}", parent.display());
+fn print_claim_outcome(name: &str, root: &std::path::Path, outcome: &ClaimOutcome) {
+    println!("Joined spot '{name}' ({})", root.display());
     println!("subject: {}", outcome.subject);
-    if let Some(name) = &outcome.auto_configured_remote
+    if let Some(remote) = &outcome.auto_configured_remote
         && let Some(url) = &outcome.remote_url
     {
-        println!("remote:  {name} -> {url}");
+        println!("remote:  {remote} -> {url}");
         if outcome.synced {
-            println!("synced:  pulled current state from {name}");
+            println!("synced:  pulled current state from {remote}");
         } else {
             println!("synced:  no (run `tonk pull` before making changes)");
         }
     }
+    println!("current spot: {name}");
 }
 
 async fn migrate(from: Option<PathBuf>, do_move: bool) -> ExitCode {
@@ -1638,6 +1668,10 @@ async fn migrate(from: Option<PathBuf>, do_move: bool) -> ExitCode {
                 outcome.destination.display()
             );
             println!("DID: {}", outcome.repo_did);
+            println!(
+                "register it as a spot: `tonk spot new <name> --site {}`",
+                outcome.destination.display()
+            );
             println!(
                 "note: any sync remotes from carry's meta branch are preserved on disk; \
                  tonk doesn't read them yet."

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -268,6 +268,24 @@ enum Command {
     },
 
     // -- setup --------------------------------------------------------
+    /// Select the current spot (used by every command from anywhere)
+    ///
+    /// The selection is global to this machine. Concurrent sessions
+    /// (agents, CI) should pin their spot per-process with --spot or
+    /// TONK_SPOT instead of relying on it.
+    #[command(after_help = "Examples:\n  tonk use garden")]
+    Use {
+        /// A registered spot name (see `tonk spot list`).
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+
+    /// Manage spots: named, centrally registered fact stores
+    Spot {
+        #[command(subcommand)]
+        command: SpotCommand,
+    },
+
     /// Show (or reset) the local profile DID
     ///
     /// With `--reset`, deletes the on-disk profile and creates a
@@ -498,6 +516,44 @@ enum RemoteCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum SpotCommand {
+    /// Create (or adopt) a spot, register it, and select it
+    ///
+    /// The site lands in the canonical store
+    /// (`~/Library/Application Support/tonk/spots/<name>` on macOS)
+    /// unless --site points elsewhere. --site aimed at an existing
+    /// site directory adopts it instead of creating fresh — the
+    /// migration path for pre-registry `.tonk/` dirs.
+    #[command(
+        after_help = "Examples:\n  tonk spot new garden\n  tonk spot new work --site ~/work/site\n  tonk spot new proj --site ~/proj/.tonk"
+    )]
+    New {
+        /// Spot name ([a-z0-9][a-z0-9-_]*).
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Store the site at this directory instead of the
+        /// canonical location.
+        #[arg(long, value_name = "PATH")]
+        site: Option<PathBuf>,
+    },
+
+    /// List registered spots and the current selection
+    #[command(after_help = "Examples:\n  tonk spot list")]
+    List,
+
+    /// Remove a spot from the registry (data stays unless --delete)
+    #[command(after_help = "Examples:\n  tonk spot rm garden\n  tonk spot rm garden --delete")]
+    Rm {
+        /// Spot name to unregister.
+        #[arg(value_name = "NAME")]
+        name: String,
+        /// Also delete the site directory from disk.
+        #[arg(long)]
+        delete: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum BlobCommand {
     /// Ingest a file and print its blob:<hash> reference
     ///
@@ -662,6 +718,15 @@ enum TelemetryAction {
 /// (never argument values) are ever reported.
 fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
     match command {
+        Command::Use { .. } => ("use", None),
+        Command::Spot { command } => (
+            "spot",
+            Some(match command {
+                SpotCommand::New { .. } => "new",
+                SpotCommand::List => "list",
+                SpotCommand::Rm { .. } => "rm",
+            }),
+        ),
         Command::Identity { .. } => ("identity", None),
         Command::Eval(_) => ("eval", None),
         Command::Guide { .. } => ("guide", None),
@@ -755,6 +820,8 @@ async fn main() {
     let is_update = matches!(cli.command, Command::Update { .. });
     let spot = cli.spot;
     let exit = match cli.command {
+        Command::Use { name } => use_op(name).await,
+        Command::Spot { command } => spot_op(command, spot.as_deref()).await,
         Command::Identity { reset } => identity(reset).await,
         Command::Eval(args) => eval(args, spot.as_deref()).await,
         Command::Guide { topic } => print_guide(topic.as_deref()),
@@ -834,6 +901,92 @@ async fn identity(reset: bool) -> ExitCode {
             ExitCode::Success
         }
         Err(err) => print_error(err.to_string()),
+    }
+}
+
+/// `tonk use` — set the global current spot.
+async fn use_op(name: String) -> ExitCode {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
+    };
+    match tonk_cli::spot::select(&store, &name) {
+        Ok(resolved) => {
+            println!(
+                "current spot: {name} ({site})",
+                name = resolved.name,
+                site = resolved.site.display(),
+            );
+            ExitCode::Success
+        }
+        Err(err) => print_error(err.to_string()),
+    }
+}
+
+/// `tonk spot new|list|rm` — registry management.
+async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return print_error(err.to_string()),
+    };
+    match command {
+        SpotCommand::New { name, site } => {
+            match tonk_cli::spot::create(&store, &name, site.as_deref(), site::default_config())
+                .await
+            {
+                Ok(outcome) => {
+                    println!("Registered spot '{}'", outcome.name);
+                    println!("site: {}", outcome.site.display());
+                    println!("DID: {}", outcome.did);
+                    println!("current spot: {}", outcome.name);
+                    ExitCode::Success
+                }
+                Err(err) => print_error(err.to_string()),
+            }
+        }
+        SpotCommand::List => {
+            let env = std::env::var(tonk_cli::spot::SPOT_ENV)
+                .ok()
+                .filter(|value| !value.is_empty());
+            match tonk_cli::spot::listing(&store, flag, env.as_deref()) {
+                Ok(listing) => {
+                    if listing.rows.is_empty() {
+                        println!("(no spots registered; create one with `tonk spot new <name>`)");
+                        return ExitCode::Success;
+                    }
+                    let current = listing.current.as_ref().map(|c| c.name.as_str());
+                    for (name, site) in &listing.rows {
+                        let marker = if Some(name.as_str()) == current {
+                            '*'
+                        } else {
+                            ' '
+                        };
+                        println!("{marker} {name}\t{site}", site = site.display());
+                    }
+                    if let Some(resolved) = &listing.current {
+                        println!(
+                            "current: {name} ({source})",
+                            name = resolved.name,
+                            source = resolved.source,
+                        );
+                    }
+                    ExitCode::Success
+                }
+                Err(err) => print_error(err.to_string()),
+            }
+        }
+        SpotCommand::Rm { name, delete } => match tonk_cli::spot::remove(&store, &name, delete) {
+            Ok(outcome) => {
+                println!("Removed spot '{}' from the registry", outcome.name);
+                if outcome.deleted {
+                    println!("site deleted: {}", outcome.site.display());
+                } else {
+                    println!("site kept at {}", outcome.site.display());
+                }
+                ExitCode::Success
+            }
+            Err(err) => print_error(err.to_string()),
+        },
     }
 }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -3,9 +3,9 @@
 //!
 //! The mutating verb is `eval`: it consumes a notation document
 //! and runs the analyze → query → plan → commit pipeline against
-//! the local `.tonk/` site. The other subcommands (`init`,
-//! `identity`, `guide`, `schema`, `migrate`) are read-only or
-//! one-shot setup helpers.
+//! the selected spot's site. The other subcommands (`identity`,
+//! `guide`, `schema`, `migrate`) are read-only or one-shot setup
+//! helpers.
 
 use std::io::{IsTerminal as _, Write as _};
 use std::path::PathBuf;
@@ -33,9 +33,14 @@ use tonk_cli::{ExitCode, guide, identity, schema, site};
     about = "Headless CLI for a datalog-flavoured, syncable fact store: define concepts, assert facts, query them, render views",
     version,
     propagate_version = true,
-    after_help = "The loop: orient, define concepts, assert facts, give them a view, share.\n\n  orient   guide · schema · concept ls · view ls · status\n  author   concept add · view add · home\n  data     assert · query · retract\n  power    eval (asserted-notation) · render\n  collab   share · invite · join · push · pull · remote\n  setup    init · blob · telemetry\n\nStart with `tonk guide`; every command's --help carries examples."
+    after_help = "The loop: orient, define concepts, assert facts, give them a view, share.\n\n  orient   guide · schema · concept ls · view ls · status\n  author   concept add · view add · home\n  data     assert · query · retract\n  power    eval (asserted-notation) · render\n  collab   share · invite · join · push · pull · remote\n  setup    spot · use · blob · telemetry\n\nStart with `tonk guide`; every command's --help carries examples."
 )]
 struct Cli {
+    /// Operate on this spot instead of the selected one.
+    /// Precedence: --spot > TONK_SPOT > `tonk use` selection.
+    #[arg(long, global = true, value_name = "NAME")]
+    spot: Option<String>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -263,17 +268,6 @@ enum Command {
     },
 
     // -- setup --------------------------------------------------------
-    /// Create a new .tonk/ repo in the current directory
-    #[command(after_help = "Examples:\n  tonk init\n  tonk init my-repo")]
-    Init {
-        /// Optional label for the repository.
-        ///
-        /// Reserved for a future `dialog.meta/name` claim;
-        /// accepted but not yet persisted.
-        #[arg(value_name = "LABEL")]
-        label: Option<String>,
-    },
-
     /// Show (or reset) the local profile DID
     ///
     /// With `--reset`, deletes the on-disk profile and creates a
@@ -668,7 +662,6 @@ enum TelemetryAction {
 /// (never argument values) are ever reported.
 fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
     match command {
-        Command::Init { .. } => ("init", None),
         Command::Identity { .. } => ("identity", None),
         Command::Eval(_) => ("eval", None),
         Command::Guide { .. } => ("guide", None),
@@ -760,41 +753,43 @@ async fn main() {
     let started = std::time::Instant::now();
     // `cli.command` is moved by the dispatch below, so ask now.
     let is_update = matches!(cli.command, Command::Update { .. });
+    let spot = cli.spot;
     let exit = match cli.command {
-        Command::Init { label } => init(label).await,
         Command::Identity { reset } => identity(reset).await,
-        Command::Eval(args) => eval(args).await,
+        Command::Eval(args) => eval(args, spot.as_deref()).await,
         Command::Guide { topic } => print_guide(topic.as_deref()),
-        Command::Schema { concept } => print_schema(concept).await,
+        Command::Schema { concept } => print_schema(concept, spot.as_deref()).await,
         Command::Query {
             concept,
             entity,
             json,
         } => match entity {
-            Some(entity) => get_op(concept, entity, json).await,
-            None => query_op(concept, json).await,
+            Some(entity) => get_op(concept, entity, json, spot.as_deref()).await,
+            None => query_op(concept, json, spot.as_deref()).await,
         },
-        Command::Assert { concept, rest } => assert_cmd(concept, rest).await,
+        Command::Assert { concept, rest } => assert_cmd(concept, rest, spot.as_deref()).await,
         Command::Retract {
             concept,
             entity,
             field,
-        } => retract_op(concept, entity, field).await,
+        } => retract_op(concept, entity, field, spot.as_deref()).await,
         Command::Migrate { from, do_move } => migrate(from, do_move).await,
-        Command::Export { out } => export_op(out).await,
-        Command::Render { route, out } => render_op(route, out).await,
-        Command::Import { file } => import_op(file).await,
-        Command::Push => sync_op(SyncOp::Push).await,
-        Command::Pull => sync_op(SyncOp::Pull).await,
-        Command::Status => status_op().await,
-        Command::Invite { base_url, remote } => mint_invite(base_url, remote).await,
+        Command::Export { out } => export_op(out, spot.as_deref()).await,
+        Command::Render { route, out } => render_op(route, out, spot.as_deref()).await,
+        Command::Import { file } => import_op(file, spot.as_deref()).await,
+        Command::Push => sync_op(SyncOp::Push, spot.as_deref()).await,
+        Command::Pull => sync_op(SyncOp::Pull, spot.as_deref()).await,
+        Command::Status => status_op(spot.as_deref()).await,
+        Command::Invite { base_url, remote } => {
+            mint_invite(base_url, remote, spot.as_deref()).await
+        }
         Command::Join { url } => claim_invite(url).await,
-        Command::Remote { command } => remote_op(command).await,
-        Command::Blob { command } => blob_op(command).await,
-        Command::Share { command } => share_op(command).await,
-        Command::Concept { command } => concept_op(command).await,
-        Command::View { command } => view_op(command).await,
-        Command::Home { models } => home_op(models).await,
+        Command::Remote { command } => remote_op(command, spot.as_deref()).await,
+        Command::Blob { command } => blob_op(command, spot.as_deref()).await,
+        Command::Share { command } => share_op(command, spot.as_deref()).await,
+        Command::Concept { command } => concept_op(command, spot.as_deref()).await,
+        Command::View { command } => view_op(command, spot.as_deref()).await,
+        Command::Home { models } => home_op(models, spot.as_deref()).await,
         Command::Telemetry { action } => telemetry_op(action),
         Command::Update {
             disable_check,
@@ -827,27 +822,6 @@ async fn main() {
     std::process::exit(exit.into_raw());
 }
 
-async fn init(label: Option<String>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-
-    match site::TonkSite::init(&cwd).await {
-        Ok(site) => {
-            println!("Initialized .tonk in {}", cwd.display());
-            println!("DID: {}", site.repository.did());
-            if let Some(label) = label {
-                eprintln!(
-                    "note: label '{label}' accepted but not yet persisted (reserved for a future dialog.meta/name claim)"
-                );
-            }
-            ExitCode::Success
-        }
-        Err(err) => print_error(err.to_string()),
-    }
-}
-
 async fn identity(reset: bool) -> ExitCode {
     let result = if reset {
         identity::reset().await
@@ -863,15 +837,10 @@ async fn identity(reset: bool) -> ExitCode {
     }
 }
 
-async fn eval(args: EvalArgs) -> ExitCode {
+async fn eval(args: EvalArgs, spot: Option<&str>) -> ExitCode {
     let source = match resolve_source(&args) {
         Ok(s) => s,
         Err(message) => return print_error(message),
-    };
-
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
     };
 
     let options = eval::Options {
@@ -880,9 +849,9 @@ async fn eval(args: EvalArgs) -> ExitCode {
         dry_run: args.dry_run,
     };
 
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     // A dry run never commits, so there's nothing to push; force
@@ -955,14 +924,10 @@ enum SyncOp {
     Pull,
 }
 
-async fn sync_op(op: SyncOp) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn sync_op(op: SyncOp, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     let result = match op {
@@ -982,14 +947,10 @@ async fn sync_op(op: SyncOp) -> ExitCode {
     }
 }
 
-async fn export_op(out: Option<PathBuf>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn export_op(out: Option<PathBuf>, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     let destination = match &out {
@@ -1014,18 +975,14 @@ async fn export_op(out: Option<PathBuf>) -> ExitCode {
     }
 }
 
-async fn render_op(route: String, out: Option<PathBuf>) -> ExitCode {
+async fn render_op(route: String, out: Option<PathBuf>, spot: Option<&str>) -> ExitCode {
     let parsed = match RenderRoute::parse(&route) {
         Ok(r) => r,
         Err(err) => return print_error(err.to_string()),
     };
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match render::render(&site, &parsed).await {
@@ -1046,14 +1003,10 @@ async fn render_op(route: String, out: Option<PathBuf>) -> ExitCode {
     }
 }
 
-async fn import_op(file: PathBuf) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn import_op(file: PathBuf, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match transfer::import(&site, &file).await {
@@ -1091,15 +1044,16 @@ fn print_sync_outcome(op: SyncOp, outcome: &SyncOutcome) {
     }
 }
 
-async fn status_op() -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
+async fn status_op(spot: Option<&str>) -> ExitCode {
+    let (resolved, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
-    };
+    println!(
+        "spot: {name} ({source})",
+        name = resolved.name,
+        source = resolved.source,
+    );
 
     match sync::status(&site).await {
         Ok(state) => {
@@ -1133,14 +1087,10 @@ fn render_revision(revision: Option<&dialog_repository::Revision>) -> String {
     }
 }
 
-async fn remote_op(command: RemoteCommand) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn remote_op(command: RemoteCommand, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match command {
@@ -1237,14 +1187,10 @@ fn print_remote_list(records: &[RemoteRecord]) {
     }
 }
 
-async fn blob_op(command: BlobCommand) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn blob_op(command: BlobCommand, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match command {
@@ -1302,14 +1248,10 @@ fn print_blob_add_outcome(outcome: &BlobAddOutcome) {
     );
 }
 
-async fn share_op(command: ShareCommand) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn share_op(command: ShareCommand, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match command {
@@ -1439,14 +1381,14 @@ fn print_set_upstream_outcome(outcome: &UpstreamOutcome) {
     );
 }
 
-async fn mint_invite(base_url: String, remote_name: Option<String>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn mint_invite(
+    base_url: String,
+    remote_name: Option<String>,
+    spot: Option<&str>,
+) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     // Resolve `--remote <name>` to its endpoint URL by reading
@@ -1572,14 +1514,10 @@ async fn list_concepts_op(site: &site::TonkSite) -> ExitCode {
 
 /// Query every instance of `concept` as rendered by
 /// [`data_ops::query`].
-async fn query_op(concept: String, json: bool) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn query_op(concept: String, json: bool, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match data_ops::query(&site, &concept, json).await {
@@ -1599,14 +1537,10 @@ async fn query_op(concept: String, json: bool) -> ExitCode {
 
 /// Print a single instance of `concept` as rendered by
 /// [`data_ops::get`].
-async fn get_op(concept: String, entity: String, json: bool) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn get_op(concept: String, entity: String, json: bool, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match data_ops::get(&site, &concept, &entity, json).await {
@@ -1630,18 +1564,14 @@ async fn get_op(concept: String, entity: String, json: bool) -> ExitCode {
 /// never starts with `-`, and flag values always follow their
 /// flag, so the first token is either a flag or the entity. Same
 /// dynamic-flag / `--help` handling as the old `add`/`set`.
-async fn assert_cmd(concept: String, rest: Vec<String>) -> ExitCode {
+async fn assert_cmd(concept: String, rest: Vec<String>, spot: Option<&str>) -> ExitCode {
     let (entity, argv) = match rest.split_first() {
         Some((first, tail)) if !first.starts_with('-') => (Some(first.clone()), tail.to_vec()),
         _ => (None, rest),
     };
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match data_ops::assert_op(&site, &concept, entity.as_deref(), &argv).await {
@@ -1661,14 +1591,15 @@ async fn assert_cmd(concept: String, rest: Vec<String>) -> ExitCode {
 
 /// Retract a single field, or a whole instance, as rendered by
 /// [`data_ops::retract`].
-async fn retract_op(concept: String, entity: String, field: Option<String>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn retract_op(
+    concept: String,
+    entity: String,
+    field: Option<String>,
+    spot: Option<&str>,
+) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match data_ops::retract(&site, &concept, &entity, field.as_deref()).await {
@@ -1687,14 +1618,10 @@ async fn retract_op(concept: String, entity: String, field: Option<String>) -> E
 }
 
 /// Author a new concept, as rendered by [`data_ops::concept_add`].
-async fn concept_op(command: ConceptCommand) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn concept_op(command: ConceptCommand, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match command {
@@ -1724,14 +1651,10 @@ async fn concept_op(command: ConceptCommand) -> ExitCode {
 /// missing or empty template surfaces as
 /// [`tonk_cli::authoring::AuthoringError::EmptyTemplate`] via
 /// `data_ops::view_add`'s own check.
-async fn view_op(command: ViewCommand) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn view_op(command: ViewCommand, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match command {
@@ -1778,14 +1701,10 @@ async fn view_op(command: ViewCommand) -> ExitCode {
 
 /// Put one or more concepts' directories on the space home, as
 /// rendered by [`data_ops::home`].
-async fn home_op(models: Vec<String>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn home_op(models: Vec<String>, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
 
     match data_ops::home(&site, &models).await {
@@ -1825,14 +1744,10 @@ fn print_view_row(out: &mut impl std::io::Write, row: &ViewSummary) -> std::io::
     writeln!(out, "{}\t{}\t{}", name, row.entity, row.body_bytes)
 }
 
-async fn print_schema(concept: Option<String>) -> ExitCode {
-    let cwd = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => return print_error(format!("could not determine current directory: {e}")),
-    };
-    let site = match site::TonkSite::discover_and_open(&cwd).await {
-        Ok(s) => s,
-        Err(err) => return print_error(err.to_string()),
+async fn print_schema(concept: Option<String>, spot: Option<&str>) -> ExitCode {
+    let (_, site) = match open_selected(spot).await {
+        Ok(opened) => opened,
+        Err(code) => return code,
     };
     let rendered = match &concept {
         Some(name) => match data_ops::schema_subset(&site, name).await {
@@ -1910,6 +1825,35 @@ async fn update(disable_check: bool, enable_check: bool) -> ExitCode {
 fn print_error(message: impl Into<String>) -> ExitCode {
     eprintln!("error: {}", message.into());
     ExitCode::IoError
+}
+
+/// Resolve the selected spot (--spot > TONK_SPOT > `tonk use`) and
+/// open its site. Every failure path names the spot and the
+/// selection source so a wrong-spot mistake is visible in the
+/// error itself. The cwd is never consulted.
+async fn open_selected(
+    flag: Option<&str>,
+) -> Result<(tonk_cli::spot::Resolved, site::TonkSite), ExitCode> {
+    let store = match tonk_cli::spot::SpotStore::open() {
+        Ok(store) => store,
+        Err(err) => return Err(print_error(err.to_string())),
+    };
+    let env = std::env::var(tonk_cli::spot::SPOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty());
+    let resolved = match store.resolve(flag, env.as_deref()) {
+        Ok(resolved) => resolved,
+        Err(err) => return Err(print_error(err.to_string())),
+    };
+    match site::TonkSite::open(&resolved.site).await {
+        Ok(site) => Ok((resolved, site)),
+        Err(err) => Err(print_error(format!(
+            "spot '{name}' (via {source}, site {site}): {err:#}",
+            name = resolved.name,
+            source = resolved.source,
+            site = resolved.site.display(),
+        ))),
+    }
 }
 
 /// Specialized [`print_error`] for parse-error mapping. Kept

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1068,7 +1068,7 @@ fn print_guide(topic: Option<&str>) -> ExitCode {
 }
 
 /// Selector for the [`sync_op`] handler. Both `tonk push` and
-/// `tonk pull` follow the same site-discovery + dispatch path;
+/// `tonk pull` follow the same spot-resolution + dispatch path;
 /// the only thing that differs is which dialog primitive they
 /// call and the verb they print on success.
 #[derive(Debug, Clone, Copy)]
@@ -1587,9 +1587,15 @@ fn print_invite_outcome(outcome: &InviteOutcome) {
 
 /// `tonk join` — claim an invite into a fresh canonical spot:
 /// site at `spots/<name>/`, registered and selected on success.
-/// Registration happens only after the claim succeeds, so a
-/// failed join never leaves a dangling registry entry (a partial
-/// site dir may remain; re-running with the same name reports it).
+/// The early registry load below is only a cheap fail-fast
+/// duplicate-name check; the invite claim is a network operation
+/// that can take seconds, so registration itself happens only
+/// after the claim succeeds, against a registry freshly reloaded
+/// at that point — a concurrent `tonk spot new`/`use`/`rm` while
+/// the claim is in flight is re-checked, never silently reverted.
+/// A failed join never leaves a dangling registry entry (a
+/// partial site dir may remain; re-running with the same name
+/// reports it).
 async fn claim_invite(url: String, name: String) -> ExitCode {
     if let Err(err) = tonk_cli::spot::validate_name(&name) {
         return print_error(err.to_string());
@@ -1598,7 +1604,7 @@ async fn claim_invite(url: String, name: String) -> ExitCode {
         Ok(store) => store,
         Err(err) => return print_error(err.to_string()),
     };
-    let mut registry = match store.load() {
+    let registry = match store.load() {
         Ok(registry) => registry,
         Err(err) => return print_error(err.to_string()),
     };
@@ -1611,6 +1617,31 @@ async fn claim_invite(url: String, name: String) -> ExitCode {
     // the joined site picks up the user's normal profile.
     match invite::claim(&root, &url, site::default_config()).await {
         Ok(outcome) => {
+            // Match `spot new`'s canonicalized form, so registered
+            // paths compare equal regardless of how they were added.
+            let root = match root.canonicalize() {
+                Ok(root) => root,
+                Err(err) => {
+                    return print_error(format!(
+                        "joined, but could not canonicalize {}: {err}",
+                        root.display()
+                    ));
+                }
+            };
+
+            let mut registry = match store.load() {
+                Ok(registry) => registry,
+                Err(err) => return print_error(err.to_string()),
+            };
+            if registry.spots.contains_key(&name) {
+                return print_error(format!(
+                    "{err}\nthe site was claimed at {root}; register it with \
+                     `tonk spot new <other-name> --site {root}`",
+                    err = tonk_cli::spot::SpotError::Exists(name.clone()),
+                    root = root.display(),
+                ));
+            }
+
             registry.spots.insert(
                 name.clone(),
                 tonk_cli::spot::SpotEntry { site: root.clone() },

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -27,6 +27,15 @@ any field mints a NEW entity unless you bind the old one with `this:`),
 and bare lowercase tokens are symbols resolved through the name table —
 quote every string literal (`name: "alice"`, not `name: alice`).
 
+## Spots
+
+Commands run against the selected *spot* (a named fact store), not
+the cwd. Resolution order: `--spot <name>` > `TONK_SPOT` env >
+`tonk use <name>` selection. In automation, always pin the spot
+per-process (`TONK_SPOT=x tonk ...` or `--spot x`) — never rely on
+`tonk use`, which is shared global state another session can change.
+`tonk spot list` shows what's registered and what is current.
+
 ## The loop
 
 1. Discover what's already on the branch — don't guess or memorize:

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -27,7 +27,7 @@ use url::Url;
 
 use crate::ExitCode;
 use crate::remote::{self, DEFAULT_REMOTE, META_BRANCH};
-use crate::site::{self, SITE_DIRNAME, SiteConfig, TonkSite};
+use crate::site::{self, SiteConfig, TonkSite};
 use crate::sync;
 
 /// Default base URL for minted invites. Mirrors
@@ -86,11 +86,11 @@ pub enum InviteError {
     /// chain was malformed.
     #[error("invalid invite: {0}")]
     InvalidInvite(String),
-    /// `claim` was asked to bootstrap a `.tonk/` directory in a
-    /// parent that already has one. Tonk is single-site per
-    /// directory; the user must remove or relocate the existing
-    /// site first.
-    #[error("a .tonk/ site already exists at {0}; remove or rename it before joining")]
+    /// `claim` was asked to bootstrap a site directory that
+    /// already exists. The join must never clobber existing site
+    /// storage; the user removes it (or picks another spot name)
+    /// first.
+    #[error("a site already exists at {0}; remove it or pick another spot name")]
     SiteAlreadyExists(PathBuf),
     /// Anything else — key generation, delegation building,
     /// storage I/O. Surfaced verbatim.
@@ -196,18 +196,20 @@ pub async fn mint(
     })
 }
 
-/// Claim an invite, bootstrapping a fresh `.tonk/` under
-/// `parent` whose repository targets the invited subject DID.
+/// Claim an invite, bootstrapping a fresh site at `root` (the
+/// site directory itself — the caller picks it, typically the
+/// canonical `spots/<name>/` dir) whose repository targets the
+/// invited subject DID.
 ///
 /// Steps:
 ///
-/// 1. Refuse if `.tonk/` already exists at `parent` — tonk is
-///    single-site per directory and the join would clobber an
-///    existing site.
+/// 1. Refuse if `root` already exists — the join must never
+///    clobber existing site storage.
 /// 2. Parse the URL via [`Invite::parse_url`]; reject malformed
 ///    invites before touching disk.
-/// 3. Stand up the on-disk `.tonk/` and build a tonk operator
-///    rooted there, opening (or creating) the local profile.
+/// 3. Stand up the on-disk site directory and build a tonk
+///    operator rooted there, opening (or creating) the local
+///    profile.
 /// 4. Claim the invite to the profile's DID and persist the
 ///    resulting chain so the operator can present it on
 ///    subsequent push/pull operations.
@@ -222,16 +224,12 @@ pub async fn mint(
 ///    starts from the upstream's state rather than an empty branch
 ///    that would diverge on the first local write.
 pub async fn claim(
-    parent: &Path,
+    root: &Path,
     invite_url: &str,
     config: SiteConfig,
 ) -> Result<ClaimOutcome, InviteError> {
-    let parent = parent.canonicalize().map_err(|e| {
-        InviteError::Io(format!("could not canonicalize {}: {e}", parent.display()))
-    })?;
-    let root = parent.join(SITE_DIRNAME);
     if root.exists() {
-        return Err(InviteError::SiteAlreadyExists(root));
+        return Err(InviteError::SiteAlreadyExists(root.to_path_buf()));
     }
 
     // Short links (`/@/{hash}#seed`) resolve to the long form first —
@@ -251,8 +249,11 @@ pub async fn claim(
     let invitation = Invitation::from_chain(&invite.chain)
         .expect("Invite invariant: chain has a specific subject");
 
-    std::fs::create_dir_all(&root)
+    std::fs::create_dir_all(root)
         .map_err(|e| InviteError::Io(format!("failed to create {}: {e}", root.display())))?;
+    let root = root
+        .canonicalize()
+        .map_err(|e| InviteError::Io(format!("could not canonicalize {}: {e}", root.display())))?;
 
     let (profile, operator) = site::build_profile_and_operator(&root, &config)
         .await

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -119,7 +119,7 @@ pub async fn mint(
 ) -> Result<InviteOutcome, InviteError> {
     // Push local state to the upstream before minting, so a joiner
     // receives current repo state — including the stdlib seed that
-    // `tonk init` committed before any upstream existed. Mirrors
+    // `tonk spot new` committed before any upstream existed. Mirrors
     // `share`'s push-before-mint. No-op when the branch has no upstream
     // (a local-only invite). Pull-before-push reconciles a possibly
     // advanced upstream, best-effort; the push error is authoritative.
@@ -215,8 +215,8 @@ pub async fn mint(
 ///    subsequent push/pull operations.
 /// 5. Mint a verifier-only credential keyed to the invited
 ///    subject DID and create a local space at `name == "main"`,
-///    matching the layout `tonk init` produces (so all the
-///    later read paths work uniformly across init- and
+///    matching the layout `tonk spot new` produces (so all the
+///    later read paths work uniformly across spot-new- and
 ///    join-bootstrapped sites).
 /// 6. If the invite carried a `remote=` URL, register it, set it
 ///    as the local `main`'s upstream, and pull once — a clean
@@ -293,7 +293,7 @@ pub async fn claim(
         .map_err(|e| InviteError::Io(format!("failed to provision local space: {e}")))?;
 
     // Open the main branch via the standard load path so the
-    // joined site's structure matches `tonk init`'s output.
+    // joined site's structure matches `tonk spot new`'s output.
     // Errors here would mean the create succeeded but the open
     // failed — surfaced as Io so the user sees the underlying
     // dialog message.

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -8,6 +8,7 @@
 //! paths the CLI does.
 //!
 //! - [`site`] — `.tonk/` discovery, repo+branch open/init.
+//! - [`spot`] — spot registry: named spots, canonical storage, selection.
 //! - [`identity`] — local profile management.
 //! - [`authoring`] — pure notation builders (concept, view, and the
 //!   space-home recipe) consumed by the noun-first authoring verbs.
@@ -43,6 +44,7 @@ pub mod render;
 pub mod schema;
 pub mod share;
 pub mod site;
+pub mod spot;
 pub mod sync;
 pub mod telemetry;
 pub mod transfer;

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -7,7 +7,7 @@
 //! the binary) and a future SDK consumer can drive the same code
 //! paths the CLI does.
 //!
-//! - [`site`] — `.tonk/` discovery, repo+branch open/init.
+//! - [`site`] — repo+branch open/init; resolved via the spot registry.
 //! - [`spot`] — spot registry: named spots, canonical storage, selection.
 //! - [`identity`] — local profile management.
 //! - [`authoring`] — pure notation builders (concept, view, and the

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -133,13 +133,30 @@ impl TonkSite {
     }
 
     /// [`Self::init`] with caller-supplied [`SiteConfig`].
+    ///
+    /// Historical parent-relative form: the site lands at
+    /// `parent/.tonk/`. Kept for the test fixtures that model the
+    /// pre-registry layout; new callers go through
+    /// [`Self::init_at_with`].
     pub async fn init_with(parent: &Path, config: SiteConfig) -> Result<Self> {
         let parent = parent
             .canonicalize()
             .with_context(|| format!("could not canonicalize {}", parent.display()))?;
-        let root = parent.join(SITE_DIRNAME);
-        std::fs::create_dir_all(&root)
+        Self::init_at_with(&parent.join(SITE_DIRNAME), config).await
+    }
+
+    /// Initialize (or adopt) a site whose directory is exactly
+    /// `root` — no `.tonk/` nesting. This is what canonical spot
+    /// storage uses: the registry maps a spot name to this
+    /// directory. Idempotent: an existing repository at `root` is
+    /// loaded, not clobbered, which is also how `tonk spot new
+    /// --site <path>` adopts pre-existing storage.
+    pub async fn init_at_with(root: &Path, config: SiteConfig) -> Result<Self> {
+        std::fs::create_dir_all(root)
             .with_context(|| format!("failed to create {}", root.display()))?;
+        let root = root
+            .canonicalize()
+            .with_context(|| format!("could not canonicalize {}", root.display()))?;
 
         let (profile, operator) = build_profile_and_operator(&root, &config).await?;
 

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -1,13 +1,15 @@
-//! `.tonk/` site discovery, init, and open.
+//! Site open and init.
 //!
-//! A *site* is a working directory that contains a `.tonk/`
-//! sub-directory, in which a single dialog repository named
-//! `main` lives. Tonk only reads and writes that one
+//! A *site* is a directory that contains a single dialog
+//! repository named `main`. Tonk only reads and writes that one
 //! repository on the `main` branch — multi-branch / multi-repo
-//! UX is intentionally not exposed.
+//! UX is intentionally not exposed. A site's directory is never
+//! located by walking the current directory: the caller resolves
+//! it through the spot registry (see [`crate::spot`]) and passes
+//! the path in directly.
 //!
 //! [`TonkSite`] is the assembled context every command works
-//! against: profile, operator (rooted at `.tonk/`), the
+//! against: profile, operator (rooted at the site directory), the
 //! repository, and the opened `main` branch.
 
 use std::path::{Path, PathBuf};
@@ -75,28 +77,11 @@ pub struct TonkSite {
 }
 
 impl TonkSite {
-    /// Walk up from `start` looking for a `.tonk/` directory and
-    /// open the site rooted there. Returns an error if no
-    /// `.tonk/` is found between `start` and the filesystem root.
-    pub async fn discover_and_open(start: &Path) -> Result<Self> {
-        let root = find_site_root(start)
-            .with_context(|| format!("no .tonk/ found above {}", start.display()))?;
-        Self::open(&root).await
-    }
-
-    /// Open an already-existing site at the given `.tonk/`
-    /// directory. Errors if the directory exists but the dialog
-    /// repository inside it is missing or unreadable.
+    /// Open an already-existing site at the given directory.
+    /// Errors if the directory exists but the dialog repository
+    /// inside it is missing or unreadable.
     pub async fn open(root: &Path) -> Result<Self> {
         Self::open_with(root, default_config()).await
-    }
-
-    /// Initialize a new site under `parent` — creates the
-    /// `.tonk/` directory if missing, bootstraps the dialog
-    /// repository, and opens the `main` branch. Idempotent: if
-    /// the site already exists, returns it without changes.
-    pub async fn init(parent: &Path) -> Result<Self> {
-        Self::init_with(parent, default_config()).await
     }
 
     /// [`Self::open`] with caller-supplied [`SiteConfig`] —
@@ -313,25 +298,6 @@ pub fn default_config() -> SiteConfig {
     SiteConfig {
         profile_name: PROFILE_NAME.to_string(),
         profile_directory: Directory::Profile,
-    }
-}
-
-/// Walk up the directory tree from `start` looking for a sibling
-/// `.tonk/` directory. Returns the absolute path to that
-/// directory if found.
-fn find_site_root(start: &Path) -> Option<PathBuf> {
-    let mut current: PathBuf = start
-        .canonicalize()
-        .ok()
-        .or_else(|| start.is_absolute().then(|| start.to_path_buf()))?;
-    loop {
-        let candidate = current.join(SITE_DIRNAME);
-        if candidate.is_dir() {
-            return Some(candidate);
-        }
-        if !current.pop() {
-            return None;
-        }
     }
 }
 

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -302,13 +302,13 @@ pub fn default_config() -> SiteConfig {
 }
 
 /// Open (or create) the shared profile and build a tonk
-/// operator rooted at `.tonk/` for repository data. Identity
-/// lives at `config.profile_directory`; only the dialog-repo
-/// blocks live under `.tonk/`.
+/// operator rooted at the site directory for repository data.
+/// Identity lives at `config.profile_directory`; only the
+/// dialog-repo blocks live under the site directory.
 ///
 /// Exposed as `pub(crate)` so the [`crate::invite`] module can
 /// reuse the same wiring when claiming an invite into a fresh
-/// `.tonk/` (the join path provisions the space from a verifier
+/// site (the join path provisions the space from a verifier
 /// credential rather than via `profile.repository(...).open()`,
 /// but the profile + operator setup is the same).
 pub(crate) async fn build_profile_and_operator(

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -109,7 +109,10 @@ pub enum SpotError {
     NoSelection,
     /// The registry has zero spots — selection is moot; the fix is
     /// creating one.
-    #[error("no spots registered; create one with `tonk spot new <name>`")]
+    #[error(
+        "no spots registered; create one with `tonk spot new <name>` \
+         (add --site <path> to adopt an existing .tonk directory)"
+    )]
     NothingRegistered,
     /// A name that isn't in the registry.
     #[error("unknown spot '{name}'{}", unknown_hint(.available))]

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -23,7 +23,7 @@
 //! hard error naming the file — never silently recreated.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -285,6 +285,156 @@ pub fn validate_name(name: &str) -> Result<(), SpotError> {
     } else {
         Err(SpotError::InvalidName(name.to_owned()))
     }
+}
+
+/// Outcome of [`create`]: the registered spot and the DID of the
+/// repository backing it.
+#[derive(Debug, Clone)]
+pub struct CreateOutcome {
+    /// Registry name.
+    pub name: String,
+    /// Absolute site directory.
+    pub site: PathBuf,
+    /// The site repository's DID.
+    pub did: String,
+}
+
+/// Outcome of [`remove`].
+#[derive(Debug, Clone)]
+pub struct RemoveOutcome {
+    /// The removed registry name.
+    pub name: String,
+    /// Where the site lived (still lives, unless `deleted`).
+    pub site: PathBuf,
+    /// Whether the site directory was deleted from disk.
+    pub deleted: bool,
+}
+
+/// Rows for `tonk spot list` plus the resolved current selection
+/// (None when nothing resolves — empty registry or dangling name).
+#[derive(Debug, Clone)]
+pub struct Listing {
+    /// `(name, site)` per registered spot, in name order.
+    pub rows: Vec<(String, PathBuf)>,
+    /// The spot a bare command would hit right now, with source.
+    pub current: Option<Resolved>,
+}
+
+/// Create (or adopt) a spot: initialize the site, register the
+/// name, and select it. The site lands in the store's canonical
+/// `spots/<name>/` unless `site_override` names another directory;
+/// because [`crate::site::TonkSite::init_at_with`] is idempotent,
+/// an override pointing at existing site storage adopts it — the
+/// migration path for pre-registry `.tonk/` dirs.
+pub async fn create(
+    store: &SpotStore,
+    name: &str,
+    site_override: Option<&Path>,
+    config: crate::site::SiteConfig,
+) -> Result<CreateOutcome, SpotError> {
+    validate_name(name)?;
+    let mut registry = store.load()?;
+    if registry.spots.contains_key(name) {
+        return Err(SpotError::Exists(name.to_owned()));
+    }
+
+    let target = site_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| store.canonical_site(name));
+    let site = crate::site::TonkSite::init_at_with(&target, config)
+        .await
+        .map_err(|e| SpotError::Init(format!("{e:#}")))?;
+
+    let outcome = CreateOutcome {
+        name: name.to_owned(),
+        site: site.root.clone(),
+        did: site.repository.did().to_string(),
+    };
+    registry.spots.insert(
+        name.to_owned(),
+        SpotEntry {
+            site: outcome.site.clone(),
+        },
+    );
+    registry.current = Some(name.to_owned());
+    store.save(&registry)?;
+    Ok(outcome)
+}
+
+/// Set the registry's `current` to `name`. This is the human
+/// selection path (`tonk use`); automation pins spots per-process
+/// via [`SPOT_ENV`] / `--spot` instead.
+pub fn select(store: &SpotStore, name: &str) -> Result<Resolved, SpotError> {
+    let mut registry = store.load()?;
+    let Some(entry) = registry.spots.get(name) else {
+        return Err(SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+        });
+    };
+    let resolved = Resolved {
+        name: name.to_owned(),
+        site: entry.site.clone(),
+        source: Source::Global,
+    };
+    registry.current = Some(name.to_owned());
+    store.save(&registry)?;
+    Ok(resolved)
+}
+
+/// Everything `tonk spot list` needs in one read: the rows plus
+/// what a bare command would currently resolve to (honouring the
+/// same `flag`/`env` precedence, so `tonk --spot x spot list`
+/// marks `x`).
+pub fn listing(
+    store: &SpotStore,
+    flag: Option<&str>,
+    env: Option<&str>,
+) -> Result<Listing, SpotError> {
+    let registry = store.load()?;
+    let rows = registry
+        .spots
+        .iter()
+        .map(|(name, entry)| (name.clone(), entry.site.clone()))
+        .collect();
+    Ok(Listing {
+        rows,
+        current: store.resolve(flag, env).ok(),
+    })
+}
+
+/// Remove `name` from the registry, clearing `current` if it
+/// pointed there. Site data stays on disk unless `delete` — the
+/// registry is the authority on names, not a lifecycle manager
+/// for storage it didn't necessarily create.
+pub fn remove(store: &SpotStore, name: &str, delete: bool) -> Result<RemoveOutcome, SpotError> {
+    let mut registry = store.load()?;
+    let Some(entry) = registry.spots.remove(name) else {
+        return Err(SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+        });
+    };
+    if registry.current.as_deref() == Some(name) {
+        registry.current = None;
+    }
+    store.save(&registry)?;
+    let deleted = if delete {
+        std::fs::remove_dir_all(&entry.site).map_err(|e| {
+            SpotError::Io(format!(
+                "entry removed, but deleting {} failed: {e}",
+                entry.site.display()
+            ))
+        })?;
+        true
+    } else {
+        false
+    };
+    Ok(RemoveOutcome {
+        name: name.to_owned(),
+        site: entry.site,
+        deleted,
+    })
 }
 
 #[cfg(test)]

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -1,0 +1,430 @@
+//! Spot registry: named spots, canonical storage, selection.
+//!
+//! A *spot* is a named entry in `spots.json` mapping to the *site*
+//! directory that backs it (see [`crate::site`]). The registry and
+//! the canonical site directories live under the platform data dir
+//! (`~/Library/Application Support/tonk/` on macOS), next to
+//! `telemetry.json` / `update.json`:
+//!
+//! ```text
+//! tonk/
+//!   spots.json      registry: name → site path, plus `current`
+//!   spots/<name>/   canonical site dirs
+//! ```
+//!
+//! Selection resolves `--spot` > `TONK_SPOT` > the registry's
+//! `current`. The flag and env forms are per-invocation /
+//! per-process, so concurrent sessions pinning their own spot can
+//! never mix regardless of who rewrites the shared `current`.
+//!
+//! `spots.json` stores absolute, expanded paths so applications
+//! built on tonk can resolve a name with zero path logic. Writes
+//! go through a temp file + atomic rename. A corrupt registry is a
+//! hard error naming the file — never silently recreated.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Environment variable naming the spot to use, beaten only by the
+/// `--spot` flag. Automation (agents, bench, CI) should always set
+/// this (or pass `--spot`) and never rely on `tonk use`.
+pub const SPOT_ENV: &str = "TONK_SPOT";
+
+/// Environment variable overriding the directory that holds
+/// `spots.json` and the canonical `spots/` root, so tests can
+/// isolate state (same pattern as `TONK_TELEMETRY_STATE`).
+pub const STATE_ENV: &str = "TONK_SPOTS_STATE";
+
+/// File name of the registry inside the store directory.
+const REGISTRY_FILE: &str = "spots.json";
+
+/// Directory name (inside the store) holding canonical site dirs.
+const SPOTS_DIRNAME: &str = "spots";
+
+/// On-disk registry: the shared `current` selection plus one entry
+/// per spot. `BTreeMap` keeps listing and serialization order
+/// stable.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Registry {
+    /// The globally selected spot, if any. A convenience for the
+    /// human at the keyboard; concurrent sessions pin their spot
+    /// via [`SPOT_ENV`] or `--spot` instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<String>,
+    /// Name → entry. Paths inside are absolute and expanded.
+    #[serde(default)]
+    pub spots: BTreeMap<String, SpotEntry>,
+}
+
+/// One registered spot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpotEntry {
+    /// Absolute path to the site directory backing this spot.
+    pub site: PathBuf,
+}
+
+/// Where a resolution's spot name came from. Surfaced in status
+/// and error output so a session can always tell what it is about
+/// to touch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `--spot` flag.
+    Flag,
+    /// [`SPOT_ENV`] environment variable.
+    Env,
+    /// The registry's `current` field.
+    Global,
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Source::Flag => "flag",
+            Source::Env => "env",
+            Source::Global => "global",
+        })
+    }
+}
+
+/// A successful resolution: which spot, where its site lives, and
+/// which selection mechanism picked it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Resolved {
+    /// The spot's registry name.
+    pub name: String,
+    /// Absolute path to the site directory.
+    pub site: PathBuf,
+    /// Which selection mechanism named it.
+    pub source: Source,
+}
+
+/// Failure modes for registry access and resolution.
+#[derive(Debug, Error)]
+pub enum SpotError {
+    /// Spots exist but nothing is selected anywhere.
+    #[error("no spot selected; run `tonk use <name>`, pass --spot, or set TONK_SPOT")]
+    NoSelection,
+    /// The registry has zero spots — selection is moot; the fix is
+    /// creating one.
+    #[error("no spots registered; create one with `tonk spot new <name>`")]
+    NothingRegistered,
+    /// A name that isn't in the registry.
+    #[error("unknown spot '{name}'{}", unknown_hint(.available))]
+    Unknown {
+        /// The name that failed to resolve.
+        name: String,
+        /// Every registered name, for the error hint.
+        available: Vec<String>,
+    },
+    /// `spot new` against a name that already exists. Re-pointing
+    /// is an explicit `rm` + `new`, never an overwrite.
+    #[error("spot '{0}' already exists; run `tonk spot rm {0}` first to re-point it")]
+    Exists(String),
+    /// The registry file exists but doesn't parse. Deliberately
+    /// not self-healing: silently recreating it would orphan every
+    /// registered spot.
+    #[error("corrupt spot registry at {path}: {detail}")]
+    Corrupt {
+        /// Path to the offending `spots.json`.
+        path: PathBuf,
+        /// The serde error text.
+        detail: String,
+    },
+    /// A name outside the allowed slug. Canonical names become
+    /// directory names, so the alphabet is conservative.
+    #[error("invalid spot name '{0}': use [a-z0-9][a-z0-9-_]*")]
+    InvalidName(String),
+    /// The platform reports no data directory (no home).
+    #[error("could not determine the platform data directory")]
+    NoDataDir,
+    /// Site bootstrap (`spot new`) failed inside the site layer.
+    #[error("failed to initialize site: {0}")]
+    Init(String),
+    /// Registry or site-directory I/O.
+    #[error("{0}")]
+    Io(String),
+}
+
+/// Hint suffix for [`SpotError::Unknown`]: list what is
+/// registered, or point at `spot new` when nothing is.
+fn unknown_hint(available: &[String]) -> String {
+    if available.is_empty() {
+        "; none registered (create one with `tonk spot new <name>`)".to_string()
+    } else {
+        format!("; registered: {}", available.join(", "))
+    }
+}
+
+/// Handle on the spot state directory. All registry reads and
+/// writes go through one of these; tests construct it with
+/// [`SpotStore::at`] over a tempdir so nothing touches the user's
+/// real data dir and no test ever mutates process-global env.
+#[derive(Debug, Clone)]
+pub struct SpotStore {
+    dir: PathBuf,
+}
+
+impl SpotStore {
+    /// The real store: [`STATE_ENV`] override, else the platform
+    /// data dir (`dirs::data_dir()/tonk`, the same base telemetry
+    /// and update state use).
+    pub fn open() -> Result<Self, SpotError> {
+        if let Ok(dir) = std::env::var(STATE_ENV)
+            && !dir.is_empty()
+        {
+            return Ok(Self { dir: dir.into() });
+        }
+        let base = dirs::data_dir().ok_or(SpotError::NoDataDir)?;
+        Ok(Self {
+            dir: base.join("tonk"),
+        })
+    }
+
+    /// A store rooted at an explicit directory (tests).
+    pub fn at(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    /// Path to `spots.json` inside this store.
+    pub fn registry_path(&self) -> PathBuf {
+        self.dir.join(REGISTRY_FILE)
+    }
+
+    /// Canonical site directory for `name` inside this store.
+    /// Purely a path computation — nothing is created.
+    pub fn canonical_site(&self, name: &str) -> PathBuf {
+        self.dir.join(SPOTS_DIRNAME).join(name)
+    }
+
+    /// Load the registry. A missing file is an empty registry (the
+    /// pre-first-use state); an unparseable one is
+    /// [`SpotError::Corrupt`].
+    pub fn load(&self) -> Result<Registry, SpotError> {
+        let path = self.registry_path();
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Registry::default());
+            }
+            Err(e) => {
+                return Err(SpotError::Io(format!(
+                    "could not read {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        serde_json::from_str(&text).map_err(|e| SpotError::Corrupt {
+            path,
+            detail: e.to_string(),
+        })
+    }
+
+    /// Persist the registry atomically: write a sibling temp file,
+    /// then rename over `spots.json` so concurrent readers never
+    /// observe a torn write.
+    pub fn save(&self, registry: &Registry) -> Result<(), SpotError> {
+        std::fs::create_dir_all(&self.dir)
+            .map_err(|e| SpotError::Io(format!("could not create {}: {e}", self.dir.display())))?;
+        let path = self.registry_path();
+        let tmp = self.dir.join(format!("{REGISTRY_FILE}.tmp"));
+        let text = serde_json::to_string_pretty(registry)
+            .map_err(|e| SpotError::Io(format!("could not serialize registry: {e}")))?;
+        std::fs::write(&tmp, text)
+            .map_err(|e| SpotError::Io(format!("could not write {}: {e}", tmp.display())))?;
+        std::fs::rename(&tmp, &path)
+            .map_err(|e| SpotError::Io(format!("could not move {} into place: {e}", tmp.display())))
+    }
+
+    /// Resolve the spot a command should operate on.
+    ///
+    /// Strict precedence: `flag` (`--spot`) > `env` ([`SPOT_ENV`],
+    /// already read and empty-filtered by the caller) > the
+    /// registry's `current`. The cwd is never consulted.
+    pub fn resolve(&self, flag: Option<&str>, env: Option<&str>) -> Result<Resolved, SpotError> {
+        let registry = self.load()?;
+        let (name, source) = if let Some(name) = flag {
+            (name.to_owned(), Source::Flag)
+        } else if let Some(name) = env {
+            (name.to_owned(), Source::Env)
+        } else if let Some(name) = registry.current.clone() {
+            (name, Source::Global)
+        } else if registry.spots.is_empty() {
+            return Err(SpotError::NothingRegistered);
+        } else {
+            return Err(SpotError::NoSelection);
+        };
+        match registry.spots.get(&name) {
+            Some(entry) => Ok(Resolved {
+                name,
+                site: entry.site.clone(),
+                source,
+            }),
+            None => Err(SpotError::Unknown {
+                name,
+                available: registry.spots.keys().cloned().collect(),
+            }),
+        }
+    }
+}
+
+/// Validate a spot name against the canonical slug:
+/// `[a-z0-9][a-z0-9-_]*`. Names become directory names under
+/// `spots/`, so the alphabet stays conservative.
+pub fn validate_name(name: &str) -> Result<(), SpotError> {
+    let mut chars = name.chars();
+    let head_ok = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    let tail_ok =
+        chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_');
+    if head_ok && tail_ok {
+        Ok(())
+    } else {
+        Err(SpotError::InvalidName(name.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, SpotStore) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = SpotStore::at(tmp.path());
+        (tmp, store)
+    }
+
+    fn registry_with(names: &[(&str, &str)], current: Option<&str>) -> Registry {
+        Registry {
+            current: current.map(str::to_owned),
+            spots: names
+                .iter()
+                .map(|(name, site)| {
+                    (
+                        (*name).to_owned(),
+                        SpotEntry {
+                            site: PathBuf::from(site),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    mod loading_and_saving {
+        use super::*;
+
+        #[test]
+        fn it_treats_a_missing_registry_as_empty() {
+            let (_tmp, store) = store();
+            let registry = store.load().expect("load");
+            assert_eq!(registry, Registry::default());
+        }
+
+        #[test]
+        fn it_round_trips_the_registry() {
+            let (_tmp, store) = store();
+            let registry = registry_with(&[("garden", "/tmp/garden")], Some("garden"));
+            store.save(&registry).expect("save");
+            assert_eq!(store.load().expect("load"), registry);
+        }
+
+        #[test]
+        fn it_errors_on_a_corrupt_registry_instead_of_recreating() {
+            let (_tmp, store) = store();
+            std::fs::create_dir_all(store.registry_path().parent().unwrap()).unwrap();
+            std::fs::write(store.registry_path(), "not json").unwrap();
+            let err = store.load().expect_err("corrupt must not load");
+            assert!(matches!(err, SpotError::Corrupt { .. }), "{err}");
+            // Still corrupt afterwards — load must not have healed it.
+            assert_eq!(
+                std::fs::read_to_string(store.registry_path()).unwrap(),
+                "not json"
+            );
+        }
+
+        #[test]
+        fn it_leaves_no_temp_file_behind_after_save() {
+            let (_tmp, store) = store();
+            store.save(&Registry::default()).expect("save");
+            let leftovers: Vec<_> = std::fs::read_dir(store.registry_path().parent().unwrap())
+                .unwrap()
+                .map(|e| e.unwrap().file_name())
+                .filter(|n| n.to_string_lossy().ends_with(".tmp"))
+                .collect();
+            assert!(leftovers.is_empty(), "{leftovers:?}");
+        }
+    }
+
+    mod resolving {
+        use super::*;
+
+        #[test]
+        fn it_prefers_flag_over_env_over_global() {
+            let (_tmp, store) = store();
+            let registry = registry_with(&[("a", "/s/a"), ("b", "/s/b"), ("c", "/s/c")], Some("c"));
+            store.save(&registry).expect("save");
+
+            let flag = store.resolve(Some("a"), Some("b")).expect("flag");
+            assert_eq!((flag.name.as_str(), flag.source), ("a", Source::Flag));
+
+            let env = store.resolve(None, Some("b")).expect("env");
+            assert_eq!((env.name.as_str(), env.source), ("b", Source::Env));
+
+            let global = store.resolve(None, None).expect("global");
+            assert_eq!((global.name.as_str(), global.source), ("c", Source::Global));
+            assert_eq!(global.site, PathBuf::from("/s/c"));
+        }
+
+        #[test]
+        fn it_errors_when_nothing_is_selected() {
+            let (_tmp, store) = store();
+            store
+                .save(&registry_with(&[("a", "/s/a")], None))
+                .expect("save");
+            let err = store.resolve(None, None).expect_err("no selection");
+            assert!(matches!(err, SpotError::NoSelection), "{err}");
+        }
+
+        #[test]
+        fn it_hints_spot_new_when_the_registry_is_empty() {
+            let (_tmp, store) = store();
+            let err = store.resolve(None, None).expect_err("empty");
+            assert!(matches!(err, SpotError::NothingRegistered), "{err}");
+            assert!(err.to_string().contains("tonk spot new"), "{err}");
+        }
+
+        #[test]
+        fn it_errors_on_an_unknown_name_listing_available() {
+            let (_tmp, store) = store();
+            store
+                .save(&registry_with(&[("a", "/s/a")], None))
+                .expect("save");
+            let err = store.resolve(Some("nope"), None).expect_err("unknown");
+            assert!(err.to_string().contains("registered: a"), "{err}");
+        }
+    }
+
+    mod naming {
+        use super::*;
+
+        #[test]
+        fn it_accepts_conservative_slugs() {
+            for name in ["a", "garden", "work-2", "a_b", "0day"] {
+                assert!(validate_name(name).is_ok(), "{name}");
+            }
+        }
+
+        #[test]
+        fn it_rejects_everything_else() {
+            for name in [
+                "", "Garden", "-lead", "_lead", "sp ace", "dot.", "sl/ash", "über",
+            ] {
+                assert!(validate_name(name).is_err(), "{name}");
+            }
+        }
+    }
+}

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -1,0 +1,173 @@
+//! CLI-level spot resolution: spawns the real `tonk` binary against
+//! an isolated registry (`TONK_SPOTS_STATE`) and pins `TONK_SPOT` /
+//! `--spot` explicitly, so these exercise the same precedence and
+//! error text a human or an agent actually sees — not just the
+//! `spot` module's in-process ops (covered by `tests/spot.rs`).
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Path to the `tonk` binary under test. Mirrors `tests/telemetry.rs`:
+/// the compile-time `CARGO_BIN_EXE_tonk` points into the sandbox the
+/// tests were built in; a `cargo nextest archive` run on another
+/// machine supplies the remapped location at runtime instead.
+fn tonk_bin() -> std::path::PathBuf {
+    std::env::var_os("NEXTEST_BIN_EXE_tonk")
+        .map(Into::into)
+        .unwrap_or_else(|| env!("CARGO_BIN_EXE_tonk").into())
+}
+
+/// A `tonk` invocation isolated from the developer's real state:
+/// registry under `state_dir`, telemetry disabled and redirected,
+/// update-check disabled and redirected — same hygiene as
+/// `tests/telemetry.rs`'s `run_tonk_guide`. `TONK_SPOT` is always
+/// removed first so the outer environment never leaks in; pass it
+/// via `extra_env` to pin it explicitly.
+fn tonk_cmd(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Command {
+    let mut cmd = Command::new(tonk_bin());
+    cmd.args(args)
+        .env("TONK_SPOTS_STATE", state_dir)
+        .env("TONK_TELEMETRY_STATE", state_dir)
+        .env("DO_NOT_TRACK", "1")
+        .env_remove("TONK_TELEMETRY")
+        .env("TONK_NO_UPDATE_CHECK", "1")
+        .env("TONK_UPDATE_STATE", state_dir)
+        .env_remove("TONK_SPOT");
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    cmd
+}
+
+fn run(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
+    tonk_cmd(state_dir, args, extra_env)
+        .output()
+        .expect("tonk binary runs")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Write a `spots.json` registry directly (bypassing the CLI) so
+/// each test starts from a known, isolated fixture. `entries` are
+/// `(name, absolute site path)` pairs; site paths need not contain a
+/// real repo — resolution and its error text are what's under test,
+/// not site opening.
+fn write_registry(state_dir: &Path, entries: &[(&str, &Path)], current: Option<&str>) {
+    let spots: String = entries
+        .iter()
+        .map(|(name, site)| {
+            format!(
+                "\"{name}\":{{\"site\":{site:?}}}",
+                name = name,
+                site = site.display().to_string(),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let current = match current {
+        Some(name) => format!("\"current\":\"{name}\","),
+        None => String::new(),
+    };
+    let json = format!("{{{current}\"spots\":{{{spots}}}}}");
+    std::fs::write(state_dir.join("spots.json"), json).expect("write spots.json");
+}
+
+mod when_nothing_is_registered {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_errors_with_spot_new_hint_when_nothing_registered() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let output = run(state.path(), &["status"], &[]);
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("no spots registered"), "{stderr}");
+        assert!(stderr.contains("--site"), "{stderr}");
+    }
+}
+
+mod when_resolving_with_precedence {
+    use super::*;
+
+    fn two_spot_registry(state: &Path) {
+        let a = state.join("site-a");
+        let b = state.join("site-b");
+        std::fs::create_dir_all(&a).expect("mkdir a");
+        std::fs::create_dir_all(&b).expect("mkdir b");
+        write_registry(state, &[("a", &a), ("b", &b)], Some("b"));
+    }
+
+    #[dialog_common::test]
+    fn it_prefers_the_flag_over_env_and_global() {
+        let state = tempfile::tempdir().expect("tempdir");
+        two_spot_registry(state.path());
+
+        let output = run(
+            state.path(),
+            &["--spot", "a", "status"],
+            &[("TONK_SPOT", "b")],
+        );
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("spot 'a' (via flag"), "{stderr}");
+    }
+
+    #[dialog_common::test]
+    fn it_reads_tonk_spot_from_the_environment() {
+        let state = tempfile::tempdir().expect("tempdir");
+        two_spot_registry(state.path());
+
+        let output = run(state.path(), &["status"], &[("TONK_SPOT", "a")]);
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("spot 'a' (via env"), "{stderr}");
+    }
+
+    #[dialog_common::test]
+    fn it_treats_an_empty_tonk_spot_as_unset() {
+        let state = tempfile::tempdir().expect("tempdir");
+        two_spot_registry(state.path());
+
+        let output = run(state.path(), &["status"], &[("TONK_SPOT", "")]);
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("spot 'b' (via global"), "{stderr}");
+    }
+
+    #[dialog_common::test]
+    fn it_errors_on_an_unknown_spot_naming_available() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let a = state.path().join("site-a");
+        std::fs::create_dir_all(&a).expect("mkdir a");
+        write_registry(state.path(), &[("a", &a)], None);
+
+        let output = run(state.path(), &["status"], &[("TONK_SPOT", "nope")]);
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("unknown spot 'nope'"), "{stderr}");
+        assert!(stderr.contains("registered: a"), "{stderr}");
+    }
+}
+
+mod when_joining {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_rejects_a_duplicate_join_name_before_any_network_work() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let a = state.path().join("site-a");
+        std::fs::create_dir_all(&a).expect("mkdir a");
+        write_registry(state.path(), &[("a", &a)], Some("a"));
+
+        let output = run(
+            state.path(),
+            &["join", "not-a-real-url", "--name", "a"],
+            &[],
+        );
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("already exists"), "{stderr}");
+    }
+}

--- a/rust/tonk-cli/tests/render.rs
+++ b/rust/tonk-cli/tests/render.rs
@@ -11,7 +11,7 @@ use tonk_cli::render::{self, RenderRoute};
 
 use crate::common::TestSite;
 
-// `tonk init` seeds the standard library (`tonk:view`,
+// Site init seeds the standard library (`tonk:view`,
 // `tonk:view/directory`, etc.), so these tests rely on the built-in
 // view concepts being present rather than seeding them by hand.
 
@@ -46,7 +46,7 @@ async fn seeded() -> Result<TestSite> {
 #[dialog_common::test]
 async fn it_seeds_the_standard_library_on_init() -> Result<()> {
     // A fresh site has the built-in `view` concept without any manual
-    // seeding — proof that `tonk init` lowered core.yaml.
+    // seeding — proof that site init lowered core.yaml.
     let test = TestSite::new().await?;
     let concepts = tonk_cli::schema::list_concepts(&test.site).await?;
     assert!(

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1537,3 +1537,35 @@ mod when_migrating_from_carry {
         Ok(())
     }
 }
+
+mod when_initializing_at_an_explicit_root {
+    use anyhow::Result;
+    use tonk_cli::site::TonkSite;
+
+    use crate::common;
+
+    /// Canonical spots put repo blocks directly in the registered
+    /// site directory — no `.tonk/` nesting. `init_at_with` must
+    /// root the site at exactly the path it is given.
+    #[dialog_common::test]
+    async fn it_roots_the_site_at_the_given_directory() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let parent = tmp.path().canonicalize()?;
+        let config = common::isolated_config(&parent)?;
+        let root = parent.join("spots").join("garden");
+
+        let site = TonkSite::init_at_with(&root, config.clone()).await?;
+        assert_eq!(site.root, root.canonicalize()?);
+        assert!(!root.join(".tonk").exists(), "no nested .tonk");
+
+        // Idempotent: a second init at the same root adopts the
+        // existing repo instead of erroring or re-seeding.
+        let reopened = TonkSite::init_at_with(&root, config.clone()).await?;
+        assert_eq!(reopened.repository.did(), site.repository.did());
+
+        // And a plain open works against it.
+        let opened = TonkSite::open_with(&root, config).await?;
+        assert_eq!(opened.repository.did(), site.repository.did());
+        Ok(())
+    }
+}

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -13,8 +13,8 @@ mod when_initializing_a_site {
     async fn it_creates_a_dialog_repository_with_a_stable_did() -> Result<()> {
         let test = common::TestSite::new().await?;
         // The repo's DID is a real ed25519 key, not the empty
-        // string — running `tonk init` produced a usable repo
-        // backed by the on-disk `.tonk/` directory.
+        // string — site init produced a usable repo backed by
+        // the on-disk `.tonk/` directory.
         let did = test.site.repository.did().to_string();
         assert!(did.starts_with("did:key:"));
         Ok(())

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -158,8 +158,9 @@ mod when_shortening_an_invite {
 
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
-        let claim_outcome = invite::claim(&claimer_parent, &short, claimer_config).await?;
+        let claim_outcome = invite::claim(&claimer_root, &short, claimer_config).await?;
         assert_eq!(claim_outcome.subject, inviter.site.repository.did());
         assert!(claim_outcome.remote_url.is_some());
         Ok(())
@@ -170,7 +171,7 @@ mod when_claiming_an_invite_with_a_remote {
     use anyhow::Result;
     use tonk_cli::invite;
     use tonk_cli::remote;
-    use tonk_cli::site::{SITE_DIRNAME, TonkSite};
+    use tonk_cli::site::TonkSite;
 
     use crate::common;
 
@@ -188,9 +189,10 @@ mod when_claiming_an_invite_with_a_remote {
         // Claimer joins into a fresh tempdir.
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
         let claim_outcome =
-            invite::claim(&claimer_parent, &invite_outcome.url, claimer_config.clone()).await?;
+            invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
 
         // Claim returned the embedded URL and surfaced the
         // auto-configured remote name.
@@ -202,8 +204,7 @@ mod when_claiming_an_invite_with_a_remote {
 
         // Open the joined site and assert the remote landed in
         // its meta branch and main's upstream is wired.
-        let joined =
-            TonkSite::open_with(&claimer_parent.join(SITE_DIRNAME), claimer_config).await?;
+        let joined = TonkSite::open_with(&claimer_root, claimer_config).await?;
         let listed = remote::list(&joined).await?;
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "origin");
@@ -224,13 +225,13 @@ mod when_claiming_an_invite_with_a_remote {
 
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
         let claim_outcome =
-            invite::claim(&claimer_parent, &invite_outcome.url, claimer_config.clone()).await?;
+            invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
 
         assert!(claim_outcome.auto_configured_remote.is_none());
-        let joined =
-            TonkSite::open_with(&claimer_parent.join(SITE_DIRNAME), claimer_config).await?;
+        let joined = TonkSite::open_with(&claimer_root, claimer_config).await?;
         let listed = remote::list(&joined).await?;
         assert!(listed.is_empty());
         Ok(())
@@ -241,7 +242,7 @@ mod when_recording_roster_facts {
     use anyhow::Result;
     use dialog_query::{Output as _, Query, Term};
     use tonk_cli::invite;
-    use tonk_cli::site::{SITE_DIRNAME, TonkSite};
+    use tonk_cli::site::TonkSite;
     use tonk_invite::Invite;
     use tonk_schema::prelude::DidExt as _;
     use tonk_schema::{Invitation, InvitedVia, Membership};
@@ -285,10 +286,10 @@ mod when_recording_roster_facts {
         // Claim into a fresh site.
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
-        invite::claim(&claimer_parent, &invite_outcome.url, claimer_config.clone()).await?;
-        let joined =
-            TonkSite::open_with(&claimer_parent.join(SITE_DIRNAME), claimer_config).await?;
+        invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
+        let joined = TonkSite::open_with(&claimer_root, claimer_config).await?;
 
         // Claimer side: membership + stamp referencing the same
         // invitation entity.
@@ -331,7 +332,7 @@ mod when_recording_roster_facts {
 mod when_minting_and_claiming_an_invite {
     use anyhow::Result;
     use tonk_cli::invite::{self, InviteError};
-    use tonk_cli::site::{self, SITE_DIRNAME, TonkSite};
+    use tonk_cli::site::{self, TonkSite};
 
     use crate::common;
 
@@ -354,9 +355,10 @@ mod when_minting_and_claiming_an_invite {
         // so we don't pre-init the site.
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
         let claim_outcome =
-            invite::claim(&claimer_parent, &invite_outcome.url, claimer_config.clone()).await?;
+            invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
         // The claimer's site now targets the inviter's subject.
         assert_eq!(claim_outcome.subject, inviter.site.repository.did());
         // No remote was attached at mint, so the outcome
@@ -364,8 +366,7 @@ mod when_minting_and_claiming_an_invite {
         assert!(claim_outcome.remote_url.is_none());
 
         // Re-opening the joined site lands the same subject.
-        let joined =
-            TonkSite::open_with(&claimer_parent.join(SITE_DIRNAME), claimer_config).await?;
+        let joined = TonkSite::open_with(&claimer_root, claimer_config).await?;
         assert_eq!(joined.repository.did(), inviter.site.repository.did());
         Ok(())
     }
@@ -375,14 +376,21 @@ mod when_minting_and_claiming_an_invite {
         let inviter = common::TestSite::new().await?;
         let invite_outcome = invite::mint(&inviter.site, None, None).await?;
 
-        // Stand up a claimer site, then try to join into the
-        // same parent — the existing `.tonk/` should block.
-        let claimer = common::TestSite::new().await?;
-        let result =
-            invite::claim(&claimer.parent, &invite_outcome.url, claimer.config.clone()).await;
+        // Claim once into a fresh root, then try to claim again
+        // against the same root — the existing site should block.
+        let claimer_tmp = tempfile::tempdir()?;
+        let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
+        let claimer_config = common::isolated_config(&claimer_parent)?;
+        invite::claim(&claimer_root, &invite_outcome.url, claimer_config.clone()).await?;
+
+        let result = invite::claim(&claimer_root, &invite_outcome.url, claimer_config).await;
         match result {
-            Err(InviteError::SiteAlreadyExists(path)) => {
-                assert_eq!(path, claimer.parent.join(SITE_DIRNAME));
+            Err(err @ InviteError::SiteAlreadyExists(_)) => {
+                assert!(
+                    err.to_string().contains("a site already exists"),
+                    "unexpected message: {err}"
+                );
             }
             other => panic!("expected SiteAlreadyExists, got: {other:?}"),
         }
@@ -393,14 +401,15 @@ mod when_minting_and_claiming_an_invite {
     async fn it_rejects_a_malformed_invite_url() -> Result<()> {
         let claimer_tmp = tempfile::tempdir()?;
         let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
         let claimer_config = common::isolated_config(&claimer_parent)?;
-        let result = invite::claim(&claimer_parent, "not-a-url", claimer_config).await;
+        let result = invite::claim(&claimer_root, "not-a-url", claimer_config).await;
         match result {
             Err(InviteError::InvalidInvite(_)) => {}
             other => panic!("expected InvalidInvite, got: {other:?}"),
         }
-        // No `.tonk/` should have been created on a parse-failure path.
-        assert!(!claimer_parent.join(SITE_DIRNAME).exists());
+        // No site directory should have been created on a parse-failure path.
+        assert!(!claimer_root.exists());
         Ok(())
     }
 

--- a/rust/tonk-cli/tests/spot.rs
+++ b/rust/tonk-cli/tests/spot.rs
@@ -1,0 +1,130 @@
+//! Spot management ops: create/register/select/list/remove against
+//! an isolated store. These exercise the `spot` module's ops layer
+//! the way the `tonk use` / `tonk spot *` commands drive it —
+//! nothing here touches process env or the user's data dir.
+
+mod common;
+
+use anyhow::Result;
+use tonk_cli::site::TonkSite;
+use tonk_cli::spot::{self, SpotStore};
+
+mod when_creating_a_spot {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_creates_registers_and_selects_in_the_canonical_dir() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        let outcome = spot::create(&store, "garden", None, config.clone()).await?;
+        assert_eq!(outcome.site, store.canonical_site("garden").canonicalize()?);
+
+        // Registered and selected: a bare resolve now finds it.
+        let resolved = store.resolve(None, None)?;
+        assert_eq!(resolved.name, "garden");
+        assert_eq!(resolved.site, outcome.site);
+
+        // And the site actually opens.
+        let opened = TonkSite::open_with(&resolved.site, config).await?;
+        assert_eq!(opened.repository.did().to_string(), outcome.did);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_adopts_an_existing_site_via_site_override() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let parent = tmp.path().canonicalize()?;
+        let config = common::isolated_config(&parent)?;
+
+        // A pre-existing site (the old cwd-`.tonk` migration case).
+        let legacy_root = parent.join("proj").join(".tonk");
+        let legacy = TonkSite::init_at_with(&legacy_root, config.clone()).await?;
+
+        let outcome = spot::create(&store, "proj", Some(&legacy_root), config.clone()).await?;
+        assert_eq!(outcome.did, legacy.repository.did().to_string());
+        assert_eq!(outcome.site, legacy_root.canonicalize()?);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_duplicate_name() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        spot::create(&store, "garden", None, config.clone()).await?;
+        let err = spot::create(&store, "garden", None, config)
+            .await
+            .expect_err("duplicate");
+        assert!(matches!(err, spot::SpotError::Exists(_)), "{err}");
+        Ok(())
+    }
+}
+
+mod when_removing_a_spot {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_unregisters_but_keeps_data_by_default() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, config).await?;
+
+        let outcome = spot::remove(&store, "garden", false)?;
+        assert!(!outcome.deleted);
+        assert!(created.site.exists(), "data kept");
+        // Entry and selection are gone.
+        assert!(store.load()?.spots.is_empty());
+        assert!(store.load()?.current.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_deletes_the_site_dir_with_delete() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, config).await?;
+
+        let outcome = spot::remove(&store, "garden", true)?;
+        assert!(outcome.deleted);
+        assert!(!created.site.exists(), "data removed");
+        Ok(())
+    }
+}
+
+mod when_selecting_and_listing {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_selects_by_name_and_lists_with_the_resolved_current() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        spot::create(&store, "a", None, config.clone()).await?;
+        spot::create(&store, "b", None, config).await?; // create selects b
+
+        let selected = spot::select(&store, "a")?;
+        assert_eq!(selected.name, "a");
+        assert_eq!(store.load()?.current.as_deref(), Some("a"));
+
+        let listing = spot::listing(&store, None, None)?;
+        assert_eq!(
+            listing
+                .rows
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert_eq!(listing.current.as_ref().map(|c| c.name.as_str()), Some("a"));
+
+        let err = spot::select(&store, "nope").expect_err("unknown");
+        assert!(matches!(err, spot::SpotError::Unknown { .. }), "{err}");
+        Ok(())
+    }
+}

--- a/rust/tonk-cli/tests/transfer.rs
+++ b/rust/tonk-cli/tests/transfer.rs
@@ -35,7 +35,7 @@ async fn it_exports_seeded_artifacts_as_csv() -> Result<()> {
 #[tokio::test]
 async fn it_round_trips_export_then_import() -> Result<()> {
     // Seed a site with extra attributes on top of the standard-library
-    // baseline `tonk init` provides, and export the whole branch.
+    // baseline site init provides, and export the whole branch.
     let source = TestSite::new().await?;
     source.eval_inline(ATTRIBUTE_DECL).await?;
     let source_csv = export_to_string(&source).await?;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `tonk` CLI to implement a new spot management feature, allowing users to create, select, and manage named spots for their dialog repositories, enhancing usability by eliminating the need to navigate to specific directories.

### Detailed summary
- Updated version numbers in `Cargo.toml` files to `0.6.0`.
- Added new test entries for `spot` in `Cargo.toml`.
- Introduced new tests for spot management in `rust/tonk-cli/tests/spot.rs`.
- Added `spot` module in `rust/tonk-cli/src/lib.rs`.
- Updated documentation to reflect changes in CLI behavior regarding spots.
- Implemented a new `spot` registry in `rust/tonk-cli/src/spot.rs`.
- Modified existing functions to support spot management, including creation, selection, and listing of spots.
- Enhanced error handling for spot-related operations.
- Updated README and documentation to guide users on using the new spot feature.

> The following files were skipped due to too many changes: `rust/tonk-cli/src/spot.rs`, `rust/tonk-cli/src/bin/tonk.rs`, `docs/superpowers/plans/2026-07-20-cli-canonical-spots.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->