### PR TITLE
feat(account): migrate existing rosters to the account root (stage 3b)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-roster-migration.md
+++ b/docs/superpowers/plans/2026-07-23-roster-migration.md
@@ -1,0 +1,491 @@
+# Roster Migration (stage 3B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a device links to an account, converge its existing device-keyed spaces onto the root DID — re-key each roster row (retract device, re-stamp root, first-wins preserved), re-anchor the capability chain to the root, back up the re-anchored chain, and fix the profile-rename no-op.
+
+**Architecture:** A wasm-only migration sweep over `profile_space_keys` runs fire-and-forget on link, beside `restore_spaces`. Per space: an atomic content-branch transaction asserts the root-keyed roster rows and retracts the device-keyed ones; then (PR 2) a `try_access()`-discriminated re-anchor mints `space -> root` (owned) or `space -> eph -> device -> root` (claimed) and backs it up. Rename is fixed to key on the resolved member DID and retract the orphaned device name.
+
+**Tech Stack:** Rust (edition 2024). `dialog-*` pinned `tonk-2026-07-17`. Reuses 3A (`account::{member_did, account_root_did, account_link}`, the `/chains/put` backup client) and the restore branch (`back_up_owned_space`).
+
+## Global Constraints
+
+- Branch `feat/roster-migration` (cut from `feat/cross-device-restore`; carries the design doc). Rebase onto `staging` as 3A/restore land.
+- Do NOT bump the pinned dialog tag `tonk-2026-07-17`.
+- `Subject::Any` is only the `root -> device` link. Space delegations (`space -> root`, `space -> eph -> device -> root`) are subject-SPECIFIC. Never `Subject::Any` for a space.
+- Migration is BEST-EFFORT and FAIL-OPEN: it never fails a link or blocks local work; one space's failure is logged and skipped. Fire-and-forget so a slow account service can't stall link.
+- Re-key is ATOMIC per space: one transaction asserts root rows + retracts device rows. First-wins stamps (`MemberRole`, `InvitedVia`) are copied from the device row's read values onto the new entity — never assumed to carry over.
+- Idempotent: a space with no device-keyed `Membership` row is skipped; re-running is safe.
+- Migration is wasm-only (reuses `profile_space_keys`, `#[cfg(target_arch = "wasm32")]`).
+- Tests `#[dialog_common::test]`; `tonk-worker` wasm mods carry `wasm_bindgen_test_configure!(run_in_service_worker)`. No `mod.rs`. Conventional Commits, no emojis. Self-contained comments (no "3b"/spec references).
+- **Wasm tests HANG in the sandbox** — verify wasm-gated code by COMPILING (`cargo clippy -p tonk-worker --all-targets` + `cargo build -p tonk-worker --target wasm32-unknown-unknown`), never `test:web:debug`. Native tests run normally. CI's `web` leg executes the wasm tests.
+- Lint gate before each PR: `cargo clippy --workspace --all-targets --all-features` + `cargo fmt --check`.
+
+## File Structure
+
+- `rust/tonk-worker/src/router/migrate.rs` — **new**: `migrate_space_roster` (facts), `migrate_rosters` (sweep + guard), and (PR 2) `reanchor_space`.
+- `rust/tonk-worker/src/router.rs` — declare `pub(crate) mod migrate;`.
+- `rust/tonk-worker/src/router/account.rs` — link handler also fires `migrate_rosters`.
+- `rust/tonk-worker/src/router/profile_name.rs` — `restamp_member_name` keys on the member DID + retracts the device name.
+
+---
+
+## PR 1 — Facts: roster re-key + rename (Tasks 1-3)
+
+### Task 1: `migrate_space_roster` — atomic per-space re-key
+
+**Files:**
+- Create: `rust/tonk-worker/src/router/migrate.rs`
+- Modify: `rust/tonk-worker/src/router.rs` (`pub(crate) mod migrate;`)
+
+**Interfaces:**
+- Consumes: `crate::router::account::member_did`, the reactor content-branch acquire/transaction pattern, `tonk_schema::{Membership, MemberRole, MemberName, InvitedVia}`, `Query`/`Term`.
+- Produces: `pub(crate) async fn migrate_space_roster(tonk: &TonkState, key: &str) -> Result<bool, RepositoryError>` — returns `true` if it migrated a device-keyed row, `false` if the space was already root-keyed / not a member / unlinked. Consumed by Task 2 and (PR 2) Task 4.
+
+- [ ] **Step 1: Write the module + the re-key function**
+
+Create `migrate.rs` (wasm-only — it reuses wasm-only enumeration and mirrors `restamp_member_name`'s reactor pattern at `profile_name.rs:217`):
+
+```rust
+//! Converge a linked device's existing device-keyed spaces onto the
+//! account root DID.
+
+#[cfg(target_arch = "wasm32")]
+use tonk_common::log;
+
+#[cfg(target_arch = "wasm32")]
+use crate::router::account;
+#[cfg(target_arch = "wasm32")]
+use crate::router::repository::{CONTENT_BRANCH, RepositoryError};
+#[cfg(target_arch = "wasm32")]
+use crate::worker::TonkState;
+
+/// Re-key one space's roster from the device DID to the account root DID,
+/// atomically. Returns `Ok(true)` when a device-keyed row was migrated,
+/// `Ok(false)` when the space is already root-keyed, the profile isn't a
+/// member, or the profile is unlinked.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn migrate_space_roster(
+    tonk: &TonkState,
+    key: &str,
+) -> Result<bool, RepositoryError> {
+    use tonk_schema::{InvitedVia, MemberName, MemberRole, Membership};
+    use tonk_schema::prelude::*;
+    use dialog_reactor::query::{Query, Term};
+
+    let member = account::member_did(tonk).await;
+    let device = tonk.profile.did();
+    // Unlinked: no root to migrate to. (member_did == device DID.)
+    if member == device {
+        return Ok(false);
+    }
+
+    let session = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("acquire content '{key}': {e}")))?;
+    let subject = session.handle().of().clone();
+
+    let device_membership = Membership::new(device.clone(), subject.clone());
+    let device_entity = device_membership.this().clone();
+
+    // Is there a device-keyed row to migrate?
+    let memberships: Vec<Membership> = session
+        .handle()
+        .query()
+        .select(Query::<Membership> {
+            this: Term::var("this"),
+            subject: Term::from(subject.this()),
+            member: Term::var("member"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("membership query '{key}': {e:?}")))?;
+    let Some(device_row) = memberships.iter().find(|m| m.this == device_entity).cloned() else {
+        return Ok(false);
+    };
+
+    // Read the device row's stamps so they can be copied and retracted.
+    let roles: Vec<MemberRole> = session
+        .handle()
+        .query()
+        .select(Query::<MemberRole> { this: Term::var("this"), role: Term::var("role") })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("role query '{key}': {e:?}")))?;
+    let device_role = roles.iter().find(|r| r.this == device_entity).cloned();
+
+    let names: Vec<MemberName> = session
+        .handle()
+        .query()
+        .select(Query::<MemberName> { this: Term::var("this"), name: Term::var("name") })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
+    let device_name = names.iter().find(|n| n.this == device_entity).cloned();
+
+    let stamps: Vec<InvitedVia> = session
+        .handle()
+        .query()
+        .select(Query::<InvitedVia> { this: Term::var("this"), invitation: Term::var("invitation") })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("invited-via query '{key}': {e:?}")))?;
+    let device_stamp = stamps.iter().find(|s| s.this == device_entity).cloned();
+
+    // Build the root-keyed rows and one atomic assert+retract transaction.
+    let root_membership = Membership::new(member.clone(), subject.clone());
+    let root_entity = root_membership.this().clone();
+
+    let mut txn = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .transaction()
+        .assert(root_membership.clone())
+        .retract(device_row);
+
+    if let Some(role) = device_role {
+        let root_role = if role.role.0.to_string() == MemberRole::FOUNDER {
+            MemberRole::founder(root_entity.clone())
+        } else {
+            MemberRole::member(root_entity.clone())
+        };
+        txn = txn.assert(root_role).retract(role);
+    }
+    if let Some(name) = device_name {
+        txn = txn
+            .assert(MemberName::new(root_entity.clone(), name.name.0.clone()))
+            .retract(name);
+    }
+    if let Some(stamp) = device_stamp {
+        txn = txn
+            .assert(InvitedVia::new(root_entity.clone(), stamp.invitation.0.clone()))
+            .retract(stamp);
+    }
+
+    txn.commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("commit migration '{key}': {e}")))?;
+    log!("migrated roster for space '{key}' to the account root");
+    Ok(true)
+}
+```
+
+Declare in `router.rs`: `pub(crate) mod migrate;`.
+
+Confirm against `rust/tonk-schema/src/membership.rs` the exact field accessors: `role.role.0` (role URI value), `name.name.0` (String), `stamp.invitation.0` (invitation `Entity`), and that `MemberRole::FOUNDER` is the founder URI constant. Confirm `CONTENT_BRANCH` and `RepositoryError` are importable from `router::repository` (they're used by `profile_name.rs`). Adjust the `Query`/`Term` import path to match `profile_name.rs`/`join.rs` (they `use` them from the same place).
+
+- [ ] **Step 2: Write the failing test**
+
+Add a wasm test mod (mirrors `join.rs`'s roster tests — an account is linked, a device-keyed membership is written, migration runs, the root row is asserted and the device row gone). Use the existing test helpers (`test_state`, the account `link` handler with a `request_for`-style `root -> device`, `content_memberships`/`content_member_roles`/`content_memberships` readers from `crate::router::tests`). Assert after `migrate_space_roster`:
+- a `Membership` with `member.0 == root_did.this()` exists;
+- no `Membership` with `member.0 == device_did.this()`;
+- the `MemberRole` (founder if the seeded row was founder) is present on the root entity;
+- a second `migrate_space_roster` call returns `Ok(false)` (idempotent).
+
+(Model the setup on `join.rs`'s `it_keys_membership_on_the_root_did_for_an_account_holder`: link an account via `crate::router::account::link`, then seed a device-keyed membership by claiming/creating a space BEFORE... simpler: seed the device row directly with a content-branch transaction asserting `Membership::new(device_did, subject)` + `MemberRole::member(...)` + `MemberName::new(...)`, then run migration.)
+
+- [ ] **Step 3: Run compile-verify (wasm tests can't execute here)**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -40` (clean)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+Note: the test is `run_in_service_worker`; compiled here, executes in CI.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/migrate.rs rust/tonk-worker/src/router.rs
+git commit -m "feat(tonk-worker): re-key a space roster from device to account root"
+```
+
+---
+
+### Task 2: The migration sweep + link trigger
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/migrate.rs`
+- Modify: `rust/tonk-worker/src/router/account.rs` (link handler tail)
+
+**Interfaces:**
+- Consumes: `migrate_space_roster` (Task 1), `crate::router::profile_name::profile_space_keys` (make it `pub(crate)` — currently private at `profile_name.rs:130`), `crate::router::account::account_link`.
+- Produces: `pub(crate) async fn migrate_rosters(tonk: &TonkState)` — best-effort sweep; consumed by the link handler.
+
+- [ ] **Step 1: Add the sweep with an in-flight guard**
+
+In `migrate.rs` (mirror `restore.rs`'s guard + best-effort loop):
+
+```rust
+#[cfg(target_arch = "wasm32")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_arch = "wasm32")]
+static MIGRATE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Converge every existing device-keyed space onto the account root.
+/// Best-effort: no-op when unlinked; one space's failure is logged and
+/// skipped. A concurrent run is skipped (the guard), since both would
+/// migrate the same spaces.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn migrate_rosters(tonk: &TonkState) {
+    if account::account_link(tonk).await.is_none() {
+        return; // unlinked
+    }
+    if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    for key in crate::router::profile_name::profile_space_keys(tonk).await {
+        if let Err(error) = migrate_space_roster(tonk, &key).await {
+            log!("roster migration for space '{key}' skipped: {error}");
+        }
+    }
+    MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
+```
+
+Make `profile_space_keys` `pub(crate)` in `profile_name.rs:130` (change `async fn` to `pub(crate) async fn`).
+
+- [ ] **Step 2: Fire migration on link, fire-and-forget**
+
+In `account.rs` `link`, in the same post-persist tail where `restore_spaces` is dispatched (the `#[cfg]` wasm `spawn_local` block), add a migration dispatch beside it (a slow account service must not stall the link response). Both can share one spawned task:
+
+```rust
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let app_state = app_state.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = app_state.read().await;
+            crate::router::migrate::migrate_rosters(&tonk).await;
+            crate::router::restore::restore_spaces(&tonk).await;
+        });
+    }
+```
+
+(If `restore_spaces` is already spawned in its own block, fold both into that single spawned task in migrate-then-restore order rather than spawning twice — migration converges local spaces, restore pulls remote ones; running migration first means restore won't re-touch a space migration just re-keyed. Confirm the existing `app_state` clone from Task-6 of restore is reused, not double-moved.)
+
+- [ ] **Step 3: Compile-verify**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -40` (clean; the `migrate_rosters`/`profile_space_keys` visibility change resolves)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+Run: `cargo fmt -p tonk-worker -- --check`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/migrate.rs rust/tonk-worker/src/router/profile_name.rs rust/tonk-worker/src/router/account.rs
+git commit -m "feat(tonk-worker): sweep and migrate rosters on device link"
+```
+
+---
+
+### Task 3: Fix the profile-rename no-op
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/profile_name.rs` (`restamp_member_name`, 217-245)
+
+**Interfaces:**
+- Consumes: `crate::router::account::member_did`.
+
+- [ ] **Step 1: Key the rename on the member DID + retract the device name**
+
+Replace the body of `restamp_member_name` (currently keys `Membership::new(tonk.profile.did(), repo_did)` and only asserts). Read the device-keyed `MemberName` (to retract it by full fact), assert the new name on the member-DID entity:
+
+```rust
+    let session = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("acquire content branch '{key}': {e}")))?;
+    let repo_did = session.handle().of().clone();
+
+    let member = crate::router::account::member_did(tonk).await;
+    let membership = Membership::new(member.clone(), repo_did.clone());
+
+    let mut txn = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .transaction()
+        .assert(MemberName::new(membership.this().clone(), name.to_string()));
+
+    // Linked profiles: a rename must also clear the orphaned device-keyed
+    // name row (cardinality-one on a different entity, so the assert above
+    // won't overwrite it).
+    let device = tonk.profile.did();
+    if member != device {
+        let device_membership = Membership::new(device, repo_did);
+        let device_entity = device_membership.this().clone();
+        let names: Vec<MemberName> = session
+            .handle()
+            .query()
+            .select(Query::<MemberName> { this: Term::var("this"), name: Term::var("name") })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
+        for stale in names.into_iter().filter(|n| n.this == device_entity) {
+            txn = txn.retract(stale);
+        }
+    }
+
+    txn.commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("restamp member name for '{key}': {e}")))?;
+    Ok(())
+```
+
+Add the `Query`/`Term` imports to the file if not already present (they're used by `profile_space_keys` above in the same file, so they are).
+
+- [ ] **Step 2: Compile-verify**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -40` (clean)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+Run: `cargo fmt -p tonk-worker -- --check`
+
+Existing rename tests in `profile_name.rs`'s test mod (if any) must still compile; for an unlinked profile `member == device`, so the behavior is the old behavior (assert on the device entity, no retract).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/profile_name.rs
+git commit -m "feat(tonk-worker): rename updates the account-root roster row"
+```
+
+**End of PR 1.** Open a PR (base = `feat/cross-device-restore` while it's unmerged, else `staging`).
+
+---
+
+## PR 2 — Capabilities: re-anchor + backup (Tasks 4-5)
+
+### Task 4: Re-anchor migrated spaces and back them up
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/migrate.rs`
+- Modify: `rust/tonk-worker/src/router/account_backup.rs` (expose a claimed re-anchor backup if needed)
+
+**Interfaces:**
+- Consumes: `back_up_owned_space` (restore branch, `account_backup.rs:330`), `tonk.profile.repository(key).load()`, `repository.try_access()`, `tonk.profile.access().claim(&repository).delegate(root_did)`, the `/chains/put` backup client.
+- Produces: `pub(crate) async fn reanchor_space(tonk: &TonkState, key: &str)` — best-effort; mints and backs up the space's `... -> root` chain. Called from the sweep after a successful `migrate_space_roster`.
+
+- [ ] **Step 1: VERIFY-FIRST — probe `remote_url` recovery**
+
+Before writing backup, determine whether a loaded space's sync URL is cleanly recoverable from its stored remote config. Load a space (`tonk.profile.repository(key).load().perform(&operator)`), read its remote configuration, and check whether the `SiteAddress`/`UcanAddress` exposes the URL string (a `Display`, `as_str`, or `to_string` that yields the `remote=` URL that `space_config`/the invite fed to `UcanAddress::new`). This is the same recovery the `put_repository` gap needs.
+- **If recoverable:** proceed to Step 2 with the recovered `remote_url`.
+- **If NOT cleanly recoverable:** STOP and report. Migration ships re-key + rename (PR 1) and re-anchor *without* cross-device backup, and the backup half is a documented follow-up. Do not force a brittle extraction.
+
+- [ ] **Step 2: Implement `reanchor_space` (both cases)**
+
+In `migrate.rs`:
+
+```rust
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn reanchor_space(tonk: &TonkState, key: &str) {
+    if let Err(error) = try_reanchor_space(tonk, key).await {
+        log!("re-anchor of space '{key}' skipped: {error}");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn try_reanchor_space(tonk: &TonkState, key: &str) -> Result<(), RepositoryError> {
+    let Some(root_did) = account::account_root_did(tonk).await else {
+        return Ok(());
+    };
+    let repository = tonk
+        .profile
+        .repository(key)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("load space '{key}': {e}")))?;
+    let remote_url = /* the recovered sync URL from Step 1, read off `repository`'s config */;
+
+    match repository.try_access() {
+        // Created/owned: space -> root, and back it up (reuses restore's helper).
+        Some(_) => {
+            crate::router::account_backup::back_up_owned_space(tonk, &repository, &remote_url).await;
+        }
+        // Claimed: profile re-delegates its held capability to the root,
+        // composing space -> eph -> device -> root; save + back up.
+        None => {
+            let chain = tonk
+                .profile
+                .access()
+                .claim(&repository)
+                .delegate(root_did)
+                .perform(&tonk.operator)
+                .await
+                .map_err(|e| RepositoryError::Internal(format!("re-anchor '{key}': {e}")))?;
+            tonk.profile
+                .access()
+                .save(chain.clone())
+                .perform(&tonk.operator)
+                .await
+                .map_err(|e| RepositoryError::Internal(format!("save re-anchor '{key}': {e}")))?;
+            crate::router::account_backup::back_up_reanchored(tonk, chain, &remote_url).await;
+        }
+    }
+    Ok(())
+}
+```
+
+`back_up_reanchored(tonk, chain, remote_url)` is a thin addition to `account_backup.rs`: it takes the composed `DelegationChain` (extract its bytes the same way `back_up_claim`/`run_backup` does), wraps `{chain_hex, remote_url}` in a `ClaimBackup`, and dispatches the same fire-and-forget `/chains/put`. Reuse `dispatch_backup`. Confirm the type `access().claim().delegate().perform()` returns (`UcanDelegation(DelegationChain)`, per the invite-mint path) and extract the chain via `.into_chain()`/`.to_bytes()` exactly as the restore-branch backup does.
+
+- [ ] **Step 3: Call the re-anchor from the sweep**
+
+In `migrate_rosters`, after a successful `migrate_space_roster(tonk, &key)` returns `Ok(true)`, call `reanchor_space(tonk, &key).await` for that key (best-effort; it has its own error swallow). A space that returned `Ok(false)` (already root-keyed) was migrated on an earlier link or claimed post-account — its chain already terminates at root, so it needs no re-anchor.
+
+- [ ] **Step 4: Compile-verify + native backup tests**
+
+Run: `cargo clippy -p tonk-worker --all-targets 2>&1 | tail -40` (clean)
+Run: `cargo build -p tonk-worker --target wasm32-unknown-unknown 2>&1 | tail -20` (clean)
+Run: `cargo test -p tonk-account-service --features helpers 2>&1 | tail -15` (the backup wire contract stays green)
+Run: `cargo fmt -p tonk-worker -- --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-worker/src/router/migrate.rs rust/tonk-worker/src/router/account_backup.rs
+git commit -m "feat(tonk-worker): re-anchor and back up migrated spaces"
+```
+
+---
+
+### Task 5: Full gates + PRs
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Workspace gate**
+
+```bash
+cargo clippy --workspace --all-targets --all-features
+cargo fmt --check
+cargo test -p tonk-account-service --features helpers
+```
+Expected: all green.
+
+- [ ] **Step 2: Note deferred wasm + staging verification in the PR body**
+
+The migration sweep, re-anchor, and rename fix are `run_in_service_worker`/wasm — executed by CI's `web` leg, not locally. For a human/staging pass: (a) join a space as a device-only user, then create an account/link → the roster row converges on the root DID; (b) rename → the name updates on the root row in every space; (c) a second device links → migrated spaces restore (depends on PR 2's backup + the restore feature).
+
+- [ ] **Step 3: Push and open PR 2**
+
+```bash
+git push
+gh pr create --base <PR1 base> --title "feat(account): re-anchor and back up migrated spaces (3b)" --body "<summary + verification checklist + design link>"
+```
+
+---
+
+## Out of scope (later)
+
+Revocation-list awareness (access-service concern, pairs with billing/access); live migration propagation (runs on link, like restore); the `put_repository` one-shot create-with-remote backup gap (tracked from the restore work).

--- a/docs/superpowers/specs/2026-07-23-roster-migration-design.md
+++ b/docs/superpowers/specs/2026-07-23-roster-migration-design.md
@@ -1,0 +1,162 @@
+# Roster migration (stage 3B)
+
+Design for converging a user's **existing** device-keyed state onto their root
+DID when they get an account. Stacks on stage 3A (root-DID rosters, merged) and
+the cross-device restore branch (reuses its backup helpers). Companion specs:
+`docs/superpowers/specs/2026-07-23-root-did-rosters-design.md`,
+`docs/superpowers/specs/2026-07-23-cross-device-restore-design.md`.
+
+## Problem
+
+Stage 3A keys *new* claims and roster writes on the root DID; restore carries
+account spaces to new devices. But a user who was a member of spaces *before*
+getting an account still has device-keyed roster rows and claim chains that
+terminate at their device DID. Those spaces don't converge across devices, and
+profile rename is a silent no-op on them (the known 3A limitation). 3B migrates
+them.
+
+## Scope
+
+**In:** on device link, sweep the profile's existing spaces and, for each one
+still keyed on the device DID: re-key its roster rows to the root DID (retract
+the old, re-stamp first-wins), re-anchor its capability chain to the root
+(`device -> root` for claimed, `space -> root` for created), back up the
+re-anchored chain so other devices restore it, and fix the profile-rename
+no-op.
+
+**Out:** revocation-list awareness (access-service concern, pairs with the
+billing/access stage); live propagation (migration runs on link, like restore).
+
+## Trigger
+
+The `link` handler (`rust/tonk-worker/src/router/account.rs:147`) — where
+account-creation-first-device and browser self-link both persist the
+`root -> device` chain, and where `restore_spaces` is already wired. Migration
+hooks the same post-persist tail, fire-and-forget (wasm `spawn_local`; native
+inline), so a slow account service never stalls the link response. It runs
+alongside restore: migration converges *existing local* spaces, restore pulls
+*backed-up remote* ones — disjoint sets, order-independent.
+
+Enumeration reuses `profile_space_keys` (`rust/tonk-worker/src/router/profile_name.rs:129`),
+which queries every `Replica` and yields each space's routing key.
+
+## Roster re-key (facts) — one atomic transaction per space
+
+For each space, read the content-branch roster (the `build_repository_info`
+query pattern, `repository.rs:3305`). A space is *unmigrated* iff it has a
+`Membership` whose `member == profile.did()` (the device DID). Post-link,
+`member_did` resolves to root, so migration matches on the device DID
+explicitly.
+
+For an unmigrated space, in **one** content-branch transaction:
+
+- **Assert** the root-keyed rows: `Membership::new(root_did, subject)`, and —
+  stamped on that new entity (`root_membership.this()`) — the copied
+  `MemberRole` (same URI, so a founder stays a founder), `MemberName` (same
+  name), and `InvitedVia` (same invitation entity).
+- **Retract** the four device-keyed facts. Retraction is by *full fact*
+  (`transaction.retract(concept)`, `dialog-reactor/src/transaction.rs:83`), so
+  each device-keyed concept is reconstructed from the values just read and
+  retracted.
+
+Atomic assert+retract means no half-migrated row ever syncs out. First-wins
+stamps are copied explicitly, never assumed to carry across the entity change
+(`Membership`'s entity is derived from `(subject, member)`, so the root row is
+a *different* entity than the device row).
+
+The device-local `Replica` index (meta branch, never syncs) stays device-keyed
+— it is the profile's own bookkeeping, not shared roster; untouched.
+
+## Re-anchor (capability) + backup
+
+Re-keying the fact gives the roster; the account also needs a *capability* into
+the space, and other devices need it. Per space, mint by ownership using
+`try_access()` (the discriminator restore already uses):
+
+- **Created / owned (`Some`):** `access.claim(repo).delegate(root)` ->
+  `space -> root`. This is exactly `back_up_owned_space`
+  (`account_backup.rs:330`, from the restore branch) — reuse it.
+- **Claimed (`None`):** `profile.access().claim(&repo).delegate(root)` -> the
+  composed `space -> eph -> device -> root` (the invite-mint path proves this
+  call shape for a delegated capability, `repository.rs:931`). Save it to the
+  access store so this device's own presign BFS composes it.
+
+Then **back up** the re-anchored chain (`{chain, remote_url}` -> `/chains/put`,
+reusing 3A's backup client) so the account's *other* devices restore these
+spaces. **Trade-off (from the identity design):** a claimed re-anchor flows
+through the old device DID, so revoking that device later severs it; the
+clean-up is a fresh invite claim or founder re-delegation.
+
+### The `remote_url` recovery risk (verify-first)
+
+Backup needs each existing space's sync URL, stored as a `SiteAddress` in its
+remote config — the same URL-recovery friction as the `put_repository` gap.
+The plan's **first step probes** whether the URL is cleanly recoverable from
+the stored config:
+
+- **If yes:** migration backs up re-anchored chains — full cross-device.
+- **If not:** migration re-keys + re-anchors *locally* (roster converges, the
+  account gains the capability on this device), and cross-device backup of
+  migrated spaces is a documented follow-up. No guessing; the fact/rename half
+  (PR 1) is unaffected either way.
+
+## Rename fix
+
+`restamp_member_name` (`rust/tonk-worker/src/router/profile_name.rs:217`)
+currently builds `Membership::new(profile.did(), repo_did)` — the device DID —
+so an account-holder's rename writes a `MemberName` against a device-keyed
+entity that no roster row uses (the 3A no-op). Fix: key on the resolved member
+DID (root when linked) **and** retract the orphaned device-keyed `MemberName`
+(cardinality-one on a *different* entity, so it isn't otherwise overwritten).
+This reuses PR 1's read-then-retract primitive.
+
+This assumes migration has converged the space (both run on link, migration
+first), so by the time a user renames, the space is root-keyed and the rename
+lands on the root row. A rename during a still-pending migration is a rare
+transient race — it writes a root `MemberName` on a not-yet-migrated space, and
+migration then re-stamps the copied (older) device name over it; it self-heals
+on the next rename. Bounded and low-impact given migration runs first on link.
+
+## Idempotency
+
+Re-running migration is safe: a migrated space has no device-keyed `Membership`
+row, so it is skipped. The per-space transaction is atomic; a crash mid-sweep
+leaves already-migrated spaces done and the rest untouched, and the next link
+finishes them.
+
+## Testing
+
+- **Native / service-worker:** a device-keyed roster (member/founder + name +
+  provenance) migrates to root — device rows gone, root rows present with role,
+  name, and provenance preserved; a second run is a no-op; rename updates the
+  root row and drops the device one.
+- **Re-anchor + backup:** reuse the restore branch's machinery
+  (`back_up_owned_space`, the device-signed `/chains/put` client), already
+  proven against the real `AccountServer`; add the claimed-space
+  `device -> root` mint + backup.
+
+## Build order
+
+Two PRs, off the restore branch (`feat/cross-device-restore`), rebased onto
+`staging` as 3A/restore land:
+
+1. **Facts:** the read-then-retract/re-stamp primitive, the migration sweep
+   (roster re-key), and the rename fix. No capability minting — mergeable on
+   its own, closes the rename no-op immediately.
+2. **Capabilities:** re-anchor mint (both cases) + backup of migrated chains,
+   with the `remote_url` verify-first probe up front.
+
+## Risks
+
+- **`remote_url` recovery** (above) — handled verify-first; worst case defers
+  the backup half, not the re-key/rename.
+- **Claimed re-anchors flow through the device DID** — revoking that device
+  severs them until a fresh invite/founder re-delegation. Inherent to the
+  no-ceremony re-anchor; the identity design already accepts it.
+- **Sweep cost at scale** — an account linked with many pre-account spaces does
+  one content transaction + one mint each on link; fire-and-forget keeps it off
+  the link's critical path, but a very large history trickles in. Acceptable.
+- **Partial-migration visibility** — because each space commits atomically and
+  the roster is authoritative on the content branch, a partially-swept account
+  shows a mix of migrated and not-yet-migrated spaces briefly; both are valid
+  rosters, and the next link converges the rest.

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -25,6 +25,8 @@ pub(crate) mod restore;
 mod join;
 pub use join::{JoinRequest, JoinResponse};
 
+pub(crate) mod migrate;
+
 mod create_invite;
 pub use create_invite::{CreateInviteRequest, CreateInviteResponse};
 

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -190,20 +190,36 @@ pub async fn link(
             TonkWorkerError::Internal(format!("failed to save local account link: {error}"))
         })?;
 
-    // A freshly linked device pulls the account's backed-up spaces in the
-    // background — a slow/hung account service must never stall the link
-    // response. On wasm, dispatch detached with its own read lock; on
-    // native there's no UI to stall, so it awaits inline using the guard
-    // already held for this handler.
+    // A freshly linked device converges its existing spaces and pulls the
+    // account's backed-up ones in the background — a slow/hung account
+    // service must never stall the link response. On native there's no UI
+    // to stall, so it awaits inline using the guard already held here.
+    //
+    // Migration runs under the WRITE lock. It is a purely local storage
+    // sweep (its backup requests are themselves dispatched detached), and
+    // handlers hold read locks while writing, so a read lock here would let
+    // the sweep's transactions run concurrently with a handler's against
+    // the same stores — which the storage layer rejects. The write lock
+    // makes the sweep mutually exclusive with request handling instead.
+    // It cannot deadlock: `spawn_local` defers the task, so this handler's
+    // read guard is dropped before the task asks for the lock.
+    //
+    // Restore deliberately stays on a read lock: it awaits account-service
+    // round trips, and holding the write lock across those would stall
+    // every handler on that latency — the one thing this dispatch exists
+    // to avoid. The lock is therefore released between the two.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         wasm_bindgen_futures::spawn_local(async move {
-            let tonk = app_state.read().await;
             // Migrate this device's existing spaces onto the root first:
             // restore only mounts subjects this device doesn't already
             // have, so running migration first means restore won't
             // re-touch a space migration just re-keyed.
-            crate::router::migrate::migrate_rosters(&tonk).await;
+            {
+                let tonk = app_state.write().await;
+                crate::router::migrate::migrate_rosters(&tonk).await;
+            }
+            let tonk = app_state.read().await;
             crate::router::restore::restore_spaces(&tonk).await;
         });
     }

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -142,24 +142,21 @@ pub async fn get(State(state): State<AppState>) -> Result<Json<AccountStatus>, T
     }))
 }
 
