### PR TITLE
feat(account): root-did rosters and claim backup (stage 3a)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-root-did-rosters.md
+++ b/docs/superpowers/plans/2026-07-23-root-did-rosters.md
@@ -1,0 +1,714 @@
+# Root-DID Rosters (stage 3A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** For account-holders, invite claims and roster writes key on the passkey-derived **root DID** instead of the device DID, and each claimed space's delegation is backed up to the account service so a later device can recover it. Device-only users are unchanged.
+
+**Architecture:** A single resolver — "my member DID is the account root if I'm linked, else my device DID" — feeds the three membership-writing sites and the invite-claim audience. Presign already composes `space → eph → root` with the device's local `root → device` link automatically (`dialog-capability` BFS), so a root-audienced claim needs no new storage shape. Backup is a best-effort, device-signed UCAN call to the account service's `/chains/put`; restore is a deferred follow-up PR.
+
+**Tech Stack:** Rust (edition 2024). `dialog-credentials` / `dialog-ucan-core` / `dialog-operator` / `dialog-varsig` (git tag `tonk-2026-07-17`). `tonk-identity` (workspace path dep). `serde_json`, `reqwest`, `web-sys` (already `tonk-worker` deps).
+
+## Global Constraints
+
+- PRs target `staging`, not `main`. Work on branch `feat/root-did-rosters` (already cut from `origin/staging`; carries the design doc + a wrangler config commit).
+- Do **not** bump the pinned dialog tag `tonk-2026-07-17`.
+- The subject-open (`Subject::Any`) shape is only ever the `root → device` link. Never mint `Subject::Any` in any invite path — invites stay subject-specific.
+- Tests: always `#[dialog_common::test]`, never `#[test]`/`#[tokio::test]`/`#[wasm_bindgen_test]` directly. BDD names `it_does_x`. `tonk-worker` tests run in the service worker — every test mod already carries `wasm_bindgen_test_configure!(run_in_service_worker)`.
+- No `mod.rs` — use `foo.rs` + `foo/` form.
+- Conventional Commits, imperative lowercase subject under 72 chars, no emojis.
+- Code comments stand on their own — no "stage 3a", "per the spec", or design-doc references in code or tests.
+- Full lint gate before the PR: `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check` must both pass (the flake check runs exactly this).
+- Design of record: `docs/superpowers/specs/2026-07-23-root-did-rosters-design.md`.
+
+## File Structure
+
+- `rust/tonk-worker/src/router/account.rs` — **modify**: add the `account_link` / `account_root_did` / `member_did` resolver next to the existing `load_link`.
+- `rust/tonk-worker/src/router/join.rs` — **modify**: claim audiences the member DID; `record_claim_on_content` keys membership on it; call the backup after persisting the chain.
+- `rust/tonk-worker/src/router/repository.rs` — **modify**: `record_membership_on_content` keys membership on the member DID.
+- `rust/tonk-identity/src/request.rs` — **create**: `build_device_invocation`, the production device-signed account-service invocation builder.
+- `rust/tonk-identity/src/lib.rs` — **modify**: `pub mod request;`.
+- `rust/tonk-account-service/tests/service.rs` — **modify**: point the test `container()` helper at the production builder (proves the server accepts it).
+- `rust/tonk-worker/src/router/account_backup.rs` — **create**: the backup artifact, the worker-side service-URL resolver, the `/chains/put` POST, and the best-effort `back_up_claim` entry.
+- `rust/tonk-worker/src/router.rs` — **modify**: declare `mod account_backup;`.
+- `rust/tonk-worker/Cargo.toml` — **modify** if needed: enable the `WorkerLocation` web-sys feature.
+
+---
+
+### Task 1: The member-DID resolver
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account.rs`
+
+**Interfaces:**
+- Consumes: the existing `load_link(&TonkState) -> Result<Option<Vec<u8>>, TonkWorkerError>` (account.rs:61), `ACCOUNT_LINK_SITE` (account.rs:15), `DelegationChain::{try_from, issuer}`.
+- Produces:
+  - `pub(crate) async fn account_link(tonk: &crate::worker::TonkState) -> Option<DelegationChain>`
+  - `pub(crate) async fn account_root_did(tonk: &crate::worker::TonkState) -> Option<dialog_varsig::Did>`
+  - `pub(crate) async fn member_did(tonk: &crate::worker::TonkState) -> dialog_varsig::Did`
+  - Consumed by Tasks 2 and 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` in `account.rs` (which already has `wasm_bindgen_test_configure!(run_in_service_worker)`, `test_state`, and the `request_for` helper). Extend the imports with `use dialog_varsig::Principal;` if not already in scope:
+
+```rust
+    #[dialog_common::test]
+    async fn it_resolves_the_member_did_to_the_root_when_linked() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let request = request_for(&[7u8; 32], device_did.clone()).await;
+        let expected_root = request.root_did.clone();
+        let _ = link(State(state.clone()), Json(request)).await.unwrap();
+
+        let tonk = state.read().await;
+        assert_eq!(member_did(&tonk).await.to_string(), expected_root);
+        assert_eq!(
+            account_root_did(&tonk).await.map(|did| did.to_string()),
+            Some(expected_root),
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_the_member_did_to_the_device_when_unlinked() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let tonk = state.read().await;
+        let device_did = tonk.profile.did();
+        assert_eq!(member_did(&tonk).await, device_did);
+        assert!(account_root_did(&tonk).await.is_none());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nix develop -c test:web:debug` (or the repo's wasm test entrypoint).
+Expected: FAIL to compile — `member_did` / `account_root_did` not found.
+
+- [ ] **Step 3: Implement the resolver**
+
+Add below `load_link` in `account.rs`, and add `use tonk_common::log;` to the module imports (the same import `create_invite.rs:29` uses):
+
+```rust
+/// The stored `root → device` delegation for this profile, or `None`
+/// when the profile is unlinked or the stored link is unreadable.
+///
+/// Fail-safe: an unreadable or malformed link resolves to `None`, so the
+/// device behaves exactly as an unlinked one and keeps working.
+pub(crate) async fn account_link(tonk: &crate::worker::TonkState) -> Option<DelegationChain> {
+    let bytes = match load_link(tonk).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(error) => {
+            log!("account link unreadable; treating profile as unlinked: {error}");
+            return None;
+        }
+    };
+    match DelegationChain::try_from(bytes.as_slice()) {
+        Ok(chain) => Some(chain),
+        Err(error) => {
+            log!("account link malformed; treating profile as unlinked: {error}");
+            None
+        }
+    }
+}
+
+/// The account root DID for this profile, or `None` when unlinked. A
+/// linked device knows its root without holding the root key: the
+/// `root → device` delegation names the root as issuer.
+pub(crate) async fn account_root_did(
+    tonk: &crate::worker::TonkState,
+) -> Option<dialog_varsig::Did> {
+    account_link(tonk).await.map(|chain| chain.issuer().clone())
+}
+
+/// The DID roster writes and invite claims key on: the account root when
+/// linked, otherwise this device's own DID.
+pub(crate) async fn member_did(tonk: &crate::worker::TonkState) -> dialog_varsig::Did {
+    match account_root_did(tonk).await {
+        Some(root) => root,
+        None => tonk.profile.did(),
+    }
+}
+```
+
+`load_link` currently takes `&crate::worker::TonkState`; the handlers call it after `let state = state.read().await`, so these helpers take the same borrowed `TonkState`. If `load_link` is not already reachable from the new functions (same module — it is), no signature change is needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS — both new tests, plus the existing account-link tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/account.rs
+git commit -m "feat(tonk-worker): resolve the member did from the account link"
+```
+
+---
+
+### Task 2: Claim and membership writers key on the member DID
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/join.rs`
+- Modify: `rust/tonk-worker/src/router/repository.rs`
+
+**Interfaces:**
+- Consumes: `crate::router::account::member_did` (Task 1); `tonk_invite::Invite::claim(&Did)`; `tonk_schema::Membership::new(Did, Did)`.
+- Produces: no new public surface — behavioural change only. Task 4 relies on the claim still persisting the chain before returning.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` in `join.rs` (imports already include `DelegationChain`, `Principal as _`, `DidExt as _`, `test_state`, `content_memberships`, `api_router_with_state`, `post_join`, `handcrafted_invite_url`):
+
+```rust
+    /// An account-holder's claim keys the roster row on their root DID,
+    /// and no device-keyed row is written.
+    #[dialog_common::test]
+    async fn it_keys_membership_on_the_root_did_for_an_account_holder() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+
+        // Link this profile to an account root.
+        let device_did = state.read().await.profile.did();
+        let root = tonk_identity::derive::derive_root_signer(&[7u8; 32])
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let delegation =
+            tonk_identity::delegation::mint_device_delegation(root, &device_did)
+                .await
+                .unwrap();
+        let request = tonk_worker_api::AccountLinkRequest {
+            root_did: root_did.to_string(),
+            delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+        };
+        crate::router::account::link(axum::extract::State(state.clone()), axum::Json(request))
+            .await
+            .unwrap();
+
+        // Join an invite.
+        let (url, key) = handcrafted_invite_url(40, 41).await;
+        assert_eq!(post_join(&app, &url).await, StatusCode::CREATED);
+
+        let memberships = content_memberships(&state, &key).await;
+        let root_entity = root_did.this();
+        let device_entity = device_did.this();
+        assert!(
+            memberships.iter().any(|m| m.member.0 == root_entity),
+            "membership keyed on the root did",
+        );
+        assert!(
+            !memberships.iter().any(|m| m.member.0 == device_entity),
+            "no device-keyed row was written",
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `nix develop -c test:web:debug`
+Expected: FAIL — membership is keyed on the device DID, so the root assertion fails and the device-keyed row is present.
+
+- [ ] **Step 3: Audience the claim on the member DID**
+
+In `join.rs` `claim_invite` (around line 176), resolve the member DID and claim to it:
+
+```rust
+    let member = crate::router::account::member_did(tonk).await;
+    let claimed = invite
+        .claim(&member)
+        .await
+        .map_err(|e| TonkWorkerError::Router(format!("invalid invite: {e}")))?;
+```
+
+- [ ] **Step 4: Key `record_claim_on_content` on the member DID**
+
+Thread `member` into `record_claim_on_content`. Change its signature (join.rs:327) to accept `member: &dialog_varsig::Did`, and change the membership line (join.rs:336) from `Membership::new(tonk.profile.did(), repository.did())` to:
+
+```rust
+    let membership = Membership::new(member.clone(), repository.did());
+```
+
+Update both call sites (join.rs:223 and join.rs:289) to pass `&member`. Leave the `self_invite` check (join.rs:386) keyed on `tonk.profile.did().this()` — it answers "did I mint this from this device", which stays device-scoped.
+
+- [ ] **Step 5: Key `record_membership_on_content` on the member DID**
+
+In `repository.rs` `record_membership_on_content` (line 2666), replace the membership line (line 2678):
+
+```rust
+    let member = crate::router::account::member_did(tonk).await;
+    let membership = Membership::new(member, repository.did());
+```
+
+This is the shared founder/create + join meta writer, so a created space's founder row also keys on the root DID.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS — the new root-keying test passes, and the existing `it_records_membership_and_provenance_on_join` (which links no account) still asserts the device-keyed row, proving device-only is unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/join.rs rust/tonk-worker/src/router/repository.rs
+git commit -m "feat(tonk-worker): key rosters and invite claims on the account root did"
+```
+
+---
+
+### Task 3: The device-signed account-service invocation builder
+
+**Files:**
+- Create: `rust/tonk-identity/src/request.rs`
+- Modify: `rust/tonk-identity/src/lib.rs`
+- Modify: `rust/tonk-account-service/tests/service.rs`
+
+**Interfaces:**
+- Consumes: `dialog_ucan_core::{InvocationBuilder, InvocationChain, DelegationChain}`, `dialog_ucan_core::promise::Promised`, `dialog_credentials::Ed25519Signer`.
+- Produces: `pub async fn build_device_invocation(device: Ed25519Signer, link: &DelegationChain, command: Vec<String>, arguments: BTreeMap<String, Promised>) -> anyhow::Result<Vec<u8>>` — raw invocation-container bytes (the POST body). Consumed by Task 4 and by the account-service tests.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `rust/tonk-identity/src/request.rs` with the test mod first:
+
+```rust
+//! Device-signed account-service invocation containers.
+//!
+//! The account service's `authorize` accepts requests issued by a device
+//! key whose `root → device` delegation is attached as a proof, with the
+//! account root as subject. This builds exactly that container from a
+//! profile's live device signer and its stored `root → device` link — no
+//! root key, no raw seed.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::InvocationChain;
+    use dialog_varsig::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    async fn it_builds_a_device_signed_invocation_the_service_verifies() {
+        let root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let device_did = device.did();
+        let link = crate::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+
+        let arguments = [("chain".to_owned(), Promised::String("deadbeef".to_owned()))]
+            .into_iter()
+            .collect();
+        let bytes = build_device_invocation(
+            device,
+            &link,
+            vec!["account".into(), "chain".into(), "put".into()],
+            arguments,
+        )
+        .await
+        .unwrap();
+
+        let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
+        chain
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(chain.issuer(), &device_did);
+        assert_eq!(chain.subject(), &root_did);
+        assert_eq!(
+            chain.command().0,
+            vec!["account".to_string(), "chain".to_string(), "put".to_string()],
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p tonk-identity`
+Expected: FAIL to compile — `build_device_invocation` not found.
+
+- [ ] **Step 3: Implement `build_device_invocation`**
+
+Add above the test mod in `request.rs` (this mirrors the account-service test helper's exact container shape):
+
+```rust
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+
+/// Build a device-signed account-service invocation container.
+///
+/// `link` is the stored `root → device` delegation: its issuer is the
+/// account root (the invocation subject and audience), and its single
+/// proof is attached so the service can bind the device to the account.
+pub async fn build_device_invocation(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    command: Vec<String>,
+    arguments: BTreeMap<String, Promised>,
+) -> Result<Vec<u8>> {
+    let root_did = link.issuer().clone();
+    let delegation = link
+        .proofs()
+        .last()
+        .context("account link carries no delegation to prove the device")?
+        .clone();
+    let cid = delegation.to_cid();
+
+    let invocation = InvocationBuilder::new()
+        .issuer(device)
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(command)
+        .arguments(arguments)
+        .proofs(vec![cid])
+        .try_build()
+        .await
+        .context("failed to sign the device invocation")?;
+
+    let mut proofs = HashMap::new();
+    proofs.insert(cid, Arc::new(delegation));
+    InvocationChain::new(invocation, proofs)
+        .to_bytes()
+        .context("failed to serialize the device invocation")
+}
+```
+
+Add to `rust/tonk-identity/src/lib.rs`:
+
+```rust
+pub mod request;
+```
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `cargo test -p tonk-identity`
+Expected: PASS.
+
+- [ ] **Step 5: Point the account-service test helper at the production builder**
+
+In `rust/tonk-account-service/tests/service.rs`, replace the hand-rolled `container` (lines 21-47) with a thin wrapper over the new builder, so the existing `/chains/put`+`/chains/get` and `/devices/list` round-trip tests now exercise production code:
+
+```rust
+/// Build a device-signed invocation container for the account's first
+/// device, using the production builder against the `root → device`
+/// delegation minted for account creation.
+async fn container(command: Vec<String>, args: BTreeMap<String, Promised>) -> Vec<u8> {
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let link = tonk_identity::delegation::mint_device_delegation(root, &device.did())
+        .await
+        .unwrap();
+    tonk_identity::request::build_device_invocation(device, &link, command, args)
+        .await
+        .unwrap()
+}
+```
+
+Remove the now-unused imports this leaves behind (`InvocationBuilder`, `Arc`, and the `Principal` import if `device.did()` is its only user — the compiler will flag them).
+
+- [ ] **Step 6: Run the account-service tests to verify they pass**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: PASS — the full-ceremony test (including the chains and devices/list round-trips) is now green against the production builder.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-identity/src/request.rs rust/tonk-identity/src/lib.rs rust/tonk-account-service/tests/service.rs
+git commit -m "feat(tonk-identity): build device-signed account-service invocations"
+```
+
+---
+
+### Task 4: Back up the claimed chain, best-effort
+
+**Files:**
+- Create: `rust/tonk-worker/src/router/account_backup.rs`
+- Modify: `rust/tonk-worker/src/router.rs` (declare the module)
+- Modify: `rust/tonk-worker/src/router/join.rs` (call the backup)
+- Modify: `rust/tonk-worker/Cargo.toml` (enable `WorkerLocation` if absent)
+
+**Interfaces:**
+- Consumes: `crate::router::account::account_link` (Task 1), `tonk_identity::request::build_device_invocation` (Task 3), the `TonkState.profile.signer()` device signer, `DelegationChain::to_bytes`.
+- Produces: `pub(crate) async fn back_up_claim(tonk: &TonkState, chain: &DelegationChain, remote_url: Option<&str>)` — best-effort, never returns an error.
+
+- [ ] **Step 1: Write the failing native resolver test**
+
+Create `rust/tonk-worker/src/router/account_backup.rs` with the artifact type, a native-only service-URL resolver, and its test:
+
+```rust
+//! Best-effort backup of a claimed space's delegation to the account
+//! service, so a later device can recover the space.
+
+use dialog_ucan_core::DelegationChain;
+use dialog_ucan_core::promise::Promised;
+
+use crate::TonkWorkerError;
+use crate::worker::TonkState;
+
+/// What gets backed up per claimed space: the delegation chain plus the
+/// invite's sync URL, which the chain itself does not carry. A restoring
+/// device needs both to mount and sync the space.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct ClaimBackup {
+    /// Hex-encoded `space → eph → root` delegation chain.
+    pub chain_hex: String,
+    /// The invite's remote/sync URL, when it carried one.
+    pub remote_url: Option<String>,
+}
+
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_prefers_the_service_url_override() {
+        // SAFETY: single-threaded test; no other reader of this var.
+        unsafe { std::env::set_var("TONK_ACCOUNT_SERVICE_URL", "http://127.0.0.1:8787") };
+        assert_eq!(
+            account_service_url().as_deref(),
+            Some("http://127.0.0.1:8787"),
+        );
+        unsafe { std::env::remove_var("TONK_ACCOUNT_SERVICE_URL") };
+        assert_eq!(account_service_url().as_deref(), Some("https://accounts.tonk.xyz"));
+    }
+}
+```
+
+(The `unsafe { set_var }` is required on edition 2024. If the surrounding test harness disallows env mutation, drop this test and assert the default arm only: `assert!(account_service_url().is_some())`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `nix develop -c test:native:debug` (or `cargo test -p tonk-worker account_backup` — this is a native test, matching the `not(wasm32)` test mods in `repository.rs`)
+Expected: FAIL to compile — `account_service_url` not found.
+
+- [ ] **Step 3: Implement the resolver, the POST, and `back_up_claim`**
+
+Add to `account_backup.rs`:
+
+```rust
+/// Resolve the account-service base URL for this context. Unknown hosts
+/// resolve to `None` so backup is skipped rather than failing.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn account_service_url() -> Option<String> {
+    use wasm_bindgen::JsCast;
+    let scope: web_sys::ServiceWorkerGlobalScope = js_sys::global().dyn_into().ok()?;
+    match scope.location().host().as_str() {
+        "tonk.spot" => Some("https://accounts.tonk.xyz".to_owned()),
+        "staging.tonk.xyz" => Some("https://accounts-staging.tonk.xyz".to_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn account_service_url() -> Option<String> {
+    std::env::var("TONK_ACCOUNT_SERVICE_URL")
+        .ok()
+        .or_else(|| Some("https://accounts.tonk.xyz".to_owned()))
+}
+
+/// POST a device-signed invocation container to the account service.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Request, RequestInit, Response};
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&js_sys::Uint8Array::from(body.as_slice()).into());
+    let request = Request::new_with_str_and_init(endpoint, &init)
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put request: {e:?}")))?;
+    let global: web_sys::ServiceWorkerGlobalScope = js_sys::global()
+        .dyn_into()
+        .map_err(|_| TonkWorkerError::Internal("not in a service-worker scope".to_owned()))?;
+    let response: Response = JsFuture::from(global.fetch_with_request(&request))
+        .await
+        .and_then(|v| v.dyn_into())
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put fetch: {e:?}")))?;
+    if !response.ok() {
+        return Err(TonkWorkerError::Internal(format!(
+            "chains/put returned HTTP {}",
+            response.status()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put: {e}")))?;
+    if !response.status().is_success() {
+        return Err(TonkWorkerError::Internal(format!(
+            "chains/put returned HTTP {}",
+            response.status()
+        )));
+    }
+    Ok(())
+}
+
+async fn try_back_up_claim(
+    tonk: &TonkState,
+    chain: &DelegationChain,
+    remote_url: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    // Only account-holders back up; an unlinked device has no account to
+    // escrow under and returns early.
+    let Some(link) = crate::router::account::account_link(tonk).await else {
+        return Ok(());
+    };
+    let Some(service) = account_service_url() else {
+        return Ok(());
+    };
+
+    let chain_bytes = chain
+        .to_bytes()
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize claimed chain: {e}")))?;
+    let artifact = ClaimBackup {
+        chain_hex: hex::encode(chain_bytes),
+        remote_url: remote_url.map(str::to_owned),
+    };
+    let artifact_bytes = serde_json::to_vec(&artifact)
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize backup artifact: {e}")))?;
+
+    let device = tonk.profile.signer().signer().clone();
+    let arguments = [(
+        "chain".to_owned(),
+        Promised::String(hex::encode(artifact_bytes)),
+    )]
+    .into_iter()
+    .collect();
+    let body = tonk_identity::request::build_device_invocation(
+        device,
+        &link,
+        vec!["account".into(), "chain".into(), "put".into()],
+        arguments,
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build backup invocation: {e}")))?;
+
+    let endpoint = format!("{}/chains/put", service.trim_end_matches('/'));
+    post_chains_put(&endpoint, body).await
+}
+
+/// Back up a claimed space's delegation to the account service.
+/// Best-effort: any failure logs and is swallowed — the claiming device
+/// already works, and the roster keys on the root regardless.
+pub(crate) async fn back_up_claim(
+    tonk: &TonkState,
+    chain: &DelegationChain,
+    remote_url: Option<&str>,
+) {
+    if let Err(error) = try_back_up_claim(tonk, chain, remote_url).await {
+        log!("claim backup skipped: {error}");
+    }
+}
+```
+
+Add `use tonk_common::log;` to the `account_backup.rs` imports (as in Task 1, Step 3). Add `mod account_backup;` to `rust/tonk-worker/src/router.rs` alongside the other `mod` declarations.
+
+If `cargo build -p tonk-worker --target wasm32-unknown-unknown` reports `WorkerLocation` unknown, add `"WorkerLocation"` to the `web-sys` features list in `rust/tonk-worker/Cargo.toml`.
+
+- [ ] **Step 4: Run the resolver test to verify it passes**
+
+Run: `nix develop -c test:native:debug` (or `cargo test -p tonk-worker account_backup` — this is a native test, matching the `not(wasm32)` test mods in `repository.rs`)
+Expected: PASS.
+
+- [ ] **Step 5: Call the backup from the claim path**
+
+In `join.rs` `claim_invite`, the chain is persisted around lines 190-197 and then `remote_url` is consumed later (line 258). Keep a clone for the save so the original chain can be backed up, and call the backup right after persisting. Change the save block to:
+
+```rust
+    tonk.profile
+        .access()
+        .save(UcanDelegation(chain.clone()))
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("failed to persist delegation chain: {e}"))
+        })?;
+
+    // Escrow the claimed chain (with the invite's sync URL) so another of
+    // this account's devices can recover the space. No-op for unlinked
+    // devices; best-effort for linked ones.
+    crate::router::account_backup::back_up_claim(tonk, &chain, remote_url.as_deref()).await;
+```
+
+`remote_url` is `Option<String>` (cloned at join.rs:182) and is not moved until join.rs:258, so `remote_url.as_deref()` borrows it safely here.
+
+- [ ] **Step 6: Verify device-only claims are unaffected**
+
+Run: `nix develop -c test:web:debug`
+Expected: PASS — the existing device-only join tests still pass. With no account linked, `back_up_claim` returns early (unlinked), so no network call is attempted and the claim behaves exactly as before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/account_backup.rs rust/tonk-worker/src/router.rs rust/tonk-worker/src/router/join.rs rust/tonk-worker/Cargo.toml
+git commit -m "feat(tonk-worker): back up a claimed chain to the account service"
+```
+
+---
+
+### Task 5: Full gates
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full lint + test gate**
+
+```bash
+cargo clippy --workspace --all-targets --all-features
+cargo fmt --check
+cargo test -p tonk-identity
+cargo test -p tonk-account-service --features helpers
+nix develop -c test:web:debug
+```
+
+Expected: all green. Fix any clippy/fmt findings in the crates this plan touched.
+
+- [ ] **Step 2: Manual staging verification (backup e2e)**
+
+The worker→service `/chains/put` POST is not automatically end-to-end tested (tonk-worker tests run in the service worker and cannot host a native account server; Task 3 proves the builder against the real server, and Task 4 tests the resolver). Verify the full path once against staging:
+
+1. Create an account in a browser on `staging.tonk.xyz`.
+2. Claim an invite as that account-holder.
+3. Confirm the account service's `chains` store gained a key for the account (a `/chains/list` invocation, or inspect the staging R2 bucket).
+
+Note the result in the PR description.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin feat/root-did-rosters
+gh pr create --repo tonk-labs/tonk --base staging \
+  --title "feat(account): root-did rosters and claim backup (stage 3a)" \
+  --body "<summary + the staging verification result + link to the design doc>"
+```
+
+---
+
+## Out of scope (immediate follow-up PR: restore)
+
+A restoring device pulling backed-up artifacts (`/chains/list` + `/chains/get`), re-running the join's replica-mount per subject using the recovered `remote_url`, saving the delegation to the access store, and recording roster rows under the root DID — plus the startup/link hooks that trigger it. Deferred to keep this PR reviewable; the `ClaimBackup` artifact and `build_device_invocation` builder are the shared foundation it will consume.
+
+## Out of scope (stage 3B)
+
+Migrating existing device-keyed members, `device → root` re-anchoring of pre-account chains, the profile-rename root switch, and revocation-list awareness.

--- a/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
+++ b/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
@@ -1,0 +1,167 @@
+# Root-DID rosters (stage 3A)
+
+Design for stage 3 of the cross-device identity system: keying rosters on the
+user's root DID. Parent spec:
+`docs/superpowers/specs/2026-07-17-identity-accounts-design.md`. This spec
+covers **stage 3A only** — new claims and roster writes for account-holders.
+Migrating existing device-keyed members is stage 3B (deferred).
+
+## Problem
+
+Stage 2 gives an account-holder a root DID and a subject-open `root -> device`
+delegation, persisted locally. But invite claims and roster rows still key on
+the **device** DID:
+
+- `rust/tonk-worker/src/router/join.rs:176` — `invite.claim(&tonk.profile.did())`
+  audiences the device DID.
+- `rust/tonk-worker/src/router/join.rs:336` — `Membership::new(tonk.profile.did(), repo.did())`.
+- `rust/tonk-worker/src/router/repository.rs:2678` — founder membership, same shape.
+
+So the two devices of one account land as two unrelated members, and the
+membership schema's content-derived `(subject, member)` convergence — designed
+for exactly this — never fires. Nothing hangs on the root DID yet.
+
+## Scope
+
+**In:** account-holders' claim and founder/create writes key on the root DID;
+a newly claimed space converges across the user's devices (chain backed up on
+claim, restored on other devices).
+
+**Out (stage 3B):** migrating existing device-keyed members, `device -> root`
+re-anchoring of pre-account chains, the profile-rename root switch, and
+revocation-list awareness.
+
+Device-only users are unchanged in every path.
+
+## Key finding: composition is automatic
+
+The presign path composes delegations from the access store on the fly. At
+presign, `CertificateStore::prove`
+(`rust/dialog-capability/src/access.rs:461-526`) walks breadth-first from the
+requesting device DID back toward the space subject, at each hop consulting
+both the subject-specific and the subject-open (powerline) index and splicing
+matches into one chain (`MAX_DEPTH = 10`). The gateway
+(`rust/dialog-remote-ucan-s3/src/authorizer.rs:289-307`) requires only that the
+presented chain terminate at whoever signed the invocation — the same device
+signer the walk starts from — so the two agree by construction.
+
+Consequence: a claim can audience the root DID and save `space -> eph -> root`
+as-is. The device's own subject-open `root -> device` delegation — already saved
+into the **access store** at stage-2 link time
+(`rust/tonk-worker/src/router/account.rs:124-132`) — is stitched in
+automatically, yielding `space -> eph -> root -> device` at presign. No
+pre-composition, no new storage artifact. The composition primitive is already
+unit-tested at `rust/tonk-identity/src/delegation.rs:72-93`.
+
+The one hard requirement this rests on: the `root -> device` delegation must
+live in the access store (via `profile.access().save(...)`), not merely at the
+credential site `tonk-account-link-v1`. Stage 2 already saves it to both.
+
+## Design
+
+### The member-DID resolver
+
+One helper, reused by every writer:
+
+```
+account_root_did(profile) -> Option<Did>
+```
+
+It reads the stored `root -> device` chain (credential site
+`tonk-account-link-v1`, mirroring the existing `load_link`/`get` in
+`rust/tonk-worker/src/router/account.rs:61-101`) and returns `chain.issuer()` —
+the root DID. Returns `None` when no account is linked or the stored link is
+malformed. Every call site resolves its member DID as:
+
+```
+let member = account_root_did(&profile).unwrap_or_else(|| profile.did());
+```
+
+Fail-safe by design: a missing or broken link falls back to the device DID, so
+the device keeps working exactly as an unlinked device would.
+
+### Claim path (`join.rs`)
+
+1. Resolve `member` (root DID if linked, else device DID).
+2. `invite.claim(&member)` — audiences `member`. The ephemeral invite signer
+   can delegate to any DID; the audience never signs, so no root key is needed
+   at claim time.
+3. Save the claimed `space -> eph -> root` chain to the access store, as today.
+   Presign's BFS composes it with the local `root -> device` — no change needed
+   to the save.
+4. `Membership::new(member, repo.did())`, `MemberName`, and the first-wins
+   `MemberRole`/`InvitedVia` stamps all key on `member` (they already derive
+   from `membership.this()`, which is content-derived from `(subject, member)`).
+
+For account-holders, claim and founder/create always operate on a **fresh**
+`(subject, member)` pair, so root-keying introduces no duplicate rows.
+
+### Founder / create path (`repository.rs`)
+
+Same resolver: `Membership::new(member, repo.did())` and the founder
+`MemberRole` stamp key on the root DID. The founder's own access to the created
+space is unaffected — it flows through the separate `repo -> operator`
+delegation, not the membership fact.
+
+### Rename is out (stage 3B)
+
+`rust/tonk-worker/src/router/profile_name.rs:233` sweeps *every existing*
+membership. Switching it to root-keying before migration exists would write a
+new root-keyed row alongside the surviving device-keyed row in every space —
+duplicate rosters. Rename's root switch is entangled with the retract-old-row
+primitive that stage 3B introduces, so it rides with 3B. Until then rename
+continues to key on the device DID.
+
+### Cross-device access
+
+**Backup on claim.** After a successful account-holder claim, push the
+`space -> eph -> root` chain to the account-service `chains` table. The put/get
+API exists from stage 1
+(`rust/tonk-account-service/src/handlers/chains.rs`, `store.rs`); stage 2 wired
+the client authentication. Best-effort: a backup failure logs and does not fail
+the claim (the local device already works).
+
+**Restore.** On device link, and on startup for an already-linked device, pull
+the account's backed-up chains and save each to the local access store. The
+local `root -> device` completes each one via BFS, so the second device can
+sync the space. Best-effort and fail-open, matching the account-service posture
+— account-service downtime never blocks local work or sync.
+
+### Coexistence
+
+The device-only claim path is byte-for-byte unchanged (`account_root_did`
+returns `None`). An account-holder who re-touches a space they joined *before*
+getting an account still sees the old device-keyed row until stage 3B migrates
+it; this is the coexistence the parent design accepts on purpose.
+
+## Testing
+
+- **Unit:** `account_root_did` returns the root when linked, the device DID
+  when unlinked, and the device DID when the stored link is malformed.
+- **Integration (extends the stage-2 CDP harness):** an account-holder claims
+  an invite; the roster row keys on the root DID; a second linked device
+  restores the backed-up chain and syncs the space.
+- **Regression:** the device-only claim path (no account) produces the same
+  chain and roster row as today.
+
+## Risks
+
+- **Duplicate rows before 3B.** An account-holder re-touching a pre-account
+  space creates a coexisting root-keyed row. Bounded and expected; 3B's
+  migration retracts the device-keyed rows.
+- **Restore staleness.** A space claimed on device A appears on device B only
+  after B's next restore (link or startup). Acceptable for 3A; a live follow
+  can come later.
+- **Malformed link fallback masks account state.** If the stored `root ->
+  device` link is unreadable, the device silently behaves as unlinked. This is
+  the safe failure, but it must be logged so a broken link is diagnosable.
+
+## Build order
+
+One PR off `origin/staging`:
+
+1. `account_root_did` resolver.
+2. Claim and founder/create key on the resolved member DID.
+3. Chain backup on claim.
+4. Restore on link/startup.
+5. Unit + integration tests; device-only regression.

--- a/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
+++ b/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
@@ -23,9 +23,15 @@ for exactly this — never fires. Nothing hangs on the root DID yet.
 
 ## Scope
 
-**In:** account-holders' claim and founder/create writes key on the root DID;
-a newly claimed space converges across the user's devices (chain backed up on
-claim, restored on other devices).
+**In:** account-holders' claim and founder/create writes key on the root DID,
+and each claimed space's chain is backed up to the account service so a later
+device can recover it.
+
+**Out — immediate follow-up PR (restore):** a second device pulling the
+backed-up chains and auto-mounting the spaces. Restore is nearly a re-run of the
+join path (mount a replica per subject, configure the remote, record roster
+rows) and is deferred to keep this PR reviewable. Backing up now means nothing
+is lost in the interim.
 
 **Out (stage 3B):** migrating existing device-keyed members, `device -> root`
 re-anchoring of pre-account chains, the profile-rename root switch, and
@@ -114,18 +120,29 @@ continues to key on the device DID.
 
 ### Cross-device access
 
-**Backup on claim.** After a successful account-holder claim, push the
-`space -> eph -> root` chain to the account-service `chains` table. The put/get
-API exists from stage 1
-(`rust/tonk-account-service/src/handlers/chains.rs`, `store.rs`); stage 2 wired
-the client authentication. Best-effort: a backup failure logs and does not fail
-the claim (the local device already works).
+**Backup on claim.** After a successful account-holder claim, push the claimed
+space's delegation to the account-service `/chains/put` endpoint. The backup
+artifact is a small struct — the `space -> eph -> root` chain **and** the
+invite's `remote_url` — because the chain alone does not carry where the space
+syncs from, and restore needs it to mount the replica. Best-effort: a backup
+failure logs and does not fail the claim (the local device already works).
 
-**Restore.** On device link, and on startup for an already-linked device, pull
-the account's backed-up chains and save each to the local access store. The
-local `root -> device` completes each one via BFS, so the second device can
-sync the space. Best-effort and fail-open, matching the account-service posture
-— account-service downtime never blocks local work or sync.
+The call is a **device-signed** UCAN invocation (issuer = device, subject =
+root, `root -> device` attached as a proof), the shape the `/chains/*` handlers'
+`authorize` requires. The device signer comes from
+`profile.signer().signer().clone()`; it drops straight into
+`InvocationBuilder::issuer(...)`, the same shape `tonk-identity`'s root builder
+already uses, and signs fine even with the non-extractable WebCrypto key on web.
+No dialog dependency change is needed. The account-service base URL is resolved
+from the worker's own host (mirroring the page's refuse-by-default map); an
+unresolvable host skips backup rather than failing.
+
+**Restore is the immediate follow-up PR.** A later device pulls the backed-up
+artifacts (`/chains/list` + `/chains/get`), and for each one re-runs the join's
+replica-mount using the recovered `remote_url`, saves the delegation to the
+access store (the local `root -> device` completes it via BFS), and records the
+roster rows under the root DID. Deferred here to keep this PR reviewable;
+because backup runs now, the artifacts are waiting when restore ships.
 
 ### Coexistence
 
@@ -139,8 +156,8 @@ it; this is the coexistence the parent design accepts on purpose.
 - **Unit:** `account_root_did` returns the root when linked, the device DID
   when unlinked, and the device DID when the stored link is malformed.
 - **Integration (extends the stage-2 CDP harness):** an account-holder claims
-  an invite; the roster row keys on the root DID; a second linked device
-  restores the backed-up chain and syncs the space.
+  an invite; the roster row keys on the root DID; the claimed chain lands in the
+  account service's `chains` store (a `/chains/list` shows the key).
 - **Regression:** the device-only claim path (no account) produces the same
   chain and roster row as today.
 
@@ -149,19 +166,23 @@ it; this is the coexistence the parent design accepts on purpose.
 - **Duplicate rows before 3B.** An account-holder re-touching a pre-account
   space creates a coexisting root-keyed row. Bounded and expected; 3B's
   migration retracts the device-keyed rows.
-- **Restore staleness.** A space claimed on device A appears on device B only
-  after B's next restore (link or startup). Acceptable for 3A; a live follow
-  can come later.
 - **Malformed link fallback masks account state.** If the stored `root ->
   device` link is unreadable, the device silently behaves as unlinked. This is
   the safe failure, but it must be logged so a broken link is diagnosable.
+- **Backup without restore (interim).** Until the restore follow-up ships, a
+  claimed space is backed up but a second device does not auto-mount it. No data
+  is lost — the artifacts accumulate server-side — and the claiming device works
+  fully.
 
 ## Build order
 
 One PR off `origin/staging`:
 
-1. `account_root_did` resolver.
+1. `account_root_did` / `member_did` resolver.
 2. Claim and founder/create key on the resolved member DID.
-3. Chain backup on claim.
-4. Restore on link/startup.
+3. Device-signed account-service invocation builder (`tonk-identity`).
+4. Chain backup on claim (`/chains/put`), best-effort, worker-side URL resolver.
 5. Unit + integration tests; device-only regression.
+
+Restore (`/chains/list` + `/chains/get`, replica mounting, roster re-record,
+link/startup hooks) is the immediate follow-up PR.

--- a/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
+++ b/docs/superpowers/specs/2026-07-23-root-did-rosters-design.md
@@ -118,6 +118,18 @@ duplicate rosters. Rename's root switch is entangled with the retract-old-row
 primitive that stage 3B introduces, so it rides with 3B. Until then rename
 continues to key on the device DID.
 
+**Known 3A limitation (until 3B):** because rename still keys on the device
+DID, an account-holder who *renames* does not update their displayed name in
+spaces they joined **as an account-holder**. Those rows are root-keyed (claim
+stamps the initial name correctly at claim time), so a later rename writes a
+`MemberName` against a device-keyed membership entity that has no `Membership`
+row — `build_repository_info`'s `names_by_membership` lookup never matches it,
+and the name silently does not change. This is a no-op, not data loss or a
+crash; the initial name is correct, only subsequent renames are affected, and
+only for the new account-holder cohort. `publish_self_identity`'s device-DID
+overlay sigil is a lesser cosmetic sibling of the same gap. Both are resolved
+by 3B's migration (which re-keys and retracts). Tracked, not a blocker for 3A.
+
 ### Cross-device access
 
 **Backup on claim.** After a successful account-holder claim, push the claimed

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -4,10 +4,8 @@
 #![cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use dialog_credentials::Ed25519Signer;
-use dialog_ucan_core::InvocationBuilder;
 use dialog_ucan_core::promise::Promised;
 use dialog_varsig::Principal;
 use tonk_account_service::helpers::AccountServer;
@@ -15,34 +13,19 @@ use tonk_account_service::helpers::AccountServer;
 const ROOT_PRF: [u8; 32] = [7u8; 32];
 const DEVICE_SEED: [u8; 32] = [8u8; 32];
 
-/// Build a signed UCAN invocation container for the account's first
-/// device, crediting the same `root -> device` delegation minted for
-/// account creation.
+/// Build a device-signed invocation container for the account's first
+/// device, using the production builder against the `root → device`
+/// delegation minted for account creation.
 async fn container(command: Vec<String>, args: BTreeMap<String, Promised>) -> Vec<u8> {
     let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
         .await
         .unwrap();
     let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
-    let root_did = root.did();
-    let chain = tonk_identity::delegation::mint_device_delegation(root, &device.did())
+    let link = tonk_identity::delegation::mint_device_delegation(root, &device.did())
         .await
         .unwrap();
-    let delegation = chain.proofs().last().unwrap().clone();
-    let cid = delegation.to_cid();
-    let invocation = InvocationBuilder::new()
-        .issuer(device.clone())
-        .audience(&root_did)
-        .subject(&root_did)
-        .command(command)
-        .arguments(args)
-        .proofs(vec![cid])
-        .try_build()
+    tonk_identity::request::build_device_invocation(device, &link, command, args)
         .await
-        .unwrap();
-    let mut proofs = std::collections::HashMap::new();
-    proofs.insert(cid, Arc::new(delegation));
-    dialog_ucan_core::InvocationChain::new(invocation, proofs)
-        .to_bytes()
         .unwrap()
 }
 

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -13,6 +13,7 @@ pub mod derive;
 mod install;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod passkey;
+pub mod request;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use install::install;

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -1,0 +1,104 @@
+//! Device-signed account-service invocation containers.
+//!
+//! The account service's `authorize` accepts requests issued by a device
+//! key whose `root → device` delegation is attached as a proof, with the
+//! account root as subject. This builds exactly that container from a
+//! profile's live device signer and its stored `root → device` link — no
+//! root key, no raw seed.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+
+/// Build a device-signed account-service invocation container.
+///
+/// `link` is the stored `root → device` delegation: its issuer is the
+/// account root (the invocation subject and audience), and its single
+/// proof is attached so the service can bind the device to the account.
+pub async fn build_device_invocation(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    command: Vec<String>,
+    arguments: BTreeMap<String, Promised>,
+) -> Result<Vec<u8>> {
+    let root_did = link.issuer().clone();
+    let delegation = link
+        .proofs()
+        .last()
+        .context("account link carries no delegation to prove the device")?
+        .clone();
+    let cid = delegation.to_cid();
+
+    let invocation = InvocationBuilder::new()
+        .issuer(device)
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(command)
+        .arguments(arguments)
+        .proofs(vec![cid])
+        .try_build()
+        .await
+        .context("failed to sign the device invocation")?;
+
+    let mut proofs = HashMap::new();
+    proofs.insert(cid, Arc::new(delegation));
+    InvocationChain::new(invocation, proofs)
+        .to_bytes()
+        .context("failed to serialize the device invocation")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::InvocationChain;
+    use dialog_varsig::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    async fn it_builds_a_device_signed_invocation_the_service_verifies() {
+        let root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let device_did = device.did();
+        let link = crate::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+
+        let arguments = [("chain".to_owned(), Promised::String("deadbeef".to_owned()))]
+            .into_iter()
+            .collect();
+        let bytes = build_device_invocation(
+            device,
+            &link,
+            vec!["account".into(), "chain".into(), "put".into()],
+            arguments,
+        )
+        .await
+        .unwrap();
+
+        let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
+        chain
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(chain.issuer(), &device_did);
+        assert_eq!(chain.subject(), &root_did);
+        assert_eq!(
+            chain.command().0,
+            vec![
+                "account".to_string(),
+                "chain".to_string(),
+                "put".to_string()
+            ],
+        );
+    }
+}

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -26,6 +26,10 @@ pub async fn build_device_invocation(
     arguments: BTreeMap<String, Promised>,
 ) -> Result<Vec<u8>> {
     let root_did = link.issuer().clone();
+    debug_assert!(
+        link.proofs().count() == 1,
+        "build_device_invocation expects a single-hop root -> device link"
+    );
     let delegation = link
         .proofs()
         .last()

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -57,6 +57,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tonk-analyzer = { workspace = true }
 tonk-common = { workspace = true }
 tonk-evaluator = { workspace = true }
+tonk-identity = { workspace = true }
 tonk-invite = { workspace = true }
 tonk-language-server = { workspace = true }
 tonk-notation = { workspace = true }
@@ -116,7 +117,6 @@ dialog-repository = { workspace = true, features = ["helpers"] }
 rand = { workspace = true }
 tonk-access-service = { workspace = true, features = ["helpers"] }
 tonk-fab = { path = "../tonk-fab" }
-tonk-identity = { workspace = true }
 tower = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -18,6 +18,8 @@ pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResp
 
 mod account;
 
+mod account_backup;
+
 mod join;
 pub use join::{JoinRequest, JoinResponse};
 

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -7,6 +7,7 @@ use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
+use tonk_common::log;
 use tonk_worker_api::{AccountLinkRequest, AccountStatus};
 
 use super::AppState;
@@ -72,6 +73,47 @@ async fn load_link(state: &crate::worker::TonkState) -> Result<Option<Vec<u8>>, 
         Err(error) => Err(TonkWorkerError::Internal(format!(
             "failed to load local account link: {error}"
         ))),
+    }
+}
+
+/// The stored `root → device` delegation for this profile, or `None`
+/// when the profile is unlinked or the stored link is unreadable.
+///
+/// Fail-safe: an unreadable or malformed link resolves to `None`, so the
+/// device behaves exactly as an unlinked one and keeps working.
+pub(crate) async fn account_link(tonk: &crate::worker::TonkState) -> Option<DelegationChain> {
+    let bytes = match load_link(tonk).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(error) => {
+            log!("account link unreadable; treating profile as unlinked: {error}");
+            return None;
+        }
+    };
+    match DelegationChain::try_from(bytes.as_slice()) {
+        Ok(chain) => Some(chain),
+        Err(error) => {
+            log!("account link malformed; treating profile as unlinked: {error}");
+            None
+        }
+    }
+}
+
+/// The account root DID for this profile, or `None` when unlinked. A
+/// linked device knows its root without holding the root key: the
+/// `root → device` delegation names the root as issuer.
+pub(crate) async fn account_root_did(
+    tonk: &crate::worker::TonkState,
+) -> Option<dialog_varsig::Did> {
+    account_link(tonk).await.map(|chain| chain.issuer().clone())
+}
+
+/// The DID roster writes and invite claims key on: the account root when
+/// linked, otherwise this device's own DID.
+pub(crate) async fn member_did(tonk: &crate::worker::TonkState) -> dialog_varsig::Did {
+    match account_root_did(tonk).await {
+        Some(root) => root,
+        None => tonk.profile.did(),
     }
 }
 
