### PR TITLE
feat(tonk-identity): passkey-derived root identity foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4437,6 +4446,23 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-streams 0.6.0",
  "web-sys",
+]
+
+[[package]]
+name = "tonk-identity"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "dialog-common",
+ "dialog-credentials",
+ "dialog-ucan-core",
+ "dialog-varsig",
+ "hex",
+ "hkdf",
+ "sha2 0.10.9",
+ "tokio",
+ "wasm-bindgen-test",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,11 +4457,17 @@ dependencies = [
  "dialog-credentials",
  "dialog-ucan-core",
  "dialog-varsig",
+ "getrandom 0.3.4",
  "hex",
  "hkdf",
+ "js-sys",
+ "rand 0.9.5",
  "sha2 0.10.9",
  "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,6 +4715,7 @@ dependencies = [
  "tonk-analytics",
  "tonk-common",
  "tonk-host",
+ "tonk-identity",
  "tonk-portal",
  "tonk-worker",
  "tonk-worker-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "rust/tonk-guest",
     "rust/tonk-host",
     "rust/tonk-invite",
+    "rust/tonk-identity",
     "rust/tonk-inspector",
     "rust/tonk-language-server",
     "rust/tonk-macros",
@@ -56,6 +57,7 @@ tonk-evaluator = { path = "./rust/tonk-evaluator" }
 tonk-host = { path = "./rust/tonk-host" }
 tonk-inspector = { path = "./rust/tonk-inspector" }
 tonk-invite = { path = "./rust/tonk-invite" }
+tonk-identity = { path = "./rust/tonk-identity" }
 tonk-language-server = { path = "./rust/tonk-language-server" }
 tonk-macros = { path = "./rust/tonk-macros" }
 tonk-notation = { path = "./rust/tonk-notation" }
@@ -161,6 +163,7 @@ webbrowser = "1.0"
 worker = "0.8.5"
 worker-macros = "0.8.5"
 serial_test = "3"
+zeroize = "1"
 
 # Bindgen
 wasm-bindgen = "=0.2.126"

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -17,6 +17,7 @@ zeroize = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom_0_3 = { workspace = true }
+hex = { workspace = true }
 js-sys = { workspace = true }
 rand = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "tonk-identity"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Root identity derived from a passkey: PRF-derived root key and the root-to-device delegation."
+
+[dependencies]
+anyhow = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-varsig = { workspace = true }
+hkdf = { workspace = true }
+sha2_0_10 = { workspace = true }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+dialog-common = { workspace = true, features = ["helpers"] }
+hex = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+wasm-bindgen-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(dialog_test_native_integration)',
+    'cfg(dialog_test_wasm_integration)',
+    'cfg(feature, values("web-integration-tests"))',
+] }

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -15,6 +15,34 @@ hkdf = { workspace = true }
 sha2_0_10 = { workspace = true }
 zeroize = { workspace = true }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom_0_3 = { workspace = true }
+js-sys = { workspace = true }
+rand = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
+    "AuthenticationExtensionsClientInputs",
+    "AuthenticationExtensionsClientOutputs",
+    "AuthenticationExtensionsPrfInputs",
+    "AuthenticationExtensionsPrfOutputs",
+    "AuthenticationExtensionsPrfValues",
+    "AuthenticatorSelectionCriteria",
+    "CredentialCreationOptions",
+    "CredentialRequestOptions",
+    "CredentialsContainer",
+    "Navigator",
+    "PublicKeyCredential",
+    "PublicKeyCredentialCreationOptions",
+    "PublicKeyCredentialParameters",
+    "PublicKeyCredentialRequestOptions",
+    "PublicKeyCredentialRpEntity",
+    "PublicKeyCredentialType",
+    "PublicKeyCredentialUserEntity",
+    "UserVerificationRequirement",
+    "Window",
+] }
+
 [dev-dependencies]
 dialog-common = { workspace = true, features = ["helpers"] }
 hex = { workspace = true }

