### PR TITLE
fix(cli): build invite links on the remote's origin

### DIFF
--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -82,7 +82,9 @@ tonk eval -c '…' --dry-run    # preview without committing
 tonk push | tonk pull                       # sync main with its upstream
 tonk remote add <name> <url>                # register a remote; the first one becomes main's upstream
 tonk remote set-upstream <name>             # re-point which remote main tracks
-tonk invite [--remote <name>]               # mint a paste-able invite URL (pushes first)
+tonk invite                                 # invite URL on the repo's remote origin (pushes first)
+tonk invite --remote <name>                 # pick the remote when several are registered
+tonk invite --no-remote                     # mint without a remote; the claimer wires one by hand
 tonk join '<invite-url>' --name <spot>      # claim an invite into a fresh spot
 tonk render <route>                         # headless HTML render (e.g. alice@person!card)
 ```

--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -82,9 +82,9 @@ tonk eval -c '…' --dry-run    # preview without committing
 tonk push | tonk pull                       # sync main with its upstream
 tonk remote add <name> <url>                # register a remote; the first one becomes main's upstream
 tonk remote set-upstream <name>             # re-point which remote main tracks
-tonk invite                                 # invite URL on the repo's remote origin (pushes first)
+tonk invite                                 # invite URL on the resolved remote's own origin (pushes first)
 tonk invite --remote <name>                 # pick the remote when several are registered
-tonk invite --no-remote                     # mint without a remote; the claimer wires one by hand
+tonk invite --no-remote                     # omit remote= (still pushes); the claimer wires one by hand
 tonk join '<invite-url>' --name <spot>      # claim an invite into a fresh spot
 tonk render <route>                         # headless HTML render (e.g. alice@person!card)
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account-service"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4400,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dialog-common",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -4584,7 +4584,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "bs58",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "dialog-capability",
  "dialog-common",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tonk Labs"]
 license = "MIT"
 edition = "2024"

--- a/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
+++ b/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
@@ -1179,6 +1179,141 @@ gh pr create --base refactor/drop-cli-share \
 
 ---
 
+### Task 9: Make the invite surface honest about where the data goes
+
+Task 6's review found that `invite::mint` pushes to the branch's **upstream**, not to the remote the caller resolved (`rust/tonk-cli/src/invite.rs:126-140`). Reproduced:
+
+```
+$ tonk invite --remote backup          # backup = http://127.0.0.1:9/other/
+error: push before invite failed: ... url (http://127.0.0.1:9/ucan/)
+```
+
+The user asked for `backup`; the push went to `origin`, because `origin` is what `main` tracks. So the link is built on backup's origin and embeds backup's endpoint, while the repo state ships somewhere else — the recipient lands on a deployment that never received the data. That is this plan's own bug class, one leg over.
+
+It is inherited: push-before-mint predates Task 6, and in the single-remote case the resolved remote *is* the upstream, so they coincide. But implicit resolution makes multi-remote `--remote` a more plausible path than it was.
+
+The decision is to **warn, not re-route**. Pushing to the resolved remote would be correct by construction, but `sync::push` is upstream-bound and a push-to-named-remote path does not exist yet — too large for this branch. A warning that names both is honest and cannot make anything worse.
+
+This task also cleans up the invite surface's prose, which Task 6 left stale.
+
+**Files:**
+- Modify: `rust/tonk-cli/src/bin/tonk.rs` (`mint_invite`, and the `--no-remote` help text on the `Invite` variant)
+- Modify: `rust/tonk-cli/README.md:63-64`
+- Modify: `rust/tonk-cli/SYNC.md:59`
+- Modify: `.claude/commands/tonk.md:85`
+- Test: `rust/tonk-cli/tests/site.rs`
+
+**Interfaces:**
+- Consumes: `remote::resolve` and `RemoteRecord` (Task 5), `remote::list`, `site.branch()` → `session.handle().upstream()`, the existing `mint_invite` in `bin/tonk.rs`.
+- Produces: nothing later tasks consume. This is the last code task.
+
+- [ ] **Step 1: Find out what the upstream can tell you**
+
+Before writing anything, establish how to decide "the resolved remote is not the upstream". Read `rust/tonk-cli/src/sync.rs` (`push`, and how it reaches the upstream), `rust/tonk-cli/src/remote.rs` (`set_upstream`, `upstream_configured`, `list`), and `rust/tonk-schema/src/tracking_branch.rs`.
+
+The question to answer: given a `TonkSite`, can you recover the *name* (or the endpoint) of the remote its `main` branch tracks? `session.handle().upstream()` returns the upstream branch handle — see what identifies it.
+
+Three outcomes, in order of preference:
+
+1. The upstream's remote name or endpoint is reachable. Compare it against the resolved `RemoteRecord` directly. Best — it is exact.
+2. Only the upstream's subject DID or branch identity is reachable. Match it against `remote::list()` rows to recover the name. Still exact.
+3. Nothing usable is reachable. Fall back to a coarser condition: warn whenever the user passed `--remote` explicitly *and* more than one remote is registered, since that is precisely when the two can diverge. Weaker, but never wrong about the risk.
+
+Write down which one you took and why. Do not add a new public function to `remote.rs` unless option 1 or 2 needs it; if it does, give it a doc comment in the style of its neighbours.
+
+- [ ] **Step 2: Write the failing test**
+
+In `rust/tonk-cli/tests/site.rs`, add a module after `mod when_resolving_a_remote` (which closes around line 174 — read to confirm).
+
+The test registers two remotes, sets the upstream to the first, and asserts that whatever you built in Step 1 reports a mismatch when asked about the second and no mismatch when asked about the first. Shape it to whatever you actually built — a helper returning `Option<String>`, a bool, whatever fits. Use `#[dialog_common::test]`, name the module `mod when_the_invite_remote_is_not_the_upstream`, and name the tests `it_does_x`.
+
+The existing `mod when_managing_remotes` shows how to register a remote (`remote::add(&test.site, "origin", ENDPOINT, None)`) and set an upstream (`remote::set_upstream(&test.site, "origin")`) against `common::TestSite`.
+
+If Step 1 landed on outcome 3, the condition is pure argument inspection with no site state, so test it as a unit test in `bin/tonk.rs`'s crate instead — say so and put it where it can actually run.
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+cd /Users/jackdouglas/tonk/tonk-invite
+cargo test -p tonk-cli --features integration-tests --test site when_the_invite_remote_is_not_the_upstream -- --test-threads=1 2>&1 | tail -20
+```
+
+Expected: FAIL to compile, naming whatever you have not written yet.
+
+- [ ] **Step 4: Implement the warning**
+
+In `mint_invite` in `rust/tonk-cli/src/bin/tonk.rs`, after the remote is resolved and before `invite::mint` is called, emit a warning to stderr when the resolved remote is not the branch's upstream. Name both, and say what actually happens — the wording matters more than the mechanism:
+
+```
+warning: the invite embeds remote 'backup' but the repo pushes to 'origin';
+         the recipient may join a deployment that has not received this data
+```
+
+Match the file's existing warning style (`eprintln!("warning: ...")` — see the shorten degradation a few lines below). Keep it a warning: minting must still succeed. A user with a deliberate split setup should not be blocked.
+
+Do not warn when there is no upstream at all — `invite::mint` skips the push entirely in that case, so there is nothing to diverge from.
+
+- [ ] **Step 5: Run the test and the suite**
+
+```bash
+cargo test -p tonk-cli --features integration-tests --test site when_the_invite_remote_is_not_the_upstream -- --test-threads=1 2>&1 | tail -20
+cargo test -p tonk-cli --features integration-tests --test site -- --test-threads=1 2>&1 | tail -5
+```
+
+Expected: the new tests pass; the suite is at its prior count plus yours.
+
+- [ ] **Step 6: Verify the warning by hand**
+
+```bash
+export TONK_SPOTS_STATE="$(mktemp -d)/spots.json"
+export TONK_SPOT=probe-mismatch
+cargo run -q -p tonk-cli --bin tonk -- spot new probe-mismatch 2>&1 | tail -2
+cargo run -q -p tonk-cli --bin tonk -- remote add origin http://127.0.0.1:9/ucan/ 2>&1 | tail -2
+cargo run -q -p tonk-cli --bin tonk -- remote add backup http://127.0.0.1:9/other/ 2>&1 | tail -2
+cargo run -q -p tonk-cli --bin tonk -- invite --remote backup 2>&1 | tail -6
+```
+
+Both remotes point at a dead port on purpose: the push fails either way, and what you are checking is that the mismatch warning appears *before* the push error. Confirm `--remote origin` produces no such warning.
+
+- [ ] **Step 7: Fix the `--no-remote` help text**
+
+Its current help says "Mint a local-only invite carrying no `remote=`". The *invite* is local-only; the mint still pulls and pushes to the upstream when one is configured. Reword so a reader does not take "local-only" to mean "no network".
+
+- [ ] **Step 8: Update the invite docs**
+
+Three files describe `tonk invite` as it behaved before Task 6, and none mention `--no-remote`:
+
+- `rust/tonk-cli/README.md:63-64` — frames `--remote prod` as "also embeds a registered remote", when embedding is now the default and the flag is the disambiguator.
+- `rust/tonk-cli/SYNC.md:59`
+- `.claude/commands/tonk.md:85`
+
+Read each in context. State the behaviour as it now is: a bare `tonk invite` resolves the repo's remote, builds the link on that remote's origin, and embeds it; `--remote <NAME>` picks one when several are registered; `--no-remote` mints without one. House style — lead with the answer, plain words, vary sentence length, no filler, match the surrounding voice.
+
+- [ ] **Step 9: Lint gate**
+
+```bash
+cargo fmt --check 2>&1 | tail -5
+cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1 | tail -10
+```
+
+Both must be clean. `nix flake check` cannot run on this machine (macOS 27 beta libffi breakage); these are the equivalent direct invocations, with args matching the flake's own check derivation.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add rust/tonk-cli/ .claude/commands/tonk.md
+git commit -m "fix(cli): warn when the invite remote is not the upstream
+
+invite::mint pushes to the branch's upstream, not to the remote the
+link embeds. With several remotes registered, --remote could build a
+link on one deployment while the data shipped to another, leaving the
+recipient on a deployment that never received it. Name both and say so.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
 ## Deploy follow-up (not code)
 
 Neither PR makes production shorten. `https://tonk.spot/@` returns 404 because the deployed worker predates `run_worker_first = ["/@", "/@/*", "/ucan", "/ucan/*"]` in `wrangler.toml`. Redeploying the current worker to the production environment fixes it. Verify with:

--- a/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
+++ b/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
@@ -384,7 +384,7 @@ Understand the whole file before editing. Note in particular: what `resolve_disp
 ```bash
 cd /Users/jackdouglas/tonk/tonk-invite
 cargo build --release -p tonk-cli 2>&1 | tail -3
-export TONK_SPOTS_STATE="$(mktemp -d)/spots.json"
+export TONK_SPOTS_STATE="$(mktemp -d)"
 export TONK_SPOT=bench-probe
 ./target/release/tonk spot new bench-probe 2>&1 | tail -2
 ./target/release/tonk eval --no-sync --format json -c 'view:' | head -40
@@ -916,7 +916,7 @@ Expected: success. `remote` and `invite` are already imported in `bin/tonk.rs`; 
 - [ ] **Step 5: Verify by hand against a scratch spot with no remote**
 
 ```bash
-export TONK_SPOTS_STATE="$(mktemp -d)/spots.json"
+export TONK_SPOTS_STATE="$(mktemp -d)"
 export TONK_SPOT=probe-noremote
 cargo run -q -p tonk-cli --bin tonk -- spot new probe-noremote 2>&1 | tail -2
 cargo run -q -p tonk-cli --bin tonk -- invite 2>&1 | tail -4
@@ -927,7 +927,7 @@ Expected: the link starts with `https://tonk.spot/join?access=` after Task 7 (be
 - [ ] **Step 6: Verify by hand against a scratch spot with a staging remote**
 
 ```bash
-export TONK_SPOTS_STATE="$(mktemp -d)/spots.json"
+export TONK_SPOTS_STATE="$(mktemp -d)"
 export TONK_SPOT=probe-staging
 cargo run -q -p tonk-cli --bin tonk -- spot new probe-staging 2>&1 | tail -2
 cargo run -q -p tonk-cli --bin tonk -- remote add origin https://staging.tonk.spot/ucan/ 2>&1 | tail -2
@@ -1265,7 +1265,7 @@ Expected: the new tests pass; the suite is at its prior count plus yours.
 - [ ] **Step 6: Verify the warning by hand**
 
 ```bash
-export TONK_SPOTS_STATE="$(mktemp -d)/spots.json"
+export TONK_SPOTS_STATE="$(mktemp -d)"
 export TONK_SPOT=probe-mismatch
 cargo run -q -p tonk-cli --bin tonk -- spot new probe-mismatch 2>&1 | tail -2
 cargo run -q -p tonk-cli --bin tonk -- remote add origin http://127.0.0.1:9/ucan/ 2>&1 | tail -2

--- a/plan/shortcut-service.md
+++ b/plan/shortcut-service.md
@@ -8,7 +8,7 @@ the **shortcut service** shortens any same-origin URL: the long URL's
 path + query is stored under its blake3 hash, and the short link is
 
 ```
-https://hub.tonk.xyz/@/{blake3-hash}#{seed}
+https://tonk.spot/@/{blake3-hash}#{seed}
 ```
 
 `GET /@/{hash}` answers with a permanent redirect whose `Location` is

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -27,8 +27,8 @@ tonk eval -c 'person:' --format json --quiet
 
 # Inspect the branch.
 tonk schema       # every named attribute + concept as re-submittable notation
-tonk concepts     # user-defined concepts: name<TAB>description
-tonk views        # entities with a text/html claim: name<TAB>entity<TAB>bytes
+tonk concept ls   # user-defined concepts: name<TAB>description
+tonk view ls      # entities with a text/html claim: name<TAB>entity<TAB>bytes
 tonk guide        # baked-in asserted-notation reference (also: guide notation|views|all)
 
 # Argument-based data verbs — a constrained front-end over `eval`.

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -61,7 +61,8 @@ tonk status       # synced | ahead | behind | diverged | no-upstream
 
 # Delegate access to the space.
 tonk invite                    # audience-open: anyone holding it can claim
-tonk invite --remote prod      # also embeds a registered remote for auto-config
+tonk invite --remote prod      # pick the remote when several are registered
+tonk invite --no-remote        # embed none; the claimer wires an upstream by hand
 tonk join 'https://...#invite'
 ```
 
@@ -119,6 +120,11 @@ Remotes are UCAN-S3 access services registered on the repository's meta branch.
 audience-open invite URL (anyone holding it can claim by redelegating from the
 embedded ephemeral key); `tonk join` claims one into a fresh spot
 (`tonk join <url> --name <spot>`).
+
+A bare `tonk invite` resolves the repo's remote, builds the link on that
+remote's origin, and embeds it so the claimer auto-configures the same access
+service. `--remote <NAME>` picks one when several are registered; `--no-remote`
+mints without one.
 
 ## Built on
 

--- a/rust/tonk-cli/SYNC.md
+++ b/rust/tonk-cli/SYNC.md
@@ -56,7 +56,7 @@ only talk to one).
 ## Surface
 
 ```
-tonk invite                                  # link on the repo's remote origin, that remote embedded
+tonk invite                                  # link on the resolved remote's own origin, that remote embedded
 tonk invite --remote <name>                  # pick the remote when several are registered
 tonk invite --no-remote                      # mint without a remote; the claimer wires one by hand
 tonk join <invite-url>                       # claim an invite into the local site

--- a/rust/tonk-cli/SYNC.md
+++ b/rust/tonk-cli/SYNC.md
@@ -56,7 +56,9 @@ only talk to one).
 ## Surface
 
 ```
-tonk invite [--remote <name>]                # mint an invite URL for the local repo
+tonk invite                                  # link on the repo's remote origin, that remote embedded
+tonk invite --remote <name>                  # pick the remote when several are registered
+tonk invite --no-remote                      # mint without a remote; the claimer wires one by hand
 tonk join <invite-url>                       # claim an invite into the local site
 
 tonk remote add <name> <url> [--subject <did>]

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -231,7 +231,7 @@ enum Command {
     Invite {
         /// Override the URL prefix the invite is built against.
         /// Defaults to `/join` on the resolved remote's origin, or
-        /// to the canonical base when the repo has no remote.
+        /// to the canonical base when no single remote resolves.
         #[arg(long, value_name = "URL")]
         base_url: Option<String>,
 
@@ -246,8 +246,11 @@ enum Command {
 
         /// Mint an invite carrying no `remote=`, even when remotes
         /// are registered. The recipient joins with no upstream and
-        /// wires one by hand. The mint still syncs this repo to its
-        /// own upstream if it has one.
+        /// wires one by hand. The link still sits on the resolved
+        /// remote's origin — only the embedded endpoint is dropped.
+        /// Also the way past the several-remotes error, which falls
+        /// back to the canonical base. The mint still syncs this
+        /// repo to its own upstream if it has one.
         #[arg(long)]
         no_remote: bool,
     },
@@ -1332,20 +1335,45 @@ async fn mint_invite(
     // deployment carrying a remote on another can't be shortened (the
     // shortcut service is same-origin) and drops the recipient on a
     // deployment that isn't serving the repo.
-    let remote_record = if no_remote {
-        None
-    } else {
-        match remote::resolve(&site, remote_name.as_deref()).await {
-            Ok(resolved) => resolved,
-            Err(err) => return print_error(err.to_string()),
+    //
+    // `--no-remote` suppresses only the embedded endpoint. The link
+    // still belongs on the remote's origin: moving it to the canonical
+    // base is the same split this resolution exists to prevent.
+    let resolved = match remote::resolve(&site, remote_name.as_deref()).await {
+        Ok(record) => record,
+        // `--no-remote` is the documented way out of the ambiguity
+        // error, so it cannot be blocked by one. Nothing picks an
+        // origin here, so the canonical base is the honest answer —
+        // said out loud, because it may not be the right one.
+        Err(remote::RemoteError::AmbiguousRemote(names)) if no_remote => {
+            eprintln!(
+                "warning: several remotes are registered ({names}); building the link on \
+                 {base}\n         name an origin with `--base-url <URL>` if that is wrong",
+                base = invite::DEFAULT_BASE_URL,
+            );
+            None
+        }
+        Err(err) => {
+            // The shared error names `--remote`; `--no-remote` is the
+            // other way out, and only the invite path has it.
+            let hint = match err {
+                remote::RemoteError::AmbiguousRemote(_) => {
+                    "\n       or pass `--no-remote` to mint a link that embeds none"
+                }
+                _ => "",
+            };
+            return print_error(format!("{err}{hint}"));
         }
     };
+
+    // `--no-remote` keeps the origin and drops the endpoint.
+    let embedded = if no_remote { None } else { resolved.clone() };
 
     // The mint pushes to whatever `main` tracks, which need not be the
     // remote the link embeds. Say so rather than re-route: a deliberate
     // split setup is legitimate, and a silent one is not. No upstream
     // means no push at all, so nothing to diverge from.
-    if let Some(record) = &remote_record {
+    if let Some(record) = &embedded {
         match remote::upstream_remote(&site).await {
             Ok(Some(upstream)) if upstream != record.name => eprintln!(
                 "warning: the invite embeds remote '{embedded}' but the repo pushes to \
@@ -1358,7 +1386,7 @@ async fn mint_invite(
         }
     }
 
-    let base_url = match (base_url, &remote_record) {
+    let base_url = match (base_url, &resolved) {
         (Some(explicit), _) => explicit,
         (None, Some(record)) => match invite::base_url_for_remote(&record.endpoint) {
             Ok(derived) => derived,
@@ -1367,7 +1395,7 @@ async fn mint_invite(
         (None, None) => invite::DEFAULT_BASE_URL.to_owned(),
     };
 
-    let remote_url = remote_record.map(|record| record.endpoint);
+    let remote_url = embedded.map(|record| record.endpoint);
 
     match invite::mint(&site, Some(&base_url), remote_url.as_deref()).await {
         Ok(mut outcome) => {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -221,18 +221,34 @@ enum Command {
     /// Mints a UCAN delegation chain over the local repo. The
     /// default form is audience-open: anyone holding the URL can
     /// claim by redelegating from the embedded ephemeral key.
-    #[command(after_help = "Examples:\n  tonk invite\n  tonk invite --remote prod")]
+    ///
+    /// The link is built on the remote's own origin, so the
+    /// recipient lands on the deployment that actually serves the
+    /// repo — and that origin's shortcut service can shorten it.
+    #[command(
+        after_help = "Examples:\n  tonk invite\n  tonk invite --remote prod\n  tonk invite --no-remote"
+    )]
     Invite {
         /// Override the URL prefix the invite is built against.
-        #[arg(long, value_name = "URL", default_value_t = tonk_invite::DEFAULT_BASE_URL.to_string())]
-        base_url: String,
+        /// Defaults to `/join` on the resolved remote's origin, or
+        /// to the canonical base when the repo has no remote.
+        #[arg(long, value_name = "URL")]
+        base_url: Option<String>,
 
         /// Embed a registered remote's URL in the invite so
         /// the claimer auto-configures the same access service
         /// after redeeming. Argument is the remote's local
         /// name (as registered with `tonk remote add`).
-        #[arg(long, value_name = "NAME")]
+        /// Defaults to the only registered remote when there
+        /// is exactly one.
+        #[arg(long, value_name = "NAME", conflicts_with = "no_remote")]
         remote: Option<String>,
+
+        /// Mint a local-only invite carrying no `remote=`, even
+        /// when remotes are registered. The recipient joins with
+        /// no upstream and wires one by hand.
+        #[arg(long)]
+        no_remote: bool,
     },
 
     /// Join a shared repo from an invite URL into a new spot
@@ -734,9 +750,11 @@ async fn main() {
         Command::Push => sync_op(SyncOp::Push, spot.as_deref()).await,
         Command::Pull => sync_op(SyncOp::Pull, spot.as_deref()).await,
         Command::Status => status_op(spot.as_deref()).await,
-        Command::Invite { base_url, remote } => {
-            mint_invite(base_url, remote, spot.as_deref()).await
-        }
+        Command::Invite {
+            base_url,
+            remote,
+            no_remote,
+        } => mint_invite(base_url, remote, no_remote, spot.as_deref()).await,
         Command::Join { url, name } => claim_invite(url, name).await,
         Command::Remote { command } => remote_op(command, spot.as_deref()).await,
         Command::Blob { command } => blob_op(command, spot.as_deref()).await,
@@ -1297,8 +1315,9 @@ fn print_set_upstream_outcome(outcome: &UpstreamOutcome) {
 }
 
 async fn mint_invite(
-    base_url: String,
+    base_url: Option<String>,
     remote_name: Option<String>,
+    no_remote: bool,
     spot: Option<&str>,
 ) -> ExitCode {
     let (_, site) = match open_selected(spot).await {
@@ -1306,21 +1325,31 @@ async fn mint_invite(
         Err(code) => return code,
     };
 
-    // Resolve `--remote <name>` to its endpoint URL by reading
-    // the meta branch. An unknown name surfaces as a friendly
-    // error before any keys are generated.
-    let remote_url = match remote_name.as_deref() {
-        Some(name) => match remote::find(&site, name).await {
-            Ok(Some(record)) => Some(record.endpoint),
-            Ok(None) => {
-                return print_error(format!(
-                    "no remote registered as '{name}'; run `tonk remote list` to see what's there"
-                ));
-            }
+    // Resolve the remote first: it decides both what gets embedded as
+    // `remote=` and, unless `--base-url` overrides, which origin the
+    // link points at. Those two have to stay in step — a link on one
+    // deployment carrying a remote on another can't be shortened (the
+    // shortcut service is same-origin) and drops the recipient on a
+    // deployment that isn't serving the repo.
+    let remote_record = if no_remote {
+        None
+    } else {
+        match remote::resolve(&site, remote_name.as_deref()).await {
+            Ok(resolved) => resolved,
+            Err(err) => return print_error(err.to_string()),
+        }
+    };
+
+    let base_url = match (base_url, &remote_record) {
+        (Some(explicit), _) => explicit,
+        (None, Some(record)) => match invite::base_url_for_remote(&record.endpoint) {
+            Ok(derived) => derived,
             Err(err) => return print_error(err.to_string()),
         },
-        None => None,
+        (None, None) => invite::DEFAULT_BASE_URL.to_owned(),
     };
+
+    let remote_url = remote_record.map(|record| record.endpoint);
 
     match invite::mint(&site, Some(&base_url), remote_url.as_deref()).await {
         Ok(mut outcome) => {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -244,9 +244,10 @@ enum Command {
         #[arg(long, value_name = "NAME", conflicts_with = "no_remote")]
         remote: Option<String>,
 
-        /// Mint a local-only invite carrying no `remote=`, even
-        /// when remotes are registered. The recipient joins with
-        /// no upstream and wires one by hand.
+        /// Mint an invite carrying no `remote=`, even when remotes
+        /// are registered. The recipient joins with no upstream and
+        /// wires one by hand. The mint still syncs this repo to its
+        /// own upstream if it has one.
         #[arg(long)]
         no_remote: bool,
     },
@@ -1339,6 +1340,23 @@ async fn mint_invite(
             Err(err) => return print_error(err.to_string()),
         }
     };
+
+    // The mint pushes to whatever `main` tracks, which need not be the
+    // remote the link embeds. Say so rather than re-route: a deliberate
+    // split setup is legitimate, and a silent one is not. No upstream
+    // means no push at all, so nothing to diverge from.
+    if let Some(record) = &remote_record {
+        match remote::upstream_remote(&site).await {
+            Ok(Some(upstream)) if upstream != record.name => eprintln!(
+                "warning: the invite embeds remote '{embedded}' but the repo pushes to \
+                 '{upstream}';\n         the recipient may join a deployment that has not \
+                 received this data",
+                embedded = record.name,
+            ),
+            Ok(_) => {}
+            Err(err) => eprintln!("warning: could not check the branch's upstream: {err}"),
+        }
+    }
 
     let base_url = match (base_url, &remote_record) {
         (Some(explicit), _) => explicit,

--- a/rust/tonk-cli/src/guide-events.md
+++ b/rust/tonk-cli/src/guide-events.md
@@ -418,9 +418,15 @@ cases 2 and 3 are exactly that false positive.
 
 ### Opening the view in tonk-ui
 
-Once the view works locally, hand the repo to a collaborator with
-`tonk invite`. They join the space and open the view there — events
-fire in the live shell, not in a standalone page.
+Events fire in the live shell, not in a standalone page, so open the
+view in the space: `/space/<space>/<model>` for the model's directory,
+`/space/<space>/<entity>@<model>!<view>` for one entity through a
+named view. `tonk render` is no substitute here — it prints the HTML
+with nothing behind it, so a click reaches no command. Use it to check
+the markup, the shell to check the wiring.
+
+To put a collaborator in front of the same view, hand them the repo
+with `tonk invite`.
 
 ### When the declarative path doesn't fit
 

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -62,7 +62,10 @@ per-process (`TONK_SPOT=x tonk ...` or `--spot x`) — never rely on
    or `<doc> | tonk eval -`. A committing eval auto-syncs unless
    `--no-sync`; `--dry-run` previews without committing (queries run,
    transaction dropped, branch untouched).
-6. Hand the repo to someone: `tonk invite`.
+6. Look at it. In the shell: `/space/<space>/<model>` (directory),
+   `/space/<space>/<entity>@<model>!<view>` (one entity, named view).
+   Headlessly: `tonk render` on the same routes.
+7. Hand the repo to someone else: `tonk invite`.
 
 ## Reference topics
 

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -58,8 +58,15 @@ Omit `view` to fall back to the built-in detail view for the model. A
 view** — every instance of the model — using the model's
 `view/directory`, or a default carousel.
 
-Hand the repo to someone: `tonk invite` (they land on the space and
-navigate to the view themselves).
+Three routes reach a view in the shell, and `tonk render` (next
+section) takes the same three:
+
+- `/space/<space>/<model>` — the model's directory.
+- `/space/<space>/<entity>@<model>` — one entity, model's own view.
+- `/space/<space>/<entity>@<model>!<view>` — one entity through a
+  named view concept.
+
+Handing the repo to someone else is a separate act: `tonk invite`.
 
 ## Render to HTML headlessly: `tonk render`
 
@@ -200,10 +207,14 @@ page!: &about
     <h1>About</h1>
 ```
 
