### PR TITLE
feat(tonk-fab): refuse remote-less invites and offer to turn on sync

### DIFF
--- a/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
+++ b/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
@@ -18,6 +18,20 @@
 - No emojis in code, comments, or commit messages.
 - Commit messages: Conventional Commits, `type(scope): subject`, imperative, lowercase, no trailing period.
 - Never reference "Phase N" or "per the spec" in code or comments. Code stands on its own.
+- Wasm tests: `nix develop -c test:web:debug` is BROKEN on this machine (exit 134 —
+  the macOS 27 libffi break kills every crane derivation). Use the crane-free
+  substitute instead: `nix develop -c ./.superpowers/sdd/wasm-test.sh -p CRATE`,
+  which is `cargo test --target wasm32-unknown-unknown` with a nix chromedriver.
+- `tonk-worker` test glue: `test_state()` returns a `TonkState`, which is NOT
+  `Clone` and has no `.read()`. The value with `.read()` is the `AppState` that
+  `api_router_with_state` returns as its second tuple element. Always write
+  `let (app, state, _lsp) = api_router_with_state(test_state().await);`.
+- Attribute-name assertions use the derive-generated inherent `the()`:
+  `Struct::the().to_string()`. There is no `Attribute::attribute()` in the pinned
+  dialog-query.
+- One test in the `tonk-worker` wasm suite fails before this branch and is not
+  yours to fix: `router::profile::tests::it_reports_a_display_name_on_the_profile`.
+  So is the `constant SHEETS is never used` warning at repository.rs:3920.
 - The lint gate is `nix develop -c cargo clippy --workspace --all-targets --all-features` plus `cargo fmt --check`. `--all-features` compiles integration tests, so a per-crate clippy can pass while the gate fails.
 - User-facing copy, exact:
   - dialog title: `Turn on sync?`
