### PR TITLE
feat(account): deliberate passkey rotation (recovery stage 1 of 3)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-recovery-ceremonies.md
+++ b/docs/superpowers/plans/2026-07-24-recovery-ceremonies.md
@@ -1,0 +1,1788 @@
+# Recovery and Rotation Ceremonies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the three missing identity-recovery ceremonies — deliberate passkey rotation (succession), surviving-device recovery, and total-loss re-anchor — so an account is no longer welded to a single passkey credential with no exit.
+
+**Architecture:** Three PR-sized sub-stages, in order. Rotation mints a subject-open `oldRoot → newRoot` succession delegation and flips the account row under old-root authority; surviving-device recovery flips it under device + new-root two-container authority; total-loss re-anchor flips it under email-code authority with no delegation bridge (space access intentionally lost). All three converge rosters and capabilities with the already-landed migration machinery (`migrate.rs`), generalized from `device → root` to `from → to`.
+
+**Tech Stack:** workers-rs (tonk-account-service), dialog-ucan-core (delegations/invocations), tonk-identity (ceremony builders + wasm bindings), tonk-worker (axum-wasm router), tonk-ui (custom element panels), rusqlite/D1 dual store.
+
+## Global Constraints
+
+- No `mod.rs` — `foo.rs` + `foo/` form everywhere.
+- Tests: `#[dialog_common::test]`, names `it_does_x`, grouped by behaviour.
+- No stage/phase/RFC references in code or doc comments.
+- Lint gate: `cargo clippy --workspace --all-targets --all-features` + `cargo fmt --check` (native); wasm-gated code must also pass `cargo check -p tonk-worker --target wasm32-unknown-unknown --tests`.
+- Account-service tests: `cargo test -p tonk-account-service --features helpers`.
+- Identity tests: `cargo test -p tonk-identity`.
+- Conventional commits, subject imperative, no trailing period.
+- wasm/service-worker tests hang locally — compile them (`--target wasm32-unknown-unknown`), rely on the CI web leg to execute, and say so in the PR body.
+- The root key exists in memory only for the seconds a ceremony needs it (`Zeroizing` seeds, signers dropped at ceremony end).
+
+## Chain shapes (load-bearing — read before any task)
+
+Delegation arrows point issuer → audience. All identity links are
+subject-open (`Subject::Any`).
+
+```
+Before rotation:
+  space chains:   space → … → oldRoot          (claimed/owned, subject-specific)
+  device links:   oldRoot → deviceN            (subject-open)
+  presentation:   [space → … → oldRoot, oldRoot → deviceN]
+
+Rotation mints:   oldRoot → newRoot            (subject-open succession)
+                  newRoot → ceremonyDevice     (fresh link for the device in hand)
+
+After rotation:
+  old devices:    [space → … → oldRoot, oldRoot → deviceN]        — still valid, untouched
+  new devices:    [space → … → oldRoot, oldRoot → newRoot, newRoot → deviceM]
+  new claims by re-linked devices anchor at newRoot directly.
+  Old devices CANNOT use newRoot-anchored chains (no newRoot → oldDevice link);
+  they re-link lazily: their next device-signed service call fails with
+  "unknown account" (subject = oldRoot no longer in the registry), which the
+  UI answers with the existing self-link ceremony (synced passkey, one prompt).
+
+Surviving-device recovery mints:
+                  newRoot → survivingDevice    (fresh link, new root key in hand)
+  and the convergence sweep re-anchors every space the surviving device holds:
+                  space → … → survivingDevice → newRoot   (claim().delegate(newRoot))
+  so newRoot (and devices later linked under it) reach everything the
+  surviving device could reach. No oldRoot key is ever needed.
+
+Total-loss re-anchor mints NOTHING. The account row points at a fresh root;
+space access is gone by design; founders re-invite (rosters keyed on the old
+root make affected spaces discoverable).
+```
+
+Registry consequences of a root flip (all three ceremonies): device rows
+other than the ceremony device keep their `oldRoot → device` delegation
+CIDs. They stay `active` in rotation and recovery (their space chains stay
+valid; only their *service* auth breaks until re-link). Total-loss revokes
+every device row. The passkey credential is "revoked" by replacement:
+`accounts.credential_id` changes and `accounts.root_did` no longer matches
+anything the old credential can derive, so the old passkey can never
+authorize another ceremony.
+
+## Decisions locked by this plan
+
+1. Two-container wire shape for rotation and recovery: JSON body with two
+   hex-encoded invocation containers; each is verified independently and
+   cross-checked by arguments (each container names the other's principal).
+2. `check_device_delegation` is renamed `check_subject_open_delegation`
+   (it is shape-generic and now validates root→device, oldRoot→newRoot,
+   and newRoot→device links; the old name would lie at two new call sites).
+3. Devices stay `active` across rotation and recovery; only total-loss
+   revokes them. Rationale in the chain-shape block above.
+4. The ceremony device is re-registered in the same service call that flips
+   the root (upsert of its `delegation_cid`), so at least one device can
+   always authorize device-signed calls immediately after a flip.
+5. The worker replaces a stored account link only with proof of continuity:
+   a succession delegation whose issuer equals the currently stored root
+   (rotation), or internally after a service-confirmed recovery. A bare
+   "overwrite my account" request still gets `Conflict`.
+6. Convergence after a flip reuses `migrate.rs`: `migrate_space_roster` is
+   generalized to `rekey_space_roster(tonk, key, from, to)` and the
+   existing `reanchor_space` runs unchanged (it reads the *new* root from
+   the freshly stored link).
+
+---
+
+## Sub-stage 1 — Succession / deliberate rotation (one PR)
+
+### Task 1: Rename the delegation check to its real shape
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/core/delegation.rs`
+- Modify: `rust/tonk-account-service/src/core/accounts.rs` (call site)
+- Modify: `rust/tonk-account-service/src/core/devices.rs` (call site)
+
+**Interfaces:**
+- Produces: `pub async fn check_subject_open_delegation(delegation_hex: &str, issuer_did: &str, audience_did: &str) -> Result<String, CeremonyError>` — identical behavior to today's `check_device_delegation`; later tasks call it for succession (`oldRoot → newRoot`) and recovery (`newRoot → device`) links.
+
+- [ ] **Step 1: Rename fn and parameters**
+
+In `rust/tonk-account-service/src/core/delegation.rs`, rename
+`check_device_delegation` → `check_subject_open_delegation`, and its
+parameters `root_did` → `issuer_did`, `device_did` → `audience_did`.
+Update the module doc and the two error strings that mention root/device:
+
+```rust
+//! Checking a subject-open, single-hop delegation chain presented during
+//! account ceremonies: `root → device` at creation and linking,
+//! `oldRoot → newRoot` at rotation, `newRoot → device` at recovery.
+
+/// Parse and check a hex-encoded subject-open delegation chain.
+///
+/// Requires exactly one proof, issued by `issuer_did` to `audience_did`,
+/// subject-open, with a valid signature. Returns the delegation's CID,
+/// stringified — the key `devices.delegation_cid` is stored under.
+pub async fn check_subject_open_delegation(
+    delegation_hex: &str,
+    issuer_did: &str,
+    audience_did: &str,
+) -> Result<String, CeremonyError> {
+```
+
+and inside, the two identity checks become:
+
+```rust
+    if chain.issuer().to_string() != issuer_did {
+        return Err(CeremonyError::Invalid(
+            "delegation issuer does not match the expected principal".to_string(),
+        ));
+    }
+    if chain.audience().to_string() != audience_did {
+        return Err(CeremonyError::Invalid(
+            "delegation audience does not match the expected principal".to_string(),
+        ));
+    }
+```
+
+- [ ] **Step 2: Update the two call sites**
+
+`core/accounts.rs` line ~44 and `core/devices.rs` line ~57: change
+`check_device_delegation(` to `check_subject_open_delegation(` (imports:
+`use crate::core::delegation::check_subject_open_delegation;`). Argument
+order and meaning are unchanged.
+
+- [ ] **Step 3: Run the crate tests**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: PASS (pure rename; existing delegation-shape tests still cover it)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-account-service/src/core/delegation.rs rust/tonk-account-service/src/core/accounts.rs rust/tonk-account-service/src/core/devices.rs
+git commit -m "refactor(tonk-account-service): name the delegation check by its shape"
+```
+
+### Task 2: Store support for flipping an account root
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/store.rs`
+- Modify: `rust/tonk-account-service/src/store/sqlite.rs`
+- Modify: `rust/tonk-account-service/src/store/d1.rs`
+
+**Interfaces:**
+- Produces on trait `Store`:
+  - `async fn rotate_root(&self, account_id: i64, new_root_did: &str, new_credential_id: &str) -> Result<(), StoreError>` — flips `accounts.root_did` + `credential_id`; `Conflict` if the new root DID is already registered.
+  - `async fn update_device_delegation(&self, account_id: i64, device_did: &str, delegation_cid: &str) -> Result<bool, StoreError>` — repoints one device row's delegation CID; `false` when no row matched.
+
+- [ ] **Step 1: Add SQL consts and trait methods in `store.rs`**
+
+After `UPDATE_DEVICE_REVOKE`:
+
+```rust
+/// SQL: flip an account's root DID and passkey credential.
+pub const UPDATE_ACCOUNT_ROOT: &str =
+    "UPDATE accounts SET root_did = ?2, credential_id = ?3 WHERE id = ?1";
+
+/// SQL: repoint one device row at a fresh delegation.
+pub const UPDATE_DEVICE_DELEGATION: &str =
+    "UPDATE devices SET delegation_cid = ?3 WHERE account_id = ?1 AND device_did = ?2";
+```
+
+Trait additions (after `revoke_device`):
+
+```rust
+    /// Flip the account's root DID and passkey credential in one
+    /// statement. Returns `StoreError::Conflict` if the new root DID is
+    /// already registered to any account.
+    async fn rotate_root(
+        &self,
+        account_id: i64,
+        new_root_did: &str,
+        new_credential_id: &str,
+    ) -> Result<(), StoreError>;
+
+    /// Repoint one device row at a fresh delegation CID. Returns `false`
+    /// if no matching device was found.
+    async fn update_device_delegation(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+    ) -> Result<bool, StoreError>;
+```
+
+- [ ] **Step 2: Write failing store tests**
+
+In `rust/tonk-account-service/src/store/sqlite.rs`'s existing test module,
+following its fixture style:
+
+```rust
+    #[dialog_common::test]
+    async fn it_rotates_the_root_and_keeps_the_row_id() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zOld", "cred-old", 100)
+            .await
+            .unwrap();
+        store.rotate_root(id, "did:key:zNew", "cred-new").await.unwrap();
+        assert!(store.account_by_root("did:key:zOld").await.unwrap().is_none());
+        let account = store.account_by_root("did:key:zNew").await.unwrap().unwrap();
+        assert_eq!((account.id, account.credential_id.as_str()), (id, "cred-new"));
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_rotating_onto_a_registered_root() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zA", "cred-a", 100)
+            .await
+            .unwrap();
+        store
+            .create_account("b@x.com", "did:key:zB", "cred-b", 100)
+            .await
+            .unwrap();
+        assert!(matches!(
+            store.rotate_root(id, "did:key:zB", "cred-x").await,
+            Err(StoreError::Conflict(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_repoints_a_device_delegation() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zA", "cred", 100)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                account_id: id,
+                device_did: "did:key:zDev".into(),
+                delegation_cid: "bafyOld".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 100,
+            })
+            .await
+            .unwrap();
+        assert!(store
+            .update_device_delegation(id, "did:key:zDev", "bafyNew")
+            .await
+            .unwrap());
+        let device = store.device_by_did("did:key:zDev").await.unwrap().unwrap();
+        assert_eq!(device.delegation_cid, "bafyNew");
+        assert!(!store
+            .update_device_delegation(id, "did:key:zGhost", "bafyNew")
+            .await
+            .unwrap());
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p tonk-account-service --features helpers rotates`
+Expected: FAIL — `rotate_root` not a member of trait `Store`
+
+- [ ] **Step 4: Implement in `sqlite.rs`**
+
+Mirroring `revoke_device`'s body style (`self.0.lock()`, `map_err`;
+uniqueness violations already map to `Conflict` via the existing
+`map_err`):
+
+```rust
+    async fn rotate_root(
+        &self,
+        account_id: i64,
+        new_root_did: &str,
+        new_credential_id: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        conn.execute(
+            UPDATE_ACCOUNT_ROOT,
+            params![account_id, new_root_did, new_credential_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    async fn update_device_delegation(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(
+                UPDATE_DEVICE_DELEGATION,
+                params![account_id, device_did, delegation_cid],
+            )
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+```
+
+Verify sqlite's `map_err` maps `SQLITE_CONSTRAINT_UNIQUE` to
+`StoreError::Conflict` (it must, since `create_account` relies on it); if
+it maps by message substring, confirm the UPDATE unique-violation message
+matches. If it does not, extend `map_err`, not the method.
+
+- [ ] **Step 5: Implement in `d1.rs`**
+
+Mirroring the existing `revoke_device` D1 body: `prepare(...).bind(&[...])`
+with `JsValue::from_f64(account_id as f64)` for the id,
+`JsValue::from(...)` for strings; `rotate_root` uses `.run()` and maps a
+D1 uniqueness error to `Conflict` the same way `create_account` does in
+that file (read its error mapping and reuse it verbatim);
+`update_device_delegation` reads `meta().rows_written` (same accessor
+`revoke_device` uses) for the `bool`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: PASS, including the three new tests
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-account-service/src/store.rs rust/tonk-account-service/src/store/sqlite.rs rust/tonk-account-service/src/store/d1.rs
+git commit -m "feat(tonk-account-service): store support for flipping an account root"
+```
+
+### Task 3: Rotation core ceremony
+
+**Files:**
+- Create: `rust/tonk-account-service/src/core/rotation.rs`
+- Modify: `rust/tonk-account-service/src/core.rs` (add `pub mod rotation;`)
+
+**Interfaces:**
+- Consumes: `check_subject_open_delegation` (Task 1), `rotate_root` / `update_device_delegation` (Task 2), `Account` from `crate::store`.
+- Produces: `pub struct RotateAccount { pub new_root_did: String, pub new_credential_id: String, pub succession_hex: String, pub device_did: String, pub device_delegation_hex: String }` and `pub async fn rotate_account<S: Store>(store: &S, account: &Account, request: &RotateAccount) -> Result<(), CeremonyError>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`rust/tonk-account-service/src/core/rotation.rs`, tests first (same
+fixture idioms as `core/devices.rs`):
+
+```rust
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::store::sqlite::SqliteStore;
+    use crate::store::{Device, DeviceStatus, Store};
+    use dialog_varsig::Principal;
+
+    const OLD_ROOT_PRF: [u8; 32] = [7u8; 32];
+    const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
+    const DEVICE_SEED: [u8; 32] = [8u8; 32];
+
+    async fn fixture(store: &SqliteStore) -> (crate::store::Account, RotateAccount, String) {
+        let old_root = tonk_identity::derive::derive_root_signer(&OLD_ROOT_PRF)
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let old_root_did = old_root.did().to_string();
+        let new_root_did = new_root.did().to_string();
+        let device_did = device.did().to_string();
+
+        let id = store
+            .create_account("a@x.com", &old_root_did, "cred-old", 100)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                account_id: id,
+                device_did: device_did.clone(),
+                delegation_cid: "bafyOld".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 100,
+            })
+            .await
+            .unwrap();
+
+        let succession =
+            tonk_identity::delegation::mint_root_succession(old_root, &new_root.did())
+                .await
+                .unwrap();
+        let device_link =
+            tonk_identity::delegation::mint_device_delegation(new_root, &device.did())
+                .await
+                .unwrap();
+        let account = store.account_by_root(&old_root_did).await.unwrap().unwrap();
+        let request = RotateAccount {
+            new_root_did: new_root_did.clone(),
+            new_credential_id: "cred-new".into(),
+            succession_hex: hex::encode(succession.to_bytes().unwrap()),
+            device_did,
+            device_delegation_hex: hex::encode(device_link.to_bytes().unwrap()),
+        };
+        (account, request, new_root_did)
+    }
+
+    #[dialog_common::test]
+    async fn it_flips_the_root_and_repoints_the_ceremony_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, request, new_root_did) = fixture(&store).await;
+
+        rotate_account(&store, &account, &request).await.unwrap();
+
+        let rotated = store.account_by_root(&new_root_did).await.unwrap().unwrap();
+        assert_eq!(rotated.id, account.id);
+        assert_eq!(rotated.credential_id, "cred-new");
+        let device = store
+            .device_by_did(&request.device_did)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(device.delegation_cid, "bafyOld");
+        assert_eq!(device.status, DeviceStatus::Active);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_succession_not_issued_by_the_account_root() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, mut request, _) = fixture(&store).await;
+        // Succession minted by an unrelated key: issuer check must fail.
+        let stranger = tonk_identity::derive::derive_root_signer(&[13u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let bogus = tonk_identity::delegation::mint_root_succession(stranger, &{
+            use dialog_varsig::Principal;
+            new_root.did()
+        })
+        .await
+        .unwrap();
+        request.succession_hex = hex::encode(bogus.to_bytes().unwrap());
+
+        assert!(matches!(
+            rotate_account(&store, &account, &request).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+        // Nothing flipped.
+        assert!(store
+            .account_by_root(&account.root_did)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_ceremony_device_unknown_to_the_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, mut request, _) = fixture(&store).await;
+        request.device_did = "did:key:zGhost".into();
+        assert!(matches!(
+            rotate_account(&store, &account, &request).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
+}
+```
+
+(`mint_root_succession` does not exist yet — Task 4 adds it to
+tonk-identity first if you are executing tasks strictly in order, swap
+Tasks 3 and 4; they are written in this order because the service core is
+the riskier surface. Both orders work; the test file compiles only when
+both tasks are done.)
+
+- [ ] **Step 2: Implement the core**
+
+```rust
+//! The account rotation ceremony: flip the account onto a new root DID
+//! under authority of the old root, keeping every registered device.
+
+use crate::core::CeremonyError;
+use crate::core::delegation::check_subject_open_delegation;
+use crate::store::{Account, Store};
+
+/// A verified request to rotate an account onto a new root.
+pub struct RotateAccount {
+    /// The DID the account rotates onto.
+    pub new_root_did: String,
+    /// The passkey credential backing the new root.
+    pub new_credential_id: String,
+    /// Hex-encoded subject-open `oldRoot → newRoot` succession chain.
+    pub succession_hex: String,
+    /// The ceremony device re-registering under the new root.
+    pub device_did: String,
+    /// Hex-encoded subject-open `newRoot → device` delegation chain.
+    pub device_delegation_hex: String,
+}
+
+/// Rotate `account` onto `request.new_root_did`.
+///
+/// Verifies the succession chain (old root delegates to the new root) and
+/// the ceremony device's fresh delegation before touching the registry.
+/// Devices other than the ceremony device keep their existing rows: their
+/// old-root delegations remain cryptographically valid for space access,
+/// and they re-link on their next service ceremony.
+pub async fn rotate_account<S: Store>(
+    store: &S,
+    account: &Account,
+    request: &RotateAccount,
+) -> Result<(), CeremonyError> {
+    check_subject_open_delegation(
+        &request.succession_hex,
+        &account.root_did,
+        &request.new_root_did,
+    )
+    .await?;
+    let delegation_cid = check_subject_open_delegation(
+        &request.device_delegation_hex,
+        &request.new_root_did,
+        &request.device_did,
+    )
+    .await?;
+
+    let repointed = store
+        .update_device_delegation(account.id, &request.device_did, &delegation_cid)
+        .await?;
+    if !repointed {
+        return Err(CeremonyError::Invalid(
+            "ceremony device is not registered under this account".to_string(),
+        ));
+    }
+    store
+        .rotate_root(account.id, &request.new_root_did, &request.new_credential_id)
+        .await?;
+    Ok(())
+}
+```
+
+Note the order: device repoint first, root flip second, so a bogus device
+DID fails before the flip. The two statements are not one transaction; a
+crash between them leaves a repointed device under the old root, which the
+next rotation attempt repairs (both operations are idempotent re-runs).
+Register `pub mod rotation;` in `core.rs`.
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test -p tonk-account-service --features helpers rotation`
+Expected: PASS (after Task 4 lands `mint_root_succession`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-account-service/src/core/rotation.rs rust/tonk-account-service/src/core.rs
+git commit -m "feat(tonk-account-service): rotation ceremony core"
+```
+
+### Task 4: Succession delegation and rotation builder in tonk-identity
+
+**Files:**
+- Modify: `rust/tonk-identity/src/delegation.rs`
+- Modify: `rust/tonk-identity/src/ceremony.rs`
+
+**Interfaces:**
+- Consumes: `DelegationBuilder`/`InvocationBuilder` exactly as the existing fns use them.
+- Produces:
+  - `pub async fn mint_root_succession(old_root: Ed25519Signer, new_root: &Did) -> Result<DelegationChain>` in `delegation.rs`.
+  - `pub struct RotationCeremony { pub old_root_did: String, pub new_root_did: String, pub succession_hex: String, pub device_delegation_hex: String, pub rotation_hex: String, pub confirmation_hex: String }` and `pub async fn rotate_account(old_root: Ed25519Signer, new_root: Ed25519Signer, new_credential_id: String, device_did: dialog_varsig::Did) -> Result<RotationCeremony>` in `ceremony.rs`.
+
+- [ ] **Step 1: Extract the subject-open builder and add succession**
+
+In `delegation.rs`, extract the shared body and keep both public names
+honest:
+
+```rust
+async fn mint_subject_open(issuer: Ed25519Signer, audience: &Did) -> Result<DelegationChain> {
+    let delegation = DelegationBuilder::new()
+        .issuer(issuer)
+        .audience(audience)
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to mint the delegation: {e}"))?;
+    Ok(DelegationChain::new(delegation))
+}
+
+/// Mint the `root → device` delegation: subject-open, audience-specific —
+/// "this device may act as me, for anything". Deliberately the opposite
+/// shape from space invites, which are subject-specific and must stay so.
+pub async fn mint_device_delegation(root: Ed25519Signer, device: &Did) -> Result<DelegationChain> {
+    mint_subject_open(root, device).await
+}
+
+/// Mint the `oldRoot → newRoot` succession delegation. Same subject-open
+/// shape as a device link: every chain anchored at the old root extends
+/// through it to the new root, so rotation never rewrites space chains.
+pub async fn mint_root_succession(
+    old_root: Ed25519Signer,
+    new_root: &Did,
+) -> Result<DelegationChain> {
+    mint_subject_open(old_root, new_root).await
+}
+```
+
+- [ ] **Step 2: Write the failing ceremony test**
+
+In `ceremony.rs` tests:
+
+```rust
+    #[dialog_common::test]
+    async fn it_builds_a_two_container_rotation() {
+        let old_root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let new_root = crate::derive::derive_root_signer(&[9u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let old_did = old_root.did().to_string();
+        let new_did = new_root.did().to_string();
+
+        let ceremony = rotate_account(old_root, new_root, "cred-new".into(), device.did())
+            .await
+            .unwrap();
+        assert_eq!(ceremony.old_root_did, old_did);
+        assert_eq!(ceremony.new_root_did, new_did);
+
+        let rotation =
+            InvocationChain::try_from(hex::decode(&ceremony.rotation_hex).unwrap().as_slice())
+                .unwrap();
+        rotation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(rotation.issuer().to_string(), old_did);
+        assert_eq!(
+            rotation.command().0,
+            vec!["account".to_string(), "rotate".to_string()]
+        );
+        assert_eq!(
+            rotation.arguments().get("newRootDid"),
+            Some(&Promised::String(new_did.clone()))
+        );
+
+        let confirmation = InvocationChain::try_from(
+            hex::decode(&ceremony.confirmation_hex).unwrap().as_slice(),
+        )
+        .unwrap();
+        confirmation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(confirmation.issuer().to_string(), new_did);
+        assert_eq!(
+            confirmation.command().0,
+            vec![
+                "account".to_string(),
+                "rotate".to_string(),
+                "confirm".to_string()
+            ]
+        );
+        assert_eq!(
+            confirmation.arguments().get("oldRootDid"),
+            Some(&Promised::String(old_did))
+        );
+    }
+```
+
+(Add `use dialog_ucan_core::promise::Promised;` to the test imports if not
+already in scope.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p tonk-identity it_builds_a_two_container_rotation`
+Expected: FAIL — `rotate_account` not found
+
+- [ ] **Step 4: Implement the builder**
+
+In `ceremony.rs` (reusing the private `build` helper for both containers —
+note `build` returns an `AccountCeremony`, whose `invocation_hex` is the
+piece each call contributes):
+
+```rust
+/// Output of the two-container rotation ceremony.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RotationCeremony {
+    /// The account's current (old) root DID.
+    pub old_root_did: String,
+    /// The root DID the account rotates onto.
+    pub new_root_did: String,
+    /// Hex-encoded `oldRoot → newRoot` succession chain.
+    pub succession_hex: String,
+    /// Hex-encoded `newRoot → device` delegation for the ceremony device.
+    pub device_delegation_hex: String,
+    /// Hex-encoded old-root-signed rotation container.
+    pub rotation_hex: String,
+    /// Hex-encoded new-root-signed confirmation container.
+    pub confirmation_hex: String,
+}
+
+/// Build both rotation containers, the succession chain, and a fresh
+/// device link. The old root signs the rotation (account authority); the
+/// new root signs the confirmation (proof the new DID is controllable, so
+/// a typo cannot strand the account on an inert root).
+pub async fn rotate_account(
+    old_root: Ed25519Signer,
+    new_root: Ed25519Signer,
+    new_credential_id: String,
+    device_did: dialog_varsig::Did,
+) -> Result<RotationCeremony> {
+    let old_root_did = old_root.did().to_string();
+    let new_root_did = new_root.did().to_string();
+
+    let succession =
+        crate::delegation::mint_root_succession(old_root.clone(), &new_root.did()).await?;
+    let succession_hex = hex::encode(
+        succession
+            .to_bytes()
+            .context("failed to serialize the succession delegation")?,
+    );
+    let device_link =
+        crate::delegation::mint_device_delegation(new_root.clone(), &device_did).await?;
+    let device_delegation_hex = hex::encode(
+        device_link
+            .to_bytes()
+            .context("failed to serialize the device delegation")?,
+    );
+
+    let rotation = build(
+        old_root,
+        vec!["account".into(), "rotate".into()],
+        strings([
+            ("newRootDid", new_root_did.clone()),
+            ("newCredentialId", new_credential_id),
+            ("succession", succession_hex.clone()),
+            ("deviceDid", device_did.to_string()),
+            ("deviceDelegation", device_delegation_hex.clone()),
+        ]),
+        device_did.to_string(),
+        device_delegation_hex.clone(),
+    )
+    .await?;
+    let confirmation = build(
+        new_root,
+        vec!["account".into(), "rotate".into(), "confirm".into()],
+        strings([("oldRootDid", old_root_did.clone())]),
+        device_did.to_string(),
+        device_delegation_hex.clone(),
+    )
+    .await?;
+
+    Ok(RotationCeremony {
+        old_root_did,
+        new_root_did,
+        succession_hex,
+        device_delegation_hex,
+        rotation_hex: rotation.invocation_hex,
+        confirmation_hex: confirmation.invocation_hex,
+    })
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p tonk-identity`
+Expected: PASS, including the new rotation test and existing delegation tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-identity/src/delegation.rs rust/tonk-identity/src/ceremony.rs
+git commit -m "feat(tonk-identity): succession delegation and rotation ceremony builder"
+```
+
+### Task 5: `POST /accounts/rotate` handler + wire
+
+**Files:**
+- Create: `rust/tonk-account-service/src/handlers/rotate.rs`
+- Modify: `rust/tonk-account-service/src/handlers.rs` (add `pub mod rotate;`)
+- Modify: `rust/tonk-account-service/src/lib.rs` (routes)
+- Modify: `rust/tonk-account-service/tests/service.rs` (integration coverage)
+
+**Interfaces:**
+- Consumes: `authorize_root` (both containers), `rotate_account` core (Task 3), `required_string`.
+- Produces: `POST /accounts/rotate`, JSON body `{ "rotation": "<hex>", "confirmation": "<hex>" }`, `200 {}` on success. All other request data rides inside the signed rotation container's arguments.
+
+- [ ] **Step 1: Write the handler**
+
+`rust/tonk-account-service/src/handlers/rotate.rs`, following
+`handlers/accounts.rs` structure exactly (`handle` + `handle_inner` +
+`handle_options`, `with_cors_headers`, `build_store`, `ceremony_error`):
+
+```rust
+//! `POST /accounts/rotate`: flip an account onto a new root DID under
+//! old-root authority, with new-root proof of control.
+
+use serde::Deserialize;
+use worker::*;
+
+use crate::auth::{authorize_root, required_string};
+use crate::core::rotation::{RotateAccount, rotate_account};
+use crate::error::{ErrorCode, ServiceError};
+use crate::handlers::{build_store, ceremony_error, with_cors_headers};
+
+#[derive(Deserialize)]
+struct RotateBody {
+    rotation: String,
+    confirmation: String,
+}
+
+/// `OPTIONS /accounts/rotate` → CORS preflight.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /accounts/rotate` → rotate an account onto a new root.
+pub async fn handle(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body: RotateBody = req.json().await.map_err(|err| {
+        ServiceError::new(ErrorCode::InvalidArgument, format!("bad body: {err}"))
+    })?;
+    let rotation_bytes = hex::decode(&body.rotation).map_err(|err| {
+        ServiceError::new(ErrorCode::InvalidArgument, format!("bad rotation hex: {err}"))
+    })?;
+    let confirmation_bytes = hex::decode(&body.confirmation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad confirmation hex: {err}"),
+        )
+    })?;
+
+    let old = authorize_root(&rotation_bytes, &["account", "rotate"])
+        .await
+        .map_err(ceremony_error)?;
+    let new = authorize_root(&confirmation_bytes, &["account", "rotate", "confirm"])
+        .await
+        .map_err(ceremony_error)?;
+
+    // Each container must name the other's principal.
+    let claimed_new = required_string(&old.arguments, "newRootDid").map_err(ceremony_error)?;
+    let claimed_old = required_string(&new.arguments, "oldRootDid").map_err(ceremony_error)?;
+    if claimed_new != new.root_did || claimed_old != old.root_did {
+        return Err(ServiceError::new(
+            ErrorCode::Forbidden,
+            "rotation and confirmation containers do not name each other",
+        ));
+    }
+
+    let store = build_store(ctx)?;
+    let account = store
+        .account_by_root(&old.root_did)
+        .await
+        .map_err(|err| ceremony_error(err.into()))?
+        .ok_or_else(|| ServiceError::new(ErrorCode::Unauthorized, "unknown account"))?;
+
+    let request = RotateAccount {
+        new_root_did: new.root_did,
+        new_credential_id: required_string(&old.arguments, "newCredentialId")
+            .map_err(ceremony_error)?,
+        succession_hex: required_string(&old.arguments, "succession").map_err(ceremony_error)?,
+        device_did: required_string(&old.arguments, "deviceDid").map_err(ceremony_error)?,
+        device_delegation_hex: required_string(&old.arguments, "deviceDelegation")
+            .map_err(ceremony_error)?,
+    };
+    rotate_account(&store, &account, &request)
+        .await
+        .map_err(ceremony_error)?;
+
+    Response::from_json(&serde_json::json!({})).map_err(|err| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {err}"))
+    })
+}
+```
+
+Check `handlers.rs` for whether `Store` needs importing for
+`account_by_root` (`use crate::store::Store;`) — match how
+`handlers/devices.rs` does it.
+
+- [ ] **Step 2: Register routes in `lib.rs`**
+
+In the wasm router, after the `/accounts` pair:
+
+```rust
+        .options_async("/accounts/rotate", handlers::rotate::handle_options)
+        .post_async("/accounts/rotate", handlers::rotate::handle)
+```
+
+(Match the exact `options_async` registration style used for `/accounts` —
+read the neighboring lines and mirror them.)
+
+- [ ] **Step 3: Extend the HTTP integration test**
+
+In `rust/tonk-account-service/tests/service.rs`, add a test (reusing that
+file's server/client helpers — read `it_drives_the_full_ceremony_over_http`
+and copy its setup verbatim) that: creates an account, calls
+`tonk_identity::ceremony::rotate_account(...)` to build the containers,
+POSTs `/accounts/rotate`, expects 200, then asserts a `/devices/list`
+device-signed invocation under the NEW root succeeds and under the OLD
+root gets 401. Note: the native binary serves only `/` and `/health` —
+this test file drives the axum-free native router; if `/accounts/rotate`
+is not reachable natively (wasm-only route registration), register it in
+the native test router the same way the existing ceremony routes are
+(follow whatever mechanism `tests/service.rs` already uses to reach
+`/accounts`; it demonstrably does, since the full-ceremony test passes).
+
+- [ ] **Step 4: Run everything**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-account-service/src/handlers/rotate.rs rust/tonk-account-service/src/handlers.rs rust/tonk-account-service/src/lib.rs rust/tonk-account-service/tests/service.rs
+git commit -m "feat(tonk-account-service): rotate an account onto a new root"
+```
+
+### Task 6: Worker relink + convergence sweep
+
+**Files:**
+- Modify: `rust/tonk-worker-api/src/lib.rs` (find `AccountLinkRequest`; add field)
+- Modify: `rust/tonk-worker/src/router/account.rs`
+- Modify: `rust/tonk-worker/src/router/migrate.rs`
+
+**Interfaces:**
+- Consumes: `persist_link`, `account_link`, `migrate_space_roster`, `reanchor_space`, `profile_space_keys` — all existing.
+- Produces:
+  - `AccountLinkRequest.succession_hex: Option<String>` (serde `#[serde(default)]`, camelCase per that crate's convention — check the struct's existing rename attributes and match).
+  - `pub(crate) async fn rekey_space_roster(tonk: &TonkState, key: &str, from: &dialog_varsig::Did, to: &dialog_varsig::Did) -> Result<bool, RepositoryError>` — generalization of `migrate_space_roster`.
+  - `pub(crate) async fn converge_after_rotation(tonk: &TonkState, old_root: &dialog_varsig::Did)` — sweep: rekey old→new + re-anchor + back up, fire-and-forget from the link handler when a succession replaced the root.
+
+- [ ] **Step 1: Generalize the re-key**
+
+In `migrate.rs`, rename `migrate_space_roster`'s body into
+`rekey_space_roster(tonk, key, from, to)`: replace the two derived DIDs —
+`let member = account::member_did(tonk).await;` becomes parameter `to`,
+`let device = tonk.profile.did();` becomes parameter `from` — and the
+early-return guard `if member == device` becomes `if from == to`. Every
+subsequent use of `device`/`member` in that function becomes `from`/`to`
+(`Membership::new(from.clone(), …)` / `Membership::new(to.clone(), …)`,
+etc.). Then reintroduce the old entry point as a thin wrapper so all
+existing tests and `migrate_rosters` compile unchanged:
+
+```rust
+/// Re-key one space's roster from the device DID to the account root DID,
+/// atomically. Returns `Ok(true)` when a device-keyed row was migrated,
+/// `Ok(false)` when the space is already root-keyed, the profile isn't a
+/// member, or the profile is unlinked.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn migrate_space_roster(
+    tonk: &TonkState,
+    key: &str,
+) -> Result<bool, RepositoryError> {
+    let to = account::member_did(tonk).await;
+    let from = tonk.profile.did();
+    rekey_space_roster(tonk, key, &from, &to).await
+}
+```
+
+- [ ] **Step 2: Add the rotation sweep**
+
+Below `migrate_rosters` (same in-flight guard — rotation and link never
+race in practice, but the guard is free):
+
+```rust
+/// Converge every space keyed on a superseded root onto the current one.
+/// Runs after a succession replaced this profile's account root:
+/// re-keys rosters `old → new` and re-anchors + backs up each space so
+/// devices linked under the new root can restore it.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn converge_after_rotation(tonk: &TonkState, old_root: &dialog_varsig::Did) {
+    let Some(new_root) = account::account_root_did(tonk).await else {
+        return;
+    };
+    if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    for key in crate::router::profile_name::profile_space_keys(tonk).await {
+        match rekey_space_roster(tonk, &key, old_root, &new_root).await {
+            Ok(_) => reanchor_space(tonk, &key).await,
+            Err(error) => log!("rotation convergence for space '{key}' skipped: {error}"),
+        }
+    }
+    MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
+```
+
+(`reanchor_space` runs on `Ok(false)` too, unlike the link sweep: a space
+claimed under the old root after this device linked has no roster row to
+re-key but still needs its chain re-anchored to the new root.)
+
+- [ ] **Step 3: Teach `persist_link` succession-authorized replacement**
+
+In `account.rs`: add `succession_hex: Option<String>` to
+`AccountLinkRequest` in `rust/tonk-worker-api` (with `#[serde(default)]`
+and the struct's existing casing attribute so old callers need no change).
+In `persist_link`, replace the conflict arm:
+
+```rust
+    if let Some(existing) = load_link(state).await? {
+        let existing = DelegationChain::try_from(existing.as_slice()).map_err(|error| {
+            TonkWorkerError::Internal(format!("stored account delegation is invalid: {error}"))
+        })?;
+        if existing.issuer() != chain.issuer() {
+            let Some(succession_hex) = &request.succession_hex else {
+                return Err(TonkWorkerError::Conflict(
+                    "profile is already linked to another account root".to_string(),
+                ));
+            };
+            let succession = validate_succession(succession_hex, existing.issuer(), chain.issuer())
+                .await?;
+            state
+                .profile
+                .access()
+                .save(UcanDelegation(succession))
+                .perform(&state.operator)
+                .await
+                .map_err(|error| {
+                    TonkWorkerError::Internal(format!(
+                        "failed to save succession delegation: {error}"
+                    ))
+                })?;
+        }
+    }
+```
+
+with the validator mirroring `validate_link`'s checks (one proof,
+subject-open, issuer = the currently stored root, audience = the new
+root, valid signature):
+
+```rust
+async fn validate_succession(
+    succession_hex: &str,
+    old_root: &dialog_varsig::Did,
+    new_root: &dialog_varsig::Did,
+) -> Result<DelegationChain, TonkWorkerError> {
+    let bytes = hex::decode(succession_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid succession hex: {error}")))?;
+    let chain = DelegationChain::try_from(bytes.as_slice())
+        .map_err(|error| TonkWorkerError::Router(format!("invalid succession chain: {error}")))?;
+    if chain.proof_cids().len() != 1 {
+        return Err(TonkWorkerError::Router(
+            "succession must contain exactly one proof".to_string(),
+        ));
+    }
+    if chain.issuer() != old_root {
+        return Err(TonkWorkerError::Forbidden(
+            "succession issuer is not the linked account root".to_string(),
+        ));
+    }
+    if chain.audience() != new_root {
+        return Err(TonkWorkerError::Forbidden(
+            "succession audience is not the new account root".to_string(),
+        ));
+    }
+    if chain.subject().is_some() {
+        return Err(TonkWorkerError::Router(
+            "succession must be subject-open".to_string(),
+        ));
+    }
+    let proof = chain
+        .proofs()
+        .next()
+        .expect("a one-proof chain contains one proof");
+    proof
+        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Forbidden(format!("invalid succession signature: {error}"))
+        })?;
+    Ok(chain)
+}
+```
+
+In the `link` handler's wasm dispatch block, capture the pre-link root
+first and run the rotation sweep when it changed:
+
+```rust
+    let previous_root = account_root_did(&state).await;
+    persist_link(&state, &request).await?;
+```
+
+and inside the spawned task, before `migrate_rosters`:
+
+```rust
+            if let Some(old_root) = previous_root.filter(|old| old.to_string() != request.root_did)
+            {
+                let tonk = app_state.write().await;
+                crate::router::migrate::converge_after_rotation(&tonk, &old_root).await;
+            }
+```
+
+(clone `previous_root` into the task alongside the existing captures; the
+non-rotation link path is unchanged — `previous_root` is either `None` or
+equals the incoming root, so the filter drops it).
+
+- [ ] **Step 4: wasm tests (compile locally, execute in CI)**
+
+In `account.rs` tests add:
+
+```rust
+    #[dialog_common::test]
+    async fn it_replaces_the_root_when_a_succession_authorizes_it() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let first = request_for(&[7u8; 32], device_did.clone()).await;
+        let _ = link(State(state.clone()), Json(first.clone())).await.unwrap();
+
+        let old_root = tonk_identity::derive::derive_root_signer(&[7u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&[8u8; 32])
+            .await
+            .unwrap();
+        let succession =
+            tonk_identity::delegation::mint_root_succession(old_root, &new_root.did())
+                .await
+                .unwrap();
+        let mut second = request_for(&[8u8; 32], device_did).await;
+        second.succession_hex = Some(hex::encode(succession.to_bytes().unwrap()));
+
+        let Json(status) = link(State(state.clone()), Json(second.clone())).await.unwrap();
+        match status {
+            AccountStatus::Linked { root_did, .. } => assert_eq!(root_did, second.root_did),
+            AccountStatus::Unlinked { .. } => panic!("relink did not persist"),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_succession_from_the_wrong_root() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let first = request_for(&[7u8; 32], device_did.clone()).await;
+        let _ = link(State(state.clone()), Json(first)).await.unwrap();
+
+        // Succession issued by an unrelated key, not the linked root.
+        let stranger = tonk_identity::derive::derive_root_signer(&[13u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&[8u8; 32])
+            .await
+            .unwrap();
+        let succession =
+            tonk_identity::delegation::mint_root_succession(stranger, &new_root.did())
+                .await
+                .unwrap();
+        let mut second = request_for(&[8u8; 32], device_did).await;
+        second.succession_hex = Some(hex::encode(succession.to_bytes().unwrap()));
+
+        assert!(matches!(
+            link(State(state), Json(second)).await,
+            Err(TonkWorkerError::Forbidden(_))
+        ));
+    }
+```
+
+(`request_for` needs `succession_hex: None` added to its struct literal.)
+Also add a `rekey_space_roster` test in `migrate.rs` mirroring
+`it_rekeys_a_device_membership_onto_the_account_root` but seeding an
+old-root-keyed membership and re-keying `old → new` between two account
+roots (seed with `link_account`'s pattern for the from-DID, assert rows
+land on the to-DID).
+
+- [ ] **Step 5: Compile both targets, run native lint gate**
+
+Run: `cargo check -p tonk-worker --target wasm32-unknown-unknown --tests && cargo clippy --workspace --all-targets --all-features && cargo fmt --check`
+Expected: clean. (wasm tests execute in the CI web leg — note it in the PR.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rust/tonk-worker-api rust/tonk-worker/src/router/account.rs rust/tonk-worker/src/router/migrate.rs
+git commit -m "feat(tonk-worker): succession-authorized relink and rotation convergence"
+```
+
+### Task 7: Browser rotation ceremony (binding + panel)
+
+**Files:**
+- Modify: `rust/tonk-identity/src/install.rs`
+- Modify: `rust/tonk-ui/src/api.rs`
+- Modify: `rust/tonk-ui/src/account.rs`
+- Modify: `rust/tonk-ui/src/account.html`
+- Modify: `rust/tonk-ui/src/account.css` (only if the new panel needs a class that doesn't exist)
+
+**Interfaces:**
+- Consumes: `tonk_identity::ceremony::rotate_account` (Task 4), service `POST /accounts/rotate` (Task 5), worker `POST /api/account/link` with `succession_hex` (Task 6).
+- Produces: `window.tonkIdentity.rotateAccount(newPasskeyName)` returning `{ oldRootDid, newRootDid, newCredentialId, successionHex, deviceDelegationHex, rotationHex, confirmationHex }`; a `rotate` panel on `<tonk-account>`.
+
+- [ ] **Step 1: STOP-and-verify passkey ordering**
+
+Read `rust/tonk-identity/src/passkey.rs` in full. The rotation closure
+must derive the OLD root before the new passkey exists, because
+`prf_output()` performs a `get()` and the browser's credential picker will
+offer every resident credential for the RP — after the new passkey is
+created there are two. Confirm:
+(a) `prf_output()` lets the user pick a credential (acceptable: the
+    ceremony derives old first, when only the old exists), and
+(b) `create_passkey` + follow-up `get()` (the `prf_output` fallback in
+    `install.rs` line ~100) can target the JUST-created credential
+    specifically (e.g. via `allowCredentials` with the returned id). If it
+    cannot — if the fallback `get()` is also picker-ambiguous — STOP and
+    report: the rotation closure then needs an `allowCredentials`
+    parameter added to `prf_output` first, and that change must be
+    designed against `passkey.rs` as it actually is.
+
+- [ ] **Step 2: Add the `rotateAccount` binding**
+
+In `install.rs`, following the existing closure pattern for
+`createAccount` (read lines ~85–125 for the exact `Reflect::set` /
+`Closure` idiom and error helper), add a closure registered as
+`"rotateAccount"` that:
+
+1. `let old_prf = crate::passkey::prf_output().await?` (old credential —
+   the only one that exists yet);
+2. `let old_root = crate::derive::derive_root_signer(&old_prf).await?`;
+3. `let created = crate::passkey::create_passkey(&name).await?`; derive
+   the new root from `created.prf_output` or the follow-up `get()` exactly
+   as the `createAccount` closure does;
+4. read the device DID the same way the existing closures obtain it
+   (whatever source `createAccount` uses — mirror it);
+5. `let ceremony = crate::ceremony::rotate_account(old_root, new_root, created.credential_id, device_did).await?`;
+6. `Reflect::set` the seven fields named in **Interfaces** onto the result
+   object (camelCase), plus `prfAtCreate` like the others.
+
+Register `"rotateAccount"` in the install list at the bottom of the file
+(the array at line ~226).
+
+- [ ] **Step 3: Add the API wrapper**
+
+In `rust/tonk-ui/src/api.rs`, next to `submit_account_ceremony` (read it
+and mirror its reqwest/fetch idiom exactly), add:
+
+```rust
+pub async fn rotate_account(
+    service_url: &str,
+    rotation_hex: &str,
+    confirmation_hex: &str,
+) -> Result<(), ApiError>
+```
+
+which POSTs `{service_url}/accounts/rotate` with JSON
+`{"rotation": rotation_hex, "confirmation": confirmation_hex}` and treats
+non-2xx like the sibling fns do. Also extend the existing
+`save_account_link` wrapper (which POSTs `/api/account/link`) with an
+optional `succession_hex: Option<&str>` parameter serialized into the
+body's new field.
+
+- [ ] **Step 4: Add the panel**
+
+In `account.html`: a `#account-rotate` panel with a passkey-name input
+(`#account-rotate-name`), a submit button (`#account-rotate-submit`), and
+one paragraph of copy: "Creates a new passkey for this account. Your
+devices keep working and re-connect to the new passkey the next time they
+sync in." Reachable via a "Rotate passkey" button (`#account-rotate-open`)
+added to the `success` panel. In `account.rs`:
+
+1. add `("rotate", "#account-rotate")` to the `set_mode` list;
+2. add `#account-rotate-submit` to `set_busy`'s selector list;
+3. wire `#account-rotate-open` → `set_mode(&host, "rotate")`;
+4. wire submit: `identity_call("rotateAccount", &name)` → deserialize the
+   seven-field object → `crate::api::rotate_account(&service_url, &rotation_hex, &confirmation_hex)` →
+   `crate::api::save_account_link(&new_root_did, &device_delegation_hex, Some(&succession_hex))` →
+   `show_success(&host)`; any error → `set_busy(false, "")` +
+   `show_error`. Follow the exact `spawn_local` + error-string plumbing of
+   the existing create flow (lines ~440–480).
+
+- [ ] **Step 5: wasm panel test (compile locally)**
+
+In `account.rs`'s `run_in_browser` test module, mirror the existing
+panel-visibility test style: assert `set_mode(host, "rotate")` hides the
+others and reveals `#account-rotate`.
+
+- [ ] **Step 6: Compile gates**
+
+Run: `cargo check -p tonk-ui --target wasm32-unknown-unknown --tests && cargo clippy --workspace --all-targets --all-features && cargo fmt --check`
+Expected: clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rust/tonk-identity/src/install.rs rust/tonk-ui/src/api.rs rust/tonk-ui/src/account.rs rust/tonk-ui/src/account.html rust/tonk-ui/src/account.css
+git commit -m "feat(tonk-ui): passkey rotation ceremony"
+```
+
+---
+
+## Sub-stage 2 — Surviving-device recovery (one PR)
+
+### Task 8: Recovery core + `POST /accounts/recover`
+
+**Files:**
+- Create: `rust/tonk-account-service/src/core/recovery.rs`
+- Create: `rust/tonk-account-service/src/handlers/recover.rs`
+- Modify: `rust/tonk-account-service/src/core.rs`, `src/handlers.rs`, `src/lib.rs`
+- Modify: `rust/tonk-account-service/tests/service.rs`
+
+**Interfaces:**
+- Consumes: `authorize` (device container — subject is the CURRENT root, issuer an ACTIVE device), `authorize_root` (confirmation container), `check_subject_open_delegation`, `rotate_root`, `update_device_delegation`.
+- Produces: `POST /accounts/recover`, JSON `{ "recovery": "<hex device-signed>", "confirmation": "<hex new-root-signed>" }`. Device container: command `["account","recover"]`, args `newRootDid`, `newCredentialId`, `deviceDelegation` (newRoot → survivingDevice). Confirmation: command `["account","recover","confirm"]`, args `oldRootDid`. Core: `pub async fn recover_account<S: Store>(store: &S, caller: &crate::auth::Caller, new_root_did: &str, new_credential_id: &str, device_delegation_hex: &str) -> Result<(), CeremonyError>`.
+
+- [ ] **Step 1: Write the failing core tests**
+
+`core/recovery.rs` tests build the device container with the same
+`container(...)` helper shape as `auth.rs`'s test module (root PRF
+`[7u8; 32]`, device seed `[8u8; 32]`), seed the account + active device,
+then:
+
+```rust
+    #[dialog_common::test]
+    async fn it_flips_the_root_under_device_and_new_root_authority() { /* asserts:
+        account_by_root(new).id == old id, credential replaced, surviving
+        device delegation_cid repointed, device still Active */ }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_delegation_not_issued_by_the_new_root() { /* bogus
+        deviceDelegation minted by a third key → CeremonyError::Invalid,
+        account row untouched */ }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_revoked_surviving_device() { /* authorize() itself
+        rejects — cover via the handler-level integration test in
+        tests/service.rs; here assert recover_account is never reached by
+        constructing the Caller manually is NOT possible (Caller fields are
+        pub) — so instead assert the core succeeds only for the device the
+        Caller names: pass a Caller whose device row was revoked after
+        construction and expect the update_device_delegation repoint to
+        return false → CeremonyError::Invalid */ }
+```
+
+Write these three tests out fully in the file — the comments above are
+their assertions, the bodies follow Task 3's fixture idiom line for line
+(create store → seed account/device → build request → call → assert).
+
+- [ ] **Step 2: Implement the core**
+
+```rust
+//! Surviving-device recovery: a linked device plus a freshly created
+//! passkey re-anchor the account when the old passkey is gone.
+
+use crate::auth::Caller;
+use crate::core::CeremonyError;
+use crate::core::delegation::check_subject_open_delegation;
+use crate::store::Store;
+
+/// Flip `caller.account` onto `new_root_did` under the authority of one
+/// of its active devices plus proof of control of the new root.
+///
+/// The surviving device's row is repointed at its fresh
+/// `newRoot → device` delegation so it can keep making device-signed
+/// calls; every other device keeps its old-root delegation (still valid
+/// for space access) and re-links on its next ceremony. The old passkey
+/// credential is superseded: the registry no longer honors the root it
+/// derives.
+pub async fn recover_account<S: Store>(
+    store: &S,
+    caller: &Caller,
+    new_root_did: &str,
+    new_credential_id: &str,
+    device_delegation_hex: &str,
+) -> Result<(), CeremonyError> {
+    let delegation_cid = check_subject_open_delegation(
+        device_delegation_hex,
+        new_root_did,
+        &caller.device.device_did,
+    )
+    .await?;
+    let repointed = store
+        .update_device_delegation(caller.account.id, &caller.device.device_did, &delegation_cid)
+        .await?;
+    if !repointed {
+        return Err(CeremonyError::Invalid(
+            "surviving device is not registered under this account".to_string(),
+        ));
+    }
+    store
+        .rotate_root(caller.account.id, new_root_did, new_credential_id)
+        .await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Handler**
+
+`handlers/recover.rs` is Task 5's handler with these differences: the
+first container goes through `authorize(&store, &recovery_bytes, &["account", "recover"])`
+(device-signed — note `authorize` needs the store, so `build_store` runs
+before authorization here), the second through
+`authorize_root(&confirmation_bytes, &["account", "recover", "confirm"])`;
+cross-check `required_string(&caller.arguments, "newRootDid") == confirm.root_did`
+and `required_string(&confirm.arguments, "oldRootDid") == caller.account.root_did`;
+then call `recover_account`. Routes:
+
+```rust
+        .options_async("/accounts/recover", handlers::recover::handle_options)
+        .post_async("/accounts/recover", handlers::recover::handle)
+```
+
+- [ ] **Step 4: Integration test**
+
+In `tests/service.rs`: full flow — create account (device A), link device
+B, "lose" the passkey, build recovery via the Task 9 builder signed by
+device B + a fresh root, POST `/accounts/recover`, expect 200; then
+device-B-signed `/devices/list` under the new root succeeds; a
+device-signed call under the old root gets 401; device A's row still
+lists as `active` with its old delegation CID.
+
+- [ ] **Step 5: Run + commit**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+Expected: PASS
+
+```bash
+git add rust/tonk-account-service/src/core/recovery.rs rust/tonk-account-service/src/handlers/recover.rs rust/tonk-account-service/src/core.rs rust/tonk-account-service/src/handlers.rs rust/tonk-account-service/src/lib.rs rust/tonk-account-service/tests/service.rs
+git commit -m "feat(tonk-account-service): surviving-device account recovery"
+```
+
+### Task 9: Recovery ceremony builder + binding
+
+**Files:**
+- Modify: `rust/tonk-identity/src/ceremony.rs`
+- Modify: `rust/tonk-identity/src/request.rs`
+- Modify: `rust/tonk-identity/src/install.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub struct RecoveryCeremony { pub new_root_did: String, pub new_credential_id: String, pub device_delegation_hex: String, pub confirmation_hex: String }` and `pub async fn recover_account(new_root: Ed25519Signer, new_credential_id: String, old_root_did: String, device_did: dialog_varsig::Did) -> Result<RecoveryCeremony>` in `ceremony.rs` — everything the NEW root signs. (The device-signed container is built worker-side, where the device key lives.)
+  - `pub async fn build_recovery_invocation(device: Ed25519Signer, link: &DelegationChain, new_root_did: String, new_credential_id: String, device_delegation_hex: String) -> Result<Vec<u8>>` in `request.rs` — a thin wrapper over `build_device_invocation` with command `["account","recover"]` and the three args; write it as a real fn (it exists so the worker route and tests share one arg-name source of truth).
+  - `window.tonkIdentity.recoverAccount(passkeyName, oldRootDid, deviceDid)` binding returning `{ newRootDid, newCredentialId, deviceDelegationHex, confirmationHex }`.
+
+- [ ] **Step 1: Tests then implementation for both fns**
+
+Follow Task 4's test/impl pattern exactly: a
+`it_builds_the_new_root_half_of_a_recovery` test asserting the
+confirmation container verifies, is issued by the new root, command
+`["account","recover","confirm"]`, args carry `oldRootDid`; and a
+`it_builds_a_device_signed_recovery_invocation` test in `request.rs`
+asserting the invocation verifies with proof = the link delegation,
+subject = old root, command `["account","recover"]`, and the three args
+present. Implementation of `recover_account`: mint
+`mint_device_delegation(new_root.clone(), &device_did)`, then `build(new_root,
+vec!["account".into(), "recover".into(), "confirm".into()],
+strings([("oldRootDid", old_root_did)]), …)`. Implementation of
+`build_recovery_invocation`:
+
+```rust
+pub async fn build_recovery_invocation(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    new_root_did: String,
+    new_credential_id: String,
+    device_delegation_hex: String,
+) -> Result<Vec<u8>> {
+    let mut arguments = BTreeMap::new();
+    arguments.insert("newRootDid".to_owned(), Promised::String(new_root_did));
+    arguments.insert(
+        "newCredentialId".to_owned(),
+        Promised::String(new_credential_id),
+    );
+    arguments.insert(
+        "deviceDelegation".to_owned(),
+        Promised::String(device_delegation_hex),
+    );
+    build_device_invocation(
+        device,
+        link,
+        vec!["account".into(), "recover".into()],
+        arguments,
+    )
+    .await
+}
+```
+
+- [ ] **Step 2: Binding**
+
+`install.rs`: `"recoverAccount"` closure — `create_passkey(name)`, derive
+the new root (create-or-follow-up-get, same as `createAccount`), call
+`ceremony::recover_account(new_root, credential_id, old_root_did, device_did)`
+with the two DIDs passed in from JS (the page reads them from
+`GET /api/account` — it knows the old root and device DID even though the
+passkey is gone, because the link is stored locally). Register in the
+install list.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p tonk-identity`
+Expected: PASS
+
+```bash
+git add rust/tonk-identity/src/ceremony.rs rust/tonk-identity/src/request.rs rust/tonk-identity/src/install.rs
+git commit -m "feat(tonk-identity): surviving-device recovery ceremony builder"
+```
+
+### Task 10: Worker recovery route
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account.rs`
+- Modify: `rust/tonk-worker-api/src/lib.rs` (request/response types)
+- Modify: `rust/tonk-worker/src/router.rs` (route registration — find where `/api/account/link` is registered and mirror)
+
+**Interfaces:**
+- Consumes: `account_link` (stored old link), profile device signer (STOP gate below), `build_recovery_invocation` (Task 9), service `POST /accounts/recover` (Task 8), `converge_after_rotation` (Task 6).
+- Produces: `POST /api/account/recover`, body `AccountRecoverRequest { new_root_did: String, new_credential_id: String, confirmation_hex: String, device_delegation_hex: String }` → flips the service registry, replaces the local link, converges; responds with the new `AccountStatus::Linked`.
+
+- [ ] **Step 1: STOP-and-verify the device signer**
+
+`build_recovery_invocation` needs the device's `Ed25519Signer`. Find how
+the worker signs device invocations today: `account_backup.rs` calls
+`build_device_invocation` for `/chains/put` — read `account_backup.rs` and
+identify exactly where its `Ed25519Signer` comes from (a
+`tonk.profile`-derived signer, a credential-store load, or a
+`dialog_operator` API). Reuse that exact mechanism. If it turns out the
+signer is NOT reachable from `TonkState` (i.e. `account_backup.rs` gets it
+some other way you cannot reuse), STOP and report before writing the
+route.
+
+- [ ] **Step 2: Implement the route**
+
+`recover` handler in `account.rs` (wasm-gated like the sweep dispatchers,
+since it drives service HTTP + convergence):
+
+1. load the stored link; `Unlinked` → 404-equivalent
+   (`TonkWorkerError::Router("profile has no account link")`).
+2. `old_root = link.issuer()`; build the device container via
+   `build_recovery_invocation` (Task 9) with the request fields.
+3. POST both containers to `{service}/accounts/recover` (service URL
+   resolution: reuse the exact helper `account_backup.rs` uses).
+   Non-2xx → surface the service error text as `TonkWorkerError::Forbidden`.
+4. On 200: validate + store the new link — call `persist_link_replacing`,
+   a new `pub(crate)` fn that is `persist_link` minus the same-issuer
+   guard (factor the shared tail out; the HTTP `link` route keeps the
+   guarded path, only the recovery route may call the replacing variant).
+5. Fire the convergence sweep exactly as the rotation arm of `link` does
+   (`converge_after_rotation(&tonk, &old_root)` then `restore_spaces`).
+6. Respond `AccountStatus::Linked { root_did: new, device_did }`.
+
+- [ ] **Step 3: wasm test (compile locally)**
+
+`it_refuses_recovery_when_unlinked`: call the handler on a fresh state,
+expect `Err(TonkWorkerError::Router(_))`. (The happy path needs a live
+account service — it is covered natively by Task 8's integration test and
+by the manual staging pass; say so in a comment above the test module.)
+
+- [ ] **Step 4: Compile gates + commit**
+
+Run: `cargo check -p tonk-worker --target wasm32-unknown-unknown --tests && cargo clippy --workspace --all-targets --all-features && cargo fmt --check`
+Expected: clean
+
+```bash
+git add rust/tonk-worker/src/router/account.rs rust/tonk-worker/src/router.rs rust/tonk-worker-api
+git commit -m "feat(tonk-worker): surviving-device account recovery route"
+```
+
+### Task 11: Recovery panel
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.rs`, `account.html`
+- Modify: `rust/tonk-ui/src/api.rs`
+
+**Interfaces:**
+- Consumes: `window.tonkIdentity.recoverAccount` (Task 9), worker `POST /api/account/recover` (Task 10), `GET /api/account` (existing `account_status`).
+
+- [ ] **Step 1: Panel + wiring**
+
+`#account-recover` panel, entered from a "Lost your passkey?" link on the
+`choice` panel — but ONLY shown when `account_status()` returns `Linked`
+(a linked device is the prerequisite; an unlinked browser shows the
+standard copy pointing at any surviving device instead — one static
+paragraph in the panel handles both, toggled on `data-mode` +
+link-status). Flow on submit: read `root_did` + `device_did` from
+`account_status()`, `identity_call("recoverAccount", …)` with
+`(name, root_did, device_did)`, POST the result to the worker recover
+route via a new `api.rs` wrapper `recover_account(request: &AccountRecoverRequest)`,
+then `show_success`. Copy requirement (verbatim in the HTML): "This
+replaces the account's passkey. Other devices keep their data and
+re-connect the next time they open tonk." Follow the create-flow error
+plumbing.
+
+- [ ] **Step 2: set_mode/set_busy registration + wasm panel test**
+
+Add `("recover", "#account-recover")` to `set_mode`,
+`#account-recover-submit` to `set_busy`, and a panel-visibility test.
+
+- [ ] **Step 3: Compile gates + commit**
+
+Run: `cargo check -p tonk-ui --target wasm32-unknown-unknown --tests && cargo clippy --workspace --all-targets --all-features && cargo fmt --check`
+
+```bash
+git add rust/tonk-ui/src/account.rs rust/tonk-ui/src/account.html rust/tonk-ui/src/api.rs
+git commit -m "feat(tonk-ui): surviving-device recovery panel"
+```
+
+---
+
+## Sub-stage 3 — Total-loss re-anchor (one PR)
+
+### Task 12: Store lookup by email + bulk revoke
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/store.rs`, `store/sqlite.rs`, `store/d1.rs`
+
+**Interfaces:**
+- Produces: `async fn account_by_email(&self, email: &str) -> Result<Option<Account>, StoreError>` and `async fn revoke_all_devices(&self, account_id: i64) -> Result<(), StoreError>` on `Store`.
+
+- [ ] **Step 1: SQL + trait + tests + both impls**
+
+```rust
+/// SQL: look up an account by verified email.
+pub const SELECT_ACCOUNT_BY_EMAIL: &str =
+    "SELECT id, email, root_did, credential_id, created_at FROM accounts WHERE email = ?1";
+
+/// SQL: revoke every device under an account.
+pub const UPDATE_DEVICES_REVOKE_ALL: &str =
+    "UPDATE devices SET status = 'revoked' WHERE account_id = ?1";
+```
+
+sqlite `account_by_email` mirrors `account_by_root`'s
+`query_row(...).optional()` body; `revoke_all_devices` mirrors
+`revoke_device` without the bool. D1 likewise. Tests:
+`it_finds_an_account_by_its_lowercased_email` (create with mixed-case via
+the core path is already lowercased; store-level test seeds lowercase and
+asserts the miss on a different email) and
+`it_revokes_every_device_at_once` (seed two devices, revoke all, list
+shows both `revoked`).
+
+- [ ] **Step 2: Run + commit**
+
+Run: `cargo test -p tonk-account-service --features helpers`
+
+```bash
+git add rust/tonk-account-service/src/store.rs rust/tonk-account-service/src/store/sqlite.rs rust/tonk-account-service/src/store/d1.rs
+git commit -m "feat(tonk-account-service): account lookup by email and bulk device revoke"
+```
+
+### Task 13: Re-anchor core + `POST /accounts/reanchor`
+
+**Files:**
+- Create: `rust/tonk-account-service/src/core/reanchor.rs`
+- Create: `rust/tonk-account-service/src/handlers/reanchor.rs`
+- Modify: `core.rs`, `handlers.rs`, `lib.rs`, `tests/service.rs`
+- Modify: `rust/tonk-identity/src/ceremony.rs` + `install.rs` (confirm builder + binding)
+
+**Interfaces:**
+- Produces: `POST /accounts/reanchor`, JSON `{ "email": …, "code": …, "confirmation": "<hex new-root-signed>" }`; confirmation command `["account","reanchor","confirm"]`, args `email`, `newCredentialId`. Core: `pub async fn reanchor_account<S: Store>(store: &S, email: &str, code: &str, new_root_did: &str, new_credential_id: &str, now: u64) -> Result<(), CeremonyError>`.
+
+- [ ] **Step 1: Core with tests**
+
+Core sequence: `verify_code(store, email, code, now)?` (consumes the code
+— the existing cooldown + attempt cap ARE the rate limit) →
+`account_by_email(email)?` else `Unauthorized("unknown account")` →
+`rotate_root(account.id, new_root_did, new_credential_id)` →
+`revoke_all_devices(account.id)`. Doc comment must state: no delegation
+bridges anything — space access is intentionally severed; rosters keyed on
+the old root make affected spaces discoverable so founders re-invite.
+Tests: `it_reanchors_with_a_valid_code_and_revokes_every_device`,
+`it_rejects_a_bad_code_before_touching_the_registry`,
+`it_rejects_an_unknown_email` — all three follow Task 3's fixture idiom.
+
+- [ ] **Step 2: Handler**
+
+Follows Task 5's shape: JSON body, `authorize_root(&confirmation_bytes,
+&["account", "reanchor", "confirm"])`, cross-check the container's `email`
+arg equals the body email (binds the code to the root that requested it),
+`new_credential_id` from the container args, `worker::console_log!` one
+structured line on success (`"account reanchored"`, account id, old root,
+new root — the "logged" requirement). Ceremony builder + binding: a
+`reanchor_account(new_root, email, new_credential_id)` fn in `ceremony.rs`
+(single container via `build(...)` with command
+`["account","reanchor","confirm"]` and args `email`, `newCredentialId` —
+mirror Task 4's test) and a `"reanchorAccount"` closure in `install.rs`
+(create passkey → derive → build). Integration test in `tests/service.rs`:
+request code → reanchor → old root 401s, new root's first `linkDevice`
+self-link succeeds, `/devices/list` shows the pre-loss devices revoked.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p tonk-account-service --features helpers && cargo test -p tonk-identity`
+
+```bash
+git add rust/tonk-account-service/src/core/reanchor.rs rust/tonk-account-service/src/handlers/reanchor.rs rust/tonk-account-service/src/core.rs rust/tonk-account-service/src/handlers.rs rust/tonk-account-service/src/lib.rs rust/tonk-account-service/tests/service.rs rust/tonk-identity/src/ceremony.rs rust/tonk-identity/src/install.rs
+git commit -m "feat(tonk-account-service): email-authorized total-loss re-anchor"
+```
+
+### Task 14: Re-anchor panel (loud copy)
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.rs`, `account.html`, `api.rs`
+
+- [ ] **Step 1: Panel**
+
+`#account-reanchor`, reached from the recovery panel's "No device either?"
+link. Two-step inside the panel (email+send-code → code+passkey-name+submit),
+reusing `request_account_code`. REQUIRED copy, verbatim, above the submit:
+"This creates a fresh identity for your account email. Your spaces do NOT
+carry over — every space must re-invite you. Only continue if no signed-in
+device exists anywhere." Submit: `identity_call("reanchorAccount", …)` →
+new `api.rs` wrapper `reanchor_account(service_url, email, code, confirmation_hex)` →
+on success, run the standard self-link (`linkDevice` ceremony + `/devices/link`
++ `save_account_link`) so the browser ends the flow linked — then
+`show_success`. Panel registration + busy list + visibility test as before.
+
+- [ ] **Step 2: Compile gates + commit**
+
+Run: `cargo check -p tonk-ui --target wasm32-unknown-unknown --tests && cargo clippy --workspace --all-targets --all-features && cargo fmt --check`
+
+```bash
+git add rust/tonk-ui/src/account.rs rust/tonk-ui/src/account.html rust/tonk-ui/src/api.rs
+git commit -m "feat(tonk-ui): total-loss re-anchor panel"
+```
+
+### Task 15: CDP e2e + staging verification notes
+
+**Files:**
+- Modify: `rust/tonk-ui/src/identity.rs`
+
+- [ ] **Step 1: Rotation e2e against the virtual authenticator**
+
+Extend the existing `web-integration-tests` harness (read
+`it_builds_a_root_signed_account_creation_in_one_browser_ceremony` for the
+`thirtyfour` + `WebAuthn.addVirtualAuthenticator` setup): one new test
+`it_rotates_onto_a_second_virtual_credential` — create passkey A, derive
+root A; call `rotateAccount` (the virtual authenticator auto-approves, so
+the two-credential picker ambiguity from Task 7's STOP gate does not bite
+here — note that in the test's doc comment); assert the returned
+`oldRootDid` == root A's DID, `newRootDid` differs, and both containers +
+the succession chain verify (decode with `InvocationChain::try_from` /
+`DelegationChain::try_from` in the test body, same as the existing test
+does).
+
+- [ ] **Step 2: Manual staging checklist into the PR body**
+
+The sub-stage PRs each carry (not in code, in the PR body): rotate on
+staging.tonk.xyz with a real passkey → old device still opens its spaces →
+second browser self-links with the new passkey and restores. Recovery and
+re-anchor equivalents for their PRs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rust/tonk-ui/src/identity.rs
+git commit -m "test(tonk-ui): passkey rotation against the virtual authenticator"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: master-design "Recovery and rotation" section — deliberate
+  rotation (Tasks 1–7), surviving-device (Tasks 8–11), total-loss
+  (Tasks 12–14), "no escrow / no new cryptographic artifacts" honored (the
+  only new artifact classes are a succession delegation and standard
+  invocation containers). Registry flip + credential replacement covers
+  "the old credential is revoked".
+- Type consistency: `check_subject_open_delegation(hex, issuer, audience)`
+  used in Tasks 3, 8; `rotate_root` / `update_device_delegation`
+  signatures identical in Tasks 2, 3, 8, 13; wire field names
+  (`newRootDid`, `newCredentialId`, `succession`, `deviceDid`,
+  `deviceDelegation`, `oldRootDid`) consistent between the ceremony
+  builders (Tasks 4, 9, 13) and the handlers (Tasks 5, 8, 13).
+- Known execution gates: Task 7 Step 1 (passkey picker ambiguity /
+  `allowCredentials`), Task 10 Step 1 (worker device-signer source), Task
+  5 Step 3 (native reachability of new routes in `tests/service.rs`),
+  Task 2 Step 4 (sqlite `map_err` Conflict mapping on UPDATE). Each is a
+  read-and-confirm against code that exists on this branch, with a STOP
+  instruction when the read contradicts the plan.

--- a/rust/tonk-account-service/src/core.rs
+++ b/rust/tonk-account-service/src/core.rs
@@ -15,6 +15,7 @@ pub mod codes;
 pub mod delegation;
 pub mod devices;
 pub mod links;
+pub mod rotation;
 
 /// Errors shared by every ceremony in this crate.
 #[derive(Debug)]

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -4,7 +4,7 @@
 
 use crate::core::CeremonyError;
 use crate::core::codes::verify_code;
-use crate::core::delegation::check_device_delegation;
+use crate::core::delegation::check_subject_open_delegation;
 use crate::store::{NewDevice, Store};
 
 /// A request to create a new account and register its first device.
@@ -41,7 +41,7 @@ pub async fn create_account<S: Store>(
     now: u64,
 ) -> Result<i64, CeremonyError> {
     verify_code(store, &request.email, &request.code, now).await?;
-    let delegation_cid = check_device_delegation(
+    let delegation_cid = check_subject_open_delegation(
         &request.delegation_hex,
         &request.root_did,
         &request.device_did,

--- a/rust/tonk-account-service/src/core/delegation.rs
+++ b/rust/tonk-account-service/src/core/delegation.rs
@@ -1,20 +1,21 @@
-//! Checking a `root → device` delegation chain presented at account
-//! creation or device linking.
+//! Checking a subject-open, single-hop delegation chain presented during
+//! account ceremonies: `root → device` at creation and linking,
+//! `oldRoot → newRoot` at rotation, `newRoot → device` at recovery.
 
 use dialog_credentials::Ed25519KeyResolver;
 use dialog_ucan_core::DelegationChain;
 
 use crate::core::CeremonyError;
 
-/// Parse and check a hex-encoded `root → device` delegation chain.
+/// Parse and check a hex-encoded subject-open delegation chain.
 ///
-/// Requires exactly one proof, issued by `root_did` to `device_did`,
+/// Requires exactly one proof, issued by `issuer_did` to `audience_did`,
 /// subject-open, with a valid signature. Returns the delegation's CID,
 /// stringified — the key `devices.delegation_cid` is stored under.
-pub async fn check_device_delegation(
+pub async fn check_subject_open_delegation(
     delegation_hex: &str,
-    root_did: &str,
-    device_did: &str,
+    issuer_did: &str,
+    audience_did: &str,
 ) -> Result<String, CeremonyError> {
     let bytes = hex::decode(delegation_hex)
         .map_err(|err| CeremonyError::Invalid(format!("bad delegation hex: {err}")))?;
@@ -26,14 +27,14 @@ pub async fn check_device_delegation(
             "delegation chain must have exactly one proof".to_string(),
         ));
     }
-    if chain.issuer().to_string() != root_did {
+    if chain.issuer().to_string() != issuer_did {
         return Err(CeremonyError::Invalid(
-            "delegation issuer does not match the claimed root".to_string(),
+            "delegation issuer does not match the expected principal".to_string(),
         ));
     }
-    if chain.audience().to_string() != device_did {
+    if chain.audience().to_string() != audience_did {
         return Err(CeremonyError::Invalid(
-            "delegation audience does not match the device".to_string(),
+            "delegation audience does not match the expected principal".to_string(),
         ));
     }
     if chain.subject().is_some() {

--- a/rust/tonk-account-service/src/core/delegation.rs
+++ b/rust/tonk-account-service/src/core/delegation.rs
@@ -39,7 +39,7 @@ pub async fn check_subject_open_delegation(
     }
     if chain.subject().is_some() {
         return Err(CeremonyError::Invalid(
-            "root to device delegation must be subject-open".to_string(),
+            "delegation chain must be subject-open".to_string(),
         ));
     }
 

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -40,12 +40,18 @@ pub async fn list_devices<S: Store>(
     Ok(devices.into_iter().map(DeviceView::from).collect())
 }
 
-/// Register a new device under an account.
+/// Register a new device under an account, or upsert its delegation and
+/// name if it is already registered under this same account.
 ///
 /// Checks that `delegation_hex` is a valid `root → device` delegation
-/// issued by `account.root_did` to `device_did` before registering the
-/// device as active. A duplicate device DID surfaces as
-/// `CeremonyError::Conflict`.
+/// issued by `account.root_did` to `device_did` before touching the
+/// registry. A `device_did` already registered under a *different*
+/// account surfaces as `CeremonyError::Conflict`. A `device_did` already
+/// registered under *this* account is upserted in place — this is the
+/// re-registration path a device takes after its account rotates onto a
+/// new root — unless the existing row is revoked, in which case it stays
+/// revoked and the request is rejected as `CeremonyError::Forbidden`; a
+/// revoked device is never silently resurrected by re-registering it.
 pub async fn register_device<S: Store>(
     store: &S,
     account: &Account,
@@ -56,6 +62,24 @@ pub async fn register_device<S: Store>(
 ) -> Result<(), CeremonyError> {
     let delegation_cid =
         check_subject_open_delegation(delegation_hex, &account.root_did, device_did).await?;
+
+    if let Some(existing) = store.device_by_did(device_did).await? {
+        if existing.account_id != account.id {
+            return Err(CeremonyError::Conflict(
+                "device DID is already registered to a different account".to_string(),
+            ));
+        }
+        if existing.status == DeviceStatus::Revoked {
+            return Err(CeremonyError::Forbidden(
+                "device has been revoked and cannot re-register".to_string(),
+            ));
+        }
+        store
+            .update_device_registration(account.id, device_did, &delegation_cid, device_name)
+            .await?;
+        return Ok(());
+    }
+
     store
         .insert_device(&Device {
             account_id: account.id,
@@ -114,14 +138,18 @@ mod tests {
     }
 
     async fn seeded_account(store: &SqliteStore) -> Account {
+        seeded_account_with(store, "a@x.com", ROOT_PRF).await
+    }
+
+    async fn seeded_account_with(store: &SqliteStore, email: &str, root_prf: [u8; 32]) -> Account {
         use dialog_varsig::Principal;
-        let root_did = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        let root_did = tonk_identity::derive::derive_root_signer(&root_prf)
             .await
             .unwrap()
             .did()
             .to_string();
         store
-            .create_account("a@x.com", &root_did, "cred", 100)
+            .create_account(email, &root_did, "cred", 100)
             .await
             .unwrap();
         store.account_by_root(&root_did).await.unwrap().unwrap()
@@ -169,5 +197,94 @@ mod tests {
         let views = list_devices(&store, &account).await.unwrap();
         assert_eq!(views.len(), 1);
         assert_eq!(views[0].status, "revoked");
+    }
+
+    #[dialog_common::test]
+    async fn it_upserts_an_active_device_reregistering_under_the_same_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let account = seeded_account(&store).await;
+        let (device_did, delegation_hex) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        register_device(&store, &account, &device_did, "phone", &delegation_hex, 200)
+            .await
+            .unwrap();
+        let original_cid = list_devices(&store, &account).await.unwrap()[0]
+            .delegation_cid
+            .clone();
+
+        let (_, delegation_hex_2) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        register_device(
+            &store,
+            &account,
+            &device_did,
+            "phone (renamed)",
+            &delegation_hex_2,
+            300,
+        )
+        .await
+        .unwrap();
+
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].name, "phone (renamed)");
+        assert_eq!(views[0].status, "active");
+        assert_ne!(views[0].delegation_cid, original_cid);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_reregistering_a_revoked_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let account = seeded_account(&store).await;
+        let (device_did, delegation_hex) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        register_device(&store, &account, &device_did, "phone", &delegation_hex, 200)
+            .await
+            .unwrap();
+        revoke_device(&store, &account, &device_did).await.unwrap();
+
+        let (_, delegation_hex_2) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        let result = register_device(
+            &store,
+            &account,
+            &device_did,
+            "phone",
+            &delegation_hex_2,
+            300,
+        )
+        .await;
+        assert!(matches!(result, Err(CeremonyError::Forbidden(_))));
+
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views[0].status, "revoked");
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_did_already_registered_to_a_different_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let account_a = seeded_account(&store).await;
+        let (device_did, delegation_hex) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        register_device(
+            &store,
+            &account_a,
+            &device_did,
+            "phone",
+            &delegation_hex,
+            200,
+        )
+        .await
+        .unwrap();
+
+        let account_b = seeded_account_with(&store, "b@x.com", FOREIGN_ROOT_PRF).await;
+        let (device_did_2, delegation_hex_2) = delegation_from(FOREIGN_ROOT_PRF, DEVICE_SEED).await;
+        assert_eq!(device_did, device_did_2);
+
+        let result = register_device(
+            &store,
+            &account_b,
+            &device_did_2,
+            "phone",
+            &delegation_hex_2,
+            300,
+        )
+        .await;
+        assert!(matches!(result, Err(CeremonyError::Conflict(_))));
     }
 }

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -2,7 +2,7 @@
 //! under an account's root DID.
 
 use crate::core::CeremonyError;
-use crate::core::delegation::check_device_delegation;
+use crate::core::delegation::check_subject_open_delegation;
 use crate::store::{Account, Device, DeviceStatus, Store};
 
 /// A device row as surfaced to API callers.
@@ -55,7 +55,7 @@ pub async fn register_device<S: Store>(
     now: u64,
 ) -> Result<(), CeremonyError> {
     let delegation_cid =
-        check_device_delegation(delegation_hex, &account.root_did, device_did).await?;
+        check_subject_open_delegation(delegation_hex, &account.root_did, device_did).await?;
     store
         .insert_device(&Device {
             account_id: account.id,

--- a/rust/tonk-account-service/src/core/links.rs
+++ b/rust/tonk-account-service/src/core/links.rs
@@ -1,7 +1,7 @@
 //! One-time browser handoffs for linking native CLI profiles.
 
 use crate::core::CeremonyError;
-use crate::core::delegation::check_device_delegation;
+use crate::core::delegation::check_subject_open_delegation;
 use crate::store::{Device, DeviceStatus, LinkRequest, Store};
 
 /// Handoffs are deliberately short-lived bearer capabilities.
@@ -130,7 +130,8 @@ pub async fn complete_link<S: Store>(
         .account_by_root(root_did)
         .await?
         .ok_or_else(|| CeremonyError::Unauthorized("unknown account".to_string()))?;
-    let delegation_cid = check_device_delegation(delegation_hex, root_did, device_did).await?;
+    let delegation_cid =
+        check_subject_open_delegation(delegation_hex, root_did, device_did).await?;
     let completed = store
         .complete_link(
             token_hash,

--- a/rust/tonk-account-service/src/core/rotation.rs
+++ b/rust/tonk-account-service/src/core/rotation.rs
@@ -1,0 +1,186 @@
+//! The account rotation ceremony: flip the account onto a new root DID
+//! under authority of the old root, keeping every registered device.
+
+use crate::core::CeremonyError;
+use crate::core::delegation::check_subject_open_delegation;
+use crate::store::{Account, Store};
+
+/// A verified request to rotate an account onto a new root.
+pub struct RotateAccount {
+    /// The DID the account rotates onto.
+    pub new_root_did: String,
+    /// The passkey credential backing the new root.
+    pub new_credential_id: String,
+    /// Hex-encoded subject-open `oldRoot → newRoot` succession chain.
+    pub succession_hex: String,
+    /// The ceremony device re-registering under the new root.
+    pub device_did: String,
+    /// Hex-encoded subject-open `newRoot → device` delegation chain.
+    pub device_delegation_hex: String,
+}
+
+/// Rotate `account` onto `request.new_root_did`.
+///
+/// Verifies the succession chain (old root delegates to the new root) and
+/// the ceremony device's fresh delegation before touching the registry.
+/// Devices other than the ceremony device keep their existing rows: their
+/// old-root delegations remain cryptographically valid for space access,
+/// and they re-link on their next service ceremony.
+pub async fn rotate_account<S: Store>(
+    store: &S,
+    account: &Account,
+    request: &RotateAccount,
+) -> Result<(), CeremonyError> {
+    check_subject_open_delegation(
+        &request.succession_hex,
+        &account.root_did,
+        &request.new_root_did,
+    )
+    .await?;
+    let delegation_cid = check_subject_open_delegation(
+        &request.device_delegation_hex,
+        &request.new_root_did,
+        &request.device_did,
+    )
+    .await?;
+
+    let repointed = store
+        .update_device_delegation(account.id, &request.device_did, &delegation_cid)
+        .await?;
+    if !repointed {
+        return Err(CeremonyError::Invalid(
+            "ceremony device is not registered under this account".to_string(),
+        ));
+    }
+    store
+        .rotate_root(
+            account.id,
+            &request.new_root_did,
+            &request.new_credential_id,
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::store::sqlite::SqliteStore;
+    use crate::store::{Device, DeviceStatus, Store};
+    use dialog_varsig::Principal;
+
+    const OLD_ROOT_PRF: [u8; 32] = [7u8; 32];
+    const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
+    const DEVICE_SEED: [u8; 32] = [8u8; 32];
+
+    async fn fixture(store: &SqliteStore) -> (crate::store::Account, RotateAccount, String) {
+        let old_root = tonk_identity::derive::derive_root_signer(&OLD_ROOT_PRF)
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let old_root_did = old_root.did().to_string();
+        let new_root_did = new_root.did().to_string();
+        let device_did = device.did().to_string();
+
+        let id = store
+            .create_account("a@x.com", &old_root_did, "cred-old", 100)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                account_id: id,
+                device_did: device_did.clone(),
+                delegation_cid: "bafyOld".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 100,
+            })
+            .await
+            .unwrap();
+
+        let succession = tonk_identity::delegation::mint_root_succession(old_root, &new_root.did())
+            .await
+            .unwrap();
+        let device_link =
+            tonk_identity::delegation::mint_device_delegation(new_root, &device.did())
+                .await
+                .unwrap();
+        let account = store.account_by_root(&old_root_did).await.unwrap().unwrap();
+        let request = RotateAccount {
+            new_root_did: new_root_did.clone(),
+            new_credential_id: "cred-new".into(),
+            succession_hex: hex::encode(succession.to_bytes().unwrap()),
+            device_did,
+            device_delegation_hex: hex::encode(device_link.to_bytes().unwrap()),
+        };
+        (account, request, new_root_did)
+    }
+
+    #[dialog_common::test]
+    async fn it_flips_the_root_and_repoints_the_ceremony_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, request, new_root_did) = fixture(&store).await;
+
+        rotate_account(&store, &account, &request).await.unwrap();
+
+        let rotated = store.account_by_root(&new_root_did).await.unwrap().unwrap();
+        assert_eq!(rotated.id, account.id);
+        assert_eq!(rotated.credential_id, "cred-new");
+        let device = store
+            .device_by_did(&request.device_did)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(device.delegation_cid, "bafyOld");
+        assert_eq!(device.status, DeviceStatus::Active);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_succession_not_issued_by_the_account_root() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, mut request, _) = fixture(&store).await;
+        // Succession minted by an unrelated key: issuer check must fail.
+        let stranger = tonk_identity::derive::derive_root_signer(&[13u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let bogus = tonk_identity::delegation::mint_root_succession(stranger, &{
+            use dialog_varsig::Principal;
+            new_root.did()
+        })
+        .await
+        .unwrap();
+        request.succession_hex = hex::encode(bogus.to_bytes().unwrap());
+
+        assert!(matches!(
+            rotate_account(&store, &account, &request).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+        // Nothing flipped.
+        assert!(
+            store
+                .account_by_root(&account.root_did)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_ceremony_device_unknown_to_the_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, mut request, _) = fixture(&store).await;
+        request.device_did = "did:key:zGhost".into();
+        assert!(matches!(
+            rotate_account(&store, &account, &request).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
+}

--- a/rust/tonk-account-service/src/core/rotation.rs
+++ b/rust/tonk-account-service/src/core/rotation.rs
@@ -3,7 +3,7 @@
 
 use crate::core::CeremonyError;
 use crate::core::delegation::check_subject_open_delegation;
-use crate::store::{Account, Store};
+use crate::store::{Account, DeviceStatus, Store};
 
 /// A verified request to rotate an account onto a new root.
 pub struct RotateAccount {
@@ -25,7 +25,10 @@ pub struct RotateAccount {
 /// the ceremony device's fresh delegation before touching the registry.
 /// Devices other than the ceremony device keep their existing rows: their
 /// old-root delegations remain cryptographically valid for space access,
-/// and they re-link on their next service ceremony.
+/// and they re-link on their next service ceremony. The ceremony device
+/// itself must be a currently *active* device on this account: a revoked
+/// device can never drive a rotation back into the registry, and is
+/// rejected as `CeremonyError::Forbidden`.
 pub async fn rotate_account<S: Store>(
     store: &S,
     account: &Account,
@@ -43,6 +46,25 @@ pub async fn rotate_account<S: Store>(
         &request.device_did,
     )
     .await?;
+
+    match store.device_by_did(&request.device_did).await? {
+        Some(device) if device.account_id != account.id => {
+            return Err(CeremonyError::Invalid(
+                "ceremony device is not registered under this account".to_string(),
+            ));
+        }
+        Some(device) if device.status == DeviceStatus::Revoked => {
+            return Err(CeremonyError::Forbidden(
+                "ceremony device has been revoked".to_string(),
+            ));
+        }
+        Some(_) => {}
+        None => {
+            return Err(CeremonyError::Invalid(
+                "ceremony device is not registered under this account".to_string(),
+            ));
+        }
+    }
 
     let repointed = store
         .update_device_delegation(account.id, &request.device_did, &delegation_cid)
@@ -182,5 +204,28 @@ mod tests {
             rotate_account(&store, &account, &request).await,
             Err(CeremonyError::Invalid(_))
         ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_revoked_ceremony_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (account, request, _) = fixture(&store).await;
+        store
+            .revoke_device(account.id, &request.device_did)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            rotate_account(&store, &account, &request).await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+        // Nothing flipped.
+        assert!(
+            store
+                .account_by_root(&account.root_did)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -14,6 +14,8 @@ pub mod codes;
 pub mod devices;
 #[cfg(target_arch = "wasm32")]
 pub mod links;
+#[cfg(target_arch = "wasm32")]
+pub mod rotate;
 
 /// Add CORS headers permitting cross-origin requests to a response.
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-account-service/src/handlers/rotate.rs
+++ b/rust/tonk-account-service/src/handlers/rotate.rs
@@ -1,0 +1,94 @@
+//! `POST /accounts/rotate`: flip an account onto a new root DID under
+//! old-root authority, with new-root proof of control.
+
+use serde::Deserialize;
+use worker::*;
+
+use crate::auth::{authorize_root, required_string};
+use crate::core::rotation::{RotateAccount, rotate_account};
+use crate::error::{ErrorCode, ServiceError};
+use crate::handlers::{build_store, ceremony_error, with_cors_headers};
+use crate::store::Store;
+
+#[derive(Deserialize)]
+struct RotateBody {
+    rotation: String,
+    confirmation: String,
+}
+
+/// `OPTIONS /accounts/rotate` → CORS preflight.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /accounts/rotate` → rotate an account onto a new root.
+pub async fn handle(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body: RotateBody = req
+        .json()
+        .await
+        .map_err(|err| ServiceError::new(ErrorCode::InvalidArgument, format!("bad body: {err}")))?;
+    let rotation_bytes = hex::decode(&body.rotation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad rotation hex: {err}"),
+        )
+    })?;
+    let confirmation_bytes = hex::decode(&body.confirmation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad confirmation hex: {err}"),
+        )
+    })?;
+
+    let old = authorize_root(&rotation_bytes, &["account", "rotate"])
+        .await
+        .map_err(ceremony_error)?;
+    let new = authorize_root(&confirmation_bytes, &["account", "rotate", "confirm"])
+        .await
+        .map_err(ceremony_error)?;
+
+    // Each container must name the other's principal.
+    let claimed_new = required_string(&old.arguments, "newRootDid").map_err(ceremony_error)?;
+    let claimed_old = required_string(&new.arguments, "oldRootDid").map_err(ceremony_error)?;
+    if claimed_new != new.root_did || claimed_old != old.root_did {
+        return Err(ServiceError::new(
+            ErrorCode::Forbidden,
+            "rotation and confirmation containers do not name each other",
+        ));
+    }
+
+    let store = build_store(ctx)?;
+    let account = store
+        .account_by_root(&old.root_did)
+        .await
+        .map_err(|err| ceremony_error(err.into()))?
+        .ok_or_else(|| ServiceError::new(ErrorCode::Unauthorized, "unknown account"))?;
+
+    let request = RotateAccount {
+        new_root_did: new.root_did,
+        new_credential_id: required_string(&old.arguments, "newCredentialId")
+            .map_err(ceremony_error)?,
+        succession_hex: required_string(&old.arguments, "succession").map_err(ceremony_error)?,
+        device_did: required_string(&old.arguments, "deviceDid").map_err(ceremony_error)?,
+        device_delegation_hex: required_string(&old.arguments, "deviceDelegation")
+            .map_err(ceremony_error)?,
+    };
+    rotate_account(&store, &account, &request)
+        .await
+        .map_err(ceremony_error)?;
+
+    Response::from_json(&serde_json::json!({})).map_err(|err| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {err}"))
+    })
+}

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -29,6 +29,7 @@ use crate::core::backup::{get_chain, list_chains, put_chain};
 use crate::core::codes::{generate_code, request_code};
 use crate::core::devices::{DeviceView, list_devices, register_device, revoke_device};
 use crate::core::links::{complete_link, consume_link, create_link, resolve_link};
+use crate::core::rotation::{RotateAccount, rotate_account};
 use crate::email::CapturedEmail;
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::ceremony_error;
@@ -129,6 +130,7 @@ async fn handle_request(
         (Method::GET, "/health") => return Ok(health_response()),
         (Method::POST, "/codes") => codes_route(req, &backends).await,
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
+        (Method::POST, "/accounts/rotate") => accounts_rotate_route(req, &backends).await,
         (Method::POST, "/devices/list") => devices_list_route(req, &backends).await,
         (Method::POST, "/devices/register") => devices_register_route(req, &backends).await,
         (Method::POST, "/devices/link") => devices_link_route(req, &backends).await,
@@ -248,6 +250,72 @@ async fn accounts_route(
         StatusCode::CREATED,
         &serde_json::json!({ "accountId": account_id }),
     ))
+}
+
+/// `POST /accounts/rotate` → rotate an account onto a new root, under
+/// old-root authority with new-root proof of control.
+async fn accounts_rotate_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    #[derive(Deserialize)]
+    struct RotateRequest {
+        rotation: String,
+        confirmation: String,
+    }
+
+    let body: RotateRequest = parse_json(req).await?;
+    let rotation_bytes = hex::decode(&body.rotation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad rotation hex: {err}"),
+        )
+    })?;
+    let confirmation_bytes = hex::decode(&body.confirmation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad confirmation hex: {err}"),
+        )
+    })?;
+
+    let old = authorize_root(&rotation_bytes, &["account", "rotate"])
+        .await
+        .map_err(ceremony_error)?;
+    let new = authorize_root(&confirmation_bytes, &["account", "rotate", "confirm"])
+        .await
+        .map_err(ceremony_error)?;
+
+    // Each container must name the other's principal.
+    let claimed_new = required_string(&old.arguments, "newRootDid").map_err(ceremony_error)?;
+    let claimed_old = required_string(&new.arguments, "oldRootDid").map_err(ceremony_error)?;
+    if claimed_new != new.root_did || claimed_old != old.root_did {
+        return Err(ServiceError::new(
+            ErrorCode::Forbidden,
+            "rotation and confirmation containers do not name each other",
+        ));
+    }
+
+    let account = backends
+        .store
+        .account_by_root(&old.root_did)
+        .await
+        .map_err(|err| ceremony_error(err.into()))?
+        .ok_or_else(|| ServiceError::new(ErrorCode::Unauthorized, "unknown account"))?;
+
+    let request = RotateAccount {
+        new_root_did: new.root_did,
+        new_credential_id: required_string(&old.arguments, "newCredentialId")
+            .map_err(ceremony_error)?,
+        succession_hex: required_string(&old.arguments, "succession").map_err(ceremony_error)?,
+        device_did: required_string(&old.arguments, "deviceDid").map_err(ceremony_error)?,
+        device_delegation_hex: required_string(&old.arguments, "deviceDelegation")
+            .map_err(ceremony_error)?,
+    };
+    rotate_account(&backends.store, &account, &request)
+        .await
+        .map_err(ceremony_error)?;
+
+    Ok(json_response(StatusCode::OK, &serde_json::json!({})))
 }
 
 /// `POST /devices/link` → register a device from a root-key ceremony.

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -32,6 +32,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/codes", handlers::codes::handle_options)
         .post_async("/accounts", handlers::accounts::handle)
         .options_async("/accounts", handlers::accounts::handle_options)
+        .post_async("/accounts/rotate", handlers::rotate::handle)
+        .options_async("/accounts/rotate", handlers::rotate::handle_options)
         .post_async("/devices/list", handlers::devices::handle_list)
         .options_async("/devices/list", handlers::devices::handle_options)
         .post_async("/devices/register", handlers::devices::handle_register)

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -190,6 +190,25 @@ pub trait Store {
     /// was found.
     async fn revoke_device(&self, account_id: i64, device_did: &str) -> Result<bool, StoreError>;
 
+    /// Flip the account's root DID and passkey credential in one
+    /// statement. Returns `StoreError::Conflict` if the new root DID is
+    /// already registered to any account.
+    async fn rotate_root(
+        &self,
+        account_id: i64,
+        new_root_did: &str,
+        new_credential_id: &str,
+    ) -> Result<(), StoreError>;
+
+    /// Repoint one device row at a fresh delegation CID. Returns `false`
+    /// if no matching device was found.
+    async fn update_device_delegation(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+    ) -> Result<bool, StoreError>;
+
     /// Create a pending CLI browser handoff.
     async fn put_link(&self, link: &LinkRequest) -> Result<(), StoreError>;
 
@@ -261,6 +280,14 @@ pub const SELECT_DEVICE_BY_DID: &str = "SELECT account_id, device_did, delegatio
 /// SQL: mark a device as revoked.
 pub const UPDATE_DEVICE_REVOKE: &str =
     "UPDATE devices SET status = 'revoked' WHERE account_id = ?1 AND device_did = ?2";
+
+/// SQL: flip an account's root DID and passkey credential.
+pub const UPDATE_ACCOUNT_ROOT: &str =
+    "UPDATE accounts SET root_did = ?2, credential_id = ?3 WHERE id = ?1";
+
+/// SQL: repoint one device row at a fresh delegation.
+pub const UPDATE_DEVICE_DELEGATION: &str =
+    "UPDATE devices SET delegation_cid = ?3 WHERE account_id = ?1 AND device_did = ?2";
 
 /// SQL: create a pending browser handoff.
 pub const INSERT_LINK: &str = "INSERT INTO link_requests \

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -209,6 +209,18 @@ pub trait Store {
         delegation_cid: &str,
     ) -> Result<bool, StoreError>;
 
+    /// Update the delegation and display name of an already-registered,
+    /// active device — used when a device re-registers under the same
+    /// account, e.g. after its account rotates onto a new root. Returns
+    /// `false` if no matching active device was found.
+    async fn update_device_registration(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+        name: &str,
+    ) -> Result<bool, StoreError>;
+
     /// Create a pending CLI browser handoff.
     async fn put_link(&self, link: &LinkRequest) -> Result<(), StoreError>;
 
@@ -288,6 +300,12 @@ pub const UPDATE_ACCOUNT_ROOT: &str =
 /// SQL: repoint one device row at a fresh delegation.
 pub const UPDATE_DEVICE_DELEGATION: &str =
     "UPDATE devices SET delegation_cid = ?3 WHERE account_id = ?1 AND device_did = ?2";
+
+/// SQL: repoint an active device row at a fresh delegation and name, on
+/// re-registration. Revoked devices never match, so a revoked device
+/// can never be silently resurrected by re-registering it.
+pub const UPDATE_DEVICE_REGISTRATION: &str = "UPDATE devices SET delegation_cid = ?3, name = ?4 \
+     WHERE account_id = ?1 AND device_did = ?2 AND status = 'active'";
 
 /// SQL: create a pending browser handoff.
 pub const INSERT_LINK: &str = "INSERT INTO link_requests \

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -17,7 +17,8 @@ use crate::store::{
     DeviceStatus, INSERT_ACCOUNT, INSERT_DEVICE, INSERT_DEVICE_FOR_LINK,
     INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK, LinkRequest, NewDevice, SELECT_ACCOUNT_BY_ROOT,
     SELECT_CODE, SELECT_DEVICE_BY_DID, SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, Store, StoreError,
-    UPDATE_ACCOUNT_ROOT, UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
+    UPDATE_ACCOUNT_ROOT, UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REGISTRATION,
+    UPDATE_DEVICE_REVOKE, UPSERT_CODE,
 };
 
 /// Cloudflare D1-backed [`Store`], for production use.
@@ -374,6 +375,34 @@ impl Store for D1Store {
                 JsValue::from_f64(account_id as f64),
                 JsValue::from(device_did),
                 JsValue::from(delegation_cid),
+            ])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        let changes = result
+            .meta()
+            .map_err(map_err)?
+            .and_then(|meta| meta.changes)
+            .unwrap_or(0);
+        Ok(changes > 0)
+    }
+
+    async fn update_device_registration(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+        name: &str,
+    ) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(UPDATE_DEVICE_REGISTRATION)
+            .bind(&[
+                JsValue::from_f64(account_id as f64),
+                JsValue::from(device_did),
+                JsValue::from(delegation_cid),
+                JsValue::from(name),
             ])
             .map_err(map_err)?
             .run()

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -17,7 +17,7 @@ use crate::store::{
     DeviceStatus, INSERT_ACCOUNT, INSERT_DEVICE, INSERT_DEVICE_FOR_LINK,
     INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK, LinkRequest, NewDevice, SELECT_ACCOUNT_BY_ROOT,
     SELECT_CODE, SELECT_DEVICE_BY_DID, SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, Store, StoreError,
-    UPDATE_DEVICE_REVOKE, UPSERT_CODE,
+    UPDATE_ACCOUNT_ROOT, UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
 };
 
 /// Cloudflare D1-backed [`Store`], for production use.
@@ -328,6 +328,52 @@ impl Store for D1Store {
             .bind(&[
                 JsValue::from_f64(account_id as f64),
                 JsValue::from(device_did),
+            ])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        let changes = result
+            .meta()
+            .map_err(map_err)?
+            .and_then(|meta| meta.changes)
+            .unwrap_or(0);
+        Ok(changes > 0)
+    }
+
+    async fn rotate_root(
+        &self,
+        account_id: i64,
+        new_root_did: &str,
+        new_credential_id: &str,
+    ) -> Result<(), StoreError> {
+        self.0
+            .prepare(UPDATE_ACCOUNT_ROOT)
+            .bind(&[
+                JsValue::from_f64(account_id as f64),
+                JsValue::from(new_root_did),
+                JsValue::from(new_credential_id),
+            ])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        Ok(())
+    }
+
+    async fn update_device_delegation(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+    ) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(UPDATE_DEVICE_DELEGATION)
+            .bind(&[
+                JsValue::from_f64(account_id as f64),
+                JsValue::from(device_did),
+                JsValue::from(delegation_cid),
             ])
             .map_err(map_err)?
             .run()

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -11,7 +11,7 @@ use super::{
     DeviceStatus, INSERT_ACCOUNT, INSERT_DEVICE, INSERT_DEVICE_FOR_LINK, INSERT_LINK, LinkRequest,
     NewDevice, SELECT_ACCOUNT_BY_ROOT, SELECT_CODE, SELECT_DEVICE_BY_DID,
     SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, Store, StoreError, UPDATE_ACCOUNT_ROOT,
-    UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
+    UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REGISTRATION, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -269,6 +269,23 @@ impl Store for SqliteStore {
             .execute(
                 UPDATE_DEVICE_DELEGATION,
                 params![account_id, device_did, delegation_cid],
+            )
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+
+    async fn update_device_registration(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+        name: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(
+                UPDATE_DEVICE_REGISTRATION,
+                params![account_id, device_did, delegation_cid, name],
             )
             .map_err(map_err)?;
         Ok(changed > 0)

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -10,7 +10,8 @@ use super::{
     Account, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE, Device,
     DeviceStatus, INSERT_ACCOUNT, INSERT_DEVICE, INSERT_DEVICE_FOR_LINK, INSERT_LINK, LinkRequest,
     NewDevice, SELECT_ACCOUNT_BY_ROOT, SELECT_CODE, SELECT_DEVICE_BY_DID,
-    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, Store, StoreError, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
+    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, Store, StoreError, UPDATE_ACCOUNT_ROOT,
+    UPDATE_DEVICE_DELEGATION, UPDATE_DEVICE_REVOKE, UPSERT_CODE,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -242,6 +243,37 @@ impl Store for SqliteStore {
         Ok(changed > 0)
     }
 
+    async fn rotate_root(
+        &self,
+        account_id: i64,
+        new_root_did: &str,
+        new_credential_id: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        conn.execute(
+            UPDATE_ACCOUNT_ROOT,
+            params![account_id, new_root_did, new_credential_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    async fn update_device_delegation(
+        &self,
+        account_id: i64,
+        device_did: &str,
+        delegation_cid: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(
+                UPDATE_DEVICE_DELEGATION,
+                params![account_id, device_did, delegation_cid],
+            )
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+
     async fn put_link(&self, link: &LinkRequest) -> Result<(), StoreError> {
         let conn = self.0.lock().expect("store mutex poisoned");
         conn.execute(
@@ -403,6 +435,86 @@ mod tests {
         assert_eq!((read.code_hash.as_str(), read.attempts), ("h2", 1));
         store.delete_code("a@x.com").await.unwrap();
         assert!(store.code("a@x.com").await.unwrap().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_rotates_the_root_and_keeps_the_row_id() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zOld", "cred-old", 100)
+            .await
+            .unwrap();
+        store
+            .rotate_root(id, "did:key:zNew", "cred-new")
+            .await
+            .unwrap();
+        assert!(
+            store
+                .account_by_root("did:key:zOld")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let account = store
+            .account_by_root("did:key:zNew")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            (account.id, account.credential_id.as_str()),
+            (id, "cred-new")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_rotating_onto_a_registered_root() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zA", "cred-a", 100)
+            .await
+            .unwrap();
+        store
+            .create_account("b@x.com", "did:key:zB", "cred-b", 100)
+            .await
+            .unwrap();
+        assert!(matches!(
+            store.rotate_root(id, "did:key:zB", "cred-x").await,
+            Err(StoreError::Conflict(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_repoints_a_device_delegation() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .create_account("a@x.com", "did:key:zA", "cred", 100)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                account_id: id,
+                device_did: "did:key:zDev".into(),
+                delegation_cid: "bafyOld".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 100,
+            })
+            .await
+            .unwrap();
+        assert!(
+            store
+                .update_device_delegation(id, "did:key:zDev", "bafyNew")
+                .await
+                .unwrap()
+        );
+        let device = store.device_by_did("did:key:zDev").await.unwrap().unwrap();
+        assert_eq!(device.delegation_cid, "bafyNew");
+        assert!(
+            !store
+                .update_device_delegation(id, "did:key:zGhost", "bafyNew")
+                .await
+                .unwrap()
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -13,6 +13,8 @@ use tonk_account_service::helpers::AccountServer;
 const ROOT_PRF: [u8; 32] = [7u8; 32];
 const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
 const DEVICE_SEED: [u8; 32] = [8u8; 32];
+const UNRELATED_NEW_ROOT_PRF: [u8; 32] = [11u8; 32];
+const UNRELATED_OLD_ROOT_PRF: [u8; 32] = [13u8; 32];
 
 /// Build a device-signed invocation container for the account's first
 /// device, using the production builder against the `root → device`
@@ -393,4 +395,218 @@ async fn it_rotates_the_account_onto_a_new_root_over_http() {
         .await
         .unwrap();
     assert_eq!(response.status(), 401);
+}
+
+#[dialog_common::test]
+async fn it_rejects_a_rotation_whose_confirmation_names_a_different_root() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Build a valid rotation container that names NEW_ROOT_PRF as the
+    // new root, then pair it with the confirmation from a *different*
+    // ceremony -- one that rotates the same old root onto an unrelated
+    // third root. The rotation's `newRootDid` and the paired
+    // confirmation's signer disagree, so the cross-check must reject it
+    // even though both containers are independently valid, root-signed
+    // rotate/confirm invocations.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let rotation =
+        tonk_identity::ceremony::rotate_account(old_root, new_root, "cred-2".into(), device.did())
+            .await
+            .unwrap();
+
+    let old_root_again = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let unrelated_new_root = tonk_identity::derive::derive_root_signer(&UNRELATED_NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let unrelated = tonk_identity::ceremony::rotate_account(
+        old_root_again,
+        unrelated_new_root,
+        "cred-3".into(),
+        device.did(),
+    )
+    .await
+    .unwrap();
+
+    let response = client
+        .post(format!("{base}/accounts/rotate"))
+        .json(&serde_json::json!({
+            "rotation": rotation.rotation_hex,
+            "confirmation": unrelated.confirmation_hex,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // The account root did not change: a device-signed invocation under
+    // the OLD root still succeeds.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+}
+
+#[dialog_common::test]
+async fn it_rejects_a_rotation_confirmed_by_an_unrelated_ceremony() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Build a valid rotation for the account (old root -> NEW_ROOT_PRF),
+    // then pair it with the confirmation from an unrelated ceremony that
+    // rotates a *different* old root onto that same new root. The
+    // confirmation's signer still matches the rotation's declared
+    // `newRootDid` (so the first arm of the cross-check is satisfied),
+    // but its `oldRootDid` argument names the unrelated old root instead
+    // of the account's actual one -- the other arm must catch it.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let rotation =
+        tonk_identity::ceremony::rotate_account(old_root, new_root, "cred-2".into(), device.did())
+            .await
+            .unwrap();
+
+    let unrelated_old_root = tonk_identity::derive::derive_root_signer(&UNRELATED_OLD_ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root_again = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let unrelated = tonk_identity::ceremony::rotate_account(
+        unrelated_old_root,
+        new_root_again,
+        "cred-4".into(),
+        device.did(),
+    )
+    .await
+    .unwrap();
+
+    let response = client
+        .post(format!("{base}/accounts/rotate"))
+        .json(&serde_json::json!({
+            "rotation": rotation.rotation_hex,
+            "confirmation": unrelated.confirmation_hex,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // The account root did not change: a device-signed invocation under
+    // the OLD root still succeeds.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
 }

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -11,6 +11,7 @@ use dialog_varsig::Principal;
 use tonk_account_service::helpers::AccountServer;
 
 const ROOT_PRF: [u8; 32] = [7u8; 32];
+const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
 const DEVICE_SEED: [u8; 32] = [8u8; 32];
 
 /// Build a device-signed invocation container for the account's first
@@ -284,4 +285,112 @@ async fn it_drives_the_full_ceremony_over_http() {
     );
     let round_tripped = response.bytes().await.unwrap();
     assert_eq!(round_tripped.as_ref(), chain_bytes.as_slice());
+}
+
+#[dialog_common::test]
+async fn it_rotates_the_account_onto_a_new_root_over_http() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // POST /accounts/rotate -> flip the account onto a new root.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let rotation =
+        tonk_identity::ceremony::rotate_account(old_root, new_root, "cred-2".into(), device.did())
+            .await
+            .unwrap();
+    let response = client
+        .post(format!("{base}/accounts/rotate"))
+        .json(&serde_json::json!({
+            "rotation": rotation.rotation_hex,
+            "confirmation": rotation.confirmation_hex,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // A device-signed invocation under the NEW root succeeds.
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let new_link = tonk_identity::delegation::mint_device_delegation(new_root, &device.did())
+        .await
+        .unwrap();
+    let body = tonk_identity::request::build_device_invocation(
+        device,
+        &new_link,
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // The same invocation, signed against the OLD root, is rejected: the
+    // account no longer resolves by its old root DID.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 401);
 }

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -35,6 +35,7 @@ web-sys = { workspace = true, features = [
     "Navigator",
     "PublicKeyCredential",
     "PublicKeyCredentialCreationOptions",
+    "PublicKeyCredentialDescriptor",
     "PublicKeyCredentialParameters",
     "PublicKeyCredentialRequestOptions",
     "PublicKeyCredentialRpEntity",

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -160,10 +160,89 @@ pub async fn complete_link(
     .await
 }
 
+/// Output of the two-container rotation ceremony.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RotationCeremony {
+    /// The account's current (old) root DID.
+    pub old_root_did: String,
+    /// The root DID the account rotates onto.
+    pub new_root_did: String,
+    /// Hex-encoded `oldRoot → newRoot` succession chain.
+    pub succession_hex: String,
+    /// Hex-encoded `newRoot → device` delegation for the ceremony device.
+    pub device_delegation_hex: String,
+    /// Hex-encoded old-root-signed rotation container.
+    pub rotation_hex: String,
+    /// Hex-encoded new-root-signed confirmation container.
+    pub confirmation_hex: String,
+}
+
+/// Build both rotation containers, the succession chain, and a fresh
+/// device link. The old root signs the rotation (account authority); the
+/// new root signs the confirmation (proof the new DID is controllable, so
+/// a typo cannot strand the account on an inert root).
+pub async fn rotate_account(
+    old_root: Ed25519Signer,
+    new_root: Ed25519Signer,
+    new_credential_id: String,
+    device_did: dialog_varsig::Did,
+) -> Result<RotationCeremony> {
+    let old_root_did = old_root.did().to_string();
+    let new_root_did = new_root.did().to_string();
+
+    let succession =
+        crate::delegation::mint_root_succession(old_root.clone(), &new_root.did()).await?;
+    let succession_hex = hex::encode(
+        succession
+            .to_bytes()
+            .context("failed to serialize the succession delegation")?,
+    );
+    let device_link =
+        crate::delegation::mint_device_delegation(new_root.clone(), &device_did).await?;
+    let device_delegation_hex = hex::encode(
+        device_link
+            .to_bytes()
+            .context("failed to serialize the device delegation")?,
+    );
+
+    let rotation = build(
+        old_root,
+        vec!["account".into(), "rotate".into()],
+        strings([
+            ("newRootDid", new_root_did.clone()),
+            ("newCredentialId", new_credential_id),
+            ("succession", succession_hex.clone()),
+            ("deviceDid", device_did.to_string()),
+            ("deviceDelegation", device_delegation_hex.clone()),
+        ]),
+        device_did.to_string(),
+        device_delegation_hex.clone(),
+    )
+    .await?;
+    let confirmation = build(
+        new_root,
+        vec!["account".into(), "rotate".into(), "confirm".into()],
+        strings([("oldRootDid", old_root_did.clone())]),
+        device_did.to_string(),
+        device_delegation_hex.clone(),
+    )
+    .await?;
+
+    Ok(RotationCeremony {
+        old_root_did,
+        new_root_did,
+        succession_hex,
+        device_delegation_hex,
+        rotation_hex: rotation.invocation_hex,
+        confirmation_hex: confirmation.invocation_hex,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use dialog_ucan_core::InvocationChain;
+    use dialog_ucan_core::promise::Promised;
 
     async fn fixture() -> (Ed25519Signer, dialog_varsig::Did) {
         let root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
@@ -265,6 +344,59 @@ mod tests {
         assert_eq!(
             chain.arguments().get("deviceDid"),
             Some(&Promised::String(device.to_string()))
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_two_container_rotation() {
+        let old_root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let new_root = crate::derive::derive_root_signer(&[9u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let old_did = old_root.did().to_string();
+        let new_did = new_root.did().to_string();
+
+        let ceremony = rotate_account(old_root, new_root, "cred-new".into(), device.did())
+            .await
+            .unwrap();
+        assert_eq!(ceremony.old_root_did, old_did);
+        assert_eq!(ceremony.new_root_did, new_did);
+
+        let rotation =
+            InvocationChain::try_from(hex::decode(&ceremony.rotation_hex).unwrap().as_slice())
+                .unwrap();
+        rotation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(rotation.issuer().to_string(), old_did);
+        assert_eq!(
+            rotation.command().0,
+            vec!["account".to_string(), "rotate".to_string()]
+        );
+        assert_eq!(
+            rotation.arguments().get("newRootDid"),
+            Some(&Promised::String(new_did.clone()))
+        );
+
+        let confirmation =
+            InvocationChain::try_from(hex::decode(&ceremony.confirmation_hex).unwrap().as_slice())
+                .unwrap();
+        confirmation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(confirmation.issuer().to_string(), new_did);
+        assert_eq!(
+            confirmation.command().0,
+            vec![
+                "account".to_string(),
+                "rotate".to_string(),
+                "confirm".to_string()
+            ]
+        );
+        assert_eq!(
+            confirmation.arguments().get("oldRootDid"),
+            Some(&Promised::String(old_did))
         );
     }
 }

--- a/rust/tonk-identity/src/delegation.rs
+++ b/rust/tonk-identity/src/delegation.rs
@@ -84,6 +84,22 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_mints_a_subject_open_delegation_to_the_new_root() {
+        let old_root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let new_root = crate::derive::derive_root_signer(&[9u8; 32]).await.unwrap();
+        let old_did = old_root.did();
+        let new_did = new_root.did();
+        let chain = mint_root_succession(old_root, &new_did).await.unwrap();
+        assert_eq!(*chain.issuer(), old_did);
+        assert_eq!(*chain.audience(), new_did);
+        assert!(
+            chain.subject().is_none(),
+            "oldRoot → newRoot must be subject-open"
+        );
+        assert_eq!(chain.proof_cids().len(), 1);
+    }
+
+    #[dialog_common::test]
     async fn it_extends_a_space_chain_through_the_root_to_the_device() {
         let space = signer(&SPACE_SEED).await;
         let space_did = space.did();

--- a/rust/tonk-identity/src/delegation.rs
+++ b/rust/tonk-identity/src/delegation.rs
@@ -6,19 +6,33 @@ use dialog_ucan_core::subject::Subject as UcanSubject;
 use dialog_ucan_core::{DelegationBuilder, DelegationChain};
 use dialog_varsig::Did;
 
-/// Mint the `root → device` delegation: subject-open, audience-specific —
-/// "this device may act as me, for anything". Deliberately the opposite
-/// shape from space invites, which are subject-specific and must stay so.
-pub async fn mint_device_delegation(root: Ed25519Signer, device: &Did) -> Result<DelegationChain> {
+async fn mint_subject_open(issuer: Ed25519Signer, audience: &Did) -> Result<DelegationChain> {
     let delegation = DelegationBuilder::new()
-        .issuer(root)
-        .audience(device)
+        .issuer(issuer)
+        .audience(audience)
         .subject(UcanSubject::Any)
         .command(vec![])
         .try_build()
         .await
-        .map_err(|e| anyhow::anyhow!("failed to mint the device delegation: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("failed to mint the delegation: {e}"))?;
     Ok(DelegationChain::new(delegation))
+}
+
+/// Mint the `root → device` delegation: subject-open, audience-specific —
+/// "this device may act as me, for anything". Deliberately the opposite
+/// shape from space invites, which are subject-specific and must stay so.
+pub async fn mint_device_delegation(root: Ed25519Signer, device: &Did) -> Result<DelegationChain> {
+    mint_subject_open(root, device).await
+}
+
+/// Mint the `oldRoot → newRoot` succession delegation. Same subject-open
+/// shape as a device link: every chain anchored at the old root extends
+/// through it to the new root, so rotation never rewrites space chains.
+pub async fn mint_root_succession(
+    old_root: Ed25519Signer,
+    new_root: &Did,
+) -> Result<DelegationChain> {
+    mint_subject_open(old_root, new_root).await
 }
 
 #[cfg(test)]

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -46,7 +46,7 @@ async fn create(name: JsValue) -> Result<JsValue, JsValue> {
 
 async fn derive_root_did() -> Result<JsValue, JsValue> {
     use dialog_varsig::Principal;
-    let prf = crate::passkey::prf_output().await.map_err(js_error)?;
+    let prf = crate::passkey::prf_output(None).await.map_err(js_error)?;
     let signer = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
@@ -97,7 +97,7 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     let prf_at_create = created.prf_output.is_some();
     let prf = match created.prf_output {
         Some(output) => output,
-        None => crate::passkey::prf_output().await.map_err(js_error)?,
+        None => crate::passkey::prf_output(None).await.map_err(js_error)?,
     };
     let root = crate::derive::derive_root_signer(&prf)
         .await
@@ -123,7 +123,7 @@ async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let device_name = string_property(&input, "deviceName")?;
-    let prf = crate::passkey::prf_output().await.map_err(js_error)?;
+    let prf = crate::passkey::prf_output(None).await.map_err(js_error)?;
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
@@ -133,13 +133,81 @@ async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
     ceremony_result(ceremony)
 }
 
+/// Rotate the account onto a freshly created passkey.
+///
+/// Derives the OLD root before the new passkey exists — at that point it
+/// is the only credential on the origin, so the discoverable-credential
+/// `get()` cannot be picker-ambiguous. Only once the new passkey is
+/// created does a second credential exist; deriving its root then scopes
+/// the follow-up `get()` (the PRF-at-create fallback) to that credential's
+/// id via `allowCredentials`, so the platform picker cannot offer the old
+/// credential in its place.
+async fn rotate_account(input: JsValue) -> Result<JsValue, JsValue> {
+    let name = string_property(&input, "name")?;
+    let device_did = string_property(&input, "deviceDid")?
+        .parse()
+        .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
+
+    let old_prf = crate::passkey::prf_output(None).await.map_err(js_error)?;
+    let old_root = crate::derive::derive_root_signer(&old_prf)
+        .await
+        .map_err(js_error)?;
+
+    let created = crate::passkey::create_passkey(&name)
+        .await
+        .map_err(js_error)?;
+    let credential_id = hex::encode(&created.id);
+    let prf_at_create = created.prf_output.is_some();
+    let new_prf = match created.prf_output {
+        Some(output) => output,
+        None => crate::passkey::prf_output(Some(&created.id))
+            .await
+            .map_err(js_error)?,
+    };
+    let new_root = crate::derive::derive_root_signer(&new_prf)
+        .await
+        .map_err(js_error)?;
+
+    let ceremony =
+        crate::ceremony::rotate_account(old_root, new_root, credential_id.clone(), device_did)
+            .await
+            .map_err(js_error)?;
+
+    let result = Object::new();
+    Reflect::set(&result, &"oldRootDid".into(), &ceremony.old_root_did.into())?;
+    Reflect::set(&result, &"newRootDid".into(), &ceremony.new_root_did.into())?;
+    Reflect::set(&result, &"newCredentialId".into(), &credential_id.into())?;
+    Reflect::set(
+        &result,
+        &"successionHex".into(),
+        &ceremony.succession_hex.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"deviceDelegationHex".into(),
+        &ceremony.device_delegation_hex.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"rotationHex".into(),
+        &ceremony.rotation_hex.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"confirmationHex".into(),
+        &ceremony.confirmation_hex.into(),
+    )?;
+    Reflect::set(&result, &"prfAtCreate".into(), &prf_at_create.into())?;
+    Ok(result.into())
+}
+
 async fn complete_link(input: JsValue) -> Result<JsValue, JsValue> {
     let token_hash = string_property(&input, "tokenHash")?;
     let device_did = string_property(&input, "deviceDid")?
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let device_name = string_property(&input, "deviceName")?;
-    let prf = crate::passkey::prf_output().await.map_err(js_error)?;
+    let prf = crate::passkey::prf_output(None).await.map_err(js_error)?;
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
@@ -205,6 +273,16 @@ pub fn install() {
     );
     complete_link.forget();
 
+    let rotate_account = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(rotate_account(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"rotateAccount".into(),
+        rotate_account.as_ref().unchecked_ref(),
+    );
+    rotate_account.forget();
+
     let _ = Reflect::set(&window, &"tonkIdentity".into(), &identity.into());
 }
 
@@ -226,6 +304,7 @@ mod tests {
             "createAccount",
             "linkDevice",
             "completeLink",
+            "rotateAccount",
         ] {
             let function = Reflect::get(&identity, &name.into()).unwrap();
             assert!(function.is_function(), "{name} must be a function");

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -135,12 +135,19 @@ async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
 
 /// Rotate the account onto a freshly created passkey.
 ///
-/// Derives the OLD root before the new passkey exists — at that point it
-/// is the only credential on the origin, so the discoverable-credential
-/// `get()` cannot be picker-ambiguous. Only once the new passkey is
-/// created does a second credential exist; deriving its root then scopes
-/// the follow-up `get()` (the PRF-at-create fallback) to that credential's
-/// id via `allowCredentials`, so the platform picker cannot offer the old
+/// Derives the OLD root before the new passkey exists, on the assumption
+/// that it is the only credential on the origin so the discoverable-
+/// credential `get()` is unambiguous — usually true, but not guaranteed:
+/// a second account's passkey or a prior rotation's leftover credential
+/// can still be sitting on the origin, and the platform picker could
+/// resolve to the wrong one. That failure mode is safe, not silent: a
+/// `get()` against the wrong credential derives a root the service does
+/// not recognize as this account's current root, so the rotation is
+/// rejected rather than corrupting the registry. Only once the new
+/// passkey is created does a second credential definitely exist;
+/// deriving its root then scopes the follow-up `get()` (the
+/// PRF-at-create fallback) to that credential's id via
+/// `allowCredentials`, so the platform picker cannot offer the old
 /// credential in its place.
 async fn rotate_account(input: JsValue) -> Result<JsValue, JsValue> {
     let name = string_property(&input, "name")?;

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -13,9 +13,9 @@ use web_sys::{
     AuthenticationExtensionsClientInputs, AuthenticationExtensionsPrfInputs,
     AuthenticationExtensionsPrfValues, AuthenticatorSelectionCriteria, CredentialCreationOptions,
     CredentialRequestOptions, CredentialsContainer, PublicKeyCredential,
-    PublicKeyCredentialCreationOptions, PublicKeyCredentialParameters,
-    PublicKeyCredentialRequestOptions, PublicKeyCredentialRpEntity, PublicKeyCredentialType,
-    PublicKeyCredentialUserEntity, UserVerificationRequirement,
+    PublicKeyCredentialCreationOptions, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialParameters, PublicKeyCredentialRequestOptions, PublicKeyCredentialRpEntity,
+    PublicKeyCredentialType, PublicKeyCredentialUserEntity, UserVerificationRequirement,
 };
 use zeroize::Zeroizing;
 
@@ -146,15 +146,34 @@ pub async fn create_passkey(user_name: &str) -> Result<PasskeyCredential> {
     Ok(PasskeyCredential { id, prf_output })
 }
 
-/// Evaluate the passkey's PRF via a discoverable-credential assertion.
-/// One biometric prompt; must be called during a user gesture.
-pub async fn prf_output() -> Result<Zeroizing<[u8; 32]>> {
+/// Evaluate the passkey's PRF via an assertion. One biometric prompt;
+/// must be called during a user gesture.
+///
+/// `allowed_credential`, when `Some`, scopes the assertion's
+/// `allowCredentials` to that one raw credential id, so the platform
+/// picker cannot offer any other resident credential for the RP —
+/// needed once a second passkey exists on the origin (rotation's
+/// follow-up derivation of the just-created credential). `None` keeps
+/// the prior discoverable-credential behavior: `allowCredentials` is
+/// left empty and the picker enumerates every resident credential,
+/// which is correct while at most one credential exists yet.
+pub async fn prf_output(allowed_credential: Option<&[u8]>) -> Result<Zeroizing<[u8; 32]>> {
     let mut challenge = rand::random::<[u8; 32]>();
     let options = PublicKeyCredentialRequestOptions::new_with_u8_slice(&mut challenge);
     options.set_user_verification(UserVerificationRequirement::Required);
     options.set_extensions(&prf_extensions());
     if let Some(id) = current_rp_id() {
         options.set_rp_id(id);
+    }
+    if let Some(credential_id) = allowed_credential {
+        let mut id = credential_id.to_vec();
+        let descriptor = PublicKeyCredentialDescriptor::new_with_u8_slice(
+            &mut id,
+            PublicKeyCredentialType::PublicKey,
+        );
+        let allow = Array::new();
+        allow.push(&descriptor);
+        options.set_allow_credentials(&allow);
     }
     let request = CredentialRequestOptions::new();
     request.set_public_key(&options);
@@ -211,6 +230,37 @@ mod tests {
         assert_eq!(apex_rp_id("localhost"), None);
         // A suffix match must not treat a sibling registrable domain as ours.
         assert_eq!(apex_rp_id("evil-tonk.spot"), None);
+    }
+
+    #[dialog_common::test]
+    fn it_leaves_allow_credentials_unset_without_a_scoping_id() {
+        let mut challenge = [0u8; 32];
+        let options = PublicKeyCredentialRequestOptions::new_with_u8_slice(&mut challenge);
+        assert!(
+            Reflect::get(&options, &"allowCredentials".into())
+                .unwrap()
+                .is_undefined()
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_scopes_allow_credentials_to_the_given_id() {
+        let mut challenge = [0u8; 32];
+        let options = PublicKeyCredentialRequestOptions::new_with_u8_slice(&mut challenge);
+        let mut id = vec![1u8, 2, 3];
+        let descriptor = PublicKeyCredentialDescriptor::new_with_u8_slice(
+            &mut id,
+            PublicKeyCredentialType::PublicKey,
+        );
+        let allow = js_sys::Array::new();
+        allow.push(&descriptor);
+        options.set_allow_credentials(&allow);
+        let allow_credentials = Reflect::get(&options, &"allowCredentials".into()).unwrap();
+        let allow_credentials = js_sys::Array::from(&allow_credentials);
+        assert_eq!(allow_credentials.length(), 1);
+        let first = allow_credentials.get(0);
+        let first_id = Reflect::get(&first, &"id".into()).unwrap();
+        assert_eq!(Uint8Array::new(&first_id).to_vec(), vec![1, 2, 3]);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -62,6 +62,7 @@
   <section id="account-success" class="account__panel" hidden>
     <p id="account-success-message" class="account__status">You're logged in.</p>
     <button id="account-manage-devices" class="account__button account__button--secondary" type="button">Manage devices</button>
+    <button id="account-rotate-open" class="account__button account__button--quiet" type="button">Rotate passkey</button>
     <a class="account__button account__button--secondary" href="/">Back to Tonk</a>
   </section>
 
@@ -73,6 +74,17 @@
       <button id="account-unlink" class="account__button account__button--quiet" type="button">Sign out on this device</button>
       <button id="account-devices-back" class="account__button account__button--secondary" type="button">Back</button>
     </div>
+  </section>
+
+  <section id="account-rotate" class="account__panel" hidden>
+    <h2>Rotate your passkey</h2>
+    <p class="account__message">Creates a new passkey for this account. Your devices keep working and re-connect to the new passkey the next time they sync in.</p>
+    <form class="account__form">
+      <label>New passkey name
+        <input id="account-rotate-name" name="New passkey name" type="text" autocomplete="off" required>
+      </label>
+      <button id="account-rotate-submit" class="account__button" type="submit">Create new passkey</button>
+    </form>
   </section>
 
   <p id="account-working" class="account__hint" role="status" aria-live="polite">Checking this browser…</p>

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -42,6 +42,7 @@
     <h2>Log in</h2>
     <form class="account__form">
       <input id="account-link-device-name" name="Device name" type="hidden" value="This browser">
+      <button id="account-relink-retry" class="account__button" type="button" hidden>Retry connecting</button>
       <button id="account-link-submit" class="account__button" type="submit">Log in</button>
       <button id="account-link-back" class="account__button account__button--quiet" type="button">Back</button>
     </form>
@@ -78,7 +79,7 @@
 
   <section id="account-rotate" class="account__panel" hidden>
     <h2>Rotate your passkey</h2>
-    <p class="account__message">Creates a new passkey for this account. Your devices keep working and re-connect to the new passkey the next time they sync in.</p>
+    <p class="account__message">Creates a new passkey for this account. Your other devices keep working on their existing delegations; re-connecting them to the new passkey is a separate step, done on each device.</p>
     <form class="account__form">
       <label>New passkey name
         <input id="account-rotate-name" name="New passkey name" type="text" autocomplete="off" required>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -319,6 +319,21 @@ fn load_devices(host: HtmlElement) {
     });
 }
 
+/// The account rotated server-side, but this browser failed to persist the
+/// new link. Send the user to log in with the new passkey rather than
+/// leaving the rotate panel (and its "create a new passkey" submit) live,
+/// which would risk a third credential.
+fn show_relink_failure(host: &HtmlElement) {
+    set_busy(host, false, "");
+    set_mode(host, "link");
+    show_error(
+        host,
+        "Your account is now on the new passkey, but this browser could not \
+         finish linking. Do not create another passkey — use Log in with your \
+         new passkey instead.",
+    );
+}
+
 fn load_status(host: HtmlElement) {
     if let Err(error) = service(&host) {
         set_mode(&host, "blocked");
@@ -739,36 +754,51 @@ fn bind(host: &HtmlElement) {
         };
         set_busy(&host, true, "Waiting for your current passkey…");
         spawn_local(async move {
-            let result = async {
+            let setup = async {
                 let device_did = crate::api::identify()
                     .await
                     .map_err(|error| error.to_string())?
                     .did;
                 let rotation: RotationOutput =
                     identity_call("rotateAccount", &RotateInput { name, device_did }).await?;
-                set_busy(&host, true, "Rotating your account…");
-                crate::api::rotate_account(
-                    &service(&host)?,
-                    &rotation.rotation_hex,
-                    &rotation.confirmation_hex,
-                )
-                .await
-                .map_err(|error| error.to_string())?;
-                crate::api::save_account_link(
-                    rotation.new_root_did,
-                    rotation.device_delegation_hex,
-                    Some(&rotation.succession_hex),
-                )
-                .await
-                .map_err(|error| error.to_string())?;
-                Ok::<(), String>(())
+                let service_url = service(&host)?;
+                Ok::<(String, RotationOutput), String>((service_url, rotation))
             }
             .await;
-            match result {
-                Ok(()) => show_success(&host),
+            let (service_url, rotation) = match setup {
+                Ok(value) => value,
                 Err(error) => {
                     set_busy(&host, false, "");
-                    show_error(&host, error);
+                    return show_error(&host, error);
+                }
+            };
+
+            set_busy(&host, true, "Rotating your account…");
+            if let Err(error) = crate::api::rotate_account(
+                &service_url,
+                &rotation.rotation_hex,
+                &rotation.confirmation_hex,
+            )
+            .await
+            {
+                // Nothing changed server-side: safe to retry the whole rotation.
+                set_busy(&host, false, "");
+                return show_error(&host, error.to_string());
+            }
+
+            match crate::api::save_account_link(
+                rotation.new_root_did,
+                rotation.device_delegation_hex,
+                Some(&rotation.succession_hex),
+            )
+            .await
+            {
+                Ok(_status) => show_success(&host),
+                Err(error) => {
+                    web_sys::console::error_1(
+                        &format!("failed to save the rotated account link: {error}").into(),
+                    );
+                    show_relink_failure(&host);
                 }
             }
         });
@@ -916,6 +946,52 @@ mod tests {
                 "{selector} should be hidden while rotate is shown"
             );
         }
+    }
+
+    #[dialog_common::test]
+    fn it_routes_a_failed_post_rotation_relink_to_log_in() {
+        let host = host();
+        set_mode(&host, "rotate");
+        set_busy(&host, true, "Rotating your account…");
+
+        show_relink_failure(&host);
+
+        assert!(
+            host.query_selector("#account-link")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none(),
+            "the log-in panel should be shown"
+        );
+        assert!(
+            host.query_selector("#account-rotate")
+                .unwrap()
+                .unwrap()
+                .has_attribute("hidden"),
+            "the rotate panel (with its create-a-new-passkey submit) must not stay live"
+        );
+        assert_eq!(
+            host.query_selector("#account-error")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some(
+                "Your account is now on the new passkey, but this browser could not \
+                 finish linking. Do not create another passkey — use Log in with your \
+                 new passkey instead."
+            )
+        );
+        assert!(
+            !host
+                .query_selector("#account-rotate-submit")
+                .unwrap()
+                .unwrap()
+                .unchecked_into::<HtmlButtonElement>()
+                .disabled(),
+            "buttons must be re-enabled, not left busy"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -14,6 +14,7 @@ const PROD: &str = "https://accounts.tonk.xyz";
 const STAGING: &str = "https://accounts-staging.tonk.xyz";
 const STYLE_ID: &str = "tonk-account-styles";
 const HANDOFF: &str = "__tonkCliHandoff";
+const PENDING_ROTATION: &str = "__tonkPendingRotation";
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -207,6 +208,7 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-manage-devices",
         "#account-unlink",
         "#account-rotate-submit",
+        "#account-relink-retry",
     ] {
         if let Ok(Some(button)) = host.query_selector(selector)
             && let Ok(button) = button.dyn_into::<HtmlButtonElement>()
@@ -319,18 +321,49 @@ fn load_devices(host: HtmlElement) {
     });
 }
 
+/// Hide the post-rotation retry control and forget any rotation output
+/// held for it, so a stale retry never lingers into an unrelated log-in.
+fn hide_relink_retry(host: &HtmlElement) {
+    if let Ok(Some(retry)) = host.query_selector("#account-relink-retry") {
+        let _ = retry.set_attribute("hidden", "");
+    }
+    let _ = Reflect::delete_property(host.as_ref(), &PENDING_ROTATION.into());
+}
+
 /// The account rotated server-side, but this browser failed to persist the
-/// new link. Send the user to log in with the new passkey rather than
-/// leaving the rotate panel (and its "create a new passkey" submit) live,
-/// which would risk a third credential.
-fn show_relink_failure(host: &HtmlElement) {
+/// new link. Keep the just-verified `rotation` output on the element so a
+/// single click can retry the same save — the common case is a transport
+/// hiccup, not a bad ceremony, and the rotation cannot be re-run (it would
+/// mint a second passkey). Leave the rotate panel (with its "create a new
+/// passkey" submit) hidden either way.
+fn show_relink_failure(host: &HtmlElement, rotation: RotationOutput) {
+    if let Ok(value) = serde_wasm_bindgen::to_value(&rotation) {
+        let _ = Reflect::set(host.as_ref(), &PENDING_ROTATION.into(), &value);
+    }
+    set_busy(host, false, "");
+    set_mode(host, "link");
+    if let Ok(Some(retry)) = host.query_selector("#account-relink-retry") {
+        let _ = retry.remove_attribute("hidden");
+    }
+    show_error(
+        host,
+        "Your account is now on the new passkey, but this browser could not \
+         finish connecting it. Try again below — if that also fails, log in \
+         with your new passkey as a last resort.",
+    );
+}
+
+/// The retry also failed: route to logging in with the new passkey. This
+/// works once the service accepts a device re-registering under the same
+/// account, so it is a safe last resort rather than a dead end.
+fn show_relink_last_resort(host: &HtmlElement) {
+    hide_relink_retry(host);
     set_busy(host, false, "");
     set_mode(host, "link");
     show_error(
         host,
-        "Your account is now on the new passkey, but this browser could not \
-         finish linking. Do not create another passkey — use Log in with your \
-         new passkey instead.",
+        "Your account is now on the new passkey, but this browser still could \
+         not finish connecting it. Log in with your new passkey instead.",
     );
 }
 
@@ -500,11 +533,13 @@ fn bind(host: &HtmlElement) {
     });
     on_click(host, "#account-choose-link", |host| {
         clear_error(&host);
+        hide_relink_retry(&host);
         set_mode(&host, "link");
     });
     for selector in ["#account-create-back", "#account-link-back"] {
         on_click(host, selector, |host| {
             clear_error(&host);
+            hide_relink_retry(&host);
             set_mode(&host, "choice");
         });
     }
@@ -781,24 +816,70 @@ fn bind(host: &HtmlElement) {
             )
             .await
             {
-                // Nothing changed server-side: safe to retry the whole rotation.
+                // A lost response here does not mean nothing happened: the
+                // service may have already applied the flip before the
+                // reply was lost in transit. Retrying from scratch mints
+                // another passkey, but that retry fails cleanly at the
+                // service (this account's old root is no longer on file)
+                // rather than corrupting anything.
                 set_busy(&host, false, "");
                 return show_error(&host, error.to_string());
             }
 
             match crate::api::save_account_link(
-                rotation.new_root_did,
-                rotation.device_delegation_hex,
+                rotation.new_root_did.clone(),
+                rotation.device_delegation_hex.clone(),
                 Some(&rotation.succession_hex),
             )
             .await
             {
-                Ok(_status) => show_success(&host),
+                Ok(_status) => {
+                    if let Ok(Some(message)) = host.query_selector("#account-success-message") {
+                        message.set_text_content(Some("Your account is on the new passkey."));
+                    }
+                    show_success(&host);
+                }
                 Err(error) => {
                     web_sys::console::error_1(
                         &format!("failed to save the rotated account link: {error}").into(),
                     );
-                    show_relink_failure(&host);
+                    show_relink_failure(&host, rotation);
+                }
+            }
+        });
+    });
+
+    on_click(host, "#account-relink-retry", |host| {
+        let rotation = Reflect::get(host.as_ref(), &PENDING_ROTATION.into())
+            .ok()
+            .filter(|value| !value.is_undefined())
+            .and_then(|value| serde_wasm_bindgen::from_value::<RotationOutput>(value).ok());
+        let Some(rotation) = rotation else {
+            return show_relink_last_resort(&host);
+        };
+        clear_error(&host);
+        set_busy(&host, true, "Reconnecting this browser…");
+        spawn_local(async move {
+            match crate::api::save_account_link(
+                rotation.new_root_did.clone(),
+                rotation.device_delegation_hex.clone(),
+                Some(&rotation.succession_hex),
+            )
+            .await
+            {
+                Ok(_status) => {
+                    hide_relink_retry(&host);
+                    if let Ok(Some(message)) = host.query_selector("#account-success-message") {
+                        message.set_text_content(Some("Your account is on the new passkey."));
+                    }
+                    show_success(&host);
+                }
+                Err(error) => {
+                    web_sys::console::error_1(
+                        &format!("retry also failed to save the rotated account link: {error}")
+                            .into(),
+                    );
+                    show_relink_last_resort(&host);
                 }
             }
         });
@@ -948,13 +1029,25 @@ mod tests {
         }
     }
 
+    fn dummy_rotation() -> RotationOutput {
+        RotationOutput {
+            old_root_did: "did:key:zOld".into(),
+            new_root_did: "did:key:zNew".into(),
+            new_credential_id: "cred-new".into(),
+            succession_hex: "aa".into(),
+            device_delegation_hex: "bb".into(),
+            rotation_hex: "cc".into(),
+            confirmation_hex: "dd".into(),
+        }
+    }
+
     #[dialog_common::test]
-    fn it_routes_a_failed_post_rotation_relink_to_log_in() {
+    fn it_routes_a_failed_post_rotation_relink_to_a_retry_control() {
         let host = host();
         set_mode(&host, "rotate");
         set_busy(&host, true, "Rotating your account…");
 
-        show_relink_failure(&host);
+        show_relink_failure(&host, dummy_rotation());
 
         assert!(
             host.query_selector("#account-link")
@@ -971,6 +1064,14 @@ mod tests {
                 .has_attribute("hidden"),
             "the rotate panel (with its create-a-new-passkey submit) must not stay live"
         );
+        assert!(
+            host.query_selector("#account-relink-retry")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none(),
+            "a retry control should be offered before routing to log in"
+        );
         assert_eq!(
             host.query_selector("#account-error")
                 .unwrap()
@@ -979,8 +1080,8 @@ mod tests {
                 .as_deref(),
             Some(
                 "Your account is now on the new passkey, but this browser could not \
-                 finish linking. Do not create another passkey — use Log in with your \
-                 new passkey instead."
+                 finish connecting it. Try again below — if that also fails, log in \
+                 with your new passkey as a last resort."
             )
         );
         assert!(
@@ -991,6 +1092,41 @@ mod tests {
                 .unchecked_into::<HtmlButtonElement>()
                 .disabled(),
             "buttons must be re-enabled, not left busy"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_routes_a_second_relink_failure_to_log_in_as_a_last_resort() {
+        let host = host();
+        show_relink_failure(&host, dummy_rotation());
+
+        show_relink_last_resort(&host);
+
+        assert!(
+            host.query_selector("#account-link")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none(),
+            "the log-in panel should still be shown"
+        );
+        assert!(
+            host.query_selector("#account-relink-retry")
+                .unwrap()
+                .unwrap()
+                .has_attribute("hidden"),
+            "the spent retry control should be hidden again"
+        );
+        assert_eq!(
+            host.query_selector("#account-error")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some(
+                "Your account is now on the new passkey, but this browser still could \
+                 not finish connecting it. Log in with your new passkey instead."
+            )
         );
     }
 

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -47,6 +47,27 @@ struct CeremonyOutput {
     invocation_hex: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RotateInput {
+    name: String,
+    device_did: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RotationOutput {
+    #[allow(dead_code)]
+    old_root_did: String,
+    new_root_did: String,
+    #[allow(dead_code)]
+    new_credential_id: String,
+    succession_hex: String,
+    device_delegation_hex: String,
+    rotation_hex: String,
+    confirmation_hex: String,
+}
+
 /// The top-document account element. WebAuthn must not run in sealed guests.
 #[derive(Default)]
 struct TonkAccount;
@@ -165,6 +186,7 @@ fn set_mode(host: &HtmlElement, mode: &str) {
         ("handoff", "#account-handoff"),
         ("success", "#account-success"),
         ("devices", "#account-devices"),
+        ("rotate", "#account-rotate"),
     ] {
         if let Ok(Some(panel)) = host.query_selector(selector) {
             if name == mode {
@@ -184,6 +206,7 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-handoff-submit",
         "#account-manage-devices",
         "#account-unlink",
+        "#account-rotate-submit",
     ] {
         if let Ok(Some(button)) = host.query_selector(selector)
             && let Ok(button) = button.dyn_into::<HtmlButtonElement>()
@@ -385,7 +408,10 @@ fn load_handoff(host: HtmlElement) {
     });
 }
 
-async fn identity_call<T: Serialize>(method: &str, input: &T) -> Result<CeremonyOutput, String> {
+async fn identity_call<I: Serialize, O: for<'de> Deserialize<'de>>(
+    method: &str,
+    input: &I,
+) -> Result<O, String> {
     let window = window().ok_or_else(|| "window is unavailable".to_string())?;
     let identity = Reflect::get(&window, &"tonkIdentity".into())
         .map_err(|error| format!("identity API unavailable: {error:?}"))?;
@@ -406,9 +432,13 @@ async fn identity_call<T: Serialize>(method: &str, input: &T) -> Result<Ceremony
 }
 
 async fn persist(ceremony: &CeremonyOutput) -> Result<(), String> {
-    crate::api::save_account_link(ceremony.root_did.clone(), ceremony.delegation_hex.clone())
-        .await
-        .map_err(|error| error.to_string())?;
+    crate::api::save_account_link(
+        ceremony.root_did.clone(),
+        ceremony.delegation_hex.clone(),
+        None,
+    )
+    .await
+    .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -524,7 +554,7 @@ fn bind(host: &HtmlElement) {
                     .await
                     .map_err(|error| error.to_string())?
                     .did;
-                let ceremony = identity_call(
+                let ceremony: CeremonyOutput = identity_call(
                     "createAccount",
                     &CreateInput {
                         email,
@@ -558,7 +588,7 @@ fn bind(host: &HtmlElement) {
                     .await
                     .map_err(|error| error.to_string())?
                     .did;
-                let ceremony = identity_call(
+                let ceremony: CeremonyOutput = identity_call(
                     "linkDevice",
                     &LinkInput {
                         device_did,
@@ -591,7 +621,7 @@ fn bind(host: &HtmlElement) {
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let result = async {
-                let ceremony = identity_call("completeLink", &handoff).await?;
+                let ceremony: CeremonyOutput = identity_call("completeLink", &handoff).await?;
                 set_busy(&host, true, "Linking the command-line profile…");
                 crate::api::submit_account_ceremony(
                     &service(&host)?,
@@ -694,6 +724,55 @@ fn bind(host: &HtmlElement) {
         let _ = list.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref());
         closure.forget();
     }
+
+    on_click(host, "#account-rotate-open", |host| {
+        clear_error(&host);
+        set_mode(&host, "rotate");
+        focus_input(&host, "#account-rotate-name");
+    });
+
+    on_click(host, "#account-rotate-submit", |host| {
+        clear_error(&host);
+        let name = match input(&host, "#account-rotate-name") {
+            Ok(value) => value,
+            Err(error) => return show_error(&host, error),
+        };
+        set_busy(&host, true, "Waiting for your current passkey…");
+        spawn_local(async move {
+            let result = async {
+                let device_did = crate::api::identify()
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .did;
+                let rotation: RotationOutput =
+                    identity_call("rotateAccount", &RotateInput { name, device_did }).await?;
+                set_busy(&host, true, "Rotating your account…");
+                crate::api::rotate_account(
+                    &service(&host)?,
+                    &rotation.rotation_hex,
+                    &rotation.confirmation_hex,
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+                crate::api::save_account_link(
+                    rotation.new_root_did,
+                    rotation.device_delegation_hex,
+                    Some(&rotation.succession_hex),
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+                Ok::<(), String>(())
+            }
+            .await;
+            match result {
+                Ok(()) => show_success(&host),
+                Err(error) => {
+                    set_busy(&host, false, "");
+                    show_error(&host, error);
+                }
+            }
+        });
+    });
 }
 
 /// Register `<tonk-account>` with the top document.
@@ -760,6 +839,9 @@ mod tests {
             "#account-create-submit",
             "#account-link-submit",
             "#account-handoff-submit",
+            "#account-rotate-open",
+            "#account-rotate-name",
+            "#account-rotate-submit",
         ] {
             assert!(
                 host.query_selector(selector).unwrap().is_some(),
@@ -805,6 +887,35 @@ mod tests {
                 .is_none(),
             "email and verification fields should be on separate screens"
         );
+    }
+
+    #[dialog_common::test]
+    fn it_reveals_the_rotate_panel_and_hides_the_others() {
+        let host = host();
+        set_mode(&host, "rotate");
+        assert!(
+            host.query_selector("#account-rotate")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none()
+        );
+        for selector in [
+            "#account-choice",
+            "#account-create",
+            "#account-verify",
+            "#account-link",
+            "#account-handoff",
+            "#account-success",
+        ] {
+            assert!(
+                host.query_selector(selector)
+                    .unwrap()
+                    .unwrap()
+                    .has_attribute("hidden"),
+                "{selector} should be hidden while rotate is shown"
+            );
+        }
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -458,6 +458,7 @@ pub async fn save_account_link(
         .json(&AccountLinkRequest {
             root_did,
             delegation_hex,
+            succession_hex: None,
         })
         .send()
         .await

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -448,9 +448,15 @@ pub async fn account_status() -> Result<AccountStatus, TonkUiError> {
 }
 
 /// Persist a verified account-root delegation in the local profile.
+///
+/// `succession_hex` is `Some` only for a rotation relink: the hex-encoded
+/// `oldRoot → newRoot` succession chain that authorizes the worker to
+/// replace an already-linked root with `root_did` instead of rejecting the
+/// request as a conflicting root.
 pub async fn save_account_link(
     root_did: String,
     delegation_hex: String,
+    succession_hex: Option<&str>,
 ) -> Result<AccountStatus, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
@@ -458,7 +464,7 @@ pub async fn save_account_link(
         .json(&AccountLinkRequest {
             root_did,
             delegation_hex,
-            succession_hex: None,
+            succession_hex: succession_hex.map(str::to_owned),
         })
         .send()
         .await
@@ -528,6 +534,41 @@ pub async fn unlink_account() -> Result<AccountStatus, TonkUiError> {
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "DELETE /api/account returned {status}: {text}"
+        )))
+    }
+}
+
+/// Submit a signed rotation ceremony to the account service.
+///
+/// `POST {service_url}/accounts/rotate` with the old-root-signed rotation
+/// container and the new-root-signed confirmation container. On success the
+/// service has flipped the account onto the new root; the caller still must
+/// relink this profile locally (`save_account_link` with the succession
+/// chain) to pick up the new custody key.
+pub async fn rotate_account(
+    service_url: &str,
+    rotation_hex: &str,
+    confirmation_hex: &str,
+) -> Result<(), TonkUiError> {
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/accounts/rotate",
+            service_url.trim_end_matches('/')
+        ))
+        .json(&serde_json::json!({
+            "rotation": rotation_hex,
+            "confirmation": confirmation_hex,
+        }))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /accounts/rotate returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -10,6 +10,10 @@ pub struct AccountLinkRequest {
     pub root_did: String,
     /// Hex-encoded UCAN delegation chain from the root to this profile.
     pub delegation_hex: String,
+    /// Hex-encoded succession delegation authorizing replacement of an
+    /// already-linked root with `root_did`, when this link is a rotation.
+    #[serde(default)]
+    pub succession_hex: Option<String>,
 }
 
 /// Local account-link state.

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -514,6 +514,34 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_rejects_a_succession_minted_for_a_different_root() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let first = request_for(&[7u8; 32], device_did.clone()).await;
+        let _ = link(State(state.clone()), Json(first)).await.unwrap();
+
+        // Succession correctly issued by the linked root, but audienced to
+        // a third DID — not the root this relink actually claims.
+        let old_root = tonk_identity::derive::derive_root_signer(&[7u8; 32])
+            .await
+            .unwrap();
+        let third_root = tonk_identity::derive::derive_root_signer(&[42u8; 32])
+            .await
+            .unwrap();
+        let succession =
+            tonk_identity::delegation::mint_root_succession(old_root, &third_root.did())
+                .await
+                .unwrap();
+        let mut second = request_for(&[8u8; 32], device_did).await;
+        second.succession_hex = Some(hex::encode(succession.to_bytes().unwrap()));
+
+        assert!(matches!(
+            link(State(state), Json(second)).await,
+            Err(TonkWorkerError::Forbidden(_))
+        ));
+    }
+
+    #[dialog_common::test]
     async fn it_resolves_the_member_did_to_the_root_when_linked() {
         let state = Arc::new(RwLock::new(test_state().await));
         let device_did = state.read().await.profile.did();

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -59,6 +59,48 @@ async fn validate_link(
     Ok((chain, bytes))
 }
 
+async fn validate_succession(
+    succession_hex: &str,
+    old_root: &dialog_varsig::Did,
+    new_root: &dialog_varsig::Did,
+) -> Result<DelegationChain, TonkWorkerError> {
+    let bytes = hex::decode(succession_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid succession hex: {error}")))?;
+    let chain = DelegationChain::try_from(bytes.as_slice())
+        .map_err(|error| TonkWorkerError::Router(format!("invalid succession chain: {error}")))?;
+    if chain.proof_cids().len() != 1 {
+        return Err(TonkWorkerError::Router(
+            "succession must contain exactly one proof".to_string(),
+        ));
+    }
+    if chain.issuer() != old_root {
+        return Err(TonkWorkerError::Forbidden(
+            "succession issuer is not the linked account root".to_string(),
+        ));
+    }
+    if chain.audience() != new_root {
+        return Err(TonkWorkerError::Forbidden(
+            "succession audience is not the new account root".to_string(),
+        ));
+    }
+    if chain.subject().is_some() {
+        return Err(TonkWorkerError::Router(
+            "succession must be subject-open".to_string(),
+        ));
+    }
+    let proof = chain
+        .proofs()
+        .next()
+        .expect("a one-proof chain contains one proof");
+    proof
+        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Forbidden(format!("invalid succession signature: {error}"))
+        })?;
+    Ok(chain)
+}
+
 async fn load_link(state: &crate::worker::TonkState) -> Result<Option<Vec<u8>>, TonkWorkerError> {
     match state
         .profile
@@ -168,9 +210,24 @@ pub(crate) async fn persist_link(
             TonkWorkerError::Internal(format!("stored account delegation is invalid: {error}"))
         })?;
         if existing.issuer() != chain.issuer() {
-            return Err(TonkWorkerError::Conflict(
-                "profile is already linked to another account root".to_string(),
-            ));
+            let Some(succession_hex) = &request.succession_hex else {
+                return Err(TonkWorkerError::Conflict(
+                    "profile is already linked to another account root".to_string(),
+                ));
+            };
+            let succession =
+                validate_succession(succession_hex, existing.issuer(), chain.issuer()).await?;
+            state
+                .profile
+                .access()
+                .save(UcanDelegation(succession))
+                .perform(&state.operator)
+                .await
+                .map_err(|error| {
+                    TonkWorkerError::Internal(format!(
+                        "failed to save succession delegation: {error}"
+                    ))
+                })?;
         }
     }
 
@@ -212,6 +269,10 @@ pub async fn link(
     let app_state = state.clone();
     let state = state.read().await;
     let device_did = state.profile.did();
+    // Only the wasm dispatch below acts on a root change; capturing it
+    // unconditionally would leave the native build with an unused binding.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    let previous_root = account_root_did(&state).await;
     persist_link(&state, &request).await?;
 
     // A freshly linked device converges its existing spaces and pulls the
@@ -234,6 +295,7 @@ pub async fn link(
     // to avoid. The lock is therefore released between the two.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
+        let new_root_did = request.root_did.clone();
         wasm_bindgen_futures::spawn_local(async move {
             // Migrate this device's existing spaces onto the root first:
             // restore only mounts subjects this device doesn't already
@@ -241,6 +303,10 @@ pub async fn link(
             // re-touch a space migration just re-keyed.
             {
                 let tonk = app_state.write().await;
+                if let Some(old_root) = previous_root.filter(|old| old.to_string() != new_root_did)
+                {
+                    crate::router::migrate::converge_after_rotation(&tonk, &old_root).await;
+                }
                 crate::router::migrate::migrate_rosters(&tonk).await;
             }
             let tonk = app_state.read().await;
@@ -300,6 +366,7 @@ pub(crate) async fn tests_request_for(
     tonk_worker_api::AccountLinkRequest {
         root_did,
         delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+        succession_hex: None,
     }
 }
 
@@ -387,6 +454,62 @@ mod tests {
         assert!(matches!(
             link(State(state), Json(second)).await,
             Err(TonkWorkerError::Conflict(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_replaces_the_root_when_a_succession_authorizes_it() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let first = request_for(&[7u8; 32], device_did.clone()).await;
+        let _ = link(State(state.clone()), Json(first.clone()))
+            .await
+            .unwrap();
+
+        let old_root = tonk_identity::derive::derive_root_signer(&[7u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&[8u8; 32])
+            .await
+            .unwrap();
+        let succession = tonk_identity::delegation::mint_root_succession(old_root, &new_root.did())
+            .await
+            .unwrap();
+        let mut second = request_for(&[8u8; 32], device_did).await;
+        second.succession_hex = Some(hex::encode(succession.to_bytes().unwrap()));
+
+        let Json(status) = link(State(state.clone()), Json(second.clone()))
+            .await
+            .unwrap();
+        match status {
+            AccountStatus::Linked { root_did, .. } => assert_eq!(root_did, second.root_did),
+            AccountStatus::Unlinked { .. } => panic!("relink did not persist"),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_succession_from_the_wrong_root() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let first = request_for(&[7u8; 32], device_did.clone()).await;
+        let _ = link(State(state.clone()), Json(first)).await.unwrap();
+
+        // Succession issued by an unrelated key, not the linked root.
+        let stranger = tonk_identity::derive::derive_root_signer(&[13u8; 32])
+            .await
+            .unwrap();
+        let new_root = tonk_identity::derive::derive_root_signer(&[8u8; 32])
+            .await
+            .unwrap();
+        let succession = tonk_identity::delegation::mint_root_succession(stranger, &new_root.did())
+            .await
+            .unwrap();
+        let mut second = request_for(&[8u8; 32], device_did).await;
+        second.succession_hex = Some(hex::encode(succession.to_bytes().unwrap()));
+
+        assert!(matches!(
+            link(State(state), Json(second)).await,
+            Err(TonkWorkerError::Forbidden(_))
         ));
     }
 

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -1095,6 +1095,7 @@ mod tests {
         let request = tonk_worker_api::AccountLinkRequest {
             root_did: root_did.to_string(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+            succession_hex: None,
         };
         crate::router::account::link(axum::extract::State(state.clone()), axum::Json(request))
             .await

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -65,6 +65,27 @@ pub(crate) async fn migrate_rosters(tonk: &TonkState) {
     MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
 }
 
+/// Converge every space keyed on a superseded root onto the current one.
+/// Runs after a succession replaced this profile's account root:
+/// re-keys rosters `old → new` and re-anchors + backs up each space so
+/// devices linked under the new root can restore it.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn converge_after_rotation(tonk: &TonkState, old_root: &dialog_varsig::Did) {
+    let Some(new_root) = account::account_root_did(tonk).await else {
+        return;
+    };
+    if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    for key in crate::router::profile_name::profile_space_keys(tonk).await {
+        match rekey_space_roster(tonk, &key, old_root, &new_root).await {
+            Ok(_) => reanchor_space(tonk, &key).await,
+            Err(error) => log!("rotation convergence for space '{key}' skipped: {error}"),
+        }
+    }
+    MIGRATE_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
+
 /// Re-key one space's roster from the device DID to the account root DID,
 /// atomically. Returns `Ok(true)` when a device-keyed row was migrated,
 /// `Ok(false)` when the space is already root-keyed, the profile isn't a
@@ -74,10 +95,23 @@ pub(crate) async fn migrate_space_roster(
     tonk: &TonkState,
     key: &str,
 ) -> Result<bool, RepositoryError> {
-    let member = account::member_did(tonk).await;
-    let device = tonk.profile.did();
-    // Unlinked: no root to migrate to. (member_did == device DID.)
-    if member == device {
+    let to = account::member_did(tonk).await;
+    let from = tonk.profile.did();
+    rekey_space_roster(tonk, key, &from, &to).await
+}
+
+/// Re-key one space's roster from one DID to another, atomically. Returns
+/// `Ok(true)` when a `from`-keyed row was migrated, `Ok(false)` when the
+/// space is already keyed on `to` (or `from` has no roster row at all), or
+/// when `from == to` (nothing to converge).
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn rekey_space_roster(
+    tonk: &TonkState,
+    key: &str,
+    from: &dialog_varsig::Did,
+    to: &dialog_varsig::Did,
+) -> Result<bool, RepositoryError> {
+    if from == to {
         return Ok(false);
     }
 
@@ -91,10 +125,10 @@ pub(crate) async fn migrate_space_roster(
     let subject = session.handle().of().clone();
     let subject_entity = subject.this();
 
-    let device_membership = Membership::new(device.clone(), subject.clone());
+    let device_membership = Membership::new(from.clone(), subject.clone());
     let device_entity = device_membership.this().clone();
 
-    let root_membership = Membership::new(member.clone(), subject.clone());
+    let root_membership = Membership::new(to.clone(), subject.clone());
     let root_entity = root_membership.this().clone();
 
     // Is there a device-keyed row to migrate?
@@ -297,7 +331,7 @@ mod tests {
     use tonk_schema::prelude::{DidExt as _, EntityExt as _};
     use tonk_schema::{InvitedVia, MemberName, MemberRole, Membership};
 
-    use super::migrate_space_roster;
+    use super::{migrate_space_roster, rekey_space_roster};
     use crate::router::api_router_with_state;
     use crate::router::tests::{
         content_invited_via, content_member_names, content_member_roles, content_memberships,
@@ -324,6 +358,7 @@ mod tests {
         let request = tonk_worker_api::AccountLinkRequest {
             root_did: root_did.to_string(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+            succession_hex: None,
         };
         let tonk = state.read().await;
         crate::router::account::persist_link(&tonk, &request)
@@ -451,6 +486,84 @@ mod tests {
             migrate_space_roster(&tonk, &key).await.unwrap()
         };
         assert!(!migrated_again, "second migration call must be a no-op");
+    }
+
+    /// `rekey_space_roster` generalizes `migrate_space_roster` to any two
+    /// DIDs — exercise it directly between two account roots, mirroring a
+    /// rotation's `old → new` convergence rather than a device migration.
+    #[dialog_common::test]
+    async fn it_rekeys_a_membership_between_two_account_roots() {
+        let state = test_state().await;
+        let (app, state, _lsp) = api_router_with_state(state);
+
+        let key = put_repo(&app, "migrate-roster-rotation").await;
+        let subject_did = {
+            let tonk = state.read().await;
+            tonk.reactor
+                .repository(&key)
+                .branch("main")
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .of()
+                .clone()
+        };
+
+        let old_root = link_account(&state).await;
+        let old_membership = Membership::new(old_root.clone(), subject_did.clone());
+        let old_entity = old_membership.this().clone();
+        seed_device_membership(&state, &key, &old_root, &subject_did).await;
+
+        use dialog_varsig::Principal as _;
+        let new_root = tonk_identity::derive::derive_root_signer(&[10u8; 32])
+            .await
+            .unwrap()
+            .did();
+
+        let migrated = {
+            let tonk = state.read().await;
+            rekey_space_roster(&tonk, &key, &old_root, &new_root)
+                .await
+                .unwrap()
+        };
+        assert!(migrated, "expected the old-root-keyed row to be migrated");
+
+        let memberships = content_memberships(&state, &key).await;
+        assert!(
+            memberships.iter().any(|m| m.member.0 == new_root.this()),
+            "new-root-keyed membership must exist after rekeying",
+        );
+        assert!(
+            !memberships.iter().any(|m| m.member.0 == old_root.this()),
+            "old-root-keyed membership must be gone after rekeying",
+        );
+
+        let roles = content_member_roles(&state, &key).await;
+        let new_membership = memberships
+            .iter()
+            .find(|m| m.member.0 == new_root.this())
+            .expect("new-root membership present");
+        assert!(
+            roles
+                .iter()
+                .any(|r| r.this == new_membership.this
+                    && r.role.0.to_string() == MemberRole::FOUNDER),
+            "founder role must carry over onto the new-root-keyed entity",
+        );
+        assert!(
+            !roles.iter().any(|r| r.this == old_entity),
+            "old-root-keyed role must be gone after rekeying",
+        );
+
+        // Idempotent: a second call finds no old-root-keyed row left to rekey.
+        let migrated_again = {
+            let tonk = state.read().await;
+            rekey_space_roster(&tonk, &key, &old_root, &new_root)
+                .await
+                .unwrap()
+        };
+        assert!(!migrated_again, "second rekey call must be a no-op");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -417,6 +417,7 @@ mod tests {
         let link_request = tonk_worker_api::AccountLinkRequest {
             root_did: root_did_str.clone(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
+            succession_hex: None,
         };
         let _ = crate::router::account::link(State(state.clone()), Json(link_request))
             .await


### PR DESCRIPTION
## Summary

Deliberate rotation — new passkey with the old one still in hand — end to end (plan: `docs/superpowers/plans/2026-07-24-recovery-ceremonies.md`, Tasks 1–7; program spec: `docs/superpowers/specs/2026-07-24-account-system-completion-design.md`).

Originally stacked on #640 (it builds on that PR's shared ceremony-window helper); #640 merged while this was in review, so the branch is rebased onto `staging` and targets it directly.

## How it works

- **Ceremony (browser)**: derive the OLD root first (only one credential exists yet), create the new passkey, derive the NEW root via a `get()` scoped with `allowCredentials` to the just-created credential — `prf_output` gained optional credential scoping (existing ceremonies unchanged, pass `None`). This ordering + scoping closes the credential-picker ambiguity that would otherwise let a wrong pick silently derive the old root as "new" and corrupt the `root_did`/`credential_id` pairing.
- **Two root-signed containers**: an old-root-signed rotation container (newRootDid, newCredentialId, deviceDid, succession `oldRoot → newRoot` subject-open, deviceDelegation `newRoot → device`) and a new-root-signed confirmation naming the old root. The service (`POST /accounts/rotate`) verifies both via `authorize_root`, cross-checks each names the other (one negative test per arm), resolves the account by the OLD root, verifies both delegations, repoints the ceremony device (must be active), and atomically flips `root_did` + `credential_id`. Replay is closed by the flip itself: the old containers no longer resolve an account.
- **Devices stay active** — their `oldRoot → device` delegations remain valid; old space chains flow forward through the succession link.
- **Worker**: relink accepts a DIFFERENT root only with a valid succession issued by the currently stored root (subject-open, single-proof, signature-verified — both issuer and audience arms test-pinned); the succession is saved to the access store before the link flips; `converge_after_rotation` re-keys rosters oldRoot→newRoot with the 3B founder-wins semantics (machinery generalized to `rekey_space_roster(from, to)`; no behavior change for the device→root call site) and re-anchors.
- **Failure UX**: if the service rotates but the local relink fails, the panel stashes the ceremony output, offers a retry that re-posts WITH the succession, and only then routes to log-in — plus `/devices/link` now upserts a same-account active device (Forbidden for revoked — no resurrection; Conflict cross-account), so the last-resort log-in path actually works.

## Deliberately deferred (this sub-stage)

- **Multi-device reconnection**: other devices keep working on existing delegations, but re-connecting them to the NEW passkey needs the succession persisted server-side (natural home: the chains backup) — copy says so honestly; follow-up tracked. Native/CLI profiles likewise get the succession-relink arm but no convergence sweep (wasm-only).
- Interrupted convergence has no retry marker yet (re-runs on next link, not next boot).
- Surviving-device recovery and total-loss re-anchor are the next two PRs of this plan.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing an account rotation feature, allowing users to change their account's root DID while maintaining device links and delegations. It includes new functions for handling rotations and updates to existing device management processes.

### Detailed summary
- Added `pub mod rotation` in `src/core.rs`.
- Introduced new structs and functions for account rotation in `src/core/rotation.rs`.
- Updated `rotate_account` function to validate succession chains and device delegations.
- Modified device registration logic to support re-registration after rotation.
- Enhanced error handling for device delegation and account linking.
- Added new routes for handling account rotation requests in `src/handlers/rotate.rs`.
- Updated UI elements to support passkey rotation in `src/account.html`.
- Implemented tests for rotation functionality in `src/core/rotation.rs`.
- Adjusted SQL queries in `src/store/sqlite.rs` to accommodate new delegation and rotation logic.

> The following files were skipped due to too many changes: `rust/tonk-account-service/src/core/rotation.rs`, `rust/tonk-account-service/tests/service.rs`, `rust/tonk-ui/src/account.rs`, `docs/superpowers/plans/2026-07-24-recovery-ceremonies.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->