### PR TITLE
chore(account): send from tonk.xyz and set the staging d1 id

### DIFF
--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -19,7 +19,7 @@ binding = "CHAINS"
 bucket_name = "tonk-account-chains"
 
 [vars]
-EMAIL_FROM = "tonk <accounts@tonk.spot>"
+EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 
 # Staging. Disjoint from production in every dimension that holds state:
 # its own worker, route, database, and bucket. The route stays off the
@@ -34,7 +34,7 @@ routes = [{ pattern = "accounts-staging.tonk.xyz", custom_domain = true }]
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "tonk-accounts-staging"
-database_id = ""
+database_id = "d82a5715-d210-4bca-bd9d-4ab64e909566"
 migrations_dir = "rust/tonk-account-service/migrations"
 
 [[env.staging.r2_buckets]]
@@ -42,4 +42,4 @@ binding = "CHAINS"
 bucket_name = "tonk-account-chains-staging"
 
 [env.staging.vars]
-EMAIL_FROM = "tonk <accounts@tonk.spot>"
+EMAIL_FROM = "tonk <accounts@tonk.xyz>"


### PR DESCRIPTION
## Summary

Config-only. Two unlanded changes from staging account-service setup:

- `EMAIL_FROM` now points at `accounts@tonk.xyz` (Resend-verified) for both the production `[vars]` and `[env.staging.vars]`, replacing `accounts@tonk.spot`.
- The provisioned staging D1 `database_id` (`d82a5715…`) is filled in so the staging worker deploys against its own database rather than an empty binding.

No code changes. D1 database ids are resource identifiers, not secrets — the production id is already committed in this file.

## Context

The stage-1/2 account service (#625, #627, #628) is on staging; this lands the deploy config that was set up out-of-band while verifying the flow e2e.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `EMAIL_FROM` address in the `wrangler.account.toml` configuration for the staging environment and provides a specific `database_id` for the `d1_databases` configuration.

### Detailed summary
- Changed `EMAIL_FROM` value from `"tonk <accounts@tonk.spot>"` to `"tonk <accounts@tonk.xyz>"` in both `[vars]` and `[env.staging.vars]`.
- Updated `database_id` in `[[env.staging.d1_databases]]` from an empty string to `"d82a5715-d210-4bca-bd9d-4ab64e909566"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->