-`tonk view ls` lists every entity carrying a `text/html` claim; the
-viewer serves each one at `/space/<space-name>/view/<entity>`. Hand
-the repo to someone with `tonk invite` and they can navigate to it
-themselves.
+`tonk view ls` lists every entity carrying a `text/html` claim. It is
+claim-driven, so a plain concept like this `page` shows up next to
+real views — but no route serves a bare claim. The page reaches a
+browser through `<tonk-portal>`, the sandboxed iframe the display
+stack mounts for a view whose projected `type` is `text/html`; the
+worker serves the body behind it. So you reach it the way you reach
+any view: `/space/<space>/<entity>@<model>!<view>`, or
+`tonk render <entity>@<model>!<view>` headlessly.
 
 ---
 

--- a/rust/tonk-cli/src/guide-workspace.md
+++ b/rust/tonk-cli/src/guide-workspace.md
@@ -78,6 +78,7 @@ workspace!:
   sheet: sheet-bob
 ```
 
-Open it in the shell: push, then
-`tonk invite` — the recipient joins the space and opens the workspace
-there.
+Open it in the shell at `/space/<space>/<entity>@workspace` —
+`lab@workspace` for the one above. `tonk render lab@workspace` prints
+the same HTML headlessly. To put someone else in it, hand them the
+repo with `tonk invite`.

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -211,7 +211,9 @@ pub async fn mint(
 /// hang `/join` off (a `data:` or `mailto:` URL, say).
 pub fn base_url_for_remote(endpoint: &str) -> Result<String, InviteError> {
     let parsed = Url::parse(endpoint).map_err(|e| {
-        InviteError::Io(format!("remote endpoint '{endpoint}' is not a valid URL: {e}"))
+        InviteError::Io(format!(
+            "remote endpoint '{endpoint}' is not a valid URL: {e}"
+        ))
     })?;
     parsed.join("/join").map(String::from).map_err(|e| {
         InviteError::Io(format!(

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -196,6 +196,30 @@ pub async fn mint(
     })
 }
 
+/// Derive the invite base URL from a remote's endpoint.
+///
+/// The invite has to live on the remote's own origin. That origin is
+/// the deployment actually serving the repo, and — because the
+/// shortcut service is same-origin by construction — the only one
+/// whose `PUT /@` can answer. This is the CLI's stand-in for the
+/// worker's `location.origin`, which the browser mint path reads
+/// straight off its own scope.
+///
+/// # Errors
+///
+/// Returns an error if `endpoint` doesn't parse, or has no origin to
+/// hang `/join` off (a `data:` or `mailto:` URL, say).
+pub fn base_url_for_remote(endpoint: &str) -> Result<String, InviteError> {
+    let parsed = Url::parse(endpoint).map_err(|e| {
+        InviteError::Io(format!("remote endpoint '{endpoint}' is not a valid URL: {e}"))
+    })?;
+    parsed.join("/join").map(String::from).map_err(|e| {
+        InviteError::Io(format!(
+            "remote endpoint '{endpoint}' has no usable origin: {e}"
+        ))
+    })
+}
+
 /// Claim an invite, bootstrapping a fresh site at `root` (the
 /// site directory itself — the caller picks it, typically the
 /// canonical `spots/<name>/` dir) whose repository targets the
@@ -486,4 +510,41 @@ async fn generate_ephemeral() -> Result<(Ed25519Signer, [u8; 32]), InviteError> 
     };
 
     Ok((signer, seed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    mod when_deriving_a_base_url_from_a_remote {
+        use super::*;
+
+        #[dialog_common::test]
+        fn it_replaces_the_access_service_path_with_join() {
+            let base = base_url_for_remote("https://staging.tonk.xyz/ucan/").unwrap();
+            assert_eq!(base, "https://staging.tonk.xyz/join");
+        }
+
+        #[dialog_common::test]
+        fn it_handles_an_endpoint_with_no_path() {
+            let base = base_url_for_remote("https://staging.tonk.xyz").unwrap();
+            assert_eq!(base, "https://staging.tonk.xyz/join");
+        }
+
+        #[dialog_common::test]
+        fn it_keeps_the_port_so_local_services_resolve() {
+            let base = base_url_for_remote("http://127.0.0.1:8787/ucan/").unwrap();
+            assert_eq!(base, "http://127.0.0.1:8787/join");
+        }
+
+        #[dialog_common::test]
+        fn it_rejects_an_endpoint_that_is_not_a_url() {
+            assert!(base_url_for_remote("not a url").is_err());
+        }
+    }
 }

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -309,7 +309,7 @@ pub async fn list(site: &TonkSite) -> Result<Vec<RemoteRecord>, RemoteError> {
 }
 
 /// Look up one remote by name. Convenience wrapper around
-/// [`list`] for the invite-mint path.
+/// [`list`], used by [`resolve`] and [`set_upstream`].
 pub async fn find(site: &TonkSite, name: &str) -> Result<Option<RemoteRecord>, RemoteError> {
     let mut remotes: HashMap<String, RemoteRecord> = list(site)
         .await?
@@ -321,9 +321,10 @@ pub async fn find(site: &TonkSite, name: &str) -> Result<Option<RemoteRecord>, R
 
 /// Pick the remote a command should act on.
 ///
-/// `explicit` names one outright. Otherwise this follows `tonk push`'s
-/// implicit-when-unambiguous rule: a lone registered remote is the
-/// obvious choice, no remotes at all means there is nothing to act on
+/// `explicit` names one outright. Otherwise a lone registered remote is
+/// the obvious choice — the same implicit-when-unambiguous reading
+/// `tonk remote add` applies when it wires a first remote as the
+/// upstream. No remotes at all means there is nothing to act on
 /// (`None`, not an error — a local-only repo is a legitimate thing to
 /// invite someone to), and several is a question only the caller can
 /// answer.

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -181,7 +181,7 @@ pub async fn upstream_remote(site: &TonkSite) -> Result<Option<String>, RemoteEr
         .map_err(|e| RemoteError::Io(format!("failed to acquire branch: {e}")))?;
     Ok(match session.handle().upstream() {
         Some(Upstream::Remote { remote, .. }) => Some(remote),
-        _ => None,
+        Some(Upstream::Local { .. }) | None => None,
     })
 }
 

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use dialog_remote_ucan_s3::UcanAddress;
-use dialog_repository::{Branch, SiteAddress};
+use dialog_repository::{Branch, SiteAddress, Upstream};
 use dialog_varsig::Did;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -162,6 +162,27 @@ pub async fn upstream_configured(site: &TonkSite) -> Result<bool, RemoteError> {
         .await
         .map_err(|e| RemoteError::Io(format!("failed to acquire branch: {e}")))?;
     Ok(session.handle().upstream().is_some())
+}
+
+/// Local name of the remote the site's `main` branch tracks, or
+/// `None` when no upstream is wired.
+///
+/// The upstream cell records the remote under the same local name
+/// it was registered with, so the answer compares straight against
+/// a [`RemoteRecord`]'s `name`. `tonk invite` uses that comparison
+/// to tell whether the remote it is about to embed in a link is the
+/// one the repo actually pushes to. An upstream pointing at another
+/// local branch names no remote and reads as `None` — tonk never
+/// wires one, and there is no remote to compare against if it did.
+pub async fn upstream_remote(site: &TonkSite) -> Result<Option<String>, RemoteError> {
+    let session = site
+        .branch()
+        .await
+        .map_err(|e| RemoteError::Io(format!("failed to acquire branch: {e}")))?;
+    Ok(match session.handle().upstream() {
+        Some(Upstream::Remote { remote, .. }) => Some(remote),
+        _ => None,
+    })
 }
 
 /// Set the local `main` branch's upstream to `<remote>/main`,

--- a/rust/tonk-cli/src/remote.rs
+++ b/rust/tonk-cli/src/remote.rs
@@ -80,6 +80,10 @@ pub enum RemoteError {
     /// meta branch.
     #[error("remote '{0}' is not registered; add it with `tonk remote add` first")]
     UnknownRemote(String),
+    /// Several remotes are registered and the caller named none, so
+    /// there is no unambiguous choice to make on their behalf.
+    #[error("several remotes are registered ({0}); name one with `--remote <NAME>`")]
+    AmbiguousRemote(String),
     /// Anything else — dialog I/O, decoding, query failure.
     #[error("{0}")]
     Io(String),
@@ -292,6 +296,39 @@ pub async fn find(site: &TonkSite, name: &str) -> Result<Option<RemoteRecord>, R
         .map(|r| (r.name.clone(), r))
         .collect();
     Ok(remotes.remove(name))
+}
+
+/// Pick the remote a command should act on.
+///
+/// `explicit` names one outright. Otherwise this follows `tonk push`'s
+/// implicit-when-unambiguous rule: a lone registered remote is the
+/// obvious choice, no remotes at all means there is nothing to act on
+/// (`None`, not an error — a local-only repo is a legitimate thing to
+/// invite someone to), and several is a question only the caller can
+/// answer.
+pub async fn resolve(
+    site: &TonkSite,
+    explicit: Option<&str>,
+) -> Result<Option<RemoteRecord>, RemoteError> {
+    if let Some(name) = explicit {
+        let record = find(site, name)
+            .await?
+            .ok_or_else(|| RemoteError::UnknownRemote(name.to_owned()))?;
+        return Ok(Some(record));
+    }
+
+    let mut remotes = list(site).await?;
+    match remotes.len() {
+        0 => Ok(None),
+        1 => Ok(Some(remotes.remove(0))),
+        _ => Err(RemoteError::AmbiguousRemote(
+            remotes
+                .iter()
+                .map(|record| record.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )),
+    }
 }
 
 // ---------------------------------------------------------------- //

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -47,7 +47,7 @@ use crate::output::EvaluateResponse;
 use crate::site::TonkSite;
 
 /// Slim summary of one named concept on the branch — just enough
-/// for `tonk concepts` to print. The full descriptor stays internal
+/// for `tonk concept ls` to print. The full descriptor stays internal
 /// to [`render`] (which needs it to re-emit the `with:` map as
 /// notation).
 #[derive(Debug, Clone)]

--- a/rust/tonk-cli/src/views.rs
+++ b/rust/tonk-cli/src/views.rs
@@ -19,7 +19,7 @@ use dialog_query::{AttributeQuery, Output as _, Term, attribute};
 
 use crate::site::TonkSite;
 
-/// One row of `tonk views`.
+/// One row of `tonk view ls`.
 #[derive(Debug, Clone)]
 pub struct ViewSummary {
     /// `dialog.meta/name` claim on the entity, when one is
@@ -27,7 +27,7 @@ pub struct ViewSummary {
     /// branch's history; we surface the current binding only.
     pub name: Option<String>,
     /// Entity URI carrying the `text/html` claim — what the
-    /// host route's `view/{entity}` segment takes.
+    /// host route's trailing `{entity}` segment takes.
     pub entity: Entity,
     /// Byte length of the body claim. Lets the listing show a
     /// rough "is this empty / huge?" without dumping the HTML.

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -20,9 +20,12 @@ fn tonk_bin() -> std::path::PathBuf {
 /// A `tonk` invocation isolated from the developer's real state:
 /// registry under `state_dir`, telemetry disabled and redirected,
 /// update-check disabled and redirected — same hygiene as
-/// `tests/telemetry.rs`'s `run_tonk_guide`. `TONK_SPOT` is always
-/// removed first so the outer environment never leaks in; pass it
-/// via `extra_env` to pin it explicitly.
+/// `tests/telemetry.rs`'s `run_tonk_guide`. `HOME` is redirected too,
+/// because the profile directory has no env override of its own and
+/// resolves off the home dir; a test that actually opens a site would
+/// otherwise write keys into the developer's real profile. `TONK_SPOT`
+/// is always removed first so the outer environment never leaks in;
+/// pass it via `extra_env` to pin it explicitly.
 fn tonk_cmd(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Command {
     let mut cmd = Command::new(tonk_bin());
     cmd.args(args)
@@ -32,6 +35,7 @@ fn tonk_cmd(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Comm
         .env_remove("TONK_TELEMETRY")
         .env("TONK_NO_UPDATE_CHECK", "1")
         .env("TONK_UPDATE_STATE", state_dir)
+        .env("HOME", state_dir)
         .env_remove("TONK_SPOT");
     for (key, value) in extra_env {
         cmd.env(key, value);
@@ -47,6 +51,33 @@ fn run(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
 
 fn stderr_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Endpoints on the discard port: valid URLs that parse and register
+/// fine, with nothing listening behind them. Anything that would reach
+/// the wire fails fast instead of touching the network.
+const DEAD_REMOTE: &str = "http://127.0.0.1:9/ucan/";
+const OTHER_DEAD_REMOTE: &str = "http://127.0.0.1:9/other/";
+
+/// Stand up a real spot through the CLI — `tonk spot new` writes the
+/// site the rest of these invocations read — then register `remotes`
+/// in order. `tonk remote add` wires the *first* remote as `main`'s
+/// upstream and leaves it alone after that, so `remotes[0]` is the one
+/// the repo pushes to.
+fn spot_with_remotes(state_dir: &Path, remotes: &[(&str, &str)]) {
+    let site = state_dir.join("site");
+    let site = site.to_str().expect("utf-8 site path");
+    let output = run(state_dir, &["spot", "new", "demo", "--site", site], &[]);
+    assert!(output.status.success(), "{}", stderr_of(&output));
+
+    for (name, endpoint) in remotes {
+        let output = run(state_dir, &["remote", "add", name, endpoint], &[]);
+        assert!(output.status.success(), "{}", stderr_of(&output));
+    }
 }
 
 /// Write a `spots.json` registry directly (bypassing the CLI) so
@@ -169,5 +200,152 @@ mod when_joining {
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
         assert!(stderr.contains("already exists"), "{stderr}");
+    }
+}
+
+/// The mismatch warning `tonk invite` prints before it mints. These
+/// run entirely offline: the mint's push to a discard-port upstream
+/// fails right after, which is fine — the warning precedes it, so
+/// nothing here asserts on the mint succeeding.
+mod when_the_invite_remote_differs_from_the_upstream {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_warns_the_recipient_may_miss_the_data() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(
+            state.path(),
+            &[("origin", DEAD_REMOTE), ("other", OTHER_DEAD_REMOTE)],
+        );
+
+        let output = run(state.path(), &["invite", "--remote", "other"], &[]);
+        let stderr = stderr_of(&output);
+        assert!(
+            stderr.contains("the invite embeds remote 'other' but the repo pushes to 'origin'"),
+            "{stderr}"
+        );
+        assert!(
+            stderr.contains("may join a deployment that has not received this data"),
+            "{stderr}"
+        );
+    }
+}
+
+mod when_the_invite_remote_is_the_upstream {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_mints_without_a_mismatch_warning() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(
+            state.path(),
+            &[("origin", DEAD_REMOTE), ("other", OTHER_DEAD_REMOTE)],
+        );
+
+        let output = run(state.path(), &["invite", "--remote", "origin"], &[]);
+        let stderr = stderr_of(&output);
+        assert!(!stderr.contains("the invite embeds remote"), "{stderr}");
+    }
+}
+
+mod when_inviting_without_a_remote {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_mints_without_a_mismatch_warning() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(
+            state.path(),
+            &[("origin", DEAD_REMOTE), ("other", OTHER_DEAD_REMOTE)],
+        );
+
+        let output = run(state.path(), &["invite", "--no-remote"], &[]);
+        let stderr = stderr_of(&output);
+        assert!(!stderr.contains("the invite embeds remote"), "{stderr}");
+    }
+}
+
+/// End-to-end mints against the in-process access service the rest of
+/// the suite uses (a local S3 plus UCAN server — no external network).
+/// A live remote is the only way to see the minted URL at all: the
+/// mint pushes to the upstream first, and shortening the link is a
+/// request to the link's own origin.
+#[cfg(feature = "integration-tests")]
+mod when_minting_against_a_live_remote {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use tonk_access_service::helpers::AccessServiceAddress;
+
+    use super::*;
+
+    /// Set a spot up and run one `tonk` invocation against it, all on
+    /// the blocking pool. `#[dialog_common::test]` expands to
+    /// `#[tokio::test]`, whose current-thread runtime is also hosting
+    /// the access service — block that thread on a subprocess and the
+    /// service the CLI is talking to can never answer.
+    async fn mint_against(state_dir: PathBuf, endpoint: String, args: &[&str]) -> Output {
+        let args: Vec<String> = args.iter().map(|arg| (*arg).to_owned()).collect();
+        tokio::task::spawn_blocking(move || {
+            spot_with_remotes(&state_dir, &[("origin", &endpoint)]);
+            let args: Vec<&str> = args.iter().map(String::as_str).collect();
+            run(&state_dir, &args, &[])
+        })
+        .await
+        .expect("blocking tonk invocation joins")
+    }
+
+    /// The regression this whole path exists for: a bare `tonk invite`
+    /// resolves the lone registered remote and builds the link on that
+    /// remote's origin, not on the hardcoded default base.
+    #[dialog_common::test]
+    async fn it_builds_the_link_on_the_lone_remotes_origin(
+        env: AccessServiceAddress,
+    ) -> Result<()> {
+        let state = tempfile::tempdir()?;
+        let origin = env.access_service_url.trim_end_matches('/').to_owned();
+
+        let output = mint_against(state.path().to_path_buf(), origin.clone(), &["invite"]).await;
+        assert!(output.status.success(), "{}", stderr_of(&output));
+
+        let stdout = stdout_of(&output);
+        let url = stdout.trim();
+        assert!(
+            url.starts_with(&format!("{origin}/@/")),
+            "short link sits on the remote's origin: {url}"
+        );
+        assert!(!url.contains("tonk.spot"), "not the default base: {url}");
+        Ok(())
+    }
+
+    /// `--base-url` still wins over the remote-derived origin.
+    #[dialog_common::test]
+    async fn it_prefers_an_explicit_base_url_over_the_remote(
+        env: AccessServiceAddress,
+    ) -> Result<()> {
+        let state = tempfile::tempdir()?;
+        let origin = env.access_service_url.trim_end_matches('/').to_owned();
+
+        let output = mint_against(
+            state.path().to_path_buf(),
+            origin,
+            &["invite", "--base-url", "http://127.0.0.1:9/join"],
+        )
+        .await;
+        assert!(output.status.success(), "{}", stderr_of(&output));
+
+        let stdout = stdout_of(&output);
+        let url = stdout.trim();
+        assert!(
+            url.starts_with("http://127.0.0.1:9/join"),
+            "explicit base wins: {url}"
+        );
+        // Nothing serves the discard port, so the link stays long.
+        let stderr = stderr_of(&output);
+        assert!(
+            stderr.contains("could not shorten the invite URL"),
+            "{stderr}"
+        );
+        Ok(())
     }
 }

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -263,6 +263,52 @@ mod when_inviting_without_a_remote {
         let stderr = stderr_of(&output);
         assert!(!stderr.contains("the invite embeds remote"), "{stderr}");
     }