@@ -206,8 +220,7 @@ Add to the existing `mod tests` at the bottom of `rust/tonk-worker/src/router/cr
 async fn it_refuses_a_repository_with_no_upstream() {
     use crate::router::create_invite::{RemoteRefusal, RemoteRequirement, resolve_remote_url};
 
-    let state = test_state().await;
-    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (app, state, _lsp) = api_router_with_state(test_state().await);
     let key = put_repo(&app, "test-no-upstream").await;
 
     let tonk = state.read().await;
@@ -453,8 +466,7 @@ Add to `rust/tonk-worker/src/router/repository.rs`'s existing wasm test mod:
 /// refusal on the overlay instead.
 #[dialog_common::test]
 async fn it_refuses_to_mint_without_a_remote() {
-    let state = test_state().await;
-    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (app, state, _lsp) = api_router_with_state(test_state().await);
     let key = put_repo(&app, "test-refuse-mint").await;
 
     run_invite_with_time(&state, &key, 1234.0).await;
@@ -950,8 +962,7 @@ In `repository.rs`'s wasm test mod:
 /// attribute and so mints a new spot instead; this guards against that.
 #[dialog_common::test]
 async fn it_attaches_the_remote_to_the_existing_spot() {
-    let state = test_state().await;
-    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (app, state, _lsp) = api_router_with_state(test_state().await);
     let (key, subject) = put_repo_info(&app, "test-enable-sync").await;
     let before = existing_space_labels(&state).await.len();
 
@@ -971,8 +982,7 @@ async fn it_attaches_the_remote_to_the_existing_spot() {
 /// Without the `share` marker the handler attaches and stops.
 #[dialog_common::test]
 async fn it_mints_only_when_asked_to_share() {
-    let state = test_state().await;
-    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (app, state, _lsp) = api_router_with_state(test_state().await);
     let (key, subject) = put_repo_info(&app, "test-enable-sync-no-share").await;
 
     dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
@@ -986,8 +996,7 @@ async fn it_mints_only_when_asked_to_share() {
 /// With the marker, the attach is followed by a mint — the single-click path.
 #[dialog_common::test]
 async fn it_mints_after_attaching_when_asked_to_share() {
-    let state = test_state().await;
-    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (app, state, _lsp) = api_router_with_state(test_state().await);
     let (key, subject) = put_repo_info(&app, "test-enable-sync-share").await;
 
     dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", true, 1.0).await;

--- a/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
+++ b/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
@@ -1,0 +1,2334 @@
+# Share enable-sync prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A share click on a spot with no sync remote refuses to mint a dead invite, and instead offers to turn sync on and complete the share in one click.
+
+**Architecture:** The worker resolves the remote *before* minting; an unresolvable remote asserts an overlay-only `ShareBlocked` fact keyed on the spot's subject and echoing the triggering command's timestamp. `<tonk-share>` picks that up on a second tagged subscription, abandons its pending clipboard write, and opens a dialog. Confirming dispatches a new `tonk:enable-sync` command whose handler attaches the remote and then mints — so success arrives back on the link subscription the element already holds.
+
+**Tech Stack:** Rust → wasm32-unknown-unknown, `custom-elements`, `dialog-reactor` command handlers, `tonk-schema` `Concept`/`Attribute` derives, Web Awesome (`<wa-dialog>`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-22-share-enable-sync-prompt-design.md`
+- Base branch: `origin/staging`. Work branch: `feat/share-enable-sync-prompt` (already created, spec already committed).
+- Tests always use `#[dialog_common::test]`, never `#[test]`/`#[tokio::test]`. Name tests `it_does_x`.
+- Every wasm-runnable test mod needs `wasm_bindgen_test_configure!` — `run_in_service_worker` for `tonk-worker`, `run_in_browser` for `tonk-fab`/`tonk-schema`.
+- No `mod.rs`. Use `foo.rs` + `foo/`.
+- No emojis in code, comments, or commit messages.
+- Commit messages: Conventional Commits, `type(scope): subject`, imperative, lowercase, no trailing period.
+- Never reference "Phase N" or "per the spec" in code or comments. Code stands on its own.
+- The lint gate is `nix develop -c cargo clippy --workspace --all-targets --all-features` plus `cargo fmt --check`. `--all-features` compiles integration tests, so a per-crate clippy can pass while the gate fails.
+- User-facing copy, exact:
+  - dialog title: `Turn on sync?`
+  - dialog body: `This spot only exists on this device. Turn on sync so the people you share with can open it.`
+  - primary button: `Turn on sync & copy link`
+  - secondary button: `Not now`
+  - `not-synced` detail: `This spot only exists on this device.`
+  - `unshareable-remote` detail: `This spot's sync server can't be shared.`
+  - `attach-failed` detail prefix: `Could not turn on sync: `
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `rust/tonk-schema/src/domain.rs` | new `share` and `command::enable_sync` attribute modules |
+| `rust/tonk-schema/src/command.rs` | new `ShareBlocked` concept and `EnableSync` command |
+| `rust/tonk-worker/src/router/create_invite.rs` | `RemoteRequirement`; `resolve_remote_url` returns it; HTTP route refuses |
+| `rust/tonk-worker/src/router/repository.rs` | `run_invite` refuses + signals; `EnableSyncHandler` |
+| `rust/tonk-worker/src/router/command.rs` | register `EnableSyncHandler` |
+| `rust/tonk-fab/src/subscribing.rs` | multiplex several tagged subscriptions on one element |
+| `rust/tonk-fab/src/logic.rs` | `ShareState::Blocked`, claim JSON, query body, default-remote URL (all pure) |
+| `rust/tonk-fab/src/share.rs` | blocked subscription, timeout, dialog open, confirm handler |
+| `rust/tonk-fab/src/markup.rs` | the `<wa-dialog>` |
+| `rust/tonk-fab/src/fab.css` | dialog styling |
+
+---
+
+### Task 1: `ShareBlocked` concept and its attributes
+
+**Files:**
+- Modify: `rust/tonk-schema/src/domain.rs` (add a `share` module after the `credential` module, which ends at line 532)
+- Modify: `rust/tonk-schema/src/command.rs` (add `ShareBlocked` after `Credential`, which ends at line 315)
+
+**Interfaces:**
+- Produces: `tonk_schema::domain::share::{Blocked, Detail, Time}` and `tonk_schema::command::ShareBlocked { this: Entity, blocked: Blocked, detail: Detail, time: Time }`. Attribute names `xyz.tonk.share/blocked`, `xyz.tonk.share/detail`, `xyz.tonk.share/time`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `rust/tonk-schema/src/command.rs`, or extend the existing `mod tests` there if one exists:
+
+```rust
+#[cfg(test)]
+mod share_blocked {
+    use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_the_share_attribute_names() {
+        use dialog_query::Attribute as _;
+
+        assert_eq!(
+            crate::domain::share::Blocked::attribute().to_string(),
+            "xyz.tonk.share/blocked"
+        );
+        assert_eq!(
+            crate::domain::share::Detail::attribute().to_string(),
+            "xyz.tonk.share/detail"
+        );
+        assert_eq!(
+            crate::domain::share::Time::attribute().to_string(),
+            "xyz.tonk.share/time"
+        );
+    }
+}
+```
+
+If `dialog_query::Attribute`'s accessor is spelled differently in this workspace, copy the spelling from an existing attribute-name assertion — grep for `::attribute()` under `rust/tonk-schema/src` and match it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p tonk-schema share_blocked`
+Expected: FAIL — `could not find 'share' in 'domain'`
+
+- [ ] **Step 3: Add the attributes**
+
+In `rust/tonk-schema/src/domain.rs`, immediately after the closing brace of `pub mod credential` (line 532):
+
+```rust
+/// Attributes on the overlay-only `tonk:share/blocked` fact — why a share
+/// click could not mint an invite. Keyed on the spot's subject entity, the
+/// same entity [`crate::command::Credential`] is keyed by, so the share
+/// control reads both off one subject.
+///
+/// Overlay-only, so it is session-scoped and never replicated: a refusal is
+/// this device's answer to this click, not a property of the spot.
+pub mod share {
+    use super::Attribute;
+
+    /// The refusal class: `not-synced` | `unshareable-remote` |
+    /// `attach-failed`. Only `not-synced` is repairable by attaching a
+    /// remote, so it is the only one that offers the prompt.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Blocked(pub String);
+
+    /// The sentence shown to the user.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Detail(pub String);
+
+    /// The timestamp of the command this refusal answers, echoed back from
+    /// the transient that triggered it.
+    ///
+    /// Load-bearing. The fact is cardinality-one on the subject, so it
+    /// lingers in the overlay and replays on every resubscribe; the share
+    /// control acts only on a refusal whose timestamp matches the click it
+    /// is currently holding a clipboard write for, and ignores every other
+    /// frame. That is what makes the fact safe to leave in place instead of
+    /// retracting it on the next success.
+    #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Time(pub f64);
+}
+```
+
+`Time` derives only `Clone, PartialEq, PartialOrd` — `f64` is not `Eq`/`Ord`. This mirrors `command::invite::TimeStamp` at `domain.rs:252`.
+
+- [ ] **Step 4: Add the concept**
+
+In `rust/tonk-schema/src/command.rs`, after `Credential` (line 315):
+
+```rust
+/// The overlay-only fact a refused `tonk:invite` asserts: why the mint did
+/// not happen, keyed by the spot's **subject** DID (`this`) — the same
+/// entity [`Credential`] is keyed by, so one subject carries both the
+/// success and the refusal.
+///
+/// All three fields are asserted together. A concept resolves only when
+/// every declared field is present, so a partial assert would never resolve
+/// (the same all-fields-required gotcha `JoinStatus`/`JoinFailure` are split
+/// to avoid).
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct ShareBlocked {
+    /// The spot's subject DID.
+    pub this: Entity,
+    /// Refusal class: `not-synced` | `unshareable-remote` | `attach-failed`.
+    pub blocked: crate::domain::share::Blocked,
+    /// The sentence shown to the user.
+    pub detail: crate::domain::share::Detail,
+    /// The refused command's timestamp, echoed so the share control can tell
+    /// this refusal from a replay of an older one.
+    pub time: crate::domain::share::Time,
+}
+```
+
+No `impl Command` — this is a fact, not a command.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nix develop -c cargo test -p tonk-schema share_blocked`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-schema/src/domain.rs rust/tonk-schema/src/command.rs
+git commit -m "feat(tonk-schema): add the overlay-only ShareBlocked fact"
+```
+
+---
+
+### Task 2: `resolve_remote_url` reports which case it took
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/create_invite.rs:344-399` (both `resolve_remote_url` and `resolve_remote_url_with`)
+- Modify: `rust/tonk-worker/src/router/create_invite.rs:181` (the HTTP route's call site — compile fix only, behaviour changes in Task 4)
+- Modify: `rust/tonk-worker/src/router/repository.rs:778` (the mint call site — compile fix only, behaviour changes in Task 3)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `pub(crate) enum RemoteRequirement { Ready(Url), Refused(RemoteRefusal) }` and `pub(crate) enum RemoteRefusal { NotSynced, UnshareableRemote }` with `RemoteRefusal::code(&self) -> &'static str` and `RemoteRefusal::detail(&self) -> &'static str`. `resolve_remote_url` and `resolve_remote_url_with` both now return `Result<RemoteRequirement, TonkWorkerError>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` at the bottom of `rust/tonk-worker/src/router/create_invite.rs` (it already has `wasm_bindgen_test_configure!(run_in_service_worker)` at its top):
+
+```rust
+/// A spot created without a remote refuses, and says which case it was.
+#[dialog_common::test]
+async fn it_refuses_a_repository_with_no_upstream() {
+    use crate::router::create_invite::{RemoteRefusal, RemoteRequirement, resolve_remote_url};
+
+    let state = test_state().await;
+    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let key = put_repo(&app, "test-no-upstream").await;
+
+    let tonk = state.read().await;
+    let repository = tonk
+        .profile
+        .repository(&key)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .expect("repository loads");
+
+    let requirement = resolve_remote_url(&tonk, &repository)
+        .await
+        .expect("probe succeeds");
+
+    assert!(matches!(
+        requirement,
+        RemoteRequirement::Refused(RemoteRefusal::NotSynced)
+    ));
+}
+
+#[dialog_common::test]
+async fn it_names_the_refusal_classes() {
+    use crate::router::create_invite::RemoteRefusal;
+
+    assert_eq!(RemoteRefusal::NotSynced.code(), "not-synced");
+    assert_eq!(
+        RemoteRefusal::UnshareableRemote.code(),
+        "unshareable-remote"
+    );
+    assert_eq!(
+        RemoteRefusal::NotSynced.detail(),
+        "This spot only exists on this device."
+    );
+    assert_eq!(
+        RemoteRefusal::UnshareableRemote.detail(),
+        "This spot's sync server can't be shared."
+    );
+}
+```
+
+`test_state`, `put_repo` and `api_router_with_state` are already imported by that mod (see its `use crate::router::tests::{...}` line). Add any that are missing.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — `cannot find type 'RemoteRequirement'`
+
+This is the only way to run wasm tests; it builds the whole workspace archive and drives headless Chrome. Expect it to be slow.
+
+- [ ] **Step 3: Add the types and change the return**
+
+In `rust/tonk-worker/src/router/create_invite.rs`, above `resolve_remote_url` (line 344):
+
+```rust
+/// Why a spot cannot produce a shareable invite.
+///
+/// Both variants mean the same thing to the recipient — an invite that can
+/// never sync, so they land in a spot that stays permanently empty — but
+/// only [`Self::NotSynced`] is repairable by attaching a remote, so only it
+/// offers the prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteRefusal {
+    /// `main` has no upstream at all. Repairable.
+    NotSynced,
+    /// `main` tracks something that is not a remote, or a remote whose site
+    /// address is not a UCAN endpoint. An invite URL has no way to express
+    /// either, so there is nothing to offer.
+    UnshareableRemote,
+}
+
+impl RemoteRefusal {
+    /// The stable class string carried on `xyz.tonk.share/blocked`.
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::NotSynced => "not-synced",
+            Self::UnshareableRemote => "unshareable-remote",
+        }
+    }
+
+    /// The sentence shown to the user.
+    pub(crate) fn detail(self) -> &'static str {
+        match self {
+            Self::NotSynced => "This spot only exists on this device.",
+            Self::UnshareableRemote => "This spot's sync server can't be shared.",
+        }
+    }
+}
+
+/// The outcome of probing a repository for a shareable sync endpoint.
+#[derive(Debug, Clone)]
+pub(crate) enum RemoteRequirement {
+    /// A UCAN endpoint an invite can advertise.
+    Ready(Url),
+    /// No such endpoint. See [`RemoteRefusal`].
+    Refused(RemoteRefusal),
+}
+```
+
+Then rewrite the two functions. Replace the doc comment on `resolve_remote_url` (lines 329-343) with:
+
+```rust
+/// Probe `main`'s upstream and, when it points at a remote, pull the
+/// UCAN access-service URL off the remote's site address.
+///
+/// - `Ok(Ready(url))` — the endpoint an invite advertises as `&remote=`.
+/// - `Ok(Refused(reason))` — no such endpoint. Callers refuse to mint:
+///   an invite with no remote lands its recipient in a spot that can never
+///   fill, so it has no use, and returning one silently would mask exactly
+///   the config drift the inviter cannot see.
+/// - `Err(...)` — branch/remote load failed or the stored UCAN endpoint
+///   won't parse. Failing loudly is right for the same reason.
+///
+/// `main` is hardcoded; see `project_main_branch_implicit_creation` memory
+/// note on why `.open()` is used here despite not being strictly read-only.
+```
+
+And change both bodies. `resolve_remote_url` keeps delegating:
+
+```rust
+pub(crate) async fn resolve_remote_url<R>(
+    tonk: &crate::worker::TonkState,
+    repository: &dialog_repository::Repository<R>,
+) -> Result<RemoteRequirement, TonkWorkerError>
+where
+    R: Principal + Clone,
+{
+    resolve_remote_url_with(repository, &tonk.operator).await
+}
+```
+
+`resolve_remote_url_with` returns the new type at each exit:
+
+```rust
+pub(crate) async fn resolve_remote_url_with<R>(
+    repository: &dialog_repository::Repository<R>,
+    operator: &crate::worker::DefaultOperator,
+) -> Result<RemoteRequirement, TonkWorkerError>
+where
+    R: Principal + Clone,
+{
+    let main = repository
+        .branch("main")
+        .open()
+        .perform(operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!(
+                "failed to probe branch 'main' while resolving remote URL: {e}"
+            ))
+        })?;
+
+    let remote_name = match main.upstream() {
+        Some(Upstream::Remote { remote, .. }) => remote,
+        None => return Ok(RemoteRequirement::Refused(RemoteRefusal::NotSynced)),
+        Some(_) => {
+            return Ok(RemoteRequirement::Refused(RemoteRefusal::UnshareableRemote));
+        }
+    };
+
+    let remote = repository
+        .remote(remote_name.as_str())
+        .load()
+        .perform(operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!(
+                "branch 'main' upstream names remote '{remote_name}' but it failed to load: {e}"
+            ))
+        })?;
+
+    match remote.address().site() {
+        SiteAddress::Ucan(ucan) => Url::parse(ucan.endpoint())
+            .map(RemoteRequirement::Ready)
+            .map_err(|e| {
+                TonkWorkerError::Internal(format!(
+                    "remote '{remote_name}' has unparseable UCAN endpoint '{}': {e}",
+                    ucan.endpoint()
+                ))
+            }),
+        _ => Ok(RemoteRequirement::Refused(RemoteRefusal::UnshareableRemote)),
+    }
+}
+```
+
+Note the split of the old `Some(_) | None` arm: that collapse is exactly what made the two cases indistinguishable.
+
+- [ ] **Step 4: Fix the two call sites so the crate compiles**
+
+These are temporary shims; Tasks 3 and 4 replace them.
+
+In `rust/tonk-worker/src/router/create_invite.rs:181`, replace `let remote_url = resolve_remote_url(&tonk, &repository).await?;` with:
+
+```rust
+    let remote_url = match resolve_remote_url(&tonk, &repository).await? {
+        RemoteRequirement::Ready(url) => Some(url),
+        RemoteRequirement::Refused(_) => None,
+    };
+```
+
+In `rust/tonk-worker/src/router/repository.rs:778`, replace the `match super::create_invite::resolve_remote_url(...)` expression with:
+
+```rust
+    let remote = match super::create_invite::resolve_remote_url(&tonk, &repository).await? {
+        super::create_invite::RemoteRequirement::Ready(url) => {
+            let encoded: String =
+                url::form_urlencoded::byte_serialize(url.as_str().as_bytes()).collect();
+            format!("&remote={encoded}")
+        }
+        super::create_invite::RemoteRequirement::Refused(_) => String::new(),
+    };
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS, including the two new tests. Every previously-passing test still passes — behaviour is unchanged so far.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/create_invite.rs rust/tonk-worker/src/router/repository.rs
+git commit -m "refactor(tonk-worker): distinguish why a remote could not be resolved"
+```
+
+---
+
+### Task 3: `run_invite` refuses before minting
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/repository.rs:705-865` (`run_invite`)
+
+**Interfaces:**
+- Consumes: `RemoteRequirement`/`RemoteRefusal` from Task 2, `tonk_schema::command::ShareBlocked` from Task 1.
+- Produces: `async fn publish_share_blocked(tonk: &TonkState, repo_name: &str, subject: Entity, code: &str, detail: &str, time: f64)` — reused by Task 6's handler.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `rust/tonk-worker/src/router/repository.rs`'s existing wasm test mod:
+
+```rust
+/// A share click on a spot with no upstream mints nothing and leaves a
+/// refusal on the overlay instead.
+#[dialog_common::test]
+async fn it_refuses_to_mint_without_a_remote() {
+    let state = test_state().await;
+    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let key = put_repo(&app, "test-refuse-mint").await;
+
+    run_invite_with_time(&state, &key, 1234.0).await;
+
+    let blocked = share_blocked_rows(&state, &key).await;
+    assert_eq!(blocked.len(), 1, "one refusal recorded");
+    assert_eq!(blocked[0].0, "not-synced");
+    assert_eq!(blocked[0].1, "This spot only exists on this device.");
+    assert_eq!(blocked[0].2, 1234.0, "echoes the command's timestamp");
+
+    let invitations = content_invitations(&state, &key).await;
+    assert!(
+        invitations.is_empty(),
+        "a refused mint records no invitation"
+    );
+}
+```
+
+`content_invitations` already exists in `crate::router::tests` (imported at `create_invite.rs`'s test mod — re-export or import it here the same way).
+
+Write the two helpers in the same test mod:
+
+```rust
+/// Drive `run_invite` with a fixed timestamp, the way a `tonk:invite`
+/// transient would.
+async fn run_invite_with_time(state: &AppState, repo: &str, time: f64) {
+    let env = crate::router::CommandEnv::new(state.clone(), crate::router::CommandOrigin::default());
+    let _ = super::run_invite(&env, repo, time).await;
+}
+
+/// Read back every `ShareBlocked` row on the repo's content branch overlay
+/// as `(blocked, detail, time)`.
+async fn share_blocked_rows(state: &AppState, repo: &str) -> Vec<(String, String, f64)> {
+    use dialog_query::Term;
+    use tonk_schema::command::ShareBlocked;
+
+    let tonk = state.read().await;
+    let branch = tonk
+        .reactor
+        .repository(repo)
+        .branch(CONTENT_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .expect("content branch opens");
+    let rows: Vec<ShareBlocked> = branch
+        .handle()
+        .query()
+        .select(dialog_query::Query::<ShareBlocked> {
+            this: Term::var("this"),
+            blocked: Term::var("blocked"),
+            detail: Term::var("detail"),
+            time: Term::var("time"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .expect("share-blocked query");
+    rows.into_iter()
+        .map(|row| (row.blocked.0, row.detail.0, row.time.0))
+        .collect()
+}
+```
+
+If the query builder spelling differs, copy it from `replica_still_recorded` at `repository.rs:1858`, which does the same shape against the meta branch.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — `run_invite` takes 2 arguments, not 3.
+
+- [ ] **Step 3: Thread the timestamp and refuse**
+
+`run_invite` needs the triggering timestamp to echo. Change its signature (line 705) to:
+
+```rust
+async fn run_invite(
+    env: &crate::router::CommandEnv,
+    repo_name: &str,
+    time: f64,
+) -> Result<(), TonkWorkerError> {
+```
+
+In `InviteHandler::run` (around line 677), decode the timestamp alongside the repo and pass it through. Add next to the existing `repo_name` decode:
+
+```rust
+        let time = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::Invite::decode(entity, facts))
+            .map(|command| command.time.0)
+            .unwrap_or_default();
+```
+
+and change the call to `run_invite(&env, &repo_name, time).await`.
+
+Inside `run_invite`, move the remote probe ahead of the keypair. Delete the `generate_ephemeral` call at the top (currently the first statement after the `use` block) and the `remote` block at line 778. The function now opens:
+
+```rust
+    let tonk = env.state().read().await;
+
+    let repository = tonk
+        .profile
+        .repository(repo_name)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::NotFound(format!("Repository '{repo_name}' not found: {e}"))
+        })?;
+
+    // Both facts are keyed by the repository's *subject* DID — the entity
+    // the share view already addresses (`entity={subject}`) — not the
+    // membership DID.
+    let subject_entity = repository
+        .did()
+        .to_string()
+        .parse::<Entity>()
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("repository subject is not a valid entity: {e}"))
+        })?;
+
+    // Resolve the sync endpoint BEFORE minting anything. An invite with no
+    // remote lands its recipient in a spot that can never fill, so there is
+    // nothing worth generating key material for. Refusing here also means a
+    // refusal costs no delegation and rotates no credential.
+    let remote_url = match super::create_invite::resolve_remote_url(&tonk, &repository).await? {
+        super::create_invite::RemoteRequirement::Ready(url) => url,
+        super::create_invite::RemoteRequirement::Refused(reason) => {
+            log!(
+                "Invite for repo '{}' refused: {}",
+                repo_name,
+                reason.code()
+            );
+            drop(tonk);
+            publish_share_blocked(
+                env.state(),
+                repo_name,
+                subject_entity,
+                reason.code(),
+                reason.detail(),
+                time,
+            )
+            .await;
+            return Ok(());
+        }
+    };
+
+    // A ready-to-append URL query suffix (`&remote=<percent-encoded-url>`).
+    // The share view appends it verbatim between `?access=…` and the `#seed`.
+    let encoded: String =
+        url::form_urlencoded::byte_serialize(remote_url.as_str().as_bytes()).collect();
+    let remote = format!("&remote={encoded}");
+
+    // Mint a fresh membership keypair. Its private seed becomes the invite
+    // URL's `#` fragment; its public DID is the audience the repo access is
+    // delegated to. The browser never sees this DID.
+    let (signer, seed_bytes) = super::create_invite::generate_ephemeral().await?;
+    let membership_did = signer.did();
+    let seed = bs58::encode(seed_bytes).into_string();
+```
+
+`generate_ephemeral` is `async` and the state guard is held across it, which is why the original called it first. Holding the read guard across an await is what the rest of this function already does (the delegation and both commits run under it), so keep it — but note the `drop(tonk)` in the refusal arm above: `publish_share_blocked` re-locks, so the guard must be released first.
+
+The rest of the function is unchanged from `let delegation` onwards.
+
+- [ ] **Step 4: Add the publish helper**
+
+Directly after `run_invite`, add:
+
+```rust
+/// Record why a share click could not mint, on the spot's content-branch
+/// session overlay, keyed by the subject.
+///
+/// Overlay-only, exactly like the `Credential` a successful mint writes: a
+/// refusal is this device's answer to this click, not a property of the spot,
+/// and it must never replicate. The write schedules a poll, so the dispatcher's
+/// drain fans it out to the share control's subscription in the same pass as a
+/// successful mint would have been.
+///
+/// `time` echoes the refused command's timestamp. The fact is cardinality-one
+/// on the subject, so it lingers and replays on every resubscribe; the echo is
+/// what lets the control tell this refusal from a replay of an older one, which
+/// is why the fact never needs retracting.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn publish_share_blocked(
+    state: &AppState,
+    repo_name: &str,
+    subject: Entity,
+    code: &str,
+    detail: &str,
+    time: f64,
+) {
+    use tonk_schema::command::ShareBlocked;
+    use tonk_schema::domain::share;
+
+    let tonk = state.read().await;
+    if let Err(error) = tonk
+        .reactor
+        .repository(repo_name)
+        .branch(CONTENT_BRANCH)
+        .overlay()
+        .assert(ShareBlocked {
+            this: subject,
+            blocked: share::Blocked(code.to_owned()),
+            detail: share::Detail(detail.to_owned()),
+            time: share::Time(time),
+        })
+        .write()
+        .perform(&tonk.operator)
+        .await
+    {
+        log!("failed to publish share refusal for '{repo_name}': {error}");
+    }
+}
+```
+
+Add a `#[cfg(not(...))]` no-op twin if the surrounding module needs one to build natively — follow whichever pattern the neighbouring `publish_sync_status_attr` uses.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS. Any pre-existing test that minted an invite against a local-only repo now fails — fix each by attaching a remote first (see `router.rs:1146-1165`, which already exercises `POST /api/repository/{repo}/remote`), not by weakening the assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/repository.rs
+git commit -m "feat(tonk-worker): refuse to mint an invite with no sync remote"
+```
+
+---
+
+### Task 4: the HTTP mint route refuses too
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/create_invite.rs:130-200`
+
+**Interfaces:**
+- Consumes: `RemoteRequirement`/`RemoteRefusal` from Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+In `create_invite.rs`'s test mod:
+
+```rust
+/// The HTTP mint route refuses a local-only repository rather than
+/// answering with an invite that can never sync.
+#[dialog_common::test]
+async fn it_rejects_a_mint_for_a_local_only_repository() {
+    let (app, _state, _lsp) = api_router_with_state(test_state().await);
+    let key = put_repo(&app, "test-http-local-only").await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/repository/{key}/invite"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+```
+
+Match the request shape (method, body) to whatever the existing mint tests in this mod send.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — got `200 OK`
+
+- [ ] **Step 3: Refuse**
+
+Replace the Task 2 shim at `create_invite.rs:181`:
+
+```rust
+    let remote_url = match resolve_remote_url(&tonk, &repository).await? {
+        RemoteRequirement::Ready(url) => url,
+        RemoteRequirement::Refused(reason) => {
+            return Err(TonkWorkerError::Conflict(format!(
+                "cannot mint an invite for '{name}': {} ({})",
+                reason.detail(),
+                reason.code()
+            )));
+        }
+    };
+```
+
+Substitute whatever the route's repository-name binding is actually called for `name`. Downstream, `remote_url` is now a `Url` rather than `Option<Url>` — remove the `Option` handling that follows it.
+
+`TonkWorkerError::Conflict` maps to HTTP 409 (`error.rs:26`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS
+
+Then sweep the rest of the workspace for callers that assumed a local-only mint succeeds:
+
+Run: `rg -n "invite" bench/ rust/tonk-cli/ --glob '!target' | rg -i "local|no.?remote"`
+Fix any that mint without attaching a remote first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/create_invite.rs
+git commit -m "feat(tonk-worker): reject HTTP invite minting without a remote"
+```
+
+---
+
+### Task 5: the `tonk:enable-sync` command concept
+
+**Files:**
+- Modify: `rust/tonk-schema/src/domain.rs` (add `enable_sync` inside the existing `pub mod command`, beside `invite` at line 242)
+- Modify: `rust/tonk-schema/src/command.rs` (add `EnableSync` after `Invite`, which ends at line 163)
+
+**Interfaces:**
+- Produces: `tonk_schema::command::EnableSync { this: Entity, time: enable_sync::TimeStamp, marker: enable_sync::EnableSync }`, plus `enable_sync::{Space, Remote, Share}` attributes read from raw facts (not matched fields). Attribute names: `dom.event/time-stamp`, `dom.event.current-target.dataset/enable-sync`, `xyz.tonk.enable-sync/space`, `xyz.tonk.enable-sync/remote`, `xyz.tonk.enable-sync/share`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `rust/tonk-schema/src/command.rs`, beside the Task 1 test mod:
+
+```rust
+#[cfg(test)]
+mod enable_sync {
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_carries_a_marker_no_other_command_carries() {
+        use dialog_query::Attribute as _;
+        use crate::domain::command::enable_sync;
+
+        assert_eq!(
+            enable_sync::EnableSync::attribute().to_string(),
+            "dom.event.current-target.dataset/enable-sync"
+        );
+        assert_eq!(
+            enable_sync::Space::attribute().to_string(),
+            "xyz.tonk.enable-sync/space"
+        );
+        assert_eq!(
+            enable_sync::Remote::attribute().to_string(),
+            "xyz.tonk.enable-sync/remote"
+        );
+        assert_eq!(
+            enable_sync::Share::attribute().to_string(),
+            "xyz.tonk.enable-sync/share"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p tonk-schema enable_sync`
+Expected: FAIL — `could not find 'enable_sync'`
+
+- [ ] **Step 3: Add the attributes**
+
+In `rust/tonk-schema/src/domain.rs`, inside `pub mod command`, after the `invite` module:
+
+```rust
+    /// Attributes the `tonk:enable-sync` command carries.
+    ///
+    /// The share control dispatches this routelessly when a user accepts the
+    /// offer to turn sync on, so the target spot and the endpoint both travel
+    /// on the transient rather than being inferred from a dispatch origin.
+    pub mod enable_sync {
+        use super::super::Entity;
+        use super::Attribute;
+
+        /// The submit event's timestamp. Makes each acceptance a distinct
+        /// transient, and is echoed back on any refusal so the share control
+        /// can match a result to the click that caused it.
+        #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+        #[domain("dom.event")]
+        pub struct TimeStamp(pub f64);
+
+        /// The marker giving this command an attribute no other command
+        /// carries, so a transient decodes as exactly one command. Same role
+        /// as [`super::invite::Invite`]; the derived attribute is
+        /// `dom.event.current-target.dataset/enable-sync`.
+        ///
+        /// An `Entity`, not a `String`: the value (`tonk:enable-sync`) has a
+        /// `:`, and the worker's untagged `Value` decode reads any `:`-bearing
+        /// string as an `Entity`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.dataset")]
+        pub struct EnableSync(pub Entity);
+
+        /// The spot to attach the remote to.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Space(pub Entity);
+
+        /// The UCAN access-service endpoint to attach as `origin`.
+        ///
+        /// Read from the raw facts rather than being a matched field: a URL
+        /// round-trips through JSON and the worker's untagged `Value` decode
+        /// picks `Entity` for any string with a `:`, so a `String`-typed field
+        /// would never decode one. The handler tolerates both representations,
+        /// the same way `remote_from_facts` does for `CreateSpace`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Remote(pub String);
+
+        /// Present when the caller wants an invite minted once the remote is
+        /// attached. Absent means attach only.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Share(pub Entity);
+    }
+```
+
+- [ ] **Step 4: Add the command**
+
+In `rust/tonk-schema/src/command.rs`, after `Invite`'s `impl Command` block (line 163):
+
+```rust
+/// Attach a sync remote to an existing spot, and optionally mint an invite
+/// once it is attached.
+///
+/// Dispatched routelessly by the share control when a user accepts the offer
+/// to turn sync on. `space`, `remote` and the `share` marker ride on the
+/// transient as raw facts the handler reads directly — `remote` because a URL
+/// cannot be a `String`-typed field (see
+/// [`crate::domain::command::enable_sync::Remote`]), the other two for
+/// symmetry with it.
+///
+/// This is deliberately NOT the `space/enable-sync` command seeded in
+/// `core.yaml`: that one shares `CreateSpace`'s trigger attribute, so a
+/// handler registered against it would fire alongside `CreateSpaceHandler`
+/// and mint a new spot instead of attaching to the existing one.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct EnableSync {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The acceptance timestamp — distinguishes one click from the next.
+    pub time: crate::domain::command::enable_sync::TimeStamp,
+    /// Per-command marker that keeps this command's shape distinct from
+    /// every other transient's.
+    pub marker: crate::domain::command::enable_sync::EnableSync,
+}
+
+/// `EnableSync` is a [`dialog_capability::Command`]; its handler lives in
+/// `tonk-worker` (attaches the remote, then mints when asked).
+impl Command for EnableSync {
+    type Input = Self;
+    type Output = ();
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nix develop -c cargo test -p tonk-schema enable_sync`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-schema/src/domain.rs rust/tonk-schema/src/command.rs
+git commit -m "feat(tonk-schema): add the tonk:enable-sync command"
+```
+
+---
+
+### Task 6: `EnableSyncHandler`
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/repository.rs` (add after `InviteHandler`, which ends around line 695)
+- Modify: `rust/tonk-worker/src/router/command.rs:120-129` (registration)
+
+**Interfaces:**
+- Consumes: `EnableSync` from Task 5, `publish_share_blocked` and the 3-arg `run_invite` from Task 3, `enable_sync_inner` (`repository.rs:1780`).
+- Produces: `pub(crate) struct EnableSyncHandler` with `EnableSyncHandler::new()`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `repository.rs`'s wasm test mod:
+
+```rust
+/// Attaching a remote through the command targets the EXISTING spot. The
+/// `space/enable-sync` command in `core.yaml` shares `CreateSpace`'s trigger
+/// attribute and so mints a new spot instead; this guards against that.
+#[dialog_common::test]
+async fn it_attaches_the_remote_to_the_existing_spot() {
+    let state = test_state().await;
+    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (key, subject) = put_repo_info(&app, "test-enable-sync").await;
+    let before = existing_space_labels(&state).await.len();
+
+    dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
+
+    assert_eq!(
+        existing_space_labels(&state).await.len(),
+        before,
+        "no new spot was created"
+    );
+    assert!(
+        has_remote_upstream(&state, &key).await,
+        "the existing spot now tracks origin/main"
+    );
+}
+
+/// Without the `share` marker the handler attaches and stops.
+#[dialog_common::test]
+async fn it_mints_only_when_asked_to_share() {
+    let state = test_state().await;
+    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (key, subject) = put_repo_info(&app, "test-enable-sync-no-share").await;
+
+    dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
+
+    assert!(
+        content_invitations(&state, &key).await.is_empty(),
+        "attach-only records no invitation"
+    );
+}
+
+/// With the marker, the attach is followed by a mint — the single-click path.
+#[dialog_common::test]
+async fn it_mints_after_attaching_when_asked_to_share() {
+    let state = test_state().await;
+    let (app, _state, _lsp) = api_router_with_state(state.clone());
+    let (key, subject) = put_repo_info(&app, "test-enable-sync-share").await;
+
+    dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", true, 1.0).await;
+
+    assert_eq!(
+        content_invitations(&state, &key).await.len(),
+        1,
+        "the attach is followed by exactly one mint"
+    );
+}
+```
+
+`put_repo_info` (`router.rs:800`) returns `(routing key, subject DID)`; the command carries the subject, the handler derives the key from it. `existing_space_labels` is already defined at `repository.rs:375`.
+
+`https://example.test/ucan/` is never dialled: `ensure_remote_config` records the remote and opens its branch handle locally. The existing wasm test at `router.rs:1146-1165` already attaches a remote this way and passes offline — if these tests turn out to need the network, copy the URL that one uses rather than adding a mock.
+
+Two helpers, in the same test mod:
+
+```rust
+/// Build the `tonk:enable-sync` transient the FAB dispatches and run it
+/// through `dispatch`, the way `/transact` does after a commit. Going through
+/// `dispatch` (not the handler directly) means this also covers registration
+/// and trigger matching.
+async fn dispatch_enable_sync(
+    state: &AppState,
+    subject: &str,
+    remote: &str,
+    share: bool,
+    time: f64,
+) {
+    use dialog_artifacts::{Changes, Statement};
+    use dialog_query::{Entity, the};
+
+    let of: Entity = "tonk:enable-sync-test".parse().expect("entity URI");
+    let mut changes = Changes::new();
+    the!("dom.event/time-stamp")
+        .of(of.clone())
+        .is(time)
+        .assert(&mut changes);
+    the!("dom.event.current-target.dataset/enable-sync")
+        .of(of.clone())
+        .is("tonk:enable-sync".parse::<Entity>().expect("marker entity"))
+        .assert(&mut changes);
+    the!("xyz.tonk.enable-sync/space")
+        .of(of.clone())
+        .is(subject.parse::<Entity>().expect("subject entity"))
+        .assert(&mut changes);
+    the!("xyz.tonk.enable-sync/remote")
+        .of(of.clone())
+        .is(remote.to_string())
+        .assert(&mut changes);
+    if share {
+        the!("xyz.tonk.enable-sync/share")
+            .of(of)
+            .is("tonk:share".parse::<Entity>().expect("share entity"))
+            .assert(&mut changes);
+    }
+
+    crate::router::dispatch(state, crate::router::CommandOrigin::default(), changes).await;
+}
+
+/// Whether the repo's `main` tracks a remote upstream — the exact condition
+/// `resolve_remote_url_with` probes.
+async fn has_remote_upstream(state: &AppState, repo: &str) -> bool {
+    use dialog_repository::Upstream;
+
+    let tonk = state.read().await;
+    let Ok(repository) = tonk
+        .profile
+        .repository(repo)
+        .load()
+        .perform(&tonk.operator)
+        .await
+    else {
+        return false;
+    };
+    let Ok(main) = repository
+        .branch("main")
+        .open()
+        .perform(&tonk.operator)
+        .await
+    else {
+        return false;
+    };
+    matches!(main.upstream(), Some(Upstream::Remote { .. }))
+}
+```
+
+The `the!(...).of(...).is(...).assert(&mut changes)` construction is copied from `ping_transient` at `command.rs:246`. Match its exact import list (`dialog_artifacts::Statement`, `dialog_query::{Entity, the}`) and adjust if the `Upstream` import path differs from what `create_invite.rs` uses.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — no handler matches, so nothing is attached.
+
+- [ ] **Step 3: Write the fact readers**
+
+In `repository.rs`, beside `remote_from_facts` (line 283):
+
+```rust
+/// The `tonk:enable-sync` transient's target spot, read from the raw facts.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_SPACE_ATTR: &str = "xyz.tonk.enable-sync/space";
+
+/// The `tonk:enable-sync` transient's endpoint, read from the raw facts.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_REMOTE_ATTR: &str = "xyz.tonk.enable-sync/remote";
+
+/// Marker asking the handler to mint once the remote is attached.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_SHARE_ATTR: &str = "xyz.tonk.enable-sync/share";
+
+/// Read a fact's value as a string, tolerating both the `String` and
+/// `Entity` representations — a URL or a DID round-trips through JSON as an
+/// `Entity` (any `:`-bearing string does), so a single-representation read
+/// would silently miss them. Mirrors [`remote_from_facts`].
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn text_fact(facts: &crate::reactor::EntityFacts, attribute: &str) -> Option<String> {
+    use dialog_artifacts::Value;
+
+    facts
+        .iter()
+        .find(|artifact| artifact.the.to_string() == attribute)
+        .and_then(|artifact| match &artifact.is {
+            Value::String(text) => Some(text.clone()),
+            Value::Entity(entity) => Some(entity.to_string()),
+            _ => None,
+        })
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+```
+
+- [ ] **Step 4: Write the handler**
+
+After `InviteHandler`'s `impl` block:
+
+```rust
+/// Attach a sync remote to an existing spot, then mint an invite when the
+/// transient asks for one.
+///
+/// The share control dispatches this when a user accepts the offer to turn
+/// sync on after a refused share. Minting from inside the handler is what
+/// makes that a single click: the control needs no completion signal for the
+/// attach, because success reaches it as a new invite link on the
+/// subscription it already holds — the same path an ordinary mint takes.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct EnableSyncHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl EnableSyncHandler {
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::EnableSync::trigger_attributes(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler<crate::router::CommandEnv> for EnableSyncHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::EnableSync::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::router::CommandEnv,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+        use tonk_schema::prelude::DidExt as _;
+
+        let time = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::EnableSync::decode(entity, facts))
+            .map(|command| command.time.0)
+            .unwrap_or_default();
+        let space = text_fact(facts, ENABLE_SYNC_SPACE_ATTR);
+        let remote = text_fact(facts, ENABLE_SYNC_REMOTE_ATTR);
+        let share = text_fact(facts, ENABLE_SYNC_SHARE_ATTR).is_some();
+        let env = env.clone();
+
+        Box::pin(async move {
+            let (Some(space), Some(remote)) = (space, remote) else {
+                log!("EnableSync: missing space or remote, skipping");
+                return;
+            };
+            let Ok(did) = space.parse::<dialog_varsig::Did>() else {
+                log!("EnableSync: '{}' is not a DID", space);
+                return;
+            };
+            let key = did.repo_key().to_owned();
+            log!("command EnableSync repo={} share={}", key, share);
+
+            if let Err(error) = enable_sync_inner(env.state(), &key, &remote).await {
+                log!("EnableSync '{}' failed: {}", key, error);
+                if share {
+                    let subject = match space.parse::<Entity>() {
+                        Ok(entity) => entity,
+                        Err(e) => {
+                            log!("EnableSync: '{}' is not an entity: {}", space, e);
+                            return;
+                        }
+                    };
+                    publish_share_blocked(
+                        env.state(),
+                        &key,
+                        subject,
+                        "attach-failed",
+                        &format!("Could not turn on sync: {error}"),
+                        time,
+                    )
+                    .await;
+                }
+                return;
+            }
+
+            if share && let Err(error) = run_invite(&env, &key, time).await {
+                log!("EnableSync '{}': mint after attach failed: {}", key, error);
+            }
+        })
+    }
+}
+```
+
+- [ ] **Step 5: Register it**
+
+In `rust/tonk-worker/src/router/command.rs`, beside the other registrations (line 122):
+
+```rust
+        registry.register(Box::new(super::repository::EnableSyncHandler::new()));
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/repository.rs rust/tonk-worker/src/router/command.rs
+git commit -m "feat(tonk-worker): add an enable-sync command that attaches and mints"
+```
+
+---
+
+### Task 7: one element, several tagged subscriptions
+
+**Files:**
+- Modify: `rust/tonk-fab/src/subscribing.rs:92-199`
+
+**Interfaces:**
+- Produces: `Scaffold::connect_all(&self, this: &HtmlElement, behaviours: Vec<Rc<dyn Subscribing>>)`. `Scaffold::connect` keeps its signature and delegates to it. Frames are routed to the behaviour whose `tag()` matches `opts.tag`; with exactly one behaviour and no tag on the frame, it goes to that behaviour.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test mod to `rust/tonk-fab/src/subscribing.rs`:
+
+```rust
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// A behaviour that records which payloads it was handed.
+    struct Recorder {
+        tag: &'static str,
+        seen: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl Subscribing for Recorder {
+        fn query_body(&self, _this: &HtmlElement) -> Result<String, String> {
+            Ok("{}".to_owned())
+        }
+        fn render_reset(&self, _host: &HtmlElement, payload: &JsValue) {
+            self.seen
+                .borrow_mut()
+                .push(payload.as_string().unwrap_or_default());
+        }
+        fn render_update(&self, _host: &HtmlElement, _payload: &JsValue) {}
+        fn tag(&self) -> &'static str {
+            self.tag
+        }
+    }
+
+    /// A frame tagged for one behaviour reaches only that behaviour.
+    #[dialog_common::test]
+    fn it_routes_frames_by_tag() {
+        let document = window().unwrap().document().unwrap();
+        let host: HtmlElement = document
+            .create_element("div")
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        host.set_attribute("space", "did:key:z6Mk").unwrap();
+
+        let first = Rc::new(RefCell::new(Vec::new()));
+        let second = Rc::new(RefCell::new(Vec::new()));
+        let scaffold = Scaffold::default();
+        scaffold.connect_all(
+            &host,
+            vec![
+                Rc::new(Recorder { tag: "one", seen: Rc::clone(&first) }),
+                Rc::new(Recorder { tag: "two", seen: Rc::clone(&second) }),
+            ],
+        );
+
+        // Deliver a frame the way the host does: element.__tonkReset(payload, {tag}).
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"tag".into(), &"two".into()).unwrap();
+        let reset = Reflect::get(&host, &"__tonkReset".into())
+            .unwrap()
+            .dyn_into::<Function>()
+            .unwrap();
+        reset
+            .call2(&JsValue::NULL, &JsValue::from_str("payload"), &opts)
+            .unwrap();
+
+        assert!(first.borrow().is_empty(), "untagged behaviour untouched");
+        assert_eq!(second.borrow().as_slice(), ["payload"]);
+    }
+}
+```
+
+Add `dialog-common`, `tokio` and `wasm-bindgen-test` dev-deps to `rust/tonk-fab/Cargo.toml` if they are missing (they are already present).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — `no method named 'connect_all'`
+
+- [ ] **Step 3: Multiplex**
+
+Replace the `Scaffold` struct and its `impl` (lines 92-160) with:
+
+```rust
+/// The shared subscribe/retry/teardown state a subscribing element's
+/// `CustomElement` struct embeds alongside its own fields.
+///
+/// An element may hold SEVERAL subscriptions. The host delivers every frame
+/// to the same `reset`/`update` methods, so they are told apart by the `tag`
+/// in the frame's options — the same tag each behaviour supplied when it
+/// subscribed. `<tonk-share>` needs this: its invite link and its refusal
+/// signal are separate inline predicates over different raw attributes, and a
+/// single predicate over both would resolve only when BOTH are present, which
+/// is never.
+#[derive(Default)]
+pub struct Scaffold {
+    /// Live subscriptions, paired with the tag they were opened under.
+    subscriptions: Rc<RefCell<Vec<(String, Subscription)>>>,
+    reset: Rc<RefCell<Option<FrameClosure>>>,
+    update: Rc<RefCell<Option<FrameClosure>>>,
+}
+
+impl Scaffold {
+    /// Run from `connected_callback` with a single behaviour. See
+    /// [`Self::connect_all`].
+    pub fn connect(&self, this: &HtmlElement, behaviour: Rc<dyn Subscribing>) {
+        self.connect_all(this, vec![behaviour]);
+    }
+
+    /// Run from `connected_callback`: stamp `with`, install the `reset`/
+    /// `update` frame delegates (forwarded from the prototype shims
+    /// [`install_frame_shims`] installs), and subscribe each behaviour under
+    /// its own tag.
+    ///
+    /// The routing context comes from the FIRST behaviour — every behaviour on
+    /// one element shares that element's `with`. A no-op when it returns
+    /// `None` (context not ready yet); the attribute-changed callback re-runs
+    /// this once it lands.
+    pub fn connect_all(&self, this: &HtmlElement, behaviours: Vec<Rc<dyn Subscribing>>) {
+        let Some(first) = behaviours.first() else {
+            return;
+        };
+        let Some(with) = first.resolve_with(this) else {
+            return;
+        };
+        let _ = this.set_attribute("with", &with);
+
+        let routed = behaviours.clone();
+        let host = this.clone();
+        let reset: FrameClosure = Closure::wrap(Box::new(move |payload: JsValue, opts: JsValue| {
+            if let Some(behaviour) = route(&routed, &opts) {
+                behaviour.render_reset(&host, &payload);
+            }
+        }));
+        let _ = Reflect::set(this, &"__tonkReset".into(), reset.as_ref());
+        *self.reset.borrow_mut() = Some(reset);
+
+        let routed = behaviours.clone();
+        let host = this.clone();
+        let update: FrameClosure = Closure::wrap(Box::new(move |payload: JsValue, opts: JsValue| {
+            if let Some(behaviour) = route(&routed, &opts) {
+                behaviour.render_update(&host, &payload);
+            }
+        }));
+        let _ = Reflect::set(this, &"__tonkUpdate".into(), update.as_ref());
+        *self.update.borrow_mut() = Some(update);
+
+        for behaviour in behaviours {
+            let subscriptions = self.subscriptions.clone();
+            let host = this.clone();
+            // Each behaviour gets its own retry budget: one query failing to
+            // build must not spend the other's attempts.
+            let retry = Rc::new(RefCell::new(RetryPolicy::default()));
+            spawn_local(async move {
+                let tag = behaviour.tag().to_owned();
+                if !host.is_connected()
+                    || subscriptions.borrow().iter().any(|(open, _)| *open == tag)
+                {
+                    return;
+                }
+                subscribe(&host, behaviour.as_ref(), subscriptions, retry);
+            });
+        }
+    }
+
+    /// Run from `disconnected_callback`: drop every subscription and the frame
+    /// delegates.
+    pub fn disconnect(&self) {
+        self.subscriptions.borrow_mut().clear();
+        self.reset.borrow_mut().take();
+        self.update.borrow_mut().take();
+    }
+}
+
+/// Pick the behaviour a frame belongs to by the `tag` in its options — the
+/// tag that behaviour supplied when it subscribed.
+///
+/// With exactly one behaviour, an absent or unrecognised tag still routes to
+/// it: single-subscription elements predate tagged routing and must keep
+/// working whether or not the host echoes a tag.
+fn route<'a>(
+    behaviours: &'a [Rc<dyn Subscribing>],
+    opts: &JsValue,
+) -> Option<&'a Rc<dyn Subscribing>> {
+    let tag = Reflect::get(opts, &"tag".into())
+        .ok()
+        .and_then(|value| value.as_string());
+    match tag {
+        Some(tag) => behaviours
+            .iter()
+            .find(|behaviour| behaviour.tag() == tag)
+            .or_else(|| (behaviours.len() == 1).then(|| &behaviours[0])),
+        None => (behaviours.len() == 1).then(|| &behaviours[0]),
+    }
+}
+```
+
+Then change `subscribe`'s signature and its success arm:
+
+```rust
+fn subscribe(
+    host: &HtmlElement,
+    behaviour: &dyn Subscribing,
+    subscriptions: Rc<RefCell<Vec<(String, Subscription)>>>,
+    retry: Rc<RefCell<RetryPolicy>>,
+) {
+```
+
+and inside, replace `*subscription.borrow_mut() = Some(sub);` with:
+
+```rust
+            subscriptions.borrow_mut().push((tag.to_owned(), sub));
+```
+
+Leave the rest of `subscribe` (query build, JSON parse, retry logging, `data-state="unavailable"`) unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS, including every existing `<ui-space-name>` / `<ui-member-roster>` / `<ui-space-switcher>` test — they call `connect`, which is unchanged in behaviour.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-fab/src/subscribing.rs
+git commit -m "feat(tonk-fab): route subscription frames to a behaviour by tag"
+```
+
+---
+
+### Task 8: FAB pure logic
+
+**Files:**
+- Modify: `rust/tonk-fab/src/logic.rs` (`ShareState` at line 884; new functions beside `invite_claim_json` at 1376 and `invite_link_query_body` at 1428)
+- Modify: `rust/tonk-fab/Cargo.toml` (add `"Location"` to the `web-sys` features list)
+
+**Interfaces:**
+- Produces:
+  - `ShareState::Blocked` with `as_str() == "blocked"`
+  - `pub fn enable_sync_claim_json(space: &str, remote: &str, share: bool, time: f64) -> Value`
+  - `pub fn share_blocked_query_body(subject: &str) -> Result<String, String>`
+  - `pub fn default_remote_url(origin: &str) -> String`
+  - `pub const SHARE_TIMEOUT_MS: i32 = 15_000;`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `rust/tonk-fab/src/logic.rs`:
+
+```rust
+#[cfg(test)]
+mod enable_sync_claim {
+    use super::*;
+
+    #[test]
+    fn it_names_the_space_remote_and_share_marker() {
+        let claim = enable_sync_claim_json(
+            "did:key:z6Mk",
+            "https://tonk.spot/ucan/",
+            true,
+            7.0,
+        );
+        let app = &claim["claims"][0]["application"];
+        assert_eq!(app["parameters"]["space"], "did:key:z6Mk");
+        assert_eq!(app["parameters"]["remote"], "https://tonk.spot/ucan/");
+        assert_eq!(app["parameters"]["share"], "tonk:share");
+        assert_eq!(app["parameters"]["marker"], "tonk:enable-sync");
+        assert_eq!(app["parameters"]["time"], 7.0);
+    }
+
+    #[test]
+    fn it_omits_the_share_marker_when_not_sharing() {
+        let claim = enable_sync_claim_json("did:key:z6Mk", "https://x.test/ucan/", false, 1.0);
+        let app = &claim["claims"][0]["application"];
+        assert!(app["parameters"].get("share").is_none());
+        assert!(
+            app["predicate"]["concept"]["with"].get("share").is_none(),
+            "an omitted parameter must not be declared, or the assert is incomplete"
+        );
+    }
+}
+
+#[cfg(test)]
+mod share_blocked_query {
+    use super::*;
+
+    #[test]
+    fn it_reads_the_raw_share_attributes() {
+        let body = share_blocked_query_body("did:key:z6Mk").expect("query body builds");
+        assert!(body.contains("xyz.tonk.share/blocked"));
+        assert!(body.contains("xyz.tonk.share/detail"));
+        assert!(body.contains("xyz.tonk.share/time"));
+        assert!(body.contains("did:key:z6Mk"));
+    }
+
+    #[test]
+    fn it_rejects_an_empty_subject() {
+        assert!(share_blocked_query_body("").is_err());
+    }
+}
+
+#[cfg(test)]
+mod default_remote {
+    use super::*;
+
+    #[test]
+    fn it_appends_the_access_service_path() {
+        assert_eq!(
+            default_remote_url("https://tonk.spot"),
+            "https://tonk.spot/ucan/"
+        );
+    }
+}
+
+#[cfg(test)]
+mod share_state_blocked {
+    use super::*;
+
+    #[test]
+    fn it_accepts_a_click_and_does_not_time_out() {
+        assert_eq!(ShareState::Blocked.as_str(), "blocked");
+        // A refused share must be retryable straight away.
+        assert!(ShareState::Blocked.accepts_click());
+        // The dialog is up; nothing should quietly revert it.
+        assert!(!ShareState::Blocked.is_transient());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nix develop -c cargo test -p tonk-fab --lib`
+Expected: FAIL — `cannot find function 'enable_sync_claim_json'`
+
+- [ ] **Step 3: Add `ShareState::Blocked`**
+
+In `logic.rs`, add the variant after `Copying` (line 889) and extend both matches:
+
+```rust
+    /// The mint was refused because the spot has no shareable sync remote.
+    /// The prompt offering to attach one is up; unlike `Copied`/`Failed` this
+    /// does not revert on a timer, because the user is being asked a question.
+    Blocked,
+```
+
+```rust
+            Self::Blocked => "blocked",
+```
+
+`accepts_click` and `is_transient` need no change: `Blocked` is neither `Copying` nor `Copied`/`Failed`, so it already accepts a click and already does not auto-revert. Do not add it to either.
+
+- [ ] **Step 4: Add the three functions and the constant**
+
+Beside `invite_claim_json`:
+
+```rust
+/// The `tonk:enable-sync` claim the share control dispatches when a user
+/// accepts the offer to turn sync on.
+///
+/// `share` adds the marker asking the worker to mint an invite once the
+/// remote is attached. When false the marker is omitted from BOTH the
+/// declared concept and the parameters — a declared field with no value makes
+/// the assert incomplete, so the transient would commit and match nothing.
+pub fn enable_sync_claim_json(space: &str, remote: &str, share: bool, time: f64) -> Value {
+    let mut with = json!({
+        "time":   { "the": "dom.event/time-stamp", "as": "Float" },
+        "space":  { "the": "xyz.tonk.enable-sync/space", "as": "Entity" },
+        "remote": { "the": "xyz.tonk.enable-sync/remote", "as": "Text" },
+        "marker": { "the": "dom.event.current-target.dataset/enable-sync", "as": "Entity" }
+    });
+    let mut parameters = json!({
+        "time": time,
+        "space": space,
+        "remote": remote,
+        "marker": "tonk:enable-sync"
+    });
+    if share {
+        with["share"] = json!({ "the": "xyz.tonk.enable-sync/share", "as": "Entity" });
+        parameters["share"] = json!("tonk:share");
+    }
+    json!({
+        "claims": [{
+            "op": "assert",
+            "application": {
+                "predicate": {
+                    "kind": "transient",
+                    "concept": {
+                        "description": "Attach a sync remote to a spot, and share it.",
+                        "with": with
+                    }
+                },
+                "parameters": parameters
+            }
+        }]
+    })
+}
+```
+
+Beside `invite_link_query_body`:
+
+```rust
+/// The subscribe body for a refused share.
+///
+/// An INLINE predicate over the raw `xyz.tonk.share/*` attributes, for the
+/// same reason [`invite_link_query_body`] is inline: rules and views are
+/// frozen at whatever `core.yaml` seeded a spot with, so reading raw
+/// attributes depends on nothing seeded and works on spots that predate this
+/// feature. `this` binds to the spot's subject DID, the entity the worker
+/// keys the refusal by.
+pub fn share_blocked_query_body(subject: &str) -> Result<String, String> {
+    if subject.is_empty() {
+        return Err("share_blocked_query_body: empty subject".into());
+    }
+    Ok(json!({
+        "predicate": { "with": {
+            "blocked": { "the": "xyz.tonk.share/blocked", "as": "Text", "cardinality": "one" },
+            "detail":  { "the": "xyz.tonk.share/detail",  "as": "Text", "cardinality": "one" },
+            "time":    { "the": "xyz.tonk.share/time",    "as": "Float", "cardinality": "one" }
+        } },
+        "terms": {
+            "this": subject,
+            "blocked": { "?": { "name": "blocked" } },
+            "detail":  { "?": { "name": "detail" } },
+            "time":    { "?": { "name": "time" } }
+        }
+    })
+    .to_string())
+}
+
+/// This page's default UCAN access-service endpoint: `origin + /ucan/`.
+///
+/// The same URL `<tonk-default-remote auto>` fills the create wizard's hidden
+/// input with. Kept pure (origin in, URL out) so it is testable off-browser;
+/// the caller supplies the origin.
+pub fn default_remote_url(origin: &str) -> String {
+    format!("{}{}", origin.trim_end_matches('/'), "/ucan/")
+}
+
+/// How long a share click waits for a result before giving up.
+///
+/// Without this the control has no failure path at all for anything other
+/// than an explicit refusal: a mint that never lands leaves the clipboard
+/// write open and the button pinned on `copying`, which
+/// [`ShareState::accepts_click`] refuses, so the button is dead for the rest
+/// of the session. Generous, because the enable-sync path holds the write
+/// across a network round-trip.
+pub const SHARE_TIMEOUT_MS: i32 = 15_000;
+```
+
+- [ ] **Step 5: Add the `Location` web-sys feature**
+
+In `rust/tonk-fab/Cargo.toml`, add `"Location",` to the `web-sys` features list (alphabetically, after `"HtmlHeadElement"`). Task 9 reads `window().location().origin()`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `nix develop -c cargo test -p tonk-fab --lib`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-fab/src/logic.rs rust/tonk-fab/Cargo.toml
+git commit -m "feat(tonk-fab): add blocked-share state, claim and query builders"
+```
+
+---
+
+### Task 9: `<tonk-share>` handles a refusal
+
+**Files:**
+- Modify: `rust/tonk-fab/src/share.rs`
+
+**Interfaces:**
+- Consumes: `Scaffold::connect_all` (Task 7); `ShareState::Blocked`, `enable_sync_claim_json`, `share_blocked_query_body`, `default_remote_url`, `SHARE_TIMEOUT_MS` (Task 8); the `#fab-enable-sync` dialog and its `[data-enable-sync-confirm]` button (Task 10, which may land after this — the lookups are `Option`-guarded, so this task's tests pass without it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `share.rs`'s existing wasm test mod:
+
+```rust
+/// A refusal whose timestamp matches the pending click abandons the copy and
+/// moves the control to `blocked`.
+#[dialog_common::test]
+fn it_blocks_on_a_matching_refusal() {
+    let host = test_host();
+    let state = Rc::new(RefCell::new(ShareStateCell::default()));
+    let pending_time = Rc::new(RefCell::new(Some(42.0)));
+    open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+    set_state(&host, ShareState::Copying);
+
+    handle_blocked(
+        &host,
+        &state,
+        &pending_time,
+        Blocked {
+            code: "not-synced".to_owned(),
+            detail: "This spot only exists on this device.".to_owned(),
+            time: 42.0,
+        },
+    );
+
+    assert_eq!(read_state(&host), ShareState::Blocked);
+    assert!(
+        state.borrow().pending.is_none(),
+        "the clipboard write is abandoned, not left open"
+    );
+}
+
+/// A refusal from an earlier click is a replay and must be ignored — the
+/// fact is cardinality-one and redelivered on every resubscribe.
+#[dialog_common::test]
+fn it_ignores_a_refusal_from_an_earlier_click() {
+    let host = test_host();
+    let state = Rc::new(RefCell::new(ShareStateCell::default()));
+    let pending_time = Rc::new(RefCell::new(Some(99.0)));
+    open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+    set_state(&host, ShareState::Copying);
+
+    handle_blocked(
+        &host,
+        &state,
+        &pending_time,
+        Blocked {
+            code: "not-synced".to_owned(),
+            detail: "stale".to_owned(),
+            time: 42.0,
+        },
+    );
+
+    assert_eq!(read_state(&host), ShareState::Copying);
+    assert!(state.borrow().pending.is_some(), "copy still pending");
+}
+
+/// An unrepairable refusal fails outright rather than offering a prompt.
+#[dialog_common::test]
+fn it_fails_without_prompting_on_an_unshareable_remote() {
+    let host = test_host();
+    let state = Rc::new(RefCell::new(ShareStateCell::default()));
+    let pending_time = Rc::new(RefCell::new(Some(42.0)));
+    open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+    set_state(&host, ShareState::Copying);
+
+    handle_blocked(
+        &host,
+        &state,
+        &pending_time,
+        Blocked {
+            code: "unshareable-remote".to_owned(),
+            detail: "This spot's sync server can't be shared.".to_owned(),
+            time: 42.0,
+        },
+    );
+
+    assert_eq!(read_state(&host), ShareState::Failed);
+}
+```
+
+Add a `test_host()` helper to that mod if one is not already there:
+
+```rust
+/// A detached `<tonk-share>` host to drive the state-machine helpers against.
+fn test_host() -> HtmlElement {
+    window()
+        .unwrap()
+        .document()
+        .unwrap()
+        .create_element("tonk-share")
+        .unwrap()
+        .dyn_into()
+        .unwrap()
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — `cannot find function 'handle_blocked'`
+
+- [ ] **Step 3: Add the refusal type and handler**
+
+In `share.rs`, after `PendingCopy`:
+
+```rust
+/// A refusal delivered on the blocked subscription.
+#[derive(Debug, Clone, PartialEq)]
+struct Blocked {
+    /// `not-synced` | `unshareable-remote` | `attach-failed`.
+    code: String,
+    /// The sentence to show.
+    detail: String,
+    /// The timestamp of the command this answers.
+    time: f64,
+}
+
+/// The refusal class the enable-sync prompt can repair.
+const BLOCKED_NOT_SYNCED: &str = "not-synced";
+
+/// Subscription tag for the refusal query, distinct from [`SUB_TAG`] so the
+/// scaffolding can tell the two subscriptions' frames apart.
+const BLOCKED_TAG: &str = "tonk-share-blocked";
+```
+
+Extend `ShareStateCell` with the timeout handle:
+
+```rust
+    /// The `setTimeout` that fails a copy nothing ever answered. Armed when
+    /// the click opens the write, cleared on every settle.
+    timeout: Option<i32>,
+```
+
+Add the handler beside `handle_link`:
+
+```rust
+/// Act on a refusal, if it answers the click we are holding a clipboard write
+/// for.
+///
+/// The refusal fact is cardinality-one on the spot's subject, so the overlay
+/// keeps the last one and redelivers it on every resubscribe. Matching on the
+/// echoed timestamp is what separates "this click was refused" from "here is
+/// an old refusal again" — without it, one refused share would poison every
+/// later one for the rest of the session.
+fn handle_blocked(
+    host: &HtmlElement,
+    state: &Rc<RefCell<ShareStateCell>>,
+    pending_time: &Rc<RefCell<Option<f64>>>,
+    blocked: Blocked,
+) {
+    if *pending_time.borrow() != Some(blocked.time) {
+        return;
+    }
+    if state.borrow().pending.is_none() {
+        return;
+    }
+    pending_time.borrow_mut().take();
+
+    if blocked.code != BLOCKED_NOT_SYNCED {
+        settle(host, state, Err(&blocked.detail));
+        return;
+    }
+
+    // Repairable: abandon the copy and ask. `settle` would stamp `Failed` and
+    // arm the revert timer, which is wrong while a question is on screen.
+    abandon(state, &blocked.detail);
+    set_state(host, ShareState::Blocked);
+    open_enable_sync_dialog(&blocked.detail);
+}
+
+/// Drop a pending clipboard write without moving the control's state. The
+/// browser releases the write and leaves the existing clipboard alone.
+fn abandon(state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
+    let mut cell = state.borrow_mut();
+    if let Some(id) = cell.timeout.take() {
+        clear_timeout(id);
+    }
+    if let Some(pending) = cell.pending.take() {
+        let _ = pending
+            .reject
+            .call1(&JsValue::NULL, &JsValue::from_str(reason));
+    }
+}
+
+/// Show the enable-sync prompt, filling in the reason. A no-op when the
+/// dialog is absent, so the element still works in a host that does not
+/// render it.
+fn open_enable_sync_dialog(detail: &str) {
+    let Some(document) = window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dialog) = document.get_element_by_id("fab-enable-sync") else {
+        return;
+    };
+    if let Ok(Some(slot)) = dialog.query_selector("[data-enable-sync-detail]") {
+        slot.set_text_content(Some(detail));
+    }
+    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::TRUE);
+}
+```
+
+Add the timeout arming and clearing. In `settle`, before taking `pending`:
+
+```rust
+    if let Some(id) = state.borrow_mut().timeout.take() {
+        clear_timeout(id);
+    }
+```
+
+And a new function beside `arm_revert`:
+
+```rust
+/// Fail a copy that nothing ever answered, so the control never pins on
+/// `copying` (which refuses further clicks) when a mint dies silently.
+fn arm_timeout(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
+    let mut cell = state.borrow_mut();
+    if let Some(id) = cell.timeout.take() {
+        clear_timeout(id);
+    }
+    let host = host.clone();
+    let state_for_timer = Rc::clone(state);
+    let expire = Closure::once_into_js(move || {
+        state_for_timer.borrow_mut().timeout = None;
+        settle(&host, &state_for_timer, Err("share: timed out"));
+    });
+    cell.timeout = Some(set_timeout(
+        expire.unchecked_ref::<Function>(),
+        SHARE_TIMEOUT_MS,
+    ));
+}
+```
+
+Import `SHARE_TIMEOUT_MS` from `crate::logic` alongside `COPIED_LINGER_MS`.
+
+- [ ] **Step 4: Wire the second subscription**
+
+Add `pending_time: Rc<RefCell<Option<f64>>>` to `TonkShare` and its `Default` impl.
+
+Add the behaviour:
+
+```rust
+/// The refusal subscription's behaviour: the same routing context as the link
+/// subscription, the raw `xyz.tonk.share/*` query, and acting on a refusal
+/// that answers the click currently in flight.
+struct ShareBlockedBehaviour {
+    state: Rc<RefCell<ShareStateCell>>,
+    pending_time: Rc<RefCell<Option<f64>>>,
+}
+
+impl subscribing::Subscribing for ShareBlockedBehaviour {
+    fn query_body(&self, this: &HtmlElement) -> Result<String, String> {
+        let space = this.get_attribute("space").unwrap_or_default();
+        share_blocked_query_body(&space)
+    }
+
+    fn render_reset(&self, host: &HtmlElement, payload: &JsValue) {
+        let rows = js_sys::Array::from(payload);
+        if let Some(blocked) = read_blocked_row(&rows.get(0)) {
+            handle_blocked(host, &self.state, &self.pending_time, blocked);
+        }
+    }
+
+    fn render_update(&self, host: &HtmlElement, payload: &JsValue) {
+        let asserted =
+            Reflect::get(payload, &JsValue::from_str("asserted")).unwrap_or(JsValue::UNDEFINED);
+        let rows = js_sys::Array::from(&asserted);
+        if let Some(blocked) = read_blocked_row(&rows.get(rows.length().saturating_sub(1))) {
+            handle_blocked(host, &self.state, &self.pending_time, blocked);
+        }
+    }
+
+    fn tag(&self) -> &'static str {
+        BLOCKED_TAG
+    }
+}
+
+/// Read `conclusion.fields.{blocked,detail,time}` off a raw subscription row.
+/// `None` for a missing row or any missing field — all three are asserted
+/// together, so a partial row is not a refusal.
+fn read_blocked_row(row: &JsValue) -> Option<Blocked> {
+    if row.is_undefined() || row.is_null() {
+        return None;
+    }
+    let fields = Reflect::get(row, &JsValue::from_str("fields")).ok()?;
+    let code = Reflect::get(&fields, &JsValue::from_str("blocked"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty())?;
+    let detail = Reflect::get(&fields, &JsValue::from_str("detail"))
+        .ok()
+        .and_then(|v| v.as_string())?;
+    let time = Reflect::get(&fields, &JsValue::from_str("time"))
+        .ok()
+        .and_then(|v| v.as_f64())?;
+    Some(Blocked { code, detail, time })
+}
+```
+
+In `connected_callback`, subscribe to both:
+
+```rust
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        let link: Rc<dyn subscribing::Subscribing> = Rc::new(ShareLinkBehaviour {
+            state: Rc::clone(&self.state),
+            current_link: Rc::clone(&self.current_link),
+        });
+        let blocked: Rc<dyn subscribing::Subscribing> = Rc::new(ShareBlockedBehaviour {
+            state: Rc::clone(&self.state),
+            pending_time: Rc::clone(&self.pending_time),
+        });
+        self.scaffold.connect_all(this, vec![link, blocked]);
+    }
+```
+
+In the click handler in `inject_children`, capture the timestamp and arm the timeout:
+
+```rust
+            let time = js_sys::Date::now();
+            *pending_time.borrow_mut() = Some(time);
+            let stale = current_link.borrow().clone();
+            match open_clipboard_write(Rc::clone(&state), stale) {
+                Ok(()) => set_state(&host, ShareState::Copying),
+                Err(e) => {
+                    warn(&format!("share: clipboard unavailable: {e:?}"));
+                    set_state(&host, ShareState::Copying);
+                }
+            }
+            arm_timeout(&host, &state);
+            dispatch_invite(&space, time);
+```
+
+Clone `self.pending_time` into the closure alongside `state` and `current_link`.
+
+Also clear the timeout in `disconnected_callback`, beside the existing `revert` clear.
+
+- [ ] **Step 5: Wire the confirm button**
+
+Add a delegated document listener, installed in `connected_callback`, so it works regardless of when the dialog markup is parsed:
+
+```rust
+/// Listen for the enable-sync prompt's confirm, wherever it is in the
+/// document.
+///
+/// Delegated rather than bound to the button: `<tonk-share>` and the dialog
+/// are set as one `innerHTML` string, so a direct lookup at connect time can
+/// race the dialog into existence.
+///
+/// The confirm click is a FRESH user activation, which is the whole reason
+/// this can complete the copy: a new clipboard write opens here and the
+/// browser holds it through the attach and the mint that follow.
+fn install_confirm_listener(&mut self, this: &HtmlElement) {
+    let Some(document) = window().and_then(|w| w.document()) else {
+        return;
+    };
+    let host = this.clone();
+    let state = Rc::clone(&self.state);
+    let current_link = Rc::clone(&self.current_link);
+    let pending_time = Rc::clone(&self.pending_time);
+    let on_confirm = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+        let Some(target) = event.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
+            return;
+        };
+        if target
+            .closest("[data-enable-sync-confirm]")
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            return;
+        }
+        event.prevent_default();
+        let Some(space) = host.get_attribute("space").filter(|s| !s.is_empty()) else {
+            return;
+        };
+        let Some(origin) = page_origin() else {
+            warn("share: cannot resolve this page's origin");
+            return;
+        };
+        let remote = crate::logic::default_remote_url(&origin);
+
+        let time = js_sys::Date::now();
+        *pending_time.borrow_mut() = Some(time);
+        let stale = current_link.borrow().clone();
+        if let Err(e) = open_clipboard_write(Rc::clone(&state), stale) {
+            warn(&format!("share: clipboard unavailable: {e:?}"));
+        }
+        set_state(&host, ShareState::Copying);
+        arm_timeout(&host, &state);
+        dispatch_enable_sync(&space, &remote, time);
+        close_enable_sync_dialog();
+    });
+    let target: &web_sys::EventTarget = document.unchecked_ref();
+    let _ = target.add_event_listener_with_callback("click", on_confirm.as_ref().unchecked_ref());
+    self.listeners.push(("click".to_owned(), on_confirm));
+}
+```
+
+`self.listeners` is removed from `this` on disconnect; this one is on `document`, so remove it from `document` too — either give `TonkShare` a second `Vec` for document-level listeners with its own teardown in `disconnected_callback`, or store the target alongside the closure. Do not `forget()` it: the element can be re-created.
+
+Supporting functions:
+
+```rust
+/// The real page origin. Inside a sealed guest the document is
+/// `about:srcdoc`, so `location.origin` is the opaque `"null"`; the portal
+/// bridge injects the true origin at `window.tonk.context.origin`.
+fn page_origin() -> Option<String> {
+    let win = window()?;
+    let context = Reflect::get(&win, &"tonk".into())
+        .ok()
+        .and_then(|tonk| Reflect::get(&tonk, &"context".into()).ok())
+        .and_then(|context| Reflect::get(&context, &"origin".into()).ok())
+        .and_then(|origin| origin.as_string())
+        .filter(|s| !s.is_empty() && s != "null");
+    if context.is_some() {
+        return context;
+    }
+    let origin = win.location().origin().ok()?;
+    (origin != "null" && !origin.is_empty()).then_some(origin)
+}
+
+/// Dispatch the `tonk:enable-sync` claim via `window.tonk.transact`,
+/// routeless — same path as [`dispatch_invite`].
+fn dispatch_enable_sync(space: &str, remote: &str, time: f64) {
+    dispatch_claim(&crate::logic::enable_sync_claim_json(
+        space, remote, true, time,
+    ));
+}
+
+fn close_enable_sync_dialog() {
+    let Some(document) = window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dialog) = document.get_element_by_id("fab-enable-sync") else {
+        return;
+    };
+    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::FALSE);
+}
+```
+
+Refactor `dispatch_invite`'s body into a shared `dispatch_claim(claim: &serde_json::Value)` (the `window.tonk.transact` lookup and call, lines 272-291) and have both callers use it. `dispatch_invite` becomes:
+
+```rust
+fn dispatch_invite(space: &str, time: f64) {
+    dispatch_claim(&invite_claim_json(space, time));
+}
+```
+
+Call `self.install_confirm_listener(this)` from `connected_callback`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-fab/src/share.rs
+git commit -m "feat(tonk-fab): prompt to turn on sync when a share is refused"
+```
+
+---
+
+### Task 10: the prompt markup
+
+**Files:**
+- Modify: `rust/tonk-fab/src/markup.rs:130-186` (add a second dialog after `#fab-space-create`)
+- Modify: `rust/tonk-fab/src/fab.css`
+
+**Interfaces:**
+- Consumes: the ids and data attributes Task 9 looks up — `#fab-enable-sync`, `[data-enable-sync-detail]`, `[data-enable-sync-confirm]`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `markup.rs`'s existing `mod tests`:
+
+```rust
+#[test]
+fn it_renders_the_enable_sync_prompt() {
+    let html = fab_html("did:key:z6Mk");
+    assert!(html.contains(r#"id="fab-enable-sync""#));
+    assert!(html.contains("data-enable-sync-detail"));
+    assert!(html.contains("data-enable-sync-confirm"));
+    assert!(html.contains("Turn on sync &amp; copy link"));
+    assert!(html.contains("Not now"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p tonk-fab --lib markup`
+Expected: FAIL — assertion failed on `id="fab-enable-sync"`
+
+- [ ] **Step 3: Add the dialog**
+
+In `markup.rs`, immediately after the closing `</wa-dialog>` of `#fab-space-create` (line 186) and before the closing `"#` of the format string:
+
+```html
+<wa-dialog id="fab-enable-sync" label="Turn on sync?" class="fab__dialog" style="--width: 28rem">
+  <p class="fab__prompt" data-enable-sync-detail>This spot only exists on this device.</p>
+  <p class="fab__prompt">Turn on sync so the people you share with can open it.</p>
+  <wa-button slot="footer" variant="primary" data-enable-sync-confirm>Turn on sync &amp; copy link</wa-button>
+  <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Not now</wa-button>
+</wa-dialog>
+```
+
+The `data-enable-sync-detail` paragraph carries a default so the dialog reads correctly even if it is ever opened before a refusal has filled it in; Task 9's `open_enable_sync_dialog` overwrites it with the worker's sentence.
+
+- [ ] **Step 4: Style it**
+
+In `rust/tonk-fab/src/fab.css`, beside the existing `.fab__dialog` rules:
+
+```css
+.fab__prompt {
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.fab__prompt:last-of-type {
+  margin-bottom: 0;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `nix develop -c cargo test -p tonk-fab --lib markup`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-fab/src/markup.rs rust/tonk-fab/src/fab.css
+git commit -m "feat(tonk-fab): add the turn-on-sync prompt dialog"
+```
+
+---
+
+### Task 11: gate and manual verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full native suite**
+
+Run: `nix develop -c test:native:debug`
+Expected: PASS
+
+- [ ] **Step 2: Run the full wasm suite**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS
+
+- [ ] **Step 3: Run the lint gate**
+
+Run: `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D warnings && nix develop -c cargo fmt --all -- --check`
+Expected: no output, exit 0.
+
+`--all-features` matters: it compiles the integration tests, so a per-crate clippy can be green while this fails.
+
+- [ ] **Step 4: Drive it in a browser**
+
+Build and serve the UI, then:
+
+1. Create a spot with the remote field blanked (edit the hidden `remote` input to `""` in devtools before submitting, so `<tonk-default-remote auto>` does not fill it).
+2. Open the spot, click share.
+3. Expect: the button does not stick on `copying`, the prompt appears reading "This spot only exists on this device."
+4. Click "Turn on sync & copy link".
+5. Expect: the dialog closes, the button goes to `copying` then `copied`, and the clipboard holds a URL containing `&remote=`.
+6. Paste that URL into a second browser profile and confirm the spot loads with content rather than "Model not found".
+
+Step 6 is the actual bug this whole change exists to prevent, so do not skip it.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin feat/share-enable-sync-prompt
+gh pr create --base staging --title "feat(tonk-fab): refuse remote-less invites and offer to turn on sync" --body "$(cat <<'EOF'
+Sharing a spot whose `main` has no remote upstream minted an invite that could
+never sync: the recipient claimed it, the join pull failed with
+`BranchHasNoUpstream`, and they landed in a permanently empty space rendering
+"Model not found".
+
+The mint now resolves the remote before generating any key material and refuses
+when it cannot. When the spot simply has no upstream, the share button offers to
+attach one; confirming attaches, mints, and copies the link in a single click.
+
+Also fixes a related gap: `<tonk-share>` had no failure path at all, so any mint
+that never landed pinned the button on `copying` for the rest of the session.
+
+Spec: `docs/superpowers/specs/2026-07-22-share-enable-sync-prompt-design.md`
+
+Not fixed here: why the create path's remote attach fails or is skipped in the
+first place, and the dead `space/enable-sync` command whose only handler mints a
+new spot instead of attaching to the existing one.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
+++ b/docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md
@@ -805,23 +805,22 @@ mod enable_sync {
 
     #[dialog_common::test]
     fn it_carries_a_marker_no_other_command_carries() {
-        use dialog_query::Attribute as _;
         use crate::domain::command::enable_sync;
 
         assert_eq!(
-            enable_sync::EnableSync::attribute().to_string(),
+            enable_sync::EnableSync::the().to_string(),
             "dom.event.current-target.dataset/enable-sync"
         );
         assert_eq!(
-            enable_sync::Space::attribute().to_string(),
+            enable_sync::Space::the().to_string(),
             "xyz.tonk.enable-sync/space"
         );
         assert_eq!(
-            enable_sync::Remote::attribute().to_string(),
+            enable_sync::Remote::the().to_string(),
             "xyz.tonk.enable-sync/remote"
         );
         assert_eq!(
-            enable_sync::Share::attribute().to_string(),
+            enable_sync::Share::the().to_string(),
             "xyz.tonk.enable-sync/share"
         );
     }

--- a/docs/superpowers/specs/2026-07-22-share-enable-sync-prompt-design.md
+++ b/docs/superpowers/specs/2026-07-22-share-enable-sync-prompt-design.md
@@ -1,0 +1,205 @@
+# Refuse remote-less invites, and offer to fix the spot
+
+## Problem
+
+Sharing a spot whose `main` branch has no remote upstream mints an invite that
+looks completely normal and can never work. The recipient claims it, the join
+flow's `pull_joined_content` fails with `BranchHasNoUpstream`, and they land in a
+permanently empty space — no seeded standard library, so `<tonk-display
+model="tonk:site">` renders "Model not found".
+
+`resolve_remote_url` (`rust/tonk-worker/src/router/create_invite.rs:357`) already
+sees this. It returns `Ok(None)` and the mint proceeds, appending no `&remote=`
+to the URL. Its own doc comment argues against exactly this outcome — "silently
+demoting to local-only would mask config drift the inviter can't see (redeemers
+would hit a downstream sync error with no link to the root cause)" — and then
+does it for the most common case.
+
+A spot reaches that state easily. `CreateSpaceHandler`
+(`rust/tonk-worker/src/router/repository.rs:483`) creates local-only first,
+navigates the creator in second, and attaches the remote third, best-effort, with
+a failure reduced to a `log!`. So the remote can be absent because it failed to
+attach, because `<tonk-default-remote auto>` never filled the hidden input
+(`rust/tonk-workspace/src/default_remote.rs:135` is `if let Some`, no else), or
+simply because the attach is still in flight while the user is already inside the
+spot clicking Share.
+
+## Decision
+
+A mint that cannot resolve a remote refuses instead of degrading.
+
+When the reason is repairable — the spot has no upstream at all — the share
+button opens a dialog offering to turn sync on, and confirming attaches the
+remote, mints the invite, and puts it on the clipboard in one click.
+
+## Refusal cases
+
+`resolve_remote_url` returns `Ok(None)` for three situations. All three refuse;
+only the first is repairable.
+
+| Case | Reason | Repairable |
+|---|---|---|
+| `main` has no upstream | `NotSynced` | yes — offer to attach |
+| upstream is not `Upstream::Remote` | `UnshareableRemote` | no |
+| remote's site is not `SiteAddress::Ucan` | `UnshareableRemote` | no |
+
+`resolve_remote_url` keeps its signature; a caller-side helper maps `None` to the
+typed reason. Both mint paths use it: the `tonk:invite` command handler
+(`repository.rs:705`) and the HTTP route `POST /api/repository/{repo}/invite`
+(`create_invite.rs:130`), which returns an error rather than a remote-less URL.
+
+A deliberately local-only spot therefore stops producing invites. That is the
+point: a remote-less invite always lands the recipient in a space that can never
+fill, so it has no legitimate use.
+
+`run_invite` currently mints a keypair and delegates before it looks at the
+remote. The check moves ahead of `generate_ephemeral`, so a refusal creates no
+key material.
+
+## How the refusal reaches the UI
+
+It cannot ride the transact response. On wasm, `spawn_dispatch`
+(`rust/tonk-worker/src/router/transact.rs:208`) detaches command dispatch through
+`spawn_local`, so the response returns before the handler runs. The failure has
+to travel the way success already does.
+
+Success travels as an overlay fact: `run_invite` asserts `Credential { seed, link
+}` into the reactor's session overlay, and `<tonk-share>` subscribes to a fully
+inline predicate over the raw `xyz.tonk.credential/link` attribute
+(`rust/tonk-fab/src/logic.rs:1428`) — inline because seeded rules and views are
+frozen per-space.
+
+So the refusal becomes a sibling overlay-only concept keyed on the space's
+subject entity, carrying the reason and **the triggering command's `time`**,
+which `tonk:invite` already supplies as `dom.event/time-stamp`:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `xyz.tonk.share/blocked` | Text | `not-synced` or `unshareable-remote` |
+| `xyz.tonk.share/detail` | Text | the user-facing sentence |
+| `xyz.tonk.share/time` | Float | echoed from the command that was refused |
+
+All three cardinality-one, asserted together, keyed on the subject.
+`<tonk-share>` reads them with a second inline predicate. Nothing is seeded, so
+it works on every existing spot; no `concept!:` entry is added to `core.yaml`
+because nothing declarative renders it.
+
+Echoing `time` is what makes the fact safe. It is cardinality-one on the subject,
+so it lingers in the overlay and replays on every reconnect. `<tonk-share>` acts
+only on a frame whose `time` matches the click it is currently holding a
+clipboard write for, and ignores every other frame. That removes any need to
+retract it, clear it on success, or guard against a stale error firing on page
+load.
+
+## The repair command
+
+There is no working command that attaches a remote to an existing spot.
+`space/enable-sync` survives in `core.yaml:183`, but the `#enable-sync` dialog and
+`enable-sync-form` it posts to are gone, and its only matching handler is
+`CreateSpaceHandler`, which always calls `create_space_inner` first — so
+submitting it would mint a *new* spot and attach the remote to that. The doc
+comment at `repository.rs:446` claiming it serves an Enable-sync form "against an
+existing space" stopped being true when create switched to freshly-minted
+identities. Fixing that command is out of scope; nothing posts to it today.
+
+Instead, a new routeless transient `tonk:enable-sync`, dispatched from the FAB the
+way `tonk:pause-sync` and `tonk:invite` are:
+
+| Field | Source |
+|---|---|
+| `space` | the spot's subject DID |
+| `remote` | this origin + `/ucan/` |
+| `time` | the confirm click's timestamp |
+| `share` | marker; present means mint after attaching |
+
+Its handler calls `enable_sync_inner` (`repository.rs:1780`), which routes to the
+idempotent `ensure_remote_config` — the same helper the HTTP attach route uses,
+including its `refresh_branch` reconciliation. On success with the `share` marker
+it calls `run_invite` directly.
+
+That is what makes the flow one click: the FAB needs no completion signal for the
+attach, because success arrives as a new `xyz.tonk.credential/link` on the
+subscription it is already holding — the identical path a normal mint takes. An
+attach failure asserts the same time-keyed status fact with the error.
+
+Being a brand-new command, it has no frozen-descriptor problem: the FAB supplies
+the predicate inline in its claim JSON (as `invite_claim_json` does at
+`logic.rs:1376`), and the handler matches on trigger attributes, so nothing needs
+reseeding.
+
+## The prompt
+
+A second `<wa-dialog>` beside `fab-space-create` in `rust/tonk-fab/src/markup.rs`.
+
+> This spot only exists on this device. Turn on sync so the people you share with
+> can open it.
+
+Primary button "Turn on sync & copy link", secondary "Not now". The URL is this
+origin + `/ucan/`, resolved the way `default_remote.rs:80` does it — including the
+`window.tonk.context.origin` fallback for a sealed guest, where
+`location.origin` is the opaque `"null"`. No input, no typing.
+
+## Flow
+
+1. Click share. `<tonk-share>` opens the clipboard write and dispatches
+   `tonk:invite`, unchanged.
+2. A blocked frame arrives with matching `time`. Abandon the pending clipboard
+   write via its `reject` — the browser drops the write and leaves the existing
+   clipboard contents alone. Set the button to a `blocked` state and open the
+   dialog.
+3. Confirm. This is a fresh user activation, so open a **new** clipboard write
+   here, dispatch `tonk:enable-sync`, and set the button back to `copying…`.
+4. Attach and mint succeed. The new link arrives on the existing subscription,
+   the clipboard write settles, the button reads `copied`.
+5. Attach fails. The time-keyed status fact carries the error, the dialog shows it
+   inline, the clipboard write is abandoned.
+
+`UnshareableRemote` skips the dialog entirely: the button settles to `failed` with
+its message.
+
+## Timeout
+
+`<tonk-share>`'s module doc already flags the gap (`rust/tonk-fab/src/share.rs:46`):
+"A failed mint has no explicit error signal in this design … there is no timeout."
+A pending copy is abandoned only on disconnect.
+
+Add a bounded timer that settles `Failed`. Without it, any mint failure other than
+the two above still hangs the button forever, and step 3 now holds a clipboard
+write open across a network round-trip.
+
+## Testing
+
+Worker:
+
+- each of the three `None` cases refuses, and asserts the status fact
+- the status fact echoes the triggering command's `time`
+- the refusal path generates no keypair
+- `EnableSyncHandler` attaches to the **existing** repository — a direct
+  regression guard against the `CreateSpaceHandler` always-creates trap
+- it mints only when the `share` marker is present
+
+FAB, native `#[test]` in `logic.rs` alongside the existing `invite_claim_json` and
+`invite_link_query_body` tests:
+
+- the `tonk:enable-sync` claim JSON names the space, remote, time and marker
+- the blocked-status query body reads the raw attribute and rejects an empty
+  subject
+
+FAB, wasm tests in `share.rs`:
+
+- a blocked frame with matching `time` opens the dialog and abandons the copy
+- a blocked frame with a different `time` is ignored
+- the timeout settles `Failed`
+
+Existing tests and bench scenarios that mint invites against local-only
+repositories will now fail. Sweeping them is part of the work.
+
+## Out of scope
+
+- The dead `space/enable-sync` command and `<tonk-sync-state>`'s enable-sync
+  trigger, which points at a dialog that no longer exists
+  (`rust/tonk-workspace/src/sync.rs:490`)
+- Why the create path's remote attach fails or is skipped in the first place —
+  this makes the consequence visible, it does not remove the cause
+- A standing "this spot is local" affordance in the FAB. The prompt appears only
+  on a share attempt, which is the moment the missing remote starts to matter

