### PR TITLE
fix(tonk-access-service): fail closed when the revocation registry is unreachable

### DIFF
--- a/docs/superpowers/plans/2026-07-24-revocation-enforcement.md
+++ b/docs/superpowers/plans/2026-07-24-revocation-enforcement.md
@@ -27,6 +27,14 @@
   (60 s TTL) so the hot path does at most one D1 query per unseen credential
   set per minute. Accepted by the master design: a revoked device gets a brief
   window during a D1 outage, never an availability loss for everyone else.
+
+  > **Superseded.** This shipped as written in #641 and was then inverted:
+  > the screen fails *closed*, with the cache extended by a 10-minute grace
+  > window that covers an unreachable registry for credentials it recently
+  > cleared. Fail-open made the security property conditional on config
+  > correctness — a renamed binding disabled enforcement with only a log
+  > line — while the grace window buys back the availability fail-open was
+  > protecting. See the completion spec's stage R for the reasoning.
 - **Entitlement seam:** billing later adds an `entitlements` lookup as a new
   method on `RevocationRegistry` (or a sibling trait) plus one more arm in the
   handler; `collect_presented`, `assess`, and the cache do not change. Keep

--- a/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
@@ -1,0 +1,186 @@
+# Signed Revocation Artifacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a revocation a signed, verifiable, portable artifact instead of a database flag. `POST /devices/revoke` records a `ucan/revoke` invocation alongside the status write, so revocation carries a cryptographic trail and a second enforcement point becomes possible without handing out a database credential.
+
+**Architecture:** The account service gains a revocation artifact written to the existing R2 chain store (`ChainStore`, namespaced by account root DID), under a `revocations/` key prefix. D1 `status = 'revoked'` stays exactly as it is and remains what the access-service presign screen reads — this stage adds an artifact, it does not move the hot path. A `GET /devices/revocations` read endpoint exposes the set so a future non-worker enforcement point can sync it.
+
+**Tech Stack:** `dialog-ucan-core` (`InvocationBuilder`, `Invocation`, `Container`), `dialog-credentials` (`Ed25519Signer`), the crate's existing `ChainStore`/`Store` traits, `dialog_common::test`.
+
+## Blocking decision — resolve before Task 2
+
+**Who signs the revocation?** UCAN semantics: the issuer of a delegation, or a principal holding a delegated `ucan/revoke` capability, may revoke it. The issuer of `root → device` is the root, and the account service does not hold the root key — it is derived from the passkey PRF on the user's device and never leaves it. So the service cannot mint this artifact itself. Two options, and they are not close to equivalent:
+
+| | Root ceremony | Delegated `ucan/revoke` |
+|---|---|---|
+| Who can revoke | only a passkey-holding device | any linked device |
+| UX | passkey prompt on every revoke | unchanged from today |
+| Stolen-device blast radius | cannot revoke its siblings | **can revoke its siblings** |
+| Client work | derive root, sign, upload | mint `root → device` with a `ucan/revoke` capability at link time; devices sign directly |
+| Migration | none | existing devices have no such capability; needs a re-link or a root-signed top-up |
+
+Recommendation: **root ceremony.** The whole point of the stage is that a revocation should be harder to forge than a database write; letting a compromised device revoke its siblings hands an attacker a denial-of-service against the legitimate owner, which is the exact scenario revocation exists for. The UX cost is a passkey prompt on an action users take approximately once.
+
+This is a user decision. Do not start Task 2 until it is recorded here.
+
+- [ ] **Decision recorded:** ______________________
+
+## Why this shape (decisions)
+
+- **Artifact next to the index, not instead of it.** D1 `status` is what the
+  presign screen reads (`tonk-access-service/src/revocation.rs`), and it is
+  one indexed lookup on the hot path. The artifact is written on the cold
+  path and read by anything that is not that worker. Replacing the index
+  with artifact verification on every presign would be a large latency
+  regression for no security gain — the worker already trusts D1 for the
+  account data it serves.
+- **Reuse `ChainStore`, do not add a table.** Chain backup already stores
+  content-addressed UCAN bytes namespaced by root DID
+  (`core/backup.rs:chain_key` hashes the bytes). Revocations are the same
+  shape of thing. A `revocations/` key prefix keeps them enumerable
+  separately from delegation backups.
+- **Append-only, never delete.** The revocation set is monotone — this is
+  what makes it safe to cache and to gossip. There is no un-revoke today
+  (`store.rs` has `revoke_device` and no inverse) and this stage must not
+  introduce one.
+- **Verify on read, not on write.** The service checks the artifact is
+  well-formed and issued by the account root before storing it, so garbage
+  cannot be parked in a user's namespace; consumers re-verify
+  independently, because a consumer that trusts the store has gained
+  nothing over trusting D1.
+
+## Global Constraints
+
+- Lint gate: `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --check`.
+- Tests: `#[dialog_common::test]`, names `it_does_x`, native tests gated `#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]`.
+- No `mod.rs`: `foo.rs` + `foo/` form.
+- No stage/phase/PR references in code or doc comments.
+- Conventional commits, scope `tonk-account-service` (client work: scope `tonk-identity`).
+- The access-service is not modified by this stage. If a task wants to touch it, stop — that is stage-creep and belongs to whatever builds the second enforcement point.
+
+---
+
+### Task 1: Verify the invariants this plan stands on
+
+**Files:** none modified — read-only verification.
+
+- [ ] **Step 1: dialog has no revocation type to conflict with**
+
+```bash
+grep -rn "Revocation\|ucan/revoke" ~/.cargo/git/checkouts/dialog-db-*/*/rust/dialog-ucan-core/src/
+```
+Expected: no matches. The revocation is modelled as an ordinary `Invocation` with command `["ucan", "revoke"]`; nothing upstream competes with or verifies that shape.
+
+- [ ] **Step 2: `InvocationBuilder` takes an arbitrary command and arguments**
+
+```bash
+grep -n "pub fn command\|pub fn arguments\|pub fn subject\|pub fn proofs" ~/.cargo/git/checkouts/dialog-db-*/*/rust/dialog-ucan-core/src/invocation/builder.rs
+```
+Expected: builder accepts `Vec<String>` command and a `BTreeMap` of arguments, so `["ucan","revoke"]` with `{"revoke": <cid string>}` needs no upstream change.
+
+- [ ] **Step 3: the chain store is reachable from the revoke handler's context**
+
+```bash
+grep -n "chain_store\|ChainStore\|R2" rust/tonk-account-service/src/handlers/devices.rs rust/tonk-account-service/src/handlers.rs
+```
+Expected: `handle_revoke_inner` currently builds only a `Store`. Note what the chains handlers do to obtain a `ChainStore` from `RouteContext` — Task 3 mirrors it. If they use a different binding pattern, follow theirs.
+
+- [ ] **Step 4: `revoke_device` is the only status writer and there is no inverse**
+
+```bash
+grep -rn "status = 'revoked'\|DeviceStatus::Active" rust/tonk-account-service/src/store/
+```
+Expected: one `UPDATE ... SET status = 'revoked'`, no path back to `active`. If an un-revoke has appeared, STOP: the monotonicity argument the cache and this stage both rest on is void, and the access-service grace window needs re-examining first.
+
+**STOP conditions:**
+- The root key is reachable server-side by any path → the blocking decision above is moot and the plan needs rewriting around service-side signing.
+- `ChainStore` has grown a delete → revocations must not be stored somewhere erasable; use a separate append-only prefix with no delete path.
+
+- [ ] **Step 5: Nothing to commit** — verification only.
+
+---
+
+### Task 2: Mint the revocation client-side
+
+**Files:**
+- Modify: `rust/tonk-identity/src/revocation.rs` (new), `rust/tonk-identity/src/lib.rs`
+
+**Interfaces:**
+- Produces: `mint_revocation(root: Ed25519Signer, delegation_cid: &Cid) -> Result<Vec<u8>>` returning container bytes, consumed by Task 3's handler and Task 5's client call.
+
+- [ ] **Step 1: Write the failing test first**
+
+`it_mints_a_root_signed_revocation_naming_the_delegation`: mint a `root → device` delegation, take its CID, mint a revocation, assert the invocation's issuer is the root DID, its command is `["ucan","revoke"]`, and its arguments carry the delegation CID as a string.
+
+- [ ] **Step 2: Implement**
+
+Mirror `mint_device_delegation` in the same crate: `InvocationBuilder::new().issuer(root).audience(&root_did).subject(&root_did).command(vec!["ucan".into(), "revoke".into()]).arguments(...)`, serialize through a container. Subject is the account root: the revocation is an act on the account, not on a space.
+
+- [ ] **Step 3: Second test** — `it_rejects_a_revocation_not_issued_by_the_root` covering the verifier from Task 4 once it exists, or leave a `TODO`-free note in the plan and add it in Task 4.
+
+- [ ] **Step 4: Commit** `feat(tonk-identity): mint signed device revocations`
+
+---
+
+### Task 3: Store the artifact on revoke
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/core/devices.rs`, `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/helpers/server.rs`
+
+**Interfaces:**
+- Consumes: Task 2's container bytes, arriving as a new required field on the revoke request body.
+- Produces: an object at `revocations/{chain_key(bytes)}` in the account's namespace.
+
+- [ ] **Step 1: Extend `revoke_device` to take the artifact**
+
+Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account, device_did, revocation_bytes)`. Verify before storing (Task 4), then write the artifact **before** flipping the status — a stored artifact with no flag is a recoverable inconsistency; a flag with no artifact is a silent gap in the audit trail.
+
+- [ ] **Step 2: Tests**
+
+`it_stores_the_artifact_and_flips_the_status`, `it_does_not_flip_the_status_when_the_artifact_is_rejected`, `it_keeps_earlier_revocations_when_a_second_device_is_revoked` (monotonicity).
+
+- [ ] **Step 3: Mirror the wiring in the native helpers server** so the HTTP integration test covers the same path.
+
+- [ ] **Step 4: Commit** `feat(tonk-account-service): record a signed artifact on device revoke`
+
+---
+
+### Task 4: Verify the artifact before accepting it
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/core/revocation.rs` (new)
+
+- [ ] **Step 1: Write the tests first** — a revocation issued by a foreign root is rejected; one naming a delegation CID that is not this device's registered `delegation_cid` is rejected; the happy path is accepted. Reuse the fixture style in `core/devices.rs` tests.
+
+- [ ] **Step 2: Implement** `check_revocation(bytes, root_did, expected_delegation_cid)` mirroring `core/delegation.rs:check_device_delegation` — parse, verify signature, check issuer equals the account root, check the named CID matches the device row.
+
+- [ ] **Step 3: Commit** `feat(tonk-account-service): verify revocation artifacts before storing them`
+
+---
+
+### Task 5: Expose the revocation set
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/lib.rs`, `rust/tonk-account-service/src/helpers/server.rs`, `rust/tonk-account-service/README.md`
+
+- [ ] **Step 1: `GET`-shaped read endpoint** `POST /devices/revocations` (device-signed invocation, command `["account","device","revocations"]` — the crate's endpoints are all POST-with-invocation; follow that, do not invent a bearer route). Returns the stored artifacts as an array of hex-encoded containers.
+
+- [ ] **Step 2: Tests** — a caller sees only their own account's revocations (mirror the cross-account `/chains/get` isolation test added in the hardening batch).
+
+- [ ] **Step 3: README** — document the endpoint and state plainly that consumers MUST verify artifacts themselves rather than trusting the service.
+
+- [ ] **Step 4: Commit** `feat(tonk-account-service): serve the signed revocation set`
+
+---
+
+### Task 6: Client plumbing and the revoke ceremony
+
+**Files:**
+- Modify: `rust/tonk-worker/` account routes, `rust/tonk-ui/` account element (whatever D built)
+
+Depends on D's device-management surface existing. If D has not landed, stop after Task 5 and let D pick this up — the endpoints are complete and testable without a UI.
+
+- [ ] **Step 1:** Wire the revoke button through the root ceremony (or the delegated capability, per the blocking decision).
+- [ ] **Step 2:** Manual staging smoke: revoke a device, confirm the artifact appears in the revocation set, confirm presigns from that device 403 within 60s, confirm the artifact verifies standalone against the account root DID.
+- [ ] **Step 3: Commit** and update the completion spec's stage S section to "shipped".

--- a/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
+++ b/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
@@ -74,12 +74,102 @@ device-management UX is meaningless without it):
   revoked device can mint fresh delegations. Verified feasible with public
   dialog APIs against the pinned dialog tag (no upstream change needed);
   unregistered device-only users produce no matches and are untouched.