+
+    /// `--no-remote` is the way past the several-remotes error, so it
+    /// can never be blocked by one. Nothing resolves an origin here, so
+    /// the base falls back — out loud, not silently.
+    #[dialog_common::test]
+    fn it_warns_and_falls_back_when_several_remotes_are_registered() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(
+            state.path(),
+            &[("origin", DEAD_REMOTE), ("other", OTHER_DEAD_REMOTE)],
+        );
+
+        let output = run(state.path(), &["invite", "--no-remote"], &[]);
+        let stderr = stderr_of(&output);
+        assert!(
+            stderr.contains("warning: several remotes are registered"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("--base-url"), "{stderr}");
+        assert!(
+            !stderr.contains("error: several remotes are registered"),
+            "{stderr}"
+        );
+    }
+}
+
+/// A bare `tonk invite` cannot pick between remotes, so it stops. The
+/// error has to name both ways forward — `--remote` to choose one and
+/// `--no-remote` to embed none.
+mod when_several_remotes_are_registered {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_names_both_ways_out_of_the_ambiguity() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(
+            state.path(),
+            &[("origin", DEAD_REMOTE), ("other", OTHER_DEAD_REMOTE)],
+        );
+
+        let output = run(state.path(), &["invite"], &[]);
+        assert!(!output.status.success());
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("--remote <NAME>"), "{stderr}");
+        assert!(stderr.contains("--no-remote"), "{stderr}");
+    }
 }
 
 /// End-to-end mints against the in-process access service the rest of