--- a/rust/dialog-reactor/src/branch/state.rs
+++ b/rust/dialog-reactor/src/branch/state.rs
@@ -108,18 +108,22 @@ impl BranchState {
     }
 
     /// Move every subscription registered on `other` into this state,
-    /// leaving `other` empty.
+    /// leaving `other` empty, and bind its engine to this state's branch.
     ///
     /// Used when the reactor replaces a cached branch handle (e.g. to
     /// pick up an upstream wired on a separate handle): the fresh
     /// [`BranchState`] adopts the live subscribers so their SSE streams
     /// keep updating instead of silently freezing on the discarded
     /// handle. Each `SubscriberSession` carries its `mpsc::Sender`, so
-    /// re-polls through the new state reach the same receivers; the
-    /// subscriptions keep their `last_hash`, so the next poll only
-    /// re-emits on a genuine change.
+    /// re-polls through the new state reach the same receivers. The engine
+    /// itself cannot move unchanged: it captures the old branch handle and
+    /// would keep evaluating its stale revision and overlay. Rebinding marks
+    /// the subscribers pending, so the next poll sends a fresh snapshot.
     pub fn adopt_subscriptions_from(&self, other: &BranchState) {
-        let moved = std::mem::take(&mut *other.subscriptions.lock());
+        let mut moved = std::mem::take(&mut *other.subscriptions.lock());
+        for subscription in moved.values_mut() {
+            subscription.rebind(&self.branch);
+        }
         *self.subscriptions.lock() = moved;
     }
 