-- **Fail-open** on D1 error/outage with a per-isolate verdict cache
-  (~60 s TTL), per the master spec's availability posture.
+- **Fail-closed** on D1 error/outage, softened by the per-isolate verdict
+  cache: a verdict is authoritative for 60 s and then usable for a further
+  10 minutes *only* to cover an unreachable registry. Credentials the
+  registry cleared recently ride out a blip; anything it has not cleared
+  inside the grace window gets `503 REVOCATION_UNAVAILABLE` (retryable,
+  distinct from the 403). A failed query is never cached, so grace is
+  anchored to the last successful lookup and repeated failures cannot walk
+  it forward. Unparseable container and missing `ACCOUNTS_DB` binding are
+  also 503 — a misconfigured binding now stops presigns loudly instead of
+  silently disabling enforcement.
 - The lookup seam is written so billing later adds its entitlement join
   without touching the handler again.
 
+Superseded decision, recorded because the reasoning matters: R shipped
+(#641) with a **fail-open** posture, on the master spec's availability
+grounds. That trades the security property for uptime in exactly the
+scenario where it is load-bearing, and makes enforcement a function of
+config correctness — a renamed binding disabled it with only a log line.
+The grace window buys back the availability that fail-open was protecting
+without making the guarantee conditional.
+
+### S — Signed revocation artifacts (R follow-on)
+
+R's registry check works, but a `devices` row is not a revocation — it is
+a status flag whose authority is "whoever can write this database". Two
+consequences. There is no cryptographic trail: a D1 write (ours, or an
+attacker's) can revoke or un-revoke with nothing to audit and nothing to
+verify against. And there is nothing portable: the day enforcement has to
+happen anywhere but this one worker — peer sync, the FS remote, the CLI,
+a second service — there is no artifact to hand it, only a database
+credential to spread around.
+
+UCAN's answer is a signed revocation: an invocation with command
+`ucan/revoke` naming the CID of the revoked delegation, optionally with a
+`path` witness, issuable by any issuer in that delegation's proof chain.
+The set is monotone and append-only, which is what makes it safe to
+gossip and to cache: you can only ever learn more revocations, so no
+distribution failure produces a wrongly-permissive answer.
+
+Decision — mint the artifact, keep the index:
+
+- `POST /devices/revoke` additionally records a signed `ucan/revoke`
+  invocation in the existing R2 chains store. D1 `status` stays exactly as
+  it is and remains what the access-service hot path reads: this adds an
+  auditable artifact, it does not add a hop to the presign path.
+- The access-service is unchanged for now. The artifact's value is that a
+  *second* enforcement point becomes possible without extending the D1
+  binding to it.
+
+The open question that decides the shape, and the reason this is a stage
+rather than a patch: **only the root can sign it.** The issuer of
+`root → device` is the root, so under UCAN semantics only the root (or a
+principal holding a delegated `ucan/revoke` capability) may revoke it. The
+account service does not hold the root key — it is derived from the
+passkey PRF on the user's own device and never leaves it. So either
+revocation becomes a root ceremony (passkey prompt, and a device without
+the passkey can no longer revoke — a UX regression that is also a real
+tightening), or the root delegates `ucan/revoke` to each device at link
+time (keeps today's UX, and means a stolen device can revoke its
+siblings). Pick before writing code. Plan:
+`2026-07-24-signed-revocation-artifacts.md`.
+
+Verified against the pinned dialog tag: `dialog-ucan-core` has no
+revocation type at all. Nothing upstream is needed — a revocation is an
+ordinary `Invocation` with command `["ucan", "revoke"]` and the CID in
+its arguments — but nothing upstream *verifies* it either, so the
+semantics live in this repo until dialog grows them.
+
 ### H — Service hardening (tracked debt from #625/#628)
+
+The first batch shipped in #640 (expiry enforcement, sanitized error text,
+the foreign-key pragma, the two negative tests). One item remains, added
+after R landed:
+
+- **Session delegations.** `root → device` is subject-open, command-open
+  and unexpiring — the most powerful thing the root can sign, held
+  indefinitely by every linked device. That shape is what forces
+  revocation to be a lookup: with no expiry there is nothing to *not*
+  renew. Split it in two. The `root → device` grant stays as it is (it is
+  what survives offline and what the registry records), but it is used to
+  mint a short-lived `device → session` delegation, and the session key is
+  what signs presign invocations. Revocation then degrades gracefully:
+  the registry check stops new sessions immediately, and an unreachable
+  registry costs at most one session lifetime rather than unbounded
+  access. This is the UCAN spec's own preference — *"Revocation SHOULD be
+  considered the last line of defense against abuse. Proactive expiry
+  through time bounds or other constraints SHOULD be preferred."*
+  Open questions for the plan: session TTL (hours, not minutes — it must
+  survive an offline stretch), whether renewal is a new account-service
+  endpoint or the device self-mints from the stored `root → device` grant
+  (self-minting needs no network and is preferred if the access-service
+  can enforce the expiry), and whether the access-service should *require*
+  a bounded invocation rather than merely accepting one, which is the
+  breaking half and wants a soak first.
+
+Shipped in #640:
 
 - Enforce **expiry on device-signed invocations** in `authorize` (the root
   path already enforces a 5-minute window; the device path checks nothing).
@@ -197,19 +287,27 @@ copy should say so).
 ## Sequencing
 
 ```
-#639 merge → H (hardening, account-service crate)
-           → R (revocation, access-service crate)   [H ∥ R, disjoint crates]
-           → D (device management: worker + UI + CLI)
-           → C (recovery ceremonies, three sub-stages)
-           → B (billing; blocked on user inputs)
+H (#640, merged) ∥ R (#641, merged)
+  → R' fail-closed + grace window (access-service)      [immediate]
+  → H' session delegations (identity + both services)   [R' ∥ H' after R']
+  → D (device management: worker + UI + CLI)
+  → S (signed revocation artifacts; needs D's revoke UX decision)
+  → C (recovery ceremonies, three sub-stages)
+  → B (billing; blocked on user inputs)
 F follow-ups and T debt interleave as small PRs whenever convenient.
-#618 refresh + merge and the #635 rename coordination are immediate,
-independent of the chain.
 ```
 
