### PR TITLE
fix: in-space navigation via a per-space synthetic origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,6 +4436,7 @@ dependencies = [
  "futures",
  "ipld-core",
  "js-sys",
+ "multibase",
  "serde",
  "serde-wasm-bindgen",
  "serde_ipld_dagjson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ axum = { version = "0.8", default-features = false }
 axum-wasm-macros = "0.1"
 base58 = "0.2"
 base64 = "0.22"
+multibase = "0.9"
 blake3 = "1.5"
 bs58 = "0.5"
 ciborium = "0.2"

--- a/rust/tonk-guest/Cargo.toml
+++ b/rust/tonk-guest/Cargo.toml
@@ -41,6 +41,7 @@ web-sys = { workspace = true, features = [
   "console",
   "Document",
   "Element",
+  "HtmlAnchorElement",
   "HtmlElement",
   "HtmlHeadElement",
   "Window",

--- a/rust/tonk-guest/src/guest_host.rs
+++ b/rust/tonk-guest/src/guest_host.rs
@@ -182,11 +182,19 @@ fn scroll_to_fragment(fragment: &str) -> bool {
 
 /// Decide what a click means.
 ///
-/// Anything that isn't a plain in-app navigation is handed to `open`, INCLUDING
-/// schemes we expect the host to refuse. Filtering them here would be security
-/// theatre: a component can call `window.tonk.open` directly, so the guest is
-/// never the control — and relaying gets a console warning out of the host
-/// instead of a silently dead click, which is the bug this change exists to fix.
+/// The guest sets a `<base href="https://{label}.tonk.spot/">` to its
+/// per-space SYNTHETIC origin, so the BROWSER resolves `anchor.href` for us —
+/// a real URL, not the opaque `null/…` it would be with no base. So we
+/// classify by ORIGIN, the way a normal page does:
+///
+/// - same origin as the synthetic base → an in-app route change (`Navigate`);
+/// - a different origin → external, handed to the host (`Open`) which decides
+///   whether to warn/refuse or open a tab (policy is the host's, never ours);
+/// - a link that only changes the fragment → scrolled HERE (`Fragment`), since
+///   the guest is the only frame that owns its own document.
+///
+/// The raw `href` attribute is still read for the empty/pure-fragment cases,
+/// which resolution alone can't distinguish from a same-page navigation.
 fn classify_click(event: &Event) -> Intent {
     let Some(mouse) = event.dyn_ref::<web_sys::MouseEvent>() else {
         return Intent::Ignore;
@@ -199,33 +207,34 @@ fn classify_click(event: &Event) -> Intent {
     let Some(anchor) = event.target().and_then(closest_anchor) else {
         return Intent::Ignore;
     };
-    let Some(href) = anchor.get_attribute("href") else {
+    let Some(href_attr) = anchor.get_attribute("href") else {
         return Intent::Ignore;
     };
-    // A FRAGMENT IS NOT SAME-DOCUMENT HERE, and leaving it native is the worst
-    // outcome available. This guest's document URL is `about:srcdoc`, but its
-    // BASE URL is inherited from the parent — so `#foo` resolves against
-    // `https://origin/space/{id}`, which differs from `about:srcdoc` by far
-    // more than a fragment. The browser therefore treats it as a full
-    // navigation and loads the ENTIRE Tonk app inside the spot's own iframe,
-    // at an opaque origin, recursively. Measured in Chrome under production's
-    // exact sandbox: `#foo` → `http://localhost:8731/index.html#foo`, and the
-    // guest unloads.
-    //
-    // Relaying it would be wrong for the mirror reason: the host would resolve
-    // `#foo` against ITS url (`/space/{id}`) and open a duplicate spot scrolled
-    // nowhere. The fragment addresses the guest's own document, so the guest is
-    // the only frame that can honour it — cancel, and scroll here.
-    if let Some(fragment) = href.strip_prefix('#') {
-        return Intent::Fragment(fragment.to_owned());
-    }
-    // `href=""` is the same whole-app load one hop shorter: it resolves to the
-    // bare inherited base URL. It reaches users through a view template whose
-    // field has not resolved (`<a href="{url}">` renders blank), so it is a
-    // live path and not a curiosity.
-    if href.is_empty() {
+    // `href=""` resolves to the bare base — a whole-app reload. It reaches
+    // users through a view template whose field hasn't resolved
+    // (`<a href="{url}">` renders blank), so it's a live path, not a curiosity.
+    if href_attr.is_empty() {
         return Intent::Empty;
     }
+    // A pure fragment (`#foo`) addresses THIS document; the guest is the only
+    // frame that can honour it. Detect it off the raw attribute (a bare `#…`),
+    // before resolution turns it into a full same-path URL.
+    if let Some(fragment) = href_attr.strip_prefix('#') {
+        return Intent::Fragment(fragment.to_owned());
+    }
+
+    // Everything else: let the browser resolve against the synthetic `<base>`.
+    // The resolved property is a real URL now (the base is a concrete origin,
+    // not `about:srcdoc`).
+    let Some(resolved) = anchor
+        .dyn_ref::<web_sys::HtmlAnchorElement>()
+        .map(|a| a.href())
+    else {
+        return Intent::Ignore;
+    };
+    let Ok(url) = web_sys::Url::new(&resolved) else {
+        return Intent::Ignore;
+    };
 
     let wants_new_tab = mouse.meta_key()
         || mouse.ctrl_key()
@@ -234,20 +243,37 @@ fn classify_click(event: &Event) -> Intent {
         || anchor
             .get_attribute("target")
             .is_some_and(|target| target == "_blank");
-    let in_app = href.starts_with('/') && !href.starts_with("//");
+
+    // Same origin as our synthetic base → in-app; different → external.
+    let in_app = base_origin().is_some_and(|origin| url.origin() == origin);
 
     if in_app && !wants_new_tab {
-        Intent::Navigate(href)
+        // Relay the guest-world path (the host re-maps it to the real route).
+        let mut path = url.pathname();
+        path.push_str(&url.search());
+        path.push_str(&url.hash());
+        Intent::Navigate(path)
     } else {
-        Intent::Open(href)
+        Intent::Open(resolved)
     }
 }
 
+/// The origin of the guest's synthetic per-space base
+/// (`https://{label}.tonk.spot`), read from the bridge context, or `None`
+/// when there is none (profile/Hub) — where every link is external to any
+/// space and falls through to the host.
+fn base_origin() -> Option<String> {
+    let win: JsValue = window()?.into();
+    let tonk = Reflect::get(&win, &JsValue::from_str("tonk")).ok()?;
+    let context = Reflect::get(&tonk, &JsValue::from_str("context")).ok()?;
+    let base = Reflect::get(&context, &JsValue::from_str("base"))
+        .ok()?
+        .as_string()
+        .filter(|b| !b.is_empty())?;
+    web_sys::Url::new(&base).ok().map(|u| u.origin())
+}
+
 /// Walk up from an event target to the nearest `<a href>`.
-///
-/// The raw `href` ATTRIBUTE is what callers read, never the resolved `.href`
-/// property, which an opaque origin mangles to `null/…`. Resolution is the
-/// host's job — it is the only frame with a real base URL.
 fn closest_anchor(target: web_sys::EventTarget) -> Option<Element> {
     target
         .dyn_into::<Element>()
@@ -337,6 +363,45 @@ mod tests {
 
     fn document() -> Document {
         window().expect("a window").document().expect("a document")
+    }
+
+    /// The test document's own origin — the synthetic per-space base the
+    /// classifier resolves against in these tests. Detached anchors resolve
+    /// their `.href` against this document's base, so pinning
+    /// `window.tonk.context.base` to the same origin makes an in-space path
+    /// (`/space/abc`) classify as same-origin `Navigate`, exactly as a real
+    /// guest whose `<base>` is its per-space origin.
+    fn test_origin() -> String {
+        window().unwrap().location().origin().unwrap()
+    }
+
+    /// Install `window.tonk.context.base = <origin>/` so [`base_origin`] has a
+    /// synthetic base to compare against. Idempotent; every classify test that
+    /// depends on origin comparison calls it first.
+    fn set_test_base() {
+        let win: JsValue = window().unwrap().into();
+        let tonk = match Reflect::get(&win, &JsValue::from_str("tonk")) {
+            Ok(v) if v.is_object() => v,
+            _ => {
+                let o = Object::new();
+                let _ = Reflect::set(&win, &JsValue::from_str("tonk"), &o);
+                o.into()
+            }
+        };
+        let context = match Reflect::get(&tonk, &JsValue::from_str("context")) {
+            Ok(v) if v.is_object() => v,
+            _ => {
+                let o = Object::new();
+                let _ = Reflect::set(&tonk, &JsValue::from_str("context"), &o);
+                o.into()
+            }
+        };
+        let base = format!("{}/", test_origin());
+        let _ = Reflect::set(
+            &context,
+            &JsValue::from_str("base"),
+            &JsValue::from_str(&base),
+        );
     }
 
     /// A detached `<a>` carrying the given attributes.
@@ -439,12 +504,20 @@ mod tests {
     }
 
     fn classify(target: &EventTarget, click: &Click) -> Intent {
+        set_test_base();
         dispatch(target, click.kind, &mouse_event(click))
     }
 
     /// Classify a click on an `<a href=…>` with no other attributes.
     fn classify_href(href: &str, click: &Click) -> Intent {
         classify(anchor(&[("href", href)]).unchecked_ref(), click)
+    }
+
+    /// The absolute URL a detached anchor's `href="…"` resolves to, against
+    /// the test document's base — what the classifier reports for an `Open`.
+    fn resolved(href: &str) -> String {
+        let a = anchor(&[("href", href)]);
+        a.unchecked_ref::<web_sys::HtmlAnchorElement>().href()
     }
 
     /// What the production listener did with a click: the bridge call it
@@ -463,6 +536,7 @@ mod tests {
     /// no classifier test can see it. Driving the production closure and
     /// recording the method NAME is the only assertion that can.
     fn relay(target: &EventTarget, click: &Click) -> Relayed {
+        set_test_base();
         let calls = Rc::new(RefCell::new(None));
         let sink = Rc::clone(&calls);
         let listener = make_nav_listener(move |method: &str, arg: &str| {
@@ -598,7 +672,7 @@ mod tests {
         for (name, click) in &modified {
             assert_eq!(
                 classify_href("/space/abc", click),
-                Intent::Open("/space/abc".to_owned()),
+                Intent::Open(resolved("/space/abc")),
                 "a {name} click should open rather than navigate in place"
             );
         }
@@ -607,12 +681,13 @@ mod tests {
     /// `target="_blank"` asks for a new tab without any modifier.
     #[dialog_common::test]
     async fn it_opens_a_target_blank_link() {
+        set_test_base();
         assert_eq!(
             classify(
                 anchor(&[("href", "/space/abc"), ("target", "_blank")]).unchecked_ref(),
                 &Click::plain(),
             ),
-            Intent::Open("/space/abc".to_owned()),
+            Intent::Open(resolved("/space/abc")),
             "target=_blank should open a new tab"
         );
         assert_eq!(
@@ -727,14 +802,17 @@ mod tests {
         );
     }
 
-    /// Anything that is not an in-app path goes to the host to open.
+    /// Anything that resolves to a DIFFERENT origin than the guest's synthetic
+    /// base goes to the host to open. The relayed href is the browser-resolved
+    /// absolute URL (a protocol-relative `//host` becomes `https://host`).
     #[dialog_common::test]
     async fn it_opens_an_off_origin_link() {
+        set_test_base();
         for href in ["https://example.com/x", "//example.com/x"] {
             assert_eq!(
                 classify_href(href, &Click::plain()),
-                Intent::Open(href.to_owned()),
-                "{href} is not an in-app path and should be opened by the host"
+                Intent::Open(resolved(href)),
+                "{href} resolves off-origin and should be opened by the host"
             );
         }
     }
@@ -746,10 +824,11 @@ mod tests {
     /// dead click.
     #[dialog_common::test]
     async fn it_relays_schemes_the_host_is_expected_to_refuse() {
+        set_test_base();
         for href in ["mailto:a@example.com", "tel:+1234", "javascript:alert(1)"] {
             assert_eq!(
                 classify_href(href, &Click::plain()),
-                Intent::Open(href.to_owned()),
+                Intent::Open(resolved(href)),
                 "{href} should reach the host, which is the one that decides"
             );
         }

--- a/rust/tonk-host/Cargo.toml
+++ b/rust/tonk-host/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bytes = { workspace = true }
 custom-elements = { workspace = true }
+multibase = { workspace = true }
 futures = { workspace = true }
 ipld-core = { workspace = true }
 js-sys = { workspace = true }

--- a/rust/tonk-host/src/lib.rs
+++ b/rust/tonk-host/src/lib.rs
@@ -94,6 +94,9 @@ pub use context::{resolve_with, route_of};
 pub mod ready;
 #[cfg(target_arch = "wasm32")]
 mod registry;
+// The per-space synthetic origin a sealed guest believes it lives at.
+// Pure string logic (no wasm), so it compiles + tests on native too.
+pub mod space_origin;
 #[cfg(target_arch = "wasm32")]
 pub mod sse;
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-host/src/space_origin.rs
+++ b/rust/tonk-host/src/space_origin.rs
@@ -1,0 +1,106 @@
+//! The per-space fake origin a sealed guest believes it lives at.
+//!
+//! A space rendered in a sealed portal iframe is given its own synthetic
+//! origin — `https://{label}.tonk.spot/` — so that navigation inside the
+//! guest resolves like an ordinary web page: in-space routes are plain
+//! absolute paths (`/`, `/activity`, `/activity/{id}`) under that origin,
+//! and any href that escapes the origin is, by definition, external. The
+//! guest sets a `<base>` to this origin and lets the browser do all URL
+//! resolution; classification then reduces to an origin comparison.
+//!
+//! It is an ILLUSION. The document is really served from the host origin
+//! (`staging.tonk.spot`) at `/space/{did}/...`; the host translates a
+//! guest-world path back to the real route at the bridge. Only the guest's
+//! internal coordinate system is the per-space origin.
+//!
+//! The `{label}` is a DNS-safe, case-insensitive encoding of the space's
+//! `did:key` identifier, following the IPFS CIDv1-subdomain precedent
+//! (gateways moved from `/ipfs/{cid}` paths to `{cid}.ipfs.dweb.link`
+//! subdomains for the same reason — content gets its own origin). The
+//! raw did suffix is base58btc (`z6Mk…`), which is case-sensitive and so
+//! unusable as a DNS label; we re-encode as base32-lower (RFC4648, no
+//! pad) which round-trips through case-insensitive DNS.
+
+use multibase::Base;
+
+/// The host suffix every space origin lives under. Purely internal (never
+/// resolved by real DNS), so the literal value only has to be stable and
+/// distinct from the real host origin.
+const SPACE_ORIGIN_SUFFIX: &str = "tonk.spot";
+
+/// The synthetic origin a guest rendering `space` (a `did:key` string)
+/// believes it lives at, WITH a trailing slash so it is a directory base
+/// (`https://{label}.tonk.spot/`). Relative in-space hrefs resolve under
+/// it; the browser's own URL resolution does the rest.
+///
+/// Returns `None` for anything that is not a `did:key` space (e.g. the
+/// profile/Hub, whose links are genuinely top-level and want the real
+/// origin).
+pub fn space_origin_for(space: &str) -> Option<String> {
+    let label = encode_label(space)?;
+    Some(format!("https://{label}.{SPACE_ORIGIN_SUFFIX}/"))
+}
+
+/// Encode a `did:key:…` string as a DNS-safe, case-insensitive label:
+/// the identifier's KEY BYTES re-encoded from base58btc (`z…`, case
+/// sensitive) to multibase base32-lower (`b…`, DNS-safe). Encoding the
+/// bytes — not the base58 string — keeps the label under the 63-char DNS
+/// limit (32 key bytes → ~52 base32 chars, vs ~77 for the string).
+///
+/// `None` when `space` is not a `did:key` or its identifier is not valid
+/// multibase.
+pub fn encode_label(space: &str) -> Option<String> {
+    let mb = space.strip_prefix("did:key:")?; // e.g. `z6Mk…` (base58btc multibase)
+    let (_base, bytes) = multibase::decode(mb).ok()?;
+    // `multibase::encode` prefixes the base code (`b` for base32-lower), which
+    // is itself a lowercase letter, so the whole label stays DNS-legal.
+    Some(multibase::encode(Base::Base32Lower, bytes))
+}
+
+/// Reverse [`encode_label`]: a subdomain label back to the full
+/// `did:key:…` string. The label is multibase base32-lower of the key
+/// bytes; re-encode those to base58btc (the did:key canonical multibase)
+/// and re-attach the `did:key:` prefix. `None` when the label is not valid
+/// multibase.
+pub fn decode_label(label: &str) -> Option<String> {
+    let (_base, bytes) = multibase::decode(label).ok()?;
+    let mb = multibase::encode(Base::Base58Btc, bytes);
+    Some(format!("did:key:{mb}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_round_trips() {
+        let did = "did:key:z6Mki8Mf2Trp2qmXqNoSihfVi9sEg8Z4aSCSnyUfadj4jB1E";
+        let label = encode_label(did).expect("did encodes");
+        // DNS-legal single label: lowercase alphanumerics only, under 63 chars.
+        assert!(
+            label.len() < 63,
+            "label too long for a DNS label: {}",
+            label.len()
+        );
+        assert!(label.starts_with('b'), "multibase base32-lower prefix");
+        assert!(
+            label
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        );
+        assert_eq!(decode_label(&label).as_deref(), Some(did));
+    }
+
+    #[test]
+    fn origin_has_trailing_slash_directory_base() {
+        let origin = space_origin_for("did:key:z6MkTest").expect("origin");
+        assert!(origin.starts_with("https://"));
+        assert!(origin.ends_with(".tonk.spot/"));
+    }
+
+    #[test]
+    fn non_did_space_has_no_origin() {
+        assert_eq!(space_origin_for("profile"), None);
+        assert_eq!(encode_label("not-a-did"), None);
+    }
+}

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -127,6 +127,15 @@ impl PortalState {
         self.allow = allow;
     }
 
+    /// This portal's target space (a `did:key` string), or `None` when it
+    /// targets the profile/Hub. Drives the guest's synthetic `<base>` origin.
+    pub(crate) fn route_space(&self) -> Option<String> {
+        self.with
+            .as_ref()
+            .and_then(|w| w.space())
+            .map(str::to_owned)
+    }
+
     /// Whether this portal's routing context and reach match exactly.
     /// `<tonk-site>` uses this to re-route a pure path change in place —
     /// same reach, live iframe — instead of rebuilding the guest.
@@ -427,14 +436,23 @@ const BOOTSTRAP_JS: &str = r#"(function(){
       return relayRequest(url,input,init);
     }
     // Absolute URL pointing at the HOST origin: some consumers resolve a path
-    // against `document.baseURI` (which the host sets to its real origin), so a
-    // host API call can arrive fully-qualified (`http://host/api/…`). At the
-    // guest's opaque origin that would be a cross-origin fetch (CORS-blocked,
-    // origin `null`), so strip the host-origin prefix and relay the path. The
-    // host origin comes from the bridge context.
-    var origin=(window.tonk&&window.tonk.context&&window.tonk.context.origin)||"";
+    // against `document.baseURI`, so a host API call can arrive fully-qualified
+    // (`http://host/api/…`). At the guest's opaque origin that would be a
+    // cross-origin fetch (CORS-blocked, origin `null`), so strip the origin
+    // prefix and relay the path. TWO origins qualify: the REAL host origin
+    // (`context.origin`), and the guest's SYNTHETIC per-space base origin
+    // (`context.base`, e.g. `https://{label}.tonk.spot`) — with a `<base>` set
+    // to the latter, a relative `/api/…` resolves against it, so a `Request`
+    // built from it is fake-origin-absolute and must be stripped the same way.
+    var ctx=(window.tonk&&window.tonk.context)||{};
+    var origin=ctx.origin||"";
     if(origin&&url.indexOf(origin+"/")===0){
       return relayRequest(url.slice(origin.length),input,init);
+    }
+    // `context.base` carries a trailing slash; drop it to get the bare origin.
+    var baseOrigin=(ctx.base||"").replace(/\/$/,"");
+    if(baseOrigin&&url.indexOf(baseOrigin+"/")===0){
+      return relayRequest(url.slice(baseOrigin.length),input,init);
     }
     return nativeFetch(input,init);
   };
@@ -653,17 +671,37 @@ const RUNTIME_BOOTSTRAP_JS: &str = r#"(function(){
   parent.postMessage({__tonkRuntime:"runtime-ready"},"*");
 })();"#;
 
+/// A `<base href>` element pinning the guest's document base to the
+/// per-space synthetic origin, so the BROWSER resolves every relative URL
+/// (links, forms, `new URL`, `<tonk-page>` location reads) under it. Empty
+/// when there is no space origin (the profile/Hub), leaving the guest's
+/// inherited base untouched. Prepended before everything so it applies from
+/// the first parsed node.
+fn base_tag(base: &str) -> String {
+    if base.is_empty() {
+        String::new()
+    } else {
+        // `base` is a same-origin literal we built (`https://{label}.tonk.spot/`),
+        // so there is nothing to escape, but keep it minimal and attribute-safe.
+        format!("<base href=\"{base}\">")
+    }
+}
+
 /// Prepend the bootstrap script that wires `window.tonk` to this
-/// portal's bridge over a `MessagePort`.
-pub(crate) fn bootstrap_srcdoc(content: &str) -> String {
-    format!("<script>{BOOTSTRAP_JS}</script>{content}")
+/// portal's bridge over a `MessagePort`. `base` is the per-space synthetic
+/// origin the guest should resolve URLs against (empty = leave inherited).
+pub(crate) fn bootstrap_srcdoc(content: &str, base: &str) -> String {
+    format!("{}<script>{BOOTSTRAP_JS}</script>{content}", base_tag(base))
 }
 
 /// Like [`bootstrap_srcdoc`], plus the runtime-injection bootstrap: the
 /// guest will ask the parent (`runtime-ready`) for the element runtime and
 /// bring it up before `content`'s custom elements upgrade.
-pub(crate) fn bootstrap_srcdoc_with_runtime(content: &str) -> String {
-    format!("<script>{BOOTSTRAP_JS}</script><script>{RUNTIME_BOOTSTRAP_JS}</script>{content}")
+pub(crate) fn bootstrap_srcdoc_with_runtime(content: &str, base: &str) -> String {
+    format!(
+        "{}<script>{BOOTSTRAP_JS}</script><script>{RUNTIME_BOOTSTRAP_JS}</script>{content}",
+        base_tag(base)
+    )
 }
 
 /// Fetch the element runtime + app CSS (the parent is trusted + networked)
@@ -1345,9 +1383,9 @@ fn make_dispatcher(
             "evaluate" => handle_evaluate(&host, &port, &data),
             "subscribe" => handle_subscribe(&host, &state, &port, &data),
             "unsubscribe" => handle_unsubscribe(&state, &data),
-            "navigate" => handle_navigate(&data),
+            "navigate" => handle_navigate(&state, &data),
             "title" => handle_title(&data),
-            "open" => handle_open(&data),
+            "open" => handle_open(&state, &data),
             "fetch" => handle_host_fetch(&state, &port, &data),
             _ => {}
         }
@@ -1588,11 +1626,39 @@ fn handle_unsubscribe(state: &Rc<RefCell<PortalState>>, data: &JsValue) {
 /// (`pushState` + `popstate`), never a reload: the top `<tonk-site>` re-routes
 /// its path in place and the running guest re-renders via its `tonk:site`
 /// subscription.
-fn handle_navigate(data: &JsValue) {
+fn handle_navigate(state: &Rc<RefCell<PortalState>>, data: &JsValue) {
     let Some(href) = get_str(data, "href").filter(|h| !h.is_empty()) else {
         return;
     };
-    tonk_host::navigate_to(&href);
+    tonk_host::navigate_to(&real_href(state, &href));
+}
+
+/// Translate a guest-world href into the REAL route the host navigates to.
+///
+/// The guest resolves links against its synthetic per-space origin
+/// (`https://{label}.tonk.spot/`), so an in-space link arrives as a bare
+/// absolute path (`/activity`). The document is really served at
+/// `/space/{did}/...`, so prefix the space segment. A guest with no space
+/// context (profile/Hub), or an already-`/space/...` path, is left as-is.
+fn real_href(state: &Rc<RefCell<PortalState>>, href: &str) -> String {
+    let Some(space) = state.borrow().route_space() else {
+        return href.to_owned();
+    };
+    // Root of the space ("/") maps to the space's own route.
+    if href == "/" {
+        return format!("/space/{space}");
+    }
+    // A leading-slash in-space path; anything else (already absolute host
+    // path, or a fragment/query) is passed through untouched.
+    if let Some(rest) = href.strip_prefix('/') {
+        if rest.starts_with("space/") {
+            href.to_owned()
+        } else {
+            format!("/space/{space}/{rest}")
+        }
+    } else {
+        href.to_owned()
+    }
 }
 
 /// Set the host page's tab title on the guest's behalf. The guest's
@@ -1620,11 +1686,15 @@ fn title_text(data: &JsValue) -> Option<String> {
 /// and no `allow-top-navigation`, so it cannot open anything itself; it posts
 /// the raw href and `tonk_host::open_external` — running on the page, which is
 /// the only place that can both resolve and open it — decides what happens.
-fn handle_open(data: &JsValue) {
+fn handle_open(state: &Rc<RefCell<PortalState>>, data: &JsValue) {
     let Some(href) = open_href(data) else {
         return;
     };
-    tonk_host::open_external(&href);
+    // `open` is for hrefs that escaped the guest's synthetic origin, so the
+    // href is normally a full external URL and passes through. Defensively map
+    // a bare in-space path too (`real_href` no-ops on external URLs, which
+    // don't start with a single `/`).
+    tonk_host::open_external(&real_href(state, &href));
 }
 
 /// Read `href` out of an `{ type: "open", href }` message, or `None` when the
@@ -2194,6 +2264,15 @@ fn build_context(host: &Element, state: &Rc<RefCell<PortalState>>) -> Object {
     let _ = Reflect::set(&context, &"this".into(), &JsValue::from_str(&this));
     let _ = Reflect::set(&context, &"model".into(), &JsValue::from_str(&model));
     let _ = Reflect::set(&context, &"origin".into(), &JsValue::from_str(&origin));
+    // The per-space SYNTHETIC origin this guest believes it lives at
+    // (`https://{label}.tonk.spot/`), so in-guest navigation resolves like an
+    // ordinary page: in-space routes are plain absolute paths under it, and an
+    // href that escapes it is external. Distinct from `origin` (the REAL host
+    // origin, which propagates down nesting and keys the `/api` relay strip).
+    // Absent for the profile/Hub (no space) — those links are genuinely
+    // top-level and want the real origin.
+    let base = tonk_host::space_origin::space_origin_for(&repo).unwrap_or_default();
+    let _ = Reflect::set(&context, &"base".into(), &JsValue::from_str(&base));
     let _ = Reflect::set(&context, &"path".into(), &JsValue::from_str(&path));
     let _ = Reflect::set(&context, &"search".into(), &JsValue::from_str(&search));
     let _ = Reflect::set(&context, &"hash".into(), &JsValue::from_str(&hash));

--- a/rust/tonk-portal/src/shared.rs
+++ b/rust/tonk-portal/src/shared.rs
@@ -90,10 +90,11 @@ pub(crate) fn connect_portal(
     // injected element runtime + CSS before `content` upgrades.
     let runtime = host.has_attribute("runtime");
     let _ = host.append_child(&iframe);
+    let base = space_base(&state.borrow());
     let srcdoc = if runtime {
-        bridge::bootstrap_srcdoc_with_runtime(&content)
+        bridge::bootstrap_srcdoc_with_runtime(&content, &base)
     } else {
-        bridge::bootstrap_srcdoc(&content)
+        bridge::bootstrap_srcdoc(&content, &base)
     };
     let _ = iframe.set_attribute("srcdoc", &srcdoc);
 
@@ -111,13 +112,24 @@ pub(crate) fn reload_portal(host: &Element, state: &Rc<RefCell<PortalState>>) {
     s.clear_subs();
     if let Some(iframe) = s.iframe.as_ref() {
         let content = host.get_attribute("content").unwrap_or_default();
+        let base = space_base(&s);
         let srcdoc = if host.has_attribute("runtime") {
-            bridge::bootstrap_srcdoc_with_runtime(&content)
+            bridge::bootstrap_srcdoc_with_runtime(&content, &base)
         } else {
-            bridge::bootstrap_srcdoc(&content)
+            bridge::bootstrap_srcdoc(&content, &base)
         };
         let _ = iframe.set_attribute("srcdoc", &srcdoc);
     }
+}
+
+/// The per-space synthetic origin (`https://{label}.tonk.spot/`) for this
+/// portal's routing context, or empty when the portal targets no space (the
+/// profile/Hub) — where in-guest links are genuinely top-level.
+fn space_base(state: &bridge::PortalState) -> String {
+    state
+        .route_space()
+        .and_then(|space| tonk_host::space_origin::space_origin_for(&space))
+        .unwrap_or_default()
 }
 
 /// Install `reset` / `update` / `error` on the named element's prototype,


### PR DESCRIPTION
## Why

Clicking an in-space link (e.g. the space home's "Day-by-day itinerary") opened it in a **new tab at a broken URL** instead of navigating in place. Views author these links as relative hrefs (`href="activity"`), which is the natural thing to write, but the sealed guest classified clicks by matching the raw href string: a relative href failed the leading-slash "in-app" test and fell through to the host's new-tab path, where it resolved against the wrong base (`/space/activity`, a space that doesn't exist).

The root problem is that the guest had no real base URL to reason about — its document is `about:srcdoc` at an opaque origin — so it resorted to string heuristics instead of letting the browser resolve URLs.

## How

Give the sealed guest its own **per-space synthetic origin** and let the browser do the work. The guest is served a `<base href="https://{label}.tonk.spot/">`, so it believes it lives at that origin; in-space routes become ordinary absolute paths under it (`/`, `/activity`, `/activity/{id}`), and any href that escapes the origin is external by definition.

- **Classification collapses to an origin compare.** `classify_click` reads the browser-resolved `anchor.href` and checks its origin against the synthetic base: same-origin → navigate in place, different → hand to the host (which decides warn/refuse/new-tab). The raw-string `starts_with('/')` heuristic is gone.
- **It's an illusion.** The document is still served from the real host at `/space/{did}/...`; the host translates the guest-world path back to the real route at the bridge, and the visible URL is unchanged. `context.origin` stays the real origin (it propagates down nesting and keys the `/api` relay); a separate `context.base` carries the synthetic one.
- **`{label}`** is the space did's key bytes re-encoded from base58btc to multibase base32-lower — DNS-safe and case-insensitive, following the IPFS CIDv1-subdomain precedent (base58 `z6Mk…` can't be a DNS label). Reversible; ~52 chars.

Validated end-to-end on localhost: in-space links resolve to `https://b5ua…tonk.spot/activity`, clicking navigates in the same tab to `/space/{did}/activity`, and the content renders.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `multibase` dependency and enhances the handling of synthetic origins in the Tonk application, improving routing and navigation within the guest context. It ensures that in-space links resolve correctly and updates related functions for better clarity and functionality.

### Detailed summary
- Added `multibase` dependency.
- Introduced `space_origin` module for synthetic origin handling.
- Updated `space_base` function to derive the synthetic origin.
- Modified `bootstrap_srcdoc` functions to include a base tag for URL resolution.
- Enhanced `handle_navigate` and `handle_open` functions to use the synthetic origin.
- Updated tests to validate new origin handling and navigation logic.
- Improved click classification logic to differentiate between internal and external links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->