--- a/rust/tonk-identity/src/delegation.rs
+++ b/rust/tonk-identity/src/delegation.rs
@@ -1,0 +1,94 @@
+//! The `root → device` delegation.
+
+use anyhow::Result;
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+use dialog_varsig::Did;
+
+/// Mint the `root → device` delegation: subject-open, audience-specific —
+/// "this device may act as me, for anything". Deliberately the opposite
+/// shape from space invites, which are subject-specific and must stay so.
+pub async fn mint_device_delegation(root: Ed25519Signer, device: &Did) -> Result<DelegationChain> {
+    let delegation = DelegationBuilder::new()
+        .issuer(root)
+        .audience(device)
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to mint the device delegation: {e}"))?;
+    Ok(DelegationChain::new(delegation))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::ed25519::Ed25519Signer;
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_varsig::principal::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const ROOT_PRF: [u8; 32] = [1u8; 32];
+    const DEVICE_SEED: [u8; 32] = [2u8; 32];
+    const SPACE_SEED: [u8; 32] = [3u8; 32];
+
+    async fn signer(seed: &[u8; 32]) -> Ed25519Signer {
+        Ed25519Signer::import(seed).await.unwrap()
+    }
+
+    /// One-hop chain `issuer → audience` scoped to `subject` — the shape
+    /// of a space delegating to a root identity.
+    async fn space_chain(issuer: Ed25519Signer, audience: &Did, subject: &Did) -> DelegationChain {
+        let delegation = DelegationBuilder::new()
+            .issuer(issuer)
+            .audience(audience)
+            .subject(UcanSubject::Specific(subject.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        DelegationChain::new(delegation)
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_a_subject_open_delegation_to_the_device() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let device = signer(&DEVICE_SEED).await;
+        let chain = mint_device_delegation(root, &device.did()).await.unwrap();
+        assert_eq!(*chain.audience(), device.did());
+        assert!(
+            chain.subject().is_none(),
+            "root → device must be subject-open"
+        );
+        assert_eq!(chain.proof_cids().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_extends_a_space_chain_through_the_root_to_the_device() {
+        let space = signer(&SPACE_SEED).await;
+        let space_did = space.did();
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let root_did = root.did();
+        let device = signer(&DEVICE_SEED).await;
+
+        // space → root, scoped to the space itself.
+        let chain = space_chain(space, &root_did, &space_did).await;
+
+        // root → device is minted independently and subject-open; pushed
+        // onto the space chain it must still verify, with the space
+        // subject carried through.
+        let device_link = mint_device_delegation(root, &device.did()).await.unwrap();
+        let device_delegation = device_link.proofs().last().unwrap().clone();
+        let composed = chain.push(device_delegation).unwrap();
+
+        assert_eq!(*composed.audience(), device.did());
+        assert_eq!(composed.subject(), Some(&space_did));
+        assert_eq!(composed.proof_cids().len(), 2);
+    }
+}

--- a/rust/tonk-identity/src/derive.rs
+++ b/rust/tonk-identity/src/derive.rs
@@ -1,5 +1,7 @@
 //! Root-key derivation from a passkey PRF output.
 
+use anyhow::Result;
+use dialog_credentials::Ed25519Signer;
 use hkdf::Hkdf;
 use sha2_0_10::Sha256;
 use zeroize::Zeroizing;
@@ -21,9 +23,21 @@ pub fn derive_root_seed(prf_output: &[u8; 32]) -> Zeroizing<[u8; 32]> {
     seed
 }
 
+/// Derive the root signer from a passkey PRF output.
+///
+/// The intermediate seed drops (and zeroizes) before this returns; on the
+/// web target the key imports into WebCrypto non-extractably.
+pub async fn derive_root_signer(prf_output: &[u8; 32]) -> Result<Ed25519Signer> {
+    let seed = derive_root_seed(prf_output);
+    Ed25519Signer::import(&*seed)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to import the root seed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::derive_root_seed;
+    use super::*;
+    use dialog_varsig::Principal;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -53,5 +67,24 @@ mod tests {
             derive_root_seed(&[1u8; 32]).as_ref(),
             derive_root_seed(&[2u8; 32]).as_ref(),
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_derives_a_stable_root_did() {
+        let a = derive_root_signer(&[7u8; 32]).await.unwrap();
+        let b = derive_root_signer(&[7u8; 32]).await.unwrap();
+        assert_eq!(a.did(), b.did());
+        assert!(
+            a.did().to_string().starts_with("did:key:z6Mk"),
+            "expected an ed25519 did:key, got {}",
+            a.did(),
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_derives_distinct_dids_from_distinct_prf_outputs() {
+        let a = derive_root_signer(&[1u8; 32]).await.unwrap();
+        let b = derive_root_signer(&[2u8; 32]).await.unwrap();
+        assert_ne!(a.did(), b.did());
     }
 }

--- a/rust/tonk-identity/src/derive.rs
+++ b/rust/tonk-identity/src/derive.rs
@@ -1,0 +1,57 @@
+//! Root-key derivation from a passkey PRF output.
+
+use hkdf::Hkdf;
+use sha2_0_10::Sha256;
+use zeroize::Zeroizing;
+
+/// Versioned derivation context. Doubles as the WebAuthn PRF eval input
+/// and the HKDF info string; bumping the version is a deliberate root
+/// rotation, never a routine change.
+pub const ROOT_KEY_CONTEXT: &[u8] = b"tonk/root-key/v1";
+
+/// Derive the root Ed25519 seed from a passkey PRF output.
+///
+/// HKDF-SHA256 with no salt and [`ROOT_KEY_CONTEXT`] as info. The seed is
+/// wiped when the returned guard drops — callers must not copy it out.
+pub fn derive_root_seed(prf_output: &[u8; 32]) -> Zeroizing<[u8; 32]> {
+    let hkdf = Hkdf::<Sha256>::new(None, prf_output);
+    let mut seed = Zeroizing::new([0u8; 32]);
+    hkdf.expand(ROOT_KEY_CONTEXT, seed.as_mut())
+        .expect("32 bytes is a valid HKDF-SHA256 output length");
+    seed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::derive_root_seed;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_the_pinned_seed_vector() {
+        let seed = derive_root_seed(&[7u8; 32]);
+        assert_eq!(
+            hex::encode(seed.as_ref()),
+            "365851595e28924dfab3007a2d043c063387e80308a612a27e40ab3c8cfdbb66",
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_derives_deterministically() {
+        assert_eq!(
+            derive_root_seed(&[9u8; 32]).as_ref(),
+            derive_root_seed(&[9u8; 32]).as_ref(),
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_derives_distinct_seeds_from_distinct_prf_outputs() {
+        assert_ne!(
+            derive_root_seed(&[1u8; 32]).as_ref(),
+            derive_root_seed(&[2u8; 32]).as_ref(),
+        );
+    }
+}

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -1,10 +1,19 @@
-//! The `window.tonk.identity` ceremony hook.
+//! The `window.tonkIdentity` ceremony hook.
 //!
 //! WebAuthn only exists on the window, so the ceremony surface installs
 //! from the page main thread; the service worker never sees key
 //! material. Installed as JS functions (rather than Rust-only API) so
 //! WebDriver-driven tests and future non-wasm callers (the CLI linking
 //! handoff page) can invoke ceremonies directly.
+//!
+//! This installs as its own global, `window.tonkIdentity`, and
+//! deliberately never touches `window.tonk`. The top page must not carry
+//! a `window.tonk` object: tonk-host's page-effect forwarding treats the
+//! bare presence of `window.tonk` as the signal that the current document
+//! is a portal guest with a bridge to its parent, rather than the page
+//! itself. Creating `window.tonk` here would make the top page look like
+//! a guest to that check, and every page effect (navigate, set title,
+//! open) would silently stop working.
 
 use js_sys::{Object, Promise, Reflect};
 use wasm_bindgen::JsValue;
@@ -44,19 +53,11 @@ async fn derive_root_did() -> Result<JsValue, JsValue> {
     Ok(JsValue::from_str(&signer.did().to_string()))
 }
 
-/// Install `window.tonk.identity` on the page. Idempotent; a no-op
+/// Install `window.tonkIdentity` on the page. Idempotent; a no-op
 /// outside a window context.
 pub fn install() {
     let Some(window) = web_sys::window() else {
         return;
-    };
-    let tonk = match Reflect::get(&window, &"tonk".into()) {
-        Ok(value) if value.is_object() => value,
-        _ => {
-            let fresh: JsValue = Object::new().into();
-            let _ = Reflect::set(&window, &"tonk".into(), &fresh);
-            fresh
-        }
     };
     let identity = Object::new();
 
@@ -78,7 +79,7 @@ pub fn install() {
     );
     derive.forget();
 
-    let _ = Reflect::set(&tonk, &"identity".into(), &identity.into());
+    let _ = Reflect::set(&window, &"tonkIdentity".into(), &identity.into());
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
@@ -89,11 +90,10 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[dialog_common::test]
-    fn it_installs_ceremony_functions_on_window_tonk() {
+    fn it_installs_ceremony_functions_on_window_tonk_identity() {
         install();
         let window = web_sys::window().unwrap();
-        let tonk = Reflect::get(&window, &"tonk".into()).unwrap();
-        let identity = Reflect::get(&tonk, &"identity".into()).unwrap();
+        let identity = Reflect::get(&window, &"tonkIdentity".into()).unwrap();
         for name in ["createPasskey", "deriveRootDid"] {
             let function = Reflect::get(&identity, &name.into()).unwrap();
             assert!(function.is_function(), "{name} must be a function");

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -18,7 +18,9 @@ fn js_error(error: anyhow::Error) -> JsValue {
 
 async fn create(name: JsValue) -> Result<JsValue, JsValue> {
     let name = name.as_string().unwrap_or_else(|| "tonk".to_owned());
-    let created = crate::passkey::create_passkey(&name).await.map_err(js_error)?;
+    let created = crate::passkey::create_passkey(&name)
+        .await
+        .map_err(js_error)?;
     let result = Object::new();
     Reflect::set(
         &result,
@@ -36,7 +38,9 @@ async fn create(name: JsValue) -> Result<JsValue, JsValue> {
 async fn derive_root_did() -> Result<JsValue, JsValue> {
     use dialog_varsig::Principal;
     let prf = crate::passkey::prf_output().await.map_err(js_error)?;
-    let signer = crate::derive::derive_root_signer(&prf).await.map_err(js_error)?;
+    let signer = crate::derive::derive_root_signer(&prf)
+        .await
+        .map_err(js_error)?;
     Ok(JsValue::from_str(&signer.did().to_string()))
 }
 
@@ -56,10 +60,9 @@ pub fn install() {
     };
     let identity = Object::new();
 
-    let create_passkey =
-        Closure::<dyn FnMut(JsValue) -> Promise>::new(|name: JsValue| {
-            future_to_promise(create(name))
-        });
+    let create_passkey = Closure::<dyn FnMut(JsValue) -> Promise>::new(|name: JsValue| {
+        future_to_promise(create(name))
+    });
     let _ = Reflect::set(
         &identity,
         &"createPasskey".into(),
@@ -67,10 +70,12 @@ pub fn install() {
     );
     create_passkey.forget();
 
-    let derive = Closure::<dyn FnMut() -> Promise>::new(|| {
-        future_to_promise(derive_root_did())
-    });
-    let _ = Reflect::set(&identity, &"deriveRootDid".into(), derive.as_ref().unchecked_ref());
+    let derive = Closure::<dyn FnMut() -> Promise>::new(|| future_to_promise(derive_root_did()));
+    let _ = Reflect::set(
+        &identity,
+        &"deriveRootDid".into(),
+        derive.as_ref().unchecked_ref(),
+    );
     derive.forget();
 
     let _ = Reflect::set(&tonk, &"identity".into(), &identity.into());

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -1,0 +1,97 @@
+//! The `window.tonk.identity` ceremony hook.
+//!
+//! WebAuthn only exists on the window, so the ceremony surface installs
+//! from the page main thread; the service worker never sees key
+//! material. Installed as JS functions (rather than Rust-only API) so
+//! WebDriver-driven tests and future non-wasm callers (the CLI linking
+//! handoff page) can invoke ceremonies directly.
+
+use js_sys::{Object, Promise, Reflect};
+use wasm_bindgen::JsValue;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+fn js_error(error: anyhow::Error) -> JsValue {
+    JsValue::from_str(&format!("{error:#}"))
+}
+
+async fn create(name: JsValue) -> Result<JsValue, JsValue> {
+    let name = name.as_string().unwrap_or_else(|| "tonk".to_owned());
+    let created = crate::passkey::create_passkey(&name).await.map_err(js_error)?;
+    let result = Object::new();
+    Reflect::set(
+        &result,
+        &"credentialId".into(),
+        &hex::encode(&created.id).into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"prfAtCreate".into(),
+        &created.prf_output.is_some().into(),
+    )?;
+    Ok(result.into())
+}
+
+async fn derive_root_did() -> Result<JsValue, JsValue> {
+    use dialog_varsig::Principal;
+    let prf = crate::passkey::prf_output().await.map_err(js_error)?;
+    let signer = crate::derive::derive_root_signer(&prf).await.map_err(js_error)?;
+    Ok(JsValue::from_str(&signer.did().to_string()))
+}
+
+/// Install `window.tonk.identity` on the page. Idempotent; a no-op
+/// outside a window context.
+pub fn install() {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let tonk = match Reflect::get(&window, &"tonk".into()) {
+        Ok(value) if value.is_object() => value,
+        _ => {
+            let fresh: JsValue = Object::new().into();
+            let _ = Reflect::set(&window, &"tonk".into(), &fresh);
+            fresh
+        }
+    };
+    let identity = Object::new();
+
+    let create_passkey =
+        Closure::<dyn FnMut(JsValue) -> Promise>::new(|name: JsValue| {
+            future_to_promise(create(name))
+        });
+    let _ = Reflect::set(
+        &identity,
+        &"createPasskey".into(),
+        create_passkey.as_ref().unchecked_ref(),
+    );
+    create_passkey.forget();
+
+    let derive = Closure::<dyn FnMut() -> Promise>::new(|| {
+        future_to_promise(derive_root_did())
+    });
+    let _ = Reflect::set(&identity, &"deriveRootDid".into(), derive.as_ref().unchecked_ref());
+    derive.forget();
+
+    let _ = Reflect::set(&tonk, &"identity".into(), &identity.into());
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use js_sys::Reflect;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_installs_ceremony_functions_on_window_tonk() {
+        install();
+        let window = web_sys::window().unwrap();
+        let tonk = Reflect::get(&window, &"tonk".into()).unwrap();
+        let identity = Reflect::get(&tonk, &"identity".into()).unwrap();
+        for name in ["createPasskey", "deriveRootDid"] {
+            let function = Reflect::get(&identity, &name.into()).unwrap();
+            assert!(function.is_function(), "{name} must be a function");
+        }
+    }
+}

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -8,3 +8,5 @@
 
 pub mod delegation;
 pub mod derive;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod passkey;

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -9,4 +9,9 @@
 pub mod delegation;
 pub mod derive;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod install;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod passkey;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub use install::install;

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -1,0 +1,9 @@
+#![warn(missing_docs)]
+//! Root identity derived from a passkey.
+//!
+//! The user's root Ed25519 key is derived on demand from their passkey's
+//! PRF output and exists in memory only for the seconds a ceremony needs
+//! it. Devices act through a subject-open `root → device` UCAN
+//! delegation; day-to-day operation never touches the root key.
+
+pub mod derive;

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -6,4 +6,5 @@
 //! it. Devices act through a subject-open `root → device` UCAN
 //! delegation; day-to-day operation never touches the root key.
 
+pub mod delegation;
 pub mod derive;

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -1,0 +1,169 @@
+//! WebAuthn passkey ceremonies.
+//!
+//! Window-context only: `navigator.credentials` does not exist in
+//! workers, so these run from the page main thread, inside a user
+//! gesture.
+
+use crate::derive::ROOT_KEY_CONTEXT;
+use anyhow::{Context, Result, anyhow};
+use js_sys::{Array, Uint8Array};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    AuthenticationExtensionsClientInputs, AuthenticationExtensionsPrfInputs,
+    AuthenticationExtensionsPrfValues, AuthenticatorSelectionCriteria, CredentialCreationOptions,
+    CredentialRequestOptions, CredentialsContainer, PublicKeyCredential,
+    PublicKeyCredentialCreationOptions, PublicKeyCredentialParameters,
+    PublicKeyCredentialRequestOptions, PublicKeyCredentialRpEntity, PublicKeyCredentialType,
+    PublicKeyCredentialUserEntity, UserVerificationRequirement,
+};
+use zeroize::Zeroizing;
+
+/// COSE algorithms offered at registration: EdDSA, ES256, RS256. The
+/// credential's own key is never used directly — only its PRF — so this
+/// list is purely for authenticator compatibility.
+const COSE_ALGORITHMS: [i32; 3] = [-8, -7, -257];
+
+/// A created passkey: the raw credential id, plus the PRF output when
+/// the platform evaluated PRF during creation (some only do so on a
+/// follow-up assertion).
+pub struct PasskeyCredential {
+    /// Raw credential id, as registered with the authenticator.
+    pub id: Vec<u8>,
+    /// PRF output, when the platform returned one at creation.
+    pub prf_output: Option<Zeroizing<[u8; 32]>>,
+}
+
+fn ceremony_error(context: &str, value: JsValue) -> anyhow::Error {
+    anyhow!("{context}: {value:?}")
+}
+
+fn credentials() -> Result<CredentialsContainer> {
+    Ok(web_sys::window()
+        .context("no window: passkey ceremonies are window-only")?
+        .navigator()
+        .credentials())
+}
+
+/// Extension inputs requesting a PRF evaluation over the versioned
+/// derivation context.
+fn prf_extensions() -> AuthenticationExtensionsClientInputs {
+    let values =
+        AuthenticationExtensionsPrfValues::new_with_u8_array(&Uint8Array::from(ROOT_KEY_CONTEXT));
+    let prf = AuthenticationExtensionsPrfInputs::new();
+    prf.set_eval(&values);
+    let extensions = AuthenticationExtensionsClientInputs::new();
+    extensions.set_prf(&prf);
+    extensions
+}
+
+/// Registration options: a discoverable, user-verified credential on
+/// this origin, with PRF requested up front.
+fn creation_options(user_name: &str) -> Result<PublicKeyCredentialCreationOptions> {
+    let mut challenge = rand::random::<[u8; 32]>();
+    let rp = PublicKeyCredentialRpEntity::new("tonk");
+    let mut user_id = rand::random::<[u8; 16]>();
+    let user = PublicKeyCredentialUserEntity::new_with_u8_slice(user_name, user_name, &mut user_id);
+    let params = Array::new();
+    for algorithm in COSE_ALGORITHMS {
+        params.push(
+            &PublicKeyCredentialParameters::new(algorithm, PublicKeyCredentialType::PublicKey)
+                .into(),
+        );
+    }
+    let options = PublicKeyCredentialCreationOptions::new_with_u8_slice(
+        &mut challenge,
+        &params.into(),
+        &rp,
+        &user,
+    );
+    let selection = AuthenticatorSelectionCriteria::new();
+    selection.set_resident_key("required");
+    selection.set_user_verification(UserVerificationRequirement::Required);
+    options.set_authenticator_selection(&selection);
+    options.set_extensions(&prf_extensions());
+    Ok(options)
+}
+
+/// Read the PRF output out of a ceremony's extension results.
+fn extract_prf(credential: &PublicKeyCredential) -> Option<Zeroizing<[u8; 32]>> {
+    let results = credential
+        .get_client_extension_results()
+        .get_prf()?
+        .get_results()?;
+    let first = Uint8Array::new(&results.get_first().into());
+    if first.length() != 32 {
+        return None;
+    }
+    let mut output = Zeroizing::new([0u8; 32]);
+    first.copy_to(output.as_mut());
+    Some(output)
+}
+
+/// Create the account passkey on this origin. One biometric prompt;
+/// must be called during a user gesture.
+pub async fn create_passkey(user_name: &str) -> Result<PasskeyCredential> {
+    let creation = CredentialCreationOptions::new();
+    creation.set_public_key(&creation_options(user_name)?);
+    let promise = credentials()?
+        .create_with_options(&creation)
+        .map_err(|e| ceremony_error("credentials.create was rejected", e))?;
+    let credential: PublicKeyCredential = JsFuture::from(promise)
+        .await
+        .map_err(|e| ceremony_error("passkey creation failed", e))?
+        .dyn_into()
+        .map_err(|_| anyhow!("credentials.create returned a non-public-key credential"))?;
+    let id = Uint8Array::new(&credential.raw_id()).to_vec();
+    let prf_output = extract_prf(&credential);
+    Ok(PasskeyCredential { id, prf_output })
+}
+
+/// Evaluate the passkey's PRF via a discoverable-credential assertion.
+/// One biometric prompt; must be called during a user gesture.
+pub async fn prf_output() -> Result<Zeroizing<[u8; 32]>> {
+    let mut challenge = rand::random::<[u8; 32]>();
+    let options = PublicKeyCredentialRequestOptions::new_with_u8_slice(&mut challenge);
+    options.set_user_verification(UserVerificationRequirement::Required);
+    options.set_extensions(&prf_extensions());
+    let request = CredentialRequestOptions::new();
+    request.set_public_key(&options);
+    let promise = credentials()?
+        .get_with_options(&request)
+        .map_err(|e| ceremony_error("credentials.get was rejected", e))?;
+    let credential: PublicKeyCredential = JsFuture::from(promise)
+        .await
+        .map_err(|e| ceremony_error("passkey assertion failed", e))?
+        .dyn_into()
+        .map_err(|_| anyhow!("credentials.get returned a non-public-key credential"))?;
+    extract_prf(&credential).ok_or_else(|| {
+        anyhow!("the authenticator returned no PRF output; this platform cannot derive a root key")
+    })
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use crate::derive::ROOT_KEY_CONTEXT;
+    use js_sys::{Reflect, Uint8Array};
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_requests_prf_evaluation_with_the_versioned_context() {
+        let extensions = prf_extensions();
+        let prf = Reflect::get(&extensions, &"prf".into()).unwrap();
+        let eval = Reflect::get(&prf, &"eval".into()).unwrap();
+        let first = Reflect::get(&eval, &"first".into()).unwrap();
+        assert_eq!(Uint8Array::new(&first).to_vec(), ROOT_KEY_CONTEXT);
+    }
+
+    #[dialog_common::test]
+    fn it_requires_a_discoverable_user_verified_credential() {
+        let options = creation_options("tester").unwrap();
+        let selection = Reflect::get(&options, &"authenticatorSelection".into()).unwrap();
+        let resident = Reflect::get(&selection, &"residentKey".into()).unwrap();
+        assert_eq!(resident.as_string().as_deref(), Some("required"));
+        let verification = Reflect::get(&selection, &"userVerification".into()).unwrap();
+        assert_eq!(verification.as_string().as_deref(), Some("required"));
+    }
+}

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true, features = ["sync", "time"] }
 bs58 = { workspace = true }
 tonk-common = { workspace = true }
 tonk-host = { workspace = true }
+tonk-identity = { workspace = true }
 tonk-portal = { workspace = true }
 tonk-worker = { workspace = true }
 tonk-worker-api = { workspace = true }

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -31,6 +31,11 @@ async fn main() {
     // themselves until the worker is up.
     tonk_host::install();
 
+    // Passkey ceremonies live on the window: `navigator.credentials`
+    // does not exist in the service worker, and each ceremony needs a
+    // user gesture. The worker never sees root-key material.
+    tonk_identity::install();
+
     // Dev-only hot reload client. `debug_assertions` is on under `trunk serve`
     // (debug profile) and off for release, so this never loads in production.
     #[cfg(debug_assertions)]

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -33,7 +33,11 @@ async fn main() {
 
     // Passkey ceremonies live on the window: `navigator.credentials`
     // does not exist in the service worker, and each ceremony needs a
-    // user gesture. The worker never sees root-key material.
+    // user gesture. The worker never sees root-key material. The hook
+    // installs as `window.tonkIdentity`, deliberately outside
+    // `window.tonk` — tonk-host's page-effect forwarding uses the bare
+    // presence of `window.tonk` to detect a portal guest, and the top
+    // page must never look like one.
     tonk_identity::install();
 
     // Dev-only hot reload client. `debug_assertions` is on under `trunk serve`

--- a/rust/tonk-ui/src/identity.rs
+++ b/rust/tonk-ui/src/identity.rs
@@ -47,7 +47,7 @@ mod tests {
                 r#"
                 const done = arguments[arguments.length - 1];
                 const wait = () =>
-                    window.tonk && window.tonk.identity ? done(true) : setTimeout(wait, 50);
+                    window.tonkIdentity ? done(true) : setTimeout(wait, 50);
                 wait();
                 "#,
                 vec![],
@@ -58,7 +58,7 @@ mod tests {
             .execute_async(
                 r#"
                 const done = arguments[arguments.length - 1];
-                window.tonk.identity.createPasskey("tester")
+                window.tonkIdentity.createPasskey("tester")
                     .then((result) => done({ ok: result }))
                     .catch((error) => done({ error: String(error) }));
                 "#,
@@ -77,7 +77,7 @@ mod tests {
                 .execute_async(
                     r#"
                     const done = arguments[arguments.length - 1];
-                    window.tonk.identity.deriveRootDid()
+                    window.tonkIdentity.deriveRootDid()
                         .then((did) => done({ did }))
                         .catch((error) => done({ error: String(error) }));
                     "#,

--- a/rust/tonk-ui/src/identity.rs
+++ b/rust/tonk-ui/src/identity.rs
@@ -1,0 +1,108 @@
+//! Passkey ceremony tests against a CDP virtual authenticator.
+
+#[allow(unused_imports)]
+mod tests {
+    use crate::helpers::TestEnvironment;
+    use anyhow::Result;
+    #[cfg(not(target_arch = "wasm32"))]
+    use serde_json::json;
+    #[cfg(not(target_arch = "wasm32"))]
+    use thirtyfour::extensions::cdp::ChromeDevTools;
+    #[cfg(not(target_arch = "wasm32"))]
+    use thirtyfour::prelude::*;
+
+    #[dialog_common::test]
+    async fn it_creates_a_passkey_and_derives_a_stable_root_did(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = env.driver().await?;
+
+        // A CTAP2.1 platform authenticator with PRF (hmac-secret), user
+        // verification, and automatic presence — the shape of a real
+        // passkey provider.
+        let devtools = ChromeDevTools::new(driver.handle.clone());
+        devtools.execute_cdp("WebAuthn.enable").await?;
+        devtools
+            .execute_cdp_with_params(
+                "WebAuthn.addVirtualAuthenticator",
+                json!({
+                    "options": {
+                        "protocol": "ctap2",
+                        "ctap2Version": "ctap2_1",
+                        "transport": "internal",
+                        "hasResidentKey": true,
+                        "hasUserVerification": true,
+                        "isUserVerified": true,
+                        "hasPrf": true,
+                        "automaticPresenceSimulation": true,
+                    }
+                }),
+            )
+            .await?;
+
+        // Wait for the ceremony hook: it installs as soon as the UI
+        // wasm main runs, independent of service-worker readiness.
+        driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                const wait = () =>
+                    window.tonk && window.tonk.identity ? done(true) : setTimeout(wait, 50);
+                wait();
+                "#,
+                vec![],
+            )
+            .await?;
+
+        let created = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                window.tonk.identity.createPasskey("tester")
+                    .then((result) => done({ ok: result }))
+                    .catch((error) => done({ error: String(error) }));
+                "#,
+                vec![],
+            )
+            .await?;
+        let created = created.json().clone();
+        assert!(
+            created.get("error").is_none(),
+            "createPasskey failed: {created:?}",
+        );
+
+        let mut dids = Vec::new();
+        for _ in 0..2 {
+            let derived = driver
+                .execute_async(
+                    r#"
+                    const done = arguments[arguments.length - 1];
+                    window.tonk.identity.deriveRootDid()
+                        .then((did) => done({ did }))
+                        .catch((error) => done({ error: String(error) }));
+                    "#,
+                    vec![],
+                )
+                .await?;
+            let derived = derived.json().clone();
+            let did = derived
+                .get("did")
+                .and_then(|did| did.as_str())
+                .unwrap_or_else(|| panic!("deriveRootDid failed: {derived:?}"))
+                .to_owned();
+            dids.push(did);
+        }
+        assert!(
+            dids[0].starts_with("did:key:z6Mk"),
+            "expected an ed25519 did:key, got {}",
+            dids[0],
+        );
+        assert_eq!(
+            dids[0], dids[1],
+            "the root did must be stable across derivations"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+}

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -18,3 +18,7 @@ pub mod error;
 /// Test helpers for integration testing.
 #[cfg(any(test, feature = "helpers"))]
 pub mod helpers;
+
+/// Real-browser passkey ceremony tests.
+#[cfg(test)]
+mod identity;


### PR DESCRIPTION
## What

The client-side foundation for cross-device identity: a new `tonk-identity` crate that derives the user's root Ed25519 key from a WebAuthn passkey, plus the browser ceremony surface. First landable slice of the identity/accounts design (spec: `docs/superpowers/specs/2026-07-17-identity-accounts-design.md` on `docs/identity-accounts-spec`).

- **Root derivation**: `PRF(credential, "tonk/root-key/v1") → HKDF-SHA256 → Ed25519 seed`, pinned test vector, seed held in `Zeroizing` and never persisted. Root DID is the `did:key` of the derived public key.
- **`root → device` delegation**: `mint_device_delegation` — subject-open, audience-specific (`Subject::Any`, audience = device DID), the deliberate opposite of invite shape. Composition test proves a subject-open link pushes onto a subject-specific space chain with the space subject preserved.
- **WebAuthn ceremonies** (wasm/window-only): `create_passkey` (discoverable, user-verified, PRF requested) and `prf_output` (discoverable-credential assertion). Typed web-sys 0.3.103 bindings; `web_sys_unstable_apis` already enabled for wasm.
- **Ceremony hook**: `window.tonkIdentity.createPasskey(name)` / `.deriveRootDid()`, installed from the tonk-ui main-thread binary. Deliberately NOT under `window.tonk`: tonk-host's page-effect forwarding detects portal guests by that object's presence, so a top-page `window.tonk` would silently kill navigate/title/open.
- **E2E test**: tonk-ui integration test drives the full create → PRF → HKDF → DID ceremony against a CDP virtual authenticator (`ctap2_1`, `hasPrf`), asserting a stable `did:key:z6Mk…` across derivations.

Out of scope (later stages): account service, self-link/CLI-handoff ceremonies and UI, root-DID rosters/invite changes, billing. No changes to profile provisioning, invite claiming, membership, or `tonk-invite`.

## Test plan

- Native: `cargo test -p tonk-identity` (7/7), workspace suite green (pre-existing `tonk-cli` parallel-test flake unrelated; passes single-threaded).
- Wasm: `cargo test -p tonk-identity --target wasm32-unknown-unknown` in headless Chrome (10/10).
- `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check` clean.
- The live-browser integration test compiles but has NOT executed yet: the harness's `nix run .#tonk-ui-test-server` build is blocked locally by the macOS 27 beta libffi/remarshal issue. Its CDP shapes were verified against the CDP schema. First real run may need the user-activation fallback (body click before `createPasskey`) — prescribed in the test's comments territory, expected per WebAuthn gesture rules.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `tonk-identity` module, which implements passkey ceremonies and root identity management. It includes tests for passkey creation and root key derivation, ensuring secure identity handling in a browser context.

### Detailed summary
- Added `tonk-identity` module to `Cargo.toml` and workspace.
- Created `identity` module with tests for passkey ceremonies in `rust/tonk-ui/src/lib.rs`.
- Implemented root-key derivation and delegation in `rust/tonk-identity/src/derive.rs` and `rust/tonk-identity/src/delegation.rs`.
- Established `window.tonkIdentity` for passkey handling in `rust/tonk-identity/src/install.rs`.
- Added tests for passkey creation and root DID derivation in `rust/tonk-identity/src/passkey.rs` and `rust/tonk-identity/src/tests.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->