+R' is the correction to R's availability posture and carries no
+dependencies. H' (session delegations) should land before D so the device
+panel documents a bounded credential rather than an unexpiring one. S
+follows D because the root-vs-delegated-`ucan/revoke` decision is really a
+question about the revoke UX, and D is where that UX gets designed.
+
 H and R are planned in full (`2026-07-24-account-service-hardening.md`,
-`2026-07-24-revocation-enforcement.md`); D and C have plans at the same
-paths pattern (`2026-07-24-device-management.md`,
+`2026-07-24-revocation-enforcement.md`); S is planned in
+`2026-07-24-signed-revocation-artifacts.md`. H' needs a plan before
+execution — the open questions in its bullet decide the task list. D and C
+have plans at the same paths pattern (`2026-07-24-device-management.md`,
 `2026-07-24-recovery-ceremonies.md`) with verify-first gates where dialog
 APIs need confirmation. B gets its plan after the Stripe decisions.
 
@@ -225,8 +323,19 @@ APIs need confirmation. B gets its plan after the Stripe decisions.
   senders of device-signed invocations live in the worker (deployed with
   the service) — verified, not assumed, in the hardening plan. CLI link
   flow uses bearer-token endpoints and is unaffected.
-- **Fail-open revocation** leaves a revoked device a brief window during a
-  D1 outage — accepted by the master spec in exchange for sync
-  availability.
+- **Fail-closed revocation can refuse legitimate presigns.** A D1 outage
+  longer than the 10-minute grace window, or one that starts before a
+  client's credentials have ever been screened by the isolate serving it,
+  returns 503 and stops sync for those requests. This is the deliberate
+  inversion of R's original posture: the grace window is sized so a blip
+  costs nothing and a sustained outage degrades rather than silently
+  unenforces. Two things must hold for that trade to stay sound — clients
+  must treat 503 as retryable (verify before relying on it), and the
+  grace window must never be extended by failed queries (pinned by
+  `it_does_not_slide_the_grace_window_on_repeated_failures`).
+- **Revocation authority is a database write, not a signature**, until S
+  lands. Anyone who can write `ACCOUNTS_DB` can revoke or un-revoke with
+  no audit trail, and no other enforcement point can check revocation
+  without that same credential.
 - **Stage B scope creep.** The entitlement seam in R must stay a seam;
   billing lands only after the log-only soak the master spec requires.