@@ -315,6 +361,60 @@ mod when_minting_against_a_live_remote {
             "short link sits on the remote's origin: {url}"
         );
         assert!(!url.contains("tonk.spot"), "not the default base: {url}");
+        Ok(())
+    }
+
+    /// Resolve a `{origin}/@/{hash}` link back to what it stands for.
+    /// The shortcut service answers with a relative `Location`, so the
+    /// header carries the path and query the mint actually produced —
+    /// the only way to inspect a link once it has been shortened.
+    async fn shortcut_target(short_url: &str) -> Result<String> {
+        let without_fragment = short_url.split('#').next().unwrap_or(short_url);
+        let response = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?
+            .get(without_fragment)
+            .send()
+            .await?;
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .expect("shortcut answers with a Location")
+            .to_str()?
+            .to_owned();
+        Ok(location)
+    }
+
+    /// `--no-remote` drops the embedded endpoint and nothing else. The
+    /// link stays on the remote's origin — rerouting it to the
+    /// canonical base would strand the recipient on a deployment that
+    /// has never seen this repo, the split this path exists to avoid.
+    #[dialog_common::test]
+    async fn it_keeps_the_lone_remotes_origin_and_embeds_no_remote(
+        env: AccessServiceAddress,
+    ) -> Result<()> {
+        let state = tempfile::tempdir()?;
+        let origin = env.access_service_url.trim_end_matches('/').to_owned();
+
+        let output = mint_against(
+            state.path().to_path_buf(),
+            origin.clone(),
+            &["invite", "--no-remote"],
+        )
+        .await;
+        assert!(output.status.success(), "{}", stderr_of(&output));
+
+        let stdout = stdout_of(&output);
+        let url = stdout.trim();
+        assert!(
+            url.starts_with(&format!("{origin}/@/")),
+            "short link sits on the remote's origin: {url}"
+        );
+        assert!(!url.contains("tonk.spot"), "not the default base: {url}");
+
+        let target = shortcut_target(url).await?;
+        assert!(target.contains("access="), "still a real invite: {target}");
+        assert!(!target.contains("remote="), "no remote embedded: {target}");
         Ok(())
     }
 

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -180,6 +180,60 @@ mod when_resolving_a_remote {
     }
 }
 
