### PR TITLE
feat(account): cross-device restore of claimed and created spaces

### DIFF
--- a/docs/superpowers/plans/2026-07-23-cross-device-restore.md
+++ b/docs/superpowers/plans/2026-07-23-cross-device-restore.md
@@ -1,0 +1,584 @@
+# Cross-device Restore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A linked device restores both claimed and created spaces from the account service and mounts them locally, so a user's spaces follow them across devices. Created spaces gain a backed-up `space -> root` delegation so they are restorable.
+
+**Architecture:** Two backup producers (claim — already done in 3A — and the create/remote-attach path, new) escrow a `{chain, remote_url}` artifact to the account service. One restore consumer pulls all artifacts and mounts each space through a shared `mount_replica` helper extracted from the claim path. Restore writes no content roster — the roster arrives over sync. Triggers are best-effort/fire-and-forget on device link and startup.
+
+**Tech Stack:** Rust (edition 2024). `dialog-*` pinned at `tonk-2026-07-17`. Builds on 3A: `tonk-worker/router/account_backup.rs`, `tonk_identity::request::build_device_invocation`, `crate::router::account::{account_link, member_did}`.
+
+## Global Constraints
+
+- Work on branch `feat/cross-device-restore` (already cut from `feat/root-did-rosters`; carries the design doc). Rebase onto `staging` once 3A (#637) merges.
+- Do NOT bump the pinned dialog tag `tonk-2026-07-17`.
+- `Subject::Any` is only ever the `root -> device` link. The `space -> root` delegation is subject-SPECIFIC (subject = the space DID). Never mint `Subject::Any` for a space.
+- Backup and restore are BEST-EFFORT and FAIL-OPEN: they never fail a claim/create/link/boot or block local work. Dispatch detached so a slow account service can't stall.
+- Restore writes NO content-branch roster. `record_membership_on_content` asserts `MemberRole` unconditionally + cardinality-one; a restore-time `member` stamp would demote a founder on a created space. The roster is authoritative on the content branch and arrives over sync.
+- Tests: `#[dialog_common::test]`; `tonk-worker` wasm test mods carry `wasm_bindgen_test_configure!(run_in_service_worker)`. No `mod.rs`. Conventional Commits, no emojis. Self-contained comments (no "3b"/spec references).
+- **Wasm/service-worker tests HANG in the local sandbox** (no browser automation). Verify wasm-gated code by COMPILING (`cargo clippy -p tonk-worker --all-targets` + `cargo build -p tonk-worker --target wasm32-unknown-unknown`), never `test:web:debug`. Native tests (`cargo test`) run normally. CI's `web` matrix leg executes the wasm tests.
+- Lint gate before each PR: `cargo clippy --workspace --all-targets --all-features` + `cargo fmt --check`.
+
+## File Structure
+
+- `rust/tonk-worker/src/router/repository.rs` — split `record_repository_meta` into `record_replica_meta` (meta + profile index) + the content-roster call; `ensure_remote_config` gains the created-space backup hook.
+- `rust/tonk-worker/src/router/join.rs` — extract `mount_replica`; rewire `claim_invite` onto it.
+- `rust/tonk-worker/src/router/account_backup.rs` — add `back_up_owned_space` (create producer) and the `list`/`get` restore client; grows the shared device-signed request plumbing.
+- `rust/tonk-worker/src/router/restore.rs` — **new**: the restore consumer (`restore_spaces`).
+- `rust/tonk-worker/src/router.rs` — declare `mod restore;`.
+- `rust/tonk-worker/src/router/account.rs` — link handler triggers restore.
+- `rust/tonk-worker/src/worker.rs` — startup triggers restore for a linked profile.
+
+---
+
+## PR 1 — Mount extraction + created-space backup (Tasks 1-3)
+
+### Task 1: Split `record_repository_meta` — carve out the content-roster write
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/repository.rs`
+
+**Interfaces:**
+- Produces: `pub(crate) async fn record_replica_meta<C: Principal + Clone>(tonk: &TonkState, repository: &Repository<C>, display_name: &str, configuration: &RepositoryConfiguration) -> Result<(), RepositoryError>` — everything `record_repository_meta` did EXCEPT the `record_membership_on_content` call. Consumed by Task 2.
+- `record_repository_meta` keeps its exact signature and behavior (now = `record_replica_meta` + the content-roster call).
+
+- [ ] **Step 1: Rename the body and re-express `record_repository_meta` as a thin wrapper**
+
+In `repository.rs`, rename the existing `record_repository_meta` function body to `record_replica_meta` by:
+1. Changing the signature at line 2448 to drop `role_uri`:
+```rust
+pub(crate) async fn record_replica_meta<C>(
+    tonk: &TonkState,
+    repository: &Repository<C>,
+    display_name: &str,
+    configuration: &RepositoryConfiguration,
+) -> Result<(), RepositoryError>
+where
+    C: Principal + Clone,
+```
+2. Deleting the content-roster call (the `record_membership_on_content(tonk, repository, key, role_uri).await?;` at line 2635 and its preceding comment block at 2630-2634).
+
+Then add a new wrapper that preserves the old surface:
+```rust
+/// Lay down the meta-branch facts and profile index, then record the
+/// opening profile's membership on the content branch. The two halves
+/// are split so the join/restore mount can reuse the meta half without
+/// the roster write (restore must not stamp a role — see the restore
+/// path).
+pub(crate) async fn record_repository_meta<C>(
+    tonk: &TonkState,
+    repository: &Repository<C>,
+    display_name: &str,
+    configuration: &RepositoryConfiguration,
+    role_uri: &str,
+) -> Result<(), RepositoryError>
+where
+    C: Principal + Clone,
+{
+    record_replica_meta(tonk, repository, display_name, configuration).await?;
+    record_membership_on_content(tonk, repository, &repository.did().repo_key(), role_uri).await
+}
+```
+
+(Check the exact `key` expression `record_membership_on_content` expects — the original computed `let key = did.repo_key();` at 2461 from `repository.did()`. Reuse that form.)
+
+- [ ] **Step 2: Verify the workspace compiles and existing tests pass**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -30`
+Expected: clean. `create_repository` (2420) and the claim path still call `record_repository_meta` with a role and get identical behavior.
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/repository.rs
+git commit -m "refactor(tonk-worker): split replica meta from the content roster write"
+```
+
+---
+
+### Task 2: Extract `mount_replica` and rewire the claim path
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/join.rs`
+
+**Interfaces:**
+- Consumes: `record_replica_meta` (Task 1), `find_replica_for_subject`, `mark_replica_initialized`, `record_membership_on_content`, `record_claim_on_content`.
+- Produces: `pub(crate) async fn mount_replica(tonk: &TonkState, subject: &Did, remote_url: Option<&str>) -> Result<(String, Repository<Credential>), TonkWorkerError>` — creates the verifier-only replica, configures the remote/branch, records the local replica meta (NO content roster). Returns the routing key AND the mounted repository handle (so the claim path can write the roster without a reload). `Credential` is the verifier-credential type from `Repository::from(space_credential)` — confirm the concrete type name and use it in the signature. Consumed by Task 5 (restore, which ignores both return values) and by the claim rewire below.
+
+- [ ] **Step 1: Add `mount_replica`, lifting the claim's mount block**
+
+In `join.rs`, add (mirrors `claim_invite`'s lines ~246-292, minus the roster writes):
+```rust
+/// Mount a local verifier-only replica for a space and configure its
+/// remote, without touching the content roster. Shared by the invite
+/// claim and by cross-device restore. Idempotent-safe callers should
+/// check `find_replica_for_subject` first.
+pub(crate) async fn mount_replica(
+    tonk: &TonkState,
+    subject: &Did,
+    remote_url: Option<&str>,
+) -> Result<String, TonkWorkerError> {
+    let key = subject.repo_key().to_owned();
+
+    let verifier: Ed25519Verifier = subject.to_string().parse().map_err(|e| {
+        TonkWorkerError::Router(format!("subject is not a valid Ed25519 did:key: {e:?}"))
+    })?;
+    let credential = Credential::from(verifier);
+    let space_capability = Subject::from(tonk.profile.did()).attenuate(Space::new(&key));
+    let space_credential = space_capability
+        .create(credential)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("failed to create local replica '{key}': {e}"))
+        })?;
+    let repository = Repository::from(space_credential);
+
+    let mut configuration = RepositoryConfiguration::default();
+    if let Some(url) = remote_url {
+        let address = SiteAddress::from(UcanAddress::new(url));
+        configuration = configuration
+            .remote(
+                DEFAULT_REMOTE,
+                RemoteConfiguration::new(address).subject(subject.clone()),
+            )
+            .branch(
+                DEFAULT_BRANCH,
+                BranchConfiguration {
+                    upstream: Some(UpstreamConfiguration::new(DEFAULT_REMOTE, DEFAULT_BRANCH)),
+                    revision: None,
+                },
+            );
+    } else {
+        configuration = configuration.branch(DEFAULT_BRANCH, BranchConfiguration::default());
+    }
+
+    crate::router::repository::record_replica_meta(tonk, &repository, &key, &configuration)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("failed to record replica meta: {e}")))?;
+
+    Ok((key, repository))
+}
+```
+
+(Confirm the `RepositoryError -> TonkWorkerError` conversion form the file already uses; if `record_replica_meta` returns `RepositoryError`, map it as shown. `mount_replica` returns the mounted `repository` so the claim path can write the roster off it without a reload.)
+
+- [ ] **Step 2: Rewire `claim_invite`'s new-replica branch onto `mount_replica`**
+
+In `claim_invite` (the block currently at ~242-299 that builds the verifier, configures the remote, and calls `record_repository_meta`), replace the inline mount + `record_repository_meta` with a `mount_replica` call, then write the roster explicitly off the returned repository so behavior is unchanged (same net writes as the old `record_repository_meta(MEMBER)` + `record_claim_on_content`):
+```rust
+    let (key, repository) = mount_replica(tonk, &subject, remote_url.as_deref()).await?;
+
+    // Roster on the content branch: the claimer is a member. (mount_replica
+    // wrote only the device-local meta; the content roster is claim-only.)
+    crate::router::repository::record_membership_on_content(
+        tonk,
+        &repository,
+        &key,
+        tonk_schema::MemberRole::MEMBER,
+    )
+    .await?;
+    record_claim_on_content(tonk, &repository, &key, &invitation, &member).await?;
+    mark_replica_initialized(tonk, &subject).await?;
+```
+The old code called `record_repository_meta(&repository, MEMBER)` (meta + content MEMBER) then `record_claim_on_content`; this reproduces exactly that — `mount_replica`'s `record_replica_meta` is the meta half, and `record_membership_on_content(MEMBER)` is the content half — with `mark_replica_initialized` last, preserving ordering. `repository` is the value `mount_replica` returns (the verifier-credential `Repository`), which satisfies `C: Principal + Clone` as the pre-refactor code proved.
+
+- [ ] **Step 3: Add the failing regression assertion is unnecessary — reuse the existing claim tests**
+
+The existing `it_records_membership_and_provenance_on_join`, `it_records_the_claimer_name_on_join`, `it_reports_provenance_in_members`, and the 3A `it_keys_membership_on_the_root_did_for_an_account_holder` all exercise the claim mount + roster. They must stay green — they are the behavior-preservation guard for this refactor.
+
+- [ ] **Step 4: Verify compile (wasm tests can't execute locally)**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -30` (clean)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+The claim tests are `run_in_service_worker`; they compile here and execute in CI's web leg. Note in the report that they were compiled, not executed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/join.rs
+git commit -m "refactor(tonk-worker): extract mount_replica shared by claim and restore"
+```
+
+---
+
+### Task 3: Back up a created space's `space -> root` delegation
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account_backup.rs`
+- Modify: `rust/tonk-worker/src/router/repository.rs` (hook in `ensure_remote_config`)
+
+**Interfaces:**
+- Consumes: `crate::router::account::{account_link, account_root_did}`, `tonk.profile.signer()`, `ClaimBackup`, `run_backup`/`build_device_invocation` plumbing.
+- Produces: `pub(crate) async fn back_up_owned_space<C: Principal + Clone>(tonk: &TonkState, repository: &Repository<C>, remote_url: &str)` — best-effort; mints `space -> root` and pushes `{chain, remote_url}` to `/chains/put`. Fire-and-forget.
+
+- [ ] **Step 1: Verify the mint API works on the repository handle in scope**
+
+Before writing the backup, confirm — in a scratch native unit test in `account_backup.rs` OR by reading `create_repository:2397` — that `repository.access().claim(repository).delegate(root_did).perform(&tonk.operator).await` yields a one-hop `space -> root` delegation with subject = `repository.did()`. This is the exact call `create_repository` already makes to delegate to the profile (`repository.rs:2397-2405`), so the API is proven for a repository that holds a signer. The open risk is whether the `repository` handed to `ensure_remote_config` (loaded via `profile.repository(key).load()`) still holds signing capability for an OWNED space. If `.access().claim()` is unavailable on the loaded handle, STOP and report — the fallback is to mint at `create_repository` time and thread the chain to the remote-attach hook, which is a larger change worth flagging before proceeding.
+
+- [ ] **Step 2: Implement `back_up_owned_space`**
+
+In `account_backup.rs`, add (reuses the existing `account_service_url`, `ClaimBackup`, `run_backup`/dispatch pattern — factor the common "resolve link+service+device, then dispatch `run_backup`" out of `back_up_claim` if it isn't already, so both callers share it):
+```rust
+/// Back up a created space's `space -> root` delegation so another of
+/// the account's devices can restore it. Best-effort and fire-and-forget;
+/// a no-op when the profile is unlinked. The space must hold its signer
+/// (an owned/created space) to issue the delegation.
+pub(crate) async fn back_up_owned_space<C>(
+    tonk: &TonkState,
+    repository: &Repository<C>,
+    remote_url: &str,
+) where
+    C: dialog_varsig::Principal + Clone,
+{
+    if let Err(error) = try_back_up_owned_space(tonk, repository, remote_url).await {
+        log!("created-space backup skipped: {error}");
+    }
+}
+
+async fn try_back_up_owned_space<C>(
+    tonk: &TonkState,
+    repository: &Repository<C>,
+    remote_url: &str,
+) -> Result<(), TonkWorkerError>
+where
+    C: dialog_varsig::Principal + Clone,
+{
+    let Some(root_did) = crate::router::account::account_root_did(tonk).await else {
+        return Ok(());
+    };
+    // space -> root, subject-specific (subject = the space DID), full authority.
+    let delegation = repository
+        .access()
+        .claim(repository)
+        .delegate(root_did)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("failed to mint space->root: {e}")))?;
+    let chain = /* the DelegationChain from `delegation` — match create_repository's `save(delegation)` value shape */;
+    dispatch_owned_backup(tonk, chain, remote_url.to_owned()).await;
+    Ok(())
+}
+```
+The exact type returned by `.access().claim(repository).delegate(root_did).perform(...)` must be resolved against the dialog API (create_repository saves it directly via `tonk.profile.access().save(delegation)` at 2409). It needs to become the hex-encoded chain in a `ClaimBackup`. If it is not already a `DelegationChain`, convert/extract its chain bytes. Then reuse the same fire-and-forget dispatch as `back_up_claim` (device signer from `tonk.profile.signer().signer().clone()`, the `root -> device` link from `account_link`, command `["account","chain","put"]`, artifact `ClaimBackup { chain_hex, remote_url: Some(remote_url) }`).
+
+- [ ] **Step 3: Hook the backup after a remote is attached to an owned space**
+
+In `repository.rs` `ensure_remote_config` (3429) — or, if `ensure_remote_config` is cross-target and the account plumbing is wasm-only, in its wasm callers `enable_sync_inner` (2023) right after `ensure_remote_config` returns `Ok` — add, after the remote is durably configured:
+```rust
+    // Escrow this owned space's delegation so the account's other devices
+    // can restore it. Best-effort; no-op for unlinked profiles.
+    crate::router::account_backup::back_up_owned_space(tonk, repository, remote).await;
+```
+Place it only where the space is OWNED (created by this profile) and `remote` is the just-attached URL. `enable_sync_inner` is the natural single hook (its doc: both the create-with-sync and enable-sync forms converge here). Confirm `repository` there holds a signer; if the loaded handle is verifier-only, fall back per Step 1.
+
+- [ ] **Step 4: Verify compile + native tests**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -30` (clean)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+Run: `cargo test -p tonk-worker back_up 2>&1 | tail -20` (any native backup tests stay green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/account_backup.rs rust/tonk-worker/src/router/repository.rs
+git commit -m "feat(tonk-worker): back up created spaces for cross-device restore"
+```
+
+**End of PR 1.** Open a PR: `git push -u origin feat/cross-device-restore` then `gh pr create --base <feat/root-did-rosters or staging> ...`. If 3A hasn't merged, base on `feat/root-did-rosters` (stacked) and note it.
+
+---
+
+## PR 2 — Restore consumer + triggers (Tasks 4-6)
+
+### Task 4: The `/chains/list` and `/chains/get` client
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account_backup.rs`
+- Modify: `rust/tonk-account-service/tests/service.rs` (extend the round-trip proof)
+
+**Interfaces:**
+- Produces:
+  - `pub(crate) async fn list_backed_up_chains(device: &Ed25519Signer, link: &DelegationChain, service: &str) -> Result<Vec<String>, TonkWorkerError>` — device-signed `/chains/list`, parses the JSON array.
+  - `pub(crate) async fn get_backed_up_chain(device: &Ed25519Signer, link: &DelegationChain, service: &str, key: &str) -> Result<Vec<u8>, TonkWorkerError>` — device-signed `/chains/get`, returns the raw artifact bytes.
+  - Consumed by Task 5.
+
+- [ ] **Step 1: Implement the two client functions**
+
+In `account_backup.rs`, parallel to the existing put client (`run_backup` builds a `["account","chain","put"]` container via `build_device_invocation` and POSTs). Add:
+```rust
+pub(crate) async fn list_backed_up_chains(
+    device: &Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+) -> Result<Vec<String>, TonkWorkerError> {
+    let body = tonk_identity::request::build_device_invocation(
+        device.clone(),
+        link,
+        vec!["account".into(), "chain".into(), "list".into()],
+        std::collections::BTreeMap::new(),
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build list invocation: {e}")))?;
+    let endpoint = format!("{}/chains/list", service.trim_end_matches('/'));
+    let bytes = post_for_bytes(&endpoint, body).await?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| TonkWorkerError::Internal(format!("parse chain keys: {e}")))
+}
+
+pub(crate) async fn get_backed_up_chain(
+    device: &Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+    key: &str,
+) -> Result<Vec<u8>, TonkWorkerError> {
+    let arguments = [("key".to_owned(), Promised::String(key.to_owned()))]
+        .into_iter()
+        .collect();
+    let body = tonk_identity::request::build_device_invocation(
+        device.clone(),
+        link,
+        vec!["account".into(), "chain".into(), "get".into()],
+        arguments,
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build get invocation: {e}")))?;
+    let endpoint = format!("{}/chains/get", service.trim_end_matches('/'));
+    post_for_bytes(&endpoint, body).await
+}
+```
+Add a `post_for_bytes(endpoint, body) -> Result<Vec<u8>, _>` cfg-split helper mirroring the existing `post_chains_put`, but returning the response body bytes (wasm: `Response.array_buffer()` → `Uint8Array` → `Vec<u8>`; native: `reqwest ... .bytes()`), with the same non-2xx → error handling. `Ed25519Signer`, `DelegationChain`, `Promised` are already imported for the put path or come from the same crates (`dialog_credentials`, `dialog_ucan_core::{DelegationChain, promise::Promised}`).
+
+- [ ] **Step 2: Extend the account-service HTTP test to prove list+get via the production client**
+
+The account-service test (`rust/tonk-account-service/tests/service.rs`) already round-trips `/chains/put` + `/chains/get` using the production `build_device_invocation` (via its `container` helper). It cannot call the tonk-worker client (different crate), but it CAN assert the wire contract the client depends on: confirm `/chains/list` returns a JSON array containing the key that `/chains/put` returned, and `/chains/get` returns the exact bytes. If the existing test only exercises put+get, add the list assertion:
+```rust
+    // /chains/list should surface the key we just put.
+    let body = container(vec!["account".into(), "chain".into(), "list".into()], BTreeMap::new()).await;
+    let response = client.post(format!("{base}/chains/list")).body(body).send().await.unwrap();
+    assert_eq!(response.status(), 200);
+    let keys: Vec<String> = response.json().await.unwrap();
+    assert!(keys.contains(&key));
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test -p tonk-account-service --features helpers 2>&1 | tail -15` (green, incl. the list assertion)
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -30` and `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/account_backup.rs rust/tonk-account-service/tests/service.rs
+git commit -m "feat(tonk-worker): client for listing and fetching backed-up chains"
+```
+
+---
+
+### Task 5: The restore consumer
+
+**Files:**
+- Create: `rust/tonk-worker/src/router/restore.rs`
+- Modify: `rust/tonk-worker/src/router.rs` (`mod restore;`)
+
+**Interfaces:**
+- Consumes: `list_backed_up_chains`, `get_backed_up_chain` (Task 4), `ClaimBackup`, `account_link`, `account_service_url` (make `account_service_url` `pub(crate)` in Task 4/5 if not already), `crate::router::join::mount_replica` (Task 2), `find_replica_for_subject`, `mark_replica_initialized`.
+- Produces: `pub(crate) async fn restore_spaces(tonk: &TonkState)` — best-effort; pulls every backed-up artifact and mounts any space not already present. Consumed by Task 6.
+
+- [ ] **Step 1: Implement `restore_spaces`**
+
+Create `restore.rs`:
+```rust
+//! Pull the account's backed-up space delegations and mount any space
+//! this device does not already have. Best-effort: failures log and are
+//! swallowed; nothing here blocks link or boot.
+
+use dialog_ucan::UcanDelegation;
+use dialog_ucan_core::DelegationChain;
+
+use crate::router::account_backup::{
+    account_service_url, get_backed_up_chain, list_backed_up_chains, ClaimBackup,
+};
+use crate::worker::TonkState;
+
+/// Restore all backed-up spaces for the linked account. No-op when
+/// unlinked or when the account service is unreachable.
+pub(crate) async fn restore_spaces(tonk: &TonkState) {
+    if let Err(error) = try_restore_spaces(tonk).await {
+        log!("restore skipped: {error}");
+    }
+}
+
+async fn try_restore_spaces(tonk: &TonkState) -> Result<(), crate::TonkWorkerError> {
+    let Some(link) = crate::router::account::account_link(tonk).await else {
+        return Ok(());
+    };
+    let Some(service) = account_service_url() else {
+        return Ok(());
+    };
+    let device = tonk.profile.signer().signer().clone();
+
+    let keys = list_backed_up_chains(&device, &link, &service).await?;
+    for key in keys {
+        if let Err(error) = restore_one(tonk, &device, &link, &service, &key).await {
+            // One bad artifact must not stop the rest.
+            log!("restore of chain '{key}' skipped: {error}");
+        }
+    }
+    Ok(())
+}
+
+async fn restore_one(
+    tonk: &TonkState,
+    device: &dialog_credentials::Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+    key: &str,
+) -> Result<(), crate::TonkWorkerError> {
+    let bytes = get_backed_up_chain(device, link, service, key).await?;
+    let artifact: ClaimBackup = serde_json::from_slice(&bytes)
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad backup artifact: {e}")))?;
+    let chain_bytes = hex::decode(&artifact.chain_hex)
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad chain hex: {e}")))?;
+    let chain = DelegationChain::try_from(chain_bytes.as_slice())
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad chain: {e}")))?;
+
+    let subject = chain
+        .subject()
+        .ok_or_else(|| crate::TonkWorkerError::Internal("backup chain has no subject".into()))?
+        .clone();
+
+    // Already have it? Nothing to do.
+    if crate::router::join::find_replica_for_subject(tonk, &subject).await? {
+        return Ok(());
+    }
+
+    // Install the delegation so presign's BFS can compose it with the
+    // local root -> device link, then mount and let sync bring the roster.
+    tonk.profile
+        .access()
+        .save(UcanDelegation(chain))
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("save restored delegation: {e}")))?;
+
+    crate::router::join::mount_replica(tonk, &subject, artifact.remote_url.as_deref()).await?;
+    crate::router::repository::mark_replica_initialized(tonk, &subject).await?;
+    Ok(())
+}
+```
+Notes for the implementer:
+- `find_replica_for_subject` and `mark_replica_initialized` are `pub(crate)` (make them so if not — `find_replica_for_subject` is at `join.rs:435`, `mark_replica_initialized` at `repository.rs:2828`). `mount_replica` returns `(key, repository)` — `restore_one` uses neither (it drives everything off `subject`), so `let _ = mount_replica(...).await?;`.
+- `account_service_url` must be `pub(crate)`.
+- `log!` = `use tonk_common::log;`.
+
+- [ ] **Step 2: Declare the module**
+
+In `rust/tonk-worker/src/router.rs`, add `mod restore;` alongside the other submodules.
+
+- [ ] **Step 3: Verify compile**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -40` (clean — expect a `restore_spaces` dead_code warning until Task 6 wires the triggers)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/restore.rs rust/tonk-worker/src/router.rs rust/tonk-worker/src/router/join.rs rust/tonk-worker/src/router/repository.rs
+git commit -m "feat(tonk-worker): restore backed-up spaces onto a device"
+```
+
+---
+
+### Task 6: Trigger restore on link and on startup
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account.rs` (link handler)
+- Modify: `rust/tonk-worker/src/worker.rs` (startup)
+
+**Interfaces:**
+- Consumes: `crate::router::restore::restore_spaces` (Task 5).
+
+- [ ] **Step 1: Trigger after a successful link**
+
+In `account.rs` `link` (147-190), after the `root -> device` chain is persisted and before returning `AccountStatus::Linked`, dispatch restore fire-and-forget so a slow account service can't stall the link response:
+```rust
+    // A freshly linked device pulls the account's spaces in the
+    // background — never block the link response on it.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let state = state.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = state.read().await;
+            crate::router::restore::restore_spaces(&tonk).await;
+        });
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        crate::router::restore::restore_spaces(&state.read().await).await;
+    }
+```
+(Confirm the `State`/`AppState` handle type and how to clone it for the spawned task — mirror the 3A `back_up_claim` dispatch pattern in `account_backup.rs`.)
+
+- [ ] **Step 2: Trigger on startup for a linked profile**
+
+In `worker.rs` `TonkServiceWorker::new`, after `bootstrap_profile(&state)` (1678-1680), dispatch restore for an already-linked profile, fire-and-forget so boot isn't blocked:
+```rust
+    // Catch up on spaces claimed/created on other devices since last boot.
+    // Fire-and-forget; account-service latency must not delay startup.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let state = state.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = state.read().await;
+            crate::router::restore::restore_spaces(&tonk).await;
+        });
+    }
+```
+(Use the same `state` handle `bootstrap_profile` received. If startup isn't inside an async context that allows `spawn_local`, place the trigger at the first activation/fetch hook instead — `worker.rs`'s `on_activate` — and note it.)
+
+- [ ] **Step 3: Verify compile (both targets) and the full gate**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -30` (clean — `restore_spaces` dead_code warning now gone)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/account.rs rust/tonk-worker/src/worker.rs
+git commit -m "feat(tonk-worker): restore spaces on device link and startup"
+```
+
+---
+
+### Task 7: Full gates
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Workspace gate**
+
+```bash
+cargo clippy --workspace --all-targets --all-features
+cargo fmt --check
+cargo test -p tonk-account-service --features helpers
+```
+Expected: all green. Fix any finding in the crates this plan touched.
+
+- [ ] **Step 2: Note the deferred wasm + staging verification in the PR body**
+
+The restore mount, the created-space backup hook, and the triggers are `run_in_service_worker`/wasm and are executed by CI's `web` matrix leg, not locally. In the PR body, list for a human/staging pass: (a) claim a space on device A (account-holder), then link device B → the space auto-mounts on B; (b) create a space with sync on device A → it appears on device B after link/restart.
+
+- [ ] **Step 3: Push and open PR 2**
+
+```bash
+git push
+gh pr create --base <feat/cross-device-restore's PR1 base> --title "feat(account): restore backed-up spaces across devices" --body "<summary + verification checklist + design link>"
+```
+
+---
+
+## Out of scope (later)
+
+Live cross-device propagation (restore is trigger-based, not push); migrating pre-account device-keyed spaces and the rename root-switch (stage 3B); revocation-list awareness. Native (CLI) created-space backup if the `ensure_remote_config` hook lands wasm-only — track as a follow-up.

--- a/docs/superpowers/specs/2026-07-23-cross-device-restore-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-device-restore-design.md
@@ -1,0 +1,165 @@
+# Cross-device restore (+ created-space backup)
+
+Design for the second half of the cross-device story: a linked device pulls the
+account's backed-up space delegations and auto-mounts each space, so a user's
+spaces follow them to every device. Stacks on stage 3A
+(`docs/superpowers/specs/2026-07-23-root-did-rosters-design.md`), which added
+the root-DID rosters and the claim-side backup.
+
+## Problem
+
+Stage 3A backs up a claimed space's `space -> eph -> root` delegation to the
+account service, but nothing pulls it back — so a second device gains nothing
+yet. And created spaces aren't backed up at all: a creator holds the space
+signing key, which no other device has, so created spaces are single-device.
+
+## Scope
+
+**In:** a linked device restores both **claimed** and **created** spaces from
+the account service and mounts them locally. To make created spaces
+restorable, the create path also backs up a `space -> root` delegation.
+
+**Out:** live cross-device propagation (a space claimed on device A appears on
+device B only after B's next link or restart — see Triggers); migration of
+pre-account spaces and the rename switch (stage 3B); revocation.
+
+## Shape
+
+Two sides, sharing the 3A artifact and the `/chains/*` endpoints unchanged:
+
+- **Backup (producers):** claim backs up `space -> eph -> root` (3A, done). New:
+  the create path backs up `space -> root`.
+- **Restore (one consumer):** pull all backed-up artifacts, mount each space,
+  let sync bring the rest.
+
+Both producers emit the existing `ClaimBackup { chain_hex, remote_url }`
+(`rust/tonk-worker/src/router/account_backup.rs:15`): a `... -> root` chain
+whose subject is the space, plus the space's sync URL. No artifact or
+account-service change.
+
+## Created-space backup (the new producer)
+
+A created space is a full signer: `create_repository`
+(`rust/tonk-worker/src/router/repository.rs:2361`) mints an `Ed25519Signer` and
+returns `Repository<SignerCredential>`. It already issues a `space -> profile`
+delegation via `repository.access().claim(&repository).delegate(profile_did)`
+(`repository.rs:2397`). We mint `space -> root` the same way —
+`.delegate(root_did)` — which is subject-specific (the space DID) and carries
+full space authority, so a restored device acts with the founder's rights
+through the composed `space -> root -> device` chain.
+
+Create is local-only; the remote is attached later. So created-space backup
+fires **when a created space gains a remote** — `enable_sync_inner`
+(`repository.rs:1988`) and the create-with-remote `put_repository` path
+(`repository.rs:216`). When the profile is account-linked: mint `space -> root`,
+push `{chain, remote_url}` to `/chains/put`. Best-effort and fire-and-forget,
+exactly like the 3A claim backup (`account_backup.rs` `back_up_claim`). A
+local-only space with no remote is not backed up — there is nothing for another
+device to sync.
+
+## Restore consumer + a shared mount helper
+
+The claim path's replica-mount is reused. Extract `mount_replica(tonk, subject,
+remote_url) -> key` from `join.rs:242-291` — the verifier-only credential
+(`Credential::from(Ed25519Verifier)`), the `Subject::from(profile).attenuate(
+Space::new(key)).create(...)` local replica, the remote/branch configuration,
+the **local replica-meta index** entry, and `mark_replica_initialized`.
+
+Crucially, `mount_replica` must **not** write the content-branch roster.
+Today `record_repository_meta` (`repository.rs:2448`) bundles two things: the
+local replica-meta index (device-local, needed by both claim and restore) and
+`record_membership_on_content` (a content-branch `Membership`/`MemberRole`/
+`MemberName` write). The extraction separates them — `mount_replica` keeps the
+local-meta half; the content-roster half stays a claim-only step. See Roster
+via sync for why restore must not write it. **Claim** = `mount_replica` +
+`record_membership_on_content` + `record_claim_on_content`; **restore** =
+`mount_replica` + save-delegation + sync.
+
+Restore, best-effort per item:
+
+1. Resolve `account_link` (the `root -> device` chain), the account-service URL,
+   and the device signer — the same three `back_up_claim` resolves.
+2. `/chains/list` -> keys; `/chains/get` per key -> `ClaimBackup` bytes.
+3. Per artifact: parse the chain, take `subject = chain.subject()`. If a replica
+   for that subject already exists (`find_replica_for_subject`), skip. Else save
+   the chain to the access store (presign's BFS composes it with the local
+   `root -> device`), `mount_replica(subject, remote_url)`, and trigger a sync.
+
+Two new client functions, `list` and `get`, parallel the 3A `put` client in
+`account_backup.rs`: the same `tonk_identity::request::build_device_invocation`
+with commands `["account","chain","list"]` (no args, JSON array of keys) and
+`["account","chain","get"]` (arg `key`, raw octet-stream body).
+
+## Roster comes via sync, not re-written
+
+Restore writes no roster rows, and this is a correctness requirement, not just
+leanness. `Membership`/`MemberRole`/`MemberName` already live on each space's
+content branch keyed on the **root DID** (written by whichever device claimed
+or created the space). Once the restored replica syncs, those rows arrive, and
+`is_self` matches (mount and reader both resolve through `member_did` -> root).
+
+If restore instead re-ran the claim's content write, it would stamp
+`MemberRole::member` — but `MemberRole` is cardinality-one, and
+`record_membership_on_content` asserts it **unconditionally** (unlike the
+claim's `record_claim_on_content`, which guards on `already_roled`). On a space
+the account *created*, that member stamp would overwrite the `founder` role
+(last-write-wins) — a self-inflicted demotion that then syncs out. So restore
+mounts and installs the delegation only; the roster is authoritative on the
+content branch and arrives over sync.
+
+## Triggers and the staleness tradeoff
+
+Restore runs best-effort and fire-and-forget at two points:
+
+- **On device link** — the `link` handler (`rust/tonk-worker/src/router/account.rs:147`),
+  after it persists the `root -> device` chain.
+- **On startup for a linked profile** — after `bootstrap_profile` in
+  `TonkServiceWorker::new` (`rust/tonk-worker/src/worker.rs:1678`), gated on
+  `account_link` being present.
+
+Both spawn detached (wasm `spawn_local`; native bounded), so a slow account
+service never blocks link or boot — the 3A posture.
+
+Tradeoff: a space claimed on device A appears on device B only after B's next
+link or restart; there is no live push. Accepted for this round. A live refresh
+(periodic, or on a sync signal) is a deliberate follow-up.
+
+## Testing
+
+- **Native:** the `list`/`get` client and the `space -> root` mint against the
+  real `AccountServer` (extend the account-service HTTP test); the
+  `mount_replica` extraction (existing claim tests stay green).
+- **Wasm/service-worker (CI web leg):** a restore run mounts a backed-up space
+  and its roster syncs in; a created space with sync enabled is backed up.
+- **Idempotency:** a second restore over the same account is a no-op (replicas
+  already mounted).
+
+## Build order
+
+Two PRs off the 3A branch (`feat/root-did-rosters`), rebased onto `staging`
+once 3A merges:
+
+1. Extract `mount_replica` (claim refactored onto it, behavior unchanged);
+   created-space backup — mint `space -> root` and push on sync-enable /
+   create-with-remote.
+2. The restore consumer — `list`/`get` client, the mount loop, and the link +
+   startup triggers.
+
+## Risks
+
+- **Staleness** (above) — restore is trigger-based, not live. Bounded and
+  documented; the space still arrives on the next link/restart.
+- **Full authority via `space -> root` for created spaces.** The delegation is
+  unattenuated, so every linked device is a full co-owner of spaces the account
+  created. That is the intent (your devices are you), but it means revoking a
+  device (stage 3B/revocation) is the only way to cut a lost device off from
+  created spaces — same trade-off the identity design already accepts for
+  `root -> device`.
+- **Backup without a remote.** A created, never-synced space is not backed up;
+  enabling sync later triggers the backup. If a space is shared before sync is
+  enabled (not a current flow), it would be missed — the backup hook must sit
+  wherever a remote is first attached.
+- **Mount/pull latency at scale.** Restoring an account with many spaces mounts
+  and syncs each on link/boot; the fire-and-forget dispatch keeps it off the
+  critical path, but a very large account could see a slow trickle of spaces
+  appearing. Acceptable for the expected space counts.

--- a/docs/superpowers/specs/2026-07-23-cross-device-restore-design.md
+++ b/docs/superpowers/specs/2026-07-23-cross-device-restore-design.md
@@ -49,13 +49,24 @@ full space authority, so a restored device acts with the founder's rights
 through the composed `space -> root -> device` chain.
 
 Create is local-only; the remote is attached later. So created-space backup
-fires **when a created space gains a remote** — `enable_sync_inner`
-(`repository.rs:1988`) and the create-with-remote `put_repository` path
-(`repository.rs:216`). When the profile is account-linked: mint `space -> root`,
+fires **when a created space gains a remote** — hooked in `enable_sync_inner`
+(`repository.rs:1988`), which is where the account-holder create flow attaches
+its remote (`CreateSpaceHandler` runs `create_space_inner` local-only, then
+`enable_sync_inner`). When the profile is account-linked: mint `space -> root`,
 push `{chain, remote_url}` to `/chains/put`. Best-effort and fire-and-forget,
 exactly like the 3A claim backup (`account_backup.rs` `back_up_claim`). A
 local-only space with no remote is not backed up — there is nothing for another
 device to sync.
+
+**Not hooked (deliberate follow-up):** the one-shot `PUT /api/repository/{name}`
+with a remote in the body (`put_repository`, `repository.rs:216`) attaches a
+remote without going through `enable_sync_inner`, so a space created that way is
+not backed up. The account-holder UI never uses this path (it creates
+local-only then enables sync), so the exposure is limited to non-UI /
+programmatic callers; it fails open (the space works locally, it just does not
+restore on another device). Hooking it needs the raw sync URL recovered from
+the parsed `SiteAddress` in the request configuration; tracked as a follow-up
+rather than done here.
 
 ## Restore consumer + a shared mount helper
 

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -205,6 +205,22 @@ async fn it_drives_the_full_ceremony_over_http() {
     let put_result: serde_json::Value = response.json().await.unwrap();
     let key = put_result["key"].as_str().unwrap().to_string();
 
+    // POST /chains/list -> the key we just put shows up.
+    let body = container(
+        vec!["account".into(), "chain".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/chains/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let keys: Vec<String> = response.json().await.unwrap();
+    assert!(keys.contains(&key));
+
     let mut get_args = BTreeMap::new();
     get_args.insert("key".to_string(), Promised::String(key));
     let body = container(

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -20,6 +20,8 @@ mod account;
 
 mod account_backup;
 
+mod restore;
+
 mod join;
 pub use join::{JoinRequest, JoinResponse};
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -20,7 +20,7 @@ mod account;
 
 mod account_backup;
 
-mod restore;
+pub(crate) mod restore;
 
 mod join;
 pub use join::{JoinRequest, JoinResponse};

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -148,6 +148,13 @@ pub async fn link(
     State(state): State<AppState>,
     Json(request): Json<AccountLinkRequest>,
 ) -> Result<Json<AccountStatus>, TonkWorkerError> {
+    // Keep the cloneable `AppState` handle around: `state` is about to be
+    // shadowed by a read guard for the body of this handler, but the
+    // fire-and-forget restore dispatch below needs its own independent
+    // read lock inside a detached task. Native awaits restore inline using
+    // the guard already held below, so it never needs this clone.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    let app_state = state.clone();
     let state = state.read().await;
     let device_did = state.profile.did();
     let (chain, bytes) = validate_link(&request, &device_did).await?;
@@ -182,6 +189,23 @@ pub async fn link(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to save local account link: {error}"))
         })?;
+
+    // A freshly linked device pulls the account's backed-up spaces in the
+    // background — a slow/hung account service must never stall the link
+    // response. On wasm, dispatch detached with its own read lock; on
+    // native there's no UI to stall, so it awaits inline using the guard
+    // already held for this handler.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = app_state.read().await;
+            crate::router::restore::restore_spaces(&tonk).await;
+        });
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        crate::router::restore::restore_spaces(&state).await;
+    }
 
     Ok(Json(AccountStatus::Linked {
         root_did: request.root_did,

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -1,5 +1,7 @@
-//! Best-effort backup of a claimed space's delegation to the account
-//! service, so a later device can recover the space.
+//! Best-effort backup of a delegation chain to the account service, so a
+//! later device can recover the space. Covers both a claimed space's
+//! `space -> eph -> root` chain and a created space's one-hop
+//! `space -> root` chain.
 
 use dialog_credentials::Ed25519Signer;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -13,12 +15,15 @@ use tonk_common::log;
 use crate::TonkWorkerError;
 use crate::worker::TonkState;
 
-/// What gets backed up per claimed space: the delegation chain plus the
-/// invite's sync URL, which the chain itself does not carry. A restoring
-/// device needs both to mount and sync the space.
+/// What gets backed up per space: the delegation chain plus the invite's
+/// sync URL, which the chain itself does not carry. A restoring device
+/// needs both to mount and sync the space. The chain is either a claimed
+/// space's `space -> eph -> root` chain or a created space's one-hop
+/// `space -> root` chain.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct ClaimBackup {
-    /// Hex-encoded `space → eph → root` delegation chain.
+    /// Hex-encoded delegation chain: `space -> eph -> root` for a claimed
+    /// space, or the one-hop `space -> root` for a created space.
     pub chain_hex: String,
     /// The invite's remote/sync URL, when it carried one.
     pub remote_url: Option<String>,
@@ -27,7 +32,7 @@ pub(crate) struct ClaimBackup {
 /// Resolve the account-service base URL for this context. Unknown hosts
 /// resolve to `None` so backup is skipped rather than failing.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn account_service_url() -> Option<String> {
+pub(crate) fn account_service_url() -> Option<String> {
     use wasm_bindgen::JsCast;
     let scope: web_sys::ServiceWorkerGlobalScope = js_sys::global().dyn_into().ok()?;
     match scope.location().host().as_str() {
@@ -38,7 +43,7 @@ fn account_service_url() -> Option<String> {
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-fn account_service_url() -> Option<String> {
+pub(crate) fn account_service_url() -> Option<String> {
     std::env::var("TONK_ACCOUNT_SERVICE_URL")
         .ok()
         .or_else(|| Some("https://accounts.tonk.xyz".to_owned()))
@@ -91,6 +96,113 @@ async fn post_chains_put(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorker
         )));
     }
     Ok(())
+}
+
+/// POST a device-signed invocation container to the account service and
+/// return the raw response body bytes.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn post_for_bytes(endpoint: &str, body: Vec<u8>) -> Result<Vec<u8>, TonkWorkerError> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Request, RequestInit, Response};
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&js_sys::Uint8Array::from(body.as_slice()).into());
+    let request = Request::new_with_str_and_init(endpoint, &init)
+        .map_err(|e| TonkWorkerError::Internal(format!("account-service request: {e:?}")))?;
+    let global: web_sys::ServiceWorkerGlobalScope = js_sys::global()
+        .dyn_into()
+        .map_err(|_| TonkWorkerError::Internal("not in a service-worker scope".to_owned()))?;
+    let response: Response = JsFuture::from(global.fetch_with_request(&request))
+        .await
+        .and_then(|v| v.dyn_into())
+        .map_err(|e| TonkWorkerError::Internal(format!("account-service fetch: {e:?}")))?;
+    if !response.ok() {
+        return Err(TonkWorkerError::Internal(format!(
+            "account-service returned HTTP {}",
+            response.status()
+        )));
+    }
+    let buffer = JsFuture::from(
+        response
+            .array_buffer()
+            .map_err(|e| TonkWorkerError::Internal(format!("account-service body: {e:?}")))?,
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("account-service body: {e:?}")))?;
+    let array = js_sys::Uint8Array::new(&buffer);
+    Ok(array.to_vec())
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn post_for_bytes(endpoint: &str, body: Vec<u8>) -> Result<Vec<u8>, TonkWorkerError> {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .body(body)
+        // Same reasoning as `post_chains_put`: bound the wait so a wedged
+        // account service can't wedge the native caller.
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("account-service: {e}")))?;
+    if !response.status().is_success() {
+        return Err(TonkWorkerError::Internal(format!(
+            "account-service returned HTTP {}",
+            response.status()
+        )));
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("account-service body: {e}")))?;
+    Ok(bytes.to_vec())
+}
+
+/// List the keys of every chain this account has backed up. Used by
+/// restore to discover what can be pulled from the account service.
+#[allow(dead_code, reason = "wired into the restore flow in a follow-up task")]
+pub(crate) async fn list_backed_up_chains(
+    device: &Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+) -> Result<Vec<String>, TonkWorkerError> {
+    let body = tonk_identity::request::build_device_invocation(
+        device.clone(),
+        link,
+        vec!["account".into(), "chain".into(), "list".into()],
+        std::collections::BTreeMap::new(),
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build list invocation: {e}")))?;
+    let endpoint = format!("{}/chains/list", service.trim_end_matches('/'));
+    let bytes = post_for_bytes(&endpoint, body).await?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| TonkWorkerError::Internal(format!("parse chain keys: {e}")))
+}
+
+/// Fetch one backed-up chain's raw artifact bytes by key. Used by restore
+/// to pull down a chain discovered via [`list_backed_up_chains`].
+#[allow(dead_code, reason = "wired into the restore flow in a follow-up task")]
+pub(crate) async fn get_backed_up_chain(
+    device: &Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+    key: &str,
+) -> Result<Vec<u8>, TonkWorkerError> {
+    let arguments = [("key".to_owned(), Promised::String(key.to_owned()))]
+        .into_iter()
+        .collect();
+    let body = tonk_identity::request::build_device_invocation(
+        device.clone(),
+        link,
+        vec!["account".into(), "chain".into(), "get".into()],
+        arguments,
+    )
+    .await
+    .map_err(|e| TonkWorkerError::Internal(format!("build get invocation: {e}")))?;
+    let endpoint = format!("{}/chains/get", service.trim_end_matches('/'));
+    post_for_bytes(&endpoint, body).await
 }
 
 /// Build the backup artifact, sign the device invocation, and POST it to

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -161,7 +161,6 @@ async fn post_for_bytes(endpoint: &str, body: Vec<u8>) -> Result<Vec<u8>, TonkWo
 
 /// List the keys of every chain this account has backed up. Used by
 /// restore to discover what can be pulled from the account service.
-#[allow(dead_code, reason = "wired into the restore flow in a follow-up task")]
 pub(crate) async fn list_backed_up_chains(
     device: &Ed25519Signer,
     link: &DelegationChain,
@@ -183,7 +182,6 @@ pub(crate) async fn list_backed_up_chains(
 
 /// Fetch one backed-up chain's raw artifact bytes by key. Used by restore
 /// to pull down a chain discovered via [`list_backed_up_chains`].
-#[allow(dead_code, reason = "wired into the restore flow in a follow-up task")]
 pub(crate) async fn get_backed_up_chain(
     device: &Ed25519Signer,
     link: &DelegationChain,

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -2,6 +2,10 @@
 //! service, so a later device can recover the space.
 
 use dialog_credentials::Ed25519Signer;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use dialog_repository::Repository;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 use dialog_ucan_core::promise::Promised;
 use tonk_common::log;
@@ -128,9 +132,10 @@ async fn run_backup(
     post_chains_put(&endpoint, body).await
 }
 
-/// Back up a claimed space's delegation to the account service.
-/// Best-effort: any failure logs and is swallowed — the claiming device
-/// already works, and the roster keys on the root regardless.
+/// Resolve the account link, service URL, and device signer, then hand the
+/// backup off to [`run_backup`]. Shared by every backup caller
+/// ([`back_up_claim`] and [`back_up_owned_space`]): a no-op when the
+/// profile is unlinked or the account service is unknown for this host.
 ///
 /// The lookups here (account link, service URL, device signer) are cheap
 /// local reads, so they run inline. The actual network POST is handed off
@@ -138,10 +143,11 @@ async fn run_backup(
 /// service can never stall the caller's `.await`; on native the caller has
 /// no UI to stall, so it awaits inline, bounded by `post_chains_put`'s
 /// request timeout.
-pub(crate) async fn back_up_claim(
+async fn dispatch_backup(
     tonk: &TonkState,
-    chain: &DelegationChain,
-    remote_url: Option<&str>,
+    context: &'static str,
+    chain: DelegationChain,
+    remote_url: Option<String>,
 ) {
     // Only account-holders back up; an unlinked device has no account to
     // escrow under and returns early.
@@ -152,14 +158,12 @@ pub(crate) async fn back_up_claim(
         return;
     };
     let device = tonk.profile.signer().signer().clone();
-    let chain = chain.clone();
-    let remote_url = remote_url.map(str::to_owned);
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         wasm_bindgen_futures::spawn_local(async move {
             if let Err(error) = run_backup(device, link, service, chain, remote_url).await {
-                log!("claim backup failed: {error}");
+                log!("{context} backup failed: {error}");
             }
         });
     }
@@ -167,9 +171,81 @@ pub(crate) async fn back_up_claim(
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
         if let Err(error) = run_backup(device, link, service, chain, remote_url).await {
-            log!("claim backup failed: {error}");
+            log!("{context} backup failed: {error}");
         }
     }
+}
+
+/// Back up a claimed space's delegation to the account service.
+/// Best-effort: any failure logs and is swallowed — the claiming device
+/// already works, and the roster keys on the root regardless.
+pub(crate) async fn back_up_claim(
+    tonk: &TonkState,
+    chain: &DelegationChain,
+    remote_url: Option<&str>,
+) {
+    dispatch_backup(tonk, "claim", chain.clone(), remote_url.map(str::to_owned)).await;
+}
+
+/// Back up a created space's `space -> root` delegation so another of the
+/// account's devices can restore it. Best-effort and fire-and-forget; a
+/// no-op when the profile is unlinked, or when `repository` doesn't hold a
+/// signer (a joined/verifier-only space has nothing to delegate from —
+/// only the space that created it can mint this).
+///
+/// Only called from the wasm worker today (its one hook is
+/// `enable_sync_inner`, which is itself worker-only), so this — like that
+/// hook — is worker-only rather than carrying dead code on native.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn back_up_owned_space(
+    tonk: &TonkState,
+    repository: &Repository,
+    remote_url: &str,
+) {
+    if let Err(error) = try_back_up_owned_space(tonk, repository, remote_url).await {
+        log!("created-space backup skipped: {error}");
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn try_back_up_owned_space(
+    tonk: &TonkState,
+    repository: &Repository,
+    remote_url: &str,
+) -> Result<(), TonkWorkerError> {
+    // A repository loaded via `.load()` carries a verifier-only credential
+    // for a space this profile only joined; only a space this profile
+    // created still holds its signing key and can mint a delegation from
+    // it directly.
+    let Some(access) = repository.try_access() else {
+        return Ok(());
+    };
+    // No account linked: nothing to escrow the delegation under.
+    let Some(root_did) = crate::router::account::account_root_did(tonk).await else {
+        return Ok(());
+    };
+
+    // One-hop, subject-specific delegation: issuer = the space itself,
+    // subject = the space DID, audience = the account root. Never
+    // `Subject::Any` — a restoring device must only ever recover the one
+    // space this chain names.
+    let delegation: UcanDelegation = access
+        .claim(repository)
+        .delegate(root_did)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| {
+            TonkWorkerError::Internal(format!("failed to mint space->root delegation: {e}"))
+        })?;
+
+    dispatch_backup(
+        tonk,
+        "created-space",
+        delegation.into_chain(),
+        Some(remote_url.to_owned()),
+    )
+    .await;
+    Ok(())
 }
 
 #[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -49,7 +49,8 @@ use tonk_schema::{
 use super::AppState;
 use super::repository::{
     BranchConfiguration, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,
-    UpstreamConfiguration, build_repository_info, mark_replica_initialized, record_repository_meta,
+    UpstreamConfiguration, build_repository_info, mark_replica_initialized,
+    record_membership_on_content, record_replica_meta,
 };
 use crate::{TonkWorkerError, worker::TonkState};
 
@@ -239,14 +240,65 @@ pub(crate) async fn claim_invite(
         });
     }
 
-    // Create a verifier-only credential keyed to the invited
-    // subject DID, then mount it as a local replica at the routing
-    // key (so path == identity). Local DID == invited subject DID, so
-    // `Replica.this` and the sigil glyph converge across recipients.
+    // Mount a verifier-only local replica keyed to the invited subject
+    // DID (so path == identity; `Replica.this` and the sigil glyph
+    // converge across recipients) and wire up its remote/branch
+    // configuration, mirroring what `PUT /api/repository/{name}` writes.
+    // `mount_replica` only lays down the device-local meta — the
+    // content roster is this claim's job, below.
+    let (key, repository) =
+        mount_replica(tonk, &subject, remote_url.as_ref().map(url::Url::as_str)).await?;
+
+    // Roster on the content branch: the claimer is a member. (mount_replica
+    // wrote only the device-local meta; the content roster is claim-only.)
+    record_membership_on_content(tonk, &repository, &key, tonk_schema::MemberRole::MEMBER).await?;
+    record_claim_on_content(tonk, &repository, &key, &invitation, &member).await?;
+
+    // `record_membership_on_content` stamps the replica's roster row, but
+    // the replica itself is still marked `blank` (the create path's
+    // "still seeding" state) by `mount_replica`. A joined replica has no
+    // local seed step — its content arrives over the pull the recipient
+    // triggers — so flip it straight to `initialized`, otherwise its Hub
+    // card is stuck on "Installing…" forever.
+    mark_replica_initialized(tonk, &subject).await?;
+
+    log!("Joined invite for subject {subject} as local replica (key {key})");
+
+    Ok(JoinOutcome {
+        key,
+        subject,
+        renewed: false,
+    })
+}
+
+/// Mount a local verifier-only replica for `subject` and configure its
+/// remote/branch, without touching the content roster.
+///
+/// Shared by the invite claim (which writes a `member` roster row
+/// afterward) and by cross-device restore (which writes nothing —
+/// the roster already exists on the content branch it pulls). Local
+/// DID == `subject` DID, so `Replica.this` (`hash(profile, subject)`)
+/// and the sigil glyph converge across every recipient of the same
+/// space.
+///
+/// Callers that care about idempotency (join, restore) should check
+/// [`find_replica_for_subject`] first — this always creates.
+///
+/// Returns the routing key (the DID suffix) and the mounted
+/// repository handle, so the caller can write further facts (e.g.
+/// the roster) without a reload.
+pub(crate) async fn mount_replica(
+    tonk: &TonkState,
+    subject: &Did,
+    remote_url: Option<&str>,
+) -> Result<(String, Repository<Credential>), TonkWorkerError> {
+    let key = subject.repo_key().to_owned();
+
+    // Create a verifier-only credential keyed to the subject DID, then
+    // mount it as a local replica at the routing key (so path ==
+    // identity).
     let verifier: Ed25519Verifier = subject.to_string().parse().map_err(|e| {
-        TonkWorkerError::Router(format!(
-            "invite subject is not a valid Ed25519 did:key: {e:?}"
-        ))
+        TonkWorkerError::Router(format!("subject is not a valid Ed25519 did:key: {e:?}"))
     })?;
     let credential = Credential::from(verifier);
 
@@ -256,18 +308,16 @@ pub(crate) async fn claim_invite(
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
-            TonkWorkerError::Internal(format!(
-                "failed to create local replica '{key}' for invited subject: {e}",
-            ))
+            TonkWorkerError::Internal(format!("failed to create local replica '{key}': {e}"))
         })?;
     let repository = Repository::from(space_credential);
 
-    // Mirror what `PUT /api/repository/{name}` writes: a single
-    // `main` branch, plus an `origin` remote tracking the
-    // invite's access service if one was attached.
+    // Mirror what `PUT /api/repository/{name}` writes: a single `main`
+    // branch, plus an `origin` remote tracking the invite's/space's
+    // access service if one was attached.
     let mut configuration = RepositoryConfiguration::default();
     if let Some(url) = remote_url {
-        let address = SiteAddress::from(UcanAddress::new(url.as_str()));
+        let address = SiteAddress::from(UcanAddress::new(url));
         configuration = configuration
             .remote(
                 DEFAULT_REMOTE,
@@ -284,35 +334,14 @@ pub(crate) async fn claim_invite(
         configuration = configuration.branch(DEFAULT_BRANCH, BranchConfiguration::default());
     }
 
-    // No display name to seed: a joined repo's name lives in the shared
-    // content branch and arrives over the pull the Hub triggers when it
-    // queries the repo for its name. `record_repository_meta` only uses
-    // this for log context + the home-demo check (never matched here), so
-    // the routing key stands in.
-    record_repository_meta(
-        tonk,
-        &repository,
-        &key,
-        &configuration,
-        tonk_schema::MemberRole::MEMBER,
-    )
-    .await?;
-    record_claim_on_content(tonk, &repository, &key, &invitation, &member).await?;
+    // No display name to seed: a joined/restored repo's name lives in
+    // the shared content branch and arrives over the pull the recipient
+    // triggers by querying the repo. `record_replica_meta` only uses
+    // this for log context, so the routing key stands in. Device-local
+    // meta only — no content roster.
+    record_replica_meta(tonk, &repository, &key, &configuration).await?;
 
-    // `record_repository_meta` stamps the replica `blank` (the create
-    // path's "still seeding" state). A joined replica has no local seed
-    // step — its content arrives over the pull the recipient triggers —
-    // so flip it straight to `initialized`, otherwise its Hub card is
-    // stuck on "Installing…" forever.
-    mark_replica_initialized(tonk, &subject).await?;
-
-    log!("Joined invite for subject {subject} as local replica (key {key})");
-
-    Ok(JoinOutcome {
-        key,
-        subject,
-        renewed: false,
-    })
+    Ok((key, repository))
 }
 
 /// Record the roster facts for a claimed invite on the repo's content

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -461,7 +461,7 @@ where
 /// The replica is a name-less membership index, so this only tests
 /// existence — the recipient's chosen join name does not flow into it
 /// (the name lives in the synced repository's own `tonk/repository`).
-async fn find_replica_for_subject(
+pub(crate) async fn find_replica_for_subject(
     tonk: &TonkState,
     subject: &Did,
 ) -> Result<bool, TonkWorkerError> {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2445,12 +2445,15 @@ pub async fn create_repository(
 /// either via `repository.access().claim().delegate()` for self-
 /// owned repos or via `profile.access().save(invite_chain)` for
 /// invited replicas).
-pub async fn record_repository_meta<C>(
+///
+/// Does not touch the content-branch roster — see
+/// [`record_repository_meta`] for the wrapper that also records
+/// membership.
+pub(crate) async fn record_replica_meta<C>(
     tonk: &TonkState,
     repository: &Repository<C>,
     display_name: &str,
     configuration: &RepositoryConfiguration,
-    role_uri: &str,
 ) -> Result<(), RepositoryError>
 where
     C: Principal + Clone,
@@ -2627,13 +2630,6 @@ where
         },
     );
 
-    // Record the opening profile's membership on the content branch.
-    // Roster facts must live on `main` (which syncs across replicas),
-    // not on the local-only meta branch — otherwise each replica only
-    // ever sees its own membership and the roster never converges. The
-    // branch loop above has already opened `main`, so it is present.
-    record_membership_on_content(tonk, repository, key, role_uri).await?;
-
     // 7. Record this replica in the profile repository's meta
     // branch so the profile keeps an index of every replica it
     // owns. Separate transaction — cross-repo atomicity isn't
@@ -2648,6 +2644,25 @@ where
     tonk.reactor.run_scheduled_polls(&tonk.operator).await;
 
     Ok(())
+}
+
+/// Lay down the meta-branch facts and profile index, then record the
+/// opening profile's membership on the content branch. The two halves
+/// are split so the join/restore mount can reuse the meta half without
+/// the roster write (restore must not stamp a role — see the restore
+/// path).
+pub async fn record_repository_meta<C>(
+    tonk: &TonkState,
+    repository: &Repository<C>,
+    display_name: &str,
+    configuration: &RepositoryConfiguration,
+    role_uri: &str,
+) -> Result<(), RepositoryError>
+where
+    C: Principal + Clone,
+{
+    record_replica_meta(tonk, repository, display_name, configuration).await?;
+    record_membership_on_content(tonk, repository, repository.did().repo_key(), role_uri).await
 }
 
 /// Assert the opening profile's [`Membership`] + [`MemberRole`] +

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2020,7 +2020,14 @@ async fn enable_sync_inner(
         }
     };
 
-    ensure_remote_config(&tonk, &repository, key, &configuration).await
+    ensure_remote_config(&tonk, &repository, key, &configuration).await?;
+
+    // Escrow this owned space's delegation so the account's other devices
+    // can restore it. Best-effort; no-op for unlinked profiles or for a
+    // repository that doesn't hold its signer (i.e. wasn't created here).
+    crate::router::account_backup::back_up_owned_space(&tonk, &repository, remote).await;
+
+    Ok(())
 }
 
 /// Spawn the background seed + status flip for a freshly created

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2847,7 +2847,7 @@ async fn set_replica_status(
 /// local seed step (its content arrives over the pull), so it would
 /// otherwise sit at the `blank` status `record_repository_meta` stamps,
 /// stuck on an installing card forever.
-pub(super) async fn mark_replica_initialized(
+pub(crate) async fn mark_replica_initialized(
     tonk: &TonkState,
     subject: &Did,
 ) -> Result<(), RepositoryError> {

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -246,6 +246,14 @@ pub async fn put_repository(
     let key = subject.repo_key().to_owned();
     let info = build_repository_info(&tonk, &key, &repository).await;
 
+    // A space created with a remote in this one shot is not escrowed for
+    // cross-device restore: the account-holder create flow attaches its
+    // remote through `enable_sync_inner` (which does escrow it), never
+    // this path, so only non-UI callers reach here with a remote. Backing
+    // it up would need the sync URL recovered from the parsed
+    // configuration; left as a follow-up. Fails open — the space works
+    // locally, it just will not follow the user to another device.
+
     // Seed asynchronously, then flip the replica to `initialized`.
     // Seeding the standard library is the slow part (~seconds of
     // prolly-tree commits); doing it inline would block this response

--- a/rust/tonk-worker/src/router/restore.rs
+++ b/rust/tonk-worker/src/router/restore.rs
@@ -1,0 +1,86 @@
+//! Pull the account's backed-up space delegations and mount any space
+//! this device does not already have. Best-effort: failures log and are
+//! swallowed; nothing here blocks link or boot.
+
+use dialog_ucan::UcanDelegation;
+use dialog_ucan_core::DelegationChain;
+use tonk_common::log;
+
+use crate::router::account_backup::{
+    ClaimBackup, account_service_url, get_backed_up_chain, list_backed_up_chains,
+};
+use crate::worker::TonkState;
+
+/// Restore all backed-up spaces for the linked account. No-op when
+/// unlinked or when the account service is unreachable.
+#[allow(
+    dead_code,
+    reason = "wired into link/startup triggers in a follow-up task"
+)]
+pub(crate) async fn restore_spaces(tonk: &TonkState) {
+    if let Err(error) = try_restore_spaces(tonk).await {
+        log!("restore skipped: {error}");
+    }
+}
+
+async fn try_restore_spaces(tonk: &TonkState) -> Result<(), crate::TonkWorkerError> {
+    let Some(link) = crate::router::account::account_link(tonk).await else {
+        return Ok(());
+    };
+    let Some(service) = account_service_url() else {
+        return Ok(());
+    };
+    let device = tonk.profile.signer().signer().clone();
+
+    let keys = list_backed_up_chains(&device, &link, &service).await?;
+    for key in keys {
+        if let Err(error) = restore_one(tonk, &device, &link, &service, &key).await {
+            // One bad artifact must not stop the rest.
+            log!("restore of chain '{key}' skipped: {error}");
+        }
+    }
+    Ok(())
+}
+
+async fn restore_one(
+    tonk: &TonkState,
+    device: &dialog_credentials::Ed25519Signer,
+    link: &DelegationChain,
+    service: &str,
+    key: &str,
+) -> Result<(), crate::TonkWorkerError> {
+    let bytes = get_backed_up_chain(device, link, service, key).await?;
+    let artifact: ClaimBackup = serde_json::from_slice(&bytes)
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad backup artifact: {e}")))?;
+    let chain_bytes = hex::decode(&artifact.chain_hex)
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad chain hex: {e}")))?;
+    let chain = DelegationChain::try_from(chain_bytes.as_slice())
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("bad chain: {e}")))?;
+
+    let subject = chain
+        .subject()
+        .ok_or_else(|| crate::TonkWorkerError::Internal("backup chain has no subject".into()))?
+        .clone();
+
+    // Already have it? Nothing to do.
+    if crate::router::join::find_replica_for_subject(tonk, &subject).await? {
+        return Ok(());
+    }
+
+    // Install the delegation so presign's BFS can compose it with the
+    // local root -> device link, then mount and let sync bring the roster.
+    tonk.profile
+        .access()
+        .save(UcanDelegation(chain))
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| crate::TonkWorkerError::Internal(format!("save restored delegation: {e}")))?;
+
+    // Restore writes no content-branch roster (`Membership`/`MemberRole`/
+    // `MemberName`) — the roster is authoritative on the content branch
+    // and arrives over sync. Writing a role here would demote a founder
+    // on a space this account created.
+    crate::router::join::mount_replica(tonk, &subject, artifact.remote_url.as_deref()).await?;
+    crate::router::repository::mark_replica_initialized(tonk, &subject).await?;
+    Ok(())
+}

--- a/rust/tonk-worker/src/router/restore.rs
+++ b/rust/tonk-worker/src/router/restore.rs
@@ -2,6 +2,8 @@
 //! this device does not already have. Best-effort: failures log and are
 //! swallowed; nothing here blocks link or boot.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 use tonk_common::log;
@@ -11,16 +13,25 @@ use crate::router::account_backup::{
 };
 use crate::worker::TonkState;
 
+/// Guards against concurrent restore runs. Startup and a device-link
+/// response can both dispatch restore fire-and-forget close together; a
+/// second concurrent run would only race the first through
+/// `find_replica_for_subject` and risk double-mounting the same subject.
+static RESTORE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
 /// Restore all backed-up spaces for the linked account. No-op when
 /// unlinked or when the account service is unreachable.
-#[allow(
-    dead_code,
-    reason = "wired into link/startup triggers in a follow-up task"
-)]
 pub(crate) async fn restore_spaces(tonk: &TonkState) {
+    // A restore already running covers the same account; a second
+    // concurrent trigger would only race it. Skip and let the running
+    // one (or the next trigger) pick up any new spaces.
+    if RESTORE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
     if let Err(error) = try_restore_spaces(tonk).await {
         log!("restore skipped: {error}");
     }
+    RESTORE_IN_FLIGHT.store(false, Ordering::SeqCst);
 }
 
 async fn try_restore_spaces(tonk: &TonkState) -> Result<(), crate::TonkWorkerError> {

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1686,6 +1686,25 @@ impl TonkServiceWorker {
         let (router, state, lsp) = api_router_with_state(state);
         let router = Arc::new(Mutex::new(router));
 
+        // Catch up on spaces claimed/created on other devices since last
+        // boot. Fire-and-forget: account-service latency must not delay
+        // startup. `restore_spaces` itself no-ops when unlinked, so an
+        // unconditional call here is fine whether or not this profile
+        // turns out to be linked.
+        //
+        // Placed here rather than right after `bootstrap_profile` above
+        // because the cloneable `AppState` handle a detached task needs to
+        // take its own read lock doesn't exist until `state` is wrapped by
+        // `api_router_with_state` immediately above.
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        {
+            let state = state.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let tonk = state.read().await;
+                crate::router::restore::restore_spaces(&tonk).await;
+            });
+        }
+
         Ok(Self {
             router,
             state,


### PR DESCRIPTION
## Summary

The second half of the cross-device story (design: `docs/superpowers/specs/2026-07-23-cross-device-restore-design.md`). A linked device pulls the account's backed-up space delegations and auto-mounts each space, so a user's spaces follow them across devices — **claimed and created spaces both**.

Builds on stage 3A (#637, **merged**); base is `staging`.

## What's in it

- **Backup, two producers, one artifact.** Claim already escrows `space → eph → root` (3A). New: the create/sync-enable path escrows `space → root` (minted via `try_access()`, subject-specific, full authority) so created spaces are restorable. Both push the same `{chain_hex, remote_url}` to `/chains/put`.
- **`mount_replica`** extracted from the claim path (via a `record_repository_meta` → `record_replica_meta` split), shared by claim and restore. The claim rewire is behavior-preserving.
- **Restore consumer** (`restore.rs`): device-signed `/chains/list` + `/chains/get`, then per artifact — skip if already mounted, save the delegation (presign's BFS composes it with the local `root → device`), `mount_replica`, and let sync bring the roster. **Restore writes no content roster** — a role stamp would demote a founder on a created space (cardinality-one `MemberRole`).
- **Triggers:** fire-and-forget on device link and startup, with a process-wide in-flight guard against double-mounts.

## Testing

- **Executed & green:** `cargo test -p tonk-account-service --features helpers` (incl. a `/chains/list` assertion driving the production device-signed client), `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --check`, `cargo build -p tonk-worker --target wasm32-unknown-unknown`.
- **Not executed here (no browser automation in the build env):** the entire restore *runtime* is `run_in_service_worker`/wasm (created-space backup hook, restore mount loop, both triggers, wasm fetch arms). Compiles clean; runs in CI's `web` matrix leg. The security-sensitive crypto (device-signed client + `space → root`/`space → eph → root` serialization) **is** proven natively against the real `AccountServer`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR implements cross-device restore functionality, allowing linked devices to pull both claimed and created spaces from the account service. It introduces backup mechanisms for created spaces and a restore consumer to manage the restoration process.

### Detailed summary
- Added `mod restore` in `rust/tonk-worker/src/router.rs`.
- Created `restore_spaces` function in `rust/tonk-worker/src/router/restore.rs` to handle restoration.
- Implemented `list_backed_up_chains` and `get_backed_up_chain` functions in `rust/tonk-worker/src/router/account_backup.rs`.
- Enhanced `back_up_owned_space` to back up created spaces.
- Updated `ensure_remote_config` to trigger space backups when a remote is attached.
- Extended tests in `rust/tonk-account-service/tests/service.rs` to validate new functionalities.

> The following files were skipped due to too many changes: `docs/superpowers/plans/2026-07-23-cross-device-restore.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->