--- a/rust/tonk-access-service/README.md
+++ b/rust/tonk-access-service/README.md
@@ -27,7 +27,15 @@ The handler reads the body, builds a `UcanAuthorizer` from the Worker environmen
 - `method`: HTTP method (GET, PUT, DELETE)
 - `headers`: headers to send with the request
 
-On failure it returns a JSON error (`{ "error": { "code", "message" } }`). Error codes map verification outcomes to HTTP status (see `src/error.rs`): `INVALID_ARGUMENT` (400); `SIGNATURE_INVALID` / `AUDIENCE_MISMATCH` / `INVOCATION_EXPIRED` (401); `CHAIN_INVALID` / `COMMAND_MISMATCH` / `SUBJECT_NOT_ALLOWED` (403); `INTERNAL_ERROR` (500).
+On failure it returns a JSON error (`{ "error": { "code", "message" } }`). Error codes map verification outcomes to HTTP status (see `src/error.rs`): `INVALID_ARGUMENT` (400); `SIGNATURE_INVALID` / `AUDIENCE_MISMATCH` / `INVOCATION_EXPIRED` (401); `CHAIN_INVALID` / `COMMAND_MISMATCH` / `SUBJECT_NOT_ALLOWED` / `DEVICE_REVOKED` (403); `INTERNAL_ERROR` (500); `REVOCATION_UNAVAILABLE` (503).
+
+## Revocation screening
+
+After cryptographic authorization succeeds, `POST /ucan/` screens the presented container against the account registry (`src/revocation.rs`). It re-parses the container independently, collects every delegation CID, every delegation issuer DID, and the invocation issuer DID, and asks whether any of them belongs to a device with `status = 'revoked'`. Matching on issuer DIDs as well as CIDs is what severs chains that flow through a delegation the registry never recorded — anything a revoked key signed, whenever it signed it. A match returns `403 DEVICE_REVOKED`; users with no account match nothing and are unaffected.
+
+The screen **fails closed**. A verdict is authoritative for 60 seconds (`REVOCATION_TTL_MS`) and then usable for a further 10 minutes (`REVOCATION_GRACE_MS`) *only* to cover an unreachable registry, so a brief D1 outage stops chains the isolate has never cleared rather than stopping active sync. Outside that window — and for an unparseable container or a missing `ACCOUNTS_DB` binding — the request gets `503 REVOCATION_UNAVAILABLE`, which clients should treat as retryable. Failed queries are never cached, so the grace window is anchored to the last successful lookup.
+
+Operationally this means a misconfigured `ACCOUNTS_DB` binding **stops presigns** rather than silently disabling enforcement. That is deliberate. Verify the binding after any change to `wrangler.toml`.
 
 ## Configuration
 