+mod when_the_invite_remote_is_not_the_upstream {
+    use anyhow::Result;
+    use tonk_cli::remote;
+
+    use crate::common;
+
+    const ENDPOINT: &str = "https://access.example.test/ucan/";
+    const OTHER: &str = "https://other.example.test/ucan/";
+
+    #[dialog_common::test]
+    async fn it_reports_no_upstream_remote_on_a_freshly_added_remote() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+
+        // Registering a remote doesn't wire it as the upstream, so
+        // there is nothing to diverge from and nothing to warn about.
+        assert!(remote::upstream_remote(&test.site).await?.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_names_the_remote_the_branch_tracks() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+        remote::add(&test.site, "backup", OTHER, None).await?;
+        remote::set_upstream(&test.site, "origin").await?;
+
+        let upstream = remote::upstream_remote(&test.site).await?;
+        assert_eq!(upstream.as_deref(), Some("origin"));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_differs_from_a_remote_the_branch_does_not_track() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+        remote::add(&test.site, "backup", OTHER, None).await?;
+        remote::set_upstream(&test.site, "origin").await?;
+
+        let upstream = remote::upstream_remote(&test.site).await?;
+
+        let backup = remote::resolve(&test.site, Some("backup"))
+            .await?
+            .expect("named remote resolves");
+        assert_ne!(upstream.as_deref(), Some(backup.name.as_str()));
+
+        let origin = remote::resolve(&test.site, Some("origin"))
+            .await?
+            .expect("named remote resolves");
+        assert_eq!(upstream.as_deref(), Some(origin.name.as_str()));
+        Ok(())
+    }
+}
+
 mod when_shortening_an_invite {
     #[cfg(feature = "integration-tests")]
     use anyhow::Result;

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -231,6 +231,33 @@ mod when_shortening_an_invite {
         assert!(claim_outcome.remote_url.is_some());
         Ok(())
     }
+
+    /// The regression: with no explicit base, the link must land on
+    /// the remote's own origin — the only origin whose same-origin
+    /// shortcut service can answer, and the deployment actually
+    /// serving the repo.
+    #[dialog_common::test]
+    async fn it_derives_the_base_from_the_remote_and_shortens(
+        env: AccessServiceAddress,
+    ) -> Result<()> {
+        let endpoint = env.access_service_url.as_str();
+        let inviter = common::TestSite::new().await?;
+        remote::add(&inviter.site, "origin", endpoint, None).await?;
+
+        let resolved = remote::resolve(&inviter.site, None)
+            .await?
+            .expect("the lone remote resolves");
+        let base = invite::base_url_for_remote(&resolved.endpoint)?;
+        assert_eq!(base, format!("{endpoint}/join"));
+
+        let outcome = invite::mint(&inviter.site, Some(&base), Some(&resolved.endpoint)).await?;
+        let short = invite::shorten(&outcome.url).await?;
+        assert!(
+            short.starts_with(&format!("{endpoint}/@/")),
+            "short link sits on the remote's origin: {short}"
+        );
+        Ok(())
+    }
 }
 
 mod when_claiming_an_invite_with_a_remote {

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -194,8 +194,10 @@ mod when_the_invite_remote_is_not_the_upstream {
         let test = common::TestSite::new().await?;
         remote::add(&test.site, "origin", ENDPOINT, None).await?;
 
-        // Registering a remote doesn't wire it as the upstream, so
-        // there is nothing to diverge from and nothing to warn about.
+        // `remote::add` only registers; it never touches the upstream,
+        // so there is nothing to diverge from and nothing to warn
+        // about. (`tonk remote add`, the command, layers a default
+        // set-upstream on top when no upstream is configured yet.)
         assert!(remote::upstream_remote(&test.site).await?.is_none());
         Ok(())
     }

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -114,6 +114,72 @@ mod when_managing_remotes {
     }
 }
 