@@ -242,5 +284,30 @@ mod tests {
             link(State(state), Json(second)).await,
             Err(TonkWorkerError::Conflict(_))
         ));
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_the_member_did_to_the_root_when_linked() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let request = request_for(&[7u8; 32], device_did.clone()).await;
+        let expected_root = request.root_did.clone();
+        let _ = link(State(state.clone()), Json(request)).await.unwrap();
+
+        let tonk = state.read().await;
+        assert_eq!(member_did(&tonk).await.to_string(), expected_root);
+        assert_eq!(
+            account_root_did(&tonk).await.map(|did| did.to_string()),
+            Some(expected_root),
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_resolves_the_member_did_to_the_device_when_unlinked() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let tonk = state.read().await;
+        let device_did = tonk.profile.did();
+        assert_eq!(member_did(&tonk).await, device_did);
+        assert!(account_root_did(&tonk).await.is_none());
     }
 }

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -1,0 +1,162 @@
+//! Best-effort backup of a claimed space's delegation to the account
+//! service, so a later device can recover the space.
+
+use dialog_ucan_core::DelegationChain;
+use dialog_ucan_core::promise::Promised;
+use tonk_common::log;
+
+use crate::TonkWorkerError;
+use crate::worker::TonkState;
+
+/// What gets backed up per claimed space: the delegation chain plus the
+/// invite's sync URL, which the chain itself does not carry. A restoring
+/// device needs both to mount and sync the space.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct ClaimBackup {
+    /// Hex-encoded `space → eph → root` delegation chain.
+    pub chain_hex: String,
+    /// The invite's remote/sync URL, when it carried one.
+    pub remote_url: Option<String>,
+}
+
+/// Resolve the account-service base URL for this context. Unknown hosts
+/// resolve to `None` so backup is skipped rather than failing.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn account_service_url() -> Option<String> {
+    use wasm_bindgen::JsCast;
+    let scope: web_sys::ServiceWorkerGlobalScope = js_sys::global().dyn_into().ok()?;
+    match scope.location().host().as_str() {
+        "tonk.spot" => Some("https://accounts.tonk.xyz".to_owned()),
+        "staging.tonk.xyz" => Some("https://accounts-staging.tonk.xyz".to_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn account_service_url() -> Option<String> {
+    std::env::var("TONK_ACCOUNT_SERVICE_URL")
+        .ok()
+        .or_else(|| Some("https://accounts.tonk.xyz".to_owned()))
+}
+
+/// POST a device-signed invocation container to the account service.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Request, RequestInit, Response};
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&js_sys::Uint8Array::from(body.as_slice()).into());
+    let request = Request::new_with_str_and_init(endpoint, &init)
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put request: {e:?}")))?;
+    let global: web_sys::ServiceWorkerGlobalScope = js_sys::global()
+        .dyn_into()
+        .map_err(|_| TonkWorkerError::Internal("not in a service-worker scope".to_owned()))?;
+    let response: Response = JsFuture::from(global.fetch_with_request(&request))
+        .await
+        .and_then(|v| v.dyn_into())
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put fetch: {e:?}")))?;
+    if !response.ok() {
+        return Err(TonkWorkerError::Internal(format!(
+            "chains/put returned HTTP {}",
+            response.status()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("chains/put: {e}")))?;
+    if !response.status().is_success() {
+        return Err(TonkWorkerError::Internal(format!(
+            "chains/put returned HTTP {}",
+            response.status()
+        )));
+    }
+    Ok(())
+}
+
+async fn try_back_up_claim(
+    tonk: &TonkState,
+    chain: &DelegationChain,
+    remote_url: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    // Only account-holders back up; an unlinked device has no account to
+    // escrow under and returns early.
+    let Some(link) = crate::router::account::account_link(tonk).await else {
+        return Ok(());
+    };
+    let Some(service) = account_service_url() else {
+        return Ok(());
+    };
+
+    let chain_bytes = chain
+        .to_bytes()
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize claimed chain: {e}")))?;
+    let artifact = ClaimBackup {
+        chain_hex: hex::encode(chain_bytes),
+        remote_url: remote_url.map(str::to_owned),
+    };
+    let artifact_bytes = serde_json::to_vec(&artifact)
+        .map_err(|e| TonkWorkerError::Internal(format!("serialize backup artifact: {e}")))?;
+
+    let device = tonk.profile.signer().signer().clone();
+    let arguments = [(
+        "chain".to_owned(),
+        Promised::String(hex::encode(artifact_bytes)),
+    )]
+    .into_iter()
+    .collect();
+    let body = tonk_identity::request::build_device_invocation(
+        device,
+        &link,
+        vec!["account".into(), "chain".into(), "put".into()],
+        arguments,
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build backup invocation: {e}")))?;
+
+    let endpoint = format!("{}/chains/put", service.trim_end_matches('/'));
+    post_chains_put(&endpoint, body).await
+}
+
+/// Back up a claimed space's delegation to the account service.
+/// Best-effort: any failure logs and is swallowed — the claiming device
+/// already works, and the roster keys on the root regardless.
+pub(crate) async fn back_up_claim(
+    tonk: &TonkState,
+    chain: &DelegationChain,
+    remote_url: Option<&str>,
+) {
+    if let Err(error) = try_back_up_claim(tonk, chain, remote_url).await {
+        log!("claim backup skipped: {error}");
+    }
+}
+
+#[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_prefers_the_service_url_override() {
+        // SAFETY: single-threaded test; no other reader of this var.
+        unsafe { std::env::set_var("TONK_ACCOUNT_SERVICE_URL", "http://127.0.0.1:8787") };
+        assert_eq!(
+            account_service_url().as_deref(),
+            Some("http://127.0.0.1:8787"),
+        );
+        unsafe { std::env::remove_var("TONK_ACCOUNT_SERVICE_URL") };
+        assert_eq!(
+            account_service_url().as_deref(),
+            Some("https://accounts.tonk.xyz")
+        );
+    }
+}

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -1,6 +1,7 @@
 //! Best-effort backup of a claimed space's delegation to the account
 //! service, so a later device can recover the space.
 
+use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::DelegationChain;
 use dialog_ucan_core::promise::Promised;
 use tonk_common::log;
@@ -72,6 +73,10 @@ async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorker
     let response = reqwest::Client::new()
         .post(endpoint)
         .body(body)
+        // Native awaits this inline (there's no UI to stall), but it must
+        // never hang indefinitely — bound it so a wedged account service
+        // can't wedge whatever native caller is doing the claim.
+        .timeout(std::time::Duration::from_secs(10))
         .send()
         .await
         .map_err(|e| TonkWorkerError::Internal(format!("chains/put: {e}")))?;
@@ -84,31 +89,26 @@ async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorker
     Ok(())
 }
 