@@ -37,6 +45,7 @@ The authorizer is constructed per request from the Worker environment (`src/hand
 - `R2_BUCKET_NAME` (var): target bucket
 - `R2_ACCESS_KEY_ID` (secret): R2 access key
 - `R2_SECRET_ACCESS_KEY` (secret): R2 secret key
+- `ACCOUNTS_DB` (D1 binding): read-only view of the account registry, owned and migrated by `tonk-account-service`. Never write through it; this crate issues nothing but `SELECT`.
 
 The S3 address uses region `auto`, as R2 requires.
 

--- a/rust/tonk-access-service/src/error.rs
+++ b/rust/tonk-access-service/src/error.rs
@@ -27,6 +27,13 @@ pub enum ErrorCode {
 
     // 500 Internal Server Error
     InternalError,
+
+    // 503 Service Unavailable - the revocation registry could not be
+    // consulted and no cached verdict covers the request. Retryable,
+    // unlike the 403s above. Same wasm-only construction as
+    // `DeviceRevoked`.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    RevocationUnavailable,
 }
 
 impl ErrorCode {
@@ -49,6 +56,9 @@ impl ErrorCode {
 
             // 500 Internal Server Error
             ErrorCode::InternalError => 500,
+
+            // 503 Service Unavailable
+            ErrorCode::RevocationUnavailable => 503,
         }
     }
 }

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -58,7 +58,7 @@ async fn handle_inner(
 
     // 3b. Screen the presented credentials against revoked devices.
     // Runs only after cryptographic authorization succeeded, and fails
-    // open: registry trouble must never take sync down.
+    // closed: a presign the screen cannot clear is refused.
     #[cfg(target_arch = "wasm32")]
     screen_revoked(&body_bytes, ctx).await?;
 
@@ -90,25 +90,26 @@ async fn screen_revoked(
     let presented = match revocation::collect_presented(body_bytes) {
         Ok(presented) => presented,
         Err(err) => {
-            // The authorizer already accepted this container; a parse
-            // failure here is a shape drift to surface, not a reason to
-            // block the request.
-            console_error!("revocation screen skipped, container unparseable: {err}");
-            return Ok(());
+            // The authorizer already accepted this container, so a parse
+            // failure here is shape drift between two parsers of the same
+            // bytes. There is no key set to screen and no cached verdict
+            // to fall back on, so the request cannot be cleared.
+            console_error!("revocation screen unavailable, container unparseable: {err}");
+            return Err(unavailable());
         }
     };
     let registry = match ctx.d1("ACCOUNTS_DB") {
         Ok(db) => D1RevocationRegistry::new(db),
         Err(err) => {
-            console_error!("revocation screen skipped, no ACCOUNTS_DB binding: {err}");
-            return Ok(());
+            console_error!("revocation screen unavailable, no ACCOUNTS_DB binding: {err}");
+            return Err(unavailable());
         }
     };
     let now_ms = Date::now().as_millis();
     match revocation::assess(&registry, &presented, now_ms).await {
         RevocationVerdict::Allowed => Ok(()),
-        RevocationVerdict::AllowedFailOpen(reason) => {
-            console_error!("revocation screen failed open: {reason}");
+        RevocationVerdict::AllowedStale(reason) => {
+            console_error!("revocation registry unreachable, serving cached verdicts: {reason}");
             Ok(())
         }
         RevocationVerdict::Revoked => {
@@ -118,7 +119,22 @@ async fn screen_revoked(
                 "a credential in the presented chain has been revoked",
             ))
         }
+        RevocationVerdict::Unavailable(reason) => {
+            console_error!("presign refused, revocation registry unreachable: {reason}");
+            Err(unavailable())
+        }
     }
+}
+
+/// The client-facing 503. The reason stays in the logs: it names
+/// internal infrastructure and the caller can do nothing with it but
+/// retry.
+#[cfg(target_arch = "wasm32")]
+fn unavailable() -> ServiceError {
+    ServiceError::new(
+        ErrorCode::RevocationUnavailable,
+        "revocation registry unavailable, retry shortly",
+    )
 }
 
 /// Create UcanAuthorizer from environment configuration.

--- a/rust/tonk-access-service/src/revocation.rs
+++ b/rust/tonk-access-service/src/revocation.rs
@@ -7,6 +7,12 @@
 //! account registry. The decision logic here is pure and natively
 //! tested; D1 glue lives in d1 and is wasm-only.
 //!
+//! An unreachable registry fails closed: a presign the screen cannot
+//! clear is refused. The cache softens that without weakening it —
+//! credentials the registry cleared recently keep working through a
+//! grace window past their TTL, so a brief D1 outage stops unseen
+//! chains rather than active sync.
+//!
 //! An entitlement lookup for billing later extends the registry trait
 //! (or adds a sibling) — the collection and decision shapes here stay
 //! as they are.
@@ -85,47 +91,74 @@ pub fn collect_presented(container_bytes: &[u8]) -> Result<PresentedCredentials,
     })
 }
 
-/// How long a revocation verdict may be served from the per-isolate
-/// cache. Short on purpose: this bounds how stale enforcement can be,
-/// and the design accepts up to a minute of lag after a revoke.
+/// How long a verdict is authoritative: within this window the screen
+/// answers from cache without touching the registry. Short on purpose —
+/// it bounds how stale enforcement can be, and the design accepts up to
+/// a minute of lag after a revoke.
 pub const REVOCATION_TTL_MS: u64 = 60_000;
+
+/// How long past its TTL a verdict may still cover an unreachable
+/// registry. Inside this window the screen serves what the registry
+/// last told it; outside it, an unanswerable request is refused. This
+/// is the whole width of the fail-closed exemption, so it is measured
+/// from the last *successful* query and never extended by a failure.
+pub const REVOCATION_GRACE_MS: u64 = 600_000;
 
 /// A cached per-key verdict.
 #[derive(Debug, Clone, Copy)]
 pub struct CachedVerdict {
     /// Whether the key matched a revoked device when last queried.
     pub revoked: bool,
-    /// Absolute expiry, in the caller's millisecond clock.
+    /// When this verdict stops being authoritative, in the caller's
+    /// millisecond clock. It survives in the cache for
+    /// [`REVOCATION_GRACE_MS`] beyond that, usable only to cover a
+    /// registry outage.
     pub expires_at_ms: u64,
 }
 
 /// The result of probing the cache for a key set.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CacheProbe {
-    /// True if any key has a live cached `revoked = true` verdict.
+    /// True if any key is cached as revoked, fresh or stale. Revocation
+    /// is monotone — the registry has no un-revoke — so a stale revoked
+    /// verdict can only have become more true.
     pub cached_revoked: bool,
-    /// Keys with no live cached verdict, needing a registry query.
+    /// Keys with no authoritative verdict, needing a registry query.
     pub misses: Vec<String>,
+    /// True if every miss still has a stale in-grace verdict, so an
+    /// unreachable registry can be covered from what was last learned.
+    pub stale_cover: bool,
 }
 
-/// Probe `map` for `keys` at `now_ms`, evicting expired entries.
+/// Probe `map` for `keys` at `now_ms`, dropping entries past the grace
+/// window. Entries between their TTL and the grace boundary count as
+/// misses — they are re-queried — but leave `stale_cover` intact.
 pub fn split_with(
     map: &mut HashMap<String, CachedVerdict>,
     keys: &[String],
     now_ms: u64,
 ) -> CacheProbe {
-    map.retain(|_, verdict| verdict.expires_at_ms > now_ms);
+    map.retain(|_, verdict| verdict.expires_at_ms + REVOCATION_GRACE_MS > now_ms);
     let mut cached_revoked = false;
     let mut misses = Vec::new();
+    let mut stale_cover = true;
     for key in keys {
         match map.get(key) {
-            Some(verdict) => cached_revoked |= verdict.revoked,
-            None => misses.push(key.clone()),
+            Some(verdict) if verdict.expires_at_ms > now_ms => cached_revoked |= verdict.revoked,
+            Some(verdict) => {
+                cached_revoked |= verdict.revoked;
+                misses.push(key.clone());
+            }
+            None => {
+                misses.push(key.clone());
+                stale_cover = false;
+            }
         }
     }
     CacheProbe {
         cached_revoked,
         misses,
+        stale_cover,
     }
 }
 
@@ -163,8 +196,8 @@ pub fn cache_record(queried: &[String], revoked: &[String], now_ms: u64) {
     VERDICTS.with(|cell| store_with(&mut cell.borrow_mut(), queried, revoked, now_ms));
 }
 
-/// A registry lookup failure. The presign path treats any of these as
-/// fail-open: log and allow, per the design's availability posture.
+/// A registry lookup failure. The presign path refuses the request
+/// unless the cache still covers every presented credential.
 #[derive(Debug)]
 pub struct RegistryError(pub String);
 
@@ -207,15 +240,23 @@ pub trait RevocationRegistry {
 pub enum RevocationVerdict {
     /// No presented credential is revoked.
     Allowed,
-    /// The registry could not answer; allowed by the fail-open posture.
-    /// Carries the reason for logging.
-    AllowedFailOpen(String),
+    /// The registry could not answer, but it cleared every presented
+    /// credential recently enough to stand in. Carries the reason for
+    /// logging.
+    AllowedStale(String),
     /// A presented credential belongs to a revoked device.
     Revoked,
+    /// The registry could not answer and the cache does not cover the
+    /// presented credentials. Carries the reason for logging.
+    Unavailable(String),
 }
 
 /// Screen presented credentials against the registry, through the
-/// per-isolate verdict cache. Fail-open results are never cached.
+/// per-isolate verdict cache.
+///
+/// A failed query is never recorded, which is what keeps the grace
+/// window anchored to the last successful one: repeated failures cannot
+/// walk it forward.
 pub async fn assess<R: RevocationRegistry>(
     registry: &R,
     presented: &PresentedCredentials,
@@ -238,7 +279,8 @@ pub async fn assess<R: RevocationRegistry>(
                 RevocationVerdict::Revoked
             }
         }
-        Err(err) => RevocationVerdict::AllowedFailOpen(err.to_string()),
+        Err(err) if probe.stale_cover => RevocationVerdict::AllowedStale(err.to_string()),
+        Err(err) => RevocationVerdict::Unavailable(err.to_string()),
     }
 }
 
@@ -416,6 +458,10 @@ mod tests {
 
         assert!(!probe.cached_revoked);
         assert_eq!(probe.misses, keys);
+        assert!(
+            !probe.stale_cover,
+            "keys never seen cannot cover a registry outage"
+        );
     }
 
     #[dialog_common::test]
@@ -431,7 +477,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_expires_cached_verdicts_after_ttl() {
+    async fn it_re_queries_a_verdict_past_its_ttl_but_keeps_it_as_cover() {
         let mut map = HashMap::new();
         let keys = vec!["a".to_string()];
         store_with(&mut map, &keys, &[], 1_000);
@@ -439,7 +485,39 @@ mod tests {
         let probe = split_with(&mut map, &keys, 1_000 + REVOCATION_TTL_MS + 1);
 
         assert!(!probe.cached_revoked);
+        assert_eq!(probe.misses, keys, "a stale verdict is still re-queried");
+        assert!(probe.stale_cover);
+    }
+
+    #[dialog_common::test]
+    async fn it_drops_verdicts_past_the_grace_window() {
+        let mut map = HashMap::new();
+        let keys = vec!["a".to_string()];
+        store_with(&mut map, &keys, &[], 1_000);
+
+        let probe = split_with(
+            &mut map,
+            &keys,
+            1_000 + REVOCATION_TTL_MS + REVOCATION_GRACE_MS + 1,
+        );
+
         assert_eq!(probe.misses, keys);
+        assert!(!probe.stale_cover);
+        assert!(map.is_empty(), "the entry is evicted, not merely ignored");
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_a_stale_revoked_verdict_binding() {
+        let mut map = HashMap::new();
+        let keys = vec!["a".to_string()];
+        store_with(&mut map, &keys, &["a".to_string()], 1_000);
+
+        let probe = split_with(&mut map, &keys, 1_000 + REVOCATION_TTL_MS + 1);
+
+        assert!(
+            probe.cached_revoked,
+            "revocation is monotone: a stale revoked verdict still binds"
+        );
     }
 
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -518,12 +596,83 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_fails_open_when_the_registry_errors() {
+    async fn it_fails_closed_when_the_registry_errors_on_unseen_credentials() {
         let registry = StubRegistry::failing();
 
         let verdict = assess(&registry, &presented("outage"), 1_000).await;
 
-        assert!(matches!(verdict, RevocationVerdict::AllowedFailOpen(_)));
+        assert!(matches!(verdict, RevocationVerdict::Unavailable(_)));
+    }
+
+    #[dialog_common::test]
+    async fn it_serves_a_stale_verdict_while_the_registry_is_unreachable() {
+        let credentials = presented("grace");
+        let cleared = assess(&StubRegistry::revoking(&[]), &credentials, 1_000).await;
+
+        let during_outage = assess(
+            &StubRegistry::failing(),
+            &credentials,
+            1_000 + REVOCATION_TTL_MS + 1,
+        )
+        .await;
+
+        assert!(matches!(cleared, RevocationVerdict::Allowed));
+        assert!(
+            matches!(during_outage, RevocationVerdict::AllowedStale(_)),
+            "credentials the registry cleared recently ride out the outage"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_closed_once_the_grace_window_lapses() {
+        let credentials = presented("lapsed");
+        let _ = assess(&StubRegistry::revoking(&[]), &credentials, 1_000).await;
+
+        let verdict = assess(
+            &StubRegistry::failing(),
+            &credentials,
+            1_000 + REVOCATION_TTL_MS + REVOCATION_GRACE_MS + 1,
+        )
+        .await;
+
+        assert!(matches!(verdict, RevocationVerdict::Unavailable(_)));
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_slide_the_grace_window_on_repeated_failures() {
+        let credentials = presented("slide");
+        let _ = assess(&StubRegistry::revoking(&[]), &credentials, 1_000).await;
+        let registry = StubRegistry::failing();
+
+        let inside = assess(&registry, &credentials, 1_000 + REVOCATION_TTL_MS + 1).await;
+        let outside = assess(
+            &registry,
+            &credentials,
+            1_000 + REVOCATION_TTL_MS + REVOCATION_GRACE_MS + 1,
+        )
+        .await;
+
+        assert!(matches!(inside, RevocationVerdict::AllowedStale(_)));
+        assert!(
+            matches!(outside, RevocationVerdict::Unavailable(_)),
+            "grace is measured from the last successful query, not the last attempt"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_revoking_a_stale_credential_during_an_outage() {
+        let credentials = presented("stalehit");
+        let cid = credentials.delegation_cids[0].clone();
+        let _ = assess(&StubRegistry::revoking(&[&cid]), &credentials, 1_000).await;
+
+        let verdict = assess(
+            &StubRegistry::failing(),
+            &credentials,
+            1_000 + REVOCATION_TTL_MS + 1,
+        )
+        .await;
+
+        assert!(matches!(verdict, RevocationVerdict::Revoked));
     }
 
     #[dialog_common::test]
@@ -544,7 +693,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_does_not_cache_a_fail_open_allowance() {
+    async fn it_does_not_cache_an_unavailable_verdict() {
         let registry = StubRegistry::failing();
         let credentials = presented("nocache");
 
@@ -554,7 +703,7 @@ mod tests {
         assert_eq!(
             registry.queries.load(Ordering::SeqCst),
             2,
-            "a fail-open result must not be served from cache"
+            "a failed query must leave no trace in the cache"
         );
     }
 


### PR DESCRIPTION
## Summary

Inverts #641's availability posture. Fail-open made the security property conditional on configuration — a renamed `ACCOUNTS_DB` binding disabled enforcement with only a log line, and any D1 outage restored full storage access to revoked devices for its duration.

The cache is what makes fail-closed affordable, so it grew a second boundary rather than a new mechanism.

## How it works

- A verdict is **authoritative for 60s** (`REVOCATION_TTL_MS`, unchanged), then survives a further **10 minutes** (`REVOCATION_GRACE_MS`) usable *only* to cover an unreachable registry. Credentials the registry cleared recently ride out a blip; a D1 outage stops chains the isolate has never cleared rather than stopping active sync.
- Everything the screen cannot clear returns **503 `REVOCATION_UNAVAILABLE`** — retryable, and deliberately distinct from the 403. That covers the two paths that previously skipped silently: an unparseable container and a missing `ACCOUNTS_DB` binding. A misconfigured binding now stops presigns loudly.
- `RevocationVerdict` went from three arms to four: `Allowed`, `AllowedStale(reason)`, `Revoked`, `Unavailable(reason)`. The client-facing 503 message is generic; the reason stays in the logs, matching the error-sanitization posture from #640.
- **A failed query is still never cached.** This is the load-bearing detail: it anchors the grace window to the last *successful* lookup, so repeated failures cannot walk it forward. Without it, fail-closed is decorative.
- Stale revoked verdicts still bind. Revocation is monotone — the registry has no un-revoke — so a stale `revoked = true` can only have become more true.

## Testing

Executed and green: `cargo test -p tonk-access-service --features helpers` (20 tests, up from 16), workspace `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `cargo check -p tonk-access-service --target wasm32-unknown-unknown`.

New coverage: stale-serve during an outage, fail-closed on unseen credentials, fail-closed once grace lapses, grace not sliding on repeated failures, a stale revoked verdict still revoking, and the cache probe's fresh/stale/evicted boundaries.

## Deploy note

Enforcement now depends on the `ACCOUNTS_DB` binding being present and correct — that is the point, but it means a bad binding is an outage rather than a silent no-op. Verify the binding on staging before this reaches production, and re-run #641's fail-open drill inverted: rename the binding, confirm presigns return 503, restore.

## Docs

Also records session delegations under stage H, adds stage S (signed revocation artifacts) with a plan, and documents the screen in the access-service README, which #641 never updated. Stage S blocks on one decision: under UCAN semantics only the root can revoke `root → device`, and the service never holds the root key.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the revocation mechanism in the `tonk-access-service` to ensure a fail-closed approach during registry outages, introducing a new `RevocationUnavailable` error code, and refining the handling of cached verdicts.

### Detailed summary
- Added `RevocationUnavailable` to `ErrorCode` with HTTP status 503.
- Changed comments and logic in `screen_revoked` to reflect fail-closed behavior.
- Updated `assess` function to handle `Unavailable` verdicts.
- Revised caching logic to ensure stale verdicts are managed correctly.
- Modified tests to validate the new fail-closed behavior and caching mechanisms.
- Enhanced documentation regarding the revocation process and error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->