### PR TITLE
fix(tonk-account-service): registry hardening — expiry enforcement, sanitized errors, isolation tests

### DIFF
--- a/docs/superpowers/plans/2026-07-24-account-service-hardening.md
+++ b/docs/superpowers/plans/2026-07-24-account-service-hardening.md
@@ -1,0 +1,680 @@
+# Account Service Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the tracked hardening debt on the account registry: sanitize internal error text, enforce the sqlite foreign-key pragma, add the two missing negative tests, enforce expiry on device-signed invocations, and document the abuse-control runbook.
+
+**Architecture:** All changes live in `rust/tonk-account-service` plus one client-side change in `rust/tonk-identity` (device invocations gain an expiration before the server starts requiring one). Error sanitization happens at `ceremony_error` — the single mapping shared by the wasm handlers and the native helpers server, whose docstring already reserves this follow-up. Expiry enforcement extracts the root path's existing five-minute-window check into a helper both `authorize` and `authorize_root` call.
+
+**Tech Stack:** Rust, workers-rs (Cloudflare Worker, wasm32), rusqlite (native test store), dialog-ucan-core (`InvocationChain`, `Timestamp`), `#[dialog_common::test]`.
+
+## Global Constraints
+
+- Test idiom: `#[dialog_common::test]`, test names `it_does_x`, grouped by behaviour.
+- No `mod.rs` files; `foo.rs` + `foo/` form.
+- Conventional commits: `type(scope): subject`, imperative, lowercase, no trailing period. Scope is the crate short name (`tonk-account-service`, `tonk-identity`).
+- Never reference plan stages, phases, or design docs inside code or code comments — code stands on its own.
+- Lint gate: `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --check` must pass (the workspace gate compiles integration tests; per-crate clippy being green is not sufficient).
+- Crate test command: `cargo test -p tonk-account-service --features helpers`.
+- **Accepted decision (do not "fix"):** no nonce/replay table. Every device-authorized endpoint is an idempotent upsert or read, so replay inside the five-minute expiry window is harmless. Expiry bounds the window; a nonce cache would be YAGNI.
+- **Accepted rollout note:** browsers running a stale cached service worker may send expiration-less chain-backup invocations for a while after deploy. Those calls are best-effort fire-and-forget (failures land in logs, no user-facing breakage), so enforcement does not wait for them.
+
+---
+
+### Task 1: Sanitize internal error text at the ceremony_error choke point
+
+`ceremony_error` in `rust/tonk-account-service/src/handlers.rs` currently copies `CeremonyError::Internal` detail (store/R2/email library text) onto the wire. Its docstring explicitly reserves sanitization as a follow-up. Replace internal detail with a generic message and log the detail instead. The handful of direct `ServiceError::new(ErrorCode::InternalError, format!("response error: {err}"))` sites in handlers serialize our own response structs and carry no stored data — leave them.
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/handlers.rs:29-54` (docstring + `ceremony_error`)
+- Test: same file, new `tests` module at the bottom
+
+**Interfaces:**
+- Consumes: `crate::core::CeremonyError`, `crate::error::{ErrorCode, ServiceError}` (existing).
+- Produces: `ceremony_error(err: CeremonyError) -> ServiceError` — same signature, but `Internal` now maps to the fixed message `"internal error"`. Later tasks and the native helpers server rely on this mapping unchanged for the non-`Internal` variants.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `rust/tonk-account-service/src/handlers.rs`:
+
+```rust
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::ceremony_error;
+    use crate::core::CeremonyError;
+    use crate::error::ErrorCode;
+
+    #[dialog_common::test]
+    async fn it_hides_internal_detail_from_the_wire() {
+        let err = ceremony_error(CeremonyError::Internal(
+            "R2 bucket 'tonk-account-chains' unreachable".into(),
+        ));
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert_eq!(err.message, "internal error");
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_ceremony_messages_through() {
+        let err = ceremony_error(CeremonyError::Forbidden(
+            "device is not an active member of this account".into(),
+        ));
+        assert_eq!(err.code, ErrorCode::Forbidden);
+        assert_eq!(
+            err.message,
+            "device is not an active member of this account"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify the first one fails**
+
+Run: `cargo test -p tonk-account-service --features helpers it_hides_internal_detail -- --nocapture`
+Expected: FAIL — message equals the raw R2 detail, not `"internal error"`. (`it_passes_ceremony_messages_through` already passes; that is fine — it pins current behaviour.)
+
+- [ ] **Step 3: Implement the sanitized mapping**
+
+In `rust/tonk-account-service/src/handlers.rs`, replace the `ceremony_error` docstring and body:
+
+```rust
+/// Map a [`crate::core::CeremonyError`] onto a
+/// [`crate::error::ServiceError`]. Ceremony-level messages (`Invalid`,
+/// `Unauthorized`, `Forbidden`, `Conflict`) pass through: they are
+/// written for callers. `Internal` detail is library/store error text
+/// that must not reach the wire — it is logged here and replaced with a
+/// generic message.
+///
+/// Shared by the wasm handlers and the native helpers server
+/// ([`crate::helpers::server`]) so the two backends can't drift apart
+/// on error mapping.
+#[cfg(any(
+    target_arch = "wasm32",
+    all(feature = "helpers", not(target_arch = "wasm32"))
+))]
+pub fn ceremony_error(err: crate::core::CeremonyError) -> crate::error::ServiceError {
+    use crate::core::CeremonyError;
+    let message = match &err {
+        CeremonyError::RateLimited => "rate limited".to_string(),
+        CeremonyError::CodeInvalid => "invalid or expired code".to_string(),
+        CeremonyError::Conflict(msg)
+        | CeremonyError::Invalid(msg)
+        | CeremonyError::Unauthorized(msg)
+        | CeremonyError::Forbidden(msg) => msg.clone(),
+        CeremonyError::Internal(detail) => {
+            #[cfg(target_arch = "wasm32")]
+            worker::console_error!("internal error: {detail}");
+            #[cfg(not(target_arch = "wasm32"))]
+            eprintln!("internal error: {detail}");
+            "internal error".to_string()
+        }
+    };
+    crate::error::ServiceError::new(err.code(), message)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p tonk-account-service --features helpers handlers::tests -- --nocapture`
+Expected: 2 passed.
+
+- [ ] **Step 5: Check the wasm target still compiles**
+
+Run: `cargo check -p tonk-account-service --target wasm32-unknown-unknown`
+Expected: clean. (`worker::console_error!` is the workers-rs logging macro; this step catches any path/feature surprise with it — if it does not resolve, use `worker::console_log!`'s error-level sibling as exported by the `worker` crate version in `Cargo.lock`, and re-run.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-account-service/src/handlers.rs
+git commit -m "fix(tonk-account-service): keep internal error detail out of responses"
+```
+
+---
+
+### Task 2: Enforce the foreign-key pragma in the sqlite test store
+
+`SqliteStore::in_memory` applies the D1 schema, whose `devices.account_id REFERENCES accounts(id)` is silently unenforced because sqlite defaults `foreign_keys` off. D1 enforces it. Turn the pragma on so the native twin matches production.
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/store/sqlite.rs:27-35` (`in_memory`)
+- Test: same file, existing `tests` module
+
+**Interfaces:**
+- Consumes: existing `Store` trait methods (`insert_device`), `StoreError`.
+- Produces: no signature changes. FK violations surface as `StoreError::Internal` (the `map_err` unique/primary-key carve-out intentionally does not cover FK violations — they indicate a bug, not a caller conflict).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `rust/tonk-account-service/src/store/sqlite.rs`:
+
+```rust
+    #[dialog_common::test]
+    async fn it_enforces_the_device_account_foreign_key() {
+        let store = SqliteStore::in_memory().unwrap();
+        let orphan = Device {
+            account_id: 999,
+            device_did: "did:key:zOrphan".into(),
+            delegation_cid: "bafyCid".into(),
+            name: "ghost".into(),
+            status: DeviceStatus::Active,
+            created_at: 1,
+        };
+        assert!(matches!(
+            store.insert_device(&orphan).await,
+            Err(StoreError::Internal(_))
+        ));
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p tonk-account-service --features helpers it_enforces_the_device_account_foreign_key -- --nocapture`
+Expected: FAIL — the insert currently succeeds (`Ok(())`), so the `matches!` assertion trips.
+
+- [ ] **Step 3: Turn the pragma on**
+
+In `rust/tonk-account-service/src/store/sqlite.rs`, `in_memory`:
+
+```rust
+    pub fn in_memory() -> Result<Self, StoreError> {
+        let conn = Connection::open_in_memory().map_err(map_err)?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .map_err(map_err)?;
+        conn.execute_batch(include_str!("../../migrations/0001_init.sql"))
+            .map_err(map_err)?;
+        conn.execute_batch(include_str!("../../migrations/0002_link_requests.sql"))
+            .map_err(map_err)?;
+        Ok(Self(Mutex::new(conn)))
+    }
+```
+
+- [ ] **Step 4: Run the full crate suite to verify nothing relied on unenforced FKs**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: all pass, including the new test and the existing HTTP integration test (`tests/service.rs`). If any existing test now trips an FK violation, that test was inserting orphaned rows — fix the fixture to create its parent account first (production D1 would have rejected it too); do not weaken the pragma.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-account-service/src/store/sqlite.rs
+git commit -m "fix(tonk-account-service): enforce foreign keys in the sqlite test store"
+```
+
+---
+
+### Task 3: Negative test — the authorize account-mismatch filter branch
+
+`authorize` has two rejection paths for a wrong-account device: chain verification failure (already tested by `it_rejects_a_device_of_a_different_account`) and the registry **filter** `device.account_id == account.id` (untested). Hit the filter: the device is registered under account A, but presents a cryptographically valid delegation from account B's root with subject = root B. Verification succeeds; the filter must reject.
+
+**Files:**
+- Test: `rust/tonk-account-service/src/auth.rs` (existing `tests` module)
+
+**Interfaces:**
+- Consumes: `authorize`, `seed_device`, `derive_root_signer`, `mint_device_delegation`, `InvocationBuilder`, `InvocationChain` — all already imported in the module.
+- Produces: nothing; test-only.
+
+- [ ] **Step 1: Write the test**
+
+Append to the `tests` module in `rust/tonk-account-service/src/auth.rs`:
+
+```rust
+    #[dialog_common::test]
+    async fn it_rejects_a_registered_device_presenting_another_accounts_root() {
+        let store = SqliteStore::in_memory().unwrap();
+
+        // The device is registered under account A…
+        let root_a = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let root_a_did = root_a.did();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let device_did = device.did();
+        seed_device(
+            &store,
+            root_a_did.as_ref(),
+            device_did.as_ref(),
+            DeviceStatus::Active,
+        )
+        .await;
+
+        // …but invokes as a delegate of account B, with a chain that
+        // verifies: root B really did delegate to this device key.
+        let root_b = tonk_identity::derive::derive_root_signer(&[9u8; 32])
+            .await
+            .unwrap();
+        let root_b_did = root_b.did();
+        store
+            .create_account("b@x.com", root_b_did.as_ref(), "cred-b", 0)
+            .await
+            .unwrap();
+
+        let chain = tonk_identity::delegation::mint_device_delegation(root_b, &device_did)
+            .await
+            .unwrap();
+        let delegation = chain.proofs().last().unwrap().clone();
+        let cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(device)
+            .audience(&root_b_did)
+            .subject(&root_b_did)
+            .command(vec!["account".into(), "device".into(), "list".into()])
+            .arguments(BTreeMap::new())
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let mut proofs = std::collections::HashMap::new();
+        proofs.insert(cid, std::sync::Arc::new(delegation));
+        let bytes = InvocationChain::new(invocation, proofs).to_bytes().unwrap();
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+    }
+```
+
+(`Forbidden` distinguishes the filter from the verification path, which yields `Unauthorized`. The expiration stamp is inert until Task 6 and required after it, so the test is stable across the ordering.)
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p tonk-account-service --features helpers it_rejects_a_registered_device_presenting_another_accounts_root -- --nocapture`
+Expected: PASS immediately — this pins existing behaviour of an untested branch. Confirm it is exercising the filter by temporarily changing the asserted variant to `Unauthorized` and watching it fail, then restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-account-service/src/auth.rs
+git commit -m "test(tonk-account-service): pin the wrong-account device filter in authorize"
+```
+
+---
+
+### Task 4: Negative test — cross-account chain get isolation
+
+`get_chain` namespaces by `account.root_did`; prove account B cannot fetch account A's backed-up artifact even with the exact content key.
+
+**Files:**
+- Test: `rust/tonk-account-service/src/core/backup.rs` (existing `tests` module)
+
+**Interfaces:**
+- Consumes: `put_chain`, `get_chain`, `MemoryChainStore`, the module's `account(id, root_did)` fixture.
+- Produces: nothing; test-only.
+
+- [ ] **Step 1: Write the test**
+
+Append to the `tests` module in `rust/tonk-account-service/src/core/backup.rs`:
+
+```rust
+    #[dialog_common::test]
+    async fn it_refuses_a_chain_get_across_accounts() {
+        let chains = MemoryChainStore::default();
+        let account_a = account(1, "did:key:root-a");
+        let account_b = account(2, "did:key:root-b");
+
+        let key = put_chain(&chains, &account_a, b"a-bytes").await.unwrap();
+
+        assert!(matches!(
+            get_chain(&chains, &account_b, &key).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p tonk-account-service --features helpers it_refuses_a_chain_get_across_accounts -- --nocapture`
+Expected: PASS (pins existing namespacing). Sanity-check it can fail: temporarily pass `&account_a` instead of `&account_b` and confirm the assertion trips, then restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-account-service/src/core/backup.rs
+git commit -m "test(tonk-account-service): pin cross-account chain get isolation"
+```
+
+---
+
+### Task 5: Stamp an expiration on device-signed invocations
+
+`build_device_invocation` (`rust/tonk-identity/src/request.rs`) stamps no expiration — verified: the builder chain goes `.proofs(vec![cid])` straight to `.try_build()`. Root-signed ceremonies already stamp `Timestamp::five_minutes_from_now()` (`rust/tonk-identity/src/ceremony.rs:55`); make device invocations match before the server enforces it (Task 6).
+
+Callers of `build_device_invocation`, enumerated by grep — all inside this repo's deploy trains, none in `tonk-cli`:
+- `rust/tonk-worker/src/router/account_backup.rs` (three sites: chain put/list/get — all best-effort)
+- `rust/tonk-account-service/tests/service.rs` (integration test)
+
+**Files:**
+- Modify: `rust/tonk-identity/src/request.rs`
+- Test: same file, existing test
+
+**Interfaces:**
+- Consumes: `dialog_ucan_core::time::timestamp::Timestamp` (same import path `ceremony.rs` uses).
+- Produces: `build_device_invocation` — signature unchanged; every produced invocation now carries `expiration = Timestamp::five_minutes_from_now()`. Task 6's server enforcement relies on this.
+
+- [ ] **Step 1: Extend the existing test to expect an expiration**
+
+In `rust/tonk-identity/src/request.rs`, inside `it_builds_a_device_signed_invocation_the_service_verifies`, after the `chain.verify(...)` unwrap, add:
+
+```rust
+        assert!(
+            chain.invocation.expiration().is_some(),
+            "device invocations must carry a ceremony expiration"
+        );
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p tonk-identity it_builds_a_device_signed_invocation -- --nocapture`
+Expected: FAIL on the new assertion (no expiration today).
+
+- [ ] **Step 3: Stamp the expiration**
+
+In `rust/tonk-identity/src/request.rs`, add the import and the builder call:
+
+```rust
+use dialog_ucan_core::time::timestamp::Timestamp;
+```
+
+and in `build_device_invocation`:
+
+```rust
+    let invocation = InvocationBuilder::new()
+        .issuer(device)
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(command)
+        .arguments(arguments)
+        .proofs(vec![cid])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .context("failed to sign the device invocation")?;
+```
+
+Also update the module docstring's contract sentence (first paragraph) to mention the stamp, e.g. append: "Invocations carry a five-minute expiration; the service refuses stale ones."
+
+- [ ] **Step 4: Run the crate tests**
+
+Run: `cargo test -p tonk-identity`
+Expected: PASS.
+
+- [ ] **Step 5: Check the wasm consumer still compiles**
+
+Run: `cargo check -p tonk-worker --target wasm32-unknown-unknown`
+Expected: clean (the three `account_backup.rs` call sites take the new behaviour with no signature change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-identity/src/request.rs
+git commit -m "feat(tonk-identity): stamp a five-minute expiration on device invocations"
+```
+
+---
+
+### Task 6: Enforce expiry on device-signed invocations in authorize
+
+The root bootstrap path (`authorize_root`) already requires an expiration inside a five-minute window; the device path (`authorize`) checks nothing. Extract the check into a shared helper and apply it to both. Update the test container helper to stamp expirations, and add the two negative tests.
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/auth.rs`
+- Test: same file, existing `tests` module
+
+**Interfaces:**
+- Consumes: Task 5 (all in-repo senders now stamp expirations), `Timestamp` (already imported).
+- Produces: `fn require_ceremony_expiration(chain: &InvocationChain<Ed25519Signature>) -> Result<(), CeremonyError>` (private); `authorize` now returns `CeremonyError::Unauthorized` for missing/expired/over-window expirations.
+
+- [ ] **Step 1: Verify the sender inventory is still complete (STOP-and-report gate)**
+
+Run: `grep -rn "build_device_invocation" rust/ --include="*.rs" | grep -v request.rs`
+Expected: exactly `rust/tonk-account-service/tests/service.rs` and three `rust/tonk-worker/src/router/account_backup.rs` sites. Also run `grep -rn "InvocationChain::new" rust/tonk-cli rust/tonk-ui --include="*.rs"` — expected: no hits building device-signed account-service requests outside those files. **If any other sender appears** (especially in `tonk-cli`, whose released binaries update slowly), STOP and report before enforcing: enforcement would break that sender's deployed versions.
+
+- [ ] **Step 2: Update the container helper and write the failing negative tests**
+
+In the `tests` module of `rust/tonk-account-service/src/auth.rs`, replace the `container` helper with an expiration-parameterized pair:
+
+```rust
+    async fn container_with_expiration(
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+        expiration: Option<Timestamp>,
+    ) -> (String, String, Vec<u8>) {
+        let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let root_did = root.did();
+        let chain = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let delegation = chain.proofs().last().unwrap().clone();
+        let cid = delegation.to_cid();
+        let mut builder = InvocationBuilder::new()
+            .issuer(device.clone())
+            .audience(&root_did)
+            .subject(&root_did)
+            .command(command)
+            .arguments(args)
+            .proofs(vec![cid]);
+        if let Some(expiration) = expiration {
+            builder = builder.expiration(expiration);
+        }
+        let invocation = builder.try_build().await.unwrap();
+        let mut proofs = std::collections::HashMap::new();
+        proofs.insert(cid, std::sync::Arc::new(delegation));
+        let bytes = InvocationChain::new(invocation, proofs).to_bytes().unwrap();
+        (root_did.to_string(), device.did().to_string(), bytes)
+    }
+
+    async fn container(
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> (String, String, Vec<u8>) {
+        container_with_expiration(command, args, Some(Timestamp::five_minutes_from_now())).await
+    }
+```
+
+Then add the negative tests:
+
+```rust
+    #[dialog_common::test]
+    async fn it_rejects_a_device_invocation_without_expiration() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, bytes) = container_with_expiration(
+            vec!["account".into(), "device".into(), "list".into()],
+            BTreeMap::new(),
+            None,
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Unauthorized(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_expired_device_invocation() {
+        use std::time::{Duration, UNIX_EPOCH};
+
+        let store = SqliteStore::in_memory().unwrap();
+        let expired = Timestamp::new(UNIX_EPOCH + Duration::from_secs(1)).unwrap();
+        let (root_did, device_did, bytes) = container_with_expiration(
+            vec!["account".into(), "device".into(), "list".into()],
+            BTreeMap::new(),
+            Some(expired),
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Unauthorized(_))
+        ));
+    }
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `cargo test -p tonk-account-service --features helpers it_rejects_a_device_invocation_without_expiration it_rejects_an_expired_device_invocation -- --nocapture`
+Expected: both FAIL — `authorize` currently accepts them (`Ok(Caller { .. })`).
+
+- [ ] **Step 4: Extract the shared expiration check and enforce it**
+
+In `rust/tonk-account-service/src/auth.rs`, add below `verified_chain`:
+
+```rust
+/// Require an expiration on the invocation and bound it to the
+/// five-minute ceremony window every account-service request uses.
+fn require_ceremony_expiration(
+    chain: &InvocationChain<Ed25519Signature>,
+) -> Result<(), CeremonyError> {
+    let expiration = chain.invocation.expiration().ok_or_else(|| {
+        CeremonyError::Unauthorized("invocation must carry an expiration".to_string())
+    })?;
+    let now = Timestamp::now();
+    if expiration < now {
+        return Err(CeremonyError::Unauthorized(
+            "invocation has expired".to_string(),
+        ));
+    }
+    if expiration > Timestamp::five_minutes_from_now() {
+        return Err(CeremonyError::Unauthorized(
+            "invocation expiration exceeds the five-minute ceremony window".to_string(),
+        ));
+    }
+    Ok(())
+}
+```
+
+(The three lines of logic are moved verbatim from `authorize_root`, so the `Timestamp` comparison forms are already known to compile.)
+
+In `authorize`, after the `verified_chain(...)` call:
+
+```rust
+    let chain = verified_chain(body, expected_command).await?;
+    require_ceremony_expiration(&chain)?;
+```
+
+In `authorize_root`, replace the inline expiration block (the `let expiration = ...` through the over-window `if`) with:
+
+```rust
+    require_ceremony_expiration(&chain)?;
+```
+
+- [ ] **Step 5: Run the full crate suite**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: all pass — the new negatives, every pre-existing `authorize` test (their containers now stamp expirations via the updated helper), `authorize_root` tests (behaviour unchanged, messages slightly generalized), and the HTTP integration test in `tests/service.rs` (its invocations gained expirations in Task 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-account-service/src/auth.rs
+git commit -m "fix(tonk-account-service): require the ceremony expiry window on device invocations"
+```
+
+---
+
+### Task 7: Abuse-controls runbook and deploy verification
+
+Code carries no per-IP limits by design — that lives at the Cloudflare edge. Document the runbook in the crate README and verify the two outstanding deploy prerequisites from the CLI-handoff work: migration `0002_link_requests.sql` applied everywhere, and the rate rule extended from `POST /codes` to also cover `POST /links`. Turnstile stays deferred until abuse is observed.
+
+**Files:**
+- Modify: `rust/tonk-account-service/README.md`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: documentation only.
+
+- [ ] **Step 1: Add the runbook section**
+
+Append to `rust/tonk-account-service/README.md`:
+
+```markdown
+## Abuse controls
+
+Application-level throttles live in `src/core/codes.rs`: per-email 60 s
+resend cooldown, 10-minute code TTL, five verification attempts per code.
+Everything IP-shaped is enforced at the Cloudflare edge, not in code:
+
+- **Rate rule** (zone `tonk.xyz`, and the staging host): one rate-limiting
+  rule covering the two unauthenticated write paths —
+
+  ```
+  (http.request.method eq "POST" and
+   http.request.uri.path in {"/codes" "/links"} and
+   http.host in {"accounts.tonk.xyz" "accounts-staging.tonk.xyz"})
+  ```
+
+  Suggested threshold to start: 10 requests per 10 minutes per IP, block
+  for 1 hour. `/links/resolve|complete|consume` need no rule: they demand
+  the 256-bit bearer secret and cheap lookups fail closed.
+- **Turnstile**: deliberately not deployed. Revisit only if the rate rule
+  proves insufficient in practice.
+
+### Deploy verification
+
+Migrations must be applied to both environments (wrangler reads
+`wrangler.account.toml`):
+
+```sh
+npx wrangler d1 migrations list tonk-accounts --remote -c wrangler.account.toml
+npx wrangler d1 migrations list tonk-accounts-staging --remote -c wrangler.account.toml --env staging
+```
+
+Both must show `0001_init.sql` and `0002_link_requests.sql` as applied;
+apply any pending ones with the matching `d1 migrations apply` command.
+Confirm the rate rule exists in the Cloudflare dashboard (Security →
+WAF → Rate limiting rules) and that its path list includes `/links`.
+```
+
+- [ ] **Step 2: Run the manual verification and record the outcome**
+
+Run both `wrangler d1 migrations list` commands above (requires Cloudflare auth; if credentials are unavailable in this session, STOP and report — the PR can land, but flag the verification as still owed in the PR body). Check the dashboard rate rule the same way. Expected: 0001 and 0002 applied in both environments; rule present with both paths.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-account-service/README.md
+git commit -m "docs(tonk-account-service): abuse-controls runbook and deploy verification"
+```
+
+---
+
+### Task 8: Full verification gate
+
+**Files:** none (verification only).
+
+**Interfaces:** consumes all prior tasks.
+
+- [ ] **Step 1: Workspace lint gate**
+
+Run: `cargo clippy --workspace --all-targets --all-features`
+Expected: no warnings. (This compiles integration tests too; it is the CI gate.)
+
+- [ ] **Step 2: Format check**
+
+Run: `cargo fmt --check`
+Expected: no diffs.
+
+- [ ] **Step 3: Crate suites**
+
+Run: `cargo test -p tonk-account-service --features helpers && cargo test -p tonk-identity`
+Expected: all pass.
+
+- [ ] **Step 4: Wasm targets**
+
+Run: `cargo check -p tonk-account-service --target wasm32-unknown-unknown && cargo check -p tonk-worker --target wasm32-unknown-unknown`
+Expected: clean.
+
+- [ ] **Step 5: Push and open the PR**
+
+Branch: `fix/account-service-hardening`, base `staging`. PR title: `fix(tonk-account-service): hardening follow-ups from the registry review`. Body lists the six review items this closes and the two accepted decisions (no nonce table; stale-service-worker rollout note), and records the Task 7 verification outcome.
+
+```bash
+git push -u origin fix/account-service-hardening
+gh pr create --base staging --title "fix(tonk-account-service): hardening follow-ups from the registry review" --body-file -
+```

--- a/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
+++ b/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
@@ -1,0 +1,232 @@
+# Account system completion
+
+Program design for finishing the cross-device identity and account system.
+Written 2026-07-24 from an audit of everything landed or in flight against
+the approved design (`2026-07-17-identity-accounts-design.md`, PR #618).
+Each remaining stage below is one PR with its own implementation plan;
+plans for stages H, R, D, and C exist alongside this spec.
+
+## Where the program stands
+
+The master design named four build stages. As built:
+
+| Stage | Delivered by | Status |
+|---|---|---|
+| 1 — account service skeleton | #625 (worker + D1 + R2 + Resend), config folded in via #637 | merged |
+| 2 — client ceremonies | #623 (identity crate), #624 (rp id), #627 (browser ceremonies), #628 (CLI handoff) | merged |
+| 3A — root-DID rosters + claim backup | #637 | merged |
+| 3A' — cross-device restore + created-space backup | #638 | merged |
+| 3B — roster migration, re-anchor, rename fix | #639 | in CI |
+| 4 — billing and entitlements | — | not started |
+
+Also relevant in flight:
+
+- **#618** — the master design doc PR. Draft, behind staging, zero review
+  threads. Needs a light as-built refresh (stage table above, restore as its
+  own PR, revocation re-sequenced per this spec) then undraft and merge.
+- **#635** — dialog bump with the `dialog.* → db.*` attribute rename sweep.
+  Its sweep predates #637–#639, so the roster/migration fact writes in
+  `tonk-worker` (roster rows, member name/role/provenance, any
+  `dialog.origin/*` reads) must be re-swept by whichever side merges second.
+  `schema::Origin → schema::Replica` also touches `tonk-worker`.
+  `rust/tonk-account-service` is unaffected (HTTP/D1/R2, no dialog
+  attributes).
+
+## What is done and verified
+
+Account creation (email code → passkey/PRF → root-signed `account/create`),
+browser self-link, CLI browser handoff, device register/list/revoke
+endpoints, chain backup (`/chains/put|list|get`), claim/created-space
+backup, cross-device restore, roster re-key + capability re-anchor on link,
+and the rename fix. Native test coverage is solid (unit + one full
+HTTP-ceremony integration test); a real CDP virtual-authenticator passkey
+e2e exists (`tonk-ui/src/identity.rs`, gated on `web-integration-tests`).
+
+## The gap map
+
+Ordered by risk, not by the original stage numbering.
+
+### R — Revocation enforcement (security gap, highest priority)
+
+`root → device` delegations are subject-open (`Subject::Any`) and carry
+**no expiration** (`tonk-identity/src/delegation.rs:12`). `POST
+/devices/revoke` flips a D1 status flag that only the account service
+itself consults (`tonk-account-service/src/auth.rs`). The access-service
+presign path (`tonk-access-service/src/handlers/ucan.rs`) does purely
+cryptographic chain verification — **a revoked device keeps full storage
+access forever**. Until this lands, revocation is cosmetic and a lost
+device is a permanent co-owner of every space it could reach.
+
+Decision — pulled forward and decoupled from billing (the master spec
+paired them; the registry check is the only kill-switch we have, and
+device-management UX is meaningless without it):
+
+- The access-service gains a **read-only D1 binding to the accounts
+  database** (same Cloudflare account; `tonk-accounts` /
+  `tonk-accounts-staging`). No HTTP hop to the account service on the hot
+  path, exactly the "one indexed lookup" shape the master spec prescribes.
+- **Dual match**: parse the presented invocation container and collect
+  both the CID of every proof delegation and every issuer DID (delegation
+  issuers + the invocation issuer); reject with 403 if any matches a
+  `devices` row with `status = 'revoked'`. The DID match is the
+  security-bearing one — re-anchored chains flow through delegations
+  *issued by* the revoked device whose CIDs the registry never saw, and a
+  revoked device can mint fresh delegations. Verified feasible with public
+  dialog APIs against the pinned dialog tag (no upstream change needed);
+  unregistered device-only users produce no matches and are untouched.
+- **Fail-open** on D1 error/outage with a per-isolate verdict cache
+  (~60 s TTL), per the master spec's availability posture.
+- The lookup seam is written so billing later adds its entitlement join
+  without touching the handler again.
+
+### H — Service hardening (tracked debt from #625/#628)
+
+- Enforce **expiry on device-signed invocations** in `authorize` (the root
+  path already enforces a 5-minute window; the device path checks nothing).
+  Clients must stamp expirations first — verify `build_device_invocation`
+  and add one if missing. Decision: **no nonce/replay table** — every
+  device-authorized endpoint is an idempotent upsert or read, so replay
+  within the window is harmless; recorded as an accepted risk.
+- `PRAGMA foreign_keys = ON` in the sqlite test store (D1 parity — absent
+  today, confirmed).
+- Error-text sanitization: `ServiceError::to_response` serializes internal
+  error strings (store/R2 details) to the wire on 500s. Log the detail,
+  return a generic message; 4xx ceremony messages stay.
+- The two missing negative tests from the #625 review: the
+  device-belongs-to-a-different-account **filter** branch in `authorize`
+  (valid chain, registered device, mismatched account), and cross-account
+  `/chains/get` isolation.
+- Ops (runbook, not code): confirm `0002_link_requests.sql` is applied to
+  staging and production D1, and extend the existing `/codes` rate rule to
+  exact-path `POST /links` (deploy prerequisite stated in #628). Decision:
+  Cloudflare zone rate rules only; **Turnstile deferred** until abuse is
+  observed.
+
+### D — Device management surface
+
+`/devices/list` and `/devices/revoke` have **no consumer** — no UI panel,
+no CLI verbs. Ships after R so revoke is real:
+
+- `tonk-ui` account element: a devices panel (list with name, created,
+  status, "this device" marker; revoke with confirm). Reuses the existing
+  device-signed invocation plumbing via a new worker route.
+- Worker: `GET /api/account/devices`, `POST /api/account/devices/revoke`
+  (device-signed invocations built from the stored link), plus a local
+  **unlink** (`DELETE /api/account`) that clears the stored `root → device`
+  link — self-service "sign out of the account on this device".
+- CLI: `tonk account devices`, `tonk account revoke <device-did>`.
+
+### C — Recovery and rotation ceremonies
+
+Specified in the master design ("ride with stage 2 or immediately after")
+but never built. None of the three exist in code. Build order within the
+stage:
+
+1. **Deliberate rotation / succession** — derive old root, mint
+   subject-open `oldRoot → newRoot`, re-assert rosters under the new DID.
+   The 3B migration sweep (`migrate.rs`) already re-keys rosters
+   device→root; succession generalizes the same machinery to
+   oldRoot→newRoot. Account service: root-signed flip of `root_did` +
+   `credential_id` on the account row.
+2. **Surviving-device recovery** (passkey lost, linked device in hand) —
+   new passkey on the tonk origin, surviving device mints
+   `device → newRoot`, two-signature ceremony (device-signed under the old
+   root + root-signed by the new root) flips the account row and revokes
+   the old credential's devices.
+3. **Total-loss re-anchor** — email code + support contact re-points the
+   account row at a fresh root DID; billing/entitlements carry, space
+   access does not. Rate-limited, logged. Needs a support posture more than
+   code; last.
+
+### B — Billing and entitlements (master stage 4)
+
+Not started; nothing in any crate references Stripe, plans, or
+entitlements. Scope per the master spec: Checkout Session + Customer
+Portal, webhook reducer into an `entitlements` table, requester-based
+gateway lookup (join on the same D1 binding stage R introduces), free tier
+for unknown DIDs, lapsed = free-tier limits, **log-only soak before
+enforcement**.
+
+**Blocked on user inputs, deliberately unplanned tonight:** Stripe account
+and mode, product/price catalogue, concrete free/paid limits (space count,
+storage bytes, bandwidth?), and whether staging gets its own Stripe
+sandbox. Write the plan (repo format) once those exist; the enforcement
+seam is already reserved in stage R.
+
+### F — Functional follow-ups carried by the 3A/3B/restore specs
+
+Small, independent, each its own commit-or-PR; none block the stages
+above:
+
+1. `put_repository` one-shot create-with-remote bypasses
+   `enable_sync_inner`, so such spaces are never backed up or restorable.
+   Hook the backup (recover the raw sync URL from the parsed
+   `SiteAddress`).
+2. Native/CLI created-space backup if the `ensure_remote_config` hook
+   remains wasm-only (CLI-created spaces currently un-backed-up).
+3. Live restore/migration propagation — today both run on link/startup
+   only; add a periodic or sync-signal refresh so a space claimed on
+   device A appears on device B without a restart.
+4. `InvitedVia` self-claim detection is device-scoped (flagged in #637;
+   cross-device provenance once restore is live).
+5. Account-service URL resolution hardcoded to
+   `tonk.spot`/`staging.tonk.xyz` in `account_backup.rs` — fine until a
+   third environment appears; fold into config when one does.
+6. Deferred by explicit earlier decision, unchanged tonight: public
+   root-signed device manifest (privacy semantics unsettled); adopting the
+   root DID as the local profile DID.
+
+Accepted, not to be fixed (documented behavior): rename-during-pending-
+migration race (bounded, self-heals on next rename); re-anchored chains
+flowing through the old device DID until fresh invites (inherent to the
+design; revoking that device severs them — R makes this visible, D's UI
+copy should say so).
+
+### T — Test and verification debt
+
+- The CDP passkey e2e and the wasm service-worker suites have **never run
+  locally** (macOS 27 libffi blocker; wasm tests hang locally) — they rely
+  on the CI web leg. Verify the `web-integration-tests` feature is actually
+  exercised in CI; wire it if not.
+- Manual staging smokes still owed: worker → service `/chains/put` (flagged
+  in #637), migration sweep + restore on a real two-device account
+  (flagged in #639).
+- Bench scenarios from the master spec's testing section (creation,
+  self-link, surviving-device recovery) once C lands.
+
+## Sequencing
+
+```
+#639 merge → H (hardening, account-service crate)
+           → R (revocation, access-service crate)   [H ∥ R, disjoint crates]
+           → D (device management: worker + UI + CLI)
+           → C (recovery ceremonies, three sub-stages)
+           → B (billing; blocked on user inputs)
+F follow-ups and T debt interleave as small PRs whenever convenient.
+#618 refresh + merge and the #635 rename coordination are immediate,
+independent of the chain.
+```
+
+H and R are planned in full (`2026-07-24-account-service-hardening.md`,
+`2026-07-24-revocation-enforcement.md`); D and C have plans at the same
+paths pattern (`2026-07-24-device-management.md`,
+`2026-07-24-recovery-ceremonies.md`) with verify-first gates where dialog
+APIs need confirmation. B gets its plan after the Stripe decisions.
+
+## Risks
+
+- **Revocation matching depends on parsing the presign container** —
+  resolved: verified against the pinned dialog tag that the `/ucan/` body
+  re-parses with public APIs (`Container::from_bytes` → invocation +
+  delegations, `to_cid()`/`issuer()` reachable, CID string parity with the
+  registry). The plan keeps a re-runnable verify task so a future dialog
+  pin drift surfaces as a STOP, not a silent break.
+- **Enforcing device-invocation expiry can strand old clients.** All
+  senders of device-signed invocations live in the worker (deployed with
+  the service) — verified, not assumed, in the hardening plan. CLI link
+  flow uses bearer-token endpoints and is unaffected.
+- **Fail-open revocation** leaves a revoked device a brief window during a
+  D1 outage — accepted by the master spec in exchange for sync
+  availability.
+- **Stage B scope creep.** The entitlement seam in R must stay a seam;
+  billing lands only after the log-only soak the master spec requires.

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -163,3 +163,39 @@ tonk account link \
   --service-url https://accounts-staging.tonk.xyz \
   --account-url https://staging.tonk.xyz/account/link
 ```
+
+## Abuse controls
+
+Application-level throttles live in `src/core/codes.rs`: per-email 60 s
+resend cooldown, 10-minute code TTL, five verification attempts per code.
+Everything IP-shaped is enforced at the Cloudflare edge, not in code:
+
+- **Rate rule** (zone `tonk.xyz`, and the staging host): one rate-limiting
+  rule covering the two unauthenticated write paths —
+
+  ```
+  (http.request.method eq "POST" and
+   http.request.uri.path in {"/codes" "/links"} and
+   http.host in {"accounts.tonk.xyz" "accounts-staging.tonk.xyz"})
+  ```
+
+  Suggested threshold to start: 10 requests per 10 minutes per IP, block
+  for 1 hour. `/links/resolve|complete|consume` need no rule: they demand
+  the 256-bit bearer secret and cheap lookups fail closed.
+- **Turnstile**: deliberately not deployed. Revisit only if the rate rule
+  proves insufficient in practice.
+
+### Deploy verification
+
+Migrations must be applied to both environments (wrangler reads
+`wrangler.account.toml`):
+
+```sh
+npx wrangler d1 migrations list tonk-accounts --remote -c wrangler.account.toml
+npx wrangler d1 migrations list tonk-accounts-staging --remote -c wrangler.account.toml --env staging
+```
+
+Both must show `0001_init.sql` and `0002_link_requests.sql` as applied;
+apply any pending ones with the matching `d1 migrations apply` command.
+Confirm the rate rule exists in the Cloudflare dashboard (Security →
+WAF → Rate limiting rules) and that its path list includes `/links`.

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -171,17 +171,19 @@ resend cooldown, 10-minute code TTL, five verification attempts per code.
 Everything IP-shaped is enforced at the Cloudflare edge, not in code:
 
 - **Rate rule** (zone `tonk.xyz`, and the staging host): one rate-limiting
-  rule covering the two unauthenticated write paths —
+  rule per environment covering the two unauthenticated write paths.
+  Each rule's expression should match both `/codes` and `/links`:
 
   ```
-  (http.request.method eq "POST" and
-   http.request.uri.path in {"/codes" "/links"} and
-   http.host in {"accounts.tonk.xyz" "accounts-staging.tonk.xyz"})
+  (http.host eq "accounts.tonk.xyz" and http.request.method eq "POST" and
+   http.request.uri.path in {"/codes" "/links"})
   ```
 
-  Suggested threshold to start: 10 requests per 10 minutes per IP, block
-  for 1 hour. `/links/resolve|complete|consume` need no rule: they demand
-  the 256-bit bearer secret and cheap lookups fail closed.
+  Deployed threshold: 3 requests per 10 seconds per IP, action Block.
+  Verify each environment's existing rule covers both paths in the expression,
+  and extend the path set if `/links` is missing.
+  `/links/resolve|complete|consume` need no rule: they demand the 256-bit
+  bearer secret and cheap lookups fail closed.
 - **Turnstile**: deliberately not deployed. Revisit only if the rate rule
   proves insufficient in practice.
 
@@ -191,8 +193,8 @@ Migrations must be applied to both environments (wrangler reads
 `wrangler.account.toml`):
 
 ```sh
-npx wrangler d1 migrations list tonk-accounts --remote -c wrangler.account.toml
-npx wrangler d1 migrations list tonk-accounts-staging --remote -c wrangler.account.toml --env staging
+wrangler d1 migrations list tonk-accounts --remote -c wrangler.account.toml
+wrangler d1 migrations list tonk-accounts-staging --remote -c wrangler.account.toml --env staging
 ```
 
 Both must show `0001_init.sql` and `0002_link_requests.sql` as applied;

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use dialog_credentials::Ed25519KeyResolver;
 use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
-use dialog_ucan_core::time::timestamp::Timestamp;
+use dialog_ucan_core::time::timestamp::{Duration, SystemTime, Timestamp};
 use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 
 use crate::core::CeremonyError;
@@ -58,8 +58,29 @@ async fn verified_chain(
     Ok(chain)
 }
 
+/// Get the latest expiration a ceremony invocation may carry: five
+/// minutes from now, plus a one-minute allowance for clock skew between
+/// the caller and this service. Mirrors [`Timestamp::five_minutes_from_now`].
+///
+/// # Panics
+///
+/// This function will panic if the current time is before the Unix epoch.
+#[allow(clippy::expect_used)]
+fn ceremony_expiration_upper_bound() -> Timestamp {
+    Timestamp::new(SystemTime::now() + Duration::from_secs(5 * 60) + CEREMONY_SKEW_ALLOWANCE)
+        .expect("the current time to be sometime in the 3rd millennium CE")
+}
+
+/// Clock-skew allowance applied to the upper bound of the ceremony
+/// expiration window, so a caller whose clock runs a little fast isn't
+/// rejected for an invocation that is, in practice, well within the
+/// five-minute ceremony window.
+const CEREMONY_SKEW_ALLOWANCE: Duration = Duration::from_secs(60);
+
 /// Require an expiration on the invocation and bound it to the
-/// five-minute ceremony window every account-service request uses.
+/// five-minute ceremony window every account-service request uses,
+/// plus a one-minute allowance for clock skew on the upper bound. The
+/// lower bound (already expired) carries no such allowance.
 fn require_ceremony_expiration(
     chain: &InvocationChain<Ed25519Signature>,
 ) -> Result<(), CeremonyError> {
@@ -72,9 +93,10 @@ fn require_ceremony_expiration(
             "invocation has expired".to_string(),
         ));
     }
-    if expiration > Timestamp::five_minutes_from_now() {
+    if expiration > ceremony_expiration_upper_bound() {
         return Err(CeremonyError::Unauthorized(
-            "invocation expiration exceeds the five-minute ceremony window".to_string(),
+            "invocation expiration exceeds the five-minute ceremony window plus skew allowance"
+                .to_string(),
         ));
     }
     Ok(())
@@ -424,10 +446,16 @@ mod tests {
         .await;
         seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
 
-        assert!(matches!(
-            authorize(&store, &bytes, &["account", "device", "list"]).await,
-            Err(CeremonyError::Unauthorized(_))
-        ));
+        match authorize(&store, &bytes, &["account", "device", "list"]).await {
+            Err(CeremonyError::Unauthorized(msg)) => {
+                assert!(
+                    msg.contains("must carry an expiration"),
+                    "unexpected message: {msg}"
+                );
+            }
+            Err(other) => panic!("expected Unauthorized, got a different error: {other:?}"),
+            Ok(_) => panic!("expected Unauthorized, got Ok"),
+        }
     }
 
     #[dialog_common::test]
@@ -444,10 +472,39 @@ mod tests {
         .await;
         seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
 
-        assert!(matches!(
-            authorize(&store, &bytes, &["account", "device", "list"]).await,
-            Err(CeremonyError::Unauthorized(_))
-        ));
+        match authorize(&store, &bytes, &["account", "device", "list"]).await {
+            Err(CeremonyError::Unauthorized(msg)) => {
+                assert!(msg.contains("has expired"), "unexpected message: {msg}");
+            }
+            Err(other) => panic!("expected Unauthorized, got a different error: {other:?}"),
+            Ok(_) => panic!("expected Unauthorized, got Ok"),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_invocation_expiring_beyond_the_ceremony_window() {
+        // Ten minutes comfortably clears the five-minute window plus the
+        // one-minute skew allowance, so this must still trip the bound.
+        let too_far_out = Timestamp::new(SystemTime::now() + Duration::from_secs(10 * 60)).unwrap();
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, bytes) = container_with_expiration(
+            vec!["account".into(), "device".into(), "list".into()],
+            BTreeMap::new(),
+            Some(too_far_out),
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+
+        match authorize(&store, &bytes, &["account", "device", "list"]).await {
+            Err(CeremonyError::Unauthorized(msg)) => {
+                assert!(
+                    msg.contains("exceeds the five-minute ceremony window"),
+                    "unexpected message: {msg}"
+                );
+            }
+            Err(other) => panic!("expected Unauthorized, got a different error: {other:?}"),
+            Ok(_) => panic!("expected Unauthorized, got Ok"),
+        }
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -58,6 +58,28 @@ async fn verified_chain(
     Ok(chain)
 }
 
+/// Require an expiration on the invocation and bound it to the
+/// five-minute ceremony window every account-service request uses.
+fn require_ceremony_expiration(
+    chain: &InvocationChain<Ed25519Signature>,
+) -> Result<(), CeremonyError> {
+    let expiration = chain.invocation.expiration().ok_or_else(|| {
+        CeremonyError::Unauthorized("invocation must carry an expiration".to_string())
+    })?;
+    let now = Timestamp::now();
+    if expiration < now {
+        return Err(CeremonyError::Unauthorized(
+            "invocation has expired".to_string(),
+        ));
+    }
+    if expiration > Timestamp::five_minutes_from_now() {
+        return Err(CeremonyError::Unauthorized(
+            "invocation expiration exceeds the five-minute ceremony window".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Parse + cryptographically verify an invocation container, require the
 /// exact command, then bind it to a registered account and an active
 /// device. The invocation subject is the root DID; the invocation issuer
@@ -68,6 +90,7 @@ pub async fn authorize<S: Store>(
     expected_command: &[&str],
 ) -> Result<Caller, CeremonyError> {
     let chain = verified_chain(body, expected_command).await?;
+    require_ceremony_expiration(&chain)?;
 
     let account = store
         .account_by_root(chain.subject().as_ref())
@@ -105,20 +128,7 @@ pub async fn authorize_root(
             "root invocation issuer must equal its subject".to_string(),
         ));
     }
-    let expiration = chain.invocation.expiration().ok_or_else(|| {
-        CeremonyError::Unauthorized("root invocation must carry an expiration".to_string())
-    })?;
-    let now = Timestamp::now();
-    if expiration < now {
-        return Err(CeremonyError::Unauthorized(
-            "root invocation has expired".to_string(),
-        ));
-    }
-    if expiration > Timestamp::five_minutes_from_now() {
-        return Err(CeremonyError::Unauthorized(
-            "root invocation expiration exceeds the five-minute ceremony window".to_string(),
-        ));
-    }
+    require_ceremony_expiration(&chain)?;
 
     Ok(RootCaller {
         root_did: chain.subject().to_string(),
@@ -155,9 +165,10 @@ mod tests {
     const ROOT_PRF: [u8; 32] = [7u8; 32];
     const DEVICE_SEED: [u8; 32] = [8u8; 32];
 
-    async fn container(
+    async fn container_with_expiration(
         command: Vec<String>,
         args: BTreeMap<String, Promised>,
+        expiration: Option<Timestamp>,
     ) -> (String, String, Vec<u8>) {
         let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
             .await
@@ -169,20 +180,28 @@ mod tests {
             .unwrap();
         let delegation = chain.proofs().last().unwrap().clone();
         let cid = delegation.to_cid();
-        let invocation = InvocationBuilder::new()
+        let mut builder = InvocationBuilder::new()
             .issuer(device.clone())
             .audience(&root_did)
             .subject(&root_did)
             .command(command)
             .arguments(args)
-            .proofs(vec![cid])
-            .try_build()
-            .await
-            .unwrap();
+            .proofs(vec![cid]);
+        if let Some(expiration) = expiration {
+            builder = builder.expiration(expiration);
+        }
+        let invocation = builder.try_build().await.unwrap();
         let mut proofs = std::collections::HashMap::new();
         proofs.insert(cid, std::sync::Arc::new(delegation));
         let bytes = InvocationChain::new(invocation, proofs).to_bytes().unwrap();
         (root_did.to_string(), device.did().to_string(), bytes)
+    }
+
+    async fn container(
+        command: Vec<String>,
+        args: BTreeMap<String, Promised>,
+    ) -> (String, String, Vec<u8>) {
+        container_with_expiration(command, args, Some(Timestamp::five_minutes_from_now())).await
     }
 
     async fn seed_device(
@@ -391,6 +410,43 @@ mod tests {
         assert!(matches!(
             authorize(&store, &bytes, &["account", "device", "list"]).await,
             Err(CeremonyError::Forbidden(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_invocation_without_expiration() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, bytes) = container_with_expiration(
+            vec!["account".into(), "device".into(), "list".into()],
+            BTreeMap::new(),
+            None,
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Unauthorized(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_expired_device_invocation() {
+        use std::time::{Duration, UNIX_EPOCH};
+
+        let store = SqliteStore::in_memory().unwrap();
+        let expired = Timestamp::new(UNIX_EPOCH + Duration::from_secs(1)).unwrap();
+        let (root_did, device_did, bytes) = container_with_expiration(
+            vec!["account".into(), "device".into(), "list".into()],
+            BTreeMap::new(),
+            Some(expired),
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Unauthorized(_))
         ));
     }
 

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -339,6 +339,62 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_rejects_a_registered_device_presenting_another_accounts_root() {
+        let store = SqliteStore::in_memory().unwrap();
+
+        // The device is registered under account A…
+        let root_a = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let root_a_did = root_a.did();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let device_did = device.did();
+        seed_device(
+            &store,
+            root_a_did.as_ref(),
+            device_did.as_ref(),
+            DeviceStatus::Active,
+        )
+        .await;
+
+        // …but invokes as a delegate of account B, with a chain that
+        // verifies: root B really did delegate to this device key.
+        let root_b = tonk_identity::derive::derive_root_signer(&[9u8; 32])
+            .await
+            .unwrap();
+        let root_b_did = root_b.did();
+        store
+            .create_account("b@x.com", root_b_did.as_ref(), "cred-b", 0)
+            .await
+            .unwrap();
+
+        let chain = tonk_identity::delegation::mint_device_delegation(root_b, &device_did)
+            .await
+            .unwrap();
+        let delegation = chain.proofs().last().unwrap().clone();
+        let cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(device)
+            .audience(&root_b_did)
+            .subject(&root_b_did)
+            .command(vec!["account".into(), "device".into(), "list".into()])
+            .arguments(BTreeMap::new())
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let mut proofs = std::collections::HashMap::new();
+        proofs.insert(cid, std::sync::Arc::new(delegation));
+        let bytes = InvocationChain::new(invocation, proofs).to_bytes().unwrap();
+
+        assert!(matches!(
+            authorize(&store, &bytes, &["account", "device", "list"]).await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+    }
+
+    #[dialog_common::test]
     async fn it_authorizes_a_request_signed_directly_by_the_root() {
         let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
             .await

--- a/rust/tonk-account-service/src/core/backup.rs
+++ b/rust/tonk-account-service/src/core/backup.rs
@@ -102,4 +102,18 @@ mod tests {
 
         assert_eq!(round_tripped, bytes);
     }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_chain_get_across_accounts() {
+        let chains = MemoryChainStore::default();
+        let account_a = account(1, "did:key:root-a");
+        let account_b = account(2, "did:key:root-b");
+
+        let key = put_chain(&chains, &account_a, b"a-bytes").await.unwrap();
+
+        assert!(matches!(
+            get_chain(&chains, &account_b, &key).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
 }

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -76,30 +76,32 @@ pub async fn read_body(
 
 /// Build a [`crate::store::d1::D1Store`] from the worker environment's
 /// `DB` binding.
+///
+/// A missing binding is a deployment/config error, not something a
+/// caller can act on: the detail is logged and never put on the wire.
 #[cfg(target_arch = "wasm32")]
 pub fn build_store(
     ctx: &worker::RouteContext<()>,
 ) -> std::result::Result<crate::store::d1::D1Store, crate::error::ServiceError> {
     let db = ctx.env.d1("DB").map_err(|err| {
-        crate::error::ServiceError::new(
-            crate::error::ErrorCode::InternalError,
-            format!("missing D1 binding: {err}"),
-        )
+        worker::console_error!("missing D1 binding: {err}");
+        crate::error::ServiceError::new(crate::error::ErrorCode::InternalError, "internal error")
     })?;
     Ok(crate::store::d1::D1Store::new(db))
 }
 
 /// Build a [`crate::chains::r2::R2ChainStore`] from the worker
 /// environment's `CHAINS` binding.
+///
+/// A missing binding is a deployment/config error, not something a
+/// caller can act on: the detail is logged and never put on the wire.
 #[cfg(target_arch = "wasm32")]
 pub fn build_chains(
     ctx: &worker::RouteContext<()>,
 ) -> std::result::Result<crate::chains::r2::R2ChainStore, crate::error::ServiceError> {
     let bucket = ctx.bucket("CHAINS").map_err(|err| {
-        crate::error::ServiceError::new(
-            crate::error::ErrorCode::InternalError,
-            format!("missing R2 binding: {err}"),
-        )
+        worker::console_error!("missing R2 binding: {err}");
+        crate::error::ServiceError::new(crate::error::ErrorCode::InternalError, "internal error")
     })?;
     Ok(crate::chains::r2::R2ChainStore::new(bucket))
 }

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -27,10 +27,11 @@ pub fn with_cors_headers(response: worker::Response) -> worker::Response {
 }
 
 /// Map a [`crate::core::CeremonyError`] onto a
-/// [`crate::error::ServiceError`], carrying its error code and message
-/// through as-is — including any library error text embedded by the
-/// `Invalid`/`Unauthorized` variants. Sanitizing that text is a
-/// deliberate follow-up, not done here.
+/// [`crate::error::ServiceError`]. Ceremony-level messages (`Invalid`,
+/// `Unauthorized`, `Forbidden`, `Conflict`) pass through: they are
+/// written for callers. `Internal` detail is library/store error text
+/// that must not reach the wire — it is logged here and replaced with a
+/// generic message.
 ///
 /// Shared by the wasm handlers and the native helpers server
 /// ([`crate::helpers::server`]) so the two backends can't drift apart
@@ -47,8 +48,14 @@ pub fn ceremony_error(err: crate::core::CeremonyError) -> crate::error::ServiceE
         CeremonyError::Conflict(msg)
         | CeremonyError::Invalid(msg)
         | CeremonyError::Unauthorized(msg)
-        | CeremonyError::Forbidden(msg)
-        | CeremonyError::Internal(msg) => msg.clone(),
+        | CeremonyError::Forbidden(msg) => msg.clone(),
+        CeremonyError::Internal(detail) => {
+            #[cfg(target_arch = "wasm32")]
+            worker::console_error!("internal error: {detail}");
+            #[cfg(not(target_arch = "wasm32"))]
+            eprintln!("internal error: {detail}");
+            "internal error".to_string()
+        }
     };
     crate::error::ServiceError::new(err.code(), message)
 }
@@ -95,4 +102,32 @@ pub fn build_chains(
         )
     })?;
     Ok(crate::chains::r2::R2ChainStore::new(bucket))
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::ceremony_error;
+    use crate::core::CeremonyError;
+    use crate::error::ErrorCode;
+
+    #[dialog_common::test]
+    async fn it_hides_internal_detail_from_the_wire() {
+        let err = ceremony_error(CeremonyError::Internal(
+            "R2 bucket 'tonk-account-chains' unreachable".into(),
+        ));
+        assert_eq!(err.code, ErrorCode::InternalError);
+        assert_eq!(err.message, "internal error");
+    }
+
+    #[dialog_common::test]
+    async fn it_passes_ceremony_messages_through() {
+        let err = ceremony_error(CeremonyError::Forbidden(
+            "device is not an active member of this account".into(),
+        ));
+        assert_eq!(err.code, ErrorCode::Forbidden);
+        assert_eq!(
+            err.message,
+            "device is not an active member of this account"
+        );
+    }
 }

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -26,6 +26,8 @@ impl SqliteStore {
     /// Cloudflare D1 in production.
     pub fn in_memory() -> Result<Self, StoreError> {
         let conn = Connection::open_in_memory().map_err(map_err)?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .map_err(map_err)?;
         conn.execute_batch(include_str!("../../migrations/0001_init.sql"))
             .map_err(map_err)?;
         conn.execute_batch(include_str!("../../migrations/0002_link_requests.sql"))
@@ -397,5 +399,22 @@ mod tests {
         assert_eq!((read.code_hash.as_str(), read.attempts), ("h2", 1));
         store.delete_code("a@x.com").await.unwrap();
         assert!(store.code("a@x.com").await.unwrap().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_enforces_the_device_account_foreign_key() {
+        let store = SqliteStore::in_memory().unwrap();
+        let orphan = Device {
+            account_id: 999,
+            device_did: "did:key:zOrphan".into(),
+            delegation_cid: "bafyCid".into(),
+            name: "ghost".into(),
+            status: DeviceStatus::Active,
+            created_at: 1,
+        };
+        assert!(matches!(
+            store.insert_device(&orphan).await,
+            Err(StoreError::Internal(_))
+        ));
     }
 }

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -21,11 +21,15 @@ use super::{
 pub struct SqliteStore(Mutex<Connection>);
 
 impl SqliteStore {
-    /// Open a fresh in-memory database and apply
-    /// `migrations/0001_init.sql` — the same schema applied to
-    /// Cloudflare D1 in production.
+    /// Open a fresh in-memory database and apply every migration under
+    /// `migrations/` — the same schema applied to Cloudflare D1 in
+    /// production.
     pub fn in_memory() -> Result<Self, StoreError> {
         let conn = Connection::open_in_memory().map_err(map_err)?;
+        // The bundled libsqlite3-sys build already defaults foreign_keys
+        // on, but this pins the behavior explicitly so a future build-flag
+        // change (e.g. switching to the system libsqlite3) can't silently
+        // drop enforcement.
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(map_err)?;
         conn.execute_batch(include_str!("../../migrations/0001_init.sql"))

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -4,7 +4,8 @@
 //! key whose `root → device` delegation is attached as a proof, with the
 //! account root as subject. This builds exactly that container from a
 //! profile's live device signer and its stored `root → device` link — no
-//! root key, no raw seed.
+//! root key, no raw seed. Invocations carry a five-minute expiration; the
+//! service refuses stale ones.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -12,6 +13,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::time::timestamp::Timestamp;
 use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
 
 /// Build a device-signed account-service invocation container.
@@ -44,6 +46,7 @@ pub async fn build_device_invocation(
         .command(command)
         .arguments(arguments)
         .proofs(vec![cid])
+        .expiration(Timestamp::five_minutes_from_now())
         .try_build()
         .await
         .context("failed to sign the device invocation")?;
@@ -94,6 +97,10 @@ mod tests {
             .verify(&dialog_credentials::Ed25519KeyResolver)
             .await
             .unwrap();
+        assert!(
+            chain.invocation.expiration().is_some(),
+            "device invocations must carry a ceremony expiration"
+        );
         assert_eq!(chain.issuer(), &device_did);
         assert_eq!(chain.subject(), &root_did);
         assert_eq!(


### PR DESCRIPTION
## Summary

Registry hardening follow-ups from the account-service review, five items:

- **Sanitized error responses** — internal error detail (SQL errors, storage internals) no longer leaks onto the wire; handlers map to opaque client-facing errors while full detail still lands in logs.
- **FK pragma parity defense** — `PRAGMA foreign_keys = ON` set explicitly in the sqlite store, plus a test pinning that the device→account foreign key is enforced.
- **Two negative isolation tests** — pin cross-account chain-get isolation and the wrong-account device filter in `authorize`, closing gaps the review flagged.
- **Expiry stamp in tonk-identity** — device invocations now carry a five-minute expiration window, stamped at signing time.
- **Expiry enforcement in authorize** — the service now requires and validates that expiry window on device invocations, rejecting unexpired-less or stale requests.

Plus an abuse-controls runbook and doc reconciliation covering the deployed WAF rate rule.

## Notes

**FK-pragma nuance:** the bundled `libsqlite3-sys` already bakes in `SQLITE_DEFAULT_FOREIGN_KEYS=1`, so the explicit pragma is defense-in-depth/parity rather than the sole enforcement mechanism. The new test (`it_enforces_the_device_account_foreign_key`) documents the enforced behavior; it does not prove the pragma itself is causal, since the compiled-in default would enforce it regardless.

**Rollout note:** stale cached service workers may briefly send device invocations without the new expiration field to the backup endpoint after deploy. These are best-effort calls — failures land in logs, not user-facing errors — and self-resolve as service workers refresh.

**Remaining operator action:** verify each environment's WAF rate rule covers exact-path `POST /codes` and `POST /links`, per the abuse-controls runbook in the README. Migrations 0001 and 0002 have already been verified applied to both environments.

## Verification (Task 8 gate)

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p tonk-account-service --features helpers` — 37 passed
- `cargo test -p tonk-identity` — 11 passed
- `cargo check -p tonk-worker --target wasm32-unknown-unknown` — clean
- `cargo check -p tonk-account-service --target wasm32-unknown-unknown` — clean

## Review follow-ups

Fixed after whole-branch review:

- **Clock-skew allowance** — `require_ceremony_expiration`'s upper bound now allows the five-minute ceremony window plus 60 seconds of clock skew (lower/already-expired bound unchanged), so a client whose clock runs a couple seconds fast no longer silently fails the device path (chain backup/restore). The over-window and expired negative tests now assert distinguishing message substrings so their branches can't collapse.
- **Rollout note update** — the earlier rollout note only covered chain backup; it now also covers cross-device restore, since stale cached service workers can delay either call. Both are best-effort, log on failure, and self-heal once the service worker updates.
- Sanitized the D1/R2 binding-lookup errors in `build_store`/`build_chains` the same way the rest of the internal-error sweep does (log detail, generic message on the wire), and fixed the `SqliteStore::in_memory` docstring, which said only migration 0001 was applied when in fact all migrations run.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on hardening the `tonk-account-service` by enforcing expiration on device-signed invocations, improving error handling, and implementing abuse controls. It also adds tests for various edge cases to ensure robustness.

### Detailed summary
- Added expiration to device invocations in `build_device_invocation`.
- Implemented `require_ceremony_expiration` to check invocation expiration.
- Enhanced error handling in `ceremony_error` to sanitize internal messages.
- Created tests for cross-account chain isolation and device invocation expirations.
- Documented abuse controls and deployment verification in the README.
- Enforced foreign key constraints in the SQLite store.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->