-async fn try_back_up_claim(
-    tonk: &TonkState,
-    chain: &DelegationChain,
-    remote_url: Option<&str>,
+/// Build the backup artifact, sign the device invocation, and POST it to
+/// the account service. Takes only owned data so it can run detached from
+/// the caller (see [`back_up_claim`]).
+async fn run_backup(
+    device: Ed25519Signer,
+    link: DelegationChain,
+    service: String,
+    chain: DelegationChain,
+    remote_url: Option<String>,
 ) -> Result<(), TonkWorkerError> {
-    // Only account-holders back up; an unlinked device has no account to
-    // escrow under and returns early.
-    let Some(link) = crate::router::account::account_link(tonk).await else {
-        return Ok(());
-    };
-    let Some(service) = account_service_url() else {
-        return Ok(());
-    };
-
     let chain_bytes = chain
         .to_bytes()
         .map_err(|e| TonkWorkerError::Internal(format!("serialize claimed chain: {e}")))?;
     let artifact = ClaimBackup {
         chain_hex: hex::encode(chain_bytes),
-        remote_url: remote_url.map(str::to_owned),
+        remote_url,
     };
     let artifact_bytes = serde_json::to_vec(&artifact)
         .map_err(|e| TonkWorkerError::Internal(format!("serialize backup artifact: {e}")))?;
 
-    let device = tonk.profile.signer().signer().clone();
     let arguments = [(
         "chain".to_owned(),
         Promised::String(hex::encode(artifact_bytes)),
@@ -131,13 +131,44 @@ async fn try_back_up_claim(
 /// Back up a claimed space's delegation to the account service.
 /// Best-effort: any failure logs and is swallowed — the claiming device
 /// already works, and the roster keys on the root regardless.
+///
+/// The lookups here (account link, service URL, device signer) are cheap
+/// local reads, so they run inline. The actual network POST is handed off
+/// to run detached: on wasm via `spawn_local`, so a slow/hung account
+/// service can never stall the caller's `.await`; on native the caller has
+/// no UI to stall, so it awaits inline, bounded by `post_chains_put`'s
+/// request timeout.
 pub(crate) async fn back_up_claim(
     tonk: &TonkState,
     chain: &DelegationChain,
     remote_url: Option<&str>,
 ) {
-    if let Err(error) = try_back_up_claim(tonk, chain, remote_url).await {
-        log!("claim backup skipped: {error}");
+    // Only account-holders back up; an unlinked device has no account to
+    // escrow under and returns early.
+    let Some(link) = crate::router::account::account_link(tonk).await else {
+        return;
+    };
+    let Some(service) = account_service_url() else {
+        return;
+    };
+    let device = tonk.profile.signer().signer().clone();
+    let chain = chain.clone();
+    let remote_url = remote_url.map(str::to_owned);
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            if let Err(error) = run_backup(device, link, service, chain, remote_url).await {
+                log!("claim backup failed: {error}");
+            }
+        });
+    }
+
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        if let Err(error) = run_backup(device, link, service, chain, remote_url).await {
+            log!("claim backup failed: {error}");
+        }
     }
 }
 

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -190,12 +190,22 @@ pub(crate) async fn claim_invite(
     // shrink, by joining.
     tonk.profile
         .access()
-        .save(UcanDelegation(chain))
+        .save(UcanDelegation(chain.clone()))
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
             TonkWorkerError::Internal(format!("failed to persist delegation chain: {e}"))
         })?;
+
+    // Escrow the claimed chain (with the invite's sync URL) so another of
+    // this account's devices can recover the space. No-op for unlinked
+    // devices; best-effort for linked ones.
+    crate::router::account_backup::back_up_claim(
+        tonk,
+        &chain,
+        remote_url.as_ref().map(url::Url::as_str),
+    )
+    .await;
 
     // The shared repository's DID is its identity; the routing/storage
     // key is the DID suffix. There is no local display name — it lives in

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -173,8 +173,9 @@ pub(crate) async fn claim_invite(
     let invitation = Invitation::from_chain(&invite.chain)
         .expect("Invite invariant: chain has a specific subject");
 
+    let member = crate::router::account::member_did(tonk).await;
     let claimed = invite
-        .claim(&tonk.profile.did())
+        .claim(&member)
         .await
         .map_err(|e| TonkWorkerError::Router(format!("invalid invite: {e}")))?;
 
@@ -220,7 +221,7 @@ pub(crate) async fn claim_invite(
                     "replica '{key}' present in profile meta but failed to load: {e}",
                 ))
             })?;