@@ -162,7 +166,10 @@ impl BranchState {
         // subscription sees ephemeral facts with no extra wiring here.
         let plan = tonk_schema::concept::QueryPlan::from(query);
         let subscription = entry.or_insert_with(|| Subscription {
-            engine: Arc::new(tokio::sync::Mutex::new(Some(self.branch.subscribe(plan)))),
+            engine: Arc::new(tokio::sync::Mutex::new(Some(
+                self.branch.subscribe(plan.clone()),
+            ))),
+            plan,
             terms,
             subscribers: Vec::new(),
         });

--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -197,8 +197,10 @@ impl Reactor {
     /// cache — sees no upstream and fails with `BranchHasNoUpstream`.
     /// Re-opening re-resolves the upstream from durable storage, so the
     /// fresh handle reflects the change; we swap it into the cache and
-    /// carry the existing subscriptions over so live SSE streams keep
-    /// updating.
+    /// rebind the existing subscriptions to it so live SSE streams keep
+    /// updating. Rebinding sends a fresh snapshot on the next poll because
+    /// the discarded engine's retained result cannot be used as a delta base
+    /// for the new branch handle.
     ///
     /// No-op when the repo or branch isn't cached: the next `acquire`
     /// opens a fresh handle that already reflects durable state.

--- a/rust/dialog-reactor/src/subscription/state.rs
+++ b/rust/dialog-reactor/src/subscription/state.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use dialog_common::Blake3Hash;
 use dialog_query::ConceptQuery;
 use dialog_query::Parameters;
+use dialog_repository::Branch;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -124,6 +125,10 @@ pub struct Subscription {
     /// the poll runs it without a guard held across the `await` (see
     /// [`EngineSlot`]).
     pub engine: EngineSlot,
+    /// The plan the engine evaluates. Retained so replacing a cached branch
+    /// handle can rebuild the engine against the fresh handle rather than
+    /// moving an engine that still reads the discarded branch.
+    pub plan: tonk_schema::concept::QueryPlan,
     /// The query's term bindings, retained for
     /// [`project`](tonk_schema::conclusion::project)
     /// — the delta / snapshot rows are `ConceptConclusion`s that
@@ -134,6 +139,17 @@ pub struct Subscription {
 }
 
 impl Subscription {
+    /// Rebuild the evaluation engine against `branch` while keeping the open
+    /// downstream channels. Every subscriber becomes pending so the first poll
+    /// on the fresh handle sends a coherent snapshot rather than a delta based
+    /// on the discarded engine's retained results.
+    pub fn rebind(&mut self, branch: &Branch) {
+        self.engine = Arc::new(AsyncMutex::new(Some(branch.subscribe(self.plan.clone()))));
+        for subscriber in &mut self.subscribers {
+            subscriber.status = Status::Pending;
+        }
+    }
+
     /// Fan a poll's result out to every subscriber, advancing each to
     /// [`Established`](Status::Established) once served.
     ///

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -136,6 +136,12 @@ view!:
           gap: var(--wa-space-xs);
           align-items: flex-start;
         }
+        /* `tonk-display` is light DOM and projects lifecycle slots by
+           toggling `hidden`. Its custom-element display rule outranks the UA
+           default, so enforce the inactive state here. */
+        .blank-canvas__deeplink tonk-display > [slot][hidden] {
+          display: none !important;
+        }
         .blank-canvas__instr {
           display: flex;
           flex-direction: column;
@@ -151,7 +157,6 @@ view!:
       <span class="blank-canvas__label">no template &middot; empty view</span>
       <h1 class="blank-canvas__title">your starting layout is in place</h1>
       <section class="blank-canvas__deeplink">
-        <div class="blank-canvas__label">agent link &middot; paste into your agent</div>
         <tonk-page onmount=tonk:invite data-invite="tonk:invite"></tonk-page>
         <tonk-origin>
           <tonk-display
@@ -159,7 +164,12 @@ view!:
             bind:base="data-base"
             model=tonk:agent-invite
             data-page="this repo">
-            <div slot="no-entity" class="blank-canvas__label">Generating link…</div>
+            <tonk-display
+              slot="no-entity"
+              entity={subject}
+              model=tonk:share/blocked>
+              <div slot="no-entity" class="blank-canvas__label">Generating link…</div>
+            </tonk-display>
           </tonk-display>
         </tonk-origin>
       </section>
@@ -392,6 +402,61 @@ concept!: &tonk/agent-invite
       the: xyz.tonk.credential/seed
       cardinality: one
       as: text
+
+# A refused invite mint, asserted into the session overlay by the worker.
+# The empty-canvas and empty-sheet agent-link panels use it as the fallback
+# behind `tonk:agent-invite`: while neither exists they show a short pending
+# label; if minting is refused they replace that label with the reason and the
+# action that makes a link possible.
+concept!: &share/blocked
+  this: tonk:share/blocked
+  description: Why the latest invite request could not produce a shareable link.
+  with:
+    blocked:
+      description: Stable refusal class.
+      the: xyz.tonk.share/blocked
+      cardinality: one
+      as: text
+    detail:
+      description: Human-readable refusal reason.
+      the: xyz.tonk.share/detail
+      cardinality: one
+      as: text
+    time:
+      description: Timestamp of the invite request this refusal answers.
+      the: xyz.tonk.share/time
+      cardinality: one
+      as: float
+
+view!:
+  this: id:tonk:share/blocked/view
+  model: tonk:share/blocked
+  display: |
+    <div class="local-invite-notice">
+      <style>
+        .local-invite-notice {
+          display: flex;
+          flex-direction: column;
+          gap: var(--wa-space-2xs);
+          color: var(--wa-color-text-quiet);
+        }
+        .local-invite-notice__label {
+          font-family: var(--wa-font-family-code);
+          font-size: var(--wa-font-size-xs);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+        .local-invite-notice p {
+          margin: 0;
+          font-family: var(--wa-font-family-body);
+          font-size: var(--wa-font-size-s);
+          line-height: var(--wa-line-height-normal);
+          text-wrap: pretty;
+        }
+      </style>
+      <span class="local-invite-notice__label">local spot &middot; no sync remote</span>
+      <p>{detail} Use Share to turn on sync and create an agent link.</p>
+    </div>
 
 # Derive `tonk:agent-invite` by joining the repo's `tonk:repository` name
 # and its live `tonk:invitation` on the same subject (`?this`). `?this`

--- a/rust/tonk-core/assets/library/sheets.yaml
+++ b/rust/tonk-core/assets/library/sheets.yaml
@@ -244,6 +244,12 @@ view!:
           gap: var(--wa-space-xs);
           align-items: flex-start;
         }
+        /* `tonk-display` is light DOM and projects lifecycle slots by
+           toggling `hidden`. Its custom-element display rule outranks the UA
+           default, so enforce the inactive state here. */
+        .empty-artifact__deeplink tonk-display > [slot][hidden] {
+          display: none !important;
+        }
         .empty-artifact__deeplink-label {
           font-family: var(--wa-font-family-code);
           font-size: var(--wa-font-size-xs);
@@ -270,7 +276,6 @@ view!:
         {title}
       </h1>
       <section class="empty-artifact__deeplink">
-        <div class="empty-artifact__deeplink-label">agent link &middot; paste into your agent</div>
         <!-- Mint a repo invite on mount via the same `tonk:invite` command
              the repo-share dialog uses. `<tonk-origin>` supplies the real
              host origin (`data-base`) and the repo subject DID (`entity`,
@@ -286,7 +291,12 @@ view!:
             bind:base="data-base"
             model=tonk:agent-invite
             data-page="{title}">
-            <div slot="no-entity" class="empty-artifact__deeplink-label">Generating link…</div>
+            <tonk-display
+              slot="no-entity"
+              bind:subject="entity"
+              model=tonk:share/blocked>
+              <div slot="no-entity" class="empty-artifact__deeplink-label">Generating link…</div>
+            </tonk-display>
           </tonk-display>
         </tonk-origin>
       </section>

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -35,6 +35,7 @@ web-sys = { workspace = true, features = [
     "HtmlCollection",
     "HtmlElement",
     "HtmlHeadElement",
+    "Location",
     "MessageEvent",
     "MouseEvent",
     "MouseEventInit",

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -35,7 +35,6 @@ web-sys = { workspace = true, features = [
     "HtmlCollection",
     "HtmlElement",
     "HtmlHeadElement",
-    "Location",
     "MessageEvent",
     "MouseEvent",
     "MouseEventInit",

--- a/rust/tonk-fab/src/fab.css
+++ b/rust/tonk-fab/src/fab.css
@@ -76,6 +76,15 @@
 .wizard__card p { margin: 0; font-size: var(--wa-font-size-s); color: var(--wa-color-text-quiet); }
 .wizard__template { display: none; }
 
+.fab__prompt {
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.fab__prompt:last-of-type {
+  margin-bottom: 0;
+}
+
 :host, tonk-fab { display: block; }
 
 /* ── Docking ──────────────────────────────────────────────────────

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1563,6 +1563,20 @@ mod enable_sync_claim {
         assert_eq!(app["parameters"]["share"], "tonk:share");
         assert_eq!(app["parameters"]["marker"], "tonk:enable-sync");
         assert_eq!(app["parameters"]["time"], 7.0);
+
+        // The `with` declaration is what the worker actually matches on: a
+        // typo here compiles and passes every assertion on `parameters`
+        // above, then silently no-ops at runtime because the transient
+        // commits and matches no handler. Pin every declared attribute name.
+        let with = &app["predicate"]["concept"]["with"];
+        assert_eq!(with["time"]["the"], "dom.event/time-stamp");
+        assert_eq!(with["space"]["the"], "xyz.tonk.enable-sync/space");
+        assert_eq!(with["remote"]["the"], "xyz.tonk.enable-sync/remote");
+        assert_eq!(
+            with["marker"]["the"],
+            "dom.event.current-target.dataset/enable-sync"
+        );
+        assert_eq!(with["share"]["the"], "xyz.tonk.enable-sync/share");
     }
 
     #[test]
@@ -1604,6 +1618,14 @@ mod default_remote {
     fn it_appends_the_access_service_path() {
         assert_eq!(
             default_remote_url("https://tonk.spot"),
+            "https://tonk.spot/ucan/"
+        );
+    }
+
+    #[test]
+    fn it_does_not_double_slash_an_origin_that_already_has_one() {
+        assert_eq!(
+            default_remote_url("https://tonk.spot/"),
             "https://tonk.spot/ucan/"
         );
     }

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -887,6 +887,10 @@ pub enum ShareState {
     /// A mint is in flight. The clipboard write is already pending on a
     /// promise this state is waiting to resolve.
     Copying,
+    /// The mint was refused because the spot has no shareable sync remote.
+    /// The prompt offering to attach one is up; unlike `Copied`/`Failed` this
+    /// does not revert on a timer, because the user is being asked a question.
+    Blocked,
     /// The link is on the clipboard. Reverts to `Idle` after
     /// [`COPIED_LINGER_MS`].
     Copied,
@@ -903,6 +907,7 @@ impl ShareState {
         match self {
             Self::Idle => "idle",
             Self::Copying => "copying",
+            Self::Blocked => "blocked",
             Self::Copied => "copied",
             Self::Failed => "failed",
         }
@@ -1399,6 +1404,47 @@ pub fn invite_claim_json(space: &str, time: f64) -> Value {
     })
 }
 
+/// The `tonk:enable-sync` claim the share control dispatches when a user
+/// accepts the offer to turn sync on.
+///
+/// `share` adds the marker asking the worker to mint an invite once the
+/// remote is attached. When false the marker is omitted from BOTH the
+/// declared concept and the parameters — a declared field with no value makes
+/// the assert incomplete, so the transient would commit and match nothing.
+pub fn enable_sync_claim_json(space: &str, remote: &str, share: bool, time: f64) -> Value {
+    let mut with = json!({
+        "time":   { "the": "dom.event/time-stamp", "as": "Float" },
+        "space":  { "the": "xyz.tonk.enable-sync/space", "as": "Entity" },
+        "remote": { "the": "xyz.tonk.enable-sync/remote", "as": "Text" },
+        "marker": { "the": "dom.event.current-target.dataset/enable-sync", "as": "Entity" }
+    });
+    let mut parameters = json!({
+        "time": time,
+        "space": space,
+        "remote": remote,
+        "marker": "tonk:enable-sync"
+    });
+    if share {
+        with["share"] = json!({ "the": "xyz.tonk.enable-sync/share", "as": "Entity" });
+        parameters["share"] = json!("tonk:share");
+    }
+    json!({
+        "claims": [{
+            "op": "assert",
+            "application": {
+                "predicate": {
+                    "kind": "transient",
+                    "concept": {
+                        "description": "Attach a sync remote to a spot, and share it.",
+                        "with": with
+                    }
+                },
+                "parameters": parameters
+            }
+        }]
+    })
+}
+
 #[cfg(test)]
 mod invite {
     use super::*;
@@ -1454,6 +1500,126 @@ mod invite_link {
     #[test]
     fn it_rejects_an_empty_subject() {
         assert!(invite_link_query_body("").is_err());
+    }
+}
+
+/// The subscribe body for a refused share.
+///
+/// An INLINE predicate over the raw `xyz.tonk.share/*` attributes, for the
+/// same reason [`invite_link_query_body`] is inline: rules and views are
+/// frozen at whatever `core.yaml` seeded a spot with, so reading raw
+/// attributes depends on nothing seeded and works on spots that predate this
+/// feature. `this` binds to the spot's subject DID, the entity the worker
+/// keys the refusal by.
+pub fn share_blocked_query_body(subject: &str) -> Result<String, String> {
+    if subject.is_empty() {
+        return Err("share_blocked_query_body: empty subject".into());
+    }
+    Ok(json!({
+        "predicate": { "with": {
+            "blocked": { "the": "xyz.tonk.share/blocked", "as": "Text", "cardinality": "one" },
+            "detail":  { "the": "xyz.tonk.share/detail",  "as": "Text", "cardinality": "one" },
+            "time":    { "the": "xyz.tonk.share/time",    "as": "Float", "cardinality": "one" }
+        } },
+        "terms": {
+            "this": subject,
+            "blocked": { "?": { "name": "blocked" } },
+            "detail":  { "?": { "name": "detail" } },
+            "time":    { "?": { "name": "time" } }
+        }
+    })
+    .to_string())
+}
+
+/// This page's default UCAN access-service endpoint: `origin + /ucan/`.
+///
+/// The same URL `<tonk-default-remote auto>` fills the create wizard's hidden
+/// input with. Kept pure (origin in, URL out) so it is testable off-browser;
+/// the caller supplies the origin.
+pub fn default_remote_url(origin: &str) -> String {
+    format!("{}{}", origin.trim_end_matches('/'), "/ucan/")
+}
+
+/// How long a share click waits for a result before giving up.
+///
+/// Without this the control has no failure path at all for anything other
+/// than an explicit refusal: a mint that never lands leaves the clipboard
+/// write open and the button pinned on `copying`, which
+/// [`ShareState::accepts_click`] refuses, so the button is dead for the rest
+/// of the session. Generous, because the enable-sync path holds the write
+/// across a network round-trip.
+pub const SHARE_TIMEOUT_MS: i32 = 15_000;
+
+#[cfg(test)]
+mod enable_sync_claim {
+    use super::*;
+
+    #[test]
+    fn it_names_the_space_remote_and_share_marker() {
+        let claim = enable_sync_claim_json("did:key:z6Mk", "https://tonk.spot/ucan/", true, 7.0);
+        let app = &claim["claims"][0]["application"];
+        assert_eq!(app["parameters"]["space"], "did:key:z6Mk");
+        assert_eq!(app["parameters"]["remote"], "https://tonk.spot/ucan/");
+        assert_eq!(app["parameters"]["share"], "tonk:share");
+        assert_eq!(app["parameters"]["marker"], "tonk:enable-sync");
+        assert_eq!(app["parameters"]["time"], 7.0);
+    }
+
+    #[test]
+    fn it_omits_the_share_marker_when_not_sharing() {
+        let claim = enable_sync_claim_json("did:key:z6Mk", "https://x.test/ucan/", false, 1.0);
+        let app = &claim["claims"][0]["application"];
+        assert!(app["parameters"].get("share").is_none());
+        assert!(
+            app["predicate"]["concept"]["with"].get("share").is_none(),
+            "an omitted parameter must not be declared, or the assert is incomplete"
+        );
+    }
+}
+
+#[cfg(test)]
+mod share_blocked_query {
+    use super::*;
+
+    #[test]
+    fn it_reads_the_raw_share_attributes() {
+        let body = share_blocked_query_body("did:key:z6Mk").expect("query body builds");
+        assert!(body.contains("xyz.tonk.share/blocked"));
+        assert!(body.contains("xyz.tonk.share/detail"));
+        assert!(body.contains("xyz.tonk.share/time"));
+        assert!(body.contains("did:key:z6Mk"));
+    }
+
+    #[test]
+    fn it_rejects_an_empty_subject() {
+        assert!(share_blocked_query_body("").is_err());
+    }
+}
+
+#[cfg(test)]
+mod default_remote {
+    use super::*;
+
+    #[test]
+    fn it_appends_the_access_service_path() {
+        assert_eq!(
+            default_remote_url("https://tonk.spot"),
+            "https://tonk.spot/ucan/"
+        );
+    }
+}
+
+#[cfg(test)]
+mod share_state_blocked {
+    use super::*;
+
+    #[test]
+    fn it_accepts_a_click_and_does_not_time_out() {
+        assert_eq!(ShareState::Blocked.as_str(), "blocked");
+        // A refused share must be retryable straight away.
+        assert!(ShareState::Blocked.accepts_click());
+        // The dialog is up; nothing should quietly revert it.
+        assert!(!ShareState::Blocked.is_transient());
     }
 }
 

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -185,6 +185,12 @@ pub fn fab_html(space_did: &str) -> String {
     </div>
   </form>
   <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
+</wa-dialog>
+<wa-dialog id="fab-enable-sync" label="Turn on sync?" class="fab__dialog" style="--width: 28rem">
+  <p class="fab__prompt" data-enable-sync-detail>This spot only exists on this device.</p>
+  <p class="fab__prompt">Turn on sync so the people you share with can open it.</p>
+  <wa-button slot="footer" variant="primary" data-enable-sync-confirm>Turn on sync &amp; copy link</wa-button>
+  <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Not now</wa-button>
 </wa-dialog>"#,
         space = space_did
     )
@@ -299,5 +305,15 @@ mod tests {
         // `<tonk-share>` must carry its own `space` so it can subscribe to
         // this space's minted invite link and dispatch the mint itself.
         assert!(html.contains(r#"<tonk-share space="did:key:z6Mk">"#));
+    }
+
+    #[test]
+    fn it_renders_the_enable_sync_prompt() {
+        let html = fab_html("did:key:z6Mk");
+        assert!(html.contains(r#"id="fab-enable-sync""#));
+        assert!(html.contains("data-enable-sync-detail"));
+        assert!(html.contains("data-enable-sync-confirm"));
+        assert!(html.contains("Turn on sync &amp; copy link"));
+        assert!(html.contains("Not now"));
     }
 }

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -57,9 +57,13 @@
 //!
 //! Anything else that goes wrong still has no explicit error signal (the
 //! deleted `<tonk-display>`'s error slot is gone with it): a subscription
-//! simply never yields a new link. [`arm_timeout`] is the backstop, so the
-//! control cannot pin on `copying` — which [`ShareState::accepts_click`]
-//! refuses — for the rest of the session.
+//! simply never yields a new link. [`arm_timeout`] is the backstop there. It
+//! is not the only one that matters: a control left on `copying` refuses every
+//! later click ([`ShareState::accepts_click`]), so every way out of a mint has
+//! to end somewhere clickable — [`fail_copy`] covers a click that never opened
+//! a clipboard write for `settle` to consume, and `disconnected_callback`
+//! covers an element re-parented mid-mint (`inject_children` runs once, so a
+//! reconnect restores no state of its own).
 //!
 //! [`ClipboardItem`]: https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem
 
@@ -147,6 +151,15 @@ struct ShareStateCell {
     /// The `setTimeout` that fails a copy nothing ever answered. Armed when
     /// the click opens the write, cleared on every settle.
     timeout: Option<i32>,
+    /// The timestamp of the command the copy in flight belongs to — set on the
+    /// share click and again on the enable-sync confirm, cleared wherever a
+    /// copy concludes. A refusal only counts if it echoes this.
+    ///
+    /// It lives in the same cell as `pending` deliberately: it is the SOLE
+    /// gate on acting on a refusal (a refusal has to reach the user whether or
+    /// not a clipboard write ever opened), so it has to move in lockstep with
+    /// the copy it names rather than drift in a cell of its own.
+    pending_time: Option<f64>,
 }
 
 /// An installed listener, paired with the `Closure` owning its JS-side memory.
@@ -161,10 +174,6 @@ pub struct TonkShare {
     /// there is no longer a DOM element (the deleted invite `<tonk-display>`)
     /// to read it back off at click time.
     current_link: Rc<RefCell<Option<String>>>,
-    /// The timestamp of the command the pending clipboard write belongs to —
-    /// set on the share click and again on the enable-sync confirm, cleared
-    /// when a refusal answers it. A refusal only counts if it echoes this.
-    pending_time: Rc<RefCell<Option<f64>>>,
     scaffold: subscribing::Scaffold,
     listeners: Vec<ListenerEntry>,
     /// Listeners installed on `document` rather than on the host, kept apart
@@ -179,7 +188,6 @@ impl Default for TonkShare {
         Self {
             state: Rc::new(RefCell::new(ShareStateCell::default())),
             current_link: Rc::new(RefCell::new(None)),
-            pending_time: Rc::new(RefCell::new(None)),
             scaffold: subscribing::Scaffold::default(),
             listeners: Vec::new(),
             document_listeners: Vec::new(),
@@ -223,7 +231,6 @@ impl subscribing::Subscribing for ShareLinkBehaviour {
 /// that answers the click currently in flight.
 struct ShareBlockedBehaviour {
     state: Rc<RefCell<ShareStateCell>>,
-    pending_time: Rc<RefCell<Option<f64>>>,
 }
 
 impl subscribing::Subscribing for ShareBlockedBehaviour {
@@ -235,7 +242,7 @@ impl subscribing::Subscribing for ShareBlockedBehaviour {
     fn render_reset(&self, host: &HtmlElement, payload: &JsValue) {
         let rows = js_sys::Array::from(payload);
         if let Some(blocked) = read_blocked_row(&rows.get(0)) {
-            handle_blocked(host, &self.state, &self.pending_time, blocked);
+            handle_blocked(host, &self.state, blocked);
         }
     }
 
@@ -244,7 +251,7 @@ impl subscribing::Subscribing for ShareBlockedBehaviour {
             Reflect::get(payload, &JsValue::from_str("asserted")).unwrap_or(JsValue::UNDEFINED);
         let rows = js_sys::Array::from(&asserted);
         if let Some(blocked) = read_blocked_row(&rows.get(rows.length().saturating_sub(1))) {
-            handle_blocked(host, &self.state, &self.pending_time, blocked);
+            handle_blocked(host, &self.state, blocked);
         }
     }
 
@@ -305,7 +312,6 @@ impl CustomElement for TonkShare {
         // in the same click task, so activation is still live for both.
         let state = Rc::clone(&self.state);
         let current_link = Rc::clone(&self.current_link);
-        let pending_time = Rc::clone(&self.pending_time);
         let host = this.clone();
         let on_click = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
             // The button is `type="submit"` inside a `<form>` (for layout
@@ -329,7 +335,7 @@ impl CustomElement for TonkShare {
             // is told from one the overlay is replaying (see
             // `handle_blocked`).
             let time = js_sys::Date::now();
-            *pending_time.borrow_mut() = Some(time);
+            state.borrow_mut().pending_time = Some(time);
             // Whatever link the last subscription frame delivered is the
             // PREVIOUS mint's. Note it so a frame still carrying it isn't
             // mistaken for our result.
@@ -363,7 +369,6 @@ impl CustomElement for TonkShare {
         });
         let blocked: Rc<dyn subscribing::Subscribing> = Rc::new(ShareBlockedBehaviour {
             state: Rc::clone(&self.state),
-            pending_time: Rc::clone(&self.pending_time),
         });
         self.scaffold.connect_all(this, vec![link, blocked]);
         self.install_confirm_listener(this);
@@ -388,7 +393,15 @@ impl CustomElement for TonkShare {
                 );
             }
         }
+        // Hand the button back. `inject_children` is the only other
+        // `set_state(Idle)` and it runs once, on first connect — so an element
+        // re-parented mid-mint would otherwise come back stamped `copying`,
+        // with nothing pending and no timer left to fail it. That state
+        // refuses every click, and nothing would ever move it: a dead button
+        // for the rest of the session.
+        set_state(this, ShareState::Idle);
         let mut state = self.state.borrow_mut();
+        state.pending_time = None;
         if let Some(id) = state.revert.take() {
             clear_timeout(id);
         }
@@ -431,7 +444,6 @@ impl TonkShare {
         let host = this.clone();
         let state = Rc::clone(&self.state);
         let current_link = Rc::clone(&self.current_link);
-        let pending_time = Rc::clone(&self.pending_time);
         let on_confirm = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
             let Some(target) = event.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
                 return;
@@ -460,7 +472,7 @@ impl TonkShare {
             let remote = default_remote_url(&origin);
 
             let time = js_sys::Date::now();
-            *pending_time.borrow_mut() = Some(time);
+            state.borrow_mut().pending_time = Some(time);
             let stale = current_link.borrow().clone();
             if let Err(e) = open_clipboard_write(Rc::clone(&state), stale) {
                 warn(&format!("share: clipboard unavailable: {e:?}"));
@@ -593,8 +605,13 @@ const MIME_TEXT: &str = "text/plain";
 /// Complete (or abandon) the clipboard write the click opened, and move the
 /// control to its confirmation state.
 fn settle(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, result: Result<String, &str>) {
-    if let Some(id) = state.borrow_mut().timeout.take() {
-        clear_timeout(id);
+    {
+        let mut cell = state.borrow_mut();
+        // The click this answers is answered: nothing later may claim it.
+        cell.pending_time = None;
+        if let Some(id) = cell.timeout.take() {
+            clear_timeout(id);
+        }
     }
     let Some(pending) = state.borrow_mut().pending.take() else {
         return;
@@ -653,7 +670,7 @@ fn arm_timeout(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
         // Clear our own handle FIRST: `settle` clears `timeout` too, and it
         // must not try to cancel the timer that is currently running.
         state_for_timer.borrow_mut().timeout = None;
-        expire_copy(&host, &state_for_timer);
+        fail_copy(&host, &state_for_timer, "share: timed out");
     });
     cell.timeout = Some(set_timeout(
         expire.unchecked_ref::<Function>(),
@@ -661,17 +678,20 @@ fn arm_timeout(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
     ));
 }
 
-/// What the timeout does when it fires: fail the copy, and make sure the
+/// Fail a copy: settle it if a clipboard write is open, and make sure the
 /// control leaves `copying` either way.
 ///
-/// The second half is not redundant. When the clipboard was unavailable the
-/// click stamped `copying` with nothing pending, so `settle` finds nothing to
-/// consume and returns without touching the state — leaving exactly the dead
-/// button this timer exists to prevent. `settle` cannot be the one to fix that:
-/// it must stay a no-op with nothing pending, or a late frame would flip an
-/// already-`copied` control to `failed`.
-fn expire_copy(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
-    settle(host, state, Err("share: timed out"));
+/// The second half is not redundant. A click that could not open a write (no
+/// promise-form `ClipboardItem`, an insecure context, a denied permission)
+/// stamped `copying` with nothing pending, so `settle` finds nothing to consume
+/// and returns without touching the state — and having just cleared the
+/// timeout, it leaves no backstop either. That is a button stuck on `copying`,
+/// which [`ShareState::accepts_click`] refuses: dead for the rest of the
+/// session. `settle` cannot be the one to fix it — it must stay a no-op with
+/// nothing pending, or a late frame would flip an already-`copied` control to
+/// `failed` (see `it_settles_only_once`).
+fn fail_copy(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
+    settle(host, state, Err(reason));
     if read_state(host) == ShareState::Copying {
         set_state(host, ShareState::Failed);
         arm_revert(host, state);
@@ -711,33 +731,33 @@ fn handle_link(
     settle(host, state, Ok(link));
 }
 
-/// Act on a refusal, if it answers the click we are holding a clipboard write
-/// for.
+/// Act on a refusal, if it answers the click currently awaiting an answer.
 ///
 /// The refusal fact is cardinality-one on the spot's subject, so the overlay
 /// keeps the last one and redelivers it on every resubscribe. Matching on the
 /// echoed timestamp is what separates "this click was refused" from "here is
 /// an old refusal again" — without it, one refused share would poison every
 /// later one for the rest of the session.
-fn handle_blocked(
-    host: &HtmlElement,
-    state: &Rc<RefCell<ShareStateCell>>,
-    pending_time: &Rc<RefCell<Option<f64>>>,
-    blocked: Blocked,
-) {
-    if *pending_time.borrow() != Some(blocked.time) {
+///
+/// That timestamp is the ONLY gate. A refusal has to reach the user whether or
+/// not a clipboard write ever opened: gating on `pending` as well would drop
+/// the refusal on exactly the browsers that cannot open one (no promise-form
+/// `ClipboardItem`), so the user would sit through the timeout instead of being
+/// offered the repair. Clearing `pending_time` here is what keeps the replay
+/// hole shut — a stale refusal's `time` can only match a click that has not
+/// already been answered.
+fn handle_blocked(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, blocked: Blocked) {
+    if state.borrow().pending_time != Some(blocked.time) {
         return;
     }
-    if state.borrow().pending.is_none() {
-        return;
-    }
-    pending_time.borrow_mut().take();
+    state.borrow_mut().pending_time = None;
 
     if blocked.code != BLOCKED_NOT_SYNCED {
         // Nothing the prompt could fix — including an attach that failed after
         // the user already accepted it. Say so rather than leaving the button
-        // spinning until the timeout.
-        settle(host, state, Err(&blocked.detail));
+        // spinning until the timeout. Through `fail_copy`, not bare `settle`,
+        // because there may be no write open to consume.
+        fail_copy(host, state, &blocked.detail);
         return;
     }
 
@@ -1156,14 +1176,13 @@ mod tests {
     fn it_blocks_on_a_matching_refusal() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        state.borrow_mut().pending_time = Some(42.0);
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&host, ShareState::Copying);
 
         handle_blocked(
             &host,
             &state,
-            &pending_time,
             Blocked {
                 code: "not-synced".to_owned(),
                 detail: "This spot only exists on this device.".to_owned(),
@@ -1184,14 +1203,13 @@ mod tests {
     fn it_ignores_a_refusal_from_an_earlier_click() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time = Rc::new(RefCell::new(Some(99.0)));
+        state.borrow_mut().pending_time = Some(99.0);
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&host, ShareState::Copying);
 
         handle_blocked(
             &host,
             &state,
-            &pending_time,
             Blocked {
                 code: "not-synced".to_owned(),
                 detail: "stale".to_owned(),
@@ -1202,7 +1220,7 @@ mod tests {
         assert_eq!(read_state(&host), ShareState::Copying);
         assert!(state.borrow().pending.is_some(), "copy still pending");
         assert_eq!(
-            *pending_time.borrow(),
+            state.borrow().pending_time,
             Some(99.0),
             "the click still in flight keeps its claim on the next refusal",
         );
@@ -1213,14 +1231,13 @@ mod tests {
     fn it_fails_without_prompting_on_an_unshareable_remote() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        state.borrow_mut().pending_time = Some(42.0);
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&host, ShareState::Copying);
 
         handle_blocked(
             &host,
             &state,
-            &pending_time,
             Blocked {
                 code: "unshareable-remote".to_owned(),
                 detail: "This spot's sync server can't be shared.".to_owned(),
@@ -1238,14 +1255,13 @@ mod tests {
     fn it_fails_when_the_attach_itself_is_refused() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time = Rc::new(RefCell::new(Some(7.0)));
+        state.borrow_mut().pending_time = Some(7.0);
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&host, ShareState::Copying);
 
         handle_blocked(
             &host,
             &state,
-            &pending_time,
             Blocked {
                 code: "attach-failed".to_owned(),
                 detail: "Could not turn on sync: offline".to_owned(),
@@ -1270,7 +1286,7 @@ mod tests {
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&with_write, ShareState::Copying);
 
-        expire_copy(&with_write, &state);
+        fail_copy(&with_write, &state, "share: timed out");
 
         assert_eq!(read_state(&with_write), ShareState::Failed);
         assert!(state.borrow().pending.is_none());
@@ -1281,7 +1297,7 @@ mod tests {
         let empty = Rc::new(RefCell::new(ShareStateCell::default()));
         set_state(&no_write, ShareState::Copying);
 
-        expire_copy(&no_write, &empty);
+        fail_copy(&no_write, &empty, "share: timed out");
 
         assert_eq!(
             read_state(&no_write),
@@ -1290,18 +1306,115 @@ mod tests {
         );
     }
 
+    /// The backstop is armed by the click and cancelled by the result, so a
+    /// settled copy leaves no timer behind to fail it later.
+    #[dialog_common::test]
+    fn it_clears_the_backstop_when_a_copy_settles() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        arm_timeout(&host, &state);
+        assert!(state.borrow().timeout.is_some(), "the backstop is armed");
+
+        settle(&host, &state, Ok("https://tonk.xyz/@/new".to_owned()));
+
+        assert_eq!(read_state(&host), ShareState::Copied);
+        assert!(
+            state.borrow().timeout.is_none(),
+            "a settled copy must leave no timer to fail it after the fact",
+        );
+    }
+
+    /// The prompt must appear even where no clipboard write could be opened —
+    /// a browser without the promise form of `ClipboardItem`, an insecure
+    /// context, a denied permission. The refusal is the thing the user needs.
+    #[dialog_common::test]
+    fn it_prompts_on_a_refusal_with_no_write_open() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(42.0);
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: "not-synced".to_owned(),
+                detail: "This spot only exists on this device.".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Blocked);
+    }
+
+    /// The same, unrepairable: it must land somewhere clickable. `settle` would
+    /// cancel the backstop and then find nothing to consume, leaving the
+    /// control on `copying` with nothing left able to move it.
+    #[dialog_common::test]
+    fn it_frees_the_button_on_an_unrepairable_refusal_with_no_write_open() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(42.0);
+        arm_timeout(&host, &state);
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: "unshareable-remote".to_owned(),
+                detail: "This spot's sync server can't be shared.".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Failed);
+        assert!(
+            read_state(&host).accepts_click(),
+            "the user must be able to try again",
+        );
+    }
+
+    /// An element re-parented mid-mint comes back clickable. `inject_children`
+    /// is the only other `set_state`, and it runs once — so a host left on
+    /// `copying` here would refuse every click for the rest of the session,
+    /// with no write pending and no timer left to fail it.
+    #[dialog_common::test]
+    fn it_gives_the_button_back_when_the_element_is_disconnected_mid_mint() {
+        let host = fresh_host();
+        let mut element = TonkShare::default();
+        let state = Rc::clone(&element.state);
+        state.borrow_mut().pending_time = Some(42.0);
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        arm_timeout(&host, &state);
+        set_state(&host, ShareState::Copying);
+
+        element.disconnected_callback(&host);
+
+        assert_eq!(read_state(&host), ShareState::Idle);
+        assert!(state.borrow().pending.is_none(), "the write is abandoned");
+        assert_eq!(
+            state.borrow().pending_time,
+            None,
+            "no click is awaiting an answer any more",
+        );
+        assert!(state.borrow().timeout.is_none(), "no timer left running");
+    }
+
     /// The refusal reaches the handler the way the host delivers it: a frame
     /// on the blocked subscription, not a direct call.
     #[dialog_common::test]
     fn it_acts_on_a_refusal_delivered_as_a_subscription_frame() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        state.borrow_mut().pending_time = Some(42.0);
         open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
         set_state(&host, ShareState::Copying);
         let behaviour = ShareBlockedBehaviour {
             state: Rc::clone(&state),
-            pending_time: Rc::clone(&pending_time),
         };
 
         behaviour.render_reset(&host, &blocked_reset_payload("not-synced", 42.0));
@@ -1314,10 +1427,8 @@ mod tests {
     fn it_leaves_the_control_alone_when_a_replayed_refusal_answers_no_click() {
         let host = fresh_host();
         let state = Rc::new(RefCell::new(ShareStateCell::default()));
-        let pending_time: Rc<RefCell<Option<f64>>> = Rc::new(RefCell::new(None));
         let behaviour = ShareBlockedBehaviour {
             state: Rc::clone(&state),
-            pending_time: Rc::clone(&pending_time),
         };
 
         behaviour.render_reset(&host, &blocked_reset_payload("not-synced", 42.0));
@@ -1369,13 +1480,12 @@ mod tests {
             .expect("attach button");
 
         let mut element = TonkShare::default();
-        let pending_time = Rc::clone(&element.pending_time);
         let state = Rc::clone(&element.state);
         element.install_confirm_listener(&host);
 
         button.unchecked_ref::<HtmlElement>().click();
         assert!(
-            pending_time.borrow().is_some(),
+            state.borrow().pending_time.is_some(),
             "the confirm click is heard through the document",
         );
         assert_eq!(
@@ -1386,7 +1496,7 @@ mod tests {
         assert!(state.borrow().pending.is_some(), "a new write is open");
 
         element.disconnected_callback(&host);
-        *pending_time.borrow_mut() = None;
+        state.borrow_mut().pending_time = None;
         // Back to `idle` on purpose: the handler refuses a click while a copy
         // is in flight, so leaving it on `copying` would make this pass
         // whether or not the listener was actually removed.
@@ -1394,7 +1504,7 @@ mod tests {
         button.unchecked_ref::<HtmlElement>().click();
 
         assert!(
-            pending_time.borrow().is_none(),
+            state.borrow().pending_time.is_none(),
             "a click after disconnect must reach nothing",
         );
         button.remove();

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -55,6 +55,13 @@
 //! so a new clipboard write opens there and the attach-then-mint the worker
 //! runs settles it — one click, from refusal to link on the clipboard.
 //!
+//! The other two classes (`unshareable-remote`, and `attach-failed` — an
+//! attach the user already approved that failed anyway) have no action the
+//! dialog could offer, but `detail` still has to reach the user: the button's
+//! "failed" label is a static string. `handle_blocked` re-opens the same
+//! dialog for these with the confirm button disabled, rather than routing the
+//! sentence to a clipboard-rejection message nothing ever reads.
+//!
 //! Anything else that goes wrong still has no explicit error signal (the
 //! deleted `<tonk-display>`'s error slot is gone with it): a subscription
 //! simply never yields a new link. [`arm_timeout`] is the backstop there. It
@@ -135,6 +142,11 @@ const BLOCKED_TAG: &str = "tonk-share-blocked";
 /// and its reason slot. Authored in `markup.rs`; every lookup here is
 /// `Option`-guarded, so the element still shares (and still refuses) in a host
 /// that renders no dialog at all.
+///
+/// The dialog is not only for `not-synced`: [`handle_blocked`] re-opens it on
+/// every refusal so `detail` always lands somewhere visible, disabling the
+/// confirm button (see `open_enable_sync_dialog`) on the two classes it
+/// cannot repair.
 const DIALOG_ID: &str = "fab-enable-sync";
 const DIALOG_CONFIRM: &str = "[data-enable-sync-confirm]";
 const DIALOG_DETAIL: &str = "[data-enable-sync-detail]";
@@ -448,10 +460,19 @@ impl TonkShare {
             let Some(target) = event.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
                 return;
             };
-            if target.closest(DIALOG_CONFIRM).ok().flatten().is_none() {
+            let Some(confirm) = target.closest(DIALOG_CONFIRM).ok().flatten() else {
+                return;
+            };
+            event.prevent_default();
+            // `open_enable_sync_dialog` disables this button on an
+            // unrepairable refusal (there is no attach to retry) but leaves
+            // the dialog itself open so the detail sentence stays visible.
+            // Nothing native backs "disabled" on a custom-element button, so
+            // this has to be checked explicitly rather than relied on to
+            // block the event.
+            if confirm.has_attribute("disabled") {
                 return;
             }
-            event.prevent_default();
             // A second confirm while the first attach is still running would
             // orphan the clipboard write this one opened — the browser would
             // hold it open forever, with nothing left able to settle it.
@@ -758,6 +779,14 @@ fn handle_blocked(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, block
         // spinning until the timeout. Through `fail_copy`, not bare `settle`,
         // because there may be no write open to consume.
         fail_copy(host, state, &blocked.detail);
+        // The button's static "failed" label carries no reason — it's the
+        // same static string every time. The detail sentence has to reach the
+        // user somewhere, so re-open the dialog to show it. There is no
+        // action it could offer (the remote is unshareable, or the attach the
+        // user just approved already failed), so the confirm button is
+        // disabled rather than absent — visible, but not a second attempt at
+        // something that cannot help.
+        open_enable_sync_dialog(&blocked.detail, false);
         return;
     }
 
@@ -766,7 +795,7 @@ fn handle_blocked(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, block
     // control would quietly flip back to "share" underneath the dialog.
     abandon(state, &blocked.detail);
     set_state(host, ShareState::Blocked);
-    open_enable_sync_dialog(&blocked.detail);
+    open_enable_sync_dialog(&blocked.detail, true);
 }
 
 /// Drop a pending clipboard write without moving the control's state. The
@@ -786,12 +815,29 @@ fn abandon(state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
 /// Show the enable-sync prompt, filling in the reason. A no-op when the
 /// dialog is absent, so the element still works in a host that does not
 /// render it.
-fn open_enable_sync_dialog(detail: &str) {
+///
+/// `offer_confirm` distinguishes the one refusal the dialog can act on
+/// (`not-synced`) from the two it can only report (`unshareable-remote`,
+/// `attach-failed`): `false` disables the confirm button — there is no
+/// attach to retry — while leaving the dialog open so `detail` stays
+/// visible. The button is reused across refusals rather than replaced, so a
+/// later repairable refusal must re-enable it: `true` clears both attributes
+/// back off.
+fn open_enable_sync_dialog(detail: &str, offer_confirm: bool) {
     let Some(dialog) = enable_sync_dialog() else {
         return;
     };
     if let Ok(Some(slot)) = dialog.query_selector(DIALOG_DETAIL) {
         slot.set_text_content(Some(detail));
+    }
+    if let Ok(Some(confirm)) = dialog.query_selector(DIALOG_CONFIRM) {
+        if offer_confirm {
+            let _ = confirm.remove_attribute("hidden");
+            let _ = confirm.remove_attribute("disabled");
+        } else {
+            let _ = confirm.set_attribute("hidden", "");
+            let _ = confirm.set_attribute("disabled", "");
+        }
     }
     let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::TRUE);
 }
@@ -976,6 +1022,44 @@ mod tests {
         let rows = js_sys::Array::new();
         rows.push(&blocked_row(code, time));
         rows.into()
+    }
+
+    /// An `update` delta payload carrying one refusal — the shape production
+    /// actually delivers a refusal in (see `share.rs`'s module doc: a
+    /// refusal always arrives after the subscription is already open).
+    fn blocked_update_payload(code: &str, time: f64) -> JsValue {
+        let asserted = js_sys::Array::new();
+        asserted.push(&blocked_row(code, time));
+        let payload = Object::new();
+        Reflect::set(&payload, &"asserted".into(), &asserted).expect("set asserted");
+        payload.into()
+    }
+
+    /// A stand-in for `markup.rs`'s `#fab-enable-sync` dialog: just enough
+    /// structure (the id, the detail slot, the confirm button) for
+    /// `open_enable_sync_dialog`'s lookups to find something. Attached to
+    /// `document.body` — `enable_sync_dialog` reads through
+    /// `document.get_element_by_id`, not a passed-in root.
+    fn dialog_stub() -> (Element, Element, Element) {
+        let document = window().expect("window").document().expect("document");
+        let dialog = document.create_element("div").expect("create dialog");
+        dialog.set_id(DIALOG_ID);
+        let detail = document.create_element("p").expect("create detail");
+        detail
+            .set_attribute("data-enable-sync-detail", "")
+            .expect("mark detail");
+        let confirm = document.create_element("button").expect("create confirm");
+        confirm
+            .set_attribute("data-enable-sync-confirm", "")
+            .expect("mark confirm");
+        dialog.append_child(&detail).expect("attach detail");
+        dialog.append_child(&confirm).expect("attach confirm");
+        document
+            .body()
+            .expect("body")
+            .append_child(&dialog)
+            .expect("attach dialog");
+        (dialog, detail, confirm)
     }
 
     #[wasm_bindgen_test]
@@ -1226,7 +1310,9 @@ mod tests {
         );
     }
 
-    /// An unrepairable refusal fails outright rather than offering a prompt.
+    /// An unrepairable refusal fails outright rather than offering a working
+    /// prompt — the dialog it also opens (see the pair of tests below) has
+    /// nothing the user can click through.
     #[dialog_common::test]
     fn it_fails_without_prompting_on_an_unshareable_remote() {
         let host = fresh_host();
@@ -1275,6 +1361,137 @@ mod tests {
             "the button must not spin on after the repair itself failed",
         );
         assert!(state.borrow().pending.is_none());
+    }
+
+    /// The whole point of `xyz.tonk.share/detail`: on a refusal the prompt
+    /// cannot repair, the sentence still has to land somewhere a user can
+    /// read it — the button's "failed" label is a static string, not this
+    /// text. `handle_blocked` re-opens the enable-sync dialog to show it, and
+    /// must leave the confirm button unusable: there is no attach to retry.
+    #[dialog_common::test]
+    fn it_shows_the_detail_and_disables_confirm_on_an_unrepairable_refusal() {
+        let (dialog, detail, confirm) = dialog_stub();
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(7.0);
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: "attach-failed".to_owned(),
+                detail: "Could not turn on sync: offline".to_owned(),
+                time: 7.0,
+            },
+        );
+
+        assert_eq!(
+            detail.text_content().as_deref(),
+            Some("Could not turn on sync: offline"),
+            "the sentence must reach the DOM, not just the rejected clipboard promise",
+        );
+        assert!(
+            confirm.has_attribute("disabled"),
+            "there is no recovery action to offer",
+        );
+
+        dialog.remove();
+    }
+
+    /// The same, for the other unrepairable class — an invite that could
+    /// never have worked, distinct from an attach that was tried and failed.
+    #[dialog_common::test]
+    fn it_shows_the_detail_on_an_unshareable_remote_too() {
+        let (dialog, detail, confirm) = dialog_stub();
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(42.0);
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: "unshareable-remote".to_owned(),
+                detail: "This spot's sync server can't be shared.".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(
+            detail.text_content().as_deref(),
+            Some("This spot's sync server can't be shared.")
+        );
+        assert!(confirm.has_attribute("disabled"));
+
+        dialog.remove();
+    }
+
+    /// A confirm button left disabled by an earlier unrepairable refusal must
+    /// not accept a click if one somehow lands on it anyway — the guard in
+    /// `install_confirm_listener` is the actual backstop, since nothing native
+    /// makes a custom-element button's `disabled` attribute block dispatch.
+    #[dialog_common::test]
+    fn it_ignores_a_click_on_a_disabled_confirm_button() {
+        let (dialog, _detail, confirm) = dialog_stub();
+        let host = fresh_host();
+        host.set_attribute("space", "did:key:z6Mk").expect("space");
+        confirm
+            .set_attribute("disabled", "")
+            .expect("disable confirm");
+
+        let mut element = TonkShare::default();
+        let state = Rc::clone(&element.state);
+        element.install_confirm_listener(&host);
+
+        confirm.unchecked_ref::<HtmlElement>().click();
+
+        assert!(
+            state.borrow().pending_time.is_none(),
+            "a disabled confirm button must not start a fresh attach",
+        );
+        assert_eq!(read_state(&host), ShareState::Idle);
+
+        element.disconnected_callback(&host);
+        dialog.remove();
+    }
+
+    /// A repairable refusal must leave (or restore) a USABLE confirm button —
+    /// including after an earlier unrepairable refusal disabled it, since the
+    /// same static dialog is reused across every refusal this element sees.
+    #[dialog_common::test]
+    fn it_re_enables_confirm_on_a_repairable_refusal_after_an_earlier_disable() {
+        let (dialog, detail, confirm) = dialog_stub();
+        confirm.set_attribute("disabled", "").expect("pre-disable");
+        confirm.set_attribute("hidden", "").expect("pre-hide");
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(1.0);
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: "not-synced".to_owned(),
+                detail: "This spot only exists on this device.".to_owned(),
+                time: 1.0,
+            },
+        );
+
+        assert_eq!(
+            detail.text_content().as_deref(),
+            Some("This spot only exists on this device.")
+        );
+        assert!(
+            !confirm.has_attribute("disabled"),
+            "a repairable refusal must offer a working confirm button",
+        );
+        assert!(!confirm.has_attribute("hidden"));
+
+        dialog.remove();
     }
 
     /// A copy nothing ever answered gives the button back, whether or not a
@@ -1418,6 +1635,29 @@ mod tests {
         };
 
         behaviour.render_reset(&host, &blocked_reset_payload("not-synced", 42.0));
+
+        assert_eq!(read_state(&host), ShareState::Blocked);
+    }
+
+    /// The path production actually takes: a refusal always arrives after the
+    /// blocked subscription is already open (the click that provokes it can
+    /// only happen once the button exists), so it lands as an `update` delta,
+    /// never a `reset` snapshot. `render_reset` being correct proves nothing
+    /// about `render_update`; the link subscription's delta reader has its own
+    /// covering test (`it_reads_a_reset_snapshot_and_an_update_delta`) for the
+    /// same reason.
+    #[dialog_common::test]
+    fn it_acts_on_a_refusal_delivered_as_an_update_delta() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(42.0);
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+        let behaviour = ShareBlockedBehaviour {
+            state: Rc::clone(&state),
+        };
+
+        behaviour.render_update(&host, &blocked_update_payload("not-synced", 42.0));
 
         assert_eq!(read_state(&host), ShareState::Blocked);
     }

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -40,12 +40,26 @@
 //! `window.tonk.transact`, mirroring `element.rs::dispatch_pause_from_cap`
 //! and `space_name.rs::dispatch_rename`.
 //!
-//! A failed mint has no explicit error signal in this design (the deleted
-//! `<tonk-display>`'s error slot is gone with it): a subscription simply
-//! never yields a new link. A pending copy is only ever abandoned on
-//! disconnect (see `disconnected_callback`) — there is no timeout. That
-//! matches this crate's scope (fixing the orphaned mounts), not a redesign
-//! of mint failure handling.
+//! ## When the mint is refused
+//!
+//! A spot whose `main` has no sync remote cannot be shared: the worker refuses
+//! to mint rather than hand out an invite that would strand whoever claimed it
+//! in an empty space. It records that refusal as `xyz.tonk.share/{blocked,
+//! detail,time}` on the spot's subject, which this element reads on a SECOND
+//! subscription (see [`ShareBlockedBehaviour`]) — separate from the link
+//! subscription because a single predicate over both would resolve only when a
+//! refusal AND a link are present, which never happens.
+//!
+//! A refusal the prompt can repair (`not-synced`) abandons the clipboard write
+//! and opens the enable-sync dialog. Confirming it is a FRESH user activation,
+//! so a new clipboard write opens there and the attach-then-mint the worker
+//! runs settles it — one click, from refusal to link on the clipboard.
+//!
+//! Anything else that goes wrong still has no explicit error signal (the
+//! deleted `<tonk-display>`'s error slot is gone with it): a subscription
+//! simply never yields a new link. [`arm_timeout`] is the backstop, so the
+//! control cannot pin on `copying` — which [`ShareState::accepts_click`]
+//! refuses — for the rest of the session.
 //!
 //! [`ClipboardItem`]: https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem
 
@@ -57,9 +71,12 @@ use js_sys::{Array, Function, JSON, Object, Promise, Reflect};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
-use web_sys::{HtmlElement, window};
+use web_sys::{Element, HtmlElement, window};
 
-use crate::logic::{COPIED_LINGER_MS, ShareState, invite_claim_json, invite_link_query_body};
+use crate::logic::{
+    COPIED_LINGER_MS, SHARE_TIMEOUT_MS, ShareState, default_remote_url, enable_sync_claim_json,
+    invite_claim_json, invite_link_query_body, share_blocked_query_body,
+};
 use crate::subscribing;
 
 #[wasm_bindgen]
@@ -92,6 +109,32 @@ struct PendingCopy {
     stale: Option<String>,
 }
 
+/// A refusal delivered on the blocked subscription.
+#[derive(Debug, Clone, PartialEq)]
+struct Blocked {
+    /// `not-synced` | `unshareable-remote` | `attach-failed`.
+    code: String,
+    /// The sentence to show.
+    detail: String,
+    /// The timestamp of the command this answers.
+    time: f64,
+}
+
+/// The refusal class the enable-sync prompt can repair.
+const BLOCKED_NOT_SYNCED: &str = "not-synced";
+
+/// Subscription tag for the refusal query, distinct from [`SUB_TAG`] so the
+/// scaffolding can tell the two subscriptions' frames apart.
+const BLOCKED_TAG: &str = "tonk-share-blocked";
+
+/// The enable-sync prompt's id, and the attribute marking its confirm button
+/// and its reason slot. Authored in `markup.rs`; every lookup here is
+/// `Option`-guarded, so the element still shares (and still refuses) in a host
+/// that renders no dialog at all.
+const DIALOG_ID: &str = "fab-enable-sync";
+const DIALOG_CONFIRM: &str = "[data-enable-sync-confirm]";
+const DIALOG_DETAIL: &str = "[data-enable-sync-detail]";
+
 /// Per-element state. One pending copy at a time — a click while a mint is in
 /// flight is dropped (see [`ShareState::accepts_click`]).
 #[derive(Default)]
@@ -101,6 +144,9 @@ struct ShareStateCell {
     /// `Idle`. Cleared and re-armed on each settle so a fresh result always
     /// gets its full linger, and cancelled on disconnect.
     revert: Option<i32>,
+    /// The `setTimeout` that fails a copy nothing ever answered. Armed when
+    /// the click opens the write, cleared on every settle.
+    timeout: Option<i32>,
 }
 
 /// An installed listener, paired with the `Closure` owning its JS-side memory.
@@ -115,8 +161,17 @@ pub struct TonkShare {
     /// there is no longer a DOM element (the deleted invite `<tonk-display>`)
     /// to read it back off at click time.
     current_link: Rc<RefCell<Option<String>>>,
+    /// The timestamp of the command the pending clipboard write belongs to —
+    /// set on the share click and again on the enable-sync confirm, cleared
+    /// when a refusal answers it. A refusal only counts if it echoes this.
+    pending_time: Rc<RefCell<Option<f64>>>,
     scaffold: subscribing::Scaffold,
     listeners: Vec<ListenerEntry>,
+    /// Listeners installed on `document` rather than on the host, kept apart
+    /// because they have to be REMOVED from `document` too: removing them from
+    /// the host would silently do nothing and leave a live closure over this
+    /// element's state behind after it is gone.
+    document_listeners: Vec<ListenerEntry>,
 }
 
 impl Default for TonkShare {
@@ -124,8 +179,10 @@ impl Default for TonkShare {
         Self {
             state: Rc::new(RefCell::new(ShareStateCell::default())),
             current_link: Rc::new(RefCell::new(None)),
+            pending_time: Rc::new(RefCell::new(None)),
             scaffold: subscribing::Scaffold::default(),
             listeners: Vec::new(),
+            document_listeners: Vec::new(),
         }
     }
 }
@@ -161,6 +218,62 @@ impl subscribing::Subscribing for ShareLinkBehaviour {
     }
 }
 
+/// The refusal subscription's behaviour: the same routing context as the link
+/// subscription, the raw `xyz.tonk.share/*` query, and acting on a refusal
+/// that answers the click currently in flight.
+struct ShareBlockedBehaviour {
+    state: Rc<RefCell<ShareStateCell>>,
+    pending_time: Rc<RefCell<Option<f64>>>,
+}
+
+impl subscribing::Subscribing for ShareBlockedBehaviour {
+    fn query_body(&self, this: &HtmlElement) -> Result<String, String> {
+        let space = this.get_attribute("space").unwrap_or_default();
+        share_blocked_query_body(&space)
+    }
+
+    fn render_reset(&self, host: &HtmlElement, payload: &JsValue) {
+        let rows = js_sys::Array::from(payload);
+        if let Some(blocked) = read_blocked_row(&rows.get(0)) {
+            handle_blocked(host, &self.state, &self.pending_time, blocked);
+        }
+    }
+
+    fn render_update(&self, host: &HtmlElement, payload: &JsValue) {
+        let asserted =
+            Reflect::get(payload, &JsValue::from_str("asserted")).unwrap_or(JsValue::UNDEFINED);
+        let rows = js_sys::Array::from(&asserted);
+        if let Some(blocked) = read_blocked_row(&rows.get(rows.length().saturating_sub(1))) {
+            handle_blocked(host, &self.state, &self.pending_time, blocked);
+        }
+    }
+
+    fn tag(&self) -> &'static str {
+        BLOCKED_TAG
+    }
+}
+
+/// Read `conclusion.fields.{blocked,detail,time}` off a raw subscription row.
+/// `None` for a missing row or any missing field — all three are asserted
+/// together, so a partial row is not a refusal.
+fn read_blocked_row(row: &JsValue) -> Option<Blocked> {
+    if row.is_undefined() || row.is_null() {
+        return None;
+    }
+    let fields = Reflect::get(row, &JsValue::from_str("fields")).ok()?;
+    let code = Reflect::get(&fields, &JsValue::from_str("blocked"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty())?;
+    let detail = Reflect::get(&fields, &JsValue::from_str("detail"))
+        .ok()
+        .and_then(|v| v.as_string())?;
+    let time = Reflect::get(&fields, &JsValue::from_str("time"))
+        .ok()
+        .and_then(|v| v.as_f64())?;
+    Some(Blocked { code, detail, time })
+}
+
 impl CustomElement for TonkShare {
     /// No Shadow DOM — `<tonk-share>` is a transparent wrapper around the
     /// share button `markup.rs` puts inside it.
@@ -192,6 +305,7 @@ impl CustomElement for TonkShare {
         // in the same click task, so activation is still live for both.
         let state = Rc::clone(&self.state);
         let current_link = Rc::clone(&self.current_link);
+        let pending_time = Rc::clone(&self.pending_time);
         let host = this.clone();
         let on_click = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
             // The button is `type="submit"` inside a `<form>` (for layout
@@ -210,6 +324,12 @@ impl CustomElement for TonkShare {
             let Some(space) = host.get_attribute("space").filter(|s| !s.is_empty()) else {
                 return;
             };
+            // The claim's timestamp is also this click's identity: a refusal
+            // echoes it back, and that is how a refusal answering THIS click
+            // is told from one the overlay is replaying (see
+            // `handle_blocked`).
+            let time = js_sys::Date::now();
+            *pending_time.borrow_mut() = Some(time);
             // Whatever link the last subscription frame delivered is the
             // PREVIOUS mint's. Note it so a frame still carrying it isn't
             // mistaken for our result.
@@ -226,18 +346,27 @@ impl CustomElement for TonkShare {
                     set_state(&host, ShareState::Copying);
                 }
             }
-            dispatch_invite(&space, js_sys::Date::now());
+            arm_timeout(&host, &state);
+            dispatch_invite(&space, time);
         });
         add_listener(this, "click", &on_click);
         self.listeners.push(("click".to_owned(), on_click));
     }
 
     fn connected_callback(&mut self, this: &HtmlElement) {
-        let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(ShareLinkBehaviour {
+        // Two subscriptions on one element: the minted link, and the refusal
+        // that says no link is coming. The scaffolding routes each frame back
+        // by the tag its behaviour subscribed under.
+        let link: Rc<dyn subscribing::Subscribing> = Rc::new(ShareLinkBehaviour {
             state: Rc::clone(&self.state),
             current_link: Rc::clone(&self.current_link),
         });
-        self.scaffold.connect(this, behaviour);
+        let blocked: Rc<dyn subscribing::Subscribing> = Rc::new(ShareBlockedBehaviour {
+            state: Rc::clone(&self.state),
+            pending_time: Rc::clone(&self.pending_time),
+        });
+        self.scaffold.connect_all(this, vec![link, blocked]);
+        self.install_confirm_listener(this);
     }
 
     fn disconnected_callback(&mut self, this: &HtmlElement) {
@@ -247,8 +376,23 @@ impl CustomElement for TonkShare {
             let _ = target
                 .remove_event_listener_with_callback(&event_type, closure.as_ref().unchecked_ref());
         }
+        // The confirm listener is on `document`, not on the host — removing it
+        // from the host would silently succeed and leave it installed, still
+        // holding this element's state.
+        if let Some(document) = window().and_then(|w| w.document()) {
+            for (event_type, closure) in self.document_listeners.drain(..) {
+                let target: &web_sys::EventTarget = document.unchecked_ref();
+                let _ = target.remove_event_listener_with_callback(
+                    &event_type,
+                    closure.as_ref().unchecked_ref(),
+                );
+            }
+        }
         let mut state = self.state.borrow_mut();
         if let Some(id) = state.revert.take() {
+            clear_timeout(id);
+        }
+        if let Some(id) = state.timeout.take() {
             clear_timeout(id);
         }
         // Abandon a clipboard write still held open by a mint that will now
@@ -262,14 +406,98 @@ impl CustomElement for TonkShare {
     }
 }
 
+impl TonkShare {
+    /// Listen for the enable-sync prompt's confirm, wherever it is in the
+    /// document.
+    ///
+    /// Delegated rather than bound to the button: `<tonk-share>` and the dialog
+    /// are set as one `innerHTML` string, so a direct lookup at connect time
+    /// can race the dialog into existence.
+    ///
+    /// The confirm click is a FRESH user activation, which is the whole reason
+    /// this can complete the copy: a new clipboard write opens here and the
+    /// browser holds it through the attach and the mint that follow. The write
+    /// the refused click opened is long gone — [`abandon`] dropped it rather
+    /// than leaving it hostage to a question the user had not answered yet.
+    fn install_confirm_listener(&mut self, this: &HtmlElement) {
+        // `connected_callback` runs again every time the element is re-parented;
+        // installing a second copy would leave the first behind on `document`.
+        if !self.document_listeners.is_empty() {
+            return;
+        }
+        let Some(document) = window().and_then(|w| w.document()) else {
+            return;
+        };
+        let host = this.clone();
+        let state = Rc::clone(&self.state);
+        let current_link = Rc::clone(&self.current_link);
+        let pending_time = Rc::clone(&self.pending_time);
+        let on_confirm = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let Some(target) = event.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
+                return;
+            };
+            if target.closest(DIALOG_CONFIRM).ok().flatten().is_none() {
+                return;
+            }
+            event.prevent_default();
+            // A second confirm while the first attach is still running would
+            // orphan the clipboard write this one opened — the browser would
+            // hold it open forever, with nothing left able to settle it.
+            if !read_state(&host).accepts_click() {
+                return;
+            }
+            let Some(space) = host.get_attribute("space").filter(|s| !s.is_empty()) else {
+                return;
+            };
+            // Inside a sealed guest the document is `about:srcdoc`, so
+            // `location.origin` is the opaque `"null"` and the remote URL
+            // built from it would be unusable. `context_origin` prefers the
+            // true origin the portal bridge injects.
+            let Some(origin) = tonk_host::bridge::context_origin() else {
+                warn("share: cannot resolve this page's origin");
+                return;
+            };
+            let remote = default_remote_url(&origin);
+
+            let time = js_sys::Date::now();
+            *pending_time.borrow_mut() = Some(time);
+            let stale = current_link.borrow().clone();
+            if let Err(e) = open_clipboard_write(Rc::clone(&state), stale) {
+                warn(&format!("share: clipboard unavailable: {e:?}"));
+            }
+            set_state(&host, ShareState::Copying);
+            arm_timeout(&host, &state);
+            dispatch_enable_sync(&space, &remote, time);
+            close_enable_sync_dialog();
+        });
+        let target: &web_sys::EventTarget = document.unchecked_ref();
+        let _ =
+            target.add_event_listener_with_callback("click", on_confirm.as_ref().unchecked_ref());
+        self.document_listeners
+            .push(("click".to_owned(), on_confirm));
+    }
+}
+
 /// Dispatch the `tonk:invite` claim via `window.tonk.transact`, routeless —
 /// mirroring `element.rs::dispatch_pause_from_cap` and
 /// `space_name.rs::dispatch_rename`. There is no `<tonk-display>` delegate
 /// installed on this Rust-owned markup to resolve the button's form
 /// submission into a claim, so the click handler dispatches it directly.
 fn dispatch_invite(space: &str, time: f64) {
-    let claim = invite_claim_json(space, time);
-    let json_str = match serde_json::to_string(&claim) {
+    dispatch_claim(&invite_claim_json(space, time));
+}
+
+/// Dispatch the `tonk:enable-sync` claim, asking the worker to attach `remote`
+/// to this spot and — because `share` is set — mint the invite the refused
+/// click was after, as soon as the attach lands.
+fn dispatch_enable_sync(space: &str, remote: &str, time: f64) {
+    dispatch_claim(&enable_sync_claim_json(space, remote, true, time));
+}
+
+/// Hand a claim to `window.tonk.transact`. A no-op wherever the bridge is not
+/// installed, rather than an error the user would see.
+fn dispatch_claim(claim: &serde_json::Value) {
+    let json_str = match serde_json::to_string(claim) {
         Ok(s) => s,
         Err(_) => return,
     };
@@ -365,6 +593,9 @@ const MIME_TEXT: &str = "text/plain";
 /// Complete (or abandon) the clipboard write the click opened, and move the
 /// control to its confirmation state.
 fn settle(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, result: Result<String, &str>) {
+    if let Some(id) = state.borrow_mut().timeout.take() {
+        clear_timeout(id);
+    }
     let Some(pending) = state.borrow_mut().pending.take() else {
         return;
     };
@@ -409,6 +640,44 @@ fn arm_revert(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
     ));
 }
 
+/// Fail a copy that nothing ever answered, so the control never pins on
+/// `copying` (which refuses further clicks) when a mint dies silently.
+fn arm_timeout(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
+    let mut cell = state.borrow_mut();
+    if let Some(id) = cell.timeout.take() {
+        clear_timeout(id);
+    }
+    let host = host.clone();
+    let state_for_timer = Rc::clone(state);
+    let expire = Closure::once_into_js(move || {
+        // Clear our own handle FIRST: `settle` clears `timeout` too, and it
+        // must not try to cancel the timer that is currently running.
+        state_for_timer.borrow_mut().timeout = None;
+        expire_copy(&host, &state_for_timer);
+    });
+    cell.timeout = Some(set_timeout(
+        expire.unchecked_ref::<Function>(),
+        SHARE_TIMEOUT_MS,
+    ));
+}
+
+/// What the timeout does when it fires: fail the copy, and make sure the
+/// control leaves `copying` either way.
+///
+/// The second half is not redundant. When the clipboard was unavailable the
+/// click stamped `copying` with nothing pending, so `settle` finds nothing to
+/// consume and returns without touching the state — leaving exactly the dead
+/// button this timer exists to prevent. `settle` cannot be the one to fix that:
+/// it must stay a no-op with nothing pending, or a late frame would flip an
+/// already-`copied` control to `failed`.
+fn expire_copy(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>) {
+    settle(host, state, Err("share: timed out"));
+    if read_state(host) == ShareState::Copying {
+        set_state(host, ShareState::Failed);
+        arm_revert(host, state);
+    }
+}
+
 /// Track a freshly delivered link and, if a copy is pending, settle it —
 /// unless this is still the previous mint's link (the new one hasn't landed
 /// yet, and the subscription can re-deliver the same row on an unrelated
@@ -440,6 +709,82 @@ fn handle_link(
         return;
     }
     settle(host, state, Ok(link));
+}
+
+/// Act on a refusal, if it answers the click we are holding a clipboard write
+/// for.
+///
+/// The refusal fact is cardinality-one on the spot's subject, so the overlay
+/// keeps the last one and redelivers it on every resubscribe. Matching on the
+/// echoed timestamp is what separates "this click was refused" from "here is
+/// an old refusal again" — without it, one refused share would poison every
+/// later one for the rest of the session.
+fn handle_blocked(
+    host: &HtmlElement,
+    state: &Rc<RefCell<ShareStateCell>>,
+    pending_time: &Rc<RefCell<Option<f64>>>,
+    blocked: Blocked,
+) {
+    if *pending_time.borrow() != Some(blocked.time) {
+        return;
+    }
+    if state.borrow().pending.is_none() {
+        return;
+    }
+    pending_time.borrow_mut().take();
+
+    if blocked.code != BLOCKED_NOT_SYNCED {
+        // Nothing the prompt could fix — including an attach that failed after
+        // the user already accepted it. Say so rather than leaving the button
+        // spinning until the timeout.
+        settle(host, state, Err(&blocked.detail));
+        return;
+    }
+
+    // Repairable: abandon the copy and ask. `settle` would stamp `Failed` and
+    // arm the revert timer, which is wrong while a question is on screen — the
+    // control would quietly flip back to "share" underneath the dialog.
+    abandon(state, &blocked.detail);
+    set_state(host, ShareState::Blocked);
+    open_enable_sync_dialog(&blocked.detail);
+}
+
+/// Drop a pending clipboard write without moving the control's state. The
+/// browser releases the write and leaves the existing clipboard alone.
+fn abandon(state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
+    let mut cell = state.borrow_mut();
+    if let Some(id) = cell.timeout.take() {
+        clear_timeout(id);
+    }
+    if let Some(pending) = cell.pending.take() {
+        let _ = pending
+            .reject
+            .call1(&JsValue::NULL, &JsValue::from_str(reason));
+    }
+}
+
+/// Show the enable-sync prompt, filling in the reason. A no-op when the
+/// dialog is absent, so the element still works in a host that does not
+/// render it.
+fn open_enable_sync_dialog(detail: &str) {
+    let Some(dialog) = enable_sync_dialog() else {
+        return;
+    };
+    if let Ok(Some(slot)) = dialog.query_selector(DIALOG_DETAIL) {
+        slot.set_text_content(Some(detail));
+    }
+    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::TRUE);
+}
+
+fn close_enable_sync_dialog() {
+    let Some(dialog) = enable_sync_dialog() else {
+        return;
+    };
+    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::FALSE);
+}
+
+fn enable_sync_dialog() -> Option<Element> {
+    window()?.document()?.get_element_by_id(DIALOG_ID)
 }
 
 /// A subscription snapshot (`reset`) frame: the invite link off the first
@@ -484,6 +829,11 @@ fn set_state(host: &HtmlElement, state: ShareState) {
 fn read_state(host: &HtmlElement) -> ShareState {
     match host.get_attribute("data-share-state").as_deref() {
         Some("copying") => ShareState::Copying,
+        // Without this arm `Blocked` reads straight back as `Idle`, and every
+        // later decision that reads the control's state — the confirm guard,
+        // the revert timer's `is_transient` check — silently sees the wrong
+        // thing.
+        Some("blocked") => ShareState::Blocked,
         Some("copied") => ShareState::Copied,
         Some("failed") => ShareState::Failed,
         _ => ShareState::Idle,
@@ -525,6 +875,7 @@ pub fn register() {
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
     use super::*;
+    use crate::subscribing::Subscribing;
     use js_sys::Object;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
     use web_sys::{Element, window};
@@ -585,6 +936,26 @@ mod tests {
         let payload = Object::new();
         Reflect::set(&payload, &JsValue::from_str("asserted"), &asserted).expect("set asserted");
         payload.into()
+    }
+
+    /// A refusal row, as the blocked subscription delivers it: `blocked` and
+    /// `detail` are text, `time` is a float (an echoed `dom.event/time-stamp`),
+    /// so this cannot reuse [`row_with_fields`]'s all-strings shape.
+    fn blocked_row(code: &str, time: f64) -> JsValue {
+        let fields = Object::new();
+        Reflect::set(&fields, &"blocked".into(), &JsValue::from_str(code)).expect("set blocked");
+        Reflect::set(&fields, &"detail".into(), &JsValue::from_str("no remote"))
+            .expect("set detail");
+        Reflect::set(&fields, &"time".into(), &JsValue::from_f64(time)).expect("set time");
+        let row = Object::new();
+        Reflect::set(&row, &"fields".into(), &fields).expect("set fields");
+        row.into()
+    }
+
+    fn blocked_reset_payload(code: &str, time: f64) -> JsValue {
+        let rows = js_sys::Array::new();
+        rows.push(&blocked_row(code, time));
+        rows.into()
     }
 
     #[wasm_bindgen_test]
@@ -713,9 +1084,13 @@ mod tests {
         // The stylesheet keys the label swap off this attribute, so a state
         // that doesn't survive the round-trip renders the wrong label.
         let host = fresh_host();
+        // `Blocked` is in here for a reason: it is stamped by `handle_blocked`
+        // and read back by every later click and timer, so a missing arm in
+        // `read_state` would silently degrade it to `Idle`.
         for state in [
             ShareState::Idle,
             ShareState::Copying,
+            ShareState::Blocked,
             ShareState::Copied,
             ShareState::Failed,
         ] {
@@ -773,6 +1148,256 @@ mod tests {
         // rejected, so the browser abandons the write instead of holding it.
         assert_eq!(read_state(&host), ShareState::Failed);
         assert!(state.borrow().pending.is_none());
+    }
+
+    /// A refusal whose timestamp matches the pending click abandons the copy
+    /// and moves the control to `blocked`.
+    #[dialog_common::test]
+    fn it_blocks_on_a_matching_refusal() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            &pending_time,
+            Blocked {
+                code: "not-synced".to_owned(),
+                detail: "This spot only exists on this device.".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Blocked);
+        assert!(
+            state.borrow().pending.is_none(),
+            "the clipboard write is abandoned, not left open"
+        );
+    }
+
+    /// A refusal from an earlier click is a replay and must be ignored — the
+    /// fact is cardinality-one and redelivered on every resubscribe.
+    #[dialog_common::test]
+    fn it_ignores_a_refusal_from_an_earlier_click() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time = Rc::new(RefCell::new(Some(99.0)));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            &pending_time,
+            Blocked {
+                code: "not-synced".to_owned(),
+                detail: "stale".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Copying);
+        assert!(state.borrow().pending.is_some(), "copy still pending");
+        assert_eq!(
+            *pending_time.borrow(),
+            Some(99.0),
+            "the click still in flight keeps its claim on the next refusal",
+        );
+    }
+
+    /// An unrepairable refusal fails outright rather than offering a prompt.
+    #[dialog_common::test]
+    fn it_fails_without_prompting_on_an_unshareable_remote() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            &pending_time,
+            Blocked {
+                code: "unshareable-remote".to_owned(),
+                detail: "This spot's sync server can't be shared.".to_owned(),
+                time: 42.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Failed);
+    }
+
+    /// An attach that fails AFTER the user accepted the prompt still reaches
+    /// them: the worker echoes the enable-sync command's own timestamp, so the
+    /// refusal matches the write the confirm click opened.
+    #[dialog_common::test]
+    fn it_fails_when_the_attach_itself_is_refused() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time = Rc::new(RefCell::new(Some(7.0)));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            &pending_time,
+            Blocked {
+                code: "attach-failed".to_owned(),
+                detail: "Could not turn on sync: offline".to_owned(),
+                time: 7.0,
+            },
+        );
+
+        assert_eq!(
+            read_state(&host),
+            ShareState::Failed,
+            "the button must not spin on after the repair itself failed",
+        );
+        assert!(state.borrow().pending.is_none());
+    }
+
+    /// A copy nothing ever answered gives the button back, whether or not a
+    /// clipboard write was ever open.
+    #[dialog_common::test]
+    fn it_frees_the_button_when_a_copy_times_out() {
+        let with_write = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&with_write, ShareState::Copying);
+
+        expire_copy(&with_write, &state);
+
+        assert_eq!(read_state(&with_write), ShareState::Failed);
+        assert!(state.borrow().pending.is_none());
+
+        // The clipboard-unavailable click: `copying`, but nothing pending for
+        // `settle` to consume.
+        let no_write = fresh_host();
+        let empty = Rc::new(RefCell::new(ShareStateCell::default()));
+        set_state(&no_write, ShareState::Copying);
+
+        expire_copy(&no_write, &empty);
+
+        assert_eq!(
+            read_state(&no_write),
+            ShareState::Failed,
+            "a click that never opened a write must not pin the button on copying",
+        );
+    }
+
+    /// The refusal reaches the handler the way the host delivers it: a frame
+    /// on the blocked subscription, not a direct call.
+    #[dialog_common::test]
+    fn it_acts_on_a_refusal_delivered_as_a_subscription_frame() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time = Rc::new(RefCell::new(Some(42.0)));
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+        let behaviour = ShareBlockedBehaviour {
+            state: Rc::clone(&state),
+            pending_time: Rc::clone(&pending_time),
+        };
+
+        behaviour.render_reset(&host, &blocked_reset_payload("not-synced", 42.0));
+
+        assert_eq!(read_state(&host), ShareState::Blocked);
+    }
+
+    /// A snapshot replayed on resubscribe, with no click in flight, is inert.
+    #[dialog_common::test]
+    fn it_leaves_the_control_alone_when_a_replayed_refusal_answers_no_click() {
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        let pending_time: Rc<RefCell<Option<f64>>> = Rc::new(RefCell::new(None));
+        let behaviour = ShareBlockedBehaviour {
+            state: Rc::clone(&state),
+            pending_time: Rc::clone(&pending_time),
+        };
+
+        behaviour.render_reset(&host, &blocked_reset_payload("not-synced", 42.0));
+
+        assert_eq!(read_state(&host), ShareState::Idle);
+    }
+
+    #[dialog_common::test]
+    fn it_reads_the_three_refusal_fields_off_a_row() {
+        let row = blocked_row("not-synced", 42.0);
+        assert_eq!(
+            read_blocked_row(&row),
+            Some(Blocked {
+                code: "not-synced".to_owned(),
+                detail: "no remote".to_owned(),
+                time: 42.0,
+            }),
+        );
+    }
+
+    /// All three attributes are asserted together, so a row missing one is not
+    /// a refusal — acting on it would mean acting on an unknown timestamp.
+    #[dialog_common::test]
+    fn it_ignores_a_partial_refusal_row() {
+        let partial = Object::new();
+        let fields = Object::new();
+        Reflect::set(&fields, &"blocked".into(), &"not-synced".into()).expect("set blocked");
+        Reflect::set(&partial, &"fields".into(), &fields).expect("set fields");
+        assert_eq!(read_blocked_row(&partial.into()), None);
+        assert_eq!(read_blocked_row(&JsValue::UNDEFINED), None);
+    }
+
+    /// The confirm listener lives on `document`, not on the host, so it must be
+    /// torn down against `document` — removing it from the host silently fails
+    /// and leaves a live closure over element state behind.
+    #[dialog_common::test]
+    fn it_removes_the_confirm_listener_from_the_document_on_disconnect() {
+        let document = window().expect("window").document().expect("document");
+        let host = fresh_host();
+        host.set_attribute("space", "did:key:z6Mk").expect("space");
+        let button = document.create_element("button").expect("create button");
+        button
+            .set_attribute("data-enable-sync-confirm", "")
+            .expect("mark button");
+        document
+            .body()
+            .expect("body")
+            .append_child(&button)
+            .expect("attach button");
+
+        let mut element = TonkShare::default();
+        let pending_time = Rc::clone(&element.pending_time);
+        let state = Rc::clone(&element.state);
+        element.install_confirm_listener(&host);
+
+        button.unchecked_ref::<HtmlElement>().click();
+        assert!(
+            pending_time.borrow().is_some(),
+            "the confirm click is heard through the document",
+        );
+        assert_eq!(
+            read_state(&host),
+            ShareState::Copying,
+            "the confirm opens a fresh clipboard write and waits for the link",
+        );
+        assert!(state.borrow().pending.is_some(), "a new write is open");
+
+        element.disconnected_callback(&host);
+        *pending_time.borrow_mut() = None;
+        // Back to `idle` on purpose: the handler refuses a click while a copy
+        // is in flight, so leaving it on `copying` would make this pass
+        // whether or not the listener was actually removed.
+        set_state(&host, ShareState::Idle);
+        button.unchecked_ref::<HtmlElement>().click();
+
+        assert!(
+            pending_time.borrow().is_none(),
+            "a click after disconnect must reach nothing",
+        );
+        button.remove();
     }
 
     #[wasm_bindgen_test]

--- a/rust/tonk-fab/src/subscribing.rs
+++ b/rust/tonk-fab/src/subscribing.rs
@@ -91,78 +91,122 @@ pub trait Subscribing {
 
 /// The shared subscribe/retry/teardown state a subscribing element's
 /// `CustomElement` struct embeds alongside its own fields.
+///
+/// An element may hold SEVERAL subscriptions. The host delivers every frame
+/// to the same `reset`/`update` methods, so they are told apart by the `tag`
+/// in the frame's options — the same tag each behaviour supplied when it
+/// subscribed. `<tonk-share>` needs this: its invite link and its refusal
+/// signal are separate inline predicates over different raw attributes, and a
+/// single predicate over both would resolve only when BOTH are present, which
+/// is never.
 #[derive(Default)]
 pub struct Scaffold {
-    subscription: Rc<RefCell<Option<Subscription>>>,
-    retry: Rc<RefCell<RetryPolicy>>,
+    /// Live subscriptions, paired with the tag they were opened under.
+    subscriptions: Rc<RefCell<Vec<(String, Subscription)>>>,
     reset: Rc<RefCell<Option<FrameClosure>>>,
     update: Rc<RefCell<Option<FrameClosure>>>,
 }
 
 impl Scaffold {
+    /// Run from `connected_callback` with a single behaviour. See
+    /// [`Self::connect_all`].
+    pub fn connect(&self, this: &HtmlElement, behaviour: Rc<dyn Subscribing>) {
+        self.connect_all(this, vec![behaviour]);
+    }
+
     /// Run from `connected_callback`: stamp `with`, install the `reset`/
     /// `update` frame delegates (forwarded from the prototype shims
-    /// [`install_frame_shims`] installs), and subscribe.
+    /// [`install_frame_shims`] installs), and subscribe each behaviour under
+    /// its own tag.
     ///
-    /// A no-op when [`Subscribing::resolve_with`] returns `None` (routing
-    /// context not ready yet — an unsubstituted `{id}` placeholder, say) —
-    /// the attribute-changed callback re-runs this once it lands.
-    pub fn connect(&self, this: &HtmlElement, behaviour: Rc<dyn Subscribing>) {
-        let Some(with) = behaviour.resolve_with(this) else {
+    /// The routing context comes from the FIRST behaviour — every behaviour on
+    /// one element shares that element's `with`. A no-op when it returns
+    /// `None` (context not ready yet); the attribute-changed callback re-runs
+    /// this once it lands.
+    pub fn connect_all(&self, this: &HtmlElement, behaviours: Vec<Rc<dyn Subscribing>>) {
+        let Some(first) = behaviours.first() else {
             return;
         };
-        // Stamp our own routing context: `resolve_with` reads THIS element's
-        // own attributes and never walks ancestors.
+        let Some(with) = first.resolve_with(this) else {
+            return;
+        };
         let _ = this.set_attribute("with", &with);
 
-        // Install the per-instance `reset` delegate: the host calls
-        // `element.reset(conclusions, { tag })` for the first (and any
-        // reconnect) frame, and the prototype shim installed by
-        // `install_frame_shims` forwards it here.
-        let render = behaviour.clone();
+        let routed = behaviours.clone();
         let host = this.clone();
         let reset: FrameClosure =
-            Closure::wrap(Box::new(move |payload: JsValue, _opts: JsValue| {
-                render.render_reset(&host, &payload);
+            Closure::wrap(Box::new(move |payload: JsValue, opts: JsValue| {
+                if let Some(behaviour) = route(&routed, &opts) {
+                    behaviour.render_reset(&host, &payload);
+                }
             }));
         let _ = Reflect::set(this, &"__tonkReset".into(), reset.as_ref());
         *self.reset.borrow_mut() = Some(reset);
 
-        // Install the per-instance `update` delegate: subsequent changes
-        // arrive as an incremental delta, not another snapshot.
-        let render = behaviour.clone();
+        let routed = behaviours.clone();
         let host = this.clone();
         let update: FrameClosure =
-            Closure::wrap(Box::new(move |payload: JsValue, _opts: JsValue| {
-                render.render_update(&host, &payload);
+            Closure::wrap(Box::new(move |payload: JsValue, opts: JsValue| {
+                if let Some(behaviour) = route(&routed, &opts) {
+                    behaviour.render_update(&host, &payload);
+                }
             }));
         let _ = Reflect::set(this, &"__tonkUpdate".into(), update.as_ref());
         *self.update.borrow_mut() = Some(update);
 
-        let subscription = self.subscription.clone();
-        let retry = self.retry.clone();
-        let host = this.clone();
-        spawn_local(async move {
-            if !host.is_connected() || subscription.borrow().is_some() {
-                return;
-            }
-            subscribe(&host, behaviour.as_ref(), subscription, retry);
-        });
+        for behaviour in behaviours {
+            let subscriptions = self.subscriptions.clone();
+            let host = this.clone();
+            // Each behaviour gets its own retry budget: one query failing to
+            // build must not spend the other's attempts.
+            let retry = Rc::new(RefCell::new(RetryPolicy::default()));
+            spawn_local(async move {
+                let tag = behaviour.tag().to_owned();
+                if !host.is_connected()
+                    || subscriptions.borrow().iter().any(|(open, _)| *open == tag)
+                {
+                    return;
+                }
+                subscribe(&host, behaviour.as_ref(), subscriptions, retry);
+            });
+        }
     }
 
-    /// Run from `disconnected_callback`: drop the subscription and frame
+    /// Run from `disconnected_callback`: drop every subscription and the frame
     /// delegates.
     pub fn disconnect(&self) {
-        self.subscription.borrow_mut().take();
+        self.subscriptions.borrow_mut().clear();
         self.reset.borrow_mut().take();
         self.update.borrow_mut().take();
+    }
+}
+
+/// Pick the behaviour a frame belongs to by the `tag` in its options — the
+/// tag that behaviour supplied when it subscribed.
+///
+/// With exactly one behaviour, an absent or unrecognised tag still routes to
+/// it: single-subscription elements predate tagged routing and must keep
+/// working whether or not the host echoes a tag.
+fn route<'a>(
+    behaviours: &'a [Rc<dyn Subscribing>],
+    opts: &JsValue,
+) -> Option<&'a Rc<dyn Subscribing>> {
+    let tag = Reflect::get(opts, &"tag".into())
+        .ok()
+        .and_then(|value| value.as_string());
+    match tag {
+        Some(tag) => behaviours
+            .iter()
+            .find(|behaviour| behaviour.tag() == tag)
+            .or_else(|| (behaviours.len() == 1).then(|| &behaviours[0])),
+        None => (behaviours.len() == 1).then(|| &behaviours[0]),
     }
 }
 
 fn subscribe(
     host: &HtmlElement,
     behaviour: &dyn Subscribing,
-    subscription: Rc<RefCell<Option<Subscription>>>,
+    subscriptions: Rc<RefCell<Vec<(String, Subscription)>>>,
     retry: Rc<RefCell<RetryPolicy>>,
 ) {
     let tag = behaviour.tag();
@@ -182,7 +226,7 @@ fn subscribe(
     match consumer::subscribe(&consumer_el, &parsed, Some(&tag_val)) {
         Ok(sub) => {
             retry.borrow_mut().reset();
-            *subscription.borrow_mut() = Some(sub);
+            subscriptions.borrow_mut().push((tag.to_owned(), sub));
         }
         Err(err) => {
             // Bounded, unlike the host's default resubscribe loop.
@@ -230,4 +274,74 @@ pub fn install_frame_shims(tag: &str) {
         "if (typeof this.__tonkUpdate === 'function') this.__tonkUpdate(payload, opts);",
     );
     let _ = Reflect::set(&proto, &"update".into(), &update_fn);
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// A behaviour that records which payloads it was handed.
+    struct Recorder {
+        tag: &'static str,
+        seen: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl Subscribing for Recorder {
+        fn query_body(&self, _this: &HtmlElement) -> Result<String, String> {
+            Ok("{}".to_owned())
+        }
+        fn render_reset(&self, _host: &HtmlElement, payload: &JsValue) {
+            self.seen
+                .borrow_mut()
+                .push(payload.as_string().unwrap_or_default());
+        }
+        fn render_update(&self, _host: &HtmlElement, _payload: &JsValue) {}
+        fn tag(&self) -> &'static str {
+            self.tag
+        }
+    }
+
+    /// A frame tagged for one behaviour reaches only that behaviour.
+    #[dialog_common::test]
+    fn it_routes_frames_by_tag() {
+        let document = window().unwrap().document().unwrap();
+        let host: HtmlElement = document.create_element("div").unwrap().dyn_into().unwrap();
+        host.set_attribute("space", "did:key:z6Mk").unwrap();
+
+        let first = Rc::new(RefCell::new(Vec::new()));
+        let second = Rc::new(RefCell::new(Vec::new()));
+        let scaffold = Scaffold::default();
+        scaffold.connect_all(
+            &host,
+            vec![
+                Rc::new(Recorder {
+                    tag: "one",
+                    seen: Rc::clone(&first),
+                }),
+                Rc::new(Recorder {
+                    tag: "two",
+                    seen: Rc::clone(&second),
+                }),
+            ],
+        );
+
+        // Deliver a frame the way the host does: element.__tonkReset(payload, {tag}).
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"tag".into(), &"two".into()).unwrap();
+        let reset = Reflect::get(&host, &"__tonkReset".into())
+            .unwrap()
+            .dyn_into::<Function>()
+            .unwrap();
+        reset
+            .call2(&JsValue::NULL, &JsValue::from_str("payload"), &opts)
+            .unwrap();
+
+        assert!(first.borrow().is_empty(), "untagged behaviour untouched");
+        assert_eq!(second.borrow().as_slice(), ["payload"]);
+    }
 }

--- a/rust/tonk-fab/src/subscribing.rs
+++ b/rust/tonk-fab/src/subscribing.rs
@@ -187,6 +187,10 @@ impl Scaffold {
 /// With exactly one behaviour, an absent or unrecognised tag still routes to
 /// it: single-subscription elements predate tagged routing and must keep
 /// working whether or not the host echoes a tag.
+///
+/// A frame that matches nothing (only possible with more than one behaviour)
+/// is dropped, not misdelivered to an arbitrary one — logged so a future
+/// host/element protocol mismatch is debuggable rather than silently inert.
 fn route<'a>(
     behaviours: &'a [Rc<dyn Subscribing>],
     opts: &JsValue,
@@ -194,13 +198,20 @@ fn route<'a>(
     let tag = Reflect::get(opts, &"tag".into())
         .ok()
         .and_then(|value| value.as_string());
-    match tag {
+    let routed = match &tag {
         Some(tag) => behaviours
             .iter()
             .find(|behaviour| behaviour.tag() == tag)
             .or_else(|| (behaviours.len() == 1).then(|| &behaviours[0])),
         None => (behaviours.len() == 1).then(|| &behaviours[0]),
+    };
+    if routed.is_none() {
+        tonk_common::log!(
+            "frame dropped: tag {tag:?} matched none of {} behaviour(s)",
+            behaviours.len()
+        );
     }
+    routed
 }
 
 fn subscribe(
@@ -343,5 +354,78 @@ mod tests {
 
         assert!(first.borrow().is_empty(), "untagged behaviour untouched");
         assert_eq!(second.borrow().as_slice(), ["payload"]);
+    }
+
+    /// A single-behaviour scaffold still delivers a frame whose `opts` carry
+    /// no `tag` key at all — the fallback that keeps `<ui-space-name>`,
+    /// `<ui-member-roster>`, and `<ui-space-switcher>` alive if the host ever
+    /// stops echoing a tag.
+    #[dialog_common::test]
+    fn it_falls_back_to_the_sole_behaviour_when_a_frame_carries_no_tag() {
+        let document = window().unwrap().document().unwrap();
+        let host: HtmlElement = document.create_element("div").unwrap().dyn_into().unwrap();
+        host.set_attribute("space", "did:key:z6Mk").unwrap();
+
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let scaffold = Scaffold::default();
+        scaffold.connect_all(
+            &host,
+            vec![Rc::new(Recorder {
+                tag: "only",
+                seen: Rc::clone(&seen),
+            })],
+        );
+
+        // No `tag` key at all on `opts` — not even an empty string.
+        let opts = js_sys::Object::new();
+        let reset = Reflect::get(&host, &"__tonkReset".into())
+            .unwrap()
+            .dyn_into::<Function>()
+            .unwrap();
+        reset
+            .call2(&JsValue::NULL, &JsValue::from_str("payload"), &opts)
+            .unwrap();
+
+        assert_eq!(seen.borrow().as_slice(), ["payload"]);
+    }
+
+    /// A multi-behaviour scaffold drops a frame carrying a tag that matches
+    /// none of its behaviours — a frame addressed to nobody must not be
+    /// misdelivered to an arbitrary behaviour.
+    #[dialog_common::test]
+    fn it_drops_a_frame_whose_tag_matches_no_behaviour() {
+        let document = window().unwrap().document().unwrap();
+        let host: HtmlElement = document.create_element("div").unwrap().dyn_into().unwrap();
+        host.set_attribute("space", "did:key:z6Mk").unwrap();
+
+        let first = Rc::new(RefCell::new(Vec::new()));
+        let second = Rc::new(RefCell::new(Vec::new()));
+        let scaffold = Scaffold::default();
+        scaffold.connect_all(
+            &host,
+            vec![
+                Rc::new(Recorder {
+                    tag: "one",
+                    seen: Rc::clone(&first),
+                }),
+                Rc::new(Recorder {
+                    tag: "two",
+                    seen: Rc::clone(&second),
+                }),
+            ],
+        );
+
+        let opts = js_sys::Object::new();
+        Reflect::set(&opts, &"tag".into(), &"unrecognised".into()).unwrap();
+        let reset = Reflect::get(&host, &"__tonkReset".into())
+            .unwrap()
+            .dyn_into::<Function>()
+            .unwrap();
+        reset
+            .call2(&JsValue::NULL, &JsValue::from_str("payload"), &opts)
+            .unwrap();
+
+        assert!(first.borrow().is_empty(), "not delivered to \"one\"");
+        assert!(second.borrow().is_empty(), "not delivered to \"two\"");
     }
 }

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -162,6 +162,38 @@ impl Command for Invite {
     type Output = ();
 }
 
+/// Attach a sync remote to an existing spot, and optionally mint an invite
+/// once it is attached.
+///
+/// Dispatched routelessly by the share control when a user accepts the offer
+/// to turn sync on. `space`, `remote` and the `share` marker ride on the
+/// transient as raw facts the handler reads directly — `remote` because a URL
+/// cannot be a `String`-typed field (see
+/// [`crate::domain::command::enable_sync::Remote`]), the other two for
+/// symmetry with it.
+///
+/// This is deliberately NOT the `space/enable-sync` command seeded in
+/// `core.yaml`: that one shares `CreateSpace`'s trigger attribute, so a
+/// handler registered against it would fire alongside `CreateSpaceHandler`
+/// and mint a new spot instead of attaching to the existing one.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct EnableSync {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The acceptance timestamp — distinguishes one click from the next.
+    pub time: crate::domain::command::enable_sync::TimeStamp,
+    /// Per-command marker that keeps this command's shape distinct from
+    /// every other transient's.
+    pub marker: crate::domain::command::enable_sync::EnableSync,
+}
+
+/// `EnableSync` is a [`dialog_capability::Command`]; its handler lives in
+/// `tonk-worker` (attaches the remote, then mints when asked).
+impl Command for EnableSync {
+    type Input = Self;
+    type Output = ();
+}
+
 /// Toggle background sync for a space's replica.
 ///
 /// Dispatched when the FAB's sync cap is alt/option-clicked. Carries the
@@ -422,6 +454,36 @@ mod share_blocked {
         assert_eq!(
             crate::domain::share::Time::the().to_string(),
             "xyz.tonk.share/time"
+        );
+    }
+}
+
+#[cfg(test)]
+mod enable_sync {
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_carries_a_marker_no_other_command_carries() {
+        use crate::domain::command::enable_sync;
+
+        assert_eq!(
+            enable_sync::EnableSync::the().to_string(),
+            "dom.event.current-target.dataset/enable-sync"
+        );
+        assert_eq!(
+            enable_sync::Space::the().to_string(),
+            "xyz.tonk.enable-sync/space"
+        );
+        assert_eq!(
+            enable_sync::Remote::the().to_string(),
+            "xyz.tonk.enable-sync/remote"
+        );
+        assert_eq!(
+            enable_sync::Share::the().to_string(),
+            "xyz.tonk.enable-sync/share"
         );
     }
 }

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -324,7 +324,9 @@ pub struct Authorization {
     pub this: Entity,
     /// The base58 delegation chain (`?access=`).
     pub proof: crate::domain::authorization::Proof,
-    /// The sync remote endpoint (`&remote=`), empty when local-only.
+    /// The sync remote endpoint (`&remote=`). Never empty — `run_invite` is
+    /// the only handler that asserts an `Authorization`, and it refuses to
+    /// mint one at all for a repository with no shareable remote.
     pub remote: crate::domain::authorization::Remote,
 }
 

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -314,6 +314,28 @@ pub struct Credential {
     pub link: crate::domain::credential::Link,
 }
 
+/// The overlay-only fact a refused `tonk:invite` asserts: why the mint did
+/// not happen, keyed by the spot's **subject** DID (`this`) — the same
+/// entity [`Credential`] is keyed by, so one subject carries both the
+/// success and the refusal.
+///
+/// All three fields are asserted together. A concept resolves only when
+/// every declared field is present, so a partial assert would never resolve
+/// (the same all-fields-required gotcha `JoinStatus`/`JoinFailure` are split
+/// to avoid).
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct ShareBlocked {
+    /// The spot's subject DID.
+    pub this: Entity,
+    /// Refusal class: `not-synced` | `unshareable-remote` | `attach-failed`.
+    pub blocked: crate::domain::share::Blocked,
+    /// The sentence shown to the user.
+    pub detail: crate::domain::share::Detail,
+    /// The refused command's timestamp, echoed so the share control can tell
+    /// this refusal from a replay of an older one.
+    pub time: crate::domain::share::Time,
+}
+
 /// Request to redeem an invite URL and join its space.
 ///
 /// Asserted transiently when `<tonk-page>` fires its `mount` event on the
@@ -378,4 +400,28 @@ pub struct JoinFailure {
     pub reason: crate::domain::join::Reason,
     /// Failure class: `malformed` | `audience-mismatch` | `claim-failed`.
     pub kind: crate::domain::join::Kind,
+}
+
+#[cfg(test)]
+mod share_blocked {
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_the_share_attribute_names() {
+        assert_eq!(
+            crate::domain::share::Blocked::the().to_string(),
+            "xyz.tonk.share/blocked"
+        );
+        assert_eq!(
+            crate::domain::share::Detail::the().to_string(),
+            "xyz.tonk.share/detail"
+        );
+        assert_eq!(
+            crate::domain::share::Time::the().to_string(),
+            "xyz.tonk.share/time"
+        );
+    }
 }

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -485,5 +485,11 @@ mod enable_sync {
             enable_sync::Share::the().to_string(),
             "xyz.tonk.enable-sync/share"
         );
+        // Shared verbatim with every other command's timestamp, so it must
+        // stay on the `dom.event` domain rather than this command's own.
+        assert_eq!(
+            enable_sync::TimeStamp::the().to_string(),
+            "dom.event/time-stamp"
+        );
     }
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -317,6 +317,10 @@ pub mod command {
         pub struct EnableSync(pub Entity);
 
         /// The spot to attach the remote to.
+        ///
+        /// An `Entity` for the same reason as [`EnableSync`]: the value is a
+        /// `did:key:…`, and the worker's untagged `Value` decode reads any
+        /// `:`-bearing string as an `Entity`.
         #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
         #[domain("xyz.tonk.enable-sync")]
         pub struct Space(pub Entity);
@@ -334,6 +338,9 @@ pub mod command {
 
         /// Present when the caller wants an invite minted once the remote is
         /// attached. Absent means attach only.
+        ///
+        /// An `Entity` for the same reason as [`EnableSync`]: the sentinel
+        /// value (`tonk:share`) carries a `:`.
         #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
         #[domain("xyz.tonk.enable-sync")]
         pub struct Share(pub Entity);

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -553,9 +553,11 @@ pub mod authorization {
     #[domain("xyz.tonk.authorization")]
     pub struct Proof(pub String);
 
-    /// The UCAN access-service endpoint for sync, when the repository
-    /// advertises a remote — the optional `&remote=` parameter suffix.
-    /// Empty when the repository is local-only.
+    /// The UCAN access-service endpoint for sync — the `&remote=` parameter
+    /// suffix. Never empty: `run_invite` refuses to mint an invite (and so
+    /// never asserts this) for a repository with no shareable remote, since
+    /// one that carried no remote would strand its recipient in a spot that
+    /// can never fill.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
     #[domain("xyz.tonk.authorization")]
     pub struct Remote(pub String);

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -531,6 +531,45 @@ pub mod credential {
     pub struct Link(pub String);
 }
 
+/// Attributes on the overlay-only `tonk:share/blocked` fact — why a share
+/// click could not mint an invite. Keyed on the spot's subject entity, the
+/// same entity [`crate::command::Credential`] is keyed by, so the share
+/// control reads both off one subject.
+///
+/// Overlay-only, so it is session-scoped and never replicated: a refusal is
+/// this device's answer to this click, not a property of the spot.
+pub mod share {
+    use super::Attribute;
+
+    /// The refusal class: `not-synced` | `unshareable-remote` |
+    /// `attach-failed`. Only `not-synced` is repairable by attaching a
+    /// remote, so it is the only one that offers the prompt.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Blocked(pub String);
+
+    /// The sentence shown to the user.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Detail(pub String);
+
+    /// The timestamp of the command this refusal answers, echoed back from
+    /// the transient that triggered it.
+    ///
+    /// Load-bearing. The fact is cardinality-one on the subject, so it
+    /// lingers in the overlay and replays on every resubscribe; the share
+    /// control acts only on a refusal whose timestamp matches the click it
+    /// is currently holding a clipboard write for, and ignores every other
+    /// frame. That is what makes the fact safe to leave in place instead of
+    /// retracting it on the next success.
+    #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+    #[domain("xyz.tonk.share")]
+    #[cardinality(one)]
+    pub struct Time(pub f64);
+}
+
 /// Attributes on the overlay-only `tonk:join/status` concept — the state
 /// of an in-flight join attempt at the fixed `tonk:join/status` entity.
 /// On success the whole fact is retracted and the durable space record is

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -288,6 +288,57 @@ pub mod command {
         pub struct Space(pub Entity);
     }
 
+    /// Attributes the `tonk:enable-sync` command carries.
+    ///
+    /// The share control dispatches this routelessly when a user accepts the
+    /// offer to turn sync on, so the target spot and the endpoint both travel
+    /// on the transient rather than being inferred from a dispatch origin.
+    pub mod enable_sync {
+        use super::super::Entity;
+        use super::Attribute;
+
+        /// The submit event's timestamp. Makes each acceptance a distinct
+        /// transient, and is echoed back on any refusal so the share control
+        /// can match a result to the click that caused it.
+        #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+        #[domain("dom.event")]
+        pub struct TimeStamp(pub f64);
+
+        /// The marker giving this command an attribute no other command
+        /// carries, so a transient decodes as exactly one command. Same role
+        /// as [`super::invite::Invite`]; the derived attribute is
+        /// `dom.event.current-target.dataset/enable-sync`.
+        ///
+        /// An `Entity`, not a `String`: the value (`tonk:enable-sync`) has a
+        /// `:`, and the worker's untagged `Value` decode reads any `:`-bearing
+        /// string as an `Entity`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.dataset")]
+        pub struct EnableSync(pub Entity);
+
+        /// The spot to attach the remote to.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Space(pub Entity);
+
+        /// The UCAN access-service endpoint to attach as `origin`.
+        ///
+        /// Read from the raw facts rather than being a matched field: a URL
+        /// round-trips through JSON and the worker's untagged `Value` decode
+        /// picks `Entity` for any string with a `:`, so a `String`-typed field
+        /// would never decode one. The handler tolerates both representations,
+        /// the same way `remote_from_facts` does for `CreateSpace`.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Remote(pub String);
+
+        /// Present when the caller wants an invite minted once the remote is
+        /// attached. Absent means attach only.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.enable-sync")]
+        pub struct Share(pub Entity);
+    }
+
     /// Attributes the `tonk:pause-sync` command carries.
     pub mod pause_sync {
         use super::super::Entity;

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -984,6 +984,115 @@ pub mod tests {
         panic!("invitation for subject {subject} never appeared after dispatch");
     }
 
+    /// The FAB dispatches enable-sync through the profile branch even though
+    /// its result is written to the named spot. A standing spot subscription
+    /// must receive that link when dispatch drains the command's writes;
+    /// otherwise the share control has nothing to settle its clipboard promise
+    /// with and times out.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    #[dialog_common::test]
+    async fn it_broadcasts_the_invite_minted_by_profile_routed_enable_sync() {
+        use futures_util::FutureExt as _;
+        use http_body_util::BodyExt as _;
+
+        let state = test_state().await;
+        let (app, state, _lsp) = super::api_router_with_state(state);
+        let (repo, subject) = put_repo_info(&app, "enable-sync-share-broadcast").await;
+        let query = serde_json::json!({
+            "predicate": { "with": { "link": {
+                "the": "xyz.tonk.credential/link", "as": "Text", "cardinality": "one"
+            } } },
+            "terms": { "this": subject, "link": { "?": { "name": "link" } } }
+        });
+        let mut body = open_subscription_with_query(&app, &repo, "main", query).await;
+        let snapshot = read_sse_frame(&mut body).await;
+        assert_eq!(
+            snapshot["conclusions"].as_array().map(Vec::len),
+            Some(0),
+            "local-only spot starts without a credential link",
+        );
+
+        let command = serde_json::json!({
+            "claims": [{
+                "op": "assert",
+                "application": {
+                    "parameters": {
+                        "space": subject,
+                        "remote": "https://sync.example.test/ucan/",
+                        "share": "tonk:share",
+                        "time": 1,
+                        "marker": "tonk:enable-sync"
+                    },
+                    "predicate": { "kind": "transient", "concept": {
+                        "description": "Attach a remote and mint an invite.",
+                        "with": {
+                            "time": { "the": "dom.event/time-stamp", "as": "Float" },
+                            "marker": { "the": "dom.event.current-target.dataset/enable-sync", "as": "Entity" },
+                            "space": { "the": "xyz.tonk.enable-sync/space", "as": "Entity" },
+                            "remote": { "the": "xyz.tonk.enable-sync/remote", "as": "Text" },
+                            "share": { "the": "xyz.tonk.enable-sync/share", "as": "Entity" }
+                        }
+                    } }
+                }
+            }]
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/profile/branch/main/transact")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(command.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // `/transact` detaches command dispatch after committing the transient.
+        // Wait until its durable invitation lands, then inspect the already-open
+        // stream. Absence after minting completed is the regression.
+        for _ in 0..50 {
+            if !content_invitations(&state, &repo).await.is_empty() {
+                break;
+            }
+            wasm_yield().await;
+        }
+        assert_eq!(
+            content_invitations(&state, &repo).await.len(),
+            1,
+            "enable-sync should finish minting the invitation",
+        );
+        let mut frame = None;
+        for _ in 0..10 {
+            if let Some(ready) = body.frame().now_or_never().flatten() {
+                frame = Some(ready.expect("SSE frame should be readable"));
+                break;
+            }
+            wasm_yield().await;
+        }
+        let frame = frame.expect("enable-sync mint should broadcast its link");
+        let bytes = frame.into_data().expect("data frame");
+        let text = std::str::from_utf8(&bytes).expect("utf8");
+        let delta: serde_json::Value = serde_json::from_str(
+            text.strip_prefix("data: ")
+                .and_then(|text| text.strip_suffix("\n\n"))
+                .expect("SSE-framed body"),
+        )
+        .expect("delta is JSON");
+        // Refreshing the branch handle deliberately rebinds its subscription
+        // engine, so this is a replacement snapshot; an ordinary mint on an
+        // unchanged handle is an incremental `asserted` delta. The FAB accepts
+        // both frame kinds.
+        let rows = delta["conclusions"]
+            .as_array()
+            .or_else(|| delta["asserted"].as_array())
+            .expect("broadcast carries conclusion rows");
+        let link = rows[0]["fields"]["link"].as_str().unwrap_or_default();
+        assert!(!link.is_empty(), "broadcast carries the minted invite link");
+    }
+
     /// The `tonk:invite` command handler asserts a queryable
     /// `tonk:invitation` join. (`mint_invite_via_command` panics if it
     /// doesn't.)
@@ -3114,6 +3223,16 @@ employee:
     /// Open an SSE subscription and return the open body so the
     /// caller can read frames as they arrive.
     async fn open_subscription(app: &Router, repo: &str, branch: &str) -> Body {
+        open_subscription_with_query(app, repo, branch, named_concept_wire_query()).await
+    }
+
+    /// Open an SSE subscription for an explicit inline query.
+    async fn open_subscription_with_query(
+        app: &Router,
+        repo: &str,
+        branch: &str,
+        query: serde_json::Value,
+    ) -> Body {
         let response = app
             .clone()
             .oneshot(
@@ -3122,7 +3241,7 @@ employee:
                     .method("POST")
                     .header("content-type", "application/json")
                     .header("accept", "text/event-stream")
-                    .body(Body::from(named_concept_wire_query().to_string()))
+                    .body(Body::from(query.to_string()))
                     .unwrap(),
             )
             .await

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -783,7 +783,7 @@ pub mod tests {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     struct MintedInvite {
         access: String,
-        /// The stored `&remote=<url>` suffix (empty for a local-only repo).
+        /// The stored `&remote=<url>` suffix.
         remote: String,
         /// The base58 membership seed the worker minted, read back from the
         /// session overlay via the `tonk:invitation` join.
@@ -818,11 +818,54 @@ pub mod tests {
         (info.name, info.subject.as_str().to_owned())
     }
 
-    /// Drive the `tonk:invite` command end to end on a fresh repo and
-    /// return the minted invite.
+    /// Attach a sync remote to `repo`'s `main` branch via `POST /remote` —
+    /// the same path the topbar "Enable sync" form drives. Tests that mint
+    /// an invite need this first: `run_invite` refuses to mint against a
+    /// repo whose `main` has no upstream (see
+    /// `repository::tests::it_refuses_to_mint_without_a_remote`).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    async fn attach_remote(app: &Router, repo: &str, endpoint: &str) {
+        use super::repository::{
+            BranchConfiguration, RemoteConfiguration, RepositoryConfiguration,
+        };
+        use dialog_remote_ucan_s3::UcanAddress;
+        use dialog_repository::SiteAddress;
+
+        let config = RepositoryConfiguration::default()
+            .remote(
+                "origin",
+                RemoteConfiguration::new(SiteAddress::from(UcanAddress::new(endpoint))),
+            )
+            .branch(
+                "main",
+                BranchConfiguration::default().upstream("origin", "main"),
+            );
+        let attach = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{repo}/remote"))
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&config).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            attach.status(),
+            StatusCode::OK,
+            "remote attach should succeed"
+        );
+    }
+
+    /// Drive the `tonk:invite` command end to end on a fresh, synced repo
+    /// and return the minted invite. Attaches a remote before minting —
+    /// a local-only repo now refuses to mint at all.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     async fn mint_invite_via_command(app: &Router, label: &str) -> MintedInvite {
         let (repo, subject) = put_repo_info(app, label).await;
+        attach_remote(app, &repo, "https://sync.example.test/ucan/").await;
         mint_invite_for(app, &repo, &subject).await
     }
 
@@ -961,6 +1004,7 @@ pub mod tests {
         let (app, app_state, _lsp) = super::api_router_with_state(state);
 
         let (repo, subject) = put_repo_info(&app, "invite-no-leak").await;
+        attach_remote(&app, &repo, "https://sync.example.test/ucan/").await;
         let minted = mint_invite_for(&app, &repo, &subject).await;
         assert!(!minted.access.is_empty(), "authorization must mint");
 
@@ -1128,16 +1172,11 @@ pub mod tests {
     /// A command-minted invite for a *synced* repo must embed the sync
     /// endpoint as a `&remote=` query parameter, so a recipient on another
     /// device knows where to pull the shared content from. (A local-only
-    /// repo correctly omits it — covered by the join test above, whose repo
-    /// has no upstream.)
+    /// repo has nothing to embed — it refuses to mint at all, covered by
+    /// `repository::tests::it_refuses_to_mint_without_a_remote` and
+    /// `create_invite::tests::it_refuses_a_repository_with_no_upstream`.)
     #[dialog_common::test]
     async fn it_embeds_the_remote_in_a_command_minted_invite() {
-        use super::repository::{
-            BranchConfiguration, RemoteConfiguration, RepositoryConfiguration,
-        };
-        use dialog_remote_ucan_s3::UcanAddress;
-        use dialog_repository::SiteAddress;
-
         let state = test_state().await;
         let (app, _state, _lsp) = super::api_router_with_state(state);
 
@@ -1145,32 +1184,7 @@ pub mod tests {
         // route (the same path the topbar "Enable sync" form drives).
         let (repo, subject) = put_repo_info(&app, "invite-remote").await;
         let endpoint = "https://sync.example.test/ucan/";
-        let config = RepositoryConfiguration::default()
-            .remote(
-                "origin",
-                RemoteConfiguration::new(SiteAddress::from(UcanAddress::new(endpoint))),
-            )
-            .branch(
-                "main",
-                BranchConfiguration::default().upstream("origin", "main"),
-            );
-        let attach = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri(format!("/api/repository/{repo}/remote"))
-                    .method("POST")
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_vec(&config).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            attach.status(),
-            StatusCode::OK,
-            "remote attach should succeed"
-        );
+        attach_remote(&app, &repo, endpoint).await;
 
         // Mint the invite through the command. `mint_invite_via_command`
         // creates its *own* fresh repo, so mint against THIS repo directly:

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -800,7 +800,7 @@ pub mod tests {
 
     /// PUT a fresh repo and return both its routing key and subject DID.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    async fn put_repo_info(app: &Router, label: &str) -> (String, String) {
+    pub(crate) async fn put_repo_info(app: &Router, label: &str) -> (String, String) {
         let response = app
             .clone()
             .oneshot(

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -747,9 +747,12 @@ pub mod tests {
         let (app, _lsp) = api_router(state);
         let repo = "test-invite-route";
 
-        // Create the repo first so the invite handler can load it.
+        // Create the repo first so the invite handler can load it. The
+        // route refuses a local-only repo, so give it a remote too —
+        // this test is only proving the route is reachable.
         let key = put_repo(&app, repo).await;
         let repo = key.as_str();
+        attach_remote(&app, repo, "https://sync.example.test/ucan/").await;
 
         let response = app
             .oneshot(
@@ -824,7 +827,7 @@ pub mod tests {
     /// repo whose `main` has no upstream (see
     /// `repository::tests::it_refuses_to_mint_without_a_remote`).
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    async fn attach_remote(app: &Router, repo: &str, endpoint: &str) {
+    pub(crate) async fn attach_remote(app: &Router, repo: &str, endpoint: &str) {
         use super::repository::{
             BranchConfiguration, RemoteConfiguration, RepositoryConfiguration,
         };

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -111,9 +111,17 @@ impl CommandEnv {
 /// (`space/remove`): replica retraction, reactor eviction, storage
 /// cleanup.
 ///
+/// [`EnableSyncHandler`] is deliberately its own command
+/// ([`tonk_schema::command::EnableSync`]), not a second handler on
+/// `space/enable-sync`: that trigger attribute belongs to `CreateSpace`, and
+/// `CreateSpaceHandler` always mints a fresh identity first, so anything
+/// registered against it would attach the remote to a brand-new spot rather
+/// than the existing one the FAB names.
+///
 /// [`CreateSpaceHandler`]: super::repository::CreateSpaceHandler
 /// [`RemoveSpaceHandler`]: super::repository::RemoveSpaceHandler
 /// [`RenameRepositoryHandler`]: super::repository::RenameRepositoryHandler
+/// [`EnableSyncHandler`]: super::repository::EnableSyncHandler
 pub fn command_registry() -> CommandRegistry<CommandEnv> {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
@@ -121,6 +129,7 @@ pub fn command_registry() -> CommandRegistry<CommandEnv> {
         registry.register(Box::new(super::repository::CreateSpaceHandler::new()));
         registry.register(Box::new(super::repository::RemoveSpaceHandler::new()));
         registry.register(Box::new(super::repository::InviteHandler::new()));
+        registry.register(Box::new(super::repository::EnableSyncHandler::new()));
         registry.register(Box::new(super::repository::PauseSyncHandler::new()));
         registry.register(Box::new(super::repository::ProfileRenameHandler::new()));
         registry.register(Box::new(super::repository::RenameRepositoryHandler::new()));

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -179,11 +179,17 @@ pub async fn create_invite(
         .map_err(|e| TonkWorkerError::Internal(format!("failed to create delegation: {e}")))?;
 
     let remote_url = match resolve_remote_url(&tonk, &repository).await? {
-        RemoteRequirement::Ready(url) => Some(url),
-        RemoteRequirement::Refused(_) => None,
+        RemoteRequirement::Ready(url) => url,
+        RemoteRequirement::Refused(reason) => {
+            return Err(TonkWorkerError::Conflict(format!(
+                "cannot mint an invite for '{repo_name}': {} ({})",
+                reason.detail(),
+                reason.code()
+            )));
+        }
     };
 
-    let invite = Invite::new(delegation.into_chain(), audience, remote_url)
+    let invite = Invite::new(delegation.into_chain(), audience, Some(remote_url))
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("failed to assemble invite: {e}")))?;
 
@@ -462,7 +468,7 @@ mod tests {
     use tonk_schema::Invitation;
     use tonk_schema::prelude::DidExt as _;
 
-    use crate::router::tests::{content_invitations, put_repo, test_state};
+    use crate::router::tests::{attach_remote, content_invitations, put_repo, test_state};
     use crate::router::{CreateInviteResponse, api_router_with_state};
 
     /// Minting an invite records an `Invitation` on the repo's content
@@ -472,8 +478,10 @@ mod tests {
     async fn it_records_the_invitation_on_mint() {
         let (app, state, _lsp) = api_router_with_state(test_state().await);
 
-        // Create the repo; address it by the minted routing key.
+        // Create the repo; address it by the minted routing key. The
+        // route now refuses a local-only repo, so give it a remote first.
         let key = put_repo(&app, "test-mint-invitation").await;
+        attach_remote(&app, &key, "https://sync.example.test/ucan/").await;
 
         // Mint an open invite.
         let response = app
@@ -553,5 +561,27 @@ mod tests {
             RemoteRefusal::UnshareableRemote.detail(),
             "This spot's sync server can't be shared."
         );
+    }
+
+    /// The HTTP mint route refuses a local-only repository rather than
+    /// answering with an invite that can never sync.
+    #[dialog_common::test]
+    async fn it_rejects_a_mint_for_a_local_only_repository() {
+        let (app, _state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "test-http-local-only").await;
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/repository/{key}/invite"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 }

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -178,7 +178,10 @@ pub async fn create_invite(
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("failed to create delegation: {e}")))?;
 
-    let remote_url = resolve_remote_url(&tonk, &repository).await?;
+    let remote_url = match resolve_remote_url(&tonk, &repository).await? {
+        RemoteRequirement::Ready(url) => Some(url),
+        RemoteRequirement::Refused(_) => None,
+    };
 
     let invite = Invite::new(delegation.into_chain(), audience, remote_url)
         .await
@@ -326,25 +329,66 @@ async fn put_shortcut(endpoint: &str, target: String) -> Result<String, TonkWork
         .map_err(|e| TonkWorkerError::Internal(format!("shortcut response: {e}")))
 }
 
+/// Why a spot cannot produce a shareable invite.
+///
+/// Both variants mean the same thing to the recipient — an invite that can
+/// never sync, so they land in a spot that stays permanently empty — but
+/// only [`Self::NotSynced`] is repairable by attaching a remote, so only it
+/// offers the prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteRefusal {
+    /// `main` has no upstream at all. Repairable.
+    NotSynced,
+    /// `main` tracks something that is not a remote, or a remote whose site
+    /// address is not a UCAN endpoint. An invite URL has no way to express
+    /// either, so there is nothing to offer.
+    UnshareableRemote,
+}
+
+impl RemoteRefusal {
+    /// The stable class string carried on `xyz.tonk.share/blocked`.
+    pub(crate) fn code(self) -> &'static str {
+        match self {
+            Self::NotSynced => "not-synced",
+            Self::UnshareableRemote => "unshareable-remote",
+        }
+    }
+
+    /// The sentence shown to the user.
+    pub(crate) fn detail(self) -> &'static str {
+        match self {
+            Self::NotSynced => "This spot only exists on this device.",
+            Self::UnshareableRemote => "This spot's sync server can't be shared.",
+        }
+    }
+}
+
+/// The outcome of probing a repository for a shareable sync endpoint.
+#[derive(Debug, Clone)]
+pub(crate) enum RemoteRequirement {
+    /// A UCAN endpoint an invite can advertise.
+    Ready(Url),
+    /// No such endpoint. See [`RemoteRefusal`].
+    Refused(RemoteRefusal),
+}
+
 /// Probe `main`'s upstream and, when it points at a remote, pull the
 /// UCAN access-service URL off the remote's site address.
 ///
-/// - `Ok(None)` — legitimate "this repo has no remote to advertise"
-///   (branch has no upstream, non-remote upstream, or non-UCAN site).
-///   The claim side tolerates invites without a remote.
+/// - `Ok(Ready(url))` — the endpoint an invite advertises as `&remote=`.
+/// - `Ok(Refused(reason))` — no such endpoint. Callers refuse to mint:
+///   an invite with no remote lands its recipient in a spot that can never
+///   fill, so it has no use, and returning one silently would mask exactly
+///   the config drift the inviter cannot see.
 /// - `Err(...)` — branch/remote load failed or the stored UCAN endpoint
-///   won't parse. Failing the whole mint is the right move: silently
-///   demoting to local-only would mask config drift the inviter can't
-///   see (redeemers would hit a downstream sync error with no link to
-///   the root cause).
+///   won't parse. Failing loudly is right for the same reason.
 ///
-/// `main` is hardcoded; see `project_main_branch_implicit_creation`
-/// memory note on why `.open()` is used here despite not being
-/// strictly read-only.
+/// `main` is hardcoded; see `project_main_branch_implicit_creation` memory
+/// note on why `.open()` is used here despite not being strictly read-only.
 pub(crate) async fn resolve_remote_url<R>(
     tonk: &crate::worker::TonkState,
     repository: &dialog_repository::Repository<R>,
-) -> Result<Option<Url>, TonkWorkerError>
+) -> Result<RemoteRequirement, TonkWorkerError>
 where
     R: Principal + Clone,
 {
@@ -357,7 +401,7 @@ where
 pub(crate) async fn resolve_remote_url_with<R>(
     repository: &dialog_repository::Repository<R>,
     operator: &crate::worker::DefaultOperator,
-) -> Result<Option<Url>, TonkWorkerError>
+) -> Result<RemoteRequirement, TonkWorkerError>
 where
     R: Principal + Clone,
 {
@@ -374,7 +418,10 @@ where
 
     let remote_name = match main.upstream() {
         Some(Upstream::Remote { remote, .. }) => remote,
-        Some(_) | None => return Ok(None),
+        None => return Ok(RemoteRequirement::Refused(RemoteRefusal::NotSynced)),
+        Some(_) => {
+            return Ok(RemoteRequirement::Refused(RemoteRefusal::UnshareableRemote));
+        }
     };
 
     let remote = repository
@@ -389,13 +436,15 @@ where
         })?;
 
     match remote.address().site() {
-        SiteAddress::Ucan(ucan) => Url::parse(ucan.endpoint()).map(Some).map_err(|e| {
-            TonkWorkerError::Internal(format!(
-                "remote '{remote_name}' has unparseable UCAN endpoint '{}': {e}",
-                ucan.endpoint()
-            ))
-        }),
-        _ => Ok(None),
+        SiteAddress::Ucan(ucan) => Url::parse(ucan.endpoint())
+            .map(RemoteRequirement::Ready)
+            .map_err(|e| {
+                TonkWorkerError::Internal(format!(
+                    "remote '{remote_name}' has unparseable UCAN endpoint '{}': {e}",
+                    ucan.endpoint()
+                ))
+            }),
+        _ => Ok(RemoteRequirement::Refused(RemoteRefusal::UnshareableRemote)),
     }
 }
 
@@ -406,6 +455,7 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use dialog_repository::RepositoryExt as _;
     use tower::ServiceExt;
 
     use tonk_invite::Invite;
@@ -457,5 +507,51 @@ mod tests {
             guard.profile.did().this()
         };
         assert_eq!(invitations[0].inviter.0, profile_entity);
+    }
+
+    /// A spot created without a remote refuses, and says which case it was.
+    #[dialog_common::test]
+    async fn it_refuses_a_repository_with_no_upstream() {
+        use crate::router::create_invite::{RemoteRefusal, RemoteRequirement, resolve_remote_url};
+
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "test-no-upstream").await;
+
+        let tonk = state.read().await;
+        let repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .expect("repository loads");
+
+        let requirement = resolve_remote_url(&tonk, &repository)
+            .await
+            .expect("probe succeeds");
+
+        assert!(matches!(
+            requirement,
+            RemoteRequirement::Refused(RemoteRefusal::NotSynced)
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_names_the_refusal_classes() {
+        use crate::router::create_invite::RemoteRefusal;
+
+        assert_eq!(RemoteRefusal::NotSynced.code(), "not-synced");
+        assert_eq!(
+            RemoteRefusal::UnshareableRemote.code(),
+            "unshareable-remote"
+        );
+        assert_eq!(
+            RemoteRefusal::NotSynced.detail(),
+            "This spot only exists on this device."
+        );
+        assert_eq!(
+            RemoteRefusal::UnshareableRemote.detail(),
+            "This spot's sync server can't be shared."
+        );
     }
 }

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -755,8 +755,8 @@ mod tests {
     use crate::router::api_router_with_state;
     use crate::router::repository::build_repository_info;
     use crate::router::tests::{
-        content_invitations, content_invited_via, content_member_roles, content_memberships,
-        put_repo, test_state,
+        attach_remote, content_invitations, content_invited_via, content_member_roles,
+        content_memberships, put_repo, test_state,
     };
 
     /// Hand-craft an audience-open invite URL for a synthetic
@@ -984,7 +984,9 @@ mod tests {
         let (app, state, _lsp) = api_router_with_state(test_state().await);
 
         // Create own repo (addressed by its routing key), mint own invite.
+        // The mint route refuses a local-only repo, so attach a remote first.
         let key = put_repo(&app, "test-self-claim").await;
+        attach_remote(&app, &key, "https://sync.example.test/ucan/").await;
         let minted_resp = app
             .clone()
             .oneshot(

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -4573,6 +4573,35 @@ mod tests {
             1,
             "blank scaffold resolves the blank model to the repo subject",
         );
+        assert_eq!(
+            count(&state, repo, "share/blocked:\n").await,
+            0,
+            "local-only fallback model is seeded before a refusal exists",
+        );
+    }
+
+    /// Both empty-state canvases keep the pending label only while the invite
+    /// request is unanswered. A refusal resolves the nested model and renders
+    /// the explicit local-only notice instead of spinning forever.
+    #[dialog_common::test]
+    fn it_routes_refused_agent_links_to_the_local_only_notice() {
+        for document in [CORE, SHEETS] {
+            assert!(
+                document.contains("slot=\"no-entity\"")
+                    && document.contains("model=tonk:share/blocked"),
+                "agent-link fallback should query the share refusal",
+            );
+            assert!(
+                !document.contains("agent link &middot; paste into your agent"),
+                "the rendered state should provide its own single label",
+            );
+            assert!(
+                document.contains("tonk-display > [slot][hidden]"),
+                "inactive pending and refusal slots should not survive a ready result",
+            );
+        }
+        assert!(CORE.contains("local spot &middot; no sync remote"));
+        assert!(CORE.contains("Use Share to turn on sync and create an agent link."));
     }
 
     /// A `RepositoryConfiguration` that attaches an `origin` remote at

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -296,22 +296,22 @@ fn remote_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
 }
 
 /// The `tonk:enable-sync` transient's target spot, read from the raw facts.
-#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ENABLE_SYNC_SPACE_ATTR: &str = "xyz.tonk.enable-sync/space";
 
 /// The `tonk:enable-sync` transient's endpoint, read from the raw facts.
-#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ENABLE_SYNC_REMOTE_ATTR: &str = "xyz.tonk.enable-sync/remote";
 
 /// Marker asking the handler to mint once the remote is attached.
-#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ENABLE_SYNC_SHARE_ATTR: &str = "xyz.tonk.enable-sync/share";
 
 /// Read a fact's value as a string, tolerating both the `String` and
 /// `Entity` representations — a URL or a DID round-trips through JSON as an
 /// `Entity` (any `:`-bearing string does), so a single-representation read
 /// would silently miss them. Mirrors [`remote_from_facts`].
-#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn text_fact(facts: &crate::reactor::EntityFacts, attribute: &str) -> Option<String> {
     use dialog_artifacts::Value;
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -295,6 +295,38 @@ fn remote_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
         .filter(|url| !url.is_empty())
 }
 
+/// The `tonk:enable-sync` transient's target spot, read from the raw facts.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_SPACE_ATTR: &str = "xyz.tonk.enable-sync/space";
+
+/// The `tonk:enable-sync` transient's endpoint, read from the raw facts.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_REMOTE_ATTR: &str = "xyz.tonk.enable-sync/remote";
+
+/// Marker asking the handler to mint once the remote is attached.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const ENABLE_SYNC_SHARE_ATTR: &str = "xyz.tonk.enable-sync/share";
+
+/// Read a fact's value as a string, tolerating both the `String` and
+/// `Entity` representations — a URL or a DID round-trips through JSON as an
+/// `Entity` (any `:`-bearing string does), so a single-representation read
+/// would silently miss them. Mirrors [`remote_from_facts`].
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn text_fact(facts: &crate::reactor::EntityFacts, attribute: &str) -> Option<String> {
+    use dialog_artifacts::Value;
+
+    facts
+        .iter()
+        .find(|artifact| artifact.the.to_string() == attribute)
+        .and_then(|artifact| match &artifact.is {
+            Value::String(text) => Some(text.clone()),
+            Value::Entity(entity) => Some(entity.to_string()),
+            _ => None,
+        })
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
 /// The create form's template field — which library template the repo
 /// should seed. Read directly from the facts (like the remote), so the
 /// command keeps decoding against an older profile descriptor that lacks
@@ -705,6 +737,107 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
     }
 }
 
+/// Attach a sync remote to an existing spot, then mint an invite when the
+/// transient asks for one.
+///
+/// The share control dispatches this when a user accepts the offer to turn
+/// sync on after a refused share. Minting from inside the handler is what
+/// makes that a single click: the control needs no completion signal for the
+/// attach, because success reaches it as a new invite link on the
+/// subscription it already holds — the same path an ordinary mint takes.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct EnableSyncHandler {
+    attributes: Vec<String>,
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl EnableSyncHandler {
+    pub(crate) fn new() -> Self {
+        use crate::reactor::Decode as _;
+        Self {
+            attributes: tonk_schema::command::EnableSync::trigger_attributes(),
+        }
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl crate::reactor::CommandHandler<crate::router::CommandEnv> for EnableSyncHandler {
+    fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
+        use crate::reactor::Decode as _;
+        facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|this| tonk_schema::command::EnableSync::decode(this, facts))
+            .is_some()
+    }
+
+    fn run(
+        &self,
+        facts: &crate::reactor::EntityFacts,
+        env: &crate::router::CommandEnv,
+    ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
+        use tonk_schema::prelude::DidExt as _;
+
+        let time = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::EnableSync::decode(entity, facts))
+            .map(|command| command.time.0)
+            .unwrap_or_default();
+        let space = text_fact(facts, ENABLE_SYNC_SPACE_ATTR);
+        let remote = text_fact(facts, ENABLE_SYNC_REMOTE_ATTR);
+        let share = text_fact(facts, ENABLE_SYNC_SHARE_ATTR).is_some();
+        let env = env.clone();
+
+        Box::pin(async move {
+            use dialog_artifacts::Entity;
+
+            let (Some(space), Some(remote)) = (space, remote) else {
+                log!("EnableSync: missing space or remote, skipping");
+                return;
+            };
+            let Ok(did) = space.parse::<dialog_varsig::Did>() else {
+                log!("EnableSync: '{}' is not a DID", space);
+                return;
+            };
+            let key = did.repo_key().to_owned();
+            log!("command EnableSync repo={} share={}", key, share);
+
+            if let Err(error) = enable_sync_inner(env.state(), &key, &remote).await {
+                log!("EnableSync '{}' failed: {}", key, error);
+                if share {
+                    let subject = match space.parse::<Entity>() {
+                        Ok(entity) => entity,
+                        Err(e) => {
+                            log!("EnableSync: '{}' is not an entity: {}", space, e);
+                            return;
+                        }
+                    };
+                    publish_share_blocked(
+                        env.state(),
+                        &key,
+                        subject,
+                        "attach-failed",
+                        &format!("Could not turn on sync: {error}"),
+                        time,
+                    )
+                    .await;
+                }
+                return;
+            }
+
+            if share && let Err(error) = run_invite(&env, &key, time).await {
+                log!("EnableSync '{}': mint after attach failed: {}", key, error);
+            }
+        })
+    }
+}
+
 /// Generate a membership keypair, delegate `repo_name`'s access to it,
 /// assert the public [`Authorization`] on the content branch, and assert
 /// the private seed as a [`Credential`] into the reactor's session
@@ -872,17 +1005,17 @@ async fn run_invite(
             TonkWorkerError::Internal(format!("failed to commit authorization fact: {e}"))
         })?;
 
-    // Record the invitation on the repo's meta branch — the durable roster
-    // half of the invite (the URL with its secret fragment is never stored).
-    // Mirrors the HTTP `create_invite` route so both mint paths leave the
-    // same roster fact for the claim side to match against.
-    let meta = repository
-        .branch(META_BRANCH)
-        .open()
-        .perform(&tonk.operator)
-        .await
-        .map_err(|e| TonkWorkerError::Internal(format!("failed to open meta branch: {e}")))?;
-    meta.transaction()
+    // Record the invitation on the repo's content branch — the durable
+    // roster half of the invite (the URL with its secret fragment is never
+    // stored). Mirrors the HTTP `create_invite` route so both mint paths
+    // leave the same roster fact for the claim side to match against, and
+    // routes through the *reactor's* cached handle for the same reason the
+    // `Authorization` commit above does: a commit on a separately-opened
+    // handle would leave the cached one pinned at a stale head.
+    tonk.reactor
+        .repository(repo_name)
+        .branch(CONTENT_BRANCH)
+        .transaction()
         .assert(invitation)
         .commit()
         .perform(&tonk.operator)
@@ -3985,9 +4118,10 @@ mod tests {
 
     use super::{
         BranchConfiguration, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,
+        existing_space_labels,
     };
     use crate::router::evaluate::evaluate_body;
-    use crate::router::tests::{content_invitations, put_repo};
+    use crate::router::tests::{content_invitations, put_repo, put_repo_info};
     use crate::router::{AppState, CreateInviteResponse, api_router_with_state, tests::test_state};
 
     /// The scaffold notation, embedded at compile time.
@@ -4883,6 +5017,125 @@ mod tests {
         rows.into_iter()
             .map(|row| (row.blocked.0, row.detail.0, row.time.0))
             .collect()
+    }
+
+    /// Attaching a remote through the command targets the EXISTING spot. The
+    /// `space/enable-sync` command in `core.yaml` shares `CreateSpace`'s trigger
+    /// attribute and so mints a new spot instead; this guards against that.
+    #[dialog_common::test]
+    async fn it_attaches_the_remote_to_the_existing_spot() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (key, subject) = put_repo_info(&app, "test-enable-sync").await;
+        let before = existing_space_labels(&state).await.len();
+
+        dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
+
+        assert_eq!(
+            existing_space_labels(&state).await.len(),
+            before,
+            "no new spot was created"
+        );
+        assert!(
+            has_remote_upstream(&state, &key).await,
+            "the existing spot now tracks origin/main"
+        );
+    }
+
+    /// Without the `share` marker the handler attaches and stops.
+    #[dialog_common::test]
+    async fn it_mints_only_when_asked_to_share() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (key, subject) = put_repo_info(&app, "test-enable-sync-no-share").await;
+
+        dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
+
+        assert!(
+            content_invitations(&state, &key).await.is_empty(),
+            "attach-only records no invitation"
+        );
+    }
+
+    /// With the marker, the attach is followed by a mint — the single-click path.
+    #[dialog_common::test]
+    async fn it_mints_after_attaching_when_asked_to_share() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (key, subject) = put_repo_info(&app, "test-enable-sync-share").await;
+
+        dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", true, 1.0).await;
+
+        assert_eq!(
+            content_invitations(&state, &key).await.len(),
+            1,
+            "the attach is followed by exactly one mint"
+        );
+    }
+
+    /// Build the `tonk:enable-sync` transient the FAB dispatches and run it
+    /// through `dispatch`, the way `/transact` does after a commit. Going through
+    /// `dispatch` (not the handler directly) means this also covers registration
+    /// and trigger matching.
+    async fn dispatch_enable_sync(
+        state: &AppState,
+        subject: &str,
+        remote: &str,
+        share: bool,
+        time: f64,
+    ) {
+        use dialog_artifacts::{Changes, Statement};
+        use dialog_query::{Entity, the};
+
+        let of: Entity = "tonk:enable-sync-test".parse().expect("entity URI");
+        let mut changes = Changes::new();
+        the!("dom.event/time-stamp")
+            .of(of.clone())
+            .is(time)
+            .assert(&mut changes);
+        the!("dom.event.current-target.dataset/enable-sync")
+            .of(of.clone())
+            .is("tonk:enable-sync".parse::<Entity>().expect("marker entity"))
+            .assert(&mut changes);
+        the!("xyz.tonk.enable-sync/space")
+            .of(of.clone())
+            .is(subject.parse::<Entity>().expect("subject entity"))
+            .assert(&mut changes);
+        the!("xyz.tonk.enable-sync/remote")
+            .of(of.clone())
+            .is(remote.to_string())
+            .assert(&mut changes);
+        if share {
+            the!("xyz.tonk.enable-sync/share")
+                .of(of)
+                .is("tonk:share".parse::<Entity>().expect("share entity"))
+                .assert(&mut changes);
+        }
+
+        crate::router::dispatch(state, crate::router::CommandOrigin::default(), changes).await;
+    }
+
+    /// Whether the repo's `main` tracks a remote upstream — the exact condition
+    /// `resolve_remote_url_with` probes.
+    async fn has_remote_upstream(state: &AppState, repo: &str) -> bool {
+        use dialog_repository::{RepositoryExt as _, Upstream};
+
+        let tonk = state.read().await;
+        let Ok(repository) = tonk
+            .profile
+            .repository(repo)
+            .load()
+            .perform(&tonk.operator)
+            .await
+        else {
+            return false;
+        };
+        let Ok(main) = repository
+            .branch("main")
+            .open()
+            .perform(&tonk.operator)
+            .await
+        else {
+            return false;
+        };
+        matches!(main.upstream(), Some(Upstream::Remote { .. }))
     }
 
     /// Build a one-entity transient `RemoveSpace{this, subject}` batch —

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -776,12 +776,12 @@ async fn run_invite(
     // can't conditionally include a parameter, and `Invite::parse_url`
     // rejects an empty `remote=`, so "no remote" must append *nothing*.
     let remote = match super::create_invite::resolve_remote_url(&tonk, &repository).await? {
-        Some(url) => {
+        super::create_invite::RemoteRequirement::Ready(url) => {
             let encoded: String =
                 url::form_urlencoded::byte_serialize(url.as_str().as_bytes()).collect();
             format!("&remote={encoded}")
         }
-        None => String::new(),
+        super::create_invite::RemoteRequirement::Refused(_) => String::new(),
     };
 
     // Assemble the invite URL the recipient opens. Built here rather than

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -664,6 +664,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
+        use crate::reactor::Decode as _;
         use tonk_schema::prelude::DidExt as _;
 
         // Read the target space off the facts opportunistically (NOT a
@@ -678,6 +679,16 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
             .and_then(|space| space.parse::<dialog_varsig::Did>().ok())
             .map(|did| did.repo_key().to_owned())
             .unwrap_or_else(|| env.origin().repo.clone());
+
+        // The triggering click's timestamp, echoed onto a refusal so a
+        // later resubscribe can tell this refusal from a replay of an
+        // older one — see `publish_share_blocked`.
+        let time = facts
+            .first()
+            .map(|artifact| artifact.of.clone())
+            .and_then(|entity| tonk_schema::command::Invite::decode(entity, facts))
+            .map(|command| command.time.0)
+            .unwrap_or_default();
         let env = env.clone();
 
         Box::pin(async move {
@@ -687,7 +698,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
             }
             log!("command Invite repo={}", repo_name);
 
-            if let Err(error) = run_invite(&env, &repo_name).await {
+            if let Err(error) = run_invite(&env, &repo_name, time).await {
                 log!("Invite for repo '{}' failed: {}", repo_name, error);
             }
         })
@@ -699,12 +710,17 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
 /// the private seed as a [`Credential`] into the reactor's session
 /// overlay (so it stays out of replicated storage).
 ///
+/// `time` is the triggering `tonk:invite` transient's timestamp — unused
+/// on the mint path, but threaded through so a refusal (see
+/// [`publish_share_blocked`]) can echo the click it answers.
+///
 /// Split out from [`InviteHandler::run`] so the `?` early-return funnels
 /// into the single `log!` there — the command future itself returns `()`.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn run_invite(
     env: &crate::router::CommandEnv,
     repo_name: &str,
+    time: f64,
 ) -> Result<(), TonkWorkerError> {
     use dialog_artifacts::Entity;
     use dialog_varsig::Principal as _;
@@ -712,13 +728,6 @@ async fn run_invite(
     use tonk_schema::command::{Authorization, Credential};
     use tonk_schema::domain::authorization::{Proof, Remote as AuthorizationRemote};
     use tonk_schema::domain::credential::{Link, Seed};
-
-    // Mint a fresh membership keypair. Its private seed becomes the
-    // invite URL's `#` fragment; its public DID is the audience the repo
-    // access is delegated to. The browser never sees this DID.
-    let (signer, seed_bytes) = super::create_invite::generate_ephemeral().await?;
-    let membership_did = signer.did();
-    let seed = bs58::encode(seed_bytes).into_string();
 
     let tonk = env.state().read().await;
 
@@ -734,8 +743,7 @@ async fn run_invite(
 
     // Both facts are keyed by the repository's *subject* DID — the entity
     // the share view already addresses (`entity={subject}`) — not the
-    // membership DID. So the membership DID is only the delegation
-    // audience; the subject is the join key for authorization + credential.
+    // membership DID.
     let subject_entity = repository
         .did()
         .to_string()
@@ -743,6 +751,41 @@ async fn run_invite(
         .map_err(|e| {
             TonkWorkerError::Internal(format!("repository subject is not a valid entity: {e}"))
         })?;
+
+    // Resolve the sync endpoint BEFORE minting anything. An invite with no
+    // remote lands its recipient in a spot that can never fill, so there is
+    // nothing worth generating key material for. Refusing here also means a
+    // refusal costs no delegation and rotates no credential.
+    let remote_url = match super::create_invite::resolve_remote_url(&tonk, &repository).await? {
+        super::create_invite::RemoteRequirement::Ready(url) => url,
+        super::create_invite::RemoteRequirement::Refused(reason) => {
+            log!("Invite for repo '{}' refused: {}", repo_name, reason.code());
+            drop(tonk);
+            publish_share_blocked(
+                env.state(),
+                repo_name,
+                subject_entity,
+                reason.code(),
+                reason.detail(),
+                time,
+            )
+            .await;
+            return Ok(());
+        }
+    };
+
+    // A ready-to-append URL query suffix (`&remote=<percent-encoded-url>`).
+    // The share view appends it verbatim between `?access=…` and the `#seed`.
+    let encoded: String =
+        url::form_urlencoded::byte_serialize(remote_url.as_str().as_bytes()).collect();
+    let remote = format!("&remote={encoded}");
+
+    // Mint a fresh membership keypair. Its private seed becomes the invite
+    // URL's `#` fragment; its public DID is the audience the repo access is
+    // delegated to. The browser never sees this DID.
+    let (signer, seed_bytes) = super::create_invite::generate_ephemeral().await?;
+    let membership_did = signer.did();
+    let seed = bs58::encode(seed_bytes).into_string();
 
     let delegation: dialog_ucan::UcanDelegation = tonk
         .profile
@@ -767,22 +810,6 @@ async fn run_invite(
         TonkWorkerError::Internal(format!("failed to serialize delegation chain: {e}"))
     })?;
     let proof = bs58::encode(&chain_bytes).into_string();
-
-    // Optional sync remote endpoint, stored as a ready-to-append URL query
-    // suffix (`&remote=<percent-encoded-url>`) — or empty when the repo is
-    // local-only. The share view appends it verbatim between `?access=…`
-    // and the `#seed`, so a recipient on another device knows where to
-    // pull from. It is a suffix (not a bare URL) because the view template
-    // can't conditionally include a parameter, and `Invite::parse_url`
-    // rejects an empty `remote=`, so "no remote" must append *nothing*.
-    let remote = match super::create_invite::resolve_remote_url(&tonk, &repository).await? {
-        super::create_invite::RemoteRequirement::Ready(url) => {
-            let encoded: String =
-                url::form_urlencoded::byte_serialize(url.as_str().as_bytes()).collect();
-            format!("&remote={encoded}")
-        }
-        super::create_invite::RemoteRequirement::Refused(_) => String::new(),
-    };
 
     // Assemble the invite URL the recipient opens. Built here rather than
     // concatenated in the view template so there is exactly one definition
@@ -864,6 +891,51 @@ async fn run_invite(
 
     log!("Minted invitation for repo '{}'", repo_name);
     Ok(())
+}
+
+/// Record why a share click could not mint, on the spot's content-branch
+/// session overlay, keyed by the subject.
+///
+/// Overlay-only, exactly like the `Credential` a successful mint writes: a
+/// refusal is this device's answer to this click, not a property of the spot,
+/// and it must never replicate. The write schedules a poll, so the dispatcher's
+/// drain fans it out to the share control's subscription in the same pass as a
+/// successful mint would have been.
+///
+/// `time` echoes the refused command's timestamp. The fact is cardinality-one
+/// on the subject, so it lingers and replays on every resubscribe; the echo is
+/// what lets the control tell this refusal from a replay of an older one, which
+/// is why the fact never needs retracting.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn publish_share_blocked(
+    state: &AppState,
+    repo_name: &str,
+    subject: dialog_artifacts::Entity,
+    code: &str,
+    detail: &str,
+    time: f64,
+) {
+    use tonk_schema::command::ShareBlocked;
+    use tonk_schema::domain::share;
+
+    let tonk = state.read().await;
+    if let Err(error) = tonk
+        .reactor
+        .repository(repo_name)
+        .branch(CONTENT_BRANCH)
+        .overlay()
+        .assert(ShareBlocked {
+            this: subject,
+            blocked: share::Blocked(code.to_owned()),
+            detail: share::Detail(detail.to_owned()),
+            time: share::Time(time),
+        })
+        .write()
+        .perform(&tonk.operator)
+        .await
+    {
+        log!("failed to publish share refusal for '{repo_name}': {error}");
+    }
 }
 
 /// Assemble the invite URL a recipient opens, shortened when the
@@ -3913,6 +3985,7 @@ mod tests {
         BranchConfiguration, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,
     };
     use crate::router::evaluate::evaluate_body;
+    use crate::router::tests::{content_invitations, put_repo};
     use crate::router::{AppState, CreateInviteResponse, api_router_with_state, tests::test_state};
 
     /// The scaffold notation, embedded at compile time.
@@ -4661,7 +4734,39 @@ mod tests {
     async fn it_restamps_state_self_after_invite_clears_the_overlay() {
         use dialog_query::{Output as _, Query, Term};
 
-        let (_app, state, key) = fresh_repo("test-invite-restamps-self").await;
+        let (app, state, key) = fresh_repo("test-invite-restamps-self").await;
+
+        // Attach a remote first — `run_invite` refuses to mint (and never
+        // reaches the credential overlay write this test exercises) against
+        // a repo whose `main` has no upstream.
+        let config = RepositoryConfiguration::default()
+            .remote(
+                "origin",
+                RemoteConfiguration::new(SiteAddress::from(UcanAddress::new(
+                    "https://sync.example.test/ucan/",
+                ))),
+            )
+            .branch(
+                "main",
+                BranchConfiguration::default().upstream("origin", "main"),
+            );
+        let attach = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{key}/remote"))
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&config).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            attach.status(),
+            StatusCode::OK,
+            "remote attach should succeed"
+        );
 
         // Prime state:self so we have something to lose.
         {
@@ -4714,6 +4819,68 @@ mod tests {
             1,
             "state:self must be re-stamped after invite clears the overlay",
         );
+    }
+
+    /// A share click on a spot with no upstream mints nothing and leaves a
+    /// refusal on the overlay instead.
+    #[dialog_common::test]
+    async fn it_refuses_to_mint_without_a_remote() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "test-refuse-mint").await;
+
+        run_invite_with_time(&state, &key, 1234.0).await;
+
+        let blocked = share_blocked_rows(&state, &key).await;
+        assert_eq!(blocked.len(), 1, "one refusal recorded");
+        assert_eq!(blocked[0].0, "not-synced");
+        assert_eq!(blocked[0].1, "This spot only exists on this device.");
+        assert_eq!(blocked[0].2, 1234.0, "echoes the command's timestamp");
+
+        let invitations = content_invitations(&state, &key).await;
+        assert!(
+            invitations.is_empty(),
+            "a refused mint records no invitation"
+        );
+    }
+
+    /// Drive `run_invite` with a fixed timestamp, the way a `tonk:invite`
+    /// transient would.
+    async fn run_invite_with_time(state: &AppState, repo: &str, time: f64) {
+        let env =
+            crate::router::CommandEnv::new(state.clone(), crate::router::CommandOrigin::default());
+        let _ = super::run_invite(&env, repo, time).await;
+    }
+
+    /// Read back every `ShareBlocked` row on the repo's content branch overlay
+    /// as `(blocked, detail, time)`.
+    async fn share_blocked_rows(state: &AppState, repo: &str) -> Vec<(String, String, f64)> {
+        use dialog_query::{Output as _, Term};
+        use tonk_schema::command::ShareBlocked;
+
+        let tonk = state.read().await;
+        let branch = tonk
+            .reactor
+            .repository(repo)
+            .branch(super::CONTENT_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .expect("content branch opens");
+        let rows: Vec<ShareBlocked> = branch
+            .handle()
+            .query()
+            .select(dialog_query::Query::<ShareBlocked> {
+                this: Term::var("this"),
+                blocked: Term::var("blocked"),
+                detail: Term::var("detail"),
+                time: Term::var("time"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .expect("share-blocked query");
+        rows.into_iter()
+            .map(|row| (row.blocked.0, row.detail.0, row.time.0))
+            .collect()
     }
 
     /// Build a one-entity transient `RemoveSpace{this, subject}` batch —

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1127,10 +1127,11 @@ fn worker_origin() -> Option<String> {
 /// against either), so it falls back to the same base the HTTP mint path
 /// defaults to — still a well-formed, redeemable invite.
 ///
-/// `remote` is already a ready-to-append `&remote=…` suffix, empty for a
-/// local-only repo. The seed is the fragment and never the query: it must
-/// not reach a server, and the shortcut service is handed only the path +
-/// query.
+/// `remote` is already a ready-to-append `&remote=…` suffix. It is never
+/// empty: `run_invite` refuses to mint at all when the repository has no
+/// shareable remote (see `RemoteRefusal`), so by the time this runs the
+/// repo has one. The seed is the fragment and never the query: it must not
+/// reach a server, and the shortcut service is handed only the path + query.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn long_invite_url(origin: Option<&str>, proof: &str, remote: &str, seed: &str) -> String {
     match origin {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -942,10 +942,12 @@ async fn publish_share_blocked(
 /// shortcut service answers.
 ///
 /// The long form is `{origin}/join?access={proof}{remote}#{seed}`, where
-/// `remote` is already a ready-to-append `&remote=…` suffix (empty for a
-/// local-only repo). This is the shape the share view used to concatenate
-/// from three overlay fields; building it here gives it one definition and
-/// lets it be shortened.
+/// `remote` is already a ready-to-append `&remote=…` suffix. It is never
+/// empty: a repo with no shareable remote is refused before any of this
+/// runs, because an invite that carries no remote strands its recipient in
+/// a spot that can never fill. This is the shape the share view used to
+/// concatenate from three overlay fields; building it here gives it one
+/// definition and lets it be shortened.
 ///
 /// Shortening is best-effort: a failed `PUT /@` (offline, no service
 /// deployed, a non-2xx) logs and yields the long URL, which is fully

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -5049,6 +5049,15 @@ mod tests {
 
         dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
 
+        // Assert the handler RAN before asserting what it declined to do.
+        // Without this, deleting the handler outright would leave the
+        // transient matching nothing, and the emptiness check below would
+        // still pass -- proving only that no invitation appeared from thin
+        // air.
+        assert!(
+            has_remote_upstream(&state, &key).await,
+            "the handler ran and attached the remote"
+        );
         assert!(
             content_invitations(&state, &key).await.is_empty(),
             "attach-only records no invitation"


### PR DESCRIPTION
## The bug

Sharing a spot whose `main` branch has no sync remote minted an invite that could never work. The recipient claimed it, the join flow's pull failed with `BranchHasNoUpstream`, and they landed in a permanently empty space rendering "Model not found".

`resolve_remote_url` already saw this — it returned `Ok(None)` and the mint proceeded, appending no `&remote=` to the URL. Its own doc comment argued against exactly that outcome ("silently demoting to local-only would mask config drift the inviter can't see") and then did it for the most common case.

A spot reaches that state easily: `CreateSpaceHandler` creates local-only first, navigates the creator in second, and attaches the remote third, best-effort, with failures reduced to a `log!`.

## What changes

Both mint paths resolve the remote **before** generating any key material and refuse when they can't:

- the `tonk:invite` command handler records an overlay-only `ShareBlocked` fact carrying a refusal class, a user-facing sentence, and the refused command's timestamp echoed back
- `POST /api/repository/{repo}/invite` returns 409

When the reason is repairable — the spot simply has no upstream — the share button opens a prompt offering to turn sync on. Confirming dispatches a new `tonk:enable-sync` command whose handler attaches a remote to the **existing** spot and then mints, so the resulting link settles the clipboard write the confirm click opened. One click from refusal to link on the clipboard.

The echoed timestamp is what makes the refusal fact safe to leave in the overlay: it's cardinality-one on the subject, so it lingers and replays on every resubscribe, and the element acts only on a refusal answering the click it currently holds a write for.

## Also fixed along the way

- **Invites minted from the share button never appeared in the "shared with" roster.** `run_invite` wrote its `Invitation` fact to the meta branch, which never syncs, while the roster reads the content branch. Pre-existing and unrelated to remotes; found because this branch's tests asserted the roster fact. Bundled into 8a6576e36.
- **`<tonk-share>` had no failure path at all.** Any mint that never landed pinned the button on `copying`, which refuses clicks — dead for the session. Added a bounded timeout, plus fixes for two more paths that reached the same state (a refusal arriving with no clipboard write open, and a mid-mint re-parent).
- Six pre-existing tests that minted against local-only repos, one of which had gone silently vacuous.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to handle remote sync for repositories, ensuring that invites can only be minted for repositories with valid remote configurations. It adds UI prompts for enabling sync and various backend changes to support this feature.

### Detailed summary
- Added `.fab__prompt` styles in `fab.css`.
- Updated comments in `lib.rs` for clarity on subscription handling.
- Introduced `attach_remote` function in `join.rs` to manage remote attachments.
- Added a dialog in `markup.rs` for enabling sync.
- Implemented tests for rendering sync prompts and handling refusals.
- Enhanced `command.rs` with `EnableSync` command structure.
- Modified `state.rs` to manage subscriptions with branch rebindings.
- Updated `create_invite.rs` to prevent invites for local-only repositories.
- Improved error handling for sync-related operations in `router.rs`.
- Added documentation for refusal cases in `share-enable-sync-prompt-design.md`.

> The following files were skipped due to too many changes: `rust/tonk-fab/src/subscribing.rs`, `rust/tonk-worker/src/router/repository.rs`, `rust/tonk-fab/src/share.rs`, `docs/superpowers/plans/2026-07-22-share-enable-sync-prompt.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->