-/// Validate and persist a `root → current profile` delegation.
-#[wasm_compat]
-pub async fn link(
-    State(state): State<AppState>,
-    Json(request): Json<AccountLinkRequest>,
-) -> Result<Json<AccountStatus>, TonkWorkerError> {
-    // Keep the cloneable `AppState` handle around: `state` is about to be
-    // shadowed by a read guard for the body of this handler, but the
-    // fire-and-forget restore dispatch below needs its own independent
-    // read lock inside a detached task. Native awaits restore inline using
-    // the guard already held below, so it never needs this clone.
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    let app_state = state.clone();
-    let state = state.read().await;
+/// Validate and store a `root → current profile` delegation.
+///
+/// This is the persistence half of [`link`], split out so it can be used
+/// without the handler's post-link convergence dispatch. Tests that only
+/// need a linked profile call this directly: going through [`link`] would
+/// also fire the background sweep, which races whatever the test does
+/// next.
+pub(crate) async fn persist_link(
+    state: &crate::worker::TonkState,
+    request: &AccountLinkRequest,
+) -> Result<(), TonkWorkerError> {
     let device_did = state.profile.did();
-    let (chain, bytes) = validate_link(&request, &device_did).await?;
+    let (chain, bytes) = validate_link(request, &device_did).await?;
 
-    if let Some(existing) = load_link(&state).await? {
+    if let Some(existing) = load_link(state).await? {
         let existing = DelegationChain::try_from(existing.as_slice()).map_err(|error| {
             TonkWorkerError::Internal(format!("stored account delegation is invalid: {error}"))
         })?;
@@ -189,6 +186,26 @@ pub async fn link(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to save local account link: {error}"))
         })?;
+    Ok(())
+}
+
+/// Validate and persist a `root → current profile` delegation, then
+/// converge this device's spaces onto the account in the background.
+#[wasm_compat]
+pub async fn link(
+    State(state): State<AppState>,
+    Json(request): Json<AccountLinkRequest>,
+) -> Result<Json<AccountStatus>, TonkWorkerError> {
+    // Keep the cloneable `AppState` handle around: `state` is about to be
+    // shadowed by a read guard for the body of this handler, but the
+    // fire-and-forget convergence dispatch below needs its own independent
+    // lock inside a detached task. Native awaits restore inline using
+    // the guard already held below, so it never needs this clone.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    let app_state = state.clone();
+    let state = state.read().await;
+    let device_did = state.profile.did();
+    persist_link(&state, &request).await?;
 
     // A freshly linked device converges its existing spaces and pulls the
     // account's backed-up ones in the background — a slow/hung account

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -199,6 +199,11 @@ pub async fn link(
     {
         wasm_bindgen_futures::spawn_local(async move {
             let tonk = app_state.read().await;
+            // Migrate this device's existing spaces onto the root first:
+            // restore only mounts subjects this device doesn't already
+            // have, so running migration first means restore won't
+            // re-touch a space migration just re-keyed.
+            crate::router::migrate::migrate_rosters(&tonk).await;
             crate::router::restore::restore_spaces(&tonk).await;
         });
     }

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -297,6 +297,20 @@ pub(crate) async fn back_up_claim(
     dispatch_backup(tonk, "claim", chain.clone(), remote_url.map(str::to_owned)).await;
 }
 
+/// Back up a re-anchored space's delegation to the account service. Used
+/// by roster migration: a claimed space's held capability re-delegated
+/// from the device to the account root, composing `space -> eph -> device
+/// -> root`. Best-effort: any failure logs and is swallowed, same as
+/// [`back_up_claim`].
+///
+/// Only called from the wasm worker's roster-migration sweep today, so
+/// this is worker-only rather than carrying dead code on native, mirroring
+/// [`back_up_owned_space`].
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn back_up_reanchored(tonk: &TonkState, chain: DelegationChain, remote_url: &str) {
+    dispatch_backup(tonk, "reanchor", chain, Some(remote_url.to_owned())).await;
+}
+
 /// Back up a created space's `space -> root` delegation so another of the
 /// account's devices can restore it. Best-effort and fire-and-forget; a
 /// no-op when the profile is unlinked, or when `repository` doesn't hold a

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -126,12 +126,7 @@ pub(crate) async fn migrate_space_roster(
         .try_vec()
         .await
         .map_err(|e| RepositoryError::Internal(format!("role query '{key}': {e:?}")))?;
-    // First-wins: if a root-keyed role row already exists, a prior
-    // migration (from another linked device) or a direct root-keyed join
-    // has already stamped it. `roles` already contains every row on the
-    // branch, so this is a plain lookup, not an extra query.
-    let root_role_exists = roles.iter().any(|r| r.this == root_entity);
-    let device_role = roles.into_iter().find(|r| r.this == device_entity);
+    let device_role = roles.iter().find(|r| r.this == device_entity).cloned();
 
     let names: Vec<MemberName> = session
         .handle()
@@ -171,19 +166,20 @@ pub(crate) async fn migrate_space_roster(
         .retract(device_row);
 
     if let Some(role) = device_role {
-        // First-wins: another device may have already migrated (or
-        // directly joined) this space onto the root entity, stamping its
-        // own role there first. Don't overwrite that — in particular,
-        // don't let a plain-member device row demote an already-recorded
-        // founder role. The device row is retracted either way, since it
-        // must not linger regardless of which role wins on the root.
-        if !root_role_exists {
-            let root_role = if role.role.0.to_string() == MemberRole::FOUNDER {
-                MemberRole::founder(root_entity.clone())
-            } else {
-                MemberRole::member(root_entity.clone())
-            };
-            txn = txn.assert(root_role);
+        // Founder-wins convergence, order-independent: a founder assertion
+        // wins over an existing member, a member never demotes an existing
+        // founder, and a member is stamped only when the root has no role
+        // yet. The device row is retracted regardless of which role wins.
+        let device_is_founder = role.role.0.to_string() == MemberRole::FOUNDER;
+        let root_is_founder = roles
+            .iter()
+            .any(|r| r.this == root_entity && r.role.0.to_string() == MemberRole::FOUNDER);
+        let root_has_role = roles.iter().any(|r| r.this == root_entity);
+
+        if device_is_founder && !root_is_founder {
+            txn = txn.assert(MemberRole::founder(root_entity.clone())); // upgrade / first founder
+        } else if !device_is_founder && !root_has_role {
+            txn = txn.assert(MemberRole::member(root_entity.clone())); // first member
         }
         txn = txn.retract(role);
     }
@@ -240,9 +236,10 @@ async fn try_reanchor_space(tonk: &TonkState, key: &str) -> Result<(), Repositor
         .await
         .map_err(|e| RepositoryError::Internal(format!("load space '{key}': {e}")))?;
 
-    // Recover the sync URL off the repo's own stored remote config, the
-    // same recovery `create_invite::resolve_remote_url` already does for
-    // the invite-mint path.
+    // Recover the sync URL off the content branch's (`main`) own stored
+    // upstream remote config — the same recovery
+    // `create_invite::resolve_remote_url` already does for the
+    // invite-mint path.
     let remote_url = match crate::router::create_invite::resolve_remote_url(tonk, &repository)
         .await
         .map_err(|e| RepositoryError::Internal(format!("resolve remote for '{key}': {e}")))?
@@ -557,6 +554,94 @@ mod tests {
                 .iter()
                 .any(|r| r.this == root_entity && r.role.0.to_string() == MemberRole::FOUNDER),
             "root founder role must survive a later device's migration unchanged",
+        );
+        assert!(
+            !roles.iter().any(|r| r.this == device_entity),
+            "device-keyed role must be gone after migration",
+        );
+
+        let memberships = content_memberships(&state, &key).await;
+        assert!(
+            !memberships.iter().any(|m| m.this == device_entity),
+            "device-keyed membership must be gone after migration",
+        );
+    }
+
+    /// Founder-wins upgrade: a linked device's *founder* row must upgrade
+    /// the root entity's role even when another device already stamped a
+    /// lesser *member* role there first (self-healing, order-independent
+    /// convergence — the mirror image of the demotion-guard test above).
+    #[dialog_common::test]
+    async fn it_upgrades_an_existing_root_member_role_to_founder() {
+        let state = test_state().await;
+        let (app, state, _lsp) = api_router_with_state(state);
+
+        let device_did = state.read().await.profile.did();
+        let key = put_repo(&app, "migrate-roster-upgrade").await;
+        let subject_did = {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .of()
+                .clone()
+        };
+
+        let root_did = link_account(&state).await;
+
+        // Simulate a prior migration (or a direct root-keyed join) that
+        // only ever recorded a plain member role on the root entity.
+        let root_membership = Membership::new(root_did.clone(), subject_did.clone());
+        let root_entity = root_membership.this().clone();
+        {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .transaction()
+                .assert(root_membership)
+                .assert(MemberRole::member(root_entity.clone()))
+                .commit()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+        }
+
+        // This device holds the true founder row for the space — its
+        // migration must upgrade the root to founder, not be blocked by
+        // the root's existing (lesser) member role.
+        let device_membership = Membership::new(device_did.clone(), subject_did.clone());
+        let device_entity = device_membership.this().clone();
+        {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .transaction()
+                .assert(device_membership)
+                .assert(MemberRole::founder(device_entity.clone()))
+                .commit()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+        }
+
+        let migrated = {
+            let tonk = state.read().await;
+            migrate_space_roster(&tonk, &key).await.unwrap()
+        };
+        assert!(migrated, "expected the device-keyed row to be migrated");
+
+        let roles = content_member_roles(&state, &key).await;
+        assert!(
+            roles
+                .iter()
+                .any(|r| r.this == root_entity && r.role.0.to_string() == MemberRole::FOUNDER),
+            "root role must be upgraded to founder by the later device's migration",
         );
         assert!(
             !roles.iter().any(|r| r.this == device_entity),

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -21,7 +21,10 @@ use crate::worker::TonkState;
 /// (mirroring `profile_name.rs`) exists only on the wasm target — gating
 /// it keeps the native `clippy -D warnings` build clean.
 #[cfg(target_arch = "wasm32")]
-#[allow(dead_code, reason = "reached only through the sweep wired in a follow-up task")]
+#[allow(
+    dead_code,
+    reason = "reached only through the sweep wired in a follow-up task"
+)]
 const CONTENT_BRANCH: &str = "main";
 
 /// Re-key one space's roster from the device DID to the account root DID,
@@ -29,7 +32,10 @@ const CONTENT_BRANCH: &str = "main";
 /// `Ok(false)` when the space is already root-keyed, the profile isn't a
 /// member, or the profile is unlinked.
 #[cfg(target_arch = "wasm32")]
-#[allow(dead_code, reason = "wired into the migration sweep in a follow-up task")]
+#[allow(
+    dead_code,
+    reason = "wired into the migration sweep in a follow-up task"
+)]
 pub(crate) async fn migrate_space_roster(
     tonk: &TonkState,
     key: &str,
@@ -138,7 +144,10 @@ pub(crate) async fn migrate_space_roster(
     }
     if let Some(stamp) = device_stamp {
         txn = txn
-            .assert(InvitedVia::new(root_entity.clone(), stamp.invitation.0.clone()))
+            .assert(InvitedVia::new(
+                root_entity.clone(),
+                stamp.invitation.0.clone(),
+            ))
             .retract(stamp);
     }
 
@@ -188,7 +197,7 @@ mod tests {
             root_did: root_did.to_string(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
         };
-        crate::router::account::link(State(state.clone()), Json(request))
+        let _ = crate::router::account::link(State(state.clone()), Json(request))
             .await
             .unwrap();
         root_did
@@ -259,9 +268,7 @@ mod tests {
 
         let memberships = content_memberships(&state, &key).await;
         assert!(
-            memberships
-                .iter()
-                .any(|m| m.member.0 == root_did.this()),
+            memberships.iter().any(|m| m.member.0 == root_did.this()),
             "root-keyed membership must exist after migration",
         );
         assert!(
@@ -277,7 +284,8 @@ mod tests {
         assert!(
             roles
                 .iter()
-                .any(|r| r.this == root_membership.this && r.role.0.to_string() == MemberRole::FOUNDER),
+                .any(|r| r.this == root_membership.this
+                    && r.role.0.to_string() == MemberRole::FOUNDER),
             "founder role must carry over onto the root-keyed entity",
         );
 

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -288,8 +288,6 @@ async fn try_reanchor_space(tonk: &TonkState, key: &str) -> Result<(), Repositor
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod tests {
-    use axum::Json;
-    use axum::extract::State;
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     #[cfg(target_arch = "wasm32")]
@@ -307,9 +305,12 @@ mod tests {
     };
 
     /// Link the given (already-open) state's profile to a fresh account
-    /// root, mirroring `join.rs`'s
-    /// `it_keys_membership_on_the_root_did_for_an_account_holder` setup.
-    /// Returns the minted root DID.
+    /// root and return the minted root DID.
+    ///
+    /// Stores the link directly rather than going through the `link`
+    /// handler: the handler also dispatches the background convergence
+    /// sweep, which would migrate these spaces itself and pre-empt the
+    /// explicit `migrate_space_roster` calls these tests are asserting on.
     async fn link_account(state: &crate::router::AppState) -> dialog_varsig::Did {
         use dialog_varsig::Principal as _;
         let device_did = state.read().await.profile.did();
@@ -324,7 +325,8 @@ mod tests {
             root_did: root_did.to_string(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
         };
-        let _ = crate::router::account::link(State(state.clone()), Json(request))
+        let tonk = state.read().await;
+        crate::router::account::persist_link(&tonk, &request)
             .await
             .unwrap();
         root_did

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -154,19 +154,28 @@ pub(crate) async fn migrate_space_roster(
 mod tests {
     use axum::Json;
     use axum::extract::State;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_service_worker);
 
-    use tonk_schema::prelude::DidExt as _;
-    use tonk_schema::{MemberName, MemberRole, Membership};
+    use dialog_artifacts::Entity;
+    use tonk_schema::prelude::{DidExt as _, EntityExt as _};
+    use tonk_schema::{InvitedVia, MemberName, MemberRole, Membership};
 
     use super::migrate_space_roster;
     use crate::router::api_router_with_state;
-    use crate::router::tests::{content_member_roles, content_memberships, put_repo, test_state};
+    use crate::router::tests::{
+        content_invited_via, content_member_names, content_member_roles, content_memberships,
+        put_repo, test_state,
+    };
 
     /// Link the given (already-open) state's profile to a fresh account
     /// root, mirroring `join.rs`'s
     /// `it_keys_membership_on_the_root_did_for_an_account_holder` setup.
     /// Returns the minted root DID.
     async fn link_account(state: &crate::router::AppState) -> dialog_varsig::Did {
+        use dialog_varsig::Principal as _;
         let device_did = state.read().await.profile.did();
         let root = tonk_identity::derive::derive_root_signer(&[9u8; 32])
             .await
@@ -187,6 +196,12 @@ mod tests {
 
     /// Seed a device-keyed founder membership directly on `key`'s content
     /// branch — the state migration is meant to converge away from.
+    ///
+    /// The `InvitedVia` stamp points at a bare stable `Entity` rather
+    /// than a full `Invitation` — mirroring `membership.rs`'s own
+    /// `it_stamps_the_membership_entity` test — since the migration
+    /// only ever copies the invitation reference, never dereferences
+    /// it.
     async fn seed_device_membership(
         state: &crate::router::AppState,
         key: &str,
@@ -196,13 +211,15 @@ mod tests {
         let tonk = state.read().await;
         let membership = Membership::new(device_did.clone(), subject_did.clone());
         let entity = membership.this().clone();
+        let invitation_entity = Entity::of(&"migrate-roster-invitation");
         tonk.reactor
             .repository(key)
             .branch("main")
             .transaction()
             .assert(membership)
             .assert(MemberRole::founder(entity.clone()))
-            .assert(MemberName::new(entity, "Device Member".to_string()))
+            .assert(MemberName::new(entity.clone(), "Device Member".to_string()))
+            .assert(InvitedVia::new(entity, invitation_entity))
             .commit()
             .perform(&tonk.operator)
             .await
@@ -228,6 +245,8 @@ mod tests {
                 .of()
                 .clone()
         };
+        let device_membership = Membership::new(device_did.clone(), subject_did.clone());
+        let device_entity = device_membership.this().clone();
         seed_device_membership(&state, &key, &device_did, &subject_did).await;
 
         let root_did = link_account(&state).await;
@@ -260,6 +279,33 @@ mod tests {
                 .iter()
                 .any(|r| r.this == root_membership.this && r.role.0.to_string() == MemberRole::FOUNDER),
             "founder role must carry over onto the root-keyed entity",
+        );
+
+        let names = content_member_names(&state, &key).await;
+        assert!(
+            names
+                .iter()
+                .any(|n| n.this == root_membership.this && n.name.0 == "Device Member"),
+            "member name must carry over onto the root-keyed entity",
+        );
+        assert!(
+            !names.iter().any(|n| n.this == device_entity),
+            "member name must be gone from the device-keyed entity",
+        );
+
+        let stamps = content_invited_via(&state, &key).await;
+        let root_stamp = stamps
+            .iter()
+            .find(|s| s.this == root_membership.this)
+            .expect("invited-via stamp must carry over onto the root-keyed entity");
+        assert!(
+            !stamps.iter().any(|s| s.this == device_entity),
+            "invited-via stamp must be gone from the device-keyed entity",
+        );
+        assert_eq!(
+            root_stamp.invitation.0,
+            Entity::of(&"migrate-roster-invitation"),
+            "invited-via must reference the same invitation entity as before migration",
         );
 
         // Idempotent: a second call finds no device-keyed row left to migrate.

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -1,0 +1,302 @@
+//! Converge a linked device's existing device-keyed spaces onto the
+//! account root DID.
+
+#[cfg(target_arch = "wasm32")]
+use dialog_query::{Output as _, Query, Term};
+#[cfg(target_arch = "wasm32")]
+use tonk_common::log;
+#[cfg(target_arch = "wasm32")]
+use tonk_schema::prelude::DidExt as _;
+#[cfg(target_arch = "wasm32")]
+use tonk_schema::{InvitedVia, MemberName, MemberRole, Membership};
+
+#[cfg(target_arch = "wasm32")]
+use crate::RepositoryError;
+#[cfg(target_arch = "wasm32")]
+use crate::router::account;
+#[cfg(target_arch = "wasm32")]
+use crate::worker::TonkState;
+
+/// Only the wasm-gated migration path re-keys a roster, so this
+/// (mirroring `profile_name.rs`) exists only on the wasm target — gating
+/// it keeps the native `clippy -D warnings` build clean.
+#[cfg(target_arch = "wasm32")]
+#[allow(dead_code, reason = "reached only through the sweep wired in a follow-up task")]
+const CONTENT_BRANCH: &str = "main";
+
+/// Re-key one space's roster from the device DID to the account root DID,
+/// atomically. Returns `Ok(true)` when a device-keyed row was migrated,
+/// `Ok(false)` when the space is already root-keyed, the profile isn't a
+/// member, or the profile is unlinked.
+#[cfg(target_arch = "wasm32")]
+#[allow(dead_code, reason = "wired into the migration sweep in a follow-up task")]
+pub(crate) async fn migrate_space_roster(
+    tonk: &TonkState,
+    key: &str,
+) -> Result<bool, RepositoryError> {
+    let member = account::member_did(tonk).await;
+    let device = tonk.profile.did();
+    // Unlinked: no root to migrate to. (member_did == device DID.)
+    if member == device {
+        return Ok(false);
+    }
+
+    let session = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("acquire content '{key}': {e}")))?;
+    let subject = session.handle().of().clone();
+    let subject_entity = subject.this();
+
+    let device_membership = Membership::new(device.clone(), subject.clone());
+    let device_entity = device_membership.this().clone();
+
+    // Is there a device-keyed row to migrate?
+    let memberships: Vec<Membership> = session
+        .handle()
+        .query()
+        .select(Query::<Membership> {
+            this: Term::var("this"),
+            subject: Term::from(subject_entity.clone()),
+            member: Term::var("member"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("membership query '{key}': {e:?}")))?;
+    let Some(device_row) = memberships.into_iter().find(|m| m.this == device_entity) else {
+        return Ok(false);
+    };
+
+    // Read the device row's stamps so they can be copied and retracted.
+    let roles: Vec<MemberRole> = session
+        .handle()
+        .query()
+        .select(Query::<MemberRole> {
+            this: Term::var("this"),
+            role: Term::var("role"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("role query '{key}': {e:?}")))?;
+    let device_role = roles.into_iter().find(|r| r.this == device_entity);
+
+    let names: Vec<MemberName> = session
+        .handle()
+        .query()
+        .select(Query::<MemberName> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
+    let device_name = names.into_iter().find(|n| n.this == device_entity);
+
+    let stamps: Vec<InvitedVia> = session
+        .handle()
+        .query()
+        .select(Query::<InvitedVia> {
+            this: Term::var("this"),
+            invitation: Term::var("invitation"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("invited-via query '{key}': {e:?}")))?;
+    let device_stamp = stamps.into_iter().find(|s| s.this == device_entity);
+
+    // Build the root-keyed rows and one atomic assert+retract transaction.
+    let root_membership = Membership::new(member.clone(), subject.clone());
+    let root_entity = root_membership.this().clone();
+
+    let mut txn = tonk
+        .reactor
+        .repository(key)
+        .branch(CONTENT_BRANCH)
+        .transaction()
+        .assert(root_membership.clone())
+        .retract(device_row);
+
+    if let Some(role) = device_role {
+        let root_role = if role.role.0.to_string() == MemberRole::FOUNDER {
+            MemberRole::founder(root_entity.clone())
+        } else {
+            MemberRole::member(root_entity.clone())
+        };
+        txn = txn.assert(root_role).retract(role);
+    }
+    if let Some(name) = device_name {
+        txn = txn
+            .assert(MemberName::new(root_entity.clone(), name.name.0.clone()))
+            .retract(name);
+    }
+    if let Some(stamp) = device_stamp {
+        txn = txn
+            .assert(InvitedVia::new(root_entity.clone(), stamp.invitation.0.clone()))
+            .retract(stamp);
+    }
+
+    txn.commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("commit migration '{key}': {e}")))?;
+    log!("migrated roster for space '{key}' to the account root");
+    Ok(true)
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use axum::Json;
+    use axum::extract::State;
+
+    use tonk_schema::prelude::DidExt as _;
+    use tonk_schema::{MemberName, MemberRole, Membership};
+
+    use super::migrate_space_roster;
+    use crate::router::api_router_with_state;
+    use crate::router::tests::{content_member_roles, content_memberships, put_repo, test_state};
+
+    /// Link the given (already-open) state's profile to a fresh account
+    /// root, mirroring `join.rs`'s
+    /// `it_keys_membership_on_the_root_did_for_an_account_holder` setup.
+    /// Returns the minted root DID.
+    async fn link_account(state: &crate::router::AppState) -> dialog_varsig::Did {
+        let device_did = state.read().await.profile.did();
+        let root = tonk_identity::derive::derive_root_signer(&[9u8; 32])
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let delegation = tonk_identity::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+        let request = tonk_worker_api::AccountLinkRequest {
+            root_did: root_did.to_string(),
+            delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+        };
+        crate::router::account::link(State(state.clone()), Json(request))
+            .await
+            .unwrap();
+        root_did
+    }
+
+    /// Seed a device-keyed founder membership directly on `key`'s content
+    /// branch — the state migration is meant to converge away from.
+    async fn seed_device_membership(
+        state: &crate::router::AppState,
+        key: &str,
+        device_did: &dialog_varsig::Did,
+        subject_did: &dialog_varsig::Did,
+    ) {
+        let tonk = state.read().await;
+        let membership = Membership::new(device_did.clone(), subject_did.clone());
+        let entity = membership.this().clone();
+        tonk.reactor
+            .repository(key)
+            .branch("main")
+            .transaction()
+            .assert(membership)
+            .assert(MemberRole::founder(entity.clone()))
+            .assert(MemberName::new(entity, "Device Member".to_string()))
+            .commit()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+    }
+
+    #[dialog_common::test]
+    async fn it_rekeys_a_device_membership_onto_the_account_root() {
+        let state = test_state().await;
+        let (app, state, _lsp) = api_router_with_state(state);
+
+        let device_did = state.read().await.profile.did();
+        let key = put_repo(&app, "migrate-roster-founder").await;
+        let subject_did = {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .of()
+                .clone()
+        };
+        seed_device_membership(&state, &key, &device_did, &subject_did).await;
+
+        let root_did = link_account(&state).await;
+
+        let migrated = {
+            let tonk = state.read().await;
+            migrate_space_roster(&tonk, &key).await.unwrap()
+        };
+        assert!(migrated, "expected a device-keyed row to be migrated");
+
+        let memberships = content_memberships(&state, &key).await;
+        assert!(
+            memberships
+                .iter()
+                .any(|m| m.member.0 == root_did.this()),
+            "root-keyed membership must exist after migration",
+        );
+        assert!(
+            !memberships.iter().any(|m| m.member.0 == device_did.this()),
+            "device-keyed membership must be gone after migration",
+        );
+
+        let roles = content_member_roles(&state, &key).await;
+        let root_membership = memberships
+            .iter()
+            .find(|m| m.member.0 == root_did.this())
+            .expect("root membership present");
+        assert!(
+            roles
+                .iter()
+                .any(|r| r.this == root_membership.this && r.role.0.to_string() == MemberRole::FOUNDER),
+            "founder role must carry over onto the root-keyed entity",
+        );
+
+        // Idempotent: a second call finds no device-keyed row left to migrate.
+        let migrated_again = {
+            let tonk = state.read().await;
+            migrate_space_roster(&tonk, &key).await.unwrap()
+        };
+        assert!(!migrated_again, "second migration call must be a no-op");
+    }
+
+    #[dialog_common::test]
+    async fn it_is_a_noop_when_unlinked() {
+        let state = test_state().await;
+        let (app, state, _lsp) = api_router_with_state(state);
+
+        let device_did = state.read().await.profile.did();
+        let key = put_repo(&app, "migrate-roster-unlinked").await;
+        let subject_did = {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .of()
+                .clone()
+        };
+        seed_device_membership(&state, &key, &device_did, &subject_did).await;
+
+        // No account link — member_did == device DID, so there is
+        // nothing to converge.
+        let migrated = {
+            let tonk = state.read().await;
+            migrate_space_roster(&tonk, &key).await.unwrap()
+        };
+        assert!(!migrated, "unlinked profile has no root to migrate to");
+    }
+}

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -7,6 +7,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_arch = "wasm32")]
 use dialog_query::{Output as _, Query, Term};
 #[cfg(target_arch = "wasm32")]
+use dialog_repository::RepositoryExt as _;
+#[cfg(target_arch = "wasm32")]
 use tonk_common::log;
 #[cfg(target_arch = "wasm32")]
 use tonk_schema::prelude::DidExt as _;
@@ -37,6 +39,14 @@ static MIGRATE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 /// Best-effort: no-op when unlinked; one space's failure is logged and
 /// skipped. A concurrent run is skipped (the guard), since both would
 /// migrate the same spaces.
+///
+/// A space whose roster migration returns `Ok(true)` (a device-keyed row
+/// was actually re-keyed) still has its capability chain anchored to this
+/// device — [`reanchor_space`] re-anchors it to the root and backs it up
+/// for the account's other devices. `Ok(false)` means the space was
+/// already root-keyed (migrated on an earlier link, or claimed
+/// post-account), so its chain already terminates at root and needs no
+/// re-anchor.
 #[cfg(target_arch = "wasm32")]
 pub(crate) async fn migrate_rosters(tonk: &TonkState) {
     if account::account_link(tonk).await.is_none() {
@@ -46,8 +56,10 @@ pub(crate) async fn migrate_rosters(tonk: &TonkState) {
         return;
     }
     for key in crate::router::profile_name::profile_space_keys(tonk).await {
-        if let Err(error) = migrate_space_roster(tonk, &key).await {
-            log!("roster migration for space '{key}' skipped: {error}");
+        match migrate_space_roster(tonk, &key).await {
+            Ok(true) => reanchor_space(tonk, &key).await,
+            Ok(false) => {}
+            Err(error) => log!("roster migration for space '{key}' skipped: {error}"),
         }
     }
     MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
@@ -202,6 +214,79 @@ pub(crate) async fn migrate_space_roster(
         .map_err(|e| RepositoryError::Internal(format!("commit migration '{key}': {e}")))?;
     log!("migrated roster for space '{key}' to the account root");
     Ok(true)
+}
+
+/// Re-anchor a just-migrated space's capability chain to the account root
+/// and back it up so the account's other devices can restore it.
+/// Best-effort, fire-and-forget: any failure is logged and swallowed —
+/// the roster is already root-keyed regardless of whether this succeeds.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn reanchor_space(tonk: &TonkState, key: &str) {
+    if let Err(error) = try_reanchor_space(tonk, key).await {
+        log!("re-anchor of space '{key}' skipped: {error}");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn try_reanchor_space(tonk: &TonkState, key: &str) -> Result<(), RepositoryError> {
+    let Some(root_did) = account::account_root_did(tonk).await else {
+        return Ok(());
+    };
+    let repository = tonk
+        .profile
+        .repository(key)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("load space '{key}': {e}")))?;
+
+    // Recover the sync URL off the repo's own stored remote config, the
+    // same recovery `create_invite::resolve_remote_url` already does for
+    // the invite-mint path.
+    let remote_url = match crate::router::create_invite::resolve_remote_url(tonk, &repository)
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("resolve remote for '{key}': {e}")))?
+    {
+        crate::router::create_invite::RemoteRequirement::Ready(url) => url.to_string(),
+        // No shareable remote: no other device could restore this space
+        // from a backup anyway, so there is nothing to back up.
+        crate::router::create_invite::RemoteRequirement::Refused(_) => return Ok(()),
+    };
+
+    match repository.try_access() {
+        // Created/owned: mint the one-hop space -> root delegation and
+        // back it up (reuses the restore branch's helper).
+        Some(_) => {
+            crate::router::account_backup::back_up_owned_space(tonk, &repository, &remote_url)
+                .await;
+        }
+        // Claimed: the profile re-delegates its held capability to the
+        // root, composing space -> eph -> device -> root. Save it to the
+        // access store, then back it up.
+        None => {
+            let chain: dialog_ucan::UcanDelegation = tonk
+                .profile
+                .access()
+                .claim(&repository)
+                .delegate(root_did)
+                .perform(&tonk.operator)
+                .await
+                .map_err(|e| RepositoryError::Internal(format!("re-anchor '{key}': {e}")))?;
+            tonk.profile
+                .access()
+                .save(chain.clone())
+                .perform(&tonk.operator)
+                .await
+                .map_err(|e| RepositoryError::Internal(format!("save re-anchor '{key}': {e}")))?;
+            crate::router::account_backup::back_up_reanchored(
+                tonk,
+                chain.into_chain(),
+                &remote_url,
+            )
+            .await;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -2,6 +2,9 @@
 //! account root DID.
 
 #[cfg(target_arch = "wasm32")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(target_arch = "wasm32")]
 use dialog_query::{Output as _, Query, Term};
 #[cfg(target_arch = "wasm32")]
 use tonk_common::log;
@@ -21,21 +24,40 @@ use crate::worker::TonkState;
 /// (mirroring `profile_name.rs`) exists only on the wasm target — gating
 /// it keeps the native `clippy -D warnings` build clean.
 #[cfg(target_arch = "wasm32")]
-#[allow(
-    dead_code,
-    reason = "reached only through the sweep wired in a follow-up task"
-)]
 const CONTENT_BRANCH: &str = "main";
+
+/// Guards against concurrent migration sweeps. A device-link response
+/// dispatches the sweep fire-and-forget; a second concurrent trigger
+/// would only race the first through the same set of spaces. Mirrors
+/// `restore.rs`'s `RESTORE_IN_FLIGHT` guard.
+#[cfg(target_arch = "wasm32")]
+static MIGRATE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// Converge every existing device-keyed space onto the account root.
+/// Best-effort: no-op when unlinked; one space's failure is logged and
+/// skipped. A concurrent run is skipped (the guard), since both would
+/// migrate the same spaces.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn migrate_rosters(tonk: &TonkState) {
+    if account::account_link(tonk).await.is_none() {
+        return; // unlinked
+    }
+    if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    for key in crate::router::profile_name::profile_space_keys(tonk).await {
+        if let Err(error) = migrate_space_roster(tonk, &key).await {
+            log!("roster migration for space '{key}' skipped: {error}");
+        }
+    }
+    MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
 
 /// Re-key one space's roster from the device DID to the account root DID,
 /// atomically. Returns `Ok(true)` when a device-keyed row was migrated,
 /// `Ok(false)` when the space is already root-keyed, the profile isn't a
 /// member, or the profile is unlinked.
 #[cfg(target_arch = "wasm32")]
-#[allow(
-    dead_code,
-    reason = "wired into the migration sweep in a follow-up task"
-)]
 pub(crate) async fn migrate_space_roster(
     tonk: &TonkState,
     key: &str,
@@ -59,6 +81,9 @@ pub(crate) async fn migrate_space_roster(
 
     let device_membership = Membership::new(device.clone(), subject.clone());
     let device_entity = device_membership.this().clone();
+
+    let root_membership = Membership::new(member.clone(), subject.clone());
+    let root_entity = root_membership.this().clone();
 
     // Is there a device-keyed row to migrate?
     let memberships: Vec<Membership> = session
@@ -89,6 +114,11 @@ pub(crate) async fn migrate_space_roster(
         .try_vec()
         .await
         .map_err(|e| RepositoryError::Internal(format!("role query '{key}': {e:?}")))?;
+    // First-wins: if a root-keyed role row already exists, a prior
+    // migration (from another linked device) or a direct root-keyed join
+    // has already stamped it. `roles` already contains every row on the
+    // branch, so this is a plain lookup, not an extra query.
+    let root_role_exists = roles.iter().any(|r| r.this == root_entity);
     let device_role = roles.into_iter().find(|r| r.this == device_entity);
 
     let names: Vec<MemberName> = session
@@ -115,12 +145,11 @@ pub(crate) async fn migrate_space_roster(
         .try_vec()
         .await
         .map_err(|e| RepositoryError::Internal(format!("invited-via query '{key}': {e:?}")))?;
+    // Same first-wins reasoning as the role guard above.
+    let root_stamp_exists = stamps.iter().any(|s| s.this == root_entity);
     let device_stamp = stamps.into_iter().find(|s| s.this == device_entity);
 
     // Build the root-keyed rows and one atomic assert+retract transaction.
-    let root_membership = Membership::new(member.clone(), subject.clone());
-    let root_entity = root_membership.this().clone();
-
     let mut txn = tonk
         .reactor
         .repository(key)
@@ -130,25 +159,41 @@ pub(crate) async fn migrate_space_roster(
         .retract(device_row);
 
     if let Some(role) = device_role {
-        let root_role = if role.role.0.to_string() == MemberRole::FOUNDER {
-            MemberRole::founder(root_entity.clone())
-        } else {
-            MemberRole::member(root_entity.clone())
-        };
-        txn = txn.assert(root_role).retract(role);
+        // First-wins: another device may have already migrated (or
+        // directly joined) this space onto the root entity, stamping its
+        // own role there first. Don't overwrite that — in particular,
+        // don't let a plain-member device row demote an already-recorded
+        // founder role. The device row is retracted either way, since it
+        // must not linger regardless of which role wins on the root.
+        if !root_role_exists {
+            let root_role = if role.role.0.to_string() == MemberRole::FOUNDER {
+                MemberRole::founder(root_entity.clone())
+            } else {
+                MemberRole::member(root_entity.clone())
+            };
+            txn = txn.assert(root_role);
+        }
+        txn = txn.retract(role);
     }
     if let Some(name) = device_name {
+        // Last-wins: unlike role/provenance, a display name has no
+        // "first stamp wins" ownership concern, so this device's name
+        // simply overwrites whatever the root entity carried before.
         txn = txn
             .assert(MemberName::new(root_entity.clone(), name.name.0.clone()))
             .retract(name);
     }
     if let Some(stamp) = device_stamp {
-        txn = txn
-            .assert(InvitedVia::new(
+        // First-wins, same reasoning as the role guard above: a prior
+        // migration's invitation provenance for the root entity must not
+        // be overwritten by a later device's migration.
+        if !root_stamp_exists {
+            txn = txn.assert(InvitedVia::new(
                 root_entity.clone(),
                 stamp.invitation.0.clone(),
-            ))
-            .retract(stamp);
+            ));
+        }
+        txn = txn.retract(stamp);
     }
 
     txn.commit()
@@ -352,5 +397,91 @@ mod tests {
             migrate_space_roster(&tonk, &key).await.unwrap()
         };
         assert!(!migrated, "unlinked profile has no root to migrate to");
+    }
+
+    /// First-wins guard: a second linked device's migration must not
+    /// demote a founder role another migration (or a direct root-keyed
+    /// join) has already stamped onto the root entity.
+    #[dialog_common::test]
+    async fn it_does_not_demote_an_existing_root_founder_role() {
+        let state = test_state().await;
+        let (app, state, _lsp) = api_router_with_state(state);
+
+        let device_did = state.read().await.profile.did();
+        let key = put_repo(&app, "migrate-roster-first-wins").await;
+        let subject_did = {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .of()
+                .clone()
+        };
+
+        let root_did = link_account(&state).await;
+
+        // Simulate a prior migration (or a direct root-keyed join): the
+        // root entity already carries a founder role.
+        let root_membership = Membership::new(root_did.clone(), subject_did.clone());
+        let root_entity = root_membership.this().clone();
+        {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .transaction()
+                .assert(root_membership)
+                .assert(MemberRole::founder(root_entity.clone()))
+                .commit()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+        }
+
+        // This device still has its own device-keyed *member* row to
+        // migrate — a lesser role than the root's existing founder.
+        let device_membership = Membership::new(device_did.clone(), subject_did.clone());
+        let device_entity = device_membership.this().clone();
+        {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .transaction()
+                .assert(device_membership)
+                .assert(MemberRole::member(device_entity.clone()))
+                .commit()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+        }
+
+        let migrated = {
+            let tonk = state.read().await;
+            migrate_space_roster(&tonk, &key).await.unwrap()
+        };
+        assert!(migrated, "expected the device-keyed row to be migrated");
+
+        let roles = content_member_roles(&state, &key).await;
+        assert!(
+            roles
+                .iter()
+                .any(|r| r.this == root_entity && r.role.0.to_string() == MemberRole::FOUNDER),
+            "root founder role must survive a later device's migration unchanged",
+        );
+        assert!(
+            !roles.iter().any(|r| r.this == device_entity),
+            "device-keyed role must be gone after migration",
+        );
+
+        let memberships = content_memberships(&state, &key).await;
+        assert!(
+            !memberships.iter().any(|m| m.this == device_entity),
+            "device-keyed membership must be gone after migration",
+        );
     }
 }

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -230,14 +230,41 @@ pub(crate) async fn restamp_member_name(
         .await
         .map_err(|e| RepositoryError::Internal(format!("acquire content branch '{key}': {e}")))?;
     let repo_did = session.handle().of().clone();
-    let membership = Membership::new(tonk.profile.did(), repo_did);
 
-    tonk.reactor
+    let member = crate::router::account::member_did(tonk).await;
+    let membership = Membership::new(member.clone(), repo_did.clone());
+
+    let mut txn = tonk
+        .reactor
         .repository(key)
         .branch(CONTENT_BRANCH)
         .transaction()
-        .assert(MemberName::new(membership.this().clone(), name.to_string()))
-        .commit()
+        .assert(MemberName::new(membership.this().clone(), name.to_string()));
+
+    // Linked profiles: a rename must also clear the orphaned device-keyed
+    // name row (cardinality-one on a different entity, so the assert above
+    // won't overwrite it).
+    let device = tonk.profile.did();
+    if member != device {
+        let device_membership = Membership::new(device, repo_did);
+        let device_entity = device_membership.this().clone();
+        let names: Vec<MemberName> = session
+            .handle()
+            .query()
+            .select(Query::<MemberName> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
+        for stale in names.into_iter().filter(|n| n.this == device_entity) {
+            txn = txn.retract(stale);
+        }
+    }
+
+    txn.commit()
         .perform(&tonk.operator)
         .await
         .map_err(|e| RepositoryError::Internal(format!("restamp member name for '{key}': {e}")))?;
@@ -336,5 +363,105 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resolve_display_name(&tonk).await, "brave-lynx");
+    }
+
+    /// A rename after linking a device to an account root must move the
+    /// space's roster row rather than duplicate it: the founder membership
+    /// was stamped on the device DID (the account was unlinked when the
+    /// space was created), so [`restamp_member_name`] has to key the new
+    /// `MemberName` on the root and retract the now-orphaned device-keyed
+    /// row.
+    #[dialog_common::test]
+    async fn it_rekeys_the_roster_name_to_the_root_and_retracts_the_device_row() {
+        use axum::Json;
+        use axum::body::Body;
+        use axum::extract::State;
+        use axum::http::{Request, StatusCode};
+        use dialog_varsig::{Did, Principal};
+        use tower::ServiceExt;
+
+        let (app, state, _lsp) =
+            crate::router::api_router_with_state(crate::router::tests::test_state().await);
+
+        // Create the space while unlinked: the founder membership is
+        // stamped on the device DID.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/repository/rename-rekey-test")
+                    .method("PUT")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let info: crate::router::RepositoryInfo = serde_json::from_slice(&body).unwrap();
+        let key = info.name;
+        let device_did = state.read().await.profile.did();
+
+        // Link the device to a root after the space already exists —
+        // exactly the order the bug depends on.
+        let root = tonk_identity::derive::derive_root_signer(&[42u8; 32])
+            .await
+            .unwrap();
+        let root_did_str = root.did().to_string();
+        let delegation = tonk_identity::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+        let link_request = tonk_worker_api::AccountLinkRequest {
+            root_did: root_did_str.clone(),
+            delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+        };
+        let _ = crate::router::account::link(State(state.clone()), Json(link_request))
+            .await
+            .unwrap();
+
+        let tonk = state.read().await;
+        restamp_member_name(&tonk, &key, "brave-lynx")
+            .await
+            .expect("restamp succeeds");
+
+        let session = tonk
+            .reactor
+            .repository(&key)
+            .branch(CONTENT_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .unwrap();
+        let repo_did = session.handle().of().clone();
+        let root_did: Did = root_did_str.parse().unwrap();
+        let root_entity = Membership::new(root_did, repo_did.clone()).this().clone();
+        let device_entity = Membership::new(device_did, repo_did).this().clone();
+
+        let names: Vec<MemberName> = session
+            .handle()
+            .query()
+            .select(Query::<MemberName> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            names
+                .iter()
+                .find(|n| n.this == root_entity)
+                .map(|n| n.name.0.as_str()),
+            Some("brave-lynx"),
+            "the renamed name lands on the root-keyed roster row",
+        );
+        assert!(
+            names.iter().all(|n| n.this != device_entity),
+            "the stale device-keyed MemberName is retracted",
+        );
     }
 }

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -127,7 +127,7 @@ pub(crate) async fn ensure_display_name(tonk: &TonkState) -> Result<(), Reposito
 /// A single unparseable subject is logged and dropped rather than failing
 /// the whole list.
 #[cfg(target_arch = "wasm32")]
-async fn profile_space_keys(tonk: &TonkState) -> Vec<String> {
+pub(crate) async fn profile_space_keys(tonk: &TonkState) -> Vec<String> {
     use dialog_varsig::Did;
     use tonk_schema::{Replica, domain::replica::Profile as ProfileEntity};
 


### PR DESCRIPTION
## Summary

Stage 3B — **roster migration** (design: `docs/superpowers/specs/2026-07-23-roster-migration-design.md`). When a device links to an account, it converges its **existing** device-keyed spaces onto the root DID: re-keys each roster row, re-anchors the capability chain to the root, backs up the re-anchored chain so other devices restore it, and fixes the profile-rename no-op from 3A.

**Stacked on cross-device restore (#638)** — base is `feat/cross-device-restore`; this PR shows only the migration diff. Rebase onto `staging` once #638 merges.

## What's in it

- **Roster re-key** (`migrate_space_roster`) — one atomic transaction asserts the root-keyed rows and retracts the device-keyed ones. Role/name/provenance are copied by value; role convergence is **founder-wins** (a founder is never demoted, and a member row is upgraded to founder regardless of arrival order), `InvitedVia` is first-wins, `MemberName` last-wins.
- **Sweep + trigger** (`migrate_rosters`) — best-effort, in-flight-guarded, fired fire-and-forget on device link (folded into the restore spawn, migrate-then-restore). Unlinked → no-op. Idempotent.
- **Re-anchor + backup** (`reanchor_space`) — `try_access()`-discriminated: created spaces mint `space → root` (`back_up_owned_space`), claimed spaces mint the composed `space → eph → device → root` (`claim().delegate(root)`), both escrowed to `/chains/put` so the account's other devices restore them. `remote_url` recovered via the existing `resolve_remote_url` helper.
- **Rename fix** — `restamp_member_name` keys on the member DID and retracts the orphaned device name, closing the 3A no-op.

## Testing

- **Executed & green:** `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --check`, `cargo test -p tonk-account-service --features helpers` (device-signed backup wire contract). The wasm migration code was compiled clean for the real target (`cargo check -p tonk-worker --target wasm32-unknown-unknown --tests` + `cargo build --target wasm32-unknown-unknown`).
- **Not executed here (no browser automation):** the entire migration runtime is `#[cfg(wasm32)]`/`run_in_service_worker` (re-key, sweep, re-anchor, rename) — it runs in CI's `web` matrix leg. The crypto core (device-signed backup, `… → root` serialization) is proven natively via the account-service test.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on migrating a device's existing spaces onto the account root when linking to an account, ensuring proper delegation and backup of capabilities while addressing issues with profile renaming.

### Detailed summary
- Introduced `pub(crate) mod migrate;` in `rust/tonk-worker/src/router.rs`.
- Added `async fn back_up_reanchored` in `rust/tonk-worker/src/router/account_backup.rs` for backing up re-anchored spaces.
- Replaced `link` function with `persist_link` in `rust/tonk-worker/src/router/account.rs` for better delegation persistence.
- Implemented `async fn migrate_rosters` and `async fn migrate_space_roster` in `rust/tonk-worker/src/router/migrate.rs` to handle the migration of device-keyed spaces.
- Updated `restamp_member_name` in `rust/tonk-worker/src/router/profile_name.rs` to key on member DID and retract device names.
- Added tests for migration functionality in `rust/tonk-worker/src/router/migrate.rs`.
- Enhanced documentation for roster migration in `docs/superpowers/specs/2026-07-23-roster-migration-design.md` and `docs/superpowers/plans/2026-07-23-roster-migration.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->