-        record_claim_on_content(tonk, &repository, &key, &invitation).await?;
+        record_claim_on_content(tonk, &repository, &key, &invitation, &member).await?;
         return Ok(JoinOutcome {
             key,
             subject,
@@ -286,7 +287,7 @@ pub(crate) async fn claim_invite(
         tonk_schema::MemberRole::MEMBER,
     )
     .await?;
-    record_claim_on_content(tonk, &repository, &key, &invitation).await?;
+    record_claim_on_content(tonk, &repository, &key, &invitation, &member).await?;
 
     // `record_repository_meta` stamps the replica `blank` (the create
     // path's "still seeding" state). A joined replica has no local seed
@@ -329,11 +330,12 @@ async fn record_claim_on_content<C>(
     repository: &Repository<C>,
     key: &str,
     invitation: &Invitation,
+    member: &dialog_varsig::Did,
 ) -> Result<(), TonkWorkerError>
 where
     C: dialog_varsig::Principal + Clone,
 {
-    let membership = Membership::new(tonk.profile.did(), repository.did());
+    let membership = Membership::new(member.clone(), repository.did());
 
     // Route both the read and the write through the *reactor's* cached
     // `main` handle (keyed by the routing key) rather than a fresh
@@ -1034,5 +1036,45 @@ mod tests {
             .find(|r| r.this == membership_entity)
             .expect("founder role stamped at creation");
         assert_eq!(role.role.0.to_string(), MemberRole::FOUNDER);
+    }
+
+    /// An account-holder's claim keys the roster row on their root DID,
+    /// and no device-keyed row is written.
+    #[dialog_common::test]
+    async fn it_keys_membership_on_the_root_did_for_an_account_holder() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+
+        // Link this profile to an account root.
+        let device_did = state.read().await.profile.did();
+        let root = tonk_identity::derive::derive_root_signer(&[7u8; 32])
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let delegation = tonk_identity::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+        let request = tonk_worker_api::AccountLinkRequest {
+            root_did: root_did.to_string(),
+            delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+        };
+        crate::router::account::link(axum::extract::State(state.clone()), axum::Json(request))
+            .await
+            .unwrap();
+
+        // Join an invite.
+        let (url, key) = handcrafted_invite_url(50, 51).await;
+        assert_eq!(post_join(&app, &url).await, StatusCode::CREATED);
+
+        let memberships = content_memberships(&state, &key).await;
+        let root_entity = root_did.this();
+        let device_entity = device_did.this();
+        assert!(
+            memberships.iter().any(|m| m.member.0 == root_entity),
+            "membership keyed on the root did",
+        );
+        assert!(
+            !memberships.iter().any(|m| m.member.0 == device_entity),
+            "no device-keyed row was written",
+        );
     }
 }

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -330,7 +330,7 @@ async fn record_claim_on_content<C>(
     repository: &Repository<C>,
     key: &str,
     invitation: &Invitation,
-    member: &dialog_varsig::Did,
+    member: &Did,
 ) -> Result<(), TonkWorkerError>
 where
     C: dialog_varsig::Principal + Clone,
@@ -1075,6 +1075,32 @@ mod tests {
         assert!(
             !memberships.iter().any(|m| m.member.0 == device_entity),
             "no device-keyed row was written",
+        );
+
+        // The viewer's self row must resolve against the same root DID
+        // the membership is keyed on, not the device DID — otherwise an
+        // account-linked user never matches their own roster row.
+        let info = {
+            let tonk = state.read().await;
+            use dialog_repository::RepositoryExt as _;
+            let repository: dialog_repository::Repository = tonk
+                .profile
+                .repository(&key)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .expect("repo loads");
+            build_repository_info(&tonk, &key, &repository).await
+        };
+        let me = info
+            .members
+            .iter()
+            .find(|m| m.is_self)
+            .expect("self present");
+        assert_eq!(
+            me.did,
+            root_did.to_string(),
+            "self row resolves against the account root, not the device did",
         );
     }
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2674,8 +2674,11 @@ where
 {
     // The opening profile is a member of this repository, stamped with
     // its role (founder on create, member on join) and named with the
-    // name their profile was opened under.
-    let membership = Membership::new(tonk.profile.did(), repository.did());
+    // name their profile was opened under. Keyed on the account root
+    // when this profile is linked, so a founder/member row converges
+    // across every device on the same account.
+    let member = crate::router::account::member_did(tonk).await;
+    let membership = Membership::new(member, repository.did());
     let role = if role_uri == MemberRole::FOUNDER {
         MemberRole::founder(membership.this().clone())
     } else {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2657,9 +2657,13 @@ where
 /// syncs across replicas; the meta branch is local-only, so a roster
 /// written there never converges. Runs on every path
 /// [`record_repository_meta`] serves: on create the opener is the
-/// `tonk:founder`; on join the claimer is a `tonk:member`. The
-/// membership entity is content-derived from `(profile, subject)`, so a
-/// repeat is a no-op; `role`/`name` are cardinality-one stamps.
+/// `tonk:founder`; on join the claimer is a `tonk:member`. The member
+/// is resolved via [`crate::router::account::member_did`] — the
+/// account root when this profile is linked, else the device DID — so
+/// a founder/member row converges across every device on the same
+/// account. The membership entity is content-derived from `(member,
+/// subject)`, so a repeat is a no-op; `role`/`name` are cardinality-one
+/// stamps.
 ///
 /// `key` is the repository's routing key (the `{repo}` param) so the
 /// write goes through the *reactor's* cached `main` handle.
@@ -3376,7 +3380,7 @@ where
         })
         .collect();
 
-    let self_entity = tonk.profile.did().this();
+    let self_entity = crate::router::account::member_did(tonk).await.this();
     let mut members: Vec<MemberInfo> = memberships
         .iter()
         .map(|m| MemberInfo {

--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -19,7 +19,7 @@ binding = "CHAINS"
 bucket_name = "tonk-account-chains"
 
 [vars]
-EMAIL_FROM = "tonk <accounts@tonk.spot>"
+EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 
 # Staging. Disjoint from production in every dimension that holds state:
 # its own worker, route, database, and bucket. The route stays off the
@@ -34,7 +34,7 @@ routes = [{ pattern = "accounts-staging.tonk.xyz", custom_domain = true }]
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "tonk-accounts-staging"
-database_id = ""
+database_id = "d82a5715-d210-4bca-bd9d-4ab64e909566"
 migrations_dir = "rust/tonk-account-service/migrations"
 
 [[env.staging.r2_buckets]]
@@ -42,4 +42,4 @@ binding = "CHAINS"
 bucket_name = "tonk-account-chains-staging"
 
 [env.staging.vars]
-EMAIL_FROM = "tonk <accounts@tonk.spot>"
+EMAIL_FROM = "tonk <accounts@tonk.xyz>"


### PR DESCRIPTION
## Summary

Stage 3A of the cross-device identity system (design: `docs/superpowers/specs/2026-07-23-root-did-rosters-design.md`). For **account-holders**, invite claims and roster writes now key on the passkey-derived **root DID** instead of the per-device DID, so a user's devices finally converge on one roster row. Each claimed space's delegation is also backed up (best-effort) to the account service so a future device can recover it. **Device-only users are unchanged in every path.**

Parent design: #618. Builds on the stage-1/2 account service (#625, #627, #628).

## What's in it

- **`member_did` resolver** (`tonk-worker/router/account.rs`) — the account root DID when the profile is account-linked, else the device DID. Fail-safe: an unreadable/malformed link falls back to the device DID (logs, never errors).
- **Rosters + claim key on it** — the invite-claim audience and all three membership writers (claim, founder/create, and `build_repository_info`'s `is_self` self-detection) resolve through the same helper, so a linked account's rows and self-row converge on one entity. Presign's existing BFS composes `space → eph → root` with the device's local `root → device` link automatically — no new storage shape.
- **Device-signed account-service invocation builder** (`tonk-identity/request.rs`) — `build_device_invocation`, proven end-to-end: the account-service full-ceremony HTTP test now drives it, so the real server verifies exactly what production emits.
- **Backup on claim** (`tonk-worker/router/account_backup.rs`) — a `{chain, remote_url}` artifact POSTed to `/chains/put`, device-signed. **Fire-and-forget** (wasm `spawn_local`; native reqwest timeout) so a slow/hung account service can never stall the claim. Unlinked profiles make zero network attempts.
- Bundled config: `wrangler.account.toml` — `EMAIL_FROM` → `accounts@tonk.xyz` and the staging D1 id.

## Testing

- **Executed & green:** `cargo test -p tonk-identity` (11), `cargo test -p tonk-account-service --features helpers` (29, incl. the full-ceremony HTTP test now driving the production builder), `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --check`, and `cargo build -p tonk-worker --target wasm32-unknown-unknown`.
- **Not executed here (no browser automation in the build env):** the `run_in_service_worker` tests that cover the roster-keying / `is_self` / claim-backup call site. They **compile** (native clippy + wasm build clean). The roster-keying change is a mechanical `device.did() → member_did()` substitution with no JS interop.

## Scope / deferred (not in this PR)

- **Restore** (a second device pulling backed-up chains and auto-mounting the space) — immediate follow-up PR; it reuses this PR's `ClaimBackup` artifact and `build_device_invocation`.
- **Stage 3B:** migrating existing device-keyed members, `device → root` re-anchoring, and the rename root-switch.
  - **Known 3A limitation:** because rename still keys on the device DID, an account-holder who *renames* does not update their displayed name in spaces they joined as an account-holder (initial name is correct; only later renames are a no-op — not data loss). Resolved by 3B's migration. See the design doc's "Rename is out" section.
  - Cross-device provenance (`InvitedVia` self-claim detection is device-scoped) is a follow-up once restore/multi-device lands.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing root-DID rosters for account-holders, allowing invite claims and roster writes to key on the user's root DID instead of the device DID. It also introduces a backup mechanism for claimed chains to the account service.

### Detailed summary
- Added `mod account_backup` to `rust/tonk-worker/src/router.rs`.
- Introduced `account_link`, `account_root_did`, and `member_did` functions in `rust/tonk-worker/src/router/account.rs`.
- Updated `claim_invite` in `rust/tonk-worker/src/router/join.rs` to use `member_did`.
- Modified `record_claim_on_content` and `record_membership_on_content` to key on the root DID.
- Created `build_device_invocation` in `rust/tonk-identity/src/request.rs` for signing invocations.
- Implemented `back_up_claim` in `rust/tonk-worker/src/router/account_backup.rs` for backing up claimed chains.
- Updated tests to verify new functionality and ensure existing device-only claims remain unaffected.
- Revised documentation to reflect changes in roster management and backup mechanisms.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->