### PR TITLE
chore(deps): bump dialog to tonk-2026-07-22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -942,10 +942,13 @@ dependencies = [
  "rkyv",
  "serde",
  "serde-big-array",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
  "serde_json",
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -954,16 +957,21 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "base58",
+ "blake3",
  "convert_case",
  "dialog-common",
  "dialog-macros",
  "dialog-varsig",
+ "ed25519-dalek",
+ "rkyv",
  "serde",
+ "serde-big-array",
  "serde_bytes",
+ "serde_ipld_dagcbor",
  "signature",
  "thiserror 2.0.18",
  "url",
@@ -972,7 +980,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1029,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1133,6 +1141,8 @@ dependencies = [
  "sieve-cache",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "wasm-bindgen-futures",
 ]
 
@@ -1169,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1285,10 +1295,12 @@ dependencies = [
  "getrandom 0.2.17",
  "parking_lot",
  "serde",
+ "serde_bytes",
  "serde_ipld_dagcbor",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1297,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1321,12 +1333,13 @@ dependencies = [
  "stable_deref_trait",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1373,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "async-trait",
  "base58",
@@ -1394,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1420,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-22#534bf48cce31346b72635c9deb2de948382240f5"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",
@@ -2400,6 +2413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2511,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -3789,6 +3817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,6 +4118,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4895,6 +4941,7 @@ dependencies = [
 name = "tonk-worker-api"
 version = "0.6.0"
 dependencies = [
+ "dialog-artifacts",
  "dialog-capability",
  "dialog-common",
  "dialog-varsig",
@@ -4998,6 +5045,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5103,6 +5180,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,35 +177,39 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-22" }
 
-# NOTE — the dialog deps above are pinned to the `tonk-2026-07-13-2` TAG:
-# `feat/overlay-retain-entities` (dialog-db #390, which tonk's `staging` already
-# depends on for `Overlay::retain_entities`) plus the Revision/TreeReference move
-# to `dialog-capability` (dialog-db #391), which is what lets the host page name a
-# revision without linking the query engine.
+# NOTE — the dialog deps above are pinned to the `tonk-2026-07-22` TAG, which
+# carries two breaking changes tonk must absorb:
 #
-# That move previously lived only on an ORPHANED commit (tagged `tonk-2026-07-12`,
-# reachable from no branch), which is why this crate used to pin the
-# `feat/engine-free-revision` branch to get it — dragging in the whole
-# version-control stack as a side effect, and resolving TWO copies of every dialog
-# crate. #391 cherry-picks it onto a real branch, so one tag now covers everything.
-# Repoint to a tag on the merged base once #390 and #391 land.
+# 1. The `dialog.` attribute namespace is now RESERVED: the artifact write path
+#    (dialog-artifacts tree.rs) rejects any Assert/Replace/Retract whose
+#    attribute starts with `dialog.` (DialogArtifactsError::ReservedAttribute).
+#    tonk pervasively writes `dialog.attribute/*`, `dialog.meta/*`,
+#    `dialog.concept/*`, `dialog.effect/*`, `dialog.name/*`, etc., so every one
+#    of those built-in attribute names must move off the `dialog.` prefix.
+#
+# 2. Binary/version-control format change (#393, #397): search-tree nodes are
+#    self-describing and rebalanced (stored data must be reseeded), and
+#    Revision/TreeReference moved from `dialog-capability` to `dialog-artifacts`.
+#    The old one-commit `Revision.cause: HashSet<TreeReference>` is replaced by a
+#    Lamport `edition` + per-origin `context: Option<Context>` history index, so
+#    `sync::classify` must be rewritten against `Context::includes`.
 
 [profile.dev]
 opt-level = 1

--- a/rust/dialog-reactor/src/env.rs
+++ b/rust/dialog-reactor/src/env.rs
@@ -13,7 +13,7 @@
 use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;
 use dialog_effects::archive::{Get, Import, Put};
-use dialog_effects::authority::Identify;
+use dialog_effects::authority::{Attest, Identify};
 use dialog_effects::blob::{Import as BlobImport, Read as BlobRead};
 use dialog_effects::memory::{Publish, Resolve};
 use dialog_effects::space::Load;
@@ -66,6 +66,7 @@ pub trait CommitProvider:
     + Provider<Resolve>
     + Provider<Publish>
     + Provider<Identify>
+    + Provider<Attest>
     + Provider<Fork<RemoteSite, Get>>
     + Provider<Fork<RemoteSite, Resolve>>
     + ConditionalSync
@@ -79,6 +80,7 @@ impl<T> CommitProvider for T where
         + Provider<Resolve>
         + Provider<Publish>
         + Provider<Identify>
+        + Provider<Attest>
         + Provider<Fork<RemoteSite, Get>>
         + Provider<Fork<RemoteSite, Resolve>>
         + ConditionalSync
@@ -94,6 +96,7 @@ pub trait PullProvider:
     + Provider<Resolve>
     + Provider<Publish>
     + Provider<Identify>
+    + Provider<Attest>
     + Provider<Fork<RemoteSite, Get>>
     + Provider<Fork<RemoteSite, Resolve>>
     + ConditionalSync
@@ -107,6 +110,7 @@ impl<T> PullProvider for T where
         + Provider<Resolve>
         + Provider<Publish>
         + Provider<Identify>
+        + Provider<Attest>
         + Provider<Fork<RemoteSite, Get>>
         + Provider<Fork<RemoteSite, Resolve>>
         + ConditionalSync

--- a/rust/dialog-reactor/src/formula.rs
+++ b/rust/dialog-reactor/src/formula.rs
@@ -285,11 +285,11 @@ async fn child_rows<Env: SelectProvider>(
         .collect();
 
     let mut rows = Vec::with_capacity(children.len());
-    for (at, (child, bound)) in children.into_iter().enumerate() {
+    for (at, (child, separator)) in children.into_iter().enumerate() {
         // Local-only read: a hit is cached, a miss is remote (the block
         // would have to be fetched). A cached child carries its full node
-        // fields; a remote one carries only what the parent's link knows —
-        // its bound key and rank — and is flagged `cached: false`.
+        // fields (size/count/kind); a remote one carries only what the
+        // parent's link knows, flagged `cached: false`.
         let mut fields = match read_local(branch, env, child).await? {
             Some(node) => {
                 let mut fields = node_fields(&node)?;
@@ -299,19 +299,28 @@ async fn child_rows<Env: SelectProvider>(
             None => {
                 let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
                 fields.insert("cached".into(), Ipld::Bool(false));
-                // The link's separator is the child's lower boundary — a
-                // front-coded key PREFIX, not a whole key, so it may decode
-                // only partially. `key_parts` still surfaces its tag + as many
-                // leading components as the prefix carries.
-                fields.insert("bound".into(), Ipld::String(bytes_hex(&bound)));
-                fields.insert("bound-parts".into(), Ipld::List(key_parts(&bound)));
-                fields.insert(
-                    "rank".into(),
-                    Ipld::Integer(Geometric::rank(&bound, &manifest) as i128),
-                );
                 fields
             }
         };
+        // The child's boundary in the outline is its LINK SEPARATOR — the
+        // left-edge key of the subtree it roots — for both cached and remote
+        // children. This is the right thing to show on the left: an index node
+        // has no whole upper-bound key of its own (its table holds
+        // separators), so without this a cached index row falls back to its
+        // opaque hash fragment. The separator is a front-coded PREFIX, so it
+        // may decode only partially; `key_parts` still surfaces its tag and as
+        // many leading components as the prefix carries. Overrides any
+        // `bound`/`bound-parts` a segment child's `node_fields` set from its
+        // own upper key, so the whole outline is keyed uniformly by separator.
+        fields.insert("bound".into(), Ipld::String(bytes_hex(&separator)));
+        fields.insert(
+            "bound-parts".into(),
+            Ipld::List(separator_parts(&separator)),
+        );
+        fields.insert(
+            "rank".into(),
+            Ipld::Integer(Geometric::rank(&separator, &manifest) as i128),
+        );
         fields.insert("child".into(), Ipld::String(to_base58(&child)));
         fields.insert("at".into(), Ipld::Integer(at as i128));
         rows.push(Conclusion {
@@ -467,11 +476,20 @@ fn key_parts(bytes: &[u8]) -> Vec<Ipld> {
     };
     let opaque = |bytes: &[u8]| vec![part("opaque", bytes_hex(bytes), bytes_hex(bytes))];
 
+    // An empty separator is the boundary of the level's GLOBAL LEFTMOST
+    // subtree: it has no lower bound (everything sorts at or after it). Show a
+    // `⊥ start` marker so the outline reads it as "the beginning" rather than
+    // falling back to the node's opaque hash.
+    if bytes.is_empty() {
+        return vec![part("min", "⊥ start".into(), String::new())];
+    }
     let Some(&tag) = bytes.first() else {
         return opaque(bytes);
     };
     let key = Key::from(bytes.to_vec());
-    let mut out = vec![part("index", tag_name(tag).into(), format!("{tag:02x}"))];
+    // The index chip shows just the tag byte; the ordering name (`entity` /
+    // `attribute` / …) rides `hex` so the client puts it in the hover tooltip.
+    let mut out = vec![part("index", tag.to_string(), tag_name(tag).into())];
 
     // The EAV/AEV/VAE orderings share the same logical fields; the `KeyView`
     // reads them regardless of physical byte order. `eav` emits the fields in
@@ -498,7 +516,10 @@ fn key_parts(bytes: &[u8]) -> Vec<Ipld> {
         [
             ("entity", entity, bytes_hex(view.entity().raw())),
             ("attribute", attribute, bytes_hex(view.attribute().raw())),
-            ("vtype", format!("{vtype}"), format!("{:02x}", vtype as u8)),
+            // The value-type chip shows just the type tag byte; the type name
+            // (`Entity` / `String` / …) rides `hex` for the hover tooltip, the
+            // same convention as the index chip.
+            ("vtype", (vtype as u8).to_string(), format!("{vtype}")),
             (val_kind, val_text, val_hex),
         ]
     }
@@ -567,6 +588,57 @@ fn key_parts(bytes: &[u8]) -> Vec<Ipld> {
         }
         _ => return opaque(bytes),
     }
+    out
+}
+
+/// Decode an index node's LINK SEPARATOR into parts. A separator is the
+/// front-coded left-edge key of a subtree — a *prefix* of a full key, not a
+/// self-contained one, so [`key_parts`]'s `KeyView` decode reads its columns as
+/// empty (the column framing that decode relies on lives past the prefix's
+/// truncation). Instead, surface the tag chip and render the post-tag prefix
+/// bytes as one glyphed-text chip, colored by the ordering's *leading* sort
+/// column (entity for EAV/history, attribute for AEV, value for VAE). This is
+/// what actually reads on the left of the outline: `\0concept:J4J64…` shows as
+/// `concept:J4J64…` in entity-blue rather than an empty `‹0 bytes›`.
+fn separator_parts(bytes: &[u8]) -> Vec<Ipld> {
+    let part = |kind: &str, text: String, hex: String| -> Ipld {
+        let mut m: BTreeMap<String, Ipld> = BTreeMap::new();
+        m.insert("kind".into(), Ipld::String(kind.into()));
+        m.insert("text".into(), Ipld::String(text));
+        m.insert("hex".into(), Ipld::String(hex));
+        Ipld::Map(m)
+    };
+
+    // The empty / leftmost-subtree separator: reuse `key_parts`' `⊥ start`.
+    if bytes.is_empty() {
+        return key_parts(bytes);
+    }
+    let Some(&tag) = bytes.first() else {
+        return vec![part("opaque", bytes_hex(bytes), bytes_hex(bytes))];
+    };
+    let prefix = &bytes[1..];
+
+    // The color/kind of the leading sort column, so the prefix text reads in
+    // the right hue. History / coverage lead with the version prefix (origin),
+    // blob with its hash; both are structural, so leave them opaque.
+    let lead_kind = match tag {
+        ENTITY_KEY_TAG => "entity",
+        ATTRIBUTE_KEY_TAG => "attribute",
+        VALUE_KEY_TAG => "value",
+        _ => "opaque",
+    };
+
+    let mut out = vec![part("index", tag.to_string(), tag_name(tag).into())];
+    if prefix.is_empty() {
+        return out;
+    }
+    // Render the whole prefix as text (glyphs substituted client-side for the
+    // structural bytes); the raw hex rides `hex` for the tooltip.
+    out.push(part(
+        lead_kind,
+        String::from_utf8_lossy(prefix).into_owned(),
+        bytes_hex(prefix),
+    ));
     out
 }
 

--- a/rust/dialog-reactor/src/formula.rs
+++ b/rust/dialog-reactor/src/formula.rs
@@ -16,8 +16,7 @@
 use std::collections::BTreeMap;
 
 use base58::{FromBase58, ToBase58};
-use dialog_artifacts::{Datum, KeyBytes, State, Value, ValueDataType};
-use dialog_common::Blake3Hash as NodeHash;
+use dialog_artifacts::{Artifact, Datum, Key, State, Value};
 use dialog_query::Term;
 use dialog_repository::{
     Branch, LocalIndex, NetworkedIndex, RepositoryArchiveExt, RepositoryMemoryExt, Upstream,
@@ -33,7 +32,7 @@ use thiserror::Error;
 use crate::{Conclusion, Query, SelectProvider};
 
 /// A decoded tree node, instantiated for the artifact key/value types.
-type TreeNode = PersistentNode<KeyBytes, State<Datum>>;
+type TreeNode = PersistentNode<Key, State<Datum>>;
 
 /// Failure modes for [`resolve_formula`].
 #[derive(Debug, Error)]
@@ -102,7 +101,7 @@ pub async fn resolve_formula<Env: SelectProvider>(
         // Decompose a composite key into its components. Pure: no
         // block read. `key` is required.
         "tree/key" => match key_input(query, "key", name)? {
-            Some(key) => Ok(vec![key_row(key)]),
+            Some(key) => Ok(vec![key_row(key)?]),
             None => Ok(vec![]),
         },
 
@@ -210,21 +209,12 @@ async fn read_local<Env: SelectProvider>(
 /// segments client-side). Shared by `tree/node` and `tree/child` so a
 /// child row carries the child's own node fields.
 fn node_fields(node: &TreeNode) -> Result<BTreeMap<String, Ipld>, FormulaError> {
-    let body = node
-        .body()
-        .map_err(|e: DialogSearchTreeError| FormulaError::Decode(e.to_string()))?;
+    let decode = |e: DialogSearchTreeError| FormulaError::Decode(e.to_string());
+    let body = node.body().map_err(decode)?;
 
-    let (kind, count, upper_bound) = match body {
-        ArchivedNodeBody::Index(index) => (
-            "index",
-            index.links.len(),
-            index.links.last().map(|link| &link.upper_bound),
-        ),
-        ArchivedNodeBody::Segment(segment) => (
-            "segment",
-            segment.entries.len(),
-            segment.entries.last().map(|entry| &entry.key),
-        ),
+    let (kind, count) = match body {
+        ArchivedNodeBody::Index(index) => ("index", index.len()),
+        ArchivedNodeBody::Segment(segment) => ("segment", segment.len()),
     };
     let size = node.buffer().as_ref().len();
 
@@ -232,14 +222,18 @@ fn node_fields(node: &TreeNode) -> Result<BTreeMap<String, Ipld>, FormulaError> 
     fields.insert("kind".into(), Ipld::String(kind.into()));
     fields.insert("size".into(), Ipld::Integer(size as i128));
     fields.insert("count".into(), Ipld::Integer(count as i128));
-    if let Some(archived_key) = upper_bound {
-        let key: KeyBytes =
-            into_owned(archived_key).map_err(|e| FormulaError::Decode(e.to_string()))?;
-        fields.insert("bound".into(), Ipld::String(key_hex(&key)));
+    // Only a segment carries a full upper-bound key; an index's table
+    // holds separators, not whole keys, so it reports no bound.
+    if let Some(bound) = node.upper_bound().map_err(decode)? {
+        let manifest = node.manifest().map_err(decode)?;
+        fields.insert("bound".into(), Ipld::String(bytes_hex(&bound)));
         // The node's rank — the boundary level its upper-bound key
-        // falls on (geometric over the key's hash). Higher rank ⇒
+        // falls on (geometric over the key bytes). Higher rank ⇒
         // higher in the tree; it's what determines the tree's shape.
-        fields.insert("rank".into(), Ipld::Integer(Geometric::rank(&key) as i128));
+        fields.insert(
+            "rank".into(),
+            Ipld::Integer(Geometric::rank(&bound, &manifest) as i128),
+        );
     }
     Ok(fields)
 }
@@ -268,28 +262,24 @@ async fn child_rows<Env: SelectProvider>(
     env: &Env,
     hash: Blake3Hash,
 ) -> Result<Vec<Conclusion>, FormulaError> {
+    let decode = |e: DialogSearchTreeError| FormulaError::Decode(e.to_string());
     let parent = read_node(branch, env, hash).await?;
-    let body = parent
-        .body()
-        .map_err(|e: DialogSearchTreeError| FormulaError::Decode(e.to_string()))?;
+    let body = parent.body().map_err(decode)?;
 
     let ArchivedNodeBody::Index(index) = body else {
         return Ok(vec![]); // a segment has no children
     };
+    let manifest = parent.manifest().map_err(decode)?;
 
-    // Collect each child's hash and upper-bound key up front so we can drop
-    // the borrow on `parent` before the awaits that read each child. The
-    // link carries the bound, so a not-cached child can still show its key.
-    let children: Vec<(Blake3Hash, KeyBytes)> = index
-        .links
-        .iter()
-        .map(|link| {
-            let hash = *<&NodeHash>::from(&link.node).as_bytes();
-            let bound: KeyBytes =
-                into_owned(&link.upper_bound).map_err(|e| FormulaError::Decode(e.to_string()))?;
-            Ok((hash, bound))
-        })
-        .collect::<Result<_, FormulaError>>()?;
+    // Collect each child's hash and separator up front so we can drop the
+    // borrow on `parent` before the awaits that read each child. The link
+    // carries the separator, so a not-cached child can still show its bound.
+    let children: Vec<(Blake3Hash, Vec<u8>)> = index
+        .links()
+        .map_err(decode)?
+        .into_iter()
+        .map(|link| (*link.node.as_bytes(), link.separator))
+        .collect();
 
     let mut rows = Vec::with_capacity(children.len());
     for (at, (child, bound)) in children.into_iter().enumerate() {
@@ -306,10 +296,10 @@ async fn child_rows<Env: SelectProvider>(
             None => {
                 let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
                 fields.insert("cached".into(), Ipld::Bool(false));
-                fields.insert("bound".into(), Ipld::String(key_hex(&bound)));
+                fields.insert("bound".into(), Ipld::String(bytes_hex(&bound)));
                 fields.insert(
                     "rank".into(),
-                    Ipld::Integer(Geometric::rank(&bound) as i128),
+                    Ipld::Integer(Geometric::rank(&bound, &manifest) as i128),
                 );
                 fields
             }
@@ -326,57 +316,76 @@ async fn child_rows<Env: SelectProvider>(
 
 /// One `tree/entry` conclusion per entry in the segment node at `hash`.
 ///
-/// Each row carries the entry's composite key (base58 of its 162 bytes,
-/// for now — `tree/key` decomposes it into components), its position in
-/// the leaf (`at`), the asserted/retracted `state`, and, for an
-/// asserted entry, the decoded datum's `entity` / `attribute` /
-/// `value-type`. An index node has no entries and yields no rows.
+/// Each row carries the entry's composite key (hex of its raw bytes —
+/// `tree/key` decomposes it into components), its position in the leaf
+/// (`at`), the asserted/retracted `state`, and, for an asserted entry, the
+/// entity / attribute / value reconstructed from the key. An index node
+/// has no entries and yields no rows.
 async fn entry_rows<Env: SelectProvider>(
     branch: &Branch,
     env: &Env,
     hash: Blake3Hash,
 ) -> Result<Vec<Conclusion>, FormulaError> {
+    let decode = |e: DialogSearchTreeError| FormulaError::Decode(e.to_string());
     let leaf = read_node(branch, env, hash).await?;
-    let body = leaf
-        .body()
-        .map_err(|e: DialogSearchTreeError| FormulaError::Decode(e.to_string()))?;
+    let body = leaf.body().map_err(decode)?;
 
     let ArchivedNodeBody::Segment(segment) = body else {
         return Ok(vec![]); // an index has no entries
     };
+    let manifest = leaf.manifest().map_err(decode)?;
 
-    let mut rows = Vec::with_capacity(segment.entries.len());
-    for (at, entry) in segment.entries.iter().enumerate() {
-        let key: KeyBytes =
-            into_owned(&entry.key).map_err(|e| FormulaError::Decode(e.to_string()))?;
+    // The columnar leaf stores keys and values in separate tables; stream
+    // the keys (in entry order) and pair each with its value slot by index.
+    // Copy each key out of the borrowed streamer so it survives the
+    // per-entry `value_at` borrow.
+    let mut keys = segment.keys::<Key>().map_err(decode)?;
+    let mut owned_keys: Vec<Vec<u8>> = Vec::with_capacity(segment.len());
+    while let Some((_, key)) = keys.next_key().map_err(decode)? {
+        owned_keys.push(key.to_vec());
+    }
+
+    let mut rows = Vec::with_capacity(owned_keys.len());
+    for (at, key_bytes) in owned_keys.into_iter().enumerate() {
         let state: State<Datum> =
-            into_owned(&entry.value).map_err(|e| FormulaError::Decode(e.to_string()))?;
+            into_owned(segment.value_at(at).map_err(decode)?).map_err(decode)?;
 
+        let key_hex = bytes_hex(&key_bytes);
         let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
-        fields.insert("key".into(), Ipld::String(key_hex(&key)));
+        fields.insert("key".into(), Ipld::String(key_hex.clone()));
         fields.insert("at".into(), Ipld::Integer(at as i128));
-        fields.insert("rank".into(), Ipld::Integer(Geometric::rank(&key) as i128));
+        fields.insert(
+            "rank".into(),
+            Ipld::Integer(Geometric::rank(&key_bytes, &manifest) as i128),
+        );
 
-        // A segment holds asserted facts; a retraction is a tombstone.
-        // Surface the datum's own columns — entity, attribute, value
-        // type (by name), and the decoded value — not the Added/Removed
-        // wrapper as a column.
-        if let State::Added(datum) = state {
-            fields.insert("entity".into(), Ipld::String(datum.entity));
-            fields.insert("attribute".into(), Ipld::String(datum.attribute));
-            let value_type = ValueDataType::from(datum.value_type);
-            fields.insert("type".into(), Ipld::String(value_type.to_string()));
-            if let Ok(value) = Value::try_from((value_type, datum.value))
-                && let Some(ipld) = value_to_ipld(&value)
-            {
-                fields.insert("value".into(), ipld);
+        // A segment holds asserted facts; a retraction is a tombstone. The
+        // entity/attribute/value all live IN the key now (the datum carries
+        // only causal metadata), so reconstruct the fact from the key —
+        // standing in a placeholder for a spilled value, since the inspector
+        // has no store to fetch the block.
+        match state {
+            State::Added(datum) => {
+                let key = Key::from(key_bytes);
+                let artifact = Artifact::from_key_datum_placeholder(&key, &datum)
+                    .map_err(|e| FormulaError::Decode(e.to_string()))?;
+                fields.insert("entity".into(), Ipld::String(artifact.of.to_string()));
+                fields.insert("attribute".into(), Ipld::String(artifact.the.to_string()));
+                fields.insert(
+                    "type".into(),
+                    Ipld::String(artifact.is.data_type().to_string()),
+                );
+                if let Some(ipld) = value_to_ipld(&artifact.is) {
+                    fields.insert("value".into(), ipld);
+                }
             }
-        } else {
-            fields.insert("retracted".into(), Ipld::Bool(true));
+            State::Removed => {
+                fields.insert("retracted".into(), Ipld::Bool(true));
+            }
         }
 
         rows.push(Conclusion {
-            this: key_hex(&key),
+            this: key_hex,
             fields,
         });
     }
@@ -403,18 +412,16 @@ fn value_to_ipld(value: &Value) -> Option<Ipld> {
     })
 }
 
-/// Composite index-key layout (bytes), per dialog-artifacts/src/key.rs:
-/// `[ Tag:1 ][ Entity:64 ][ Attribute:64 ][ ValueType:1 ][ ValueRef:32 ]`.
-const KEY_TAG: usize = 0;
-const KEY_ENTITY: std::ops::Range<usize> = 1..65;
-const KEY_ATTRIBUTE: std::ops::Range<usize> = 65..129;
-const KEY_VALUE_TYPE: usize = 129;
-const KEY_VALUE_REF: std::ops::Range<usize> = 130..162;
-const KEY_LEN: usize = 162;
+/// Key tags, per dialog-artifacts/src/key.rs. The M3 key format is
+/// variable-length and columnar — a fixed byte layout no longer applies —
+/// so the components are recovered by decoding, not slicing.
+const ENTITY_KEY_TAG: u8 = 0;
+const ATTRIBUTE_KEY_TAG: u8 = 1;
+const VALUE_KEY_TAG: u8 = 2;
 
-/// Resolve the required `key` input: a `#<base58>` string of the 162-byte
-/// composite key.
-fn key_input(query: &Query, param: &str, formula: &str) -> Result<Option<KeyBytes>, FormulaError> {
+/// Resolve the required `key` input: a `0x`-prefixed hex string of the raw
+/// composite key bytes.
+fn key_input(query: &Query, param: &str, formula: &str) -> Result<Option<Key>, FormulaError> {
     let bad = |reason: String| FormulaError::BadInput {
         formula: formula.into(),
         reason,
@@ -422,54 +429,60 @@ fn key_input(query: &Query, param: &str, formula: &str) -> Result<Option<KeyByte
     match query.terms.get(param) {
         Some(Term::Constant(Value::String(s))) => {
             let raw = s.strip_prefix("0x").unwrap_or(s);
+            if raw.len() % 2 != 0 {
+                return Err(bad(format!("hex key {s:?} has an odd digit count")));
+            }
             let bytes = (0..raw.len())
                 .step_by(2)
                 .map(|i| u8::from_str_radix(&raw[i..i + 2], 16))
                 .collect::<Result<Vec<u8>, _>>()
                 .map_err(|e| bad(format!("invalid hex key {s:?}: {e}")))?;
-            let key: KeyBytes = bytes
-                .try_into()
-                .map_err(|v: Vec<u8>| bad(format!("key is {} bytes, want {KEY_LEN}", v.len())))?;
-            Ok(Some(key))
+            Ok(Some(Key::from(bytes)))
         }
         Some(_) => Err(bad(format!("`{param}` must be a key string"))),
         None => Err(bad(format!("`{param}` is required"))),
     }
 }
 
-/// One `tree/key` conclusion: the key's components, each base58-encoded.
-/// The tag byte names the index ordering (entity / attribute / value);
-/// the other components are the raw entity / attribute / value-reference
-/// slots. Human-readable resolution (entity → did:key, attribute →
-/// domain/name) is a later refinement.
-fn key_row(key: KeyBytes) -> Conclusion {
-    let tag = match key[KEY_TAG] {
-        0 => "entity",
-        1 => "attribute",
-        2 => "value",
+/// One `tree/key` conclusion: the key's decoded components. The tag names
+/// the index ordering (entity / attribute / value); the entity, attribute,
+/// value type, and (for an inline key) value are reconstructed from the
+/// columnar key. A spilled value shows the placeholder.
+fn key_row(key: Key) -> Result<Conclusion, FormulaError> {
+    let tag = match key.tag() {
+        ENTITY_KEY_TAG => "entity",
+        ATTRIBUTE_KEY_TAG => "attribute",
+        VALUE_KEY_TAG => "value",
         _ => "unknown",
     };
 
     let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
     fields.insert("tag".into(), Ipld::String(tag.into()));
-    fields.insert("entity".into(), Ipld::String(key[KEY_ENTITY].to_base58()));
-    fields.insert(
-        "attribute".into(),
-        Ipld::String(key[KEY_ATTRIBUTE].to_base58()),
-    );
-    fields.insert(
-        "value-type".into(),
-        Ipld::Integer(key[KEY_VALUE_TYPE] as i128),
-    );
-    fields.insert(
-        "value-ref".into(),
-        Ipld::String(key[KEY_VALUE_REF].to_base58()),
-    );
 
-    Conclusion {
-        this: key_hex(&key),
-        fields,
+    // A bare key carries no datum, so reconstruct the fact against an empty
+    // one (only its `cause` is read, and that is absent here).
+    let datum = Datum::for_artifact(&Artifact {
+        the: "x/x".parse().expect("placeholder attribute parses"),
+        of: dialog_artifacts::Entity::new().expect("placeholder entity mints"),
+        is: Value::Boolean(false),
+        cause: None,
+    });
+    if let Ok(artifact) = Artifact::from_key_datum_placeholder(&key, &datum) {
+        fields.insert("entity".into(), Ipld::String(artifact.of.to_string()));
+        fields.insert("attribute".into(), Ipld::String(artifact.the.to_string()));
+        fields.insert(
+            "value-type".into(),
+            Ipld::String(artifact.is.data_type().to_string()),
+        );
+        if let Some(ipld) = value_to_ipld(&artifact.is) {
+            fields.insert("value".into(), ipld);
+        }
     }
+
+    Ok(Conclusion {
+        this: bytes_hex(key.as_ref()),
+        fields,
+    })
 }
 
 /// Format a node hash as the `#<base58>` string used across `tree/*`.
@@ -477,14 +490,14 @@ fn to_base58(hash: &Blake3Hash) -> String {
     format!("#{}", hash.to_base58())
 }
 
-/// Encode a composite key as a `0x`-prefixed hex string. Keys are 162
-/// bytes — too long for the `base58` crate's fixed decode buffer — so
-/// they travel as hex, which the client decodes without a length cap.
+/// Encode raw key bytes as a `0x`-prefixed hex string. Keys are
+/// variable-length and can exceed the `base58` crate's fixed decode buffer,
+/// so they travel as hex, which the client decodes without a length cap.
 /// (Node hashes are 32 bytes and stay base58.)
-fn key_hex(key: &KeyBytes) -> String {
-    let mut s = String::with_capacity(2 + key.len() * 2);
+fn bytes_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(2 + bytes.len() * 2);
     s.push_str("0x");
-    for b in key.iter() {
+    for b in bytes {
         s.push_str(&format!("{b:02x}"));
     }
     s

--- a/rust/dialog-reactor/src/formula.rs
+++ b/rust/dialog-reactor/src/formula.rs
@@ -227,6 +227,9 @@ fn node_fields(node: &TreeNode) -> Result<BTreeMap<String, Ipld>, FormulaError> 
     if let Some(bound) = node.upper_bound().map_err(decode)? {
         let manifest = node.manifest().map_err(decode)?;
         fields.insert("bound".into(), Ipld::String(bytes_hex(&bound)));
+        // The decoded, self-describing components of the bound key — the
+        // inspector renders these as textual/colored chips (see `key_parts`).
+        fields.insert("bound-parts".into(), Ipld::List(key_parts(&bound)));
         // The node's rank — the boundary level its upper-bound key
         // falls on (geometric over the key bytes). Higher rank ⇒
         // higher in the tree; it's what determines the tree's shape.
@@ -296,7 +299,12 @@ async fn child_rows<Env: SelectProvider>(
             None => {
                 let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
                 fields.insert("cached".into(), Ipld::Bool(false));
+                // The link's separator is the child's lower boundary — a
+                // front-coded key PREFIX, not a whole key, so it may decode
+                // only partially. `key_parts` still surfaces its tag + as many
+                // leading components as the prefix carries.
                 fields.insert("bound".into(), Ipld::String(bytes_hex(&bound)));
+                fields.insert("bound-parts".into(), Ipld::List(key_parts(&bound)));
                 fields.insert(
                     "rank".into(),
                     Ipld::Integer(Geometric::rank(&bound, &manifest) as i128),
@@ -353,6 +361,8 @@ async fn entry_rows<Env: SelectProvider>(
         let key_hex = bytes_hex(&key_bytes);
         let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
         fields.insert("key".into(), Ipld::String(key_hex.clone()));
+        // The decoded, self-describing key components for the entry's key row.
+        fields.insert("key-parts".into(), Ipld::List(key_parts(&key_bytes)));
         fields.insert("at".into(), Ipld::Integer(at as i128));
         fields.insert(
             "rank".into(),
@@ -418,6 +428,198 @@ fn value_to_ipld(value: &Value) -> Option<Ipld> {
 const ENTITY_KEY_TAG: u8 = 0;
 const ATTRIBUTE_KEY_TAG: u8 = 1;
 const VALUE_KEY_TAG: u8 = 2;
+const HISTORY_KEY_TAG: u8 = 3;
+const BLOB_KEY_TAG: u8 = 4;
+const COVERAGE_KEY_TAG: u8 = 5;
+
+/// The human name of a key's index ordering, from its leading tag byte.
+fn tag_name(tag: u8) -> &'static str {
+    match tag {
+        ENTITY_KEY_TAG => "entity",
+        ATTRIBUTE_KEY_TAG => "attribute",
+        VALUE_KEY_TAG => "value",
+        HISTORY_KEY_TAG => "history",
+        BLOB_KEY_TAG => "blob",
+        COVERAGE_KEY_TAG => "coverage",
+        _ => "unknown",
+    }
+}
+
+/// Decode a raw key into structured, self-describing parts for the tree
+/// inspector. Each part is a map `{ kind, text, hex }`: `kind` selects the
+/// UI's color/glyph, `text` is the human rendering (a `did:key:…` entity, a
+/// `db.meta/name` attribute, a typed value, a decimal edition), and `hex` is
+/// the raw bytes for the detail/tooltip. The client renders these directly —
+/// it no longer re-implements the variable-length key parse.
+///
+/// A key that does not parse under its tag's schema (a `min`/`max` sentinel,
+/// a truncated separator, or an unknown tag) falls back to a single opaque
+/// `hex` part so the row still shows *something* legible.
+fn key_parts(bytes: &[u8]) -> Vec<Ipld> {
+    use dialog_artifacts::{AttributeKey, EntityKey, Key, ValueKey};
+
+    let part = |kind: &str, text: String, hex: String| -> Ipld {
+        let mut m: BTreeMap<String, Ipld> = BTreeMap::new();
+        m.insert("kind".into(), Ipld::String(kind.into()));
+        m.insert("text".into(), Ipld::String(text));
+        m.insert("hex".into(), Ipld::String(hex));
+        Ipld::Map(m)
+    };
+    let opaque = |bytes: &[u8]| vec![part("opaque", bytes_hex(bytes), bytes_hex(bytes))];
+
+    let Some(&tag) = bytes.first() else {
+        return opaque(bytes);
+    };
+    let key = Key::from(bytes.to_vec());
+    let mut out = vec![part("index", tag_name(tag).into(), format!("{tag:02x}"))];
+
+    // The EAV/AEV/VAE orderings share the same logical fields; the `KeyView`
+    // reads them regardless of physical byte order. `eav` emits the fields in
+    // EAV logical order (entity, attribute, vtype, value); the AEV/VAE arms
+    // reorder the chips to match their own sort. `part` is `Copy`-free so it
+    // is threaded in.
+    fn eav_fields<V: dialog_artifacts::KeyView>(view: &V) -> [(&'static str, String, String); 4] {
+        let entity = String::from_utf8_lossy(view.entity().raw()).into_owned();
+        let attribute = String::from_utf8_lossy(view.attribute().raw()).into_owned();
+        let vtype = view.value_type();
+        let (val_kind, val_text, val_hex) = if view.value_is_spilled() {
+            (
+                "spill",
+                "⇥ spilled".to_owned(),
+                view.value_spill_hash().map(bytes_hex).unwrap_or_default(),
+            )
+        } else {
+            (
+                "value",
+                format_inline_value(vtype, view.value_payload()),
+                bytes_hex(view.value_payload()),
+            )
+        };
+        [
+            ("entity", entity, bytes_hex(view.entity().raw())),
+            ("attribute", attribute, bytes_hex(view.attribute().raw())),
+            ("vtype", format!("{vtype}"), format!("{:02x}", vtype as u8)),
+            (val_kind, val_text, val_hex),
+        ]
+    }
+    let push_fields =
+        |out: &mut Vec<Ipld>, order: &[usize], f: [(&'static str, String, String); 4]| {
+            // Clone into a reusable vec so we can pick fields by sort order.
+            let f: Vec<(&'static str, String, String)> = f.to_vec();
+            for &i in order {
+                let (k, t, h) = &f[i];
+                out.push(part(k, t.clone(), h.clone()));
+            }
+        };
+
+    match tag {
+        // Sort order: entity ‖ attribute ‖ vtype ‖ value (EAV logical order).
+        ENTITY_KEY_TAG => {
+            let f = eav_fields(&EntityKey(&key));
+            push_fields(&mut out, &[0, 1, 2, 3], f);
+        }
+        // Sort order: attribute ‖ entity ‖ vtype ‖ value.
+        ATTRIBUTE_KEY_TAG => {
+            let f = eav_fields(&AttributeKey(&key));
+            push_fields(&mut out, &[1, 0, 2, 3], f);
+        }
+        // Sort order: vtype ‖ value ‖ attribute ‖ entity.
+        VALUE_KEY_TAG => {
+            let f = eav_fields(&ValueKey(&key));
+            push_fields(&mut out, &[2, 3, 1, 0], f);
+        }
+        // History / coverage: tag ‖ origin(32) ‖ edition(8, big-endian) ‖ EAV…
+        // The version prefix (origin, edition) is what these regions sort by;
+        // surface it, then reuse the EAV view for the trailing fact fields.
+        HISTORY_KEY_TAG | COVERAGE_KEY_TAG => {
+            if bytes.len() >= 1 + 32 + 8 {
+                let origin = &bytes[1..33];
+                let edition = u64::from_be_bytes(bytes[33..41].try_into().unwrap_or_default());
+                out.push(part(
+                    "origin",
+                    format!("origin:{}", short_hex(origin)),
+                    bytes_hex(origin),
+                ));
+                out.push(part("edition", format!("@{edition}"), format!("{edition}")));
+                // The fact fields follow the version prefix under the ENTITY
+                // (EAV) ordering; parse the tail as an entity-tagged key.
+                let tail = &bytes[41..];
+                if !tail.is_empty() {
+                    let mut synthetic = Vec::with_capacity(tail.len() + 1);
+                    synthetic.push(ENTITY_KEY_TAG);
+                    synthetic.extend_from_slice(tail);
+                    let tail_key = Key::from(synthetic);
+                    let f = eav_fields(&EntityKey(&tail_key));
+                    push_fields(&mut out, &[0, 1, 2, 3], f);
+                }
+            } else {
+                return opaque(bytes);
+            }
+        }
+        // Blob: tag ‖ blob_hash. One content-addressed reference.
+        BLOB_KEY_TAG => {
+            let hash = &bytes[1..];
+            out.push(part(
+                "blob",
+                format!("blob:{}", short_hex(hash)),
+                bytes_hex(hash),
+            ));
+        }
+        _ => return opaque(bytes),
+    }
+    out
+}
+
+/// A short hex preview (first 8 bytes) for origin / blob hashes shown in a
+/// chip; the full hex rides the `hex` field for the tooltip.
+fn short_hex(bytes: &[u8]) -> String {
+    let n = bytes.len().min(8);
+    let mut s = String::with_capacity(n * 2 + 1);
+    for b in &bytes[..n] {
+        s.push_str(&format!("{b:02x}"));
+    }
+    if bytes.len() > n {
+        s.push('…');
+    }
+    s
+}
+
+/// Render a key's inline value payload as legible text, by its declared type.
+/// Falls back to hex for bytes/records and undecodable payloads — the goal is
+/// a readable chip in the inspector, not a round-trip decode.
+fn format_inline_value(vtype: dialog_artifacts::ValueDataType, payload: &[u8]) -> String {
+    use dialog_artifacts::{Value, decode_value};
+    match decode_value(vtype, payload) {
+        Some((value, _rest)) => match value {
+            Value::String(s) => format!("\"{s}\""),
+            Value::Entity(e) => e.to_string(),
+            Value::Symbol(s) => s.to_string(),
+            Value::Boolean(b) => b.to_string(),
+            Value::UnsignedInt(u) => u.to_string(),
+            Value::SignedInt(i) => {
+                if i >= 0 {
+                    format!("+{i}")
+                } else {
+                    i.to_string()
+                }
+            }
+            Value::Float(f) => {
+                if f.fract() == 0.0 {
+                    format!("{f:.1}")
+                } else {
+                    f.to_string()
+                }
+            }
+            // Bytes / records are opaque binary — a full hex dump would swamp
+            // the chip (a revision record is hundreds of bytes). Label them
+            // with their size; the raw hex still rides the part's `hex` field
+            // for the inspector detail.
+            Value::Bytes(b) => format!("‹{} bytes›", b.len()),
+            Value::Record(b) => format!("‹record, {} bytes›", b.len()),
+        },
+        None => format!("‹{} bytes›", payload.len()),
+    }
+}
 
 /// Resolve the required `key` input: a `0x`-prefixed hex string of the raw
 /// composite key bytes.
@@ -449,35 +651,11 @@ fn key_input(query: &Query, param: &str, formula: &str) -> Result<Option<Key>, F
 /// value type, and (for an inline key) value are reconstructed from the
 /// columnar key. A spilled value shows the placeholder.
 fn key_row(key: Key) -> Result<Conclusion, FormulaError> {
-    let tag = match key.tag() {
-        ENTITY_KEY_TAG => "entity",
-        ATTRIBUTE_KEY_TAG => "attribute",
-        VALUE_KEY_TAG => "value",
-        _ => "unknown",
-    };
-
     let mut fields: BTreeMap<String, Ipld> = BTreeMap::new();
-    fields.insert("tag".into(), Ipld::String(tag.into()));
-
-    // A bare key carries no datum, so reconstruct the fact against an empty
-    // one (only its `cause` is read, and that is absent here).
-    let datum = Datum::for_artifact(&Artifact {
-        the: "x/x".parse().expect("placeholder attribute parses"),
-        of: dialog_artifacts::Entity::new().expect("placeholder entity mints"),
-        is: Value::Boolean(false),
-        cause: None,
-    });
-    if let Ok(artifact) = Artifact::from_key_datum_placeholder(&key, &datum) {
-        fields.insert("entity".into(), Ipld::String(artifact.of.to_string()));
-        fields.insert("attribute".into(), Ipld::String(artifact.the.to_string()));
-        fields.insert(
-            "value-type".into(),
-            Ipld::String(artifact.is.data_type().to_string()),
-        );
-        if let Some(ipld) = value_to_ipld(&artifact.is) {
-            fields.insert("value".into(), ipld);
-        }
-    }
+    fields.insert("tag".into(), Ipld::String(tag_name(key.tag()).into()));
+    // The decoded, self-describing components — the single source of truth for
+    // the inspector's key rendering (entity/attribute/value-type/value chips).
+    fields.insert("parts".into(), Ipld::List(key_parts(key.as_ref())));
 
     Ok(Conclusion {
         this: bytes_hex(key.as_ref()),

--- a/rust/tonk-analyzer/src/analysis.rs
+++ b/rust/tonk-analyzer/src/analysis.rs
@@ -251,7 +251,7 @@ impl DocumentAnalysis {
     /// [`Rule`](tonk_schema::rule::Rule), in the same
     /// document/eval order as [`statements`](Self::statements). These
     /// have no [`TransactRequest`] representation (the `Claim` wire
-    /// can't carry `dialog.effect/*` triples), so they are returned
+    /// can't carry `db.effect/*` triples), so they are returned
     /// separately for a seed loop to `assert` directly.
     ///
     /// Only `assert` rule installs are returned; a rule retract has

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -555,7 +555,7 @@ fn expand(
 /// tree's [`AssertionAnalysis`]. `Concept` carries the resolved
 /// descriptor tagged with its true durability — `transient` is
 /// the flag the analyzer recovered from the head concept's
-/// `dialog.concept/transient` marker. `Domain` carries the claim
+/// `db.concept/transient` marker. `Domain` carries the claim
 /// domain prefix; a domain head names no concept, so it is
 /// always durable (and the [`Predicate::Domain`] arm carries no
 /// descriptor anyway).
@@ -624,7 +624,7 @@ fn synthesize_implicit_queries(document: &mut DocumentAnalysis) {
             continue;
         }
         // Rules don't write a snapshotable entity — install /
-        // retract of `dialog.effect/*` claims contributes no
+        // retract of `db.effect/*` claims contributes no
         // implicit query.
         let application = planned.statement.application();
         if matches!(
@@ -791,6 +791,7 @@ mod tests {
         tonk_schema::concept::QueryEnv
         + dialog_query::Provider<dialog_effects::memory::Publish>
         + dialog_query::Provider<dialog_effects::archive::Import>
+        + dialog_query::Provider<dialog_effects::authority::Attest>
     {
     }
 
@@ -798,6 +799,7 @@ mod tests {
         T: tonk_schema::concept::QueryEnv
             + dialog_query::Provider<dialog_effects::memory::Publish>
             + dialog_query::Provider<dialog_effects::archive::Import>
+            + dialog_query::Provider<dialog_effects::authority::Attest>
     {
     }
 
@@ -897,34 +899,30 @@ mod tests {
                     .and_then(|v| v.as_str().map(str::to_owned))
                     .unwrap_or_else(|| "Text".to_owned());
                 txn = txn
+                    .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                        "{}/{}",
+                        attr.domain(),
+                        attr.name()
+                    )))
                     .assert(
-                        the!("dialog.attribute/id")
-                            .of(attr_entity.clone())
-                            .is(format!("{}/{}", attr.domain(), attr.name())),
-                    )
-                    .assert(
-                        the!("dialog.attribute/type")
+                        the!("db.attribute/type")
                             .of(attr_entity.clone())
                             .is(type_label),
                     )
                     .assert(
-                        the!("dialog.attribute/cardinality")
+                        the!("db.attribute/cardinality")
                             .of(attr_entity.clone())
                             .is("one".to_owned()),
                     )
                     .assert(
-                        the!("dialog.meta/description")
+                        the!("db.meta/description")
                             .of(attr_entity)
                             .is(String::new()),
                     );
             }
             let concept_entity = descriptor.this();
             let id_entity: Entity = format!("id:{name}").parse().expect("id:<name> parses");
-            txn = txn.assert(
-                the!("dialog.name/referent")
-                    .of(id_entity)
-                    .is(concept_entity),
-            );
+            txn = txn.assert(the!("db.name/referent").of(id_entity).is(concept_entity));
             txn = txn.assert(AnonymousConcept::new(descriptor.clone()));
             txn.commit()
                 .perform(&self.operator)
@@ -934,9 +932,9 @@ mod tests {
 
         /// Assert standalone attributes on the branch and publish
         /// each under a name. Builds a throwaway concept descriptor
-        /// so [`assert_concept_named`] writes the `dialog.attribute/
+        /// so [`assert_concept_named`] writes the `db.attribute/
         /// {id,type,cardinality}` claims an `AttributeDefinition`
-        /// needs, then publishes a `dialog.name/referent` for each
+        /// needs, then publishes a `db.name/referent` for each
         /// attribute entity so a bare-symbol reference resolves it by
         /// name (mirrors `attribute!: &name` in real notation).
         ///
@@ -986,38 +984,38 @@ mod tests {
             for (_, attr) in descriptor.with().iter() {
                 let attr_entity: Entity = attr.to_uri().parse().expect("attribute URI");
                 txn = txn
+                    .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                        "{}/{}",
+                        attr.domain(),
+                        attr.name()
+                    )))
                     .assert(
-                        the!("dialog.attribute/id")
-                            .of(attr_entity.clone())
-                            .is(format!("{}/{}", attr.domain(), attr.name())),
-                    )
-                    .assert(
-                        the!("dialog.attribute/type")
+                        the!("db.attribute/type")
                             .of(attr_entity.clone())
                             .is("Text".to_owned()),
                     )
                     .assert(
-                        the!("dialog.attribute/cardinality")
+                        the!("db.attribute/cardinality")
                             .of(attr_entity.clone())
                             .is("one".to_owned()),
                     )
                     .assert(
-                        the!("dialog.meta/description")
+                        the!("db.meta/description")
                             .of(attr_entity)
                             .is(String::new()),
                     );
             }
             // Pin the concept at `entity` by emitting its facts there
             // directly (mirrors `emit_concept_facts`): the marker plus
-            // one `dialog.concept.with/<field>` per field.
+            // one `db.concept.with/<field>` per field.
             txn = txn.assert(
-                the!("dialog.meta/concept")
+                the!("db.meta/concept")
                     .of(entity.clone())
                     .is("db:concept".parse::<Entity>().expect("db:concept")),
             );
             for (field, attr) in descriptor.with().iter() {
                 let attr_entity: Entity = attr.to_uri().parse().expect("attribute URI");
-                let the = format!("dialog.concept.with/{field}")
+                let the = format!("db.concept.with/{field}")
                     .parse::<dialog_query::attribute::The>()
                     .expect("with attribute parses");
                 txn = txn.assert(the.of(entity.clone()).is(attr_entity));
@@ -1028,14 +1026,14 @@ mod tests {
                 .expect("pinned concept assertion commits");
         }
 
-        /// Publish a `dialog.name/referent` claim binding `name`
+        /// Publish a `db.name/referent` claim binding `name`
         /// to `entity`. Used by tests that need a name to resolve
         /// to a specific entity (not a concept the test asserted).
         async fn publish_name(&self, name: &str, entity: Entity) {
             let id_entity: Entity = format!("id:{name}").parse().expect("id:<name> parses");
             self.branch
                 .transaction()
-                .assert(the!("dialog.name/referent").of(id_entity).is(entity))
+                .assert(the!("db.name/referent").of(id_entity).is(entity))
                 .commit()
                 .perform(&self.operator)
                 .await
@@ -1429,7 +1427,7 @@ concept!: &issue
     /// alongside bare-symbol references. Each inline definition
     /// becomes its own `Statement::Assert` so the attribute
     /// surfaces in `attribute:` queries; the inline attrs are
-    /// anonymous (no `dialog.meta/name` claim, since the field
+    /// anonymous (no `db.meta/name` claim, since the field
     /// key is the concept's local name, not a global label).
     #[dialog_common::test]
     async fn it_emits_inline_attribute_definitions_from_concept_with() {
@@ -1679,7 +1677,7 @@ concept!: &view
   with:
     source:
       description: "Source concept"
-      the:         dialog.view/source
+      the:         db.view/source
       as:          Entity
       cardinality: one
 view!: &title
@@ -1727,7 +1725,7 @@ attribute!: &foo
 
     /// Variable-form `attribute!:` with `this: ?foo` (no anchor)
     /// lands in `variables`, not `declarations`, and does NOT
-    /// emit a `dialog.meta/name` claim (the name is doc-scoped
+    /// emit a `db.meta/name` claim (the name is doc-scoped
     /// only).
     #[dialog_common::test]
     async fn it_keeps_variable_form_attribute_doc_scoped() {
@@ -1761,7 +1759,7 @@ attribute!:
 
     /// `attribute!: &foo` (anchored): the head's `name` slot
     /// records the published name. The planner emits the
-    /// `dialog.meta/name` claim on `id:<name>`, not as a
+    /// `db.meta/name` claim on `id:<name>`, not as a
     /// parameter on the predicate.
     #[dialog_common::test]
     async fn it_records_published_name_for_anchored_attribute() {
@@ -2351,7 +2349,7 @@ attribute:
         // cardinality/description — must all be present in the
         // unified term map. `name` is intentionally not in the
         // built-in `attribute:` view (only anchor-form attrs
-        // carry a `dialog.meta/name` claim).
+        // carry a `db.meta/name` claim).
         for field in ["id", "type", "cardinality", "description"] {
             assert!(query.terms.contains(field), "missing {field}");
         }
@@ -2456,7 +2454,7 @@ person:
 
     /// `name` is a built-in concept resolvable without a branch
     /// — same as `attribute` and `concept`. Backed by the single
-    /// `dialog.meta/name` attribute (cardinality one).
+    /// `db.meta/name` attribute (cardinality one).
     #[dialog_common::test]
     async fn it_resolves_builtin_name_concept() {
         let syntax = must_parse(
@@ -2480,7 +2478,7 @@ name:
     #[dialog_common::test]
     async fn it_uses_db_concept_uri_for_concept_marker() {
         // Asserting any concept emits a marker claim
-        // `(this, dialog.meta/concept, db:concept)`. We can read
+        // `(this, db.meta/concept, db:concept)`. We can read
         // it back by inspecting the `concept` term of the
         // emitted concept-head application.
         let syntax = must_parse(
@@ -4410,7 +4408,7 @@ rule!:
     /// `Transient` variant on `AssertionAnalysis::predicate`;
     /// one against a durable concept carries `Durable`. The
     /// analyzer recovers the tag from the head concept's
-    /// `dialog.concept/transient` marker at tree-build time.
+    /// `db.concept/transient` marker at tree-build time.
     #[dialog_common::test]
     async fn it_tags_the_assertion_predicate_with_its_durability() {
         use crate::analysis::{ExpressionAnalysis, Predicate};
@@ -4539,7 +4537,10 @@ person!:
     #[dialog_common::test]
     async fn it_compiles_a_negation_premise_omitting_a_concept_field() {
         let specs = [
-            fixed_concept_typed("replica", &[("subject", "dialog.origin/subject", "Entity")]),
+            fixed_concept_typed(
+                "replica",
+                &[("subject", "dialog.replica/subject", "Entity")],
+            ),
             fixed_concept_typed("binder", &[("active", "xyz.tonk.binder/active", "Entity")]),
         ];
 

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -373,7 +373,7 @@ pub(crate) fn build_assertion_application(
 ///   - bare symbol → resolved through the name table to
 ///     [`ThisIntent::Uri(entity)`]. Resolution order matches
 ///     [`super::field::field_value_to_term`]: doc-local
-///     declarations first, then the branch's `dialog.meta/name`
+///     declarations first, then the branch's `db.meta/name`
 ///     index. Unresolvable symbols surface as `UnknownNameReference`.
 ///
 /// - **Naming** — the `&name` on the value side, captured by the
@@ -387,7 +387,7 @@ pub(crate) fn derive_head_intent(
     anchor: Option<&Anchor>,
     scope: &Scope,
 ) -> Result<(ThisIntent, Option<AnchorName>), AnalyzeError> {
-    // The anchor desugars to a `dialog.meta/name` claim on
+    // The anchor desugars to a `db.meta/name` claim on
     // `id:<name>`. Validate it into an `AnchorName` here — the one
     // place the name is parsed — so a name that can't be published
     // surfaces as a clear error rather than being silently dropped at
@@ -464,7 +464,7 @@ pub(crate) fn derive_head_intent(
 ///
 /// - `Derived` + no `name`: mint a body-content-derived entity.
 /// - `Derived` + `name`: body-derived entity. The
-///   `dialog.meta/name` claim on `id:<name>` is emitted by the
+///   `db.meta/name` claim on `id:<name>` is emitted by the
 ///   planner from `ApplicationPlan::name`, not as a parameter
 ///   on the predicate. Also registers the name → entity binding
 ///   in `analysis.declarations` so duplicate-name checks across

--- a/rust/tonk-analyzer/src/analyzer/declaration.rs
+++ b/rust/tonk-analyzer/src/analyzer/declaration.rs
@@ -199,14 +199,14 @@ pub(crate) struct ConceptBody {
     pub asserts_nothing: bool,
     /// `true` when the body carried the `transient:` tag (bare
     /// key with no value, or the explicit `transient: true`).
-    /// Drives emission of the `dialog.concept/transient` marker
+    /// Drives emission of the `db.concept/transient` marker
     /// fact in [`concept_application`] so the reactor's effects
     /// loop classifies this concept's facts as transient.
     pub transient: bool,
     /// Attributes defined inline in the `with:` map (as opposed
     /// to referenced by name / URI). Each carries the descriptor
-    /// needed to emit `dialog.attribute/{id,type,cardinality}`
-    /// and `dialog.meta/description` claims so the attribute is
+    /// needed to emit `db.attribute/{id,type,cardinality}`
+    /// and `db.meta/description` claims so the attribute is
     /// queryable via `attribute:` after the `concept!` commits.
     pub inline_attributes: Vec<AttributeBody>,
 }
@@ -368,7 +368,7 @@ const STUB_FIELD: &str = "_";
 /// The placeholder attribute spec paired with [`STUB_FIELD`].
 fn stub_attr() -> serde_json::Value {
     serde_json::json!({
-        "the": "dialog.concept/stub",
+        "the": "db.concept/stub",
         "as": "Text",
         "cardinality": "one",
     })
@@ -464,7 +464,7 @@ fn parse_concept_field_block(
             // `field: _` retracts the named field from the stored
             // concept. It is NOT a reference and never enters the
             // descriptor — recorded separately so the emitter
-            // dissociates `dialog.concept.<block>/<field>` (plus the
+            // dissociates `db.concept.<block>/<field>` (plus the
             // `optional` sibling) without re-asserting anything.
             retracted.push(RetractedField {
                 name: sub.name.clone(),
@@ -538,7 +538,7 @@ fn resolve_concept_field(
 /// asserted predicate is the built-in `attribute` schema; the
 /// `this` slot is the descriptor-derived entity URI; the
 /// per-field terms carry the descriptor's id/type/cardinality/
-/// description. The published name (`dialog.meta/name` claim on
+/// description. The published name (`db.meta/name` claim on
 /// `id:<name>`) is emitted by the planner from `Application`'s
 /// `name` slot, not as a body parameter.
 ///
@@ -592,7 +592,7 @@ pub(crate) fn attribute_application(
 /// Build the `Application` for a `concept!` head — the asserted
 /// predicate is a synthesized concept-of-concept schema (one
 /// `with.<field>` per field of the user's concept, plus the
-/// `dialog.meta/concept` marker and `dialog.meta/description`).
+/// `db.meta/concept` marker and `db.meta/description`).
 /// The `this` slot is the descriptor-derived entity URI; the
 /// published name is emitted by the planner from
 /// `Application`'s `name` slot.
@@ -638,7 +638,7 @@ pub(crate) fn concept_application(
             Term::Constant(Value::String(desc.to_owned())),
         );
     }
-    // `transient: true` adds a `(this, dialog.concept/transient,
+    // `transient: true` adds a `(this, db.concept/transient,
     // db:transient)` marker fact. The synthesized
     // `concept_schema` includes a matching field; durable
     // concepts skip the term so no claim is emitted (the
@@ -669,7 +669,7 @@ pub(crate) fn concept_application(
 /// `resolved` is the concept as read off the branch (the scope's
 /// prefetch). Retraction is strict: a body that asks to drop a field
 /// must target a concept that exists on the branch and actually
-/// carries that field — otherwise there's no `dialog.concept.with/…`
+/// carries that field — otherwise there's no `db.concept.with/…`
 /// triple to dissociate (its value is unknown). Both cases surface
 /// as [`AnalyzeErrorKind::InvalidConceptBody`].
 pub(crate) fn build_concept_retractions(
@@ -731,7 +731,7 @@ pub(crate) fn build_concept_retractions(
 ///
 /// `stored` is the concept as resolved off the branch — it supplies
 /// each retracted field's attribute `the:` so the predicate maps the
-/// field to the right `dialog.concept.with/<field>` relation. The
+/// field to the right `db.concept.with/<field>` relation. The
 /// field terms are emitted **blank** (`Term::blank()`): the evaluator
 /// reads each as a retraction directive and queries the branch for
 /// the stored value to dissociate (mirroring how instance `..: _`
@@ -750,7 +750,7 @@ fn concept_field_retraction(
     // Lift exactly the fields being dropped into a sub-descriptor,
     // carrying each one's stored `ConceptFieldDescriptor` (its `the:`
     // attribute) so `concept_schema` maps it to the right
-    // `dialog.concept.with/<field>` relation.
+    // `db.concept.with/<field>` relation.
     let with = stored.with();
     let sub_fields: Vec<(String, ConceptFieldDescriptor)> = fields
         .iter()
@@ -795,11 +795,11 @@ fn attribute_schema() -> ConceptDescriptor {
     }
     let json = serde_json::json!({
         "with": {
-            "id":          { "the": "dialog.attribute/id",          "as": "Text", "cardinality": cardinality_one() },
-            "type":        { "the": "dialog.attribute/type",        "as": "Text", "cardinality": cardinality_one() },
-            "cardinality": { "the": "dialog.attribute/cardinality", "as": "Text", "cardinality": cardinality_one() },
-            "description": { "the": "dialog.meta/description",      "as": "Text", "cardinality": cardinality_one() },
-            "name":        { "the": "dialog.meta/name",             "as": "Text", "cardinality": cardinality_one() },
+            "id":          { "the": "db.attribute/id",          "as": "Text", "cardinality": cardinality_one() },
+            "type":        { "the": "db.attribute/type",        "as": "Text", "cardinality": cardinality_one() },
+            "cardinality": { "the": "db.attribute/cardinality", "as": "Text", "cardinality": cardinality_one() },
+            "description": { "the": "db.meta/description",      "as": "Text", "cardinality": cardinality_one() },
+            "name":        { "the": "db.meta/name",             "as": "Text", "cardinality": cardinality_one() },
         }
     });
     serde_json::from_value(json).expect("attribute schema is well-formed")
@@ -807,7 +807,7 @@ fn attribute_schema() -> ConceptDescriptor {
 
 /// Build a `concept!` schema descriptor — one `with.<field>` per
 /// field of the concept being defined, plus the
-/// `dialog.meta/concept` marker (so branch-wide `concept:` queries
+/// `db.meta/concept` marker (so branch-wide `concept:` queries
 /// can find every concept entity) and optional name and
 /// description fields.
 fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
@@ -816,7 +816,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
         with.insert(
             format!("with.{name}"),
             serde_json::json!({
-                "the": format!("dialog.concept.with/{name}"),
+                "the": format!("db.concept.with/{name}"),
                 "as": "Entity",
                 "cardinality": "one",
             }),
@@ -827,7 +827,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
             with.insert(
                 format!("optional.{name}"),
                 serde_json::json!({
-                    "the": format!("dialog.concept.optional/{name}"),
+                    "the": format!("db.concept.optional/{name}"),
                     "as": "Boolean",
                     "cardinality": "one",
                 }),
@@ -837,7 +837,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
     with.insert(
         "concept".into(),
         serde_json::json!({
-            "the": "dialog.meta/concept",
+            "the": "db.meta/concept",
             "as": "Entity",
             "cardinality": "one",
         }),
@@ -845,7 +845,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
     with.insert(
         "name".into(),
         serde_json::json!({
-            "the": "dialog.meta/name",
+            "the": "db.meta/name",
             "as": "Text",
             "cardinality": "one",
         }),
@@ -853,7 +853,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
     with.insert(
         "description".into(),
         serde_json::json!({
-            "the": "dialog.meta/description",
+            "the": "db.meta/description",
             "as": "Text",
             "cardinality": "one",
         }),
@@ -861,7 +861,7 @@ fn concept_schema(descriptor: &ConceptDescriptor) -> ConceptDescriptor {
     with.insert(
         "transient".into(),
         serde_json::json!({
-            "the": "dialog.concept/transient",
+            "the": "db.concept/transient",
             "as": "Entity",
             "cardinality": "one",
         }),

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -282,7 +282,7 @@ pub enum AnalyzeErrorKind {
         reason: String,
     },
     /// An `&anchor` name doesn't form a valid `id:<name>` entity
-    /// URI. The anchor desugars to a `dialog.meta/name` claim on
+    /// URI. The anchor desugars to a `db.meta/name` claim on
     /// `id:<name>`; if that URI can't be built the name could never
     /// be published or resolved. Caught here so it's a clear error
     /// rather than a silently-dropped name at write time.

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -163,7 +163,7 @@ pub(crate) trait Resolve {
         entity: &Entity,
     ) -> Result<Option<AttributeDefinition>, ResolveError>;
     /// Resolve an attribute by its `domain/name` selector id (the
-    /// `dialog.attribute/id` claim). Used by claim-domain heads to
+    /// `db.attribute/id` claim). Used by claim-domain heads to
     /// discover declared attributes for their body fields.
     async fn attribute_by_id(&self, id: &str) -> Result<Option<AttributeDefinition>, ResolveError>;
     async fn named_entity(&self, name: &str) -> Result<Option<Entity>, ResolveError>;

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -926,6 +926,7 @@ mod tests {
         tonk_schema::concept::QueryEnv
         + dialog_query::Provider<dialog_effects::memory::Publish>
         + dialog_query::Provider<dialog_effects::archive::Import>
+        + dialog_query::Provider<dialog_effects::authority::Attest>
     {
     }
 
@@ -933,6 +934,7 @@ mod tests {
         T: tonk_schema::concept::QueryEnv
             + dialog_query::Provider<dialog_effects::memory::Publish>
             + dialog_query::Provider<dialog_effects::archive::Import>
+            + dialog_query::Provider<dialog_effects::authority::Attest>
     {
     }
 
@@ -978,34 +980,30 @@ mod tests {
                     .and_then(|v| v.as_str().map(str::to_owned))
                     .unwrap_or_else(|| "String".to_owned());
                 txn = txn
+                    .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                        "{}/{}",
+                        attr.domain(),
+                        attr.name()
+                    )))
                     .assert(
-                        the!("dialog.attribute/id")
-                            .of(attr_entity.clone())
-                            .is(format!("{}/{}", attr.domain(), attr.name())),
-                    )
-                    .assert(
-                        the!("dialog.attribute/type")
+                        the!("db.attribute/type")
                             .of(attr_entity.clone())
                             .is(type_label),
                     )
                     .assert(
-                        the!("dialog.attribute/cardinality")
+                        the!("db.attribute/cardinality")
                             .of(attr_entity.clone())
                             .is("one".to_owned()),
                     )
                     .assert(
-                        the!("dialog.meta/description")
+                        the!("db.meta/description")
                             .of(attr_entity)
                             .is(String::new()),
                     );
             }
             let concept_entity = descriptor.this();
             let id_entity: Entity = format!("id:{name}").parse().expect("id:<name> parses");
-            txn = txn.assert(
-                the!("dialog.name/referent")
-                    .of(id_entity)
-                    .is(concept_entity),
-            );
+            txn = txn.assert(the!("db.name/referent").of(id_entity).is(concept_entity));
             txn = txn.assert(AnonymousConcept::new(descriptor.clone()));
             txn.commit()
                 .perform(&self.operator)

--- a/rust/tonk-cli/src/authoring.rs
+++ b/rust/tonk-cli/src/authoring.rs
@@ -10,7 +10,7 @@
 //! `.superpowers/sdd/repoint-findings.md` §"THE MINIMAL WORKING
 //! RECIPE". That document records a from-scratch investigation into
 //! why a home page renders (or silently doesn't): the root concept's
-//! one `with:` field must map to `the: dialog.origin/subject` /
+//! one `with:` field must map to `the: dialog.replica/subject` /
 //! `as: entity` — the only attribute guaranteed already-asserted on
 //! the entity the space-home route renders — and the inline
 //! attribute under `with:` must carry its own `description:` (a hard
@@ -314,7 +314,7 @@ pub fn build_home_recipe(models: &[String]) -> String {
         "      description: {}",
         quote_string("The repository's subject DID.")
     );
-    out.push_str("      the: dialog.origin/subject\n");
+    out.push_str("      the: dialog.replica/subject\n");
     out.push_str("      as: entity\n");
     out.push('\n');
 
@@ -473,7 +473,7 @@ mod tests {
         let doc = build_home_recipe(&["habit".into(), "entry".into()]);
         assert!(doc.contains("concept!: &space-home"));
         assert!(doc.contains("this: space:home"));
-        assert!(doc.contains("the: dialog.origin/subject"));
+        assert!(doc.contains("the: dialog.replica/subject"));
         assert!(doc.contains("view!: &space-home-view"));
         assert!(doc.contains("this: id:space:home/view"));
         assert!(doc.contains("<tonk-display model=habit />"));

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1165,10 +1165,9 @@ async fn import_op(file: PathBuf, spot: Option<&str>) -> ExitCode {
     match transfer::import(&site, &file).await {
         Ok(revision) => {
             println!(
-                "imported {} -> revision {}.{}",
+                "imported {} -> revision {}",
                 file.display(),
-                revision.period,
-                revision.moment,
+                revision.edition.value(),
             );
             ExitCode::Success
         }

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -5,7 +5,7 @@
 //!
 //! 1. The built-in `attribute` concept enumerates every attribute
 //!    (named or not). For each, a separate lookup against
-//!    `dialog.name/referent` recovers the bookmark name where one
+//!    `db.name/referent` recovers the bookmark name where one
 //!    exists.
 //! 2. The built-in `concept` concept enumerates every concept
 //!    *with* a name claim — the concept-of-concept descriptor
@@ -20,7 +20,7 @@
 //! would multiply the test surface for a corner case we haven't
 //! seen in real schemas yet.
 //!
-//! Known fidelity gap: `dialog.meta/description` claims on
+//! Known fidelity gap: `db.meta/description` claims on
 //! *concepts* are not surfaced. The dialog query engine's
 //! anonymous-concept dispatch path (which the `concept:` head
 //! lands on) only binds `this`, `name`, and a synthesised
@@ -53,10 +53,10 @@ use crate::site::TonkSite;
 /// notation).
 #[derive(Debug, Clone)]
 pub struct ConceptSummary {
-    /// Bookmark name published via `dialog.name/referent` on
+    /// Bookmark name published via `db.name/referent` on
     /// the matching `id:<name>` entity.
     pub name: String,
-    /// Human description claim (`dialog.meta/description`), if
+    /// Human description claim (`db.meta/description`), if
     /// asserted. Concept descriptions are optional in the
     /// analyzer.
     pub description: Option<String>,
@@ -145,7 +145,7 @@ pub async fn render_one(site: &TonkSite, name: &str) -> Result<Option<String>> {
 
 #[derive(Debug)]
 struct AttributeInfo {
-    /// Bookmark name (the `<n>` from an `id:<n>` `dialog.name/referent`
+    /// Bookmark name (the `<n>` from an `id:<n>` `db.name/referent`
     /// claim pointing at this entity), when one is published.
     name: Option<String>,
     /// Attribute URI (`xyz.tonk.task/title`).
@@ -156,7 +156,7 @@ struct AttributeInfo {
     type_name: String,
     /// `one` / `many`, matching the analyzer's accepted values.
     cardinality: String,
-    /// Human description claim (`dialog.meta/description`).
+    /// Human description claim (`db.meta/description`).
     description: String,
 }
 
@@ -167,7 +167,7 @@ pub struct ConceptInfo {
     /// Bookmark name. Required — anonymous concepts aren't yet
     /// surfaced.
     pub name: String,
-    /// `dialog.meta/description` when present.
+    /// `db.meta/description` when present.
     pub description: Option<String>,
     /// Decoded descriptor — the source of truth for the rendered
     /// `with:` map.
@@ -234,16 +234,16 @@ async fn enumerate_attributes(site: &TonkSite) -> Result<Vec<AttributeInfo>> {
 /// (the built-in `attribute` concept descriptor doesn't carry
 /// `name`).
 ///
-/// Names are stored inverted under `dialog.name/referent`: each
-/// anchor `&foo` publishes `(dialog.name/referent, id:foo,
+/// Names are stored inverted under `db.name/referent`: each
+/// anchor `&foo` publishes `(db.name/referent, id:foo,
 /// <target-entity>)`. The *name* lives in the claim's subject as
 /// `id:<name>`; the *target* is the value. We invert that mapping
 /// here so callers can ask "what's this entity's display name?"
 /// in one lookup.
 async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String>> {
-    let name_attr: dialog_artifacts::Attribute = "dialog.name/referent"
+    let name_attr: dialog_artifacts::Attribute = "db.name/referent"
         .parse()
-        .context("dialog.name/referent should be a valid attribute URI")?;
+        .context("db.name/referent should be a valid attribute URI")?;
     let the_term: attribute::The = name_attr.into();
     let session = site.branch().await?;
     let claims: Vec<dialog_query::Claim> = session
@@ -259,7 +259,7 @@ async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String
         .perform(&site.operator)
         .try_vec()
         .await
-        .map_err(|e| anyhow!("dialog.name/referent query failed: {e:?}"))?;
+        .map_err(|e| anyhow!("db.name/referent query failed: {e:?}"))?;
 
     let mut out = HashMap::with_capacity(claims.len());
     for claim in claims {

--- a/rust/tonk-cli/src/share.rs
+++ b/rust/tonk-cli/src/share.rs
@@ -318,7 +318,7 @@ pub async fn share_concept(
 /// existing `text/html` body via the host route's iframe viewer.
 ///
 /// `target` is either a bookmark name (resolved via
-/// `dialog.meta/name` on the branch) or a `did:key:…` entity URI.
+/// `db.meta/name` on the branch) or a `did:key:…` entity URI.
 /// Either way the resolved entity must already carry at least
 /// one `text/html` claim — otherwise the host route would 404 on
 /// the embedded path and we'd hand the human a useless URL.
@@ -481,7 +481,7 @@ fn compose_display_then(subject: &str, view: Option<&str>, model: Option<&str>) 
 
 /// Map a `<target>` argument into an `(entity, optional_name)`
 /// pair. `did:key:…` strings are taken as URIs; everything else
-/// is looked up as a `dialog.meta/name` bookmark. `missing` is
+/// is looked up as a `db.meta/name` bookmark. `missing` is
 /// invoked when the bookmark doesn't resolve — callers choose
 /// between [`ShareError::ViewNotFound`] and
 /// [`ShareError::SubjectNotFound`] so the message matches the

--- a/rust/tonk-cli/src/views.rs
+++ b/rust/tonk-cli/src/views.rs
@@ -25,7 +25,7 @@ use crate::site::TonkSite;
 /// One row of `tonk views`.
 #[derive(Debug, Clone)]
 pub struct ViewSummary {
-    /// `dialog.meta/name` claim on the entity, when one is
+    /// `db.meta/name` claim on the entity, when one is
     /// asserted. The same name might be reused across the
     /// branch's history; we surface the current binding only.
     pub name: Option<String>,
@@ -48,7 +48,7 @@ pub struct ViewSummary {
 /// One row per entity. When an entity carries multiple
 /// `text/html` claims, the [`ViewSummary::body_bytes`] field
 /// records the longest; the name lookup is unaffected (each
-/// entity has at most one `dialog.meta/name` claim).
+/// entity has at most one `db.meta/name` claim).
 pub async fn list(site: &TonkSite) -> Result<Vec<ViewSummary>> {
     let entities_with_lengths = enumerate_view_claims(site).await?;
     if entities_with_lengths.is_empty() {
@@ -151,16 +151,16 @@ fn body_byte_len(value: &Value) -> usize {
 /// per-entity lookups and avoids N+1 round trips against a large
 /// branch.
 ///
-/// Names are stored inverted under the `dialog.name/referent`
+/// Names are stored inverted under the `db.name/referent`
 /// relation: each anchor `&foo` publishes
-/// `(dialog.name/referent, id:foo, <target-entity>)`. The *name*
+/// `(db.name/referent, id:foo, <target-entity>)`. The *name*
 /// lives in the claim's subject as `id:<name>`; the *target* is
 /// the value. We invert that mapping here so callers can ask
 /// "what's this entity's display name?" with one lookup.
 async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String>> {
-    let name_attr: Attribute = "dialog.name/referent"
+    let name_attr: Attribute = "db.name/referent"
         .parse()
-        .context("dialog.name/referent should be a valid attribute URI")?;
+        .context("db.name/referent should be a valid attribute URI")?;
     let the_term: attribute::The = name_attr.into();
     let session = site.branch().await?;
     let claims: Vec<dialog_query::Claim> = session
@@ -176,7 +176,7 @@ async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String
         .perform(&site.operator)
         .try_vec()
         .await
-        .map_err(|e| anyhow!("dialog.name/referent query failed: {e:?}"))?;
+        .map_err(|e| anyhow!("db.name/referent query failed: {e:?}"))?;
     let mut out = HashMap::with_capacity(claims.len());
     for claim in claims {
         let Some(name) = name_from_id_entity(&claim.of) else {
@@ -195,7 +195,7 @@ fn name_from_id_entity(entity: &Entity) -> Option<String> {
     entity.to_string().strip_prefix("id:").map(str::to_owned)
 }
 
-/// Look up the entity bound to a `dialog.meta/name` bookmark on
+/// Look up the entity bound to a `db.meta/name` bookmark on
 /// the local branch. `Ok(None)` when nothing matches. Used by
 /// `tonk share view` to resolve a positional name argument
 /// into an entity URI for the launcher path. Delegates to

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -957,7 +957,7 @@ mod when_sharing_a_view {
         // Seed a task fixture alongside the view fixture; sharing
         // the task bookmark should fail because the task entity
         // doesn't carry a text/html claim — even though it does
-        // resolve through the same `dialog.meta/name` index.
+        // resolve through the same `db.meta/name` index.
         let test = shareable_view_site().await?;
         test.eval_inline(common::ATTRIBUTE_DECL).await?;
         test.eval_inline(common::CONCEPT_DECL).await?;

--- a/rust/tonk-core/assets/library/board.yaml
+++ b/rust/tonk-core/assets/library/board.yaml
@@ -38,7 +38,7 @@
 # ============================================================
 
 # The board root, bound to the replica entity exactly like the wiki
-# root: it shares `dialog.origin/subject` with `tonk/replica`, so
+# root: it shares `dialog.replica/subject` with `tonk/replica`, so
 # every replica IS a board row and the shell view can render for it
 # without any extra seeding. `name` is the board title shown in the
 # top bar; absent until first renamed (the component falls back to
@@ -52,7 +52,7 @@ concept!: &board/canvas
   with:
     subject:
       description: The repository's subject DID (shared with tonk/replica)
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       as: entity
   maybe:
     name:

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -90,7 +90,7 @@ concept!: &blank
   with:
     subject:
       description: The repository's subject DID (the replica's subject).
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       cardinality: one
       as: entity
 
@@ -1195,12 +1195,12 @@ concept!: &db/origin:
     subject:
       description: |
           The repository subject (as did:key) representing it's unique identifier
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       as: entity
     profile:
       description: |
           Profile entity (as did:key) representing persistent identity on this device
-      the: dialog.origin/profile
+      the: dialog.replica/profile
       as: entity
 
 concept!: &db/branch:
@@ -1215,22 +1215,22 @@ concept!: &db/branch:
       description: The branch name
       the: dialog.branch/name
       as: text
-    origin:
-      description: The origin of this branch
-      the: dialog.branch/origin
+    replica:
+      description: The replica this branch belongs to
+      the: dialog.branch/replica
       as: entity
     tree:
       description: The tree root of this branch
       the: dialog.branch/tree
       as: entity
-    period:
-      description: Synchronization point with an upstream
-      the: dialog.branch/period
+    revision:
+      description: The current revision entity of this branch
+      the: dialog.branch/revision
       as: entity
-    moment:
-      description: Number of commits made since last synchronization
-      the: dialog.branch/moment
-      as: entity
+    edition:
+      description: Causal depth (Lamport edition) of the current revision
+      the: dialog.branch/edition
+      as: unsigned-integer
 
 # A space (replica) the profile has access to. These records live on
 # the profile repository's main branch — one per repository this device
@@ -1278,12 +1278,12 @@ concept!: &tonk/replica
     subject:
       description: |
           The repository subject (as did:key) representing it's unique identifier
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       as: entity
     profile:
       description: |
           Profile entity (as did:key) representing persistent identity on this device
-      the: dialog.origin/profile
+      the: dialog.replica/profile
       as: entity
 
 # This device's live sync STATUS — the observation the chip renders. The worker

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -1631,7 +1631,7 @@ concept!: &diagnose
   with:
     name:
       description: A label for the inspector (unused; satisfies the concept shape).
-      the: dialog.diagnose/name
+      the: db.diagnose/name
       cardinality: one
       as: text
 

--- a/rust/tonk-core/assets/library/sheets.yaml
+++ b/rust/tonk-core/assets/library/sheets.yaml
@@ -778,7 +778,7 @@ concept!: &tonk/binder
         an entity, so the binder carries the replica's `subject` and the
         shell view can read `{subject}` directly to mount the
         repository-name banner — no bridge view needed.
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       as: entity
   maybe:
     active:

--- a/rust/tonk-core/assets/library/wiki.yaml
+++ b/rust/tonk-core/assets/library/wiki.yaml
@@ -206,7 +206,7 @@ concept!: &wiki/link
       as: entity
 
 # The wiki root, bound to the replica entity exactly like the sheets
-# binder: it shares `dialog.origin/subject` with `tonk/replica`, so
+# binder: it shares `dialog.replica/subject` with `tonk/replica`, so
 # every replica IS a wiki row and the shell view can render for it
 # without any extra seeding. `active` records the last selected page
 # so it survives a reload; the components own the live selection.
@@ -216,7 +216,7 @@ concept!: &wiki
   with:
     subject:
       description: The repository's subject DID (shared with tonk/replica)
-      the: dialog.origin/subject
+      the: dialog.replica/subject
       as: entity
   maybe:
     active:

--- a/rust/tonk-core/src/effect.rs
+++ b/rust/tonk-core/src/effect.rs
@@ -24,21 +24,21 @@
 //!
 //! Each effect entity carries:
 //!
-//! - `dialog.effect/source` — the full
+//! - `db.effect/source` — the full
 //!   [`InductiveRuleDescriptor`](dialog_query::InductiveRuleDescriptor)
 //!   serialized as JSON. Source of truth: anything we need to
 //!   re-evaluate the rule can be reconstructed from this single
 //!   text claim.
-//! - `dialog.effect/conclusion` — index pointing at the head
+//! - `db.effect/conclusion` — index pointing at the head
 //!   concept entity, equal to
 //!   [`ConceptDescriptor::this`](dialog_query::ConceptDescriptor::this).
 //!   One claim per effect; the name matches the upstream
 //!   `InductiveRule::conclusion()` accessor regardless of
 //!   polarity.
-//! - `dialog.effect/polarity` — `"assert"` or `"retract"`, the
+//! - `db.effect/polarity` — `"assert"` or `"retract"`, the
 //!   polarity of the rule's head. Disambiguates two effects with
 //!   structurally-identical descriptors but different intent.
-//! - `dialog.effect/on` — index listing every attribute the
+//! - `db.effect/on` — index listing every attribute the
 //!   body reads from, encoded as `on:<domain>/<name>` entity
 //!   URIs. Cardinality-many; one claim per distinct attribute
 //!   in any premise (positive `when` ∪ negative `unless`). The
@@ -49,7 +49,7 @@
 //!   prefix into 32 bytes and hashes any overflow, so short
 //!   attribute names get full sort-locality and long ones still
 //!   collide cleanly.
-//! - `dialog.meta/description` — optional human-readable
+//! - `db.meta/description` — optional human-readable
 //!   description.
 //!
 //! The index attributes are pure projections of the source.
@@ -97,10 +97,10 @@ pub static EFFECT_SYSTEM: LazyLock<Entity> = LazyLock::new(|| {
 // ---------------------------------------------------------------- //
 
 /// The canonical JSON of an effect's [`InductiveRuleDescriptor`].
-/// Source of truth — every other `dialog.effect/*` attribute is a
+/// Source of truth — every other `db.effect/*` attribute is a
 /// derived index that the reactor recomputes from this claim.
 #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[domain("dialog.effect")]
+#[domain("db.effect")]
 pub struct Source(pub String);
 
 /// The head concept entity referenced by the rule, regardless of
@@ -110,14 +110,14 @@ pub struct Source(pub String);
 /// [`InductiveRule::conclusion`](dialog_query::InductiveRule::conclusion).
 /// One claim per effect.
 #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[domain("dialog.effect")]
+#[domain("db.effect")]
 pub struct Conclusion(pub Entity);
 
 /// `"assert"` or `"retract"`. Distinguishes effects whose head
 /// produces new persistent facts from effects whose head
 /// produces retracts of existing cells.
 #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[domain("dialog.effect")]
+#[domain("db.effect")]
 pub struct Polarity(pub String);
 
 /// An attribute the effect's body reads from, encoded as the
@@ -129,7 +129,7 @@ pub struct Polarity(pub String);
 /// reads (positive `when` ∪ negative `unless`).
 #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cardinality(many)]
-#[domain("dialog.effect")]
+#[domain("db.effect")]
 pub struct On(pub Entity);
 
 // ---------------------------------------------------------------- //
@@ -150,7 +150,7 @@ pub enum EffectPolarity {
 }
 
 impl EffectPolarity {
-    /// String form for the `dialog.effect/polarity` claim's
+    /// String form for the `db.effect/polarity` claim's
     /// value. Matches the lowercase variant name.
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -160,7 +160,7 @@ impl EffectPolarity {
     }
 
     /// Parse from the string form stored in
-    /// `dialog.effect/polarity`. Returns `None` on unknown
+    /// `db.effect/polarity`. Returns `None` on unknown
     /// variants.
     pub fn parse(s: &str) -> Option<Self> {
         match s {
@@ -186,14 +186,14 @@ pub enum EffectError {
     )]
     MissingTrigger,
 
-    /// Could not deserialize the effect's `dialog.effect/source`
+    /// Could not deserialize the effect's `db.effect/source`
     /// claim as an [`InductiveRuleDescriptor`].
     #[error("failed to parse stored effect source: {0}")]
     Deserialize(String),
 
-    /// The effect's `dialog.effect/polarity` claim was missing or
+    /// The effect's `db.effect/polarity` claim was missing or
     /// unrecognized.
-    #[error("missing or invalid dialog.effect/polarity for stored effect")]
+    #[error("missing or invalid db.effect/polarity for stored effect")]
     InvalidPolarity,
 }
 
@@ -270,14 +270,14 @@ impl Effect {
     }
 
     /// Canonical JSON form of the rule descriptor — the value of
-    /// the `dialog.effect/source` claim.
+    /// the `db.effect/source` claim.
     pub fn source(&self) -> String {
         serde_json::to_string(&self.rule.descriptor())
             .expect("InductiveRuleDescriptor always serializes to JSON")
     }
 
     /// The head concept entity — the value of the
-    /// `dialog.effect/conclusion` claim.
+    /// `db.effect/conclusion` claim.
     pub fn conclusion(&self) -> Entity {
         self.rule.conclusion().this()
     }
@@ -286,7 +286,7 @@ impl Effect {
     /// attribute the body reads from. For each
     /// `Proposition::Concept` premise in `when` or `unless`,
     /// every attribute referenced by the premise's predicate
-    /// contributes one URI. Values of the `dialog.effect/on`
+    /// contributes one URI. Values of the `db.effect/on`
     /// claims.
     ///
     /// The URI form is recoverable at runtime from a `Changes`

--- a/rust/tonk-core/src/meta.rs
+++ b/rust/tonk-core/src/meta.rs
@@ -18,16 +18,16 @@ use dialog_query::{Attribute, Concept};
 /// Newtype for the attribute backing the [`Name`] concept's
 /// `entity` field. Submodule so the struct name `Referent`
 /// kebab-cases into `referent` (yielding the relation
-/// `dialog.name/referent`) without colliding with [`Name`].
+/// `db.name/referent`) without colliding with [`Name`].
 pub mod name {
     use super::{Attribute, Entity};
 
-    /// The `dialog.name/referent` attribute — the entity a name
+    /// The `db.name/referent` attribute — the entity a name
     /// currently points at. Cardinality `one` (the derive
     /// default), so re-pointing a name supersedes the prior
     /// claim instead of accumulating.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[domain("dialog.name")]
+    #[domain("db.name")]
     pub struct Referent(pub Entity);
 }
 
@@ -137,51 +137,51 @@ pub struct Name {
 
 /// Human-readable description for any entity.
 ///
-/// Stored as `dialog.meta/description` with cardinality `one`.
+/// Stored as `db.meta/description` with cardinality `one`.
 /// Conventionally a short prose paragraph explaining what the
 /// entity represents; not used in identity derivation by either
 /// `dialog_query::AttributeDescriptor` or
 /// `dialog_query::ConceptDescriptor`, so changing it is safe and
 /// does not fork the entity.
 #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[domain("dialog.meta")]
+#[domain("db.meta")]
 pub struct Description(pub String);
 
 /// Newtypes for the `dialog.attribute` namespace.
 ///
 /// Submodule so each newtype's *struct name* ends up
 /// kebab-cased into the right relation slot (`Id` →
-/// `dialog.attribute/id`, etc.) without colliding with the
+/// `db.attribute/id`, etc.) without colliding with the
 /// `Attribute` derive trait re-imported by anyone using
 /// `tonk_schema::meta::*`.
 pub mod attribute {
     use super::Attribute;
 
     /// The selector value of an attribute entity —
-    /// `dialog.attribute/id`. Carries the human-readable
+    /// `db.attribute/id`. Carries the human-readable
     /// `domain/name` form (e.g. `io.gozala.person/name`); one
     /// claim per attribute entity, cardinality `one`. Written by
     /// the interpreter so "find the attribute entity for
     /// selector `xyz/foo`" runs as a normal EAV match.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[domain("dialog.attribute")]
+    #[domain("db.attribute")]
     pub struct Id(pub String);
 
     /// The dialog `Type` discriminant of an attribute entity —
-    /// `dialog.attribute/type`. The string form (e.g. `"Text"`,
+    /// `db.attribute/type`. The string form (e.g. `"Text"`,
     /// `"UnsignedInteger"`) is what
     /// `dialog_query::AttributeDescriptor` round-trips through
     /// serde, not the underlying `ValueDataType` variant name.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[domain("dialog.attribute")]
+    #[domain("db.attribute")]
     pub struct Type(pub String);
 
     /// The cardinality of an attribute entity —
-    /// `dialog.attribute/cardinality`. Takes `"one"` or
+    /// `db.attribute/cardinality`. Takes `"one"` or
     /// `"many"`; the textual form matches what
     /// `dialog_query::Cardinality` serialises to.
     #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[domain("dialog.attribute")]
+    #[domain("db.attribute")]
     pub struct Cardinality(pub String);
 }
 

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1042,12 +1042,12 @@ fn first_field(value: &JsValue, field: &str) -> Result<Option<String>, ErrorDeta
 /// `(entity, descriptor_json)`.
 ///
 /// A bare name is first resolved through the **Name concept**
-/// (`id:<name>` → `dialog.name/referent`) into a concept entity URI,
+/// (`id:<name>` → `db.name/referent`) into a concept entity URI,
 /// then that URI drives the Phase-1 concept-of-concepts lookup by
 /// `this`. This is the path that makes a model or view named after a
 /// concept pinned to a `this:` URI (e.g. `workspace` → `tonk:workspace`)
 /// resolve — the concept carries a `Name` claim but no
-/// `dialog.meta/name`, so a direct `name`-filtered Phase-1 would miss
+/// `db.meta/name`, so a direct `name`-filtered Phase-1 would miss
 /// it. A value that is already a URI skips name resolution.
 async fn resolve_model(host: &Element, source: &str) -> Result<(String, String), ErrorDetail> {
     let phase1_q = resolve_model_query(host, source).await?;
@@ -1059,7 +1059,7 @@ async fn resolve_model(host: &Element, source: &str) -> Result<(String, String),
 ///
 /// Splits the front half of [`resolve_model`]: a bare bookmark name is
 /// resolved through the Name concept (`id:<name>` →
-/// `dialog.name/referent`) into a concept URI (a one-shot `query`),
+/// `db.name/referent`) into a concept URI (a one-shot `query`),
 /// then `phase1_query` is built from the resolved `ParsedSource`. The
 /// caller decides whether to run it once or open a subscription on it —
 /// the model link subscribes so a late-seeded concept recovers.
@@ -3104,7 +3104,7 @@ mod tests {
         // each view frame carries the value that decides portal mode.
         //
         // `resolve_model` resolves a bare name through the Name concept
-        // first (`id:<name>` → `dialog.name/referent`), then runs the
+        // first (`id:<name>` → `db.name/referent`), then runs the
         // Phase-1 concept query by `this`. So each bare-name resolution
         // is TWO queries: a name lookup, then the concept lookup. The
         // fixture answers in dispatch order, so a name-resolution row

--- a/rust/tonk-display/src/events/path.rs
+++ b/rust/tonk-display/src/events/path.rs
@@ -322,7 +322,7 @@ mod tests {
             Classification::Other
         ));
         assert!(matches!(
-            classify("dialog.name/referent"),
+            classify("db.name/referent"),
             Classification::Other
         ));
         // Looks like a prefix match but the next char isn't a

--- a/rust/tonk-display/src/notation_format.rs
+++ b/rust/tonk-display/src/notation_format.rs
@@ -192,7 +192,7 @@ pub fn looks_like_uri(s: &str) -> bool {
         return true;
     }
     // Reverse-dotted attribute URI (`xyz.tonk.view/greeting`,
-    // `dialog.name/referent`) — both a dotted prefix and a `/`
+    // `db.name/referent`) — both a dotted prefix and a `/`
     // separator. Plain string values rarely look like this, so
     // emitting them bare is the right default.
     s.contains('.') && s.contains('/')

--- a/rust/tonk-display/src/render.rs
+++ b/rust/tonk-display/src/render.rs
@@ -917,6 +917,30 @@ fn render_binding(
     render_segments_with_shadow(segments, &member.this, &member.fields, shadow)
 }
 
+/// Whether any `{field}` segment of `binding` references a field missing
+/// from both `shadow` and `row_fields` (i.e. genuinely absent, not
+/// present-but-empty). `{this}` and `{text}` segments never count as absent.
+/// Used to hold off writing a partially-resolved multi-segment attribute
+/// binding (`with="main@{id}"`) until its field lands — see
+/// [`apply_attribute_binding`].
+fn binding_has_absent_field(
+    binding: &Binding,
+    row_fields: &BTreeMap<String, Ipld>,
+    shadow: &BTreeMap<String, Ipld>,
+) -> bool {
+    use crate::template::Segment;
+    let segments = match &binding.kind {
+        BindingKind::Text { segments } => segments,
+        BindingKind::Attribute { segments, .. } => segments,
+    };
+    segments.iter().any(|seg| match seg {
+        Segment::Field(name) => {
+            name != "this" && shadow.get(name).is_none() && row_fields.get(name).is_none()
+        }
+        Segment::Text(_) => false,
+    })
+}
+
 /// Write a binding's rendered value to the target DOM node.
 fn write_binding(
     scope_root: &Node,
@@ -944,7 +968,14 @@ fn write_binding(
                 )));
             }
             let value = single_field_value(binding, &member.this, &member.fields, shadow);
-            apply_attribute_binding(scope_root, binding, rendered, value.as_ref());
+            let has_absent_field = binding_has_absent_field(binding, &member.fields, shadow);
+            apply_attribute_binding(
+                scope_root,
+                binding,
+                rendered,
+                value.as_ref(),
+                has_absent_field,
+            );
         }
     }
 }

--- a/rust/tonk-display/src/template.rs
+++ b/rust/tonk-display/src/template.rs
@@ -373,6 +373,7 @@ mod dom {
         binding: &Binding,
         rendered: &str,
         single_field_value: Option<&Ipld>,
+        has_absent_field: bool,
     ) {
         let BindingKind::Attribute {
             attr_name,
@@ -399,6 +400,22 @@ mod dom {
         // still writes `""`; only a missing field clears the attribute.
         let absent_single_field = single_field_value.is_none()
             && matches!(segments.as_slice(), [Segment::Field(name)] if name != "this");
+
+        // A MULTI-segment binding (e.g. `with="main@{id}"`) with a genuinely
+        // absent `{field}` component (`has_absent_field`, computed by the
+        // caller against the shadow + row fields) is only PARTIALLY resolved:
+        // the value it stands for hasn't arrived yet. Writing it now
+        // substitutes the absent field to nothing, turning `main@{id}` into
+        // the misleading `main@` — a value that no longer contains a `{…}`
+        // placeholder, so `<tonk-site>` (and any consumer that skips
+        // unresolved templates) mistakes it for a resolved-but-MALFORMED
+        // value and errors permanently instead of waiting. Leave the
+        // attribute untouched (its prior `{…}` placeholder survives) until a
+        // frame carrying the field lands. The lone-single-field case is
+        // handled separately above (it clears the attribute instead).
+        if !absent_single_field && has_absent_field {
+            return;
+        }
 
         if *force_attribute {
             if absent_single_field {

--- a/rust/tonk-evaluator/src/effect_query.rs
+++ b/rust/tonk-evaluator/src/effect_query.rs
@@ -135,7 +135,7 @@ fn the(domain: &str, name: &str) -> dialog_query::attribute::The {
 }
 
 /// Builder for [`effect_by_entity`]. Resolves the
-/// `dialog.effect/source` and `dialog.effect/polarity` claims and
+/// `db.effect/source` and `db.effect/polarity` claims and
 /// rehydrates the effect.
 pub struct EffectByEntity {
     entity: Entity,
@@ -152,7 +152,7 @@ impl EffectByEntity {
         let source_claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the("dialog.effect", "source"))
+                Term::<dialog_query::attribute::The>::from(the("db.effect", "source"))
                     .of(Term::from(self.entity.clone()))
                     .is(Term::<String>::var("source")),
             ))
@@ -168,7 +168,7 @@ impl EffectByEntity {
             Value::String(s) => s,
             other => {
                 return Err(EffectLookupError::Query(format!(
-                    "dialog.effect/source claim was not a string: {other:?}"
+                    "db.effect/source claim was not a string: {other:?}"
                 )));
             }
         };
@@ -177,7 +177,7 @@ impl EffectByEntity {
         let polarity_claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the("dialog.effect", "polarity"))
+                Term::<dialog_query::attribute::The>::from(the("db.effect", "polarity"))
                     .of(Term::from(self.entity.clone()))
                     .is(Term::<String>::var("polarity")),
             ))
@@ -201,7 +201,7 @@ impl EffectByEntity {
     }
 }
 
-/// Look up all effect entities whose `dialog.effect/on` index
+/// Look up all effect entities whose `db.effect/on` index
 /// contains the given attribute. `attribute_name` is the runtime
 /// `domain/name` form (what a [`Changes`](dialog_artifacts::Changes)
 /// instruction's `Attribute` displays as); this builder wraps it
@@ -224,7 +224,7 @@ pub struct EffectsByOn {
 }
 
 impl EffectsByOn {
-    /// Resolve every effect entity whose `dialog.effect/on`
+    /// Resolve every effect entity whose `db.effect/on`
     /// index includes `attribute_entity`.
     pub async fn resolve<Env: EffectEnv>(
         self,
@@ -234,7 +234,7 @@ impl EffectsByOn {
         let claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the("dialog.effect", "on"))
+                Term::<dialog_query::attribute::The>::from(the("db.effect", "on"))
                     .of(Term::<Entity>::var("effect"))
                     .is(Term::<Entity>::from(self.attribute_entity.clone())),
             ))
@@ -379,48 +379,48 @@ mod tests {
             .expect("`db:effect` is a valid entity URI");
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.meta/effect"
+                c.the.to_string() == "db.meta/effect"
                     && c.of == this
                     && matches!(&c.is, Value::Entity(e) if *e == marker)
             }),
-            "missing dialog.meta/effect marker"
+            "missing db.meta/effect marker"
         );
 
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/source"
+                c.the.to_string() == "db.effect/source"
                     && c.of == this
                     && matches!(&c.is, Value::String(s) if s == &source)
             }),
-            "missing dialog.effect/source claim"
+            "missing db.effect/source claim"
         );
 
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/conclusion"
+                c.the.to_string() == "db.effect/conclusion"
                     && c.of == this
                     && matches!(&c.is, Value::Entity(e) if *e == conclusion)
             }),
-            "missing dialog.effect/conclusion claim"
+            "missing db.effect/conclusion claim"
         );
 
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/polarity"
+                c.the.to_string() == "db.effect/polarity"
                     && c.of == this
                     && matches!(&c.is, Value::String(s) if s == "assert")
             }),
-            "missing dialog.effect/polarity claim"
+            "missing db.effect/polarity claim"
         );
 
         for attribute in &on_set {
             assert!(
                 asserted.iter().any(|c| {
-                    c.the.to_string() == "dialog.effect/on"
+                    c.the.to_string() == "db.effect/on"
                         && c.of == this
                         && matches!(&c.is, Value::Entity(e) if *e == *attribute)
                 }),
-                "missing dialog.effect/on claim for {attribute}"
+                "missing db.effect/on claim for {attribute}"
             );
         }
     }
@@ -447,11 +447,11 @@ mod tests {
 
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/polarity"
+                c.the.to_string() == "db.effect/polarity"
                     && c.of == this
                     && matches!(&c.is, Value::String(s) if s == "retract")
             }),
-            "missing dialog.effect/polarity = retract claim"
+            "missing db.effect/polarity = retract claim"
         );
     }
 

--- a/rust/tonk-evaluator/src/effects.rs
+++ b/rust/tonk-evaluator/src/effects.rs
@@ -313,7 +313,7 @@ fn the(domain: &str, name: &str) -> dialog_query::attribute::The {
 }
 
 /// Query the transaction's overlay for effect entities whose
-/// `dialog.effect/on` index lists the given attribute name.
+/// `db.effect/on` index lists the given attribute name.
 /// Equivalent to [`effects_by_on`](crate::effect_query::effects_by_on)
 /// but reads through the transaction so in-flight effect
 /// installs and retracts are visible.
@@ -329,7 +329,7 @@ async fn effects_on<Env: InduceEnv>(
     let claims: Vec<dialog_query::Claim> = txn
         .query()
         .select(dialog_query::AttributeQuery::from(
-            Term::<dialog_query::attribute::The>::from(the("dialog.effect", "on"))
+            Term::<dialog_query::attribute::The>::from(the("db.effect", "on"))
                 .of(Term::<Entity>::var("effect"))
                 .is(Term::<Entity>::from(attribute_entity)),
         ))
@@ -356,7 +356,7 @@ async fn load_effect<Env: InduceEnv>(
     let source_claims: Vec<dialog_query::Claim> = txn
         .query()
         .select(dialog_query::AttributeQuery::from(
-            Term::<dialog_query::attribute::The>::from(the("dialog.effect", "source"))
+            Term::<dialog_query::attribute::The>::from(the("db.effect", "source"))
                 .of(Term::<Entity>::from(entity.clone()))
                 .is(Term::<String>::var("source")),
         ))
@@ -372,7 +372,7 @@ async fn load_effect<Env: InduceEnv>(
         Value::String(s) => s,
         other => {
             return Err(InduceError::Query(format!(
-                "dialog.effect/source was not a string: {other:?}"
+                "db.effect/source was not a string: {other:?}"
             )));
         }
     };
@@ -380,7 +380,7 @@ async fn load_effect<Env: InduceEnv>(
     let polarity_claims: Vec<dialog_query::Claim> = txn
         .query()
         .select(dialog_query::AttributeQuery::from(
-            Term::<dialog_query::attribute::The>::from(the("dialog.effect", "polarity"))
+            Term::<dialog_query::attribute::The>::from(the("db.effect", "polarity"))
                 .of(Term::<Entity>::from(entity))
                 .is(Term::<String>::var("polarity")),
         ))
@@ -392,12 +392,12 @@ async fn load_effect<Env: InduceEnv>(
     let polarity_claim = polarity_claims
         .into_iter()
         .next()
-        .ok_or_else(|| InduceError::Query("missing dialog.effect/polarity".to_string()))?;
+        .ok_or_else(|| InduceError::Query("missing db.effect/polarity".to_string()))?;
     let polarity_str = match polarity_claim.is {
         Value::String(s) => s,
         _ => {
             return Err(InduceError::Query(
-                "dialog.effect/polarity was not a string".to_string(),
+                "db.effect/polarity was not a string".to_string(),
             ));
         }
     };
@@ -535,7 +535,7 @@ async fn fire_effect<Env: InduceEnv>(
 }
 
 /// Query the transaction overlay for the
-/// `(<concept>, dialog.concept/transient, db:transient)` marker
+/// `(<concept>, db.concept/transient, db:transient)` marker
 /// so the loop can classify emitted heads.
 async fn is_transient<Env: InduceEnv>(
     txn: &Transaction<'_>,
@@ -548,7 +548,7 @@ async fn is_transient<Env: InduceEnv>(
     let claims: Vec<dialog_query::Claim> = dialog_query::Output::try_vec(
         txn.query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the("dialog.concept", "transient"))
+                Term::<dialog_query::attribute::The>::from(the("db.concept", "transient"))
                     .of(Term::from(concept_entity))
                     .is(Term::from(marker_target)),
             ))
@@ -759,7 +759,7 @@ mod tests {
         one_field_concept(domain, name, Type::String)
     }
 
-    /// The string form dialog stores in `dialog.attribute/type`
+    /// The string form dialog stores in `db.attribute/type`
     /// for each `Type` variant the tests need. The labels match
     /// dialog's `TypeDescriptor` names (Text for String,
     /// UnsignedInteger for UnsignedInt, etc.), not the variant
@@ -789,23 +789,23 @@ mod tests {
                 .unwrap_or("String")
                 .to_string();
             txn = txn
+                .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                    "{}/{}",
+                    attr.domain(),
+                    attr.name()
+                )))
                 .assert(
-                    the!("dialog.attribute/id")
-                        .of(attr_entity.clone())
-                        .is(format!("{}/{}", attr.domain(), attr.name())),
-                )
-                .assert(
-                    the!("dialog.attribute/type")
+                    the!("db.attribute/type")
                         .of(attr_entity.clone())
                         .is(type_label),
                 )
                 .assert(
-                    the!("dialog.attribute/cardinality")
+                    the!("db.attribute/cardinality")
                         .of(attr_entity.clone())
                         .is("one".to_string()),
                 )
                 .assert(
-                    the!("dialog.meta/description")
+                    the!("db.meta/description")
                         .of(attr_entity)
                         .is(String::new()),
                 );

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -1059,7 +1059,7 @@ mod tests {
         .unwrap()
     }
 
-    /// Install the `dialog.attribute/*` and `dialog.meta/description`
+    /// Install the `db.attribute/*` and `db.meta/description`
     /// facts a concept's fields need so the analyzer can rehydrate
     /// the descriptor from the branch.
     fn install_attribute_facts<'a>(
@@ -1070,23 +1070,23 @@ mod tests {
             let attr_entity: dialog_artifacts::Entity =
                 attr.to_uri().parse().expect("attribute URI");
             txn = txn
+                .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                    "{}/{}",
+                    attr.domain(),
+                    attr.name()
+                )))
                 .assert(
-                    the!("dialog.attribute/id")
-                        .of(attr_entity.clone())
-                        .is(format!("{}/{}", attr.domain(), attr.name())),
-                )
-                .assert(
-                    the!("dialog.attribute/type")
+                    the!("db.attribute/type")
                         .of(attr_entity.clone())
                         .is("Text".to_string()),
                 )
                 .assert(
-                    the!("dialog.attribute/cardinality")
+                    the!("db.attribute/cardinality")
                         .of(attr_entity.clone())
                         .is("one".to_string()),
                 )
                 .assert(
-                    the!("dialog.meta/description")
+                    the!("db.meta/description")
                         .of(attr_entity)
                         .is(String::new()),
                 );
@@ -1096,7 +1096,7 @@ mod tests {
 
     /// Install a concept and publish it under a name so the
     /// analyzer's resolver finds it via `lookup_concept`. Uses
-    /// the existing `name!` desugar through a `dialog.meta/name`
+    /// the existing `name!` desugar through a `db.meta/name`
     /// claim against `id:<name>`.
     fn install_named_concept<'a>(
         txn: Transaction<'a>,
@@ -1106,15 +1106,11 @@ mod tests {
     ) -> Transaction<'a> {
         let entity = descriptor.this();
         // Publish the name — `id:<name>` carries the
-        // `dialog.meta/name` claim pointing at the concept
+        // `db.meta/name` claim pointing at the concept
         // entity. This is the same shape `name!:` produces.
         let id_entity: dialog_artifacts::Entity =
             format!("id:{name}").parse().expect("id:<name> is valid");
-        let mut txn = txn.assert(
-            the!("dialog.name/referent")
-                .of(id_entity)
-                .is(entity.clone()),
-        );
+        let mut txn = txn.assert(the!("db.name/referent").of(id_entity).is(entity.clone()));
         if transient {
             txn = txn.assert(TransientConcept::new(descriptor.clone()));
         } else {
@@ -1289,7 +1285,7 @@ attribute!: &foo/title
         let id_demo: dialog_artifacts::Entity = "id:demo".parse()?;
         branch
             .transaction()
-            .assert(the!("dialog.name/referent").of(id_demo).is(target.clone()))
+            .assert(the!("db.name/referent").of(id_demo).is(target.clone()))
             .commit()
             .perform(&operator)
             .await?;
@@ -1327,7 +1323,7 @@ name!:
         let claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.name/referent"))
+                Term::<dialog_query::attribute::The>::from(the!("db.name/referent"))
                     .of(Term::<dialog_artifacts::Entity>::from(id_copy))
                     .is(Term::<dialog_artifacts::Entity>::var("referent")),
             ))
@@ -1389,11 +1385,11 @@ name!:
             .await
             .map_err(|e| anyhow::anyhow!("commit (install rule): {e}"))?;
 
-        // Sanity: the rule's dialog.effect/source claim landed.
+        // Sanity: the rule's db.effect/source claim landed.
         let effect_source_claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.effect/source"))
+                Term::<dialog_query::attribute::The>::from(the!("db.effect/source"))
                     .of(Term::<dialog_artifacts::Entity>::var("effect"))
                     .is(Term::<String>::var("source")),
             ))
@@ -1478,7 +1474,7 @@ name!:
     /// directly).
     ///
     /// Verifies the `transient:` field on `concept!:` flows all
-    /// the way to the `dialog.concept/transient` marker fact —
+    /// the way to the `db.concept/transient` marker fact —
     /// without it, the rule would fail validate (no transient
     /// trigger) and the body wouldn't classify head emissions
     /// correctly.
@@ -1542,7 +1538,7 @@ rule!:
         let marker_claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.concept/transient"))
+                Term::<dialog_query::attribute::The>::from(the!("db.concept/transient"))
                     .of(Term::from(ping_entity.clone()))
                     .is(Term::from(marker_target.clone())),
             ))
@@ -1552,7 +1548,7 @@ rule!:
         assert_eq!(
             marker_claims.len(),
             1,
-            "expected one dialog.concept/transient claim on ping; saw {marker_claims:?}"
+            "expected one db.concept/transient claim on ping; saw {marker_claims:?}"
         );
 
         // And the durable pong concept has no marker.
@@ -1561,7 +1557,7 @@ rule!:
         let pong_marker_claims: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.concept/transient"))
+                Term::<dialog_query::attribute::The>::from(the!("db.concept/transient"))
                     .of(Term::from(pong_entity))
                     .is(Term::from(marker_target)),
             ))
@@ -1705,7 +1701,7 @@ counter!: &counter-demo
         let referent: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.name/referent"))
+                Term::<dialog_query::attribute::The>::from(the!("db.name/referent"))
                     .of(Term::from(counter_demo))
                     .is(Term::<dialog_artifacts::Entity>::var("e")),
             ))
@@ -1878,7 +1874,7 @@ counter!: &counter-demo
         let referent: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.name/referent"))
+                Term::<dialog_query::attribute::The>::from(the!("db.name/referent"))
                     .of(Term::from(counter_demo))
                     .is(Term::<dialog_artifacts::Entity>::var("e")),
             ))
@@ -1997,7 +1993,7 @@ counter!: &counter-demo
         let referent: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.name/referent"))
+                Term::<dialog_query::attribute::The>::from(the!("db.name/referent"))
                     .of(Term::from(counter_demo))
                     .is(Term::<dialog_artifacts::Entity>::var("e")),
             ))
@@ -2112,7 +2108,7 @@ concept!: &pong
     }
 
     /// `rule!: this: <entity>, assert!: ..` installs the rule at the
-    /// user-chosen entity. The `dialog.effect/source` claim must land
+    /// user-chosen entity. The `db.effect/source` claim must land
     /// at that entity, not at the content-derived `Effect::this`.
     /// This is the install-at-named-entity path mirroring task #90's
     /// retract-at-named-entity flow.
@@ -2173,12 +2169,12 @@ concept!: &pong
             .await
             .map_err(|e| anyhow::anyhow!("commit (rule): {e}"))?;
 
-        // The `dialog.effect/source` claim should hang off the
+        // The `db.effect/source` claim should hang off the
         // chosen entity, not off the content-derived hash.
         let at_chosen: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.effect/source"))
+                Term::<dialog_query::attribute::The>::from(the!("db.effect/source"))
                     .of(Term::<Entity>::from(chosen.clone()))
                     .is(Term::<String>::var("source")),
             ))
@@ -2188,7 +2184,7 @@ concept!: &pong
         assert_eq!(
             at_chosen.len(),
             1,
-            "dialog.effect/source must land at id:my-counter, saw {at_chosen:?}"
+            "db.effect/source must land at id:my-counter, saw {at_chosen:?}"
         );
 
         // And there's exactly one installed effect — no orphan at
@@ -2196,7 +2192,7 @@ concept!: &pong
         let all_sources: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
-                Term::<dialog_query::attribute::The>::from(the!("dialog.effect/source"))
+                Term::<dialog_query::attribute::The>::from(the!("db.effect/source"))
                     .of(Term::<Entity>::var("any"))
                     .is(Term::<String>::var("source")),
             ))
@@ -2220,7 +2216,7 @@ concept!: &pong
     /// to end through the notation path: parse → analyze →
     /// `Statement::RetractEffect` → evaluator resolves a `Rule`
     /// retract handle off the branch → transaction.retract →
-    /// commit. After the commit the `dialog.effect/source` claim
+    /// commit. After the commit the `db.effect/source` claim
     /// at the named entity must be gone (proving #87's
     /// stored-bytes dissociate) and the rule must stop firing.
     #[dialog_common::test]
@@ -2283,7 +2279,7 @@ concept!: &pong
 
         // Sanity: the source claim is at the chosen entity.
         let source_query = dialog_query::AttributeQuery::from(
-            Term::<dialog_query::attribute::The>::from(the!("dialog.effect/source"))
+            Term::<dialog_query::attribute::The>::from(the!("db.effect/source"))
                 .of(Term::<Entity>::from(chosen.clone()))
                 .is(Term::<String>::var("source")),
         );
@@ -2324,7 +2320,7 @@ concept!: &pong
             .await?;
         assert!(
             post.is_empty(),
-            "dialog.effect/source at {chosen} must be empty after retract, saw {post:?}"
+            "db.effect/source at {chosen} must be empty after retract, saw {post:?}"
         );
 
         Ok(())
@@ -2540,7 +2536,7 @@ concept!: &person
 
         // Re-open the branch from storage before the instance
         // commit — the rule must be *loaded* from the branch's
-        // dialog.effect/* facts, not held in memory. This is what
+        // db.effect/* facts, not held in memory. This is what
         // a separate /evaluate request does.
         let branch = repo.branch("main").open().perform(&operator).await?;
 
@@ -3675,7 +3671,7 @@ workspace!:
     }
 
     /// End-to-end: a `concept!` with a `maybe:` block lands the
-    /// optional marker (`dialog.concept.optional/{field}`) on the
+    /// optional marker (`db.concept.optional/{field}`) on the
     /// branch for the optional field only — the required `with:`
     /// field carries none. Proves the notation → analyzer →
     /// storage round-trip for optionality.
@@ -3742,7 +3738,7 @@ workspace!:
         let entity = descriptor.this();
 
         let nickname_the: dialog_query::attribute::The =
-            "dialog.concept.optional/nickname".parse().unwrap();
+            "db.concept.optional/nickname".parse().unwrap();
         let nickname_markers: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(
@@ -3760,8 +3756,7 @@ workspace!:
         );
         assert_eq!(nickname_markers[0].is, Value::Boolean(true));
 
-        let name_the: dialog_query::attribute::The =
-            "dialog.concept.optional/name".parse().unwrap();
+        let name_the: dialog_query::attribute::The = "db.concept.optional/name".parse().unwrap();
         let name_markers: Vec<dialog_query::Claim> = branch
             .query()
             .select(dialog_query::AttributeQuery::from(

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -115,18 +115,25 @@ impl CustomElement for TonkFab {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &[]
+        // Observe `space` so a LATE-resolving `space="{id}"` binding — the
+        // mounting view stamps the placeholder before the site's `id` field
+        // lands, then rewrites the attribute once it does — re-authors the bar
+        // with the real DID. Without this the bar renders once with the
+        // unresolved `{id}` (or an empty value) and the space-name chip stays
+        // "Untitled", the sync chip never subscribes, and the share/rename
+        // caps target nothing.
+        &["space"]
     }
 
-    /// Author the FAB's own DOM. The `space` attribute is stamped by the
-    /// mounting view (`<tonk-fab with="main@profile:tonk" space="{id}">`) and
-    /// is already resolved by the time `inject_children` runs — per the
-    /// `custom-elements` crate, this is deferred to (and runs before) the
-    /// first `connectedCallback`, i.e. after HTML parsing has set the
-    /// element's attributes.
+    /// Author the FAB's own DOM against the current `space` attribute. The
+    /// mounting view stamps `space="{id}"`; that `{id}` resolves to the space
+    /// DID only once the site's `id` field lands, so `space` can still be the
+    /// unresolved placeholder (or empty) when `inject_children` first runs.
+    /// [`observed_attributes`] lists `space`, so
+    /// [`attribute_changed_callback`] re-authors the bar when the real value
+    /// arrives — see the `render_bar` helper both share.
     fn inject_children(&mut self, this: &HtmlElement) {
-        let space = this.get_attribute("space").unwrap_or_default();
-        this.set_inner_html(&crate::markup::fab_html(&space));
+        render_bar(this);
     }
 
     fn connected_callback(&mut self, this: &HtmlElement) {
@@ -193,11 +200,56 @@ impl CustomElement for TonkFab {
 
     fn attribute_changed_callback(
         &mut self,
-        _this: &HtmlElement,
-        _name: String,
-        _old: Option<String>,
-        _new: Option<String>,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
     ) {
+        // The mounting view stamps `space="{id}"` and rewrites it to the real
+        // space DID once the site's `id` field resolves. Propagate that change
+        // to the bar's space-scoped children so their own subscriptions re-run
+        // against the resolved space. Skip the no-op initial set (`old == new`,
+        // fired once when the attribute is first observed) and any still-
+        // unresolved placeholder value.
+        if name != "space" || old == new {
+            return;
+        }
+        let Some(space) = new.filter(|s| !s.is_empty() && !s.contains('{')) else {
+            return;
+        };
+        propagate_space(this, &space);
+    }
+}
+
+/// Author the FAB bar against `this`'s current `space` attribute. Shared by
+/// `inject_children` (first mount) and — through `propagate_space` — the
+/// `space` observer.
+fn render_bar(this: &HtmlElement) {
+    let space = this.get_attribute("space").unwrap_or_default();
+    this.set_inner_html(&crate::markup::fab_html(&space));
+}
+
+/// Propagate a resolved `space` DID to the bar's space-scoped children,
+/// updating their routing attributes in place so their live subscriptions
+/// re-run. Patches attributes rather than re-authoring the whole bar so the
+/// host- and child-level listeners `connected_callback` attached survive.
+fn propagate_space(this: &HtmlElement, space: &str) {
+    // `<ui-space-name space="{space}">` — the rename chip. Its own
+    // `observed_attributes` includes `space`, so setting it re-subscribes.
+    if let Ok(Some(name_chip)) = this.query_selector("ui-space-name") {
+        let _ = name_chip.set_attribute("space", space);
+    }
+    // `<ui-sync-status with="main@{space}">` — the sync/pause chip. Its
+    // routing contract is a full `branch@repo` location, not a bare DID.
+    if let Ok(Some(sync_chip)) = this.query_selector("ui-sync-status") {
+        let _ = sync_chip.set_attribute("with", &crate::logic::space_with(space));
+    }
+    // `<ui-dropdown exclude="{space}">` / `<ui-space-switcher exclude="{space}">`
+    // — hide the active space from the switcher list.
+    for sel in ["ui-dropdown[exclude]", "ui-space-switcher[exclude]"] {
+        if let Ok(Some(el)) = this.query_selector(sel) {
+            let _ = el.set_attribute("exclude", space);
+        }
     }
 }
 

--- a/rust/tonk-fab/src/space_name.rs
+++ b/rust/tonk-fab/src/space_name.rs
@@ -88,6 +88,36 @@ impl subscribing::Subscribing for SpaceNameBehaviour {
     }
 }
 
+impl UiSpaceNameElement {
+    /// Wire the `<tonk-editable>` commit listener and open the repo-name
+    /// subscription against the element's current (resolved) `space`. Shared
+    /// by `connected_callback` (mount with a resolved space) and
+    /// `attribute_changed_callback` (a `space` that resolved after mount).
+    fn start(&mut self, this: &HtmlElement) {
+        // Attach the commit listener to the `<tonk-editable>` child. There is
+        // no `tonk-display` event delegation here (this markup is Rust-owned,
+        // not a resolved template), so the `change` binding is wired directly.
+        if self.change.borrow().is_none()
+            && let Some(editable) = this.query_selector("tonk-editable").ok().flatten()
+        {
+            let claim_target = editable.clone();
+            let current_name = self.current_name.clone();
+            let host = this.clone();
+            let on_change: ChangeClosure = Closure::wrap(Box::new(move |event: Event| {
+                handle_commit(&event, &claim_target, &current_name, &host);
+            }));
+            let _ = editable
+                .add_event_listener_with_callback("change", on_change.as_ref().unchecked_ref());
+            *self.change.borrow_mut() = Some(on_change);
+        }
+
+        let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(SpaceNameBehaviour {
+            current_name: self.current_name.clone(),
+        });
+        self.scaffold.connect(this, behaviour);
+    }
+}
+
 impl CustomElement for UiSpaceNameElement {
     fn inject_children(&mut self, this: &HtmlElement) {
         *self.current_name.borrow_mut() = UNTITLED.to_owned();
@@ -113,33 +143,37 @@ impl CustomElement for UiSpaceNameElement {
     fn connected_callback(&mut self, this: &HtmlElement) {
         if this
             .get_attribute("space")
-            .filter(|s| !s.is_empty())
+            .filter(|s| !s.is_empty() && !s.contains('{'))
             .is_none()
         {
-            // No space yet (an unsubstituted `{id}` placeholder, say) — the
-            // attribute callback re-runs this when it lands.
+            // No space yet (an unsubstituted `{id}` placeholder, say) —
+            // `attribute_changed_callback` runs `start` when it lands.
             return;
         }
+        self.start(this);
+    }
 
-        // Attach the commit listener to the `<tonk-editable>` child. There is
-        // no `tonk-display` event delegation here (this markup is Rust-owned,
-        // not a resolved template), so the `change` binding is wired directly.
-        if let Some(editable) = this.query_selector("tonk-editable").ok().flatten() {
-            let claim_target = editable.clone();
-            let current_name = self.current_name.clone();
-            let host = this.clone();
-            let on_change: ChangeClosure = Closure::wrap(Box::new(move |event: Event| {
-                handle_commit(&event, &claim_target, &current_name, &host);
-            }));
-            let _ = editable
-                .add_event_listener_with_callback("change", on_change.as_ref().unchecked_ref());
-            *self.change.borrow_mut() = Some(on_change);
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        // The mounting FAB stamps `space="{id}"` and rewrites it to the space
+        // DID once the site's `id` resolves (see `tonk-fab`'s `propagate_space`).
+        // `connected_callback` bails when `space` is still a placeholder, so
+        // this callback drives the (re)subscribe once the real value lands.
+        if name != "space" || old == new || !this.is_connected() {
+            return;
         }
-
-        let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(SpaceNameBehaviour {
-            current_name: self.current_name.clone(),
-        });
-        self.scaffold.connect(this, behaviour);
+        // Tear down any prior subscription (a placeholder connect installed the
+        // change listener but no subscription) and re-run against the new space.
+        self.scaffold.disconnect();
+        self.change.borrow_mut().take();
+        if new.filter(|s| !s.is_empty() && !s.contains('{')).is_some() {
+            self.start(this);
+        }
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {

--- a/rust/tonk-macros/src/lib.rs
+++ b/rust/tonk-macros/src/lib.rs
@@ -33,7 +33,7 @@ use syn::{LitStr, parse_macro_input};
 /// an analysis error all become compile errors.
 ///
 /// Rules have no `TransactRequest` representation (the `Claim` wire
-/// can't carry `dialog.effect/*` triples), so each `rule!:` install
+/// can't carry `db.effect/*` triples), so each `rule!:` install
 /// is embedded as its `(source, polarity)` and rebuilt at runtime
 /// via [`tonk_core::effect::Effect::from_source`] +
 /// `tonk_schema::rule::Rule::asserting`. A document with no `rule!:`

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -217,7 +217,7 @@ const BOOTSTRAP_JS: &str = r#"(function(){
   // In-flight de-duplication for one-shot queries. Many <tonk-display>
   // elements resolve the SAME concept descriptor (phase-1) or bookmark name
   // on one page load — e.g. three displays of `tonk:repository` each fire an
-  // identical `dialog.meta/*` query. Coalesce identical concurrent queries
+  // identical `db.meta/*` query. Coalesce identical concurrent queries
   // onto one request keyed by (route + body); every caller shares the single
   // promise. Purely in-flight (cleared when it settles), so no staleness —
   // just fewer round-trips. A subscription is never deduped here (it's a

--- a/rust/tonk-render/src/page/orchestrate.rs
+++ b/rust/tonk-render/src/page/orchestrate.rs
@@ -194,7 +194,7 @@ async fn resolve_model<B: QueryBackend>(
     Ok((row.this, descriptor))
 }
 
-/// Resolve a bookmark name to its entity URI via `dialog.name/referent`.
+/// Resolve a bookmark name to its entity URI via `db.name/referent`.
 async fn resolve_name<B: QueryBackend>(backend: &B, name: &str) -> Result<String, RenderError> {
     let rows = run_query(backend, name_query(name)).await?;
     let row = rows

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -14,7 +14,7 @@
 //! These types only define the *shape* a command carries. The handler
 //! that reacts to one lives in `tonk-worker`; the transient-ness is a
 //! property of how the command is asserted (the
-//! `dialog.concept/transient` marker), not of the type.
+//! `db.concept/transient` marker), not of the type.
 
 use dialog_artifacts::Entity;
 use dialog_capability::Command;

--- a/rust/tonk-schema/src/concept.rs
+++ b/rust/tonk-schema/src/concept.rs
@@ -11,11 +11,11 @@
 //! "the `title` of this recipe" rather than "the value at attribute
 //! `recipe/title` of this entity". This module captures that link
 //! as a separate fact: for each field of a concept, an EAV claim
-//! whose `the` is `dialog.concept.with/{fieldName}` and whose value
+//! whose `the` is `db.concept.with/{fieldName}` and whose value
 //! is the attribute entity URI. Optional fields additionally carry a
-//! boolean marker claim `dialog.concept.optional/{fieldName}`.
+//! boolean marker claim `db.concept.optional/{fieldName}`.
 //!
-//! The relation namespace (`dialog.concept.with`) matches the one
+//! The relation namespace (`db.concept.with`) matches the one
 //! used by the `carry` CLI so that field-name facts written by
 //! either tool describe the same concept identically.
 
@@ -45,16 +45,16 @@ use crate::rule_query::{AnonymousRuleQuery, rule_of_rule_descriptor};
 use tonk_core::meta::AnonymousAttribute;
 
 /// Domain prefix for required-field claims.
-const WITH_DOMAIN: &str = "dialog.concept.with";
+const WITH_DOMAIN: &str = "db.concept.with";
 
 /// Domain prefix for the per-field optional marker.
-const OPTIONAL_DOMAIN: &str = "dialog.concept.optional";
+const OPTIONAL_DOMAIN: &str = "db.concept.optional";
 
 /// Build the claim relation that names a required field of a
 /// concept.
 ///
 /// The returned [`ArtifactsAttribute`] has the form
-/// `dialog.concept.with/{field_name}`. Used as the `the` of an EAV
+/// `db.concept.with/{field_name}`. Used as the `the` of an EAV
 /// claim `concept_entity --with(name)--> attribute_entity` to
 /// record that the concept has a required field named `name`
 /// pointing at the given attribute.
@@ -72,9 +72,9 @@ pub fn with(
 /// Build the marker relation that flags a concept field as optional.
 ///
 /// The returned [`ArtifactsAttribute`] has the form
-/// `dialog.concept.optional/{field_name}`. Emitted as a boolean
+/// `db.concept.optional/{field_name}`. Emitted as a boolean
 /// marker claim `concept_entity --optional(name)--> true` alongside
-/// the field's `dialog.concept.with/{name}` attribute link. Required
+/// the field's `db.concept.with/{name}` attribute link. Required
 /// fields carry no such marker, so their storage is byte-identical to
 /// the pre-optionality encoding.
 pub fn optional(
@@ -84,7 +84,7 @@ pub fn optional(
 }
 
 /// Recover the field name from a relation in the
-/// `dialog.concept.with` domain. Returns `None` if `the` is in any
+/// `db.concept.with` domain. Returns `None` if `the` is in any
 /// other domain.
 pub fn parse_with(the: &ArtifactsAttribute) -> Option<String> {
     let s = String::from(the);
@@ -94,7 +94,7 @@ pub fn parse_with(the: &ArtifactsAttribute) -> Option<String> {
 }
 
 /// Recover the field name from a relation in the
-/// `dialog.concept.optional` domain. Returns `None` if `the` is in
+/// `db.concept.optional` domain. Returns `None` if `the` is in
 /// any other domain.
 pub fn parse_optional(the: &ArtifactsAttribute) -> Option<String> {
     let s = String::from(the);
@@ -112,7 +112,7 @@ pub fn parse_optional(the: &ArtifactsAttribute) -> Option<String> {
 #[derive(Debug, Clone)]
 pub struct Concept {
     /// The concept entity URI (`concept:…` or whatever entity
-    /// carries the `dialog.concept.with/*` claims).
+    /// carries the `db.concept.with/*` claims).
     pub entity: Entity,
     /// The reconstructed descriptor.
     pub descriptor: ConceptDescriptor,
@@ -123,7 +123,7 @@ pub struct Concept {
 #[derive(Debug, Error)]
 pub enum ConceptLookupError {
     /// A field of the concept references an entity that doesn't
-    /// carry `dialog.attribute/*` facts — i.e., the concept's
+    /// carry `db.attribute/*` facts — i.e., the concept's
     /// schema is corrupt or out of sync.
     #[error(
         "concept field {field:?} references entity {entity} \
@@ -182,7 +182,7 @@ impl<T> QueryEnv for T where
 
 impl Concept {
     /// Look up a concept by its published name. The branch's
-    /// `id:<name>` entity carries the `dialog.meta/name` claim
+    /// `id:<name>` entity carries the `db.meta/name` claim
     /// that points at the concept entity; the resolver chases
     /// that pointer and reconstructs the descriptor.
     pub fn by_name(name: impl Into<String>) -> ConceptByName {
@@ -206,11 +206,11 @@ impl ConceptByName {
     /// Resolve the concept against a branch.
     ///
     /// The user-facing name `<name>` is published as a separate
-    /// entity at `id:<name>` carrying a `dialog.meta/name`
+    /// entity at `id:<name>` carrying a `db.meta/name`
     /// claim that points at the actual concept entity. Two
     /// steps:
     ///
-    /// 1. Look up `(id:<name>, dialog.meta/name, ?value)` to
+    /// 1. Look up `(id:<name>, db.meta/name, ?value)` to
     ///    get the concept entity.
     /// 2. Delegate to [`ConceptByEntity::resolve`] for the
     ///    field-list reconstruction.
@@ -233,7 +233,7 @@ pub struct ConceptByEntity {
 
 impl ConceptByEntity {
     /// Resolve the concept's full descriptor by enumerating its
-    /// `dialog.concept.with/*` claims and reconstructing each
+    /// `db.concept.with/*` claims and reconstructing each
     /// referenced [`AttributeDescriptor`].
     pub async fn resolve<Env: QueryEnv>(
         self,
@@ -242,7 +242,7 @@ impl ConceptByEntity {
     ) -> Result<Option<Concept>, ConceptLookupError> {
         // Pull every claim where `(*entity, the, value)` matches
         // — `the` is left as a variable so the engine returns the
-        // full set; we filter to the `dialog.concept.with/*`
+        // full set; we filter to the `db.concept.with/*`
         // namespace in Rust.
         let raw_claims: Vec<dialog_query::Claim> = source
             .select(dialog_query::AttributeQuery::from(
@@ -380,7 +380,7 @@ impl AttributeByEntity {
 }
 
 /// Builder for looking up an attribute by its *selector id* — the
-/// `domain/name` string stored as its `dialog.attribute/id` claim.
+/// `domain/name` string stored as its `db.attribute/id` claim.
 /// This is how a claim-domain head (`xyz.tonk!:`) discovers whether
 /// the `<domain>/<field>` attribute a body field maps onto is
 /// declared on the branch, so the declared cardinality and value
@@ -432,7 +432,7 @@ impl AttributeById {
 
 /// Builder for looking up an attribute by its published name —
 /// the user-facing label `<name>` whose `id:<name>` entity
-/// carries a `dialog.meta/name` claim pointing at the attribute.
+/// carries a `db.meta/name` claim pointing at the attribute.
 pub struct AttributeByName {
     name: String,
 }
@@ -447,7 +447,7 @@ impl AttributeByName {
     ///
     /// Two-step query mirroring [`ConceptByName::resolve`]:
     /// first find the entity carrying
-    /// `dialog.meta/name = <name>`, then delegate to
+    /// `db.meta/name = <name>`, then delegate to
     /// [`AttributeByEntity::resolve`] for the fact-set
     /// reconstruction.
     pub async fn resolve<Env: QueryEnv>(
@@ -504,13 +504,13 @@ fn build_attribute_descriptor(facts: &AnonymousAttribute) -> Result<AttributeDes
 // therefore hand-write [`AnonymousConcept`], which presents the
 // same `Statement` interface as a derived concept: assert/retract
 // walk the wrapped descriptor and emit the right
-// `dialog.concept.with/{field}` claims plus the meta marker.
+// `db.concept.with/{field}` claims plus the meta marker.
 //
 // Naming used to live on a sister `NamedConcept` wrapper that
-// also wrote a `dialog.meta/name` claim *onto the named target*.
+// also wrote a `db.meta/name` claim *onto the named target*.
 // That direction was wrong under the new name model — names are
 // now their own concept whose entity (`id:<n>`) carries the
-// `dialog.meta/name` claim *pointing at* the named target. The
+// `db.meta/name` claim *pointing at* the named target. The
 // analyzer's anchor desugar emits the name assertion separately
 // via `ApplicationPlan::name`, so the wrapper is no longer
 // needed; only `AnonymousConcept` remains.
@@ -521,10 +521,10 @@ use dialog_artifacts::{Statement, Update, Value};
 /// Identity comes from the wrapped descriptor's
 /// content-addressed entity (`descriptor.this()`).
 ///
-/// `assert` writes one `dialog.concept.with/{field}` claim per
+/// `assert` writes one `db.concept.with/{field}` claim per
 /// field of the descriptor's `with` map (value =
 /// content-addressed attribute entity), plus a
-/// `dialog.meta/description` when the descriptor carries one.
+/// `db.meta/description` when the descriptor carries one.
 /// `retract` mirrors.
 #[derive(Debug, Clone)]
 pub struct AnonymousConcept {
@@ -556,9 +556,9 @@ impl Statement for AnonymousConcept {
 }
 
 /// Marker entity asserted as the value of
-/// `dialog.concept/transient` on every transient concept. Same
+/// `db.concept/transient` on every transient concept. Same
 /// role as [`concept_marker_entity`] for the
-/// `dialog.meta/concept` marker: gives queries a known triple
+/// `db.meta/concept` marker: gives queries a known triple
 /// to start from when looking for all transient concepts on a
 /// branch.
 fn transient_marker_entity() -> Entity {
@@ -579,7 +579,7 @@ fn transient_marker_entity() -> Entity {
 ///
 /// Storage: emits everything [`AnonymousConcept`] emits
 /// (concept marker, attribute field claims, optional
-/// description), plus a `dialog.concept/transient: true` marker
+/// description), plus a `db.concept/transient: true` marker
 /// triple that the reactor reads at commit time to decide which
 /// facts to strip.
 #[derive(Debug, Clone)]
@@ -608,7 +608,7 @@ impl TransientConcept {
 impl TransientConcept {
     /// Look up whether a concept entity is marked transient on
     /// a branch. Returns `true` iff
-    /// `(<entity>, dialog.concept/transient, db:transient)`
+    /// `(<entity>, db.concept/transient, db:transient)`
     /// holds; `false` if the marker is absent.
     pub fn is_transient(entity: Entity) -> IsTransient {
         IsTransient { entity }
@@ -616,7 +616,7 @@ impl TransientConcept {
 }
 
 /// Builder for [`TransientConcept::is_transient`]. Resolves the
-/// `dialog.concept/transient` marker claim and answers a yes/no.
+/// `db.concept/transient` marker claim and answers a yes/no.
 pub struct IsTransient {
     entity: Entity,
 }
@@ -632,7 +632,7 @@ impl IsTransient {
         let claims: Vec<dialog_query::Claim> = source
             .select(dialog_query::AttributeQuery::from(
                 Term::<dialog_query::attribute::The>::from(meta_attr_typed(
-                    "dialog.concept",
+                    "db.concept",
                     "transient",
                 ))
                 .of(Term::from(self.entity))
@@ -661,7 +661,7 @@ impl Statement for TransientConcept {
     fn assert(self, update: &mut impl Update) {
         emit_concept_facts(&self.this, &self.descriptor, update, Update::associate);
         update.associate_unique(
-            meta_attr("dialog.concept", "transient"),
+            meta_attr("db.concept", "transient"),
             self.this,
             Value::Entity(transient_marker_entity()),
         );
@@ -670,7 +670,7 @@ impl Statement for TransientConcept {
     fn retract(self, update: &mut impl Update) {
         emit_concept_facts(&self.this, &self.descriptor, update, Update::dissociate);
         update.dissociate(
-            meta_attr("dialog.concept", "transient"),
+            meta_attr("db.concept", "transient"),
             self.this,
             Value::Entity(transient_marker_entity()),
         );
@@ -725,7 +725,7 @@ impl dialog_query::Concept for AnonymousConcept {
 ///
 /// 1. **Built-ins** — every entry of [`concept_registry`].
 /// 2. **Branch** — every entity carrying the
-///    `dialog.meta/concept = db:concept` marker claim, with
+///    `db.meta/concept = db:concept` marker claim, with
 ///    its descriptor reconstructed from the on-branch facts.
 ///
 /// Built-ins win on `name` collision: a branch concept whose name
@@ -744,7 +744,7 @@ pub struct AnonymousConceptQuery {
     /// When `true`, restrict enumeration to transient (command)
     /// concepts: skip the always-durable built-ins entirely and
     /// drop any branch concept lacking the
-    /// `dialog.concept/transient` marker. This is what backs the
+    /// `db.concept/transient` marker. This is what backs the
     /// `command:` head — see [`AnonymousConceptQuery::commands`].
     pub transient_only: bool,
 }
@@ -840,7 +840,7 @@ impl Application for AnonymousConceptQuery {
                     Some(e) => Term::Constant(dialog_query::Value::Entity(e.clone())),
                     None => Term::var("__concept_query_this"),
                 };
-                let claims: Vec<Claim> = the!("dialog.meta/concept")
+                let claims: Vec<Claim> = the!("db.meta/concept")
                     .of(this_term_for_marker)
                     .is(marker)
                     .perform(env)
@@ -856,7 +856,7 @@ impl Application for AnonymousConceptQuery {
                     || app.transient_only
                 {
                     let transient_marker = transient_marker_entity();
-                    let transient_claims: Vec<Claim> = the!("dialog.concept/transient")
+                    let transient_claims: Vec<Claim> = the!("db.concept/transient")
                         .of(Term::<Entity>::var("__concept_query_transient_this"))
                         .is(transient_marker)
                         .perform(env)
@@ -938,7 +938,7 @@ fn stub_predicate() -> ConceptDescriptor {
     ConceptDescriptor::try_from(vec![(
         "_",
         AttributeDescriptor::new(
-            the!("dialog.concept/stub"),
+            the!("db.concept/stub"),
             "",
             dialog_query::Cardinality::default(),
             None,
@@ -953,7 +953,7 @@ fn stub_predicate() -> ConceptDescriptor {
 
 /// The well-known descriptor for the "concept of concept" head.
 ///
-/// Its `with` map names the marker (`dialog.meta/concept`), bookmark
+/// Its `with` map names the marker (`db.meta/concept`), bookmark
 /// name, description, and the synthesised `source` field — enough
 /// for the analyzer to project the fields a `concept:` head
 /// exposes. The `source` claim has no real EAV backing; it is
@@ -966,11 +966,11 @@ pub fn concept_of_concept_descriptor() -> &'static ConceptDescriptor {
         serde_json::from_value(serde_json::json!({
             "description": "Every concept asserted on a branch.",
             "with": {
-                "concept":     { "the": "dialog.meta/concept",     "as": "Entity",  "cardinality": "one" },
-                "name":        { "the": "dialog.meta/name",        "as": "Text",    "cardinality": "one" },
-                "description": { "the": "dialog.meta/description", "as": "Text",    "cardinality": "one" },
-                "source":      { "the": "dialog.meta/source",      "as": "Text",    "cardinality": "one" },
-                "transient":   { "the": "dialog.concept/transient", "as": "Boolean", "cardinality": "one" }
+                "concept":     { "the": "db.meta/concept",     "as": "Entity",  "cardinality": "one" },
+                "name":        { "the": "db.meta/name",        "as": "Text",    "cardinality": "one" },
+                "description": { "the": "db.meta/description", "as": "Text",    "cardinality": "one" },
+                "source":      { "the": "db.meta/source",      "as": "Text",    "cardinality": "one" },
+                "transient":   { "the": "db.concept/transient", "as": "Boolean", "cardinality": "one" }
             }
         }))
         .expect("concept-of-concept descriptor is well-formed")
@@ -992,7 +992,7 @@ fn concept_of_concept_entity() -> &'static Entity {
 /// rows as the concept-of-concept query but filtered to transient
 /// concepts only (see [`AnonymousConceptQuery::commands`]). Its
 /// `with` map mirrors [`concept_of_concept_descriptor`] *plus* a
-/// `command` marker field — the extra `dialog.meta/command`
+/// `command` marker field — the extra `db.meta/command`
 /// attribute URI is what makes this descriptor's content-derived
 /// `this()` distinct from the concept sentinel's. Without it the
 /// two would share an entity (identity is the attribute-URI set,
@@ -1004,12 +1004,12 @@ pub fn command_of_command_descriptor() -> &'static ConceptDescriptor {
         serde_json::from_value(serde_json::json!({
             "description": "Every transient (command) concept asserted on a branch.",
             "with": {
-                "command":     { "the": "dialog.meta/command",      "as": "Entity",  "cardinality": "one" },
-                "concept":     { "the": "dialog.meta/concept",      "as": "Entity",  "cardinality": "one" },
-                "name":        { "the": "dialog.meta/name",         "as": "Text",    "cardinality": "one" },
-                "description": { "the": "dialog.meta/description",   "as": "Text",    "cardinality": "one" },
-                "source":      { "the": "dialog.meta/source",       "as": "Text",    "cardinality": "one" },
-                "transient":   { "the": "dialog.concept/transient", "as": "Boolean", "cardinality": "one" }
+                "command":     { "the": "db.meta/command",      "as": "Entity",  "cardinality": "one" },
+                "concept":     { "the": "db.meta/concept",      "as": "Entity",  "cardinality": "one" },
+                "name":        { "the": "db.meta/name",         "as": "Text",    "cardinality": "one" },
+                "description": { "the": "db.meta/description",   "as": "Text",    "cardinality": "one" },
+                "source":      { "the": "db.meta/source",       "as": "Text",    "cardinality": "one" },
+                "transient":   { "the": "db.concept/transient", "as": "Boolean", "cardinality": "one" }
             }
         }))
         .expect("command-of-command descriptor is well-formed")
@@ -1168,7 +1168,7 @@ fn resolve_string_filter(term: &Option<Term<dialog_query::Any>>, input: &Match) 
 }
 
 /// Reconstruct the descriptor for a branch concept entity by
-/// enumerating its `dialog.concept.with/*` claims and resolving
+/// enumerating its `db.concept.with/*` claims and resolving
 /// each referenced attribute via the [`AnonymousAttribute`]
 /// concept query.
 async fn resolve_branch_descriptor<'a, Env>(
@@ -1243,7 +1243,7 @@ where
     let descriptor = ConceptDescriptor::try_from(fields)
         .map_err(|e| EvaluationError::Store(format!("invalid concept descriptor: {e:?}")))?;
     // `ConceptDescriptor::try_from` leaves `description` as `None`.
-    // The concept's own `dialog.meta/description` claim carries
+    // The concept's own `db.meta/description` claim carries
     // it, so fetch that and fold it in — a JSON round-trip is the
     // only way in since the field has no public setter.
     let Some(description) = lookup_entity_description(entity, env).await? else {
@@ -1265,8 +1265,8 @@ where
 /// Look up the published name of `entity`, if any.
 ///
 /// Inverted from the pre-Stage-2 model: instead of asking "what
-/// `dialog.meta/name` claim sits on `entity`?", this asks "what
-/// `id:<n>` URI carries a `dialog.meta/name = entity` claim?"
+/// `db.meta/name` claim sits on `entity`?", this asks "what
+/// `id:<n>` URI carries a `db.meta/name = entity` claim?"
 /// and recovers the `<n>` portion. Returns `None` when no `id:`
 /// URI points at the entity.
 async fn lookup_entity_name<'a, Env>(
@@ -1292,7 +1292,7 @@ where
         .and_then(|row| name_from_id_uri(&row.this)))
 }
 
-/// Read the `dialog.meta/description` claim attached to a concept
+/// Read the `db.meta/description` claim attached to a concept
 /// entity, if any.
 ///
 /// `emit_concept_facts` writes this claim only when the asserted
@@ -1305,7 +1305,7 @@ async fn lookup_entity_description<'a, Env>(
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
-    let claims: Vec<Claim> = the!("dialog.meta/description")
+    let claims: Vec<Claim> = the!("db.meta/description")
         .of(Term::<Entity>::from(entity.clone()))
         .is(Term::<String>::var("__concept_query_description"))
         .perform(env)
@@ -1328,13 +1328,13 @@ fn name_from_id_uri(entity: &Entity) -> Option<String> {
 }
 
 /// Resolve a published name to the entity it points at by
-/// reading the `dialog.meta/name` claim attached to `id:<name>`.
+/// reading the `db.meta/name` claim attached to `id:<name>`.
 ///
 /// Returns `None` when:
 /// - The `id:<name>` URI itself doesn't parse as an entity
 ///   (only happens if `name` contains characters the URI scheme
 ///   rejects).
-/// - The branch has no `dialog.meta/name` claim attached to
+/// - The branch has no `db.meta/name` claim attached to
 ///   that entity (no name was ever published with this label,
 ///   or the prior publication was retracted).
 pub async fn lookup_named_entity<'a, Env: QueryEnv>(
@@ -1363,8 +1363,8 @@ pub async fn lookup_named_entity<'a, Env: QueryEnv>(
 
 /// Walk a [`ConceptDescriptor`] and call `op` (either
 /// [`Update::associate`] or [`Update::dissociate`]) for every
-/// fact the concept implies — `dialog.concept.with/{field}`
-/// per field, plus `dialog.meta/description` when the
+/// fact the concept implies — `db.concept.with/{field}`
+/// per field, plus `db.meta/description` when the
 /// descriptor carries one. Shared between `assert` and
 /// `retract` so the two stay in lock-step.
 fn emit_concept_facts<U: Update, F: Fn(&mut U, ArtifactsAttribute, Entity, Value)>(
@@ -1374,13 +1374,13 @@ fn emit_concept_facts<U: Update, F: Fn(&mut U, ArtifactsAttribute, Entity, Value
     op: F,
 ) {
     // Marker claim — every concept entity carries
-    // `(?this, dialog.meta/concept, "db:concept")` so
+    // `(?this, db.meta/concept, "db:concept")` so
     // queries that want "all concepts on this branch" have a
     // selectable triple to start from (the engine refuses
     // selections with no bound component).
     op(
         update,
-        meta_attr("dialog.meta", "concept"),
+        meta_attr("db.meta", "concept"),
         entity.clone(),
         Value::Entity(concept_marker_entity()),
     );
@@ -1413,7 +1413,7 @@ fn emit_concept_facts<U: Update, F: Fn(&mut U, ArtifactsAttribute, Entity, Value
     {
         op(
             update,
-            meta_attr("dialog.meta", "description"),
+            meta_attr("db.meta", "description"),
             entity.clone(),
             Value::String(description.to_owned()),
         );
@@ -1421,9 +1421,9 @@ fn emit_concept_facts<U: Update, F: Fn(&mut U, ArtifactsAttribute, Entity, Value
 }
 
 /// The well-known entity used as the value of the
-/// `dialog.meta/concept` marker claim. Every concept entity
+/// `db.meta/concept` marker claim. Every concept entity
 /// asserted on a branch carries
-/// `(?this, dialog.meta/concept, db:concept)`. Same URI as the
+/// `(?this, db.meta/concept, db:concept)`. Same URI as the
 /// `concept` built-in's own entity in [`crate::builtin`].
 fn concept_marker_entity() -> Entity {
     "db:concept"
@@ -1453,13 +1453,13 @@ mod tests {
     #[dialog_common::test]
     fn with_constructs_namespaced_relation() {
         let the = with("title").unwrap();
-        assert_eq!(String::from(&the), "dialog.concept.with/title");
+        assert_eq!(String::from(&the), "db.concept.with/title");
     }
 
     #[dialog_common::test]
     fn optional_constructs_namespaced_relation() {
         let the = optional("subtitle").unwrap();
-        assert_eq!(String::from(&the), "dialog.concept.optional/subtitle");
+        assert_eq!(String::from(&the), "db.concept.optional/subtitle");
     }
 
     #[dialog_common::test]
@@ -1476,7 +1476,7 @@ mod tests {
 
     #[dialog_common::test]
     fn parse_with_rejects_other_domains() {
-        let the: ArtifactsAttribute = "dialog.meta/name".parse().unwrap();
+        let the: ArtifactsAttribute = "db.meta/name".parse().unwrap();
         assert_eq!(parse_with(&the), None);
         assert_eq!(parse_optional(&the), None);
     }
@@ -1501,9 +1501,9 @@ mod tests {
     }
 
     /// `AnonymousConcept::assert` should write one
-    /// `dialog.concept.with/{field}` claim per field plus
-    /// `dialog.meta/description` when set, plus the marker
-    /// claim `dialog.meta/concept = db:concept` that lets
+    /// `db.concept.with/{field}` claim per field plus
+    /// `db.meta/description` when set, plus the marker
+    /// claim `db.meta/concept = db:concept` that lets
     /// branch-wide concept enumeration find this entity.
     #[dialog_common::test]
     fn anonymous_concept_writes_with_claims_and_description() {
@@ -1525,7 +1525,7 @@ mod tests {
 
     /// `TransientConcept::assert` should write everything
     /// `AnonymousConcept::assert` writes plus a
-    /// `(?this, dialog.concept/transient, db:transient)` marker
+    /// `(?this, db.concept/transient, db:transient)` marker
     /// triple. The marker is what the reactor reads at commit
     /// time to decide which facts to strip from the persistable
     /// delta.
@@ -1546,7 +1546,7 @@ mod tests {
 
         let instructions = changes.into_instructions();
         let marker_target = transient_marker_entity();
-        let transient_attr = meta_attr("dialog.concept", "transient");
+        let transient_attr = meta_attr("db.concept", "transient");
 
         assert!(
             instructions.iter().any(|inst| match inst {
@@ -1557,12 +1557,12 @@ mod tests {
                 }
                 _ => false,
             }),
-            "missing dialog.concept/transient marker"
+            "missing db.concept/transient marker"
         );
 
         // Also writes the normal concept-marker so concept-enumeration
         // queries find this entity.
-        let concept_marker_attr = meta_attr("dialog.meta", "concept");
+        let concept_marker_attr = meta_attr("db.meta", "concept");
         let concept_marker = concept_marker_entity();
         assert!(
             instructions.iter().any(|inst| match inst {
@@ -1573,12 +1573,12 @@ mod tests {
                 }
                 _ => false,
             }),
-            "missing dialog.meta/concept marker"
+            "missing db.meta/concept marker"
         );
     }
 
     /// Every concept assert must include the
-    /// `(?this, dialog.meta/concept, db:concept)` marker so
+    /// `(?this, db.meta/concept, db:concept)` marker so
     /// `concept:` queries with `?this` unbound can drive
     /// selection from a single bound triple.
     #[dialog_common::test]
@@ -1593,7 +1593,7 @@ mod tests {
         let concept = AnonymousConcept::new(descriptor);
         let mut changes = Changes::new();
         concept.assert(&mut changes);
-        let marker_attr = meta_attr("dialog.meta", "concept");
+        let marker_attr = meta_attr("db.meta", "concept");
         let marker_value = Value::Entity(concept_marker_entity());
         let saw_marker = changes
             .into_instructions()
@@ -1604,7 +1604,7 @@ mod tests {
             });
         assert!(
             saw_marker,
-            "expected dialog.meta/concept = db:concept marker claim",
+            "expected db.meta/concept = db:concept marker claim",
         );
     }
 
@@ -1623,7 +1623,7 @@ mod tests {
         let concept = AnonymousConcept::new(descriptor);
         let mut changes = Changes::new();
         concept.retract(&mut changes);
-        let marker_attr = meta_attr("dialog.meta", "concept");
+        let marker_attr = meta_attr("db.meta", "concept");
         let marker_value = Value::Entity(concept_marker_entity());
         let saw_retract = changes
             .into_instructions()
@@ -1632,10 +1632,7 @@ mod tests {
                 Instruction::Retract(a) => a.the == marker_attr && a.is == marker_value,
                 _ => false,
             });
-        assert!(
-            saw_retract,
-            "expected dialog.meta/concept marker retraction",
-        );
+        assert!(saw_retract, "expected db.meta/concept marker retraction",);
     }
 
     /// Compile-time check: `AnonymousConcept` implements the
@@ -1688,7 +1685,7 @@ mod tests {
 
     /// The command sentinel must not collide with the concept
     /// sentinel — identity is the attribute-URI set, so the extra
-    /// `dialog.meta/command` marker attribute is load-bearing.
+    /// `db.meta/command` marker attribute is load-bearing.
     #[dialog_common::test]
     fn it_distinguishes_command_sentinel_from_concept_sentinel() {
         assert_ne!(
@@ -1745,7 +1742,7 @@ mod tests {
     /// synthesised `source` field.
     ///
     /// Asserting the concept writes the marker claim and the
-    /// `dialog.concept.with/{field}` claims. The query
+    /// `db.concept.with/{field}` claims. The query
     /// enumerates the branch via the marker, reconstructs the
     /// descriptor for each entity, and binds it as a JSON
     /// string in `source`.
@@ -1772,8 +1769,8 @@ mod tests {
             }"#,
         )?;
         // The concept references one attribute by URI; the
-        // attribute's own facts (`dialog.attribute/id|type|
-        // cardinality`, `dialog.meta/description`) must exist on
+        // attribute's own facts (`db.attribute/id|type|
+        // cardinality`, `db.meta/description`) must exist on
         // the branch for [`AnonymousConceptQuery`] to reconstruct
         // the descriptor — emit them inline alongside the concept.
         let (_, attr_descriptor) = descriptor.with().iter().next().expect("one field");
@@ -1783,7 +1780,7 @@ mod tests {
         branch
             .transaction()
             .assert(
-                dialog_query::the!("dialog.attribute/id")
+                dialog_query::the!("db.attribute/id")
                     .of(attr_entity.clone())
                     .is(format!(
                         "{}/{}",
@@ -1792,17 +1789,17 @@ mod tests {
                     )),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/type")
+                dialog_query::the!("db.attribute/type")
                     .of(attr_entity.clone())
                     .is("Text".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/cardinality")
+                dialog_query::the!("db.attribute/cardinality")
                     .of(attr_entity.clone())
                     .is("one".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.meta/description")
+                dialog_query::the!("db.meta/description")
                     .of(attr_entity)
                     .is(String::new()),
             )
@@ -1884,23 +1881,23 @@ mod tests {
         for (_, field) in descriptor.with().iter() {
             let attr_entity: Entity = field.to_uri().parse()?;
             txn = txn
+                .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                    "{}/{}",
+                    field.domain(),
+                    field.name()
+                )))
                 .assert(
-                    the!("dialog.attribute/id")
-                        .of(attr_entity.clone())
-                        .is(format!("{}/{}", field.domain(), field.name())),
-                )
-                .assert(
-                    the!("dialog.attribute/type")
+                    the!("db.attribute/type")
                         .of(attr_entity.clone())
                         .is("Text".to_string()),
                 )
                 .assert(
-                    the!("dialog.attribute/cardinality")
+                    the!("db.attribute/cardinality")
                         .of(attr_entity.clone())
                         .is("one".to_string()),
                 )
                 .assert(
-                    the!("dialog.meta/description")
+                    the!("db.meta/description")
                         .of(attr_entity)
                         .is(String::new()),
                 );
@@ -1981,43 +1978,43 @@ mod tests {
             .transaction()
             // Transient concept attribute facts.
             .assert(
-                dialog_query::the!("dialog.attribute/id")
+                dialog_query::the!("db.attribute/id")
                     .of(t_attr_entity.clone())
                     .is(format!("{}/{}", t_attr.domain(), t_attr.name())),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/type")
+                dialog_query::the!("db.attribute/type")
                     .of(t_attr_entity.clone())
                     .is("Entity".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/cardinality")
+                dialog_query::the!("db.attribute/cardinality")
                     .of(t_attr_entity.clone())
                     .is("one".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.meta/description")
+                dialog_query::the!("db.meta/description")
                     .of(t_attr_entity)
                     .is(String::new()),
             )
             // Durable concept attribute facts.
             .assert(
-                dialog_query::the!("dialog.attribute/id")
+                dialog_query::the!("db.attribute/id")
                     .of(d_attr_entity.clone())
                     .is(format!("{}/{}", d_attr.domain(), d_attr.name())),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/type")
+                dialog_query::the!("db.attribute/type")
                     .of(d_attr_entity.clone())
                     .is("Text".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/cardinality")
+                dialog_query::the!("db.attribute/cardinality")
                     .of(d_attr_entity.clone())
                     .is("one".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.meta/description")
+                dialog_query::the!("db.meta/description")
                     .of(d_attr_entity)
                     .is(String::new()),
             )
@@ -2116,42 +2113,42 @@ mod tests {
         branch
             .transaction()
             .assert(
-                dialog_query::the!("dialog.attribute/id")
+                dialog_query::the!("db.attribute/id")
                     .of(c_attr_entity.clone())
                     .is(format!("{}/{}", c_attr.domain(), c_attr.name())),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/type")
+                dialog_query::the!("db.attribute/type")
                     .of(c_attr_entity.clone())
                     .is("Entity".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/cardinality")
+                dialog_query::the!("db.attribute/cardinality")
                     .of(c_attr_entity.clone())
                     .is("one".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.meta/description")
+                dialog_query::the!("db.meta/description")
                     .of(c_attr_entity)
                     .is(String::new()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/id")
+                dialog_query::the!("db.attribute/id")
                     .of(d_attr_entity.clone())
                     .is(format!("{}/{}", d_attr.domain(), d_attr.name())),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/type")
+                dialog_query::the!("db.attribute/type")
                     .of(d_attr_entity.clone())
                     .is("Text".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.attribute/cardinality")
+                dialog_query::the!("db.attribute/cardinality")
                     .of(d_attr_entity.clone())
                     .is("one".to_string()),
             )
             .assert(
-                dialog_query::the!("dialog.meta/description")
+                dialog_query::the!("db.meta/description")
                     .of(d_attr_entity)
                     .is(String::new()),
             )
@@ -2194,7 +2191,7 @@ mod tests {
     }
 
     /// `lookup_named_entity("alice")` reads the
-    /// `(id:alice, dialog.name/referent, ?target)` claim
+    /// `(id:alice, db.name/referent, ?target)` claim
     /// and returns the target entity. Round-trip a hand-written
     /// claim through a branch and confirm the lookup recovers
     /// the target.
@@ -2210,7 +2207,7 @@ mod tests {
         let target: Entity = "did:key:z6MkfpAVgERtxfLXxr8wpJp3CQpXi2VZkAjJBgvw9q5tGBkv".parse()?;
         branch
             .transaction()
-            .assert(the!("dialog.name/referent").of(id_alice).is(target.clone()))
+            .assert(the!("db.name/referent").of(id_alice).is(target.clone()))
             .commit()
             .perform(&operator)
             .await?;
@@ -2243,9 +2240,9 @@ mod tests {
     ///
     /// Models the page-disambiguation bug from user feedback:
     /// when the analyzer's name publication writes
-    /// `(id:page, dialog.meta/name, page-v1)` in tx1 and
-    /// `(id:page, dialog.meta/name, page-v2)` in tx2, querying
-    /// for "page" via `dialog.meta/name` should return only
+    /// `(id:page, db.meta/name, page-v1)` in tx1 and
+    /// `(id:page, db.meta/name, page-v2)` in tx2, querying
+    /// for "page" via `db.meta/name` should return only
     /// `page-v2` — the previous pointer should have been
     /// superseded by the cardinality-one constraint.
     ///
@@ -2264,7 +2261,7 @@ mod tests {
 
         // A minimal one-attribute concept whose only field is
         // cardinality-one. `Pointer` mirrors the shape of the
-        // `dialog.meta/name` claim — id-shaped `this`, single
+        // `db.meta/name` claim — id-shaped `this`, single
         // entity-typed value.
         mod pointer {
             use dialog_artifacts::Entity;
@@ -2410,7 +2407,7 @@ mod tests {
     ///
     /// This is the regression test for the page-disambiguation
     /// bug. Before the rewrite, `lookup_entity_name` used a raw
-    /// `the!("dialog.meta/name").of(?).is(value)` query that
+    /// `the!("db.meta/name").of(?).is(value)` query that
     /// surfaces the superseded v1 claim from the EAV log. Going
     /// through the `Name` concept's derived `Query` runs the
     /// same cardinality-one filter dialog applies to the forward

--- a/rust/tonk-schema/src/deductive_rule.rs
+++ b/rust/tonk-schema/src/deductive_rule.rs
@@ -4,7 +4,7 @@
 //!
 //! Where [`Rule`](crate::rule::Rule) packages an
 //! [`Effect`](tonk_core::effect::Effect) (an inductive rule with
-//! polarity) with its `dialog.effect/*` storage shape, this packages
+//! polarity) with its `db.effect/*` storage shape, this packages
 //! a [`DeductiveRule`](dialog_query::DeductiveRule) with a
 //! `db.rule/*` storage shape so a deductive `rule!:` (the `assert:`
 //! no-bang form) flows through dialog's `Statement` trait.
@@ -33,9 +33,9 @@
 //!   entity ([`ConceptDescriptor::this`](dialog_query::ConceptDescriptor::this)).
 //!   The [`RuleSource`](dialog_repository::RuleSource) resolver looks
 //!   rules up by this: "every rule whose conclusion is concept X".
-//! - `dialog.meta/rule` — marker (value `db:rule`), so "all deductive
+//! - `db.meta/rule` — marker (value `db:rule`), so "all deductive
 //!   rules on this branch" has a known triple to start from.
-//! - `dialog.meta/description` — optional human-readable description.
+//! - `db.meta/description` — optional human-readable description.
 //!
 //! # Identity
 //!
@@ -225,9 +225,9 @@ impl dialog_artifacts::Statement for DeductiveRule {
         let description = self.rule.descriptor().description.clone();
         let conclusion = self.conclusion();
 
-        // Marker — `(?this, dialog.meta/rule, db:rule)`.
+        // Marker — `(?this, db.meta/rule, db:rule)`.
         update.associate_unique(
-            meta_attr("dialog.meta", "rule"),
+            meta_attr("db.meta", "rule"),
             this.clone(),
             Value::Entity(rule_marker_entity()),
         );
@@ -248,7 +248,7 @@ impl dialog_artifacts::Statement for DeductiveRule {
             && !description.is_empty()
         {
             update.associate_unique(
-                meta_attr("dialog.meta", "description"),
+                meta_attr("db.meta", "description"),
                 this,
                 Value::String(description),
             );
@@ -261,7 +261,7 @@ impl dialog_artifacts::Statement for DeductiveRule {
         let conclusion = self.conclusion();
 
         update.dissociate(
-            meta_attr("dialog.meta", "rule"),
+            meta_attr("db.meta", "rule"),
             this.clone(),
             Value::Entity(rule_marker_entity()),
         );
@@ -279,7 +279,7 @@ impl dialog_artifacts::Statement for DeductiveRule {
             && !description.is_empty()
         {
             update.dissociate(
-                meta_attr("dialog.meta", "description"),
+                meta_attr("db.meta", "description"),
                 this,
                 Value::String(description),
             );
@@ -308,7 +308,7 @@ fn meta_attr(domain: &str, name: &str) -> ArtifactsAttribute {
         .expect("dialog meta-attribute names should always be valid")
 }
 
-/// Marker entity asserted as the value of `dialog.meta/rule` on every
+/// Marker entity asserted as the value of `db.meta/rule` on every
 /// deductive-rule entity. Same role `db:effect` plays for effects and
 /// `db:concept` for concepts.
 fn rule_marker_entity() -> Entity {
@@ -411,7 +411,7 @@ mod tests {
         assert!(
             claims
                 .iter()
-                .any(|(e, a)| *e == this && a == "dialog.meta/rule"),
+                .any(|(e, a)| *e == this && a == "db.meta/rule"),
             "marker claim present"
         );
         assert!(

--- a/rust/tonk-schema/src/replica.rs
+++ b/rust/tonk-schema/src/replica.rs
@@ -223,14 +223,14 @@ impl Replica {
             Self::repository_kind()
         };
         Self {
-            // Derive `this` via dialog's own `Origin` so a tonk `Replica` and a
-            // dialog `Origin` for the same `(profile, subject)` are the SAME
+            // Derive `this` via dialog's own `Replica` so a tonk `Replica` and a
+            // dialog `Replica` for the same `(profile, subject)` are the SAME
             // entity. They are the same thing — this device's view of a repo —
             // and the library's `tonk/replica` / `tonk:binder` concepts key on
-            // `dialog.origin/*`, so they must land on this entity. (Deriving a
+            // `dialog.replica/*`, so they must land on this entity. (Deriving a
             // separate `This::Replica`-tagged hash split them, which silently
             // put binder/replica facts on two different entities.)
-            this: dialog_repository::schema::Origin::new(profile.clone(), subject.clone()).this,
+            this: dialog_repository::schema::Replica::new(profile.clone(), subject.clone()).this,
             subject: Subject(subject.this()),
             profile: Profile(profile.this()),
             kind,

--- a/rust/tonk-schema/src/resolution.rs
+++ b/rust/tonk-schema/src/resolution.rs
@@ -46,7 +46,7 @@ pub type ResolveError = ConceptLookupError;
 // References — names of things to resolve.
 // -----------------------------------------------------------------
 
-/// A published name — `id:<n>` carries a `dialog.name/referent`
+/// A published name — `id:<n>` carries a `db.name/referent`
 /// claim pointing at whatever the name currently identifies.
 ///
 /// Distinct from the [`Name`] concept schema type: this is the
@@ -135,7 +135,7 @@ impl AttributeReference {
 /// `descriptor` is tonk's durability-tagged [`ConceptDescriptor`]:
 /// [`resolve`](ConceptReference::resolve)'s `perform` reconstructs
 /// the dialog field-set from the entity's EAV facts and reads the
-/// `dialog.concept/transient` marker to pick the `Durable` /
+/// `db.concept/transient` marker to pick the `Durable` /
 /// `Transient` variant.
 #[derive(Debug, Clone)]
 pub struct ConceptDefinition {
@@ -172,10 +172,10 @@ impl ResolveConcept<'_> {
     /// Resolve the reference to a [`ConceptDefinition`].
     ///
     /// A name reference is resolved to an entity first
-    /// (`dialog.name/referent` on `id:<n>`); the entity is then
-    /// reconstructed by enumerating its `dialog.concept.with/*`
+    /// (`db.name/referent` on `id:<n>`); the entity is then
+    /// reconstructed by enumerating its `db.concept.with/*`
     /// claims, resolving each field attribute, and reading the
-    /// `dialog.concept/transient` marker to tag durability.
+    /// `db.concept/transient` marker to tag durability.
     ///
     /// Returns `None` when the name has no published claim, or the
     /// entity carries no concept facts.
@@ -221,7 +221,7 @@ impl ResolveAttribute<'_> {
     /// Resolve the reference to an [`AttributeDefinition`].
     ///
     /// A name reference is resolved to an entity first; the entity
-    /// is then reconstructed from its `dialog.attribute/*` facts.
+    /// is then reconstructed from its `db.attribute/*` facts.
     /// An entity that carries no attribute facts but does carry a
     /// published-name referent (an `id:<name>` URI used directly)
     /// is chased one step: the referent is the attribute, exactly
@@ -261,7 +261,7 @@ impl ResolveAttribute<'_> {
     }
 }
 
-/// Read the `dialog.name/referent` claim attached to `entity`, if
+/// Read the `db.name/referent` claim attached to `entity`, if
 /// any — the one-step name indirection behind `id:<name>` URIs.
 async fn lookup_referent<Env: QueryEnv>(
     entity: &Entity,
@@ -282,7 +282,7 @@ async fn lookup_referent<Env: QueryEnv>(
 }
 
 /// Resolve a [`Target`] to the entity it names — a direct entity
-/// passes through, a name is chased through `dialog.name/referent`.
+/// passes through, a name is chased through `db.name/referent`.
 async fn resolve_target<Env: QueryEnv>(
     target: Target,
     source: &Source<'_>,
@@ -327,7 +327,7 @@ pub struct ListConcepts<'a> {
 impl ListConcepts<'_> {
     /// Resolve every concept the source holds.
     ///
-    /// Enumerates the branch via the `dialog.meta/concept` marker,
+    /// Enumerates the branch via the `db.meta/concept` marker,
     /// then resolves each entity through
     /// [`ConceptReference::resolve`] so every returned definition
     /// carries its durability tag.
@@ -344,9 +344,9 @@ impl ListConcepts<'_> {
             .source
             .select(AttributeQuery::from(
                 Term::<The>::from(
-                    "dialog.meta/concept"
+                    "db.meta/concept"
                         .parse::<The>()
-                        .expect("`dialog.meta/concept` is a valid attribute"),
+                        .expect("`db.meta/concept` is a valid attribute"),
                 )
                 .of(Term::<Entity>::var("concept"))
                 .is(Term::from(marker)),
@@ -420,30 +420,31 @@ mod tests {
     where
         Env: QueryEnv
             + dialog_capability::Provider<dialog_effects::memory::Publish>
-            + dialog_capability::Provider<dialog_effects::archive::Import>,
+            + dialog_capability::Provider<dialog_effects::archive::Import>
+            + dialog_capability::Provider<dialog_effects::authority::Attest>,
     {
         let txn = branch.transaction();
         let mut txn = txn;
         for (_, attr) in descriptor.with().iter() {
             let attr_entity: Entity = attr.to_uri().parse()?;
             txn = txn
+                .assert(the!("db.attribute/id").of(attr_entity.clone()).is(format!(
+                    "{}/{}",
+                    attr.domain(),
+                    attr.name()
+                )))
                 .assert(
-                    the!("dialog.attribute/id")
-                        .of(attr_entity.clone())
-                        .is(format!("{}/{}", attr.domain(), attr.name())),
-                )
-                .assert(
-                    the!("dialog.attribute/type")
+                    the!("db.attribute/type")
                         .of(attr_entity.clone())
                         .is("Text".to_string()),
                 )
                 .assert(
-                    the!("dialog.attribute/cardinality")
+                    the!("db.attribute/cardinality")
                         .of(attr_entity.clone())
                         .is("one".to_string()),
                 )
                 .assert(
-                    the!("dialog.meta/description")
+                    the!("db.meta/description")
                         .of(attr_entity)
                         .is(String::new()),
                 );

--- a/rust/tonk-schema/src/rule.rs
+++ b/rust/tonk-schema/src/rule.rs
@@ -2,12 +2,12 @@
 //! [`AnonymousConcept`](crate::concept::AnonymousConcept).
 //!
 //! `AnonymousConcept` packages a [`ConceptDescriptor`] with the
-//! storage shape (`dialog.meta/concept` marker plus
-//! `dialog.concept.with/*` per-field claims) so a `concept!:` notation
+//! storage shape (`db.meta/concept` marker plus
+//! `db.concept.with/*` per-field claims) so a `concept!:` notation
 //! can flow through dialog's `Statement` trait. [`Rule`] plays the
 //! same role for installed inductive rules: it packages an
-//! [`Effect`] with the storage shape (`dialog.meta/effect` marker
-//! plus `dialog.effect/{source,conclusion,polarity,on}` claims) so
+//! [`Effect`] with the storage shape (`db.meta/effect` marker
+//! plus `db.effect/{source,conclusion,polarity,on}` claims) so
 //! `rule!:` notation flows through the same trait.
 //!
 //! # Two construction paths — symmetric assert, careful retract
@@ -15,7 +15,7 @@
 //! Asserting a new rule is purely synthetic: hash the rule body,
 //! serialise the source, emit claims. Retracting needs to *match*
 //! what was previously stored. The risk lives in
-//! `dialog.effect/source`: it carries the JSON-encoded
+//! `db.effect/source`: it carries the JSON-encoded
 //! [`InductiveRuleDescriptor`], and serialisation is not guaranteed
 //! to round-trip byte-for-byte (premise order, optional fields,
 //! whitespace…). If a fresh [`Effect::source`] disagrees with the
@@ -31,7 +31,7 @@
 //!   string a moment later, so the symmetry holds for an
 //!   assert+retract pair issued back-to-back in the same process.
 //! - [`Rule::retracting`] — async builder that reads the stored
-//!   `dialog.effect/source` and `dialog.effect/polarity` claims off
+//!   `db.effect/source` and `db.effect/polarity` claims off
 //!   a branch and bakes them into a [`Rule`] whose `Statement`
 //!   impl dissociates using *those exact* bytes. This is the path
 //!   for `rule!: this: <entity> ..: _` deletions where the rule
@@ -67,7 +67,7 @@ use crate::concept::QueryEnv;
 use crate::query_source::Source;
 
 /// A rule installed on a branch — pairs an [`Effect`] with the
-/// exact `dialog.effect/source` string and polarity tag used to
+/// exact `db.effect/source` string and polarity tag used to
 /// store it (or to retract it).
 ///
 /// See the [module docs](self) for why this carries the source
@@ -81,7 +81,7 @@ use crate::query_source::Source;
 pub struct Rule {
     /// The installed effect — head, body, polarity.
     pub effect: Effect,
-    /// The entity URI the `dialog.effect/*` claims are written
+    /// The entity URI the `db.effect/*` claims are written
     /// against. Defaults to [`Effect::this`] (content-derived) for
     /// [`Rule::asserting`]; callers can override via
     /// [`Rule::asserting_at`] to install at a stable, user-chosen
@@ -90,12 +90,12 @@ pub struct Rule {
     /// the same EAVs that were written.
     this: Entity,
     /// The exact source string carried on
-    /// `dialog.effect/source`. Synthesised by
+    /// `db.effect/source`. Synthesised by
     /// [`Effect::source`](tonk_core::effect::Effect::source) on
     /// the assert path; read off the branch on the retract path.
     source: String,
     /// The polarity string carried on
-    /// `dialog.effect/polarity`. Stored as a separate field rather
+    /// `db.effect/polarity`. Stored as a separate field rather
     /// than re-derived so the retract path is symmetric with
     /// assert.
     polarity: EffectPolarity,
@@ -108,7 +108,7 @@ impl Rule {
     /// The carried `source` string is whatever the effect
     /// serialises to right now. That's exactly what
     /// [`Statement::assert`](dialog_artifacts::Statement::assert)
-    /// will write under the `dialog.effect/source` claim, so the
+    /// will write under the `db.effect/source` claim, so the
     /// pair is consistent by construction.
     pub fn asserting(effect: Effect) -> Self {
         let this = effect.this();
@@ -133,7 +133,7 @@ impl Rule {
 
     /// Begin building a [`Rule`] for a `retract` mutation. The
     /// returned [`Retracting`] resolves against a branch to read
-    /// the stored `dialog.effect/source` + `dialog.effect/polarity`
+    /// the stored `db.effect/source` + `db.effect/polarity`
     /// claims and bake those exact bytes into the resulting `Rule`,
     /// so the dissociate matches byte-for-byte and the source claim
     /// is actually removed.
@@ -141,12 +141,12 @@ impl Rule {
         Retracting { entity }
     }
 
-    /// The entity URI the `dialog.effect/*` claims live under.
+    /// The entity URI the `db.effect/*` claims live under.
     pub fn this(&self) -> Entity {
         self.this.clone()
     }
 
-    /// The exact `dialog.effect/source` string (JSON-encoded
+    /// The exact `db.effect/source` string (JSON-encoded
     /// [`InductiveRuleDescriptor`]). Paired with [`Rule::polarity`]
     /// this round-trips through
     /// [`Effect::from_source`](tonk_core::effect::Effect::from_source),
@@ -158,7 +158,7 @@ impl Rule {
     }
 
     /// The polarity tag (`assert` / `retract`) carried on
-    /// `dialog.effect/polarity`.
+    /// `db.effect/polarity`.
     pub fn polarity(&self) -> EffectPolarity {
         self.polarity
     }
@@ -171,34 +171,34 @@ impl dialog_artifacts::Statement for Rule {
         let conclusion = self.effect.conclusion();
         let attributes = self.effect.on_entities();
 
-        // Marker — `(?this, dialog.meta/effect, db:effect)`.
+        // Marker — `(?this, db.meta/effect, db:effect)`.
         update.associate_unique(
-            meta_attr("dialog.meta", "effect"),
+            meta_attr("db.meta", "effect"),
             this.clone(),
             Value::Entity(effect_marker_entity()),
         );
         // Source-of-truth claim.
         update.associate_unique(
-            meta_attr("dialog.effect", "source"),
+            meta_attr("db.effect", "source"),
             this.clone(),
             Value::String(self.source),
         );
         // Head concept index.
         update.associate_unique(
-            meta_attr("dialog.effect", "conclusion"),
+            meta_attr("db.effect", "conclusion"),
             this.clone(),
             Value::Entity(conclusion),
         );
         // Polarity tag.
         update.associate_unique(
-            meta_attr("dialog.effect", "polarity"),
+            meta_attr("db.effect", "polarity"),
             this.clone(),
             Value::String(self.polarity.as_str().to_owned()),
         );
         // Per-attribute reverse index (cardinality-many).
         for attribute in attributes {
             update.associate(
-                meta_attr("dialog.effect", "on"),
+                meta_attr("db.effect", "on"),
                 this.clone(),
                 Value::Entity(attribute),
             );
@@ -208,7 +208,7 @@ impl dialog_artifacts::Statement for Rule {
             && !description.is_empty()
         {
             update.associate_unique(
-                meta_attr("dialog.meta", "description"),
+                meta_attr("db.meta", "description"),
                 this,
                 Value::String(description),
             );
@@ -222,28 +222,28 @@ impl dialog_artifacts::Statement for Rule {
         let attributes = self.effect.on_entities();
 
         update.dissociate(
-            meta_attr("dialog.meta", "effect"),
+            meta_attr("db.meta", "effect"),
             this.clone(),
             Value::Entity(effect_marker_entity()),
         );
         update.dissociate(
-            meta_attr("dialog.effect", "source"),
+            meta_attr("db.effect", "source"),
             this.clone(),
             Value::String(self.source),
         );
         update.dissociate(
-            meta_attr("dialog.effect", "conclusion"),
+            meta_attr("db.effect", "conclusion"),
             this.clone(),
             Value::Entity(conclusion),
         );
         update.dissociate(
-            meta_attr("dialog.effect", "polarity"),
+            meta_attr("db.effect", "polarity"),
             this.clone(),
             Value::String(self.polarity.as_str().to_owned()),
         );
         for attribute in attributes {
             update.dissociate(
-                meta_attr("dialog.effect", "on"),
+                meta_attr("db.effect", "on"),
                 this.clone(),
                 Value::Entity(attribute),
             );
@@ -252,7 +252,7 @@ impl dialog_artifacts::Statement for Rule {
             && !description.is_empty()
         {
             update.dissociate(
-                meta_attr("dialog.meta", "description"),
+                meta_attr("db.meta", "description"),
                 this,
                 Value::String(description),
             );
@@ -261,7 +261,7 @@ impl dialog_artifacts::Statement for Rule {
 }
 
 /// Builder for [`Rule::retracting`]. Reads the stored
-/// `dialog.effect/source` + `dialog.effect/polarity` claims off a
+/// `db.effect/source` + `db.effect/polarity` claims off a
 /// branch so the resulting [`Rule`]'s `retract` dissociates the
 /// stored bytes verbatim. See the [module docs](self) for why this
 /// extra round-trip matters.
@@ -272,7 +272,7 @@ pub struct Retracting {
 
 impl Retracting {
     /// Resolve against a branch. Returns `None` when the entity
-    /// has no `dialog.effect/source` claim (no such rule installed).
+    /// has no `db.effect/source` claim (no such rule installed).
     pub async fn resolve<Env: QueryEnv>(
         self,
         source: &Source<'_>,
@@ -293,7 +293,7 @@ impl Retracting {
         };
         let Value::String(source_string) = source_claim.is else {
             return Err(RuleResolveError::Storage(
-                "dialog.effect/source claim was not a string".to_owned(),
+                "db.effect/source claim was not a string".to_owned(),
             ));
         };
 
@@ -309,12 +309,12 @@ impl Retracting {
             .map_err(|e| RuleResolveError::Query(format!("polarity lookup failed: {e:?}")))?;
         let Some(polarity_claim) = polarity_claims.into_iter().next() else {
             return Err(RuleResolveError::Storage(
-                "missing dialog.effect/polarity claim".to_owned(),
+                "missing db.effect/polarity claim".to_owned(),
             ));
         };
         let Value::String(polarity_string) = polarity_claim.is else {
             return Err(RuleResolveError::Storage(
-                "dialog.effect/polarity claim was not a string".to_owned(),
+                "db.effect/polarity claim was not a string".to_owned(),
             ));
         };
         let polarity = EffectPolarity::parse(&polarity_string).ok_or_else(|| {
@@ -373,15 +373,15 @@ fn meta_attr(domain: &str, name: &str) -> ArtifactsAttribute {
 }
 
 /// Build the typed [`dialog_query::attribute::The`] selector for a
-/// `dialog.effect/<name>` attribute. The retract resolver needs the
+/// `db.effect/<name>` attribute. The retract resolver needs the
 /// typed form when constructing an [`AttributeQuery`].
 fn effect_attr(name: &str) -> dialog_query::attribute::The {
-    format!("dialog.effect/{name}")
+    format!("db.effect/{name}")
         .parse()
-        .expect("dialog.effect/<name> is a valid attribute URI")
+        .expect("db.effect/<name> is a valid attribute URI")
 }
 
-/// Marker entity asserted as the value of `dialog.meta/effect` on
+/// Marker entity asserted as the value of `db.meta/effect` on
 /// every effect entity. Same role as `db:concept` for concepts:
 /// gives "all effects on this branch" queries a known triple to
 /// start from.
@@ -493,7 +493,7 @@ mod tests {
     /// Install an effect, then retract it by resolving its
     /// [`Rule::retracting`] handle off the branch and committing the
     /// dissociates. After the retract commit the rule should *not*
-    /// surface in a `dialog.effect/source` query — proving the
+    /// surface in a `db.effect/source` query — proving the
     /// dissociate matched the stored bytes verbatim. This pins the
     /// regression that bit
     /// commit `fd1cea8f` (reverted at `2abb4b2f`): the previous
@@ -562,7 +562,7 @@ mod tests {
             .await?;
         assert!(
             post.is_empty(),
-            "dialog.effect/source claim should be gone after retract, saw {post:?}"
+            "db.effect/source claim should be gone after retract, saw {post:?}"
         );
 
         Ok(())
@@ -599,36 +599,36 @@ mod tests {
         let marker = effect_marker_entity();
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.meta/effect"
+                c.the.to_string() == "db.meta/effect"
                     && c.of == this
                     && matches!(&c.is, Value::Entity(e) if *e == marker)
             }),
-            "missing dialog.meta/effect marker"
+            "missing db.meta/effect marker"
         );
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/conclusion"
+                c.the.to_string() == "db.effect/conclusion"
                     && c.of == this
                     && matches!(&c.is, Value::Entity(e) if *e == conclusion)
             }),
-            "missing dialog.effect/conclusion claim"
+            "missing db.effect/conclusion claim"
         );
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/polarity"
+                c.the.to_string() == "db.effect/polarity"
                     && c.of == this
                     && matches!(&c.is, Value::String(s) if s == "assert")
             }),
-            "missing dialog.effect/polarity claim"
+            "missing db.effect/polarity claim"
         );
         for attribute in &on_set {
             assert!(
                 asserted.iter().any(|c| {
-                    c.the.to_string() == "dialog.effect/on"
+                    c.the.to_string() == "db.effect/on"
                         && c.of == this
                         && matches!(&c.is, Value::Entity(e) if *e == *attribute)
                 }),
-                "missing dialog.effect/on claim for {attribute}"
+                "missing db.effect/on claim for {attribute}"
             );
         }
     }
@@ -672,7 +672,7 @@ mod tests {
         let marker = effect_marker_entity();
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.meta/effect"
+                c.the.to_string() == "db.meta/effect"
                     && c.of == chosen
                     && matches!(&c.is, Value::Entity(e) if *e == marker)
             }),
@@ -681,12 +681,12 @@ mod tests {
         assert!(
             asserted
                 .iter()
-                .any(|c| { c.the.to_string() == "dialog.effect/source" && c.of == chosen }),
+                .any(|c| { c.the.to_string() == "db.effect/source" && c.of == chosen }),
             "source claim should hang off the chosen entity"
         );
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/conclusion"
+                c.the.to_string() == "db.effect/conclusion"
                     && c.of == chosen
                     && matches!(&c.is, Value::Entity(e) if *e == conclusion)
             }),
@@ -694,7 +694,7 @@ mod tests {
         );
         assert!(
             asserted.iter().any(|c| {
-                c.the.to_string() == "dialog.effect/polarity"
+                c.the.to_string() == "db.effect/polarity"
                     && c.of == chosen
                     && matches!(&c.is, Value::String(s) if s == "assert")
             }),
@@ -703,7 +703,7 @@ mod tests {
         for attribute in &on_set {
             assert!(
                 asserted.iter().any(|c| {
-                    c.the.to_string() == "dialog.effect/on"
+                    c.the.to_string() == "db.effect/on"
                         && c.of == chosen
                         && matches!(&c.is, Value::Entity(e) if *e == *attribute)
                 }),

--- a/rust/tonk-schema/src/rule_query.rs
+++ b/rust/tonk-schema/src/rule_query.rs
@@ -28,8 +28,8 @@ use serde::{Deserialize, Serialize};
 use crate::effect::{Effect, EffectPolarity};
 
 /// The well-known marker entity asserted as the value of
-/// `dialog.meta/effect` on every effect entity, mirroring how
-/// concept entities carry `(?this, dialog.meta/concept,
+/// `db.meta/effect` on every effect entity, mirroring how
+/// concept entities carry `(?this, db.meta/concept,
 /// db:concept)`. Lets "all effects on this branch" queries start
 /// from a selectable triple.
 fn effect_marker_entity() -> Entity {
@@ -67,10 +67,10 @@ impl RuleDefinition {
 /// Custom query application that surfaces every inductive rule
 /// installed on a branch as a [`ConceptConclusion`].
 ///
-/// Rules are reified as `dialog.effect/*` facts (see the
+/// Rules are reified as `db.effect/*` facts (see the
 /// [`effect`](crate::effect) module docs). This query enumerates
-/// every entity carrying the `dialog.meta/effect = db:effect`
-/// marker, rehydrates each via its `dialog.effect/*` claims, and
+/// every entity carrying the `db.meta/effect = db:effect`
+/// marker, rehydrates each via its `db.effect/*` claims, and
 /// materialises its definition into a synthesised `definition`
 /// field alongside `this` (the effect entity). It is the
 /// rule-side parallel of
@@ -130,7 +130,7 @@ impl Application for AnonymousRuleQuery {
                 let this_filter = resolve_entity_filter(&this_term, &input);
 
                 // Enumerate every effect entity via the
-                // `dialog.meta/effect = db:effect` marker. When
+                // `db.meta/effect = db:effect` marker. When
                 // `this` is a constant the selection is already
                 // narrowed to that entity.
                 let marker = effect_marker_entity();
@@ -138,7 +138,7 @@ impl Application for AnonymousRuleQuery {
                     Some(e) => Term::Constant(Value::Entity(e.clone())),
                     None => Term::var("__rule_query_this"),
                 };
-                let claims: Vec<dialog_query::Claim> = the!("dialog.meta/effect")
+                let claims: Vec<dialog_query::Claim> = the!("db.meta/effect")
                     .of(this_term_for_marker)
                     .is(marker)
                     .perform(env)
@@ -183,7 +183,7 @@ impl Application for AnonymousRuleQuery {
             predicate: ConceptDescriptor::try_from(vec![(
                 "_",
                 dialog_query::AttributeDescriptor::new(
-                    the!("dialog.rule/stub"),
+                    the!("db.rule/stub"),
                     "",
                     dialog_query::Cardinality::default(),
                     None,
@@ -195,8 +195,8 @@ impl Application for AnonymousRuleQuery {
     }
 }
 
-/// Rehydrate an effect from its `dialog.effect/source` and
-/// `dialog.effect/polarity` claims read straight off a query
+/// Rehydrate an effect from its `db.effect/source` and
+/// `db.effect/polarity` claims read straight off a query
 /// selection environment.
 ///
 /// Takes the raw `Provider<Select>` selection env that
@@ -210,7 +210,7 @@ async fn load_effect_facts<'a, Env>(
 where
     Env: Provider<Select<'a>> + Provider<SelectRules> + ConditionalSync,
 {
-    let source_claims: Vec<dialog_query::Claim> = the!("dialog.effect/source")
+    let source_claims: Vec<dialog_query::Claim> = the!("db.effect/source")
         .of(Term::<Entity>::from(entity.clone()))
         .is(Term::<String>::var("__rule_query_source"))
         .perform(env)
@@ -221,11 +221,11 @@ where
     };
     let Value::String(source) = source_claim.is else {
         return Err(EvaluationError::Store(
-            "dialog.effect/source claim was not a string".to_string(),
+            "db.effect/source claim was not a string".to_string(),
         ));
     };
 
-    let polarity_claims: Vec<dialog_query::Claim> = the!("dialog.effect/polarity")
+    let polarity_claims: Vec<dialog_query::Claim> = the!("db.effect/polarity")
         .of(Term::<Entity>::from(entity.clone()))
         .is(Term::<String>::var("__rule_query_polarity"))
         .perform(env)
@@ -233,12 +233,12 @@ where
         .await?;
     let Some(polarity_claim) = polarity_claims.into_iter().next() else {
         return Err(EvaluationError::Store(
-            "missing dialog.effect/polarity claim".to_string(),
+            "missing db.effect/polarity claim".to_string(),
         ));
     };
     let Value::String(polarity_str) = polarity_claim.is else {
         return Err(EvaluationError::Store(
-            "dialog.effect/polarity claim was not a string".to_string(),
+            "db.effect/polarity claim was not a string".to_string(),
         ));
     };
     let polarity = EffectPolarity::parse(&polarity_str)
@@ -251,7 +251,7 @@ where
 
 /// The well-known descriptor for the "rule of rules" head.
 ///
-/// Its `with` map names the marker (`dialog.meta/effect`) and the
+/// Its `with` map names the marker (`db.meta/effect`) and the
 /// synthesised `definition` field — enough for the analyzer to
 /// project the fields a `rule:` head exposes. The `definition`
 /// claim has no real EAV backing; it is produced only by
@@ -264,8 +264,8 @@ pub fn rule_of_rule_descriptor() -> &'static ConceptDescriptor {
         serde_json::from_value(serde_json::json!({
             "description": "Every inductive rule installed on a branch.",
             "with": {
-                "effect":     { "the": "dialog.meta/effect",     "as": "Entity", "cardinality": "one" },
-                "definition": { "the": "dialog.effect/source",   "as": "Text",   "cardinality": "one" }
+                "effect":     { "the": "db.meta/effect",     "as": "Entity", "cardinality": "one" },
+                "definition": { "the": "db.effect/source",   "as": "Text",   "cardinality": "one" }
             }
         }))
         .expect("rule-of-rule descriptor is well-formed")

--- a/rust/tonk-schema/src/sync.rs
+++ b/rust/tonk-schema/src/sync.rs
@@ -3,7 +3,7 @@
 //! The types and the classifier moved to `tonk-worker-api` (the
 //! engine-free wire crate) so the web page can name `SyncState` and
 //! classify without linking the datalog engine. They only need a
-//! [`Revision`](dialog_capability::Revision), which is itself
+//! [`Revision`](dialog_artifacts::Revision), which is itself
 //! engine-free. Re-exported here at their historical
 //! `tonk_schema::sync::*` paths for the native CLI, the worker, and
 //! the workspace.

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -7,8 +7,8 @@
 //! - [`Application`] captures "predicate applied to terms," shared
 //!   between queries and mutations. [`Application::Rule`] is the
 //!   rule-install / rule-retract counterpart: a rule is not a
-//!   generic concept (its storage shape is the `dialog.effect/*`
-//!   claims, not a per-attribute `dialog.concept.with/*` map), so
+//!   generic concept (its storage shape is the `db.effect/*`
+//!   claims, not a per-attribute `db.concept.with/*` map), so
 //!   it gets its own variant.
 //! - [`Statement::Assert`] / [`Statement::Retract`] are the
 //!   write-direction wrappers. A rule install is
@@ -159,8 +159,8 @@ pub enum Application {
     },
     /// `rule!:` head — an installed or to-be-installed rule.
     /// Distinct from `Concept` because a rule's storage shape is
-    /// the `dialog.effect/*` claim set, not a per-attribute
-    /// `dialog.concept.with/*` map.
+    /// the `db.effect/*` claim set, not a per-attribute
+    /// `db.concept.with/*` map.
     ///
     /// For an install, the carried [`Rule`] was built fresh from
     /// the body lift; for a retract it was resolved off the branch
@@ -420,7 +420,7 @@ impl Planner for Application {
 /// concept-like application — built-in `attribute`/`concept`,
 /// user-defined concepts, and synthesised domain predicates).
 /// [`ApplicationPlan::Rule`] carries the resolved [`Rule`] whose
-/// [`ArtifactsStatement`] impl emits the `dialog.effect/*` storage
+/// [`ArtifactsStatement`] impl emits the `db.effect/*` storage
 /// shape.
 pub enum ApplicationPlan {
     /// Per-attribute concept storage (concept / domain / built-in).
@@ -429,7 +429,7 @@ pub enum ApplicationPlan {
     /// `Rule` variant) would otherwise leave a large size gap between
     /// variants.
     Concept(Box<ConceptPlan>),
-    /// `dialog.effect/*` rule storage. Boxed because [`Rule`]'s
+    /// `db.effect/*` rule storage. Boxed because [`Rule`]'s
     /// embedded [`InductiveRule`] would otherwise inflate every
     /// concept-shaped plan to rule-storage size.
     Rule(Box<Rule>),
@@ -492,7 +492,7 @@ fn entity_of_this(terms: &Parameters) -> Option<Entity> {
 /// (`person!: &alice`) desugars to.
 ///
 /// The anchor name `alice` becomes the entity URI `id:alice`, and
-/// that entity carries a `dialog.meta/name` claim pointing at the
+/// that entity carries a `db.meta/name` claim pointing at the
 /// body-derived target. Equivalent to:
 ///
 /// ```yaml
@@ -501,7 +501,7 @@ fn entity_of_this(terms: &Parameters) -> Option<Entity> {
 ///   entity: <body-derived target>
 /// ```
 ///
-/// Cardinality-one on `dialog.meta/name` means re-running with a
+/// Cardinality-one on `db.meta/name` means re-running with a
 /// different body retracts the prior `entity:` claim and binds the
 /// name to the new target — same git-tag semantics, but the EAV
 /// hangs off the *name* entity, not the named one.
@@ -716,14 +716,14 @@ mod tests {
 
         let id_alice: Entity = "id:alice".parse().unwrap();
         let target: Entity = target_uri.parse().unwrap();
-        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
+        let meta_name: dialog_artifacts::Attribute = "db.name/referent".parse().unwrap();
 
         let mut id_alice_name_claim_count = 0;
         let mut wrong_direction_count = 0;
         for inst in changes.into_instructions() {
             // Cardinality-one fields use `Instruction::Replace`
             // (added in dialog tonk-2026-05-11). The anchor name
-            // is `dialog.name/referent` with cardinality one, so
+            // is `db.name/referent` with cardinality one, so
             // the desugared `name!` lands as a Replace, not an
             // Assert.
             let artifact = match &inst {
@@ -741,7 +741,7 @@ mod tests {
         }
         assert_eq!(
             id_alice_name_claim_count, 1,
-            "expected exactly one (id:alice, dialog.meta/name, target) claim"
+            "expected exactly one (id:alice, db.meta/name, target) claim"
         );
         assert_eq!(
             wrong_direction_count, 0,
@@ -760,7 +760,7 @@ mod tests {
 
         let id_alice: Entity = "id:alice".parse().unwrap();
         let target: Entity = target_uri.parse().unwrap();
-        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
+        let meta_name: dialog_artifacts::Attribute = "db.name/referent".parse().unwrap();
 
         let saw_dissociate = changes.into_instructions().into_iter().any(|inst| {
             matches!(
@@ -771,7 +771,7 @@ mod tests {
         });
         assert!(
             saw_dissociate,
-            "expected (id:alice, dialog.meta/name, target) dissociation"
+            "expected (id:alice, db.meta/name, target) dissociation"
         );
     }
 
@@ -801,14 +801,14 @@ mod tests {
         let mut changes = Changes::new();
         plan.assert(&mut changes);
 
-        let meta_name: dialog_artifacts::Attribute = "dialog.name/referent".parse().unwrap();
+        let meta_name: dialog_artifacts::Attribute = "db.name/referent".parse().unwrap();
         let saw_meta_name = changes
             .into_instructions()
             .into_iter()
             .any(|inst| matches!(inst, Instruction::Assert(a) if a.the == meta_name));
         assert!(
             !saw_meta_name,
-            "anonymous bindings should not emit any dialog.meta/name claim"
+            "anonymous bindings should not emit any db.meta/name claim"
         );
     }
 

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -244,16 +244,16 @@ fn hex_digit(b: u8) -> Option<u8> {
 
 /// Build the name-resolution query: resolve a bookmark `name` to the
 /// entity it points at through the **Name concept** — the `id:<name>`
-/// entity's `dialog.name/referent` claim (cardinality one, so at most
+/// entity's `db.name/referent` claim (cardinality one, so at most
 /// one match).
 ///
 /// This is the single source of truth for "what does this name refer
 /// to": the analyzer publishes a `Name` claim for every `&anchor`,
 /// including concepts pinned to a `this:` URI (e.g. `&workspace` +
 /// `this: tonk:workspace` → `id:workspace` → `tonk:workspace`). A
-/// concept's `dialog.meta/name` claim, by contrast, is only emitted
+/// concept's `db.meta/name` claim, by contrast, is only emitted
 /// when its `this:` is *derived*, so resolving a model/view name
-/// against `dialog.meta/name` misses pinned concepts. Resolving names
+/// against `db.meta/name` misses pinned concepts. Resolving names
 /// here and feeding the resulting URI to [`phase1_query`] makes model,
 /// view, and entity name resolution agree.
 ///
@@ -266,7 +266,7 @@ pub fn name_query(name: &str) -> Query {
         },
         "predicate": {
             "with": {
-                "entity": { "the": "dialog.name/referent", "as": "Entity", "cardinality": "one" }
+                "entity": { "the": "db.name/referent", "as": "Entity", "cardinality": "one" }
             }
         }
     });
@@ -279,7 +279,7 @@ pub fn name_query(name: &str) -> Query {
 /// `parsed.name_or_uri` is expected to be a concept entity URI — a
 /// bookmark name should be resolved to its referent via [`name_query`]
 /// first. (For backwards compatibility a non-URI value still falls
-/// back to a `dialog.meta/name` filter, but that path misses concepts
+/// back to a `db.meta/name` filter, but that path misses concepts
 /// pinned to a `this:` URI; prefer resolving the name first.)
 ///
 /// Reads back as `(this, name, source)` — the descriptor JSON is
@@ -299,11 +299,11 @@ pub fn phase1_query(parsed: &ParsedSource) -> Query {
         "terms": terms,
         "predicate": {
             "with": {
-                "concept":     { "the": "dialog.meta/concept",     "as": "Entity",  "cardinality": "one" },
-                "name":        { "the": "dialog.meta/name",        "as": "Text",    "cardinality": "one" },
-                "description": { "the": "dialog.meta/description", "as": "Text",    "cardinality": "one" },
-                "source":      { "the": "dialog.meta/source",      "as": "Text",    "cardinality": "one" },
-                "transient":   { "the": "dialog.concept/transient", "as": "Boolean", "cardinality": "one" }
+                "concept":     { "the": "db.meta/concept",     "as": "Entity",  "cardinality": "one" },
+                "name":        { "the": "db.meta/name",        "as": "Text",    "cardinality": "one" },
+                "description": { "the": "db.meta/description", "as": "Text",    "cardinality": "one" },
+                "source":      { "the": "db.meta/source",      "as": "Text",    "cardinality": "one" },
+                "transient":   { "the": "db.concept/transient", "as": "Boolean", "cardinality": "one" }
             }
         }
     });
@@ -606,9 +606,9 @@ mod tests {
     #[dialog_common::test]
     fn it_resolves_a_name_through_the_name_concept() {
         // A bare name resolves via the Name concept: `id:<name>`'s
-        // `dialog.name/referent`. This is what lets `workspace` (a
+        // `db.name/referent`. This is what lets `workspace` (a
         // concept pinned to `this: tonk:workspace`, so carrying a Name
-        // claim but no `dialog.meta/name`) resolve at all.
+        // claim but no `db.meta/name`) resolve at all.
         let q = name_query("workspace");
         let this = q.terms.get("this").expect("this term");
         assert_eq!(
@@ -628,7 +628,7 @@ mod tests {
             predicate
                 .pointer("/with/entity/the")
                 .and_then(|v| v.as_str()),
-            Some("dialog.name/referent"),
+            Some("db.name/referent"),
             "the name query constrains on the Name referent attribute",
         );
     }

--- a/rust/tonk-tree/src/inspector.rs
+++ b/rust/tonk-tree/src/inspector.rs
@@ -71,10 +71,10 @@ pub fn render(state: &Shared) {
         },
     ));
 
-    if let Some(bound) = &node.bound {
+    if !node.bound_parts.is_empty() {
         let _ = body.append_child(&kv("upper key", ""));
         let keyrow = el("div").class("keybytes");
-        append_key_full(&keyrow, bound);
+        append_key_full(&keyrow, &node.bound_parts);
         let _ = body.append_child(&keyrow);
     }
 
@@ -215,7 +215,7 @@ fn entry_detail(entry: &TreeEntry) -> Element {
         let _ = box_.append_child(&kv("value", &key::format_value(v, t)));
     }
     let keyrow = el("div").class("keybytes");
-    append_key_full(&keyrow, &entry.key);
+    append_key_full(&keyrow, &entry.key_parts);
     let _ = box_.append_child(&el("div").class("k").text("key"));
     let _ = box_.append_child(&keyrow);
     box_

--- a/rust/tonk-tree/src/key.rs
+++ b/rust/tonk-tree/src/key.rs
@@ -62,6 +62,7 @@ fn part_of(kind: &str) -> (Part, &'static str) {
         "origin" => (Part::Structural, "Revision origin"),
         "edition" => (Part::Structural, "Revision edition"),
         "blob" => (Part::ValueRef, "Blob (content-addressed)"),
+        "min" => (Part::Structural, "Leftmost subtree (no lower bound)"),
         "opaque" => (Part::Unknown, "Key"),
         _ => (Part::Unknown, "Key"),
     }
@@ -96,10 +97,17 @@ pub fn components(parts: &[KeyPart]) -> Vec<Component> {
     let mut offset = 0usize;
     for p in parts {
         let (part, label) = part_of(&p.kind);
-        let len = hex_len(&p.hex).max(1);
+        // The index and value-type chips carry a NAME in `hex` (not real
+        // bytes) for the tooltip, and always span one byte (the tag). Every
+        // other part's byte span comes from its `hex` length.
+        let (len, label) = match p.kind.as_str() {
+            "index" => (1usize, capitalize(&p.hex)),
+            "vtype" => (1usize, format!("Value type: {}", p.hex)),
+            _ => (hex_len(&p.hex).max(1), label.to_owned()),
+        };
         let text = glyphs(&p.text);
         out.push(Component {
-            label: label.to_owned(),
+            label,
             part,
             full: text.clone(),
             text,
@@ -108,6 +116,16 @@ pub fn components(parts: &[KeyPart]) -> Vec<Component> {
         offset += len;
     }
     out
+}
+
+/// Title-case an ordering name for the index tooltip (`entity` → `Entity
+/// index`).
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => format!("{}{} index", first.to_uppercase(), chars.as_str()),
+        None => "Index".to_owned(),
+    }
 }
 
 /// Decode a `0x`-prefixed hex key into raw bytes, for the pivot comparison.

--- a/rust/tonk-tree/src/key.rs
+++ b/rust/tonk-tree/src/key.rs
@@ -1,78 +1,116 @@
-//! Decoding a composite index key into its colored components, and
+//! Rendering the worker-decoded key components as colored chips, and
 //! formatting fact values so their type reads from the value itself.
 //!
-//! A key is the 162 bytes carried as a `0x<hex>` string. The byte layout
-//! depends on the leading tag byte (the index ordering): entity, attribute,
-//! and value index keys place the parts at different offsets (see `layout`).
+//! The M3 key format is variable-length and schema-driven, so the *decoding*
+//! lives on the worker (`dialog-reactor`'s `key_parts`): it hands us a list of
+//! `{kind, text, hex}` components already split and textualized (a `did:key:…`
+//! entity, a `db.meta/name` attribute, a typed value, a history `origin` /
+//! `edition`). This module maps each component to a display [`Component`]
+//! (label, color part, text with structural-byte glyphs) — no byte slicing.
 
-/// One component of a key: its label (for a tooltip), which `Part` of the
-/// key it is (selects the CSS class / background color), and the short
-/// displayed text plus the full value.
+use crate::model::KeyPart;
+
+/// One component of a key, ready to render: its label (for a tooltip), which
+/// [`Part`] it is (the CSS color class), and the displayed text plus the full
+/// text for the detail pane.
 pub struct Component {
     pub label: String,
     pub part: Part,
     pub text: String,
     pub full: String,
-    /// The byte range this component occupies in the 162-byte key. Used to
-    /// locate the routing pivot (the first byte that diverges from the
-    /// previous sibling) within the chip.
+    /// The byte range this component occupies in the raw key, for the routing
+    /// pivot. Derived from the parts' `hex` lengths in document order.
     pub bytes: std::ops::Range<usize>,
 }
 
-/// Which part of the composite key a segment is. Each maps to a CSS class
-/// (`seg-<part>`) carrying that part's Bauhaus background color, so all
-/// styling lives in the stylesheet, not inline: entity → circle/blue,
-/// attribute → triangle/yellow, value-type & value-ref → square/red. The
-/// index-type chip reuses the matching index part's color (via `tag_fill`)
-/// and `append_key` adds `seg-index-type` for its chip shape.
+/// Which part of a key a component is — selects the `seg-<part>` CSS color.
+/// entity → circle/blue, attribute → triangle/yellow, value & type →
+/// square/red, structural (index/origin/edition/blob/spill) → neutral.
 #[derive(Clone, Copy, PartialEq)]
 pub enum Part {
     Entity,
     Attribute,
     ValueType,
     ValueRef,
+    Structural,
     Unknown,
 }
 
 impl Part {
-    /// The CSS class for this part — `seg-entity`, `seg-attribute`, etc.
-    /// The stylesheet keys the background color off it.
+    /// The CSS class for this part — the stylesheet keys the color off it.
     pub fn class(self) -> &'static str {
         match self {
             Part::Entity => "seg-entity",
             Part::Attribute => "seg-attribute",
             Part::ValueType => "seg-vtype",
             Part::ValueRef => "seg-value",
+            Part::Structural => "seg-index-type",
             Part::Unknown => "seg-unknown",
         }
     }
 }
 
-/// The index ordering a key belongs to, from its tag byte.
-pub fn tag_of(byte: u8) -> &'static str {
-    match byte {
-        0 => "entity",
-        1 => "attribute",
-        2 => "value",
-        _ => "unknown",
+/// Map a worker `kind` to its color part and human label.
+fn part_of(kind: &str) -> (Part, &'static str) {
+    match kind {
+        "index" => (Part::Structural, "Index"),
+        "entity" => (Part::Entity, "Entity"),
+        "attribute" => (Part::Attribute, "Attribute"),
+        "vtype" => (Part::ValueType, "Value type"),
+        "value" => (Part::ValueRef, "Value"),
+        "spill" => (Part::ValueRef, "Spilled value (hash reference)"),
+        "origin" => (Part::Structural, "Revision origin"),
+        "edition" => (Part::Structural, "Revision edition"),
+        "blob" => (Part::ValueRef, "Blob (content-addressed)"),
+        "opaque" => (Part::Unknown, "Key"),
+        _ => (Part::Unknown, "Key"),
     }
 }
 
-/// The index-type chip's tooltip label — `Entity Index`, `Attribute
-/// Index`, `Value Index`.
-fn index_label(byte: u8) -> String {
-    match byte {
-        0 => "Entity Index",
-        1 => "Attribute Index",
-        2 => "Value Index",
-        _ => "Unknown Index",
-    }
-    .to_owned()
+/// Substitute glyphs for non-printing / structural bytes so a UTF-8-ish
+/// component reads as text: a NUL terminator becomes `␀`, other control bytes
+/// become `·`. Printable text passes through unchanged. Used for the `text`
+/// of entity/attribute chips (which are UTF-8 in the key) so a trailing `0x00`
+/// separator is visible rather than an invisible gap.
+fn glyphs(text: &str) -> String {
+    text.chars()
+        .map(|c| match c {
+            '\0' => '␀',
+            c if c.is_control() => '·',
+            c => c,
+        })
+        .collect()
 }
 
-/// Decode a `0x`-prefixed hex key into bytes. Keys travel as hex (they
-/// are 162 bytes — too long for base58 decode buffers). Returns `None`
-/// on malformed input.
+/// The number of raw bytes a hex string represents (2 hex digits per byte).
+fn hex_len(hex: &str) -> usize {
+    hex.strip_prefix("0x").unwrap_or(hex).len() / 2
+}
+
+/// Map the worker-decoded parts into display components, threading each part's
+/// byte offset (from its `hex` length) so the pivot logic can locate the
+/// routing divergence. `text` gets glyph substitution; the index chip shows
+/// its ordering name.
+pub fn components(parts: &[KeyPart]) -> Vec<Component> {
+    let mut out = Vec::with_capacity(parts.len());
+    let mut offset = 0usize;
+    for p in parts {
+        let (part, label) = part_of(&p.kind);
+        let len = hex_len(&p.hex).max(1);
+        let text = glyphs(&p.text);
+        out.push(Component {
+            label: label.to_owned(),
+            part,
+            full: text.clone(),
+            text,
+            bytes: offset..offset + len,
+        });
+        offset += len;
+    }
+    out
+}
+
+/// Decode a `0x`-prefixed hex key into raw bytes, for the pivot comparison.
 fn decode(key: &str) -> Option<Vec<u8>> {
     let raw = key.strip_prefix("0x").unwrap_or(key);
     if !raw.len().is_multiple_of(2) {
@@ -84,220 +122,39 @@ fn decode(key: &str) -> Option<Vec<u8>> {
         .collect()
 }
 
-/// Lowercase hex of a byte slice. Hex is order-preserving — the chips'
-/// left-to-right order then reflects the key's actual lexicographic sort
-/// (base58 would hide it, since base58 string order ≠ byte order).
-fn hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
-}
-
-fn trunc(s: &str, head: usize, tail: usize) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() > head + tail + 1 {
-        let h: String = chars[..head].iter().collect();
-        let t: String = chars[chars.len() - tail..].iter().collect();
-        format!("{h}…{t}")
-    } else {
-        s.to_owned()
-    }
-}
-
-const TYPE_NAMES: [&str; 9] = [
-    "Bytes",
-    "Entity",
-    "Boolean",
-    "Text",
-    "UnsignedInt",
-    "SignedInt",
-    "Float",
-    "Record",
-    "Symbol",
-];
-
-fn type_name(byte: u8) -> &'static str {
-    TYPE_NAMES.get(byte as usize).copied().unwrap_or("?")
-}
-
-/// A human, kebab-cased value-type name for tooltips
-/// (`SignedInt` → `signed-integer`).
-fn type_label(byte: u8) -> &'static str {
-    match byte {
-        0 => "bytes",
-        1 => "entity",
-        2 => "boolean",
-        3 => "text",
-        4 => "unsigned-integer",
-        5 => "signed-integer",
-        6 => "float",
-        7 => "record",
-        8 => "symbol",
-        _ => "unknown",
-    }
-}
-
-/// Where each part sits in the 162 key bytes for a given index tag. The
-/// byte order is index-dependent (the sort key puts the leading part
-/// first), so the offsets shift per tag — matching dialog-artifacts'
-/// `key/{entity,attribute,value}.rs`.
-struct Layout {
-    entity: usize,
-    attribute: usize,
-    value_type: usize,
-    value_ref: usize,
-}
-
-fn layout(tag: u8) -> Layout {
-    match tag {
-        // value : [tag][type 1][value 32][attribute 64][entity 64]
-        2 => Layout {
-            value_type: 1,
-            value_ref: 2,
-            attribute: 34,
-            entity: 98,
-        },
-        // attribute : [tag][attribute 64][entity 64][type 1][value 32]
-        1 => Layout {
-            attribute: 1,
-            entity: 65,
-            value_type: 129,
-            value_ref: 130,
-        },
-        // entity : [tag][entity 64][attribute 64][type 1][value 32]
-        _ => Layout {
-            entity: 1,
-            attribute: 65,
-            value_type: 129,
-            value_ref: 130,
-        },
-    }
-}
-
-/// Decode a key into its ordered, labeled, colored components. The tag
-/// segment is first and always present; the rest follow the index's byte
-/// order so the sort prefix reads left to right.
-pub fn components(key: &str) -> Vec<Component> {
-    let Some(bytes) = decode(key) else {
-        return vec![Component {
-            label: "key".into(),
-            part: Part::Unknown,
-            text: key.into(),
-            full: key.into(),
-            bytes: 0..0,
-        }];
-    };
-    if bytes.len() < 162 {
-        let n = bytes.len();
-        return vec![Component {
-            label: "key".into(),
-            part: Part::Unknown,
-            text: hex(&bytes),
-            full: key.into(),
-            bytes: 0..n,
-        }];
-    }
-
-    let tag = bytes[0];
-    let l = layout(tag);
-    let slice = |off: usize, len: usize| hex(&bytes[off..off + len]);
-
-    let entity = slice(l.entity, 64);
-    let attribute = slice(l.attribute, 64);
-    let value_ref = slice(l.value_ref, 32);
-    let type_byte = bytes[l.value_type];
-
-    let entity_seg = Component {
-        label: "Entity".into(),
-        part: Part::Entity,
-        text: trunc(&entity, 10, 4),
-        full: entity,
-        bytes: l.entity..l.entity + 64,
-    };
-    let attribute_seg = Component {
-        label: "Attribute".into(),
-        part: Part::Attribute,
-        text: trunc(&attribute, 10, 4),
-        full: attribute,
-        bytes: l.attribute..l.attribute + 64,
-    };
-    // The value-type chip: its content is the type byte; the human type
-    // name is in the tooltip. It shares the value background so it reads as
-    // the value's type.
-    let type_seg = Component {
-        label: format!("Value type: {}", type_label(type_byte)),
-        part: Part::ValueType,
-        text: type_byte.to_string(),
-        full: format!("{type_byte} ({})", type_name(type_byte)),
-        bytes: l.value_type..l.value_type + 1,
-    };
-    let value_seg = Component {
-        label: "Value".into(),
-        part: Part::ValueRef,
-        text: trunc(&value_ref, 10, 4),
-        full: value_ref,
-        bytes: l.value_ref..l.value_ref + 32,
-    };
-    // The index-type chip is neutral (mode-inverse background via
-    // `seg-index-type`); its content is the tag byte (0/1/2).
-    let index_seg = Component {
-        label: index_label(tag),
-        part: Part::Unknown,
-        text: tag.to_string(),
-        full: format!("{tag} ({})", tag_of(tag)),
-        bytes: 0..1,
-    };
-
-    match tag {
-        2 => vec![index_seg, type_seg, value_seg, attribute_seg, entity_seg],
-        1 => vec![index_seg, attribute_seg, entity_seg, type_seg, value_seg],
-        _ => vec![index_seg, entity_seg, attribute_seg, type_seg, value_seg],
-    }
-}
-
 /// The routing pivot: the index of the last byte that must stay bright for
-/// this bound to be distinguishable from *both* its neighbors. A row's
-/// bright prefix has to show where it diverges from the previous sibling
-/// (proving it sorts after) AND from the next sibling (proving it sorts
-/// before) — otherwise two adjacent rows sharing a long prefix (e.g. several
-/// `concept:` keys) would all cut at byte 0 and look identical. So the pivot
-/// is the *max* of the two divergence points.
+/// this bound to be distinguishable from *both* its neighbors. A row's bright
+/// prefix has to show where it diverges from the previous sibling (proving it
+/// sorts after) AND from the next sibling (proving it sorts before) — the
+/// pivot is the *max* of the two divergence points. Computed on the raw key
+/// hex, so it is independent of how the components decode.
 ///
-/// `prev` is the previous sibling's bound (or the all-zero minimum key for a
-/// first child); `next` is the next sibling's bound, if any.
+/// `prev` is the previous sibling's bound (or the all-zero minimum for a first
+/// child); `next` is the next sibling's bound, if any.
 pub fn pivot_byte(key: &str, prev: Option<&str>, next: Option<&str>) -> Option<usize> {
     let a = decode(key)?;
-    // First byte where `a` diverges from `other`; `None` if `other` is a
-    // prefix of (or equal to) `a` over the shared length.
     let diverge = |other: &[u8]| -> Option<usize> {
         let n = a.len().min(other.len());
         (0..n).find(|&i| a[i] != other[i])
     };
-
-    // Lower edge: previous sibling, or the all-zero minimum key.
     let lower = match prev {
         Some(p) => decode(p)?,
         None => vec![0u8; a.len()],
     };
     let from_prev = diverge(&lower);
     let from_next = next.and_then(decode).and_then(|n| diverge(&n));
-
     match (from_prev, from_next) {
         (Some(p), Some(n)) => Some(p.max(n)),
         (Some(p), None) => Some(p),
         (None, Some(n)) => Some(n),
-        // Identical to both over the shared length — keep it all bright.
         (None, None) => Some(a.len()),
     }
 }
 
-/// Format a fact value so its type is legible from the value itself
-/// (entities underlined elsewhere; here we shape the text):
+/// Format a fact value so its type is legible from the value itself:
 ///   string → quoted, float → always a `.`, signed → ±, bytes → hex.
-/// `value` is the already-decoded JSON value the worker sent; `type_name`
-/// is its dialog `ValueDataType` name.
+/// `value` is the already-decoded JSON value the worker sent; `type_name` is
+/// its dialog `ValueDataType` name.
 pub fn format_value(value: &serde_json::Value, type_name: &str) -> String {
     use serde_json::Value as J;
     match type_name {
@@ -338,7 +195,6 @@ pub fn format_value(value: &serde_json::Value, type_name: &str) -> String {
                 .join(" "),
             other => other.to_string(),
         },
-        // Entity / Symbol / UnsignedInt / Boolean / Record: plain.
         _ => match value {
             J::String(s) => s.clone(),
             other => other.to_string(),

--- a/rust/tonk-tree/src/model.rs
+++ b/rust/tonk-tree/src/model.rs
@@ -20,6 +20,19 @@ pub enum Kind {
     Segment,
 }
 
+/// One decoded, self-describing component of a key, as the worker's
+/// `key_parts` emits it. `kind` selects the UI color/glyph, `text` is the
+/// human rendering (a `did:key:…` entity, a `db.meta/name` attribute, a typed
+/// value, a decimal edition), and `hex` is the raw bytes for the tooltip.
+#[derive(Clone, Deserialize)]
+pub struct KeyPart {
+    pub kind: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub hex: String,
+}
+
 /// One node's fields — the `tree/node` / `tree/child` shape.
 #[derive(Clone)]
 pub struct TreeNode {
@@ -27,7 +40,11 @@ pub struct TreeNode {
     pub kind: Kind,
     pub size: u64,
     pub count: u64,
+    /// The bound key's raw hex — kept for the front-coding pivot, which
+    /// compares raw bytes across siblings.
     pub bound: Option<NodeHash>,
+    /// The bound key's decoded components (the worker's `bound-parts`).
+    pub bound_parts: Vec<KeyPart>,
     pub rank: Option<u64>,
     pub cached: bool,
 }
@@ -35,7 +52,8 @@ pub struct TreeNode {
 /// One entry in a segment — the `tree/entry` shape.
 #[derive(Clone)]
 pub struct TreeEntry {
-    pub key: NodeHash,
+    /// The entry key's decoded components (the worker's `key-parts`).
+    pub key_parts: Vec<KeyPart>,
     pub retracted: bool,
     pub entity: Option<String>,
     pub attribute: Option<String>,
@@ -56,6 +74,13 @@ fn s(map: &serde_json::Map<String, serde_json::Value>, k: &str) -> Option<String
 }
 fn u(map: &serde_json::Map<String, serde_json::Value>, k: &str) -> Option<u64> {
     map.get(k).and_then(|v| v.as_u64())
+}
+/// Parse a `[{kind, text, hex}, …]` parts array off a fields map. Absent or
+/// malformed → an empty list (the caller falls back to the raw hex).
+fn parts(map: &serde_json::Map<String, serde_json::Value>, k: &str) -> Vec<KeyPart> {
+    map.get(k)
+        .and_then(|v| serde_json::from_value::<Vec<KeyPart>>(v.clone()).ok())
+        .unwrap_or_default()
 }
 
 /// The worker-backed tree loader for a `{repo, branch}`. Cheap to clone
@@ -139,6 +164,7 @@ impl Loader {
             size: u(f, "size").unwrap_or(0),
             count: u(f, "count").unwrap_or(0),
             bound: s(f, "bound"),
+            bound_parts: parts(f, "bound-parts"),
             rank: u(f, "rank"),
             cached: f.get("cached").and_then(|v| v.as_bool()) != Some(false),
         }
@@ -168,7 +194,7 @@ impl Loader {
             .map(|r| {
                 let f = &r.fields;
                 TreeEntry {
-                    key: s(f, "key").unwrap_or_else(|| r.this.clone()),
+                    key_parts: parts(f, "key-parts"),
                     retracted: f.get("retracted").and_then(|v| v.as_bool()) == Some(true),
                     entity: s(f, "entity"),
                     attribute: s(f, "attribute"),

--- a/rust/tonk-tree/src/web.rs
+++ b/rust/tonk-tree/src/web.rs
@@ -289,10 +289,11 @@ fn build_row(state: &Shared, node: &TreeNode, prev: Option<&str>, next: Option<&
 
     // The key, front-coded against the neighboring siblings.
     let keystr = el("span").class("keystr").attr("title", &node.hash);
-    if let Some(bound) = &node.bound {
-        append_key(&keystr, bound, prev, next);
-    } else {
-        keystr.set_text_content(Some(&short(&node.hash, 8)));
+    match (&node.bound, node.bound_parts.is_empty()) {
+        (Some(bound), false) => append_key(&keystr, &node.bound_parts, bound, prev, next),
+        // A bound with no decoded parts (or none at all) falls back to the
+        // node hash — a leaf we have not fetched, or an undecodable bound.
+        _ => keystr.set_text_content(Some(&short(&node.hash, 8))),
     }
     let _ = row.append_child(&keystr);
 
@@ -346,9 +347,15 @@ fn next_seg_id() -> String {
 /// branches, so they stay bright; the tail past the pivot is dimmed. The
 /// chip containing the pivot shows the hex bright through the pivot digit
 /// then a short dim tail.
-pub fn append_key(parent: &Element, key_str: &str, prev: Option<&str>, next: Option<&str>) {
-    let comps = key::components(key_str);
-    let pivot = key::pivot_byte(key_str, prev, next);
+pub fn append_key(
+    parent: &Element,
+    parts: &[crate::model::KeyPart],
+    key_hex: &str,
+    prev: Option<&str>,
+    next: Option<&str>,
+) {
+    let comps = key::components(parts);
+    let pivot = key::pivot_byte(key_hex, prev, next);
     for (i, c) in comps.iter().enumerate() {
         let mut base = format!("key-seg {}", c.part.class());
         if i == 0 {
@@ -372,45 +379,43 @@ pub fn append_key(parent: &Element, key_str: &str, prev: Option<&str>, next: Opt
             let _ = parent.append_child(&el("wa-tooltip").attr("for", &id).text(&c.label));
         };
 
+        // Dimming is per-chip now that chips carry decoded TEXT (not hex): a
+        // component whose bytes begin past the routing pivot is noise for this
+        // row's placement, so it dims whole; a component containing or before
+        // the pivot stays bright. (The old per-hex-digit split relied on the
+        // 2-chars-per-byte hex mapping, which no longer holds.)
         match pivot {
-            // Chip lies entirely past the pivot → one dim pill, kept short.
-            Some(p) if c.bytes.start > p => emit(&c.text, true),
-            // Chip straddles the pivot → a bright pill through the pivot
-            // byte and a separate dim pill for the short tail, so the tail's
-            // background dims with its text (the rest is routing noise).
-            Some(p) if c.bytes.end > p + 1 && p + 1 > c.bytes.start => {
-                let bright_chars = (p + 1 - c.bytes.start) * 2;
-                let full: Vec<char> = c.full.chars().collect();
-                let head: String = full.iter().take(bright_chars).collect();
-                let rest = full.len() - bright_chars;
-                let tail: String = if rest > 6 {
-                    let t: String = full.iter().skip(full.len() - 4).collect();
-                    format!("…{t}")
-                } else {
-                    full.iter().skip(bright_chars).collect()
-                };
-                emit(&head, false);
-                if !tail.is_empty() {
-                    emit(&tail, true);
-                }
-            }
+            Some(p) if c.bytes.start > p => emit(&elide(&c.text), true),
             // Chip is at or before the pivot, or no pivot → bright, truncated.
-            _ => emit(&c.text, false),
+            _ => emit(&elide(&c.text), false),
         }
     }
 }
 
+/// Shorten a chip's text for the dense outline: keep the head, elide the
+/// middle of anything long (a `did:key:…` entity, a long value). The inspector
+/// pane shows the full text; here we keep rows compact.
+fn elide(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= 18 {
+        return text.to_owned();
+    }
+    let head: String = chars[..12].iter().collect();
+    let tail: String = chars[chars.len() - 4..].iter().collect();
+    format!("{head}…{tail}")
+}
+
 /// Append a key's segments in full (the inspector pane): every chip shows
 /// its complete hex, nothing dimmed or truncated, so the row may wrap.
-pub fn append_key_full(parent: &Element, key_str: &str) {
-    for (i, c) in key::components(key_str).iter().enumerate() {
+pub fn append_key_full(parent: &Element, parts: &[crate::model::KeyPart]) {
+    for (i, c) in key::components(parts).iter().enumerate() {
         let mut cls = format!("key-seg {}", c.part.class());
         if i == 0 {
             cls.push_str(" seg-index-type");
         }
-        // Single-byte chips (index type, value type) show just the byte;
-        // the multi-byte parts show their full hex.
-        let text = if c.bytes.len() <= 1 { &c.text } else { &c.full };
+        // Every chip shows its full decoded text (the worker already
+        // textualized it — entity URI, attribute name, typed value).
+        let text = &c.full;
         let id = next_seg_id();
         let chip = el("span")
             .attr("id", &id)
@@ -765,9 +770,17 @@ wa-tree-item > .dot-leaf { position: absolute; z-index: 5;
 .keystr { white-space: nowrap; display: inline-flex; align-items: center; gap: 3px;
   flex: 1 1 auto; min-width: 0; }
 /* In the outline, key segments are colored TEXT (no background fill) so
-   the row stays compact. The component class sets the color. */
+   the row stays compact. The component class sets the color. A thin divider
+   separates adjacent chips so the decoded parts read as a delimited key
+   (entity · attribute · value) rather than running together. */
 .key-seg { font-weight: var(--wa-font-weight-semibold, 600);
   display: inline-flex; align-items: center; }
+.keystr .key-seg + .key-seg::before {
+  content: "\2009\00B7\2009"; color: var(--wa-color-text-quiet, #94959b);
+  font-weight: 400; }
+/* A NUL / control byte rendered as a glyph (␀ / ·) reads as structure, not
+   text; dim it so the real content stands out. */
+.key-seg .seg-text { unicode-bidi: plaintext; }
 .key-seg.seg-entity { color: var(--tonk-circle, #3d6da8); }
 .key-seg.seg-attribute { color: var(--tonk-triangle, #c89a2b); }
 .key-seg.seg-value { color: var(--tonk-square, #b94a3d); }

--- a/rust/tonk-tree/src/web.rs
+++ b/rust/tonk-tree/src/web.rs
@@ -784,7 +784,9 @@ wa-tree-item > .dot-leaf { position: absolute; z-index: 5;
 .key-seg.seg-entity { color: var(--tonk-circle, #3d6da8); }
 .key-seg.seg-attribute { color: var(--tonk-triangle, #c89a2b); }
 .key-seg.seg-value { color: var(--tonk-square, #b94a3d); }
-.key-seg.seg-vtype { color: var(--tonk-square, #b94a3d); }
+/* The value-TYPE tag reads as a distinct marker (a muted violet), so it never
+   blurs into the red value it precedes. */
+.key-seg.seg-vtype { color: #8a6ab0; font-weight: var(--wa-font-weight-normal, 400); }
 .key-seg.seg-unknown { color: var(--tonk-closure, #7a7268); }
 /* The index-type segment is neutral (the page's normal text color). */
 .key-seg.seg-index-type { color: var(--wa-color-text-normal); }
@@ -834,7 +836,7 @@ wa-tree-item > .dot-leaf { position: absolute; z-index: 5;
 .keybytes .key-seg.seg-entity { background: var(--tonk-circle, #3d6da8); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-attribute { background: var(--tonk-triangle, #c89a2b); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-value { background: var(--tonk-square, #b94a3d); color: light-dark(#000, #fff); }
-.keybytes .key-seg.seg-vtype { background: var(--tonk-square, #b94a3d); color: light-dark(#000, #fff); }
+.keybytes .key-seg.seg-vtype { background: #8a6ab0; color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-unknown { background: var(--tonk-closure, #7a7268); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-index-type { background: light-dark(#000, #fff);
   color: light-dark(#fff, #000); }

--- a/rust/tonk-worker-api/Cargo.toml
+++ b/rust/tonk-worker-api/Cargo.toml
@@ -13,6 +13,7 @@ ipld-core = { workspace = true }
 lsp-types = { workspace = true }
 dialog-varsig = { workspace = true }
 dialog-capability = { workspace = true }
+dialog-artifacts = { workspace = true }
 
 [dev-dependencies]
 dialog-common = { workspace = true, features = ["helpers"] }

--- a/rust/tonk-worker-api/src/evaluate.rs
+++ b/rust/tonk-worker-api/src/evaluate.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use dialog_capability::Revision;
+use dialog_artifacts::Revision;
 use serde::{Deserialize, Serialize};
 
 /// Matches for one source-expression query, projected back into

--- a/rust/tonk-worker-api/src/repository.rs
+++ b/rust/tonk-worker-api/src/repository.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use dialog_capability::Revision;
+use dialog_artifacts::Revision;
 use dialog_varsig::Did;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};

--- a/rust/tonk-worker-api/src/sync.rs
+++ b/rust/tonk-worker-api/src/sync.rs
@@ -7,7 +7,7 @@
 //! `SyncState` and even classify without linking the engine.
 //! `tonk-schema` re-exports them for the native CLI and the worker.
 
-use dialog_capability::Revision;
+use dialog_artifacts::Revision;
 use serde::{Deserialize, Serialize};
 
 /// How a branch's local head relates to its upstream head.
@@ -74,26 +74,29 @@ impl From<Comparison> for SyncState {
 ///
 /// - identical trees (including both heads absent) → [`Comparison::Synced`];
 /// - one side absent and the other present → the present side leads;
-/// - the remote head is the local head's recorded parent → [`Comparison::Ahead`];
-/// - the local head is the remote head's recorded parent → [`Comparison::Behind`].
+/// - the local context includes the remote's → [`Comparison::Ahead`]
+///   (local has observed everything the remote has, and more);
+/// - the remote context includes the local's → [`Comparison::Behind`].
 ///
-/// Anything else is [`Comparison::Diverged`]. Two deliberate limits feed
-/// that fallback:
+/// Anything else is [`Comparison::Diverged`]. The comparison rests on each
+/// head's causal [`Context`](dialog_artifacts::history::Context) — the
+/// per-origin watermark of everything the revision has observed. Unlike the
+/// old immediate-parent set, an included context proves the relationship
+/// across arbitrary linear distance, so a branch many commits ahead of (or
+/// behind) its upstream reads correctly, not conservatively as `Diverged`.
 ///
-/// - **One-commit horizon.** [`Revision::cause`] records only the immediate
-///   parent, so the ahead/behind checks span a single commit. A strictly
-///   linear branch two or more commits ahead of (or behind) its upstream
-///   reads as `Diverged`, not `Ahead`/`Behind` — proving the longer
-///   relationship would need the history walk this function avoids. A
-///   pull-then-push still reconciles such a branch correctly; only the
-///   reported label is conservative.
-/// - **No clock tiebreak.** The logical clocks (`period`, `moment`) are not
-///   consulted: two replicas that fork while the same issuer keeps committing
-///   produce the same clock signature as a genuine linear lead, so the clocks
-///   can't distinguish "ahead" from "diverged".
+/// Two cases still fall back to `Diverged`:
 ///
-/// Reporting `Diverged` in both cases keeps the invariant that we never claim
-/// a direction we can't back up from the heads alone.
+/// - **No published context.** [`Revision::context`] is `None` on heads
+///   minted before the history index existed. Without it the direction
+///   cannot be proven from the head alone, so such a pairing reads as
+///   `Diverged` (a pull-then-push still reconciles it; only the label is
+///   conservative).
+/// - **Genuinely concurrent.** Neither context includes the other — the two
+///   replicas each hold revisions the other lacks.
+///
+/// Reporting `Diverged` in these cases keeps the invariant that we never
+/// claim a direction we can't back up from the heads alone.
 pub fn classify(local: Option<&Revision>, remote: Option<&Revision>) -> Comparison {
     match (local, remote) {
         (None, None) => Comparison::Synced,
@@ -101,13 +104,22 @@ pub fn classify(local: Option<&Revision>, remote: Option<&Revision>) -> Comparis
         (None, Some(_)) => Comparison::Behind,
         (Some(local), Some(remote)) => {
             if local.tree == remote.tree {
-                Comparison::Synced
-            } else if local.cause.contains(&remote.tree) {
-                Comparison::Ahead
-            } else if remote.cause.contains(&local.tree) {
-                Comparison::Behind
-            } else {
-                Comparison::Diverged
+                return Comparison::Synced;
+            }
+            let (Some(local_ctx), Some(remote_ctx)) = (&local.context, &remote.context) else {
+                // A head minted before the history index carries no context,
+                // so the direction can't be proven from the heads alone.
+                return Comparison::Diverged;
+            };
+            let local_leads = local_ctx.includes(remote_ctx);
+            let remote_leads = remote_ctx.includes(local_ctx);
+            match (local_leads, remote_leads) {
+                // Trees differ yet each observed all the other has: not a
+                // relationship the heads can order, so stay conservative.
+                (true, true) => Comparison::Diverged,
+                (true, false) => Comparison::Ahead,
+                (false, true) => Comparison::Behind,
+                (false, false) => Comparison::Diverged,
             }
         }
     }
@@ -149,38 +161,56 @@ pub struct SyncStatusResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dialog_capability::{Did, TreeReference};
+    use dialog_artifacts::history::{Context, Edition, Origin, Version};
+    use dialog_artifacts::{Entity, TreeReference};
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
 
-    fn did() -> Did {
-        "did:key:test".parse().unwrap()
-    }
-
     fn tree(byte: u8) -> TreeReference {
         TreeReference::from([byte; 32])
     }
 
-    /// A revision with the given head tree and recorded parent trees.
-    fn rev(head: TreeReference, cause: &[TreeReference]) -> Revision {
-        Revision {
-            subject: did(),
-            issuer: did(),
-            authority: did(),
-            tree: head,
-            cause: cause.iter().cloned().collect(),
-            period: 0,
-            moment: 0,
+    fn origin(byte: u8) -> Origin {
+        Origin([byte; 32])
+    }
+
+    /// A context that has observed each origin's chain up to the given
+    /// edition (one `record` per edition, so the revision count matches
+    /// the depth). Passing `&[(origin, depth)]` builds the per-origin
+    /// watermark map `classify` compares.
+    fn context(watermarks: &[(Origin, u64)]) -> Context {
+        let mut ctx = Context::new();
+        for (origin, depth) in watermarks {
+            for edition in 1..=*depth {
+                ctx.record(Version::new(*origin, Edition::new(edition)));
+            }
         }
+        ctx
+    }
+
+    fn branch() -> Entity {
+        "did:key:test".parse().unwrap()
+    }
+
+    /// A revision with the given head tree and causal context.
+    fn rev(head: TreeReference, context: Context) -> Revision {
+        let mut revision = Revision::new(head, branch(), "did:key:test".parse().unwrap());
+        revision.context = Some(context);
+        revision
+    }
+
+    /// A revision minted before the history index existed: no context.
+    fn contextless(head: TreeReference) -> Revision {
+        Revision::new(head, branch(), "did:key:test".parse().unwrap())
     }
 
     #[dialog_common::test]
     fn it_is_synced_when_heads_match() {
-        let local = rev(tree(1), &[]);
-        let remote = rev(tree(1), &[]);
+        let local = rev(tree(1), context(&[(origin(0), 1)]));
+        let remote = rev(tree(1), context(&[(origin(0), 1)]));
         assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Synced);
     }
 
@@ -191,46 +221,56 @@ mod tests {
 
     #[dialog_common::test]
     fn it_is_ahead_when_remote_is_absent() {
-        let local = rev(tree(1), &[]);
+        let local = rev(tree(1), context(&[(origin(0), 1)]));
         assert_eq!(classify(Some(&local), None), Comparison::Ahead);
     }
 
     #[dialog_common::test]
     fn it_is_behind_when_local_is_absent() {
-        let remote = rev(tree(1), &[]);
+        let remote = rev(tree(1), context(&[(origin(0), 1)]));
         assert_eq!(classify(None, Some(&remote)), Comparison::Behind);
     }
 
     #[dialog_common::test]
-    fn it_is_ahead_when_remote_is_the_local_parent() {
-        let remote = rev(tree(1), &[]);
-        let local = rev(tree(2), &[tree(1)]);
+    fn it_is_ahead_when_local_context_includes_remote() {
+        // Same origin, local one edition deeper: local has observed
+        // everything remote has, and more.
+        let remote = rev(tree(1), context(&[(origin(0), 1)]));
+        let local = rev(tree(2), context(&[(origin(0), 2)]));
         assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Ahead);
     }
 
     #[dialog_common::test]
-    fn it_is_behind_when_local_is_the_remote_parent() {
-        let local = rev(tree(1), &[]);
-        let remote = rev(tree(2), &[tree(1)]);
+    fn it_is_behind_when_remote_context_includes_local() {
+        let local = rev(tree(1), context(&[(origin(0), 1)]));
+        let remote = rev(tree(2), context(&[(origin(0), 2)]));
         assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Behind);
     }
 
     #[dialog_common::test]
-    fn it_is_diverged_when_heads_are_unrelated() {
-        let local = rev(tree(1), &[tree(3)]);
-        let remote = rev(tree(2), &[tree(4)]);
+    fn it_is_diverged_when_contexts_are_concurrent() {
+        // Each side holds a revision from an origin the other lacks:
+        // neither context includes the other.
+        let local = rev(tree(1), context(&[(origin(1), 1)]));
+        let remote = rev(tree(2), context(&[(origin(2), 1)]));
         assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Diverged);
     }
 
     #[dialog_common::test]
-    fn it_is_diverged_when_local_leads_by_more_than_one_commit() {
-        // `cause` records only the immediate parent, so a strictly
-        // linear branch two commits ahead reads as Diverged: the shared
-        // base tree(1) is the grandparent, absent from tree(3)'s cause.
-        // This pins the documented one-commit horizon (a pull-then-push
-        // still reconciles it; only the reported label is conservative).
-        let remote = rev(tree(1), &[]);
-        let local = rev(tree(3), &[tree(2)]);
+    fn it_is_ahead_across_a_multi_commit_lead() {
+        // The context proves ahead/behind across arbitrary linear
+        // distance — a branch several commits ahead reads as Ahead, not
+        // conservatively as Diverged the way the old parent-set check did.
+        let remote = rev(tree(1), context(&[(origin(0), 1)]));
+        let local = rev(tree(3), context(&[(origin(0), 5)]));
+        assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Ahead);
+    }
+
+    #[dialog_common::test]
+    fn it_is_diverged_when_a_head_carries_no_context() {
+        // A pre-history-index head can't be ordered from the head alone.
+        let remote = contextless(tree(1));
+        let local = rev(tree(2), context(&[(origin(0), 2)]));
         assert_eq!(classify(Some(&local), Some(&remote)), Comparison::Diverged);
     }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1885,7 +1885,7 @@ concept!: &person
     /// A concept's `with` block can address an attribute defined
     /// in a *prior* transaction by bookmark name. The
     /// branch-backed resolver looks up the previously-asserted
-    /// attribute by `dialog.meta/name`, reconstructs its
+    /// attribute by `db.meta/name`, reconstructs its
     /// descriptor, and lets the concept hash correctly.
     #[dialog_common::test]
     async fn it_resolves_bookmarks_across_transactions() {
@@ -2335,7 +2335,7 @@ person!:
     /// body derives a *new* entity from the new body and rebinds
     /// the `id:alice → entity` claim from the old entity to the
     /// new one (cardinality-one supersession on
-    /// `dialog.meta/name`). After the rebind, the old entity
+    /// `db.meta/name`). After the rebind, the old entity
     /// still
     /// holds its facts but is no longer addressable by `.alice`.
     #[dialog_common::test]
@@ -3366,7 +3366,7 @@ employee:
     /// Unlike `it_broadcasts_changed_snapshot_after_commit`, this does
     /// NOT grow the result set. Declaring an attribute anchor publishes
     /// a `meta::Name` (`id:<anchor>` carries a cardinality-one
-    /// `dialog.name/referent` pointing at the attribute entity).
+    /// `db.name/referent` pointing at the attribute entity).
     /// Re-declaring the SAME anchor with a different `the:` re-points
     /// that referent: the `id:<anchor>` row keeps its identity but its
     /// `entity` field changes. The subscription must observe that

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -4344,6 +4344,57 @@ mod tests {
             .unwrap_or(0)
     }
 
+    /// The FAB space-rename must PERSIST. The repository banner writes a
+    /// transient `tonk/rename-repository` command (its `subject` is the repo's
+    /// own DID, `name` the typed value); the standard-library rule fires on
+    /// commit and asserts the durable `tonk/repository` name
+    /// (`xyz.tonk.repo/name`, keyed by the subject DID) on the content branch.
+    /// The banner then reads that fact back, so a refresh keeps the new name
+    /// rather than reverting.
+    ///
+    /// Regression guard: the rename flows entirely through the standard
+    /// library on the content branch, but the branch query that drives the
+    /// rule's fixpoint also carries dialog's auto-injected session/replica
+    /// facts. A drift in those injected names breaks the rule's evaluation
+    /// context, so the command commits nothing and the name silently reverts —
+    /// exactly the FAB "rename dropped on refresh" symptom.
+    #[dialog_common::test]
+    async fn it_persists_a_space_rename() {
+        use dialog_repository::RepositoryExt as _;
+
+        let (_app, state, key) = fresh_repo("test-space-rename").await;
+        let repo = key.as_str();
+        seed(&state, repo, CORE).await;
+
+        // Fire the FAB's rename command: a transient `tonk/rename-repository`
+        // whose `subject` is the repository's own DID (the banner stamps it
+        // from `data-subject`) and whose `name` is the new value. Evaluating
+        // with `transact=true` commits it, which fires the library rule.
+        let rename =
+            format!("tonk/rename-repository!:\n  subject: {key}\n  name: \"brave-lynx\"\n");
+        seed(&state, repo, &rename).await;
+
+        // Read the name back exactly as the Hub/banner does — through
+        // `repository_label`, which queries `tonk/repository` on the content
+        // branch keyed by the subject DID.
+        let label = {
+            let tonk = state.read().await;
+            let repository: dialog_repository::Repository = tonk
+                .profile
+                .repository(repo)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .expect("repo loads");
+            super::repository_label(&tonk, &repository, repo).await
+        };
+
+        assert_eq!(
+            label, "brave-lynx",
+            "a space rename persists to xyz.tonk.repo/name; got {label:?}",
+        );
+    }
+
     /// The lean scaffold (core alone) carries the blank canvas concept,
     /// not the sheets workspace. The blank model resolves to exactly one
     /// instance — the repo's own subject — which the blank-canvas view
@@ -4356,12 +4407,44 @@ mod tests {
 
         // The lean scaffold carries the blank canvas concept, not the
         // sheets workspace. `blank:` resolves to the repo subject (its
-        // sole `dialog.origin/subject`-derived attribute); a
+        // sole `dialog.replica/subject`-derived attribute); a
         // `workspace/sheet:` query would fault on an unresolved concept.
         assert_eq!(
             count(&state, repo, "blank:\n").await,
             1,
             "blank scaffold resolves the blank model to the repo subject",
+        );
+    }
+
+    /// Regression guard for the dialog-injected replica identity fact the
+    /// standard library queries. Dialog materializes this device's replica
+    /// identity under the reserved `dialog.` namespace, and the blank canvas
+    /// resolves its `subject` from `dialog.replica/subject`. When dialog
+    /// renamed that attribute from `dialog.origin/subject` to
+    /// `dialog.replica/subject`, a stale name in the library silently unbound
+    /// the field: `blank:` resolved zero rows instead of one, so the space's
+    /// content rendered an empty "Concept mismatch: subject: _" instead of the
+    /// canvas.
+    ///
+    /// `it_seeds_blank_scaffold` above already asserts the count is 1; this
+    /// test pins the *reason* — the attribute name must track what dialog
+    /// injects — so a future dialog rename fails here with a clear message
+    /// rather than as a blank space in the browser. This is the exact failure
+    /// mode a native `cargo test` cannot catch: the fact exists only on a real
+    /// branch, materialized by the reactor, which only runs on wasm.
+    #[dialog_common::test]
+    async fn it_binds_the_dialog_injected_replica_subject() {
+        let (_app, state, repo) = fresh_repo("test-replica-subject-binds").await;
+        let repo = repo.as_str();
+        seed(&state, repo, CORE).await;
+
+        // `blank:` resolves `tonk:blank`, whose sole `with` field
+        // (`subject`) reads `dialog.replica/subject`. A zero means that
+        // attribute name drifted from what dialog injects for the replica.
+        assert_eq!(
+            count(&state, repo, "blank:\n").await,
+            1,
+            "blank resolves its subject via dialog.replica/subject",
         );
     }
 

--- a/rust/tonk-worker/src/router/session.rs
+++ b/rust/tonk-worker/src/router/session.rs
@@ -569,26 +569,26 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for LoadHandler {
     }
 }
 
-/// The existing dialog [`Origin`](dialog_repository::schema::Origin) entity for
+/// The existing dialog [`Replica`](dialog_repository::schema::Replica) entity for
 /// this device's `(profile, subject)` on the branch — the entity `tonk/replica`
 /// and `tonk:binder` live on. Queried (not derived) so it stays correct even if
-/// tonk's and dialog's hashing drift. `None` if no origin is on the branch yet.
+/// tonk's and dialog's hashing drift. `None` if no replica is on the branch yet.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn origin_entity(
     tonk: &crate::worker::TonkState,
     state: &dialog_reactor::BranchSession,
 ) -> Option<dialog_artifacts::Entity> {
     use dialog_query::{Output as _, Query, Term};
-    use dialog_repository::schema::origin::{Profile, Subject};
-    use dialog_repository::schema::{DidExt as _, Origin};
+    use dialog_repository::schema::replica::{Profile, Subject};
+    use dialog_repository::schema::{DidExt as _, Replica};
 
     let subject = state.handle().of().this();
     let profile = tonk.profile.did().this();
 
-    let origins: Vec<Origin> = state
+    let replicas: Vec<Replica> = state
         .handle()
         .query()
-        .select(Query::<Origin> {
+        .select(Query::<Replica> {
             this: Term::var("this"),
             subject: Term::from(Subject(subject)),
             profile: Term::from(Profile(profile)),
@@ -598,7 +598,7 @@ async fn origin_entity(
         .await
         .unwrap_or_default();
 
-    origins.into_iter().next().map(|origin| origin.this)
+    replicas.into_iter().next().map(|replica| replica.this)
 }
 
 /// A matched route: the route-table entry, the model the shell mounts, and the

--- a/rust/tonk-workspace/src/ui_sync_status.rs
+++ b/rust/tonk-workspace/src/ui_sync_status.rs
@@ -56,6 +56,44 @@ pub(crate) struct UiSyncStatus {
     error: Rc<RefCell<Option<ResetClosure>>>,
 }
 
+impl UiSyncStatus {
+    /// Open the status subscription against the element's current `with`
+    /// routing context. A no-op if already subscribed. Shared by
+    /// `connected_callback` and `attribute_changed_callback` (a `with` that
+    /// resolved after mount).
+    ///
+    /// Subscribes on a microtask, NOT synchronously: when a render pass runs
+    /// inside an outer custom-element reaction, the reaction queue delivers
+    /// this only after that reaction finishes — by which time the diff may have
+    /// detached this element, and a dispatch from a detached tree never reaches
+    /// the document listeners. By microtask time the DOM has settled; skip if
+    /// no longer connected.
+    fn subscribe_now(&self, this: &HtmlElement) {
+        let subscription = self.subscription.clone();
+        let host = this.clone();
+        spawn_local(async move {
+            if !host.is_connected() || subscription.borrow().is_some() {
+                return;
+            }
+            let consumer: Element = host.into();
+            match status_query_body() {
+                Ok(body) => {
+                    let tag = JsValue::from_str(SUB_TAG);
+                    match consumer::subscribe(&consumer, &body, Some(&tag)) {
+                        Ok(sub) => *subscription.borrow_mut() = Some(sub),
+                        Err(err) => {
+                            // Dispatch failure: leave the pending disc;
+                            // nothing to subscribe to.
+                            tonk_common::log!("ui-sync-status: subscribe failed: {err:?}");
+                        }
+                    }
+                }
+                Err(err) => tonk_common::log!("ui-sync-status: query build failed: {err}"),
+            }
+        });
+    }
+}
+
 impl CustomElement for UiSyncStatus {
     fn shadow() -> bool {
         // Light DOM: the disc's CSS lives in the app stylesheet, and the
@@ -64,7 +102,12 @@ impl CustomElement for UiSyncStatus {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &[]
+        // Observe `with` so a late-resolving routing context — the FAB stamps
+        // `with="main@{space}"` and rewrites it once the space DID lands — drives
+        // a (re)subscribe. Without this the chip subscribes once against the
+        // still-unresolved `main@` (a malformed location the host rejects) and
+        // stays stuck "offline".
+        &["with"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -110,35 +153,25 @@ impl CustomElement for UiSyncStatus {
         let _ = Reflect::set(this, &"__tonkError".into(), error.as_ref());
         *self.error.borrow_mut() = Some(error);
 
-        // Subscribe on a microtask, NOT synchronously: when a render pass
-        // runs inside an outer custom-element reaction, the reaction queue
-        // delivers this callback only after that reaction finishes — by
-        // which time the diff may have detached this element again, and a
-        // dispatch from a detached tree never reaches the document
-        // listeners. By microtask time the DOM has settled; skip if no
-        // longer connected (a real re-connection re-runs this callback).
-        let subscription = self.subscription.clone();
-        let host = this.clone();
-        spawn_local(async move {
-            if !host.is_connected() || subscription.borrow().is_some() {
-                return;
-            }
-            let consumer: Element = host.into();
-            match status_query_body() {
-                Ok(body) => {
-                    let tag = JsValue::from_str(SUB_TAG);
-                    match consumer::subscribe(&consumer, &body, Some(&tag)) {
-                        Ok(sub) => *subscription.borrow_mut() = Some(sub),
-                        Err(err) => {
-                            // Dispatch failure: leave the pending disc;
-                            // nothing to subscribe to.
-                            tonk_common::log!("ui-sync-status: subscribe failed: {err:?}");
-                        }
-                    }
-                }
-                Err(err) => tonk_common::log!("ui-sync-status: query build failed: {err}"),
-            }
-        });
+        self.subscribe_now(this);
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        // The FAB rewrites `with="main@{space}"` to the resolved location once
+        // the space DID lands. Re-subscribe against the new routing context.
+        if name != "with" || old == new || !this.is_connected() {
+            return;
+        }
+        // Drop the prior (failed-or-stale) subscription so `subscribe_now`
+        // re-establishes it against the new `with`.
+        self.subscription.borrow_mut().take();
+        self.subscribe_now(this);
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {


### PR DESCRIPTION
## What

Upgrades the dialog-db dependency from `tonk-2026-07-17` to `tonk-2026-07-22` and absorbs the breaking changes that tag carries. **Draft** — the core upgrade is done and verified, but one FAB-related regression is still under investigation (see "Open issue" below).

## Why

`tonk-2026-07-22` makes two large changes: the `dialog.` attribute namespace is now reserved (the artifact write path rejects any assert to it), and the binary/version-control format was redesigned (search-tree nodes, `Revision`, sync).

## Done and verified

**1. Reserved `dialog.` namespace → tonk attributes moved to `db.`**
The write path (`dialog-artifacts/tree.rs`) now rejects any `Assert`/`Replace`/`Retract` whose attribute starts with `dialog.`. tonk pervasively asserted `dialog.attribute/*`, `dialog.meta/*`, `dialog.concept/*`, `dialog.effect/*`, `dialog.name/*`, `dialog.origin/*`, `dialog.rule/*`, `dialog.view/*`. All renamed to `db.*` across Rust + the library YAML assets, including the split-domain forms (`meta_attr("dialog.X", …)`, `#[domain("dialog.X")]`, `the("dialog.X", …)`) and the four `format!` strings. Dialog-owned reserved attrs (`session`/`replica`/`branch`/`revision`/`db`) were left untouched — tonk only reads those.

**2. Dialog-injected fact renames** (these are read-only, reserved, dialog-injected — NOT renamed to `db.`, they track dialog's new names)
- `dialog.origin/{subject,profile}` → `dialog.replica/{subject,profile}` (dialog renamed its device-identity concept `Origin` → `Replica`)
- `dialog.branch/{origin,period,moment}` → `dialog.branch/{replica,revision,edition}` (the version-control redesign dropped the legacy clock fields)
- `schema::Origin` → `schema::Replica` in `tonk-worker` / `tonk-schema`

**3. Binary/version-control format**
- `Revision`/`TreeReference` moved `dialog_capability` → `dialog_artifacts`; added the dep to `tonk-worker-api`.
- `Revision` shape changed (`cause: HashSet` → `edition` + `context: Option<Context>`); rewrote `sync::classify` against `Context::includes` (now proves ahead/behind across arbitrary linear distance, not just one commit).
- `Provider<Attest>` (head-signing) added to the reactor `CommitProvider`/`PullProvider` bounds and the fixture/commit env bounds in `tonk-analyzer` (×2) and `tonk-schema`.
- Ported `dialog-reactor`'s `tree/*` inspector (`formula.rs`) to the new columnar node format (`Key` instead of `KeyBytes`, `index.links()`/`segment.keys()`+`value_at()`, EAV reconstructed from the key via `Artifact::from_key_datum_placeholder`, manifest-aware `Geometric::rank`).

**Verification** (live, against a running local instance):
- CORE seeds clean; `blank:` resolves the space subject via `dialog.replica/subject`; `tonk/repository` resolves the renamed name; `concept:origin`/`space:` resolve; pull/push succeed; spaces render.
- Native + wasm builds clean for all bundle crates; native test suites pass.
- Regression tests added: `it_binds_the_dialog_injected_replica_subject` and `it_persists_a_space_rename` (both wasm/service-worker tests). The rename test **passes** through the `evaluate`/rule path — the rename rule itself works.

**Gotchas that bit us (worth remembering):**
- Several breaks were `#[cfg(wasm32)]`-gated, so a native `cargo check --workspace` passed while the trunk (wasm) build failed. Always `cargo check --target wasm32-unknown-unknown -p tonk-worker -p tonk-guest -p tonk-ui` after a dialog-facing change.
- Trunk silently serves the last-good `dist/` when a build fails, and leaves stale hashed snippet dirs, which caused a `WebAssembly.instantiate: Import … inline0.js` SW crash. A clean `rm -rf rust/tonk-ui/dist` + rebuild fixes it.
- The `db.rule/*` rename **converges** with dialog's native deductive-rule storage (not a collision). Heads-up: dialog PR #405 will rename `db.rule` → `dialog.rule` (moving it under the reserved namespace) — so tonk's `db.rule/*` will need to become `dialog.rule/*` (read-only) once #405 lands.

## Open issue — FAB regression (still debugging)

On this branch, in-space the FAB dock chip shows **"Untitled"** (not the renamed name), the sync-status chip reads **offline**, the **share** button spins, and renaming shows **no visible transactions**. These work on `origin/staging`.

**Confirmed NOT the cause** (all verified identical to staging / correct on this branch):
- The data layer: `tonk/repository name`, `blank` subject, the FAB's exact `xyz.tonk.repo/name` inline query all resolve correctly via direct HTTP.
- The FAB code, the routes, and the `xyz.tonk.site/repo`-vs-`space` naming are unchanged from staging (my commit doesn't touch `tonk-fab` at all).
- The served bundle is fresh; there are no app-originated failing requests.

**Localized to:** the sealed guest renders `<tonk-site with="main@">` (empty repo) → `route_from` rejects the malformed `with` → the subscription's host never writes `detail.subscription` → the FAB/status subscriptions fail → "Untitled" + no live updates. The divergence from staging: querying `workspace/shell` on the space **content branch**, `xyz.tonk.site/repo` is **populated on staging but empty on this branch**. `stamp_site_on` stamps `("repo", repo)` explicitly, and is gated by `origin_entity` (the `Origin`→`Replica` query I changed). The current hypothesis is that the space-mode site stamp is landing with an empty `repo` (or being skipped), leaving only the profile-mode (empty-repo) stamp for the guest to read.

**Diagnostic commit** (`debug: introspection …`, to be reverted before merge) adds logging to `dispatch` (arriving transient attributes + matched-handler count) and `stamp_site_on` (`repo`/`branch`/`profile`/route it stamps). Next step: reload with a fresh worker build and read the **SW console** to see exactly what `repo`/`profile` the guest's content-branch site stamp carries, and whether the FAB rename transient reaches `dispatch` at all (the "no transactions" symptom suggests it may not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the naming conventions and attribute references across the codebase, primarily changing instances of `dialog` to `db` in various files, which likely indicates a shift in the underlying architecture or data model.

### Detailed summary
- Changed `dialog.name/referent` to `db.name/referent` in multiple files.
- Updated attribute references from `dialog.meta` to `db.meta`.
- Replaced `dialog.effect` with `db.effect` in effect-related queries.
- Modified `dialog.capability` to `dialog.artifacts` in relevant imports.
- Adjusted YAML files to reflect the new naming conventions for subjects.
- Refactored function signatures and internal logic to accommodate the new attribute names.

> The following files were skipped due to too many changes: `rust/tonk-schema/src/resolution.rs`, `rust/tonk-worker/src/router/repository.rs`, `rust/tonk-schema/src/transact.rs`, `rust/tonk-schema/src/rule_query.rs`, `Cargo.toml`, `rust/tonk-core/src/effect.rs`, `rust/tonk-tree/src/web.rs`, `rust/tonk-analyzer/src/analyzer/declaration.rs`, `rust/tonk-analyzer/src/analyzer.rs`, `rust/tonk-worker-api/src/sync.rs`, `rust/tonk-evaluator/src/evaluate.rs`, `Cargo.lock`, `rust/tonk-schema/src/rule.rs`, `rust/tonk-tree/src/key.rs`, `rust/dialog-reactor/src/formula.rs`, `rust/tonk-schema/src/concept.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->