+mod when_resolving_a_remote {
+    use anyhow::Result;
+    use tonk_cli::remote::{self, RemoteError};
+
+    use crate::common;
+
+    const ENDPOINT: &str = "https://access.example.test/ucan/";
+    const OTHER: &str = "https://other.example.test/ucan/";
+
+    #[dialog_common::test]
+    async fn it_resolves_nothing_when_no_remote_is_registered() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        assert!(remote::resolve(&test.site, None).await?.is_none());
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_the_only_registered_remote() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+
+        let resolved = remote::resolve(&test.site, None).await?;
+        assert_eq!(resolved.expect("a lone remote resolves").endpoint, ENDPOINT);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_the_named_remote_when_several_exist() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+        remote::add(&test.site, "backup", OTHER, None).await?;
+
+        let resolved = remote::resolve(&test.site, Some("backup")).await?;
+        assert_eq!(resolved.expect("named remote resolves").endpoint, OTHER);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_to_guess_between_several_remotes() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+        remote::add(&test.site, "backup", OTHER, None).await?;
+
+        match remote::resolve(&test.site, None).await {
+            Err(RemoteError::AmbiguousRemote(names)) => {
+                assert!(names.contains("origin"), "names both: {names}");
+                assert!(names.contains("backup"), "names both: {names}");
+            }
+            other => panic!("expected AmbiguousRemote, got: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_errors_on_a_name_that_is_not_registered() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        remote::add(&test.site, "origin", ENDPOINT, None).await?;
+
+        match remote::resolve(&test.site, Some("missing")).await {
+            Err(RemoteError::UnknownRemote(name)) => assert_eq!(name, "missing"),
+            other => panic!("expected UnknownRemote, got: {other:?}"),
+        }
+        Ok(())
+    }
+}
+
 mod when_shortening_an_invite {
     #[cfg(feature = "integration-tests")]
     use anyhow::Result;

--- a/rust/tonk-invite/README.md
+++ b/rust/tonk-invite/README.md
@@ -32,7 +32,7 @@ audience-scoped ([`InviteAudience::Scoped`]): only the chain's recorded
 audience DID can claim. The *subject* axis (which repo) is always scoped and is
 orthogonal to this.
 
-[`DEFAULT_BASE_URL`] (`https://hub.tonk.xyz/join`) is the canonical base for
+[`DEFAULT_BASE_URL`] (`https://tonk.spot/join`) is the canonical base for
 minted links.
 
 ## Mint and claim

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -37,11 +37,14 @@ use dialog_ucan_core::{DelegationBuilder, DelegationChain, subject::Subject as U
 use dialog_varsig::{Did, Principal};
 use url::Url;
 
-/// Canonical base URL for tonk invite links. Callers serializing an
-/// [`Invite`] can pass this to [`Invite::to_url`] to mint a link rooted at
-/// hub.tonk.xyz. Changing this value is a breaking change for any outstanding
-/// invite URLs that embed it.
-pub const DEFAULT_BASE_URL: &str = "https://hub.tonk.xyz/join";
+/// Canonical base URL for tonk invite links, and the fallback for a repo
+/// with no remote to take an origin from. Callers serializing an [`Invite`]
+/// pass this to [`Invite::to_url`] to mint a link rooted at tonk.spot.
+///
+/// Changing it does not invalidate outstanding invites: the base is not a
+/// lookup key, so a link already minted against another host keeps
+/// redeeming for as long as that host stays up.
+pub const DEFAULT_BASE_URL: &str = "https://tonk.spot/join";
 
 /// Length in bytes of the Ed25519 seed embedded in the URL fragment for
 /// audience-open invites.


### PR DESCRIPTION
Stacked on #631 — rebase onto staging once that merges.

`tonk invite` minted against a hardcoded base URL independent of the
remote it embedded, so the link and the repo could name different
deployments:

```
$ tonk invite
warning: could not shorten the invite URL: shortcut PUT returned HTTP 404 Not Found
https://hub.tonk.xyz/join?access=RzwAxwTx3pBx...   (~2.8 KB of base58)

$ tonk remote list
origin  https://staging.tonk.xyz/ucan/  did:key:z6Mkjd4...
```

Shortening PUTs to the link's own origin — the shortcut service is
same-origin by construction — so a prod link carrying a staging remote
can never be shortened, and it drops the recipient on a deployment that
is not serving the repo. The web UI never hits this because it reads
its own worker scope; the CLI had no equivalent anchor and picked one
by fiat.

## What changed

- `invite::base_url_for_remote` derives `/join` on the remote's origin
- `remote::resolve` picks the remote implicitly when unambiguous, so a
  bare `tonk invite` carries an upstream instead of stranding the joiner
- `--base-url` becomes optional and overrides the derivation
- `--no-remote` mints without a `remote=` while keeping the link on the
  remote's origin
- `DEFAULT_BASE_URL` moves to `https://tonk.spot/join`
- `tonk invite` warns when the remote it embeds is not the branch's
  upstream, because `invite::mint` pushes to the upstream — see below

Verified end to end against live staging:
`https://staging.tonk.spot/@/31YdvA5g...#EmbTkUoy...`, short, on the
remote's own origin, no warning.

## Breaking changes

**`tonk invite` now errors when 2+ remotes are registered.** It used to
mint a local-only invite silently. Pass `--remote <NAME>` to pick one,
or `--no-remote` for the old behaviour. Both are named in the error.

**`tonk invite --remote bogus` changed its error text**, from
"no remote registered as 'bogus'; run `tonk remote list` to see what's
there" to "remote 'bogus' is not registered; add it with
`tonk remote add` first" — a deliberate dedup onto
`RemoteError::UnknownRemote`, but user-visible.

## Known gap

`invite::mint` pushes to the branch's **upstream**, not to the remote
the link embeds. With several remotes registered, `--remote backup`
builds the link on backup's origin and ships the data to origin. This
PR warns rather than re-routing: `sync::push` is upstream-bound and a
push-to-named-remote path does not exist yet. In the single-remote
case they coincide.

## Deploy follow-up

Production will not shorten until `tonk.spot` is redeployed —
`PUT /@` 404s there today because the worker predates
`run_worker_first = ["/@", ...]`. `staging.tonk.spot` works.

Separately: `rust/tonk-analytics/src/web.rs:69` classifies environment
by hostname and knows only `hub.tonk.xyz` and `staging.tonk.xyz`, so
recipients arriving from CLI invites will register as `dev` in PostHog.
Pre-existing mapping, newly relevant.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `tonk` CLI to improve the handling of invite links, particularly regarding remote endpoints and upstream tracking. It introduces warnings when the invite remote differs from the upstream, ensuring users are aware of potential data discrepancies.

### Detailed summary
- Updated `Cargo.toml` and `Cargo.lock` versions to `0.6.1`.
- Changed base URLs from `https://hub.tonk.xyz` to `https://tonk.spot`.
- Updated documentation to clarify invite link behavior.
- Improved `mint_invite` function to warn when the invite remote is not the upstream.
- Added tests for remote resolution and invite handling.
- Enhanced command-line help texts for clarity on `--remote` and `--no-remote` options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->