### PR TITLE
feat(account): surviving-device recovery (recovery stage 2 of 3)

### DIFF
--- a/rust/tonk-account-service/src/core.rs
+++ b/rust/tonk-account-service/src/core.rs
@@ -15,6 +15,7 @@ pub mod codes;
 pub mod delegation;
 pub mod devices;
 pub mod links;
+pub mod recovery;
 pub mod rotation;
 
 /// Errors shared by every ceremony in this crate.

--- a/rust/tonk-account-service/src/core/recovery.rs
+++ b/rust/tonk-account-service/src/core/recovery.rs
@@ -1,0 +1,264 @@
+//! Surviving-device recovery: a linked device plus a freshly created
+//! passkey re-anchor the account when the old passkey is gone.
+
+use crate::auth::Caller;
+use crate::core::CeremonyError;
+use crate::core::delegation::check_subject_open_delegation;
+use crate::store::Store;
+
+/// Flip `caller.account` onto `new_root_did` under the authority of one
+/// of its active devices plus proof of control of the new root.
+///
+/// The surviving device's row is repointed at its fresh
+/// `newRoot → device` delegation so it can keep making device-signed
+/// calls; every other device keeps its old-root delegation (still valid
+/// for space access) and re-links on its next ceremony. The old passkey
+/// credential is superseded: the registry no longer honors the root it
+/// derives.
+pub async fn recover_account<S: Store>(
+    store: &S,
+    caller: &Caller,
+    new_root_did: &str,
+    new_credential_id: &str,
+    device_delegation_hex: &str,
+) -> Result<(), CeremonyError> {
+    let delegation_cid = check_subject_open_delegation(
+        device_delegation_hex,
+        new_root_did,
+        &caller.device.device_did,
+    )
+    .await?;
+    let repointed = store
+        .update_device_delegation(
+            caller.account.id,
+            &caller.device.device_did,
+            &delegation_cid,
+        )
+        .await?;
+    if !repointed {
+        return Err(CeremonyError::Invalid(
+            "surviving device is not registered under this account".to_string(),
+        ));
+    }
+    store
+        .rotate_root(caller.account.id, new_root_did, new_credential_id)
+        .await?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::auth::authorize;
+    use crate::store::sqlite::SqliteStore;
+    use crate::store::{Device, DeviceStatus, Store};
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::promise::Promised;
+    use dialog_ucan_core::time::timestamp::Timestamp;
+    use dialog_ucan_core::{InvocationBuilder, InvocationChain};
+    use dialog_varsig::Principal;
+    use std::collections::BTreeMap;
+
+    const OLD_ROOT_PRF: [u8; 32] = [7u8; 32];
+    const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
+    const DEVICE_SEED: [u8; 32] = [8u8; 32];
+
+    /// Build the device-signed recovery container: subject = the old
+    /// root, issuer = the surviving device, proof = its existing
+    /// `oldRoot → device` delegation — the same `container(...)` shape
+    /// as `auth.rs`'s test module.
+    async fn container(
+        old_root: Ed25519Signer,
+        device: Ed25519Signer,
+        args: BTreeMap<String, Promised>,
+    ) -> Vec<u8> {
+        let old_root_did = old_root.did();
+        let chain = tonk_identity::delegation::mint_device_delegation(old_root, &device.did())
+            .await
+            .unwrap();
+        let delegation = chain.proofs().last().unwrap().clone();
+        let cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(device)
+            .audience(&old_root_did)
+            .subject(&old_root_did)
+            .command(vec!["account".into(), "recover".into()])
+            .arguments(args)
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let mut proofs = std::collections::HashMap::new();
+        proofs.insert(cid, std::sync::Arc::new(delegation));
+        InvocationChain::new(invocation, proofs).to_bytes().unwrap()
+    }
+
+    fn recovery_args(
+        new_root_did: &str,
+        new_credential_id: &str,
+        device_delegation_hex: &str,
+    ) -> BTreeMap<String, Promised> {
+        let mut args = BTreeMap::new();
+        args.insert(
+            "newRootDid".to_string(),
+            Promised::String(new_root_did.to_string()),
+        );
+        args.insert(
+            "newCredentialId".to_string(),
+            Promised::String(new_credential_id.to_string()),
+        );
+        args.insert(
+            "deviceDelegation".to_string(),
+            Promised::String(device_delegation_hex.to_string()),
+        );
+        args
+    }
+
+    /// Seed an account (root PRF `[7u8; 32]`) with one active device
+    /// (seed `[8u8; 32]`).
+    async fn fixture(store: &SqliteStore) -> (Ed25519Signer, Ed25519Signer, String, String) {
+        let old_root = tonk_identity::derive::derive_root_signer(&OLD_ROOT_PRF)
+            .await
+            .unwrap();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let old_root_did = old_root.did().to_string();
+        let device_did = device.did().to_string();
+
+        let id = store
+            .create_account("a@x.com", &old_root_did, "cred-old", 100)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                account_id: id,
+                device_did: device_did.clone(),
+                delegation_cid: "bafyOld".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 100,
+            })
+            .await
+            .unwrap();
+
+        (old_root, device, old_root_did, device_did)
+    }
+
+    #[dialog_common::test]
+    async fn it_flips_the_root_under_device_and_new_root_authority() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (old_root, device, _old_root_did, device_did) = fixture(&store).await;
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let new_root_did = new_root.did().to_string();
+
+        let device_delegation =
+            tonk_identity::delegation::mint_device_delegation(new_root, &device.did())
+                .await
+                .unwrap();
+        let device_delegation_hex = hex::encode(device_delegation.to_bytes().unwrap());
+
+        let args = recovery_args(&new_root_did, "cred-new", &device_delegation_hex);
+        let bytes = container(old_root, device, args).await;
+        let caller = authorize(&store, &bytes, &["account", "recover"])
+            .await
+            .unwrap();
+        let account_id = caller.account.id;
+
+        recover_account(
+            &store,
+            &caller,
+            &new_root_did,
+            "cred-new",
+            &device_delegation_hex,
+        )
+        .await
+        .unwrap();
+
+        let rotated = store.account_by_root(&new_root_did).await.unwrap().unwrap();
+        assert_eq!(rotated.id, account_id);
+        assert_eq!(rotated.credential_id, "cred-new");
+        let repointed = store.device_by_did(&device_did).await.unwrap().unwrap();
+        assert_ne!(repointed.delegation_cid, "bafyOld");
+        assert_eq!(repointed.status, DeviceStatus::Active);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_delegation_not_issued_by_the_new_root() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (old_root, device, old_root_did, _device_did) = fixture(&store).await;
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let new_root_did = new_root.did().to_string();
+        let stranger = tonk_identity::derive::derive_root_signer(&[13u8; 32])
+            .await
+            .unwrap();
+
+        // Bogus deviceDelegation minted by a third key, not the new root.
+        let bogus = tonk_identity::delegation::mint_device_delegation(stranger, &device.did())
+            .await
+            .unwrap();
+        let bogus_hex = hex::encode(bogus.to_bytes().unwrap());
+
+        let args = recovery_args(&new_root_did, "cred-new", &bogus_hex);
+        let bytes = container(old_root, device, args).await;
+        let caller = authorize(&store, &bytes, &["account", "recover"])
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            recover_account(&store, &caller, &new_root_did, "cred-new", &bogus_hex).await,
+            Err(CeremonyError::Invalid(_))
+        ));
+        // Account untouched.
+        assert!(
+            store
+                .account_by_root(&old_root_did)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_revoked_surviving_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (old_root, device, _old_root_did, device_did) = fixture(&store).await;
+        let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+            .await
+            .unwrap();
+        let new_root_did = new_root.did().to_string();
+        let device_delegation =
+            tonk_identity::delegation::mint_device_delegation(new_root, &device.did())
+                .await
+                .unwrap();
+        let device_delegation_hex = hex::encode(device_delegation.to_bytes().unwrap());
+
+        let args = recovery_args(&new_root_did, "cred-new", &device_delegation_hex);
+        let bytes = container(old_root, device, args).await;
+        let caller = authorize(&store, &bytes, &["account", "recover"])
+            .await
+            .unwrap();
+
+        // The device row is revoked only after the Caller has already
+        // been constructed: the repoint itself must catch this.
+        store
+            .revoke_device(caller.account.id, &device_did)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            recover_account(
+                &store,
+                &caller,
+                &new_root_did,
+                "cred-new",
+                &device_delegation_hex
+            )
+            .await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
+}

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -15,6 +15,8 @@ pub mod devices;
 #[cfg(target_arch = "wasm32")]
 pub mod links;
 #[cfg(target_arch = "wasm32")]
+pub mod recover;
+#[cfg(target_arch = "wasm32")]
 pub mod rotate;
 
 /// Add CORS headers permitting cross-origin requests to a response.

--- a/rust/tonk-account-service/src/handlers/recover.rs
+++ b/rust/tonk-account-service/src/handlers/recover.rs
@@ -1,0 +1,98 @@
+//! `POST /accounts/recover`: flip an account onto a freshly created
+//! passkey root under the authority of a surviving device, with proof of
+//! control of the new root.
+
+use serde::Deserialize;
+use worker::*;
+
+use crate::auth::{authorize, authorize_root, required_string};
+use crate::core::recovery::recover_account;
+use crate::error::{ErrorCode, ServiceError};
+use crate::handlers::{build_store, ceremony_error, with_cors_headers};
+
+#[derive(Deserialize)]
+struct RecoverBody {
+    recovery: String,
+    confirmation: String,
+}
+
+/// `OPTIONS /accounts/recover` → CORS preflight.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /accounts/recover` → recover an account onto a new root under
+/// surviving-device authority.
+pub async fn handle(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body: RecoverBody = req
+        .json()
+        .await
+        .map_err(|err| ServiceError::new(ErrorCode::InvalidArgument, format!("bad body: {err}")))?;
+    let recovery_bytes = hex::decode(&body.recovery).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad recovery hex: {err}"),
+        )
+    })?;
+    let confirmation_bytes = hex::decode(&body.confirmation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad confirmation hex: {err}"),
+        )
+    })?;
+
+    // `authorize` needs the store to resolve the device-signed
+    // container's subject/issuer onto an account and device, so it must
+    // be built before authorization here (unlike the root-signed-only
+    // rotation handler).
+    let store = build_store(ctx)?;
+
+    let caller = authorize(&store, &recovery_bytes, &["account", "recover"])
+        .await
+        .map_err(ceremony_error)?;
+    let confirm = authorize_root(&confirmation_bytes, &["account", "recover", "confirm"])
+        .await
+        .map_err(ceremony_error)?;
+
+    // Each container must name the other's principal.
+    let claimed_new_root =
+        required_string(&caller.arguments, "newRootDid").map_err(ceremony_error)?;
+    let claimed_old_root =
+        required_string(&confirm.arguments, "oldRootDid").map_err(ceremony_error)?;
+    if claimed_new_root != confirm.root_did || claimed_old_root != caller.account.root_did {
+        return Err(ServiceError::new(
+            ErrorCode::Forbidden,
+            "recovery and confirmation containers do not name each other",
+        ));
+    }
+
+    let new_credential_id =
+        required_string(&caller.arguments, "newCredentialId").map_err(ceremony_error)?;
+    let device_delegation_hex =
+        required_string(&caller.arguments, "deviceDelegation").map_err(ceremony_error)?;
+
+    recover_account(
+        &store,
+        &caller,
+        &claimed_new_root,
+        &new_credential_id,
+        &device_delegation_hex,
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    Response::from_json(&serde_json::json!({})).map_err(|err| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {err}"))
+    })
+}

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -29,6 +29,7 @@ use crate::core::backup::{get_chain, list_chains, put_chain};
 use crate::core::codes::{generate_code, request_code};
 use crate::core::devices::{DeviceView, list_devices, register_device, revoke_device};
 use crate::core::links::{complete_link, consume_link, create_link, resolve_link};
+use crate::core::recovery::recover_account;
 use crate::core::rotation::{RotateAccount, rotate_account};
 use crate::email::CapturedEmail;
 use crate::error::{ErrorCode, ServiceError};
@@ -131,6 +132,7 @@ async fn handle_request(
         (Method::POST, "/codes") => codes_route(req, &backends).await,
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
         (Method::POST, "/accounts/rotate") => accounts_rotate_route(req, &backends).await,
+        (Method::POST, "/accounts/recover") => accounts_recover_route(req, &backends).await,
         (Method::POST, "/devices/list") => devices_list_route(req, &backends).await,
         (Method::POST, "/devices/register") => devices_register_route(req, &backends).await,
         (Method::POST, "/devices/link") => devices_link_route(req, &backends).await,
@@ -314,6 +316,70 @@ async fn accounts_rotate_route(
     rotate_account(&backends.store, &account, &request)
         .await
         .map_err(ceremony_error)?;
+
+    Ok(json_response(StatusCode::OK, &serde_json::json!({})))
+}
+
+/// `POST /accounts/recover` → recover an account onto a freshly created
+/// passkey root, under the authority of a surviving device plus proof of
+/// control of the new root.
+async fn accounts_recover_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    #[derive(Deserialize)]
+    struct RecoverRequest {
+        recovery: String,
+        confirmation: String,
+    }
+
+    let body: RecoverRequest = parse_json(req).await?;
+    let recovery_bytes = hex::decode(&body.recovery).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad recovery hex: {err}"),
+        )
+    })?;
+    let confirmation_bytes = hex::decode(&body.confirmation).map_err(|err| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("bad confirmation hex: {err}"),
+        )
+    })?;
+
+    let caller = authorize(&backends.store, &recovery_bytes, &["account", "recover"])
+        .await
+        .map_err(ceremony_error)?;
+    let confirm = authorize_root(&confirmation_bytes, &["account", "recover", "confirm"])
+        .await
+        .map_err(ceremony_error)?;
+
+    // Each container must name the other's principal.
+    let claimed_new_root =
+        required_string(&caller.arguments, "newRootDid").map_err(ceremony_error)?;
+    let claimed_old_root =
+        required_string(&confirm.arguments, "oldRootDid").map_err(ceremony_error)?;
+    if claimed_new_root != confirm.root_did || claimed_old_root != caller.account.root_did {
+        return Err(ServiceError::new(
+            ErrorCode::Forbidden,
+            "recovery and confirmation containers do not name each other",
+        ));
+    }
+
+    let new_credential_id =
+        required_string(&caller.arguments, "newCredentialId").map_err(ceremony_error)?;
+    let device_delegation_hex =
+        required_string(&caller.arguments, "deviceDelegation").map_err(ceremony_error)?;
+
+    recover_account(
+        &backends.store,
+        &caller,
+        &claimed_new_root,
+        &new_credential_id,
+        &device_delegation_hex,
+    )
+    .await
+    .map_err(ceremony_error)?;
 
     Ok(json_response(StatusCode::OK, &serde_json::json!({})))
 }

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -34,6 +34,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/accounts", handlers::accounts::handle_options)
         .post_async("/accounts/rotate", handlers::rotate::handle)
         .options_async("/accounts/rotate", handlers::rotate::handle_options)
+        .post_async("/accounts/recover", handlers::recover::handle)
+        .options_async("/accounts/recover", handlers::recover::handle_options)
         .post_async("/devices/list", handlers::devices::handle_list)
         .options_async("/devices/list", handlers::devices::handle_options)
         .post_async("/devices/register", handlers::devices::handle_register)

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -200,8 +200,9 @@ pub trait Store {
         new_credential_id: &str,
     ) -> Result<(), StoreError>;
 
-    /// Repoint one device row at a fresh delegation CID. Returns `false`
-    /// if no matching device was found.
+    /// Repoint one *active* device row at a fresh delegation CID.
+    /// Returns `false` if no matching active device was found — in
+    /// particular, a revoked device never matches.
     async fn update_device_delegation(
         &self,
         account_id: i64,
@@ -297,9 +298,11 @@ pub const UPDATE_DEVICE_REVOKE: &str =
 pub const UPDATE_ACCOUNT_ROOT: &str =
     "UPDATE accounts SET root_did = ?2, credential_id = ?3 WHERE id = ?1";
 
-/// SQL: repoint one device row at a fresh delegation.
-pub const UPDATE_DEVICE_DELEGATION: &str =
-    "UPDATE devices SET delegation_cid = ?3 WHERE account_id = ?1 AND device_did = ?2";
+/// SQL: repoint one active device row at a fresh delegation. Revoked
+/// devices never match, so a revoked device can never drive a
+/// rotation or recovery ceremony back into the registry.
+pub const UPDATE_DEVICE_DELEGATION: &str = "UPDATE devices SET delegation_cid = ?3 \
+     WHERE account_id = ?1 AND device_did = ?2 AND status = 'active'";
 
 /// SQL: repoint an active device row at a fresh delegation and name, on
 /// re-registration. Revoked devices never match, so a revoked device

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -639,54 +639,36 @@ async fn it_recovers_the_account_via_surviving_device_and_new_root_over_http() {
     let device_link = tonk_identity::delegation::mint_device_delegation(old_root, &device_b.did())
         .await
         .unwrap();
-    let fresh_delegation =
-        tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
-            .await
-            .unwrap();
-    let device_delegation_hex = hex::encode(fresh_delegation.to_bytes().unwrap());
 
-    let mut recovery_args = BTreeMap::new();
-    recovery_args.insert(
-        "newRootDid".to_string(),
-        Promised::String(new_root_did.clone()),
-    );
-    recovery_args.insert(
-        "newCredentialId".to_string(),
-        Promised::String("cred-recovered".to_string()),
-    );
-    recovery_args.insert(
-        "deviceDelegation".to_string(),
-        Promised::String(device_delegation_hex.clone()),
-    );
-    let recovery_bytes = tonk_identity::request::build_device_invocation(
-        device_b,
-        &device_link,
-        vec!["account".into(), "recover".into()],
-        recovery_args,
+    // The production ceremony builder produces the new-root-signed half
+    // (confirmation) plus the fresh device delegation; the production
+    // request builder wraps that into the device-signed half (recovery),
+    // proved by the OLD root's link to device B.
+    let recovery_ceremony = tonk_identity::ceremony::recover_account(
+        new_root,
+        "cred-recovered".to_string(),
+        old_root_did.clone(),
+        device_b.did(),
     )
     .await
     .unwrap();
+    assert_eq!(recovery_ceremony.new_root_did, new_root_did);
 
-    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
-        .await
-        .unwrap();
-    let mut confirmation_args = BTreeMap::new();
-    confirmation_args.insert(
-        "oldRootDid".to_string(),
-        Promised::String(old_root_did.clone()),
-    );
-    let confirmation_bytes = root_container(
-        new_root,
-        vec!["account".into(), "recover".into(), "confirm".into()],
-        confirmation_args,
+    let recovery_bytes = tonk_identity::request::build_recovery_invocation(
+        device_b,
+        &device_link,
+        recovery_ceremony.new_root_did.clone(),
+        recovery_ceremony.new_credential_id.clone(),
+        recovery_ceremony.device_delegation_hex.clone(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let response = client
         .post(format!("{base}/accounts/recover"))
         .json(&serde_json::json!({
             "recovery": hex::encode(recovery_bytes),
-            "confirmation": hex::encode(confirmation_bytes),
+            "confirmation": recovery_ceremony.confirmation_hex,
         }))
         .send()
         .await

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -855,3 +855,489 @@ async fn it_rejects_a_rotation_confirmed_by_an_unrelated_ceremony() {
         .unwrap();
     assert_eq!(response.status(), 200);
 }
+
+#[dialog_common::test]
+async fn it_rejects_a_recovery_whose_confirmation_names_a_different_new_root() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony,
+    // device A its first device.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_a = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device_a.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Link device B (the surviving device) from the root ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_b = Ed25519Signer::import(&SURVIVING_DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::link_device(root, device_b.did(), "phone".into())
+        .await
+        .unwrap();
+    let response = client
+        .post(format!("{base}/devices/link"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Build a valid device-signed recovery container that names
+    // NEW_ROOT_PRF as the new root, then pair it with a confirmation
+    // signed by an *unrelated* third root that correctly names the
+    // account's old root. The recovery's `newRootDid` and the paired
+    // confirmation's signer disagree, so the cross-check must reject it
+    // even though both containers are independently valid, correctly
+    // signed device/root invocations.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let old_root_did = old_root.did().to_string();
+    let new_root_did = new_root.did().to_string();
+
+    let device_link = tonk_identity::delegation::mint_device_delegation(old_root, &device_b.did())
+        .await
+        .unwrap();
+    let fresh_delegation =
+        tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+            .await
+            .unwrap();
+    let device_delegation_hex = hex::encode(fresh_delegation.to_bytes().unwrap());
+
+    let mut recovery_args = BTreeMap::new();
+    recovery_args.insert(
+        "newRootDid".to_string(),
+        Promised::String(new_root_did.clone()),
+    );
+    recovery_args.insert(
+        "newCredentialId".to_string(),
+        Promised::String("cred-recovered".to_string()),
+    );
+    recovery_args.insert(
+        "deviceDelegation".to_string(),
+        Promised::String(device_delegation_hex.clone()),
+    );
+    let recovery_bytes = tonk_identity::request::build_device_invocation(
+        device_b,
+        &device_link,
+        vec!["account".into(), "recover".into()],
+        recovery_args,
+    )
+    .await
+    .unwrap();
+
+    // The confirmation is signed by an unrelated new root and correctly
+    // names the account's actual old root -- only the `newRootDid` arm
+    // of the cross-check is violated.
+    let unrelated_new_root = tonk_identity::derive::derive_root_signer(&UNRELATED_NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let mut confirmation_args = BTreeMap::new();
+    confirmation_args.insert(
+        "oldRootDid".to_string(),
+        Promised::String(old_root_did.clone()),
+    );
+    let confirmation_bytes = root_container(
+        unrelated_new_root,
+        vec!["account".into(), "recover".into(), "confirm".into()],
+        confirmation_args,
+    )
+    .await;
+
+    let response = client
+        .post(format!("{base}/accounts/recover"))
+        .json(&serde_json::json!({
+            "recovery": hex::encode(recovery_bytes),
+            "confirmation": hex::encode(confirmation_bytes),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // The account root did not change: a device-signed invocation under
+    // the OLD root still succeeds.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+}
+
+#[dialog_common::test]
+async fn it_rejects_a_recovery_confirmed_for_a_different_account() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony,
+    // device A its first device.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_a = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device_a.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Link device B (the surviving device) from the root ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_b = Ed25519Signer::import(&SURVIVING_DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::link_device(root, device_b.did(), "phone".into())
+        .await
+        .unwrap();
+    let response = client
+        .post(format!("{base}/devices/link"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Build a valid device-signed recovery container naming NEW_ROOT_PRF
+    // as the new root, and pair it with a confirmation correctly signed
+    // by that same new root -- satisfying the `newRootDid` arm -- but
+    // whose `oldRootDid` argument names an unrelated account's old root
+    // instead of this account's actual one. The other arm must catch it.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root_did = new_root.did().to_string();
+
+    let device_link = tonk_identity::delegation::mint_device_delegation(old_root, &device_b.did())
+        .await
+        .unwrap();
+    let fresh_delegation =
+        tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+            .await
+            .unwrap();
+    let device_delegation_hex = hex::encode(fresh_delegation.to_bytes().unwrap());
+
+    let mut recovery_args = BTreeMap::new();
+    recovery_args.insert(
+        "newRootDid".to_string(),
+        Promised::String(new_root_did.clone()),
+    );
+    recovery_args.insert(
+        "newCredentialId".to_string(),
+        Promised::String("cred-recovered".to_string()),
+    );
+    recovery_args.insert(
+        "deviceDelegation".to_string(),
+        Promised::String(device_delegation_hex.clone()),
+    );
+    let recovery_bytes = tonk_identity::request::build_device_invocation(
+        device_b,
+        &device_link,
+        vec!["account".into(), "recover".into()],
+        recovery_args,
+    )
+    .await
+    .unwrap();
+
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let unrelated_old_root = tonk_identity::derive::derive_root_signer(&UNRELATED_OLD_ROOT_PRF)
+        .await
+        .unwrap();
+    let unrelated_old_root_did = unrelated_old_root.did().to_string();
+    let mut confirmation_args = BTreeMap::new();
+    confirmation_args.insert(
+        "oldRootDid".to_string(),
+        Promised::String(unrelated_old_root_did),
+    );
+    let confirmation_bytes = root_container(
+        new_root,
+        vec!["account".into(), "recover".into(), "confirm".into()],
+        confirmation_args,
+    )
+    .await;
+
+    let response = client
+        .post(format!("{base}/accounts/recover"))
+        .json(&serde_json::json!({
+            "recovery": hex::encode(recovery_bytes),
+            "confirmation": hex::encode(confirmation_bytes),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // The account root did not change: a device-signed invocation under
+    // the OLD root still succeeds.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+}
+
+#[dialog_common::test]
+async fn it_rejects_a_replayed_recovery() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony,
+    // device A its first device.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_a = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device_a.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Link device B (the surviving device) from the root ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_b = Ed25519Signer::import(&SURVIVING_DEVICE_SEED).await.unwrap();
+    let ceremony = tonk_identity::ceremony::link_device(root, device_b.did(), "phone".into())
+        .await
+        .unwrap();
+    let response = client
+        .post(format!("{base}/devices/link"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Recover the account onto a fresh root, exactly as the happy path
+    // does.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let old_root_did = old_root.did().to_string();
+    let new_root_did = new_root.did().to_string();
+
+    let device_link = tonk_identity::delegation::mint_device_delegation(old_root, &device_b.did())
+        .await
+        .unwrap();
+    let fresh_delegation =
+        tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+            .await
+            .unwrap();
+    let device_delegation_hex = hex::encode(fresh_delegation.to_bytes().unwrap());
+
+    let mut recovery_args = BTreeMap::new();
+    recovery_args.insert(
+        "newRootDid".to_string(),
+        Promised::String(new_root_did.clone()),
+    );
+    recovery_args.insert(
+        "newCredentialId".to_string(),
+        Promised::String("cred-recovered".to_string()),
+    );
+    recovery_args.insert(
+        "deviceDelegation".to_string(),
+        Promised::String(device_delegation_hex.clone()),
+    );
+    let recovery_bytes = tonk_identity::request::build_device_invocation(
+        device_b.clone(),
+        &device_link,
+        vec!["account".into(), "recover".into()],
+        recovery_args,
+    )
+    .await
+    .unwrap();
+
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let mut confirmation_args = BTreeMap::new();
+    confirmation_args.insert(
+        "oldRootDid".to_string(),
+        Promised::String(old_root_did.clone()),
+    );
+    let confirmation_bytes = root_container(
+        new_root,
+        vec!["account".into(), "recover".into(), "confirm".into()],
+        confirmation_args,
+    )
+    .await;
+
+    let response = client
+        .post(format!("{base}/accounts/recover"))
+        .json(&serde_json::json!({
+            "recovery": hex::encode(&recovery_bytes),
+            "confirmation": hex::encode(&confirmation_bytes),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Replay the identical {recovery, confirmation} container pair. The
+    // recovery container's subject is still the OLD root, which no
+    // longer resolves to any account -- the replay must be rejected.
+    let response = client
+        .post(format!("{base}/accounts/recover"))
+        .json(&serde_json::json!({
+            "recovery": hex::encode(&recovery_bytes),
+            "confirmation": hex::encode(&confirmation_bytes),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        response.status() == 401 || response.status() == 403,
+        "expected the replayed recovery to be rejected, got {}",
+        response.status()
+    );
+
+    // The account is still on the NEW root -- not reverted or
+    // corrupted: a device-signed call under the new root still
+    // succeeds.
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let new_link = tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+        .await
+        .unwrap();
+    let body = tonk_identity::request::build_device_invocation(
+        device_b,
+        &new_link,
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+}

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -7,6 +7,8 @@ use std::collections::BTreeMap;
 
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::time::timestamp::Timestamp;
+use dialog_ucan_core::{InvocationBuilder, InvocationChain};
 use dialog_varsig::Principal;
 use tonk_account_service::helpers::AccountServer;
 
@@ -15,6 +17,7 @@ const NEW_ROOT_PRF: [u8; 32] = [9u8; 32];
 const DEVICE_SEED: [u8; 32] = [8u8; 32];
 const UNRELATED_NEW_ROOT_PRF: [u8; 32] = [11u8; 32];
 const UNRELATED_OLD_ROOT_PRF: [u8; 32] = [13u8; 32];
+const SURVIVING_DEVICE_SEED: [u8; 32] = [20u8; 32];
 
 /// Build a device-signed invocation container for the account's first
 /// device, using the production builder against the `root → device`
@@ -29,6 +32,33 @@ async fn container(command: Vec<String>, args: BTreeMap<String, Promised>) -> Ve
         .unwrap();
     tonk_identity::request::build_device_invocation(device, &link, command, args)
         .await
+        .unwrap()
+}
+
+/// Build a root-signed ceremony container: issuer, audience, and subject
+/// all equal `root`, with no proofs -- the same shape `authorize_root`
+/// requires. Not yet available as a production builder (that lands with
+/// the recovery ceremony's client-facing crate), so tests assemble it
+/// directly.
+async fn root_container(
+    root: Ed25519Signer,
+    command: Vec<String>,
+    args: BTreeMap<String, Promised>,
+) -> Vec<u8> {
+    let root_did = root.did();
+    let invocation = InvocationBuilder::new()
+        .issuer(root)
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(command)
+        .arguments(args)
+        .proofs(vec![])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .unwrap();
+    InvocationChain::new(invocation, std::collections::HashMap::new())
+        .to_bytes()
         .unwrap()
 }
 
@@ -502,6 +532,221 @@ async fn it_rejects_a_rotation_whose_confirmation_names_a_different_root() {
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
+}
+
+#[dialog_common::test]
+async fn it_recovers_the_account_via_surviving_device_and_new_root_over_http() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    // POST /codes -> request a verification code, then read it back out
+    // of the captured emails instead of receiving mail.
+    let response = client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "person@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "person@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent to person@example.com")
+    };
+
+    // POST /accounts -> create the account from a root-signed ceremony,
+    // device A its first device.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_a = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+    let device_a_did = device_a.did().to_string();
+    let ceremony = tonk_identity::ceremony::create_account(
+        root,
+        "person@example.com".into(),
+        code,
+        "cred-1".into(),
+        device_a.did(),
+        "laptop".into(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/accounts"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+
+    // Link device B (the surviving device) from the root ceremony.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let device_b = Ed25519Signer::import(&SURVIVING_DEVICE_SEED).await.unwrap();
+    let device_b_did = device_b.did().to_string();
+    let ceremony = tonk_identity::ceremony::link_device(root, device_b.did(), "phone".into())
+        .await
+        .unwrap();
+    let response = client
+        .post(format!("{base}/devices/link"))
+        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Capture device A's delegation CID before recovery, so we can prove
+    // recovery leaves it untouched.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let devices: serde_json::Value = response.json().await.unwrap();
+    let devices = devices.as_array().unwrap();
+    let device_a_original_cid = devices
+        .iter()
+        .find(|d| d["did"] == device_a_did)
+        .expect("device A is registered")["delegationCid"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // The old passkey is lost: recovery flips the account onto a freshly
+    // created root, under device B's authority plus proof the new root
+    // is controllable.
+    let old_root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let old_root_did = old_root.did().to_string();
+    let new_root_did = new_root.did().to_string();
+
+    let device_link = tonk_identity::delegation::mint_device_delegation(old_root, &device_b.did())
+        .await
+        .unwrap();
+    let fresh_delegation =
+        tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+            .await
+            .unwrap();
+    let device_delegation_hex = hex::encode(fresh_delegation.to_bytes().unwrap());
+
+    let mut recovery_args = BTreeMap::new();
+    recovery_args.insert(
+        "newRootDid".to_string(),
+        Promised::String(new_root_did.clone()),
+    );
+    recovery_args.insert(
+        "newCredentialId".to_string(),
+        Promised::String("cred-recovered".to_string()),
+    );
+    recovery_args.insert(
+        "deviceDelegation".to_string(),
+        Promised::String(device_delegation_hex.clone()),
+    );
+    let recovery_bytes = tonk_identity::request::build_device_invocation(
+        device_b,
+        &device_link,
+        vec!["account".into(), "recover".into()],
+        recovery_args,
+    )
+    .await
+    .unwrap();
+
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let mut confirmation_args = BTreeMap::new();
+    confirmation_args.insert(
+        "oldRootDid".to_string(),
+        Promised::String(old_root_did.clone()),
+    );
+    let confirmation_bytes = root_container(
+        new_root,
+        vec!["account".into(), "recover".into(), "confirm".into()],
+        confirmation_args,
+    )
+    .await;
+
+    let response = client
+        .post(format!("{base}/accounts/recover"))
+        .json(&serde_json::json!({
+            "recovery": hex::encode(recovery_bytes),
+            "confirmation": hex::encode(confirmation_bytes),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Device B, signed under the new root, can now list devices.
+    let new_root = tonk_identity::derive::derive_root_signer(&NEW_ROOT_PRF)
+        .await
+        .unwrap();
+    let device_b = Ed25519Signer::import(&SURVIVING_DEVICE_SEED).await.unwrap();
+    let new_link = tonk_identity::delegation::mint_device_delegation(new_root, &device_b.did())
+        .await
+        .unwrap();
+    let body = tonk_identity::request::build_device_invocation(
+        device_b,
+        &new_link,
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await
+    .unwrap();
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let devices: serde_json::Value = response.json().await.unwrap();
+    let devices = devices.as_array().unwrap();
+    assert_eq!(devices.len(), 2);
+
+    let device_a_row = devices
+        .iter()
+        .find(|d| d["did"] == device_a_did)
+        .expect("device A is still registered");
+    assert_eq!(device_a_row["status"], "active");
+    assert_eq!(device_a_row["delegationCid"], device_a_original_cid);
+
+    let device_b_row = devices
+        .iter()
+        .find(|d| d["did"] == device_b_did)
+        .expect("device B is still registered");
+    assert_eq!(device_b_row["status"], "active");
+
+    // A device-signed call under the OLD root is rejected: the account
+    // no longer resolves by its old root DID.
+    let body = container(
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/list"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 401);
 }
 
 #[dialog_common::test]

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -238,6 +238,61 @@ pub async fn rotate_account(
     })
 }
 
+/// Output of the new-root half of the surviving-device recovery ceremony.
+///
+/// The device-signed half (command `["account", "recover"]`, carrying
+/// these same `newRootDid`/`newCredentialId`/`deviceDelegationHex`
+/// values plus proof of the old `root → device` link) is built
+/// worker-side, where the device key lives — see
+/// `request::build_recovery_invocation`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryCeremony {
+    /// The root DID the account recovers onto.
+    pub new_root_did: String,
+    /// The credential id backing the new root's passkey.
+    pub new_credential_id: String,
+    /// Hex-encoded `newRoot → device` delegation for the ceremony device.
+    pub device_delegation_hex: String,
+    /// Hex-encoded new-root-signed confirmation container.
+    pub confirmation_hex: String,
+}
+
+/// Build the new-root-signed confirmation half of a surviving-device
+/// recovery: proof the new DID is controllable, naming the account's old
+/// root so the service can cross-check it against the device-signed
+/// recovery container.
+pub async fn recover_account(
+    new_root: Ed25519Signer,
+    new_credential_id: String,
+    old_root_did: String,
+    device_did: dialog_varsig::Did,
+) -> Result<RecoveryCeremony> {
+    let new_root_did = new_root.did().to_string();
+
+    let device_link = mint_device_delegation(new_root.clone(), &device_did).await?;
+    let device_delegation_hex = hex::encode(
+        device_link
+            .to_bytes()
+            .context("failed to serialize the device delegation")?,
+    );
+
+    let confirmation = build(
+        new_root,
+        vec!["account".into(), "recover".into(), "confirm".into()],
+        strings([("oldRootDid", old_root_did)]),
+        device_did.to_string(),
+        device_delegation_hex.clone(),
+    )
+    .await?;
+
+    Ok(RecoveryCeremony {
+        new_root_did,
+        new_credential_id,
+        device_delegation_hex,
+        confirmation_hex: confirmation.invocation_hex,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,6 +446,42 @@ mod tests {
             vec![
                 "account".to_string(),
                 "rotate".to_string(),
+                "confirm".to_string()
+            ]
+        );
+        assert_eq!(
+            confirmation.arguments().get("oldRootDid"),
+            Some(&Promised::String(old_did))
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_the_new_root_half_of_a_recovery() {
+        let old_root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let new_root = crate::derive::derive_root_signer(&[9u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let old_did = old_root.did().to_string();
+        let new_did = new_root.did().to_string();
+
+        let ceremony = recover_account(new_root, "cred-new".into(), old_did.clone(), device.did())
+            .await
+            .unwrap();
+        assert_eq!(ceremony.new_root_did, new_did);
+        assert_eq!(ceremony.new_credential_id, "cred-new");
+
+        let confirmation =
+            InvocationChain::try_from(hex::decode(&ceremony.confirmation_hex).unwrap().as_slice())
+                .unwrap();
+        confirmation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(confirmation.issuer().to_string(), new_did);
+        assert_eq!(
+            confirmation.command().0,
+            vec![
+                "account".to_string(),
+                "recover".to_string(),
                 "confirm".to_string()
             ]
         );

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -208,6 +208,62 @@ async fn rotate_account(input: JsValue) -> Result<JsValue, JsValue> {
     Ok(result.into())
 }
 
+/// Recover the account onto a freshly created passkey under the
+/// authority of a surviving device.
+///
+/// `old_root_did` and `device_did` are supplied by the caller (the page
+/// reads them from `GET /api/account`, which the surviving device can
+/// still reach even though the old passkey is gone) rather than derived
+/// locally, since there is no credential left on this origin to derive
+/// the old root from.
+async fn recover_account(input: JsValue) -> Result<JsValue, JsValue> {
+    let name = string_property(&input, "name")?;
+    let old_root_did = string_property(&input, "oldRootDid")?;
+    let device_did = string_property(&input, "deviceDid")?
+        .parse()
+        .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
+
+    let created = crate::passkey::create_passkey(&name)
+        .await
+        .map_err(js_error)?;
+    let credential_id = hex::encode(&created.id);
+    let prf_at_create = created.prf_output.is_some();
+    let prf = match created.prf_output {
+        Some(output) => output,
+        None => crate::passkey::prf_output(Some(&created.id))
+            .await
+            .map_err(js_error)?,
+    };
+    let new_root = crate::derive::derive_root_signer(&prf)
+        .await
+        .map_err(js_error)?;
+
+    let ceremony =
+        crate::ceremony::recover_account(new_root, credential_id.clone(), old_root_did, device_did)
+            .await
+            .map_err(js_error)?;
+
+    let result = Object::new();
+    Reflect::set(&result, &"newRootDid".into(), &ceremony.new_root_did.into())?;
+    Reflect::set(
+        &result,
+        &"newCredentialId".into(),
+        &ceremony.new_credential_id.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"deviceDelegationHex".into(),
+        &ceremony.device_delegation_hex.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"confirmationHex".into(),
+        &ceremony.confirmation_hex.into(),
+    )?;
+    Reflect::set(&result, &"prfAtCreate".into(), &prf_at_create.into())?;
+    Ok(result.into())
+}
+
 async fn complete_link(input: JsValue) -> Result<JsValue, JsValue> {
     let token_hash = string_property(&input, "tokenHash")?;
     let device_did = string_property(&input, "deviceDid")?
@@ -270,6 +326,16 @@ pub fn install() {
     );
     link_device.forget();
 
+    let recover_account = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(recover_account(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"recoverAccount".into(),
+        recover_account.as_ref().unchecked_ref(),
+    );
+    recover_account.forget();
+
     let complete_link = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
         future_to_promise(complete_link(input))
     });
@@ -312,6 +378,7 @@ mod tests {
             "linkDevice",
             "completeLink",
             "rotateAccount",
+            "recoverAccount",
         ] {
             let function = Reflect::get(&identity, &name.into()).unwrap();
             assert!(function.is_function(), "{name} must be a function");

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -58,6 +58,36 @@ pub async fn build_device_invocation(
         .context("failed to serialize the device invocation")
 }
 
+/// Build the device-signed half of the surviving-device recovery
+/// ceremony: proof of the old `root → device` link (attached as `link`'s
+/// proof), naming the new root, its credential, and the fresh
+/// `newRoot → device` delegation the service installs on success.
+pub async fn build_recovery_invocation(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    new_root_did: String,
+    new_credential_id: String,
+    device_delegation_hex: String,
+) -> Result<Vec<u8>> {
+    let mut arguments = BTreeMap::new();
+    arguments.insert("newRootDid".to_owned(), Promised::String(new_root_did));
+    arguments.insert(
+        "newCredentialId".to_owned(),
+        Promised::String(new_credential_id),
+    );
+    arguments.insert(
+        "deviceDelegation".to_owned(),
+        Promised::String(device_delegation_hex),
+    );
+    build_device_invocation(
+        device,
+        link,
+        vec!["account".into(), "recover".into()],
+        arguments,
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,6 +140,53 @@ mod tests {
                 "chain".to_string(),
                 "put".to_string()
             ],
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_device_signed_recovery_invocation() {
+        let old_root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let old_root_did = old_root.did();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let device_did = device.did();
+        let link = crate::delegation::mint_device_delegation(old_root, &device_did)
+            .await
+            .unwrap();
+        let expected_proof = link.proofs().last().unwrap().to_cid();
+
+        let bytes = build_recovery_invocation(
+            device,
+            &link,
+            "did:key:new-root".to_owned(),
+            "cred-new".to_owned(),
+            "deadbeef".to_owned(),
+        )
+        .await
+        .unwrap();
+
+        let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
+        chain
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(chain.issuer(), &device_did);
+        assert_eq!(chain.subject(), &old_root_did);
+        assert_eq!(chain.proofs(), &vec![expected_proof]);
+        assert_eq!(
+            chain.command().0,
+            vec!["account".to_string(), "recover".to_string()],
+        );
+        assert_eq!(
+            chain.arguments().get("newRootDid"),
+            Some(&Promised::String("did:key:new-root".to_owned()))
+        );
+        assert_eq!(
+            chain.arguments().get("newCredentialId"),
+            Some(&Promised::String("cred-new".to_owned()))
+        );
+        assert_eq!(
+            chain.arguments().get("deviceDelegation"),
+            Some(&Promised::String("deadbeef".to_owned()))
         );
     }
 }

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -12,6 +12,7 @@
       <button id="account-choose-create" class="account__button" type="button">Create account</button>
       <button id="account-choose-link" class="account__button account__button--secondary" type="button">Log in</button>
     </div>
+    <button id="account-choose-recover" class="account__button account__button--quiet" type="button">Lost your passkey?</button>
   </section>
 
   <section id="account-create" class="account__panel" hidden>
@@ -64,6 +65,7 @@
     <p id="account-success-message" class="account__status">You're logged in.</p>
     <button id="account-manage-devices" class="account__button account__button--secondary" type="button">Manage devices</button>
     <button id="account-rotate-open" class="account__button account__button--quiet" type="button">Rotate passkey</button>
+    <button id="account-recover-open" class="account__button account__button--quiet" type="button">Lost your passkey?</button>
     <a class="account__button account__button--secondary" href="/">Back to Tonk</a>
   </section>
 
@@ -85,6 +87,17 @@
         <input id="account-rotate-name" name="New passkey name" type="text" autocomplete="off" required>
       </label>
       <button id="account-rotate-submit" class="account__button" type="submit">Create new passkey</button>
+    </form>
+  </section>
+
+  <section id="account-recover" class="account__panel" hidden>
+    <h2>Recover your account</h2>
+    <p id="account-recover-message" class="account__message">This replaces the account's passkey. Other devices keep their data and re-connect the next time they open tonk.</p>
+    <form class="account__form" id="account-recover-form" hidden>
+      <label>New passkey name
+        <input id="account-recover-name" name="New passkey name" type="text" autocomplete="off" required>
+      </label>
+      <button id="account-recover-submit" class="account__button" type="submit">Create new passkey</button>
     </form>
   </section>
 

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -92,7 +92,7 @@
 
   <section id="account-recover" class="account__panel" hidden>
     <h2>Recover your account</h2>
-    <p id="account-recover-message" class="account__message">This replaces the account's passkey. Other devices keep their data and re-connect the next time they open tonk.</p>
+    <p id="account-recover-message" class="account__message">This replaces the account's passkey. Other devices keep their local data, but reconnecting them to the recovered account is a separate step that isn't available yet.</p>
     <form class="account__form" id="account-recover-form" hidden>
       <label>New passkey name
         <input id="account-recover-name" name="New passkey name" type="text" autocomplete="off" required>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::{JsFuture, spawn_local};
 use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement, window};
 
-use tonk_worker_api::AccountStatus;
+use tonk_worker_api::{AccountRecoverRequest, AccountStatus};
 
 const PROD: &str = "https://accounts.tonk.xyz";
 const STAGING: &str = "https://accounts-staging.tonk.xyz";
@@ -52,6 +52,14 @@ struct CeremonyOutput {
 #[serde(rename_all = "camelCase")]
 struct RotateInput {
     name: String,
+    device_did: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RecoverInput {
+    name: String,
+    old_root_did: String,
     device_did: String,
 }
 
@@ -188,6 +196,7 @@ fn set_mode(host: &HtmlElement, mode: &str) {
         ("success", "#account-success"),
         ("devices", "#account-devices"),
         ("rotate", "#account-rotate"),
+        ("recover", "#account-recover"),
     ] {
         if let Ok(Some(panel)) = host.query_selector(selector) {
             if name == mode {
@@ -209,6 +218,7 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-unlink",
         "#account-rotate-submit",
         "#account-relink-retry",
+        "#account-recover-submit",
     ] {
         if let Ok(Some(button)) = host.query_selector(selector)
             && let Ok(button) = button.dyn_into::<HtmlButtonElement>()
@@ -241,6 +251,54 @@ fn focus_input(host: &HtmlElement, selector: &str) {
     {
         let _ = input.focus();
     }
+}
+
+/// Gate the recovery panel's message and form on whether this browser
+/// currently holds an account link. Recovery is driven by a surviving
+/// device — one that already holds a `root → device` delegation, which is
+/// what lets the worker build the device-signed half of the ceremony. An
+/// unlinked browser cannot do that, so it sees only the static message
+/// pointing at a device that can.
+fn set_recover_availability(host: &HtmlElement, linked: bool) {
+    if let Ok(Some(message)) = host.query_selector("#account-recover-message") {
+        message.set_text_content(Some(if linked {
+            "This replaces the account's passkey. Other devices keep their data and \
+             re-connect the next time they open tonk."
+        } else {
+            "This browser isn't connected to the account, so it can't recover it. Open \
+             tonk on a device that's still connected and continue from there instead."
+        }));
+    }
+    if let Ok(Some(form)) = host.query_selector("#account-recover-form") {
+        if linked {
+            let _ = form.remove_attribute("hidden");
+        } else {
+            let _ = form.set_attribute("hidden", "");
+        }
+    }
+}
+
+/// Enter the recovery panel and resolve which of its two faces to show.
+/// Reachable from a browser in either link state — the choice panel (not
+/// yet linked) and the success panel (already linked) both offer the
+/// "Lost your passkey?" entry point — so the availability check is a live
+/// read rather than assumed from which entry point was used.
+fn open_recover(host: &HtmlElement) {
+    clear_error(host);
+    set_mode(host, "recover");
+    set_busy(host, true, "Checking this browser…");
+    let host = host.clone();
+    spawn_local(async move {
+        let linked = matches!(
+            crate::api::account_status().await,
+            Ok(AccountStatus::Linked { .. })
+        );
+        set_recover_availability(&host, linked);
+        set_busy(&host, false, "");
+        if linked {
+            focus_input(&host, "#account-recover-name");
+        }
+    });
 }
 
 fn show_success(host: &HtmlElement) {
@@ -781,6 +839,10 @@ fn bind(host: &HtmlElement) {
         focus_input(&host, "#account-rotate-name");
     });
 
+    for selector in ["#account-choose-recover", "#account-recover-open"] {
+        on_click(host, selector, |host| open_recover(&host));
+    }
+
     on_click(host, "#account-rotate-submit", |host| {
         clear_error(&host);
         let name = match input(&host, "#account-rotate-name") {
@@ -884,6 +946,62 @@ fn bind(host: &HtmlElement) {
             }
         });
     });
+
+    on_click(host, "#account-recover-submit", |host| {
+        clear_error(&host);
+        let name = match input(&host, "#account-recover-name") {
+            Ok(value) => value,
+            Err(error) => return show_error(&host, error),
+        };
+        set_busy(&host, true, "Checking this browser's link…");
+        spawn_local(async move {
+            let result = async {
+                let (old_root_did, device_did) = match crate::api::account_status()
+                    .await
+                    .map_err(|error| error.to_string())?
+                {
+                    AccountStatus::Linked {
+                        root_did,
+                        device_did,
+                    } => (root_did, device_did),
+                    AccountStatus::Unlinked { .. } => {
+                        return Err("This browser isn't connected to the account, so it can't \
+                             recover it. Open tonk on a device that's still connected."
+                            .to_string());
+                    }
+                };
+                set_busy(&host, true, "Waiting for your new passkey…");
+                let request: AccountRecoverRequest = identity_call(
+                    "recoverAccount",
+                    &RecoverInput {
+                        name,
+                        old_root_did,
+                        device_did,
+                    },
+                )
+                .await?;
+                set_busy(&host, true, "Recovering your account…");
+                crate::api::recover_account(&request)
+                    .await
+                    .map_err(|error| error.to_string())
+            }
+            .await;
+            match result {
+                Ok(_status) => {
+                    if let Ok(Some(message)) = host.query_selector("#account-success-message") {
+                        message.set_text_content(Some(
+                            "Your account is recovered on the new passkey.",
+                        ));
+                    }
+                    show_success(&host);
+                }
+                Err(error) => {
+                    set_busy(&host, false, "");
+                    show_error(&host, error);
+                }
+            }
+        });
+    });
 }
 
 /// Register `<tonk-account>` with the top document.
@@ -953,6 +1071,10 @@ mod tests {
             "#account-rotate-open",
             "#account-rotate-name",
             "#account-rotate-submit",
+            "#account-choose-recover",
+            "#account-recover-open",
+            "#account-recover-name",
+            "#account-recover-submit",
         ] {
             assert!(
                 host.query_selector(selector).unwrap().is_some(),
@@ -1018,6 +1140,7 @@ mod tests {
             "#account-link",
             "#account-handoff",
             "#account-success",
+            "#account-recover",
         ] {
             assert!(
                 host.query_selector(selector)
@@ -1027,6 +1150,94 @@ mod tests {
                 "{selector} should be hidden while rotate is shown"
             );
         }
+    }
+
+    #[dialog_common::test]
+    fn it_reveals_the_recover_panel_and_hides_the_others() {
+        let host = host();
+        set_mode(&host, "recover");
+        assert!(
+            host.query_selector("#account-recover")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none()
+        );
+        for selector in [
+            "#account-choice",
+            "#account-create",
+            "#account-verify",
+            "#account-link",
+            "#account-handoff",
+            "#account-success",
+            "#account-rotate",
+        ] {
+            assert!(
+                host.query_selector(selector)
+                    .unwrap()
+                    .unwrap()
+                    .has_attribute("hidden"),
+                "{selector} should be hidden while recover is shown"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_hides_the_recovery_form_until_link_status_is_resolved() {
+        let host = host();
+        assert!(
+            host.query_selector("#account-recover-form")
+                .unwrap()
+                .unwrap()
+                .has_attribute("hidden"),
+            "the recovery form must default to hidden — an unresolved link \
+             status must not expose the submit control"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_shows_the_recovery_form_only_once_this_browser_is_linked() {
+        let host = host();
+        set_recover_availability(&host, false);
+        assert!(
+            host.query_selector("#account-recover-form")
+                .unwrap()
+                .unwrap()
+                .has_attribute("hidden"),
+            "an unlinked browser cannot drive recovery, so the form stays hidden"
+        );
+        assert_eq!(
+            host.query_selector("#account-recover-message")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some(
+                "This browser isn't connected to the account, so it can't recover it. Open \
+                 tonk on a device that's still connected and continue from there instead."
+            )
+        );
+
+        set_recover_availability(&host, true);
+        assert!(
+            host.query_selector("#account-recover-form")
+                .unwrap()
+                .unwrap()
+                .get_attribute("hidden")
+                .is_none(),
+            "a linked browser is the recovery prerequisite, so the form is revealed"
+        );
+        assert_eq!(
+            host.query_selector("#account-recover-message")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some(
+                "This replaces the account's passkey. Other devices keep their data and \
+                 re-connect the next time they open tonk."
+            )
+        );
     }
 
     fn dummy_rotation() -> RotationOutput {

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -262,8 +262,9 @@ fn focus_input(host: &HtmlElement, selector: &str) {
 fn set_recover_availability(host: &HtmlElement, linked: bool) {
     if let Ok(Some(message)) = host.query_selector("#account-recover-message") {
         message.set_text_content(Some(if linked {
-            "This replaces the account's passkey. Other devices keep their data and \
-             re-connect the next time they open tonk."
+            "This replaces the account's passkey. Other devices keep their local data, \
+             but reconnecting them to the recovered account is a separate step that isn't \
+             available yet."
         } else {
             "This browser isn't connected to the account, so it can't recover it. Open \
              tonk on a device that's still connected and continue from there instead."
@@ -1234,8 +1235,9 @@ mod tests {
                 .text_content()
                 .as_deref(),
             Some(
-                "This replaces the account's passkey. Other devices keep their data and \
-                 re-connect the next time they open tonk."
+                "This replaces the account's passkey. Other devices keep their local data, \
+                 but reconnecting them to the recovered account is a separate step that isn't \
+                 available yet."
             )
         );
     }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -1,9 +1,9 @@
 use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_worker_api::{
-    AccountDevice, AccountLinkRequest, AccountStatus, EvaluateResponse, IdentifyResponse,
-    JoinRequest, JoinResponse, QueryResponse, RepositoryInfo, RevokeDeviceRequest, SyncResponse,
-    SyncStatusResponse,
+    AccountDevice, AccountLinkRequest, AccountRecoverRequest, AccountStatus, EvaluateResponse,
+    IdentifyResponse, JoinRequest, JoinResponse, QueryResponse, RepositoryInfo, RevokeDeviceRequest,
+    SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -569,6 +569,33 @@ pub async fn rotate_account(
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "POST /accounts/rotate returned {status}: {text}"
+        )))
+    }
+}
+
+/// Recover an account onto a fresh root under a surviving device's
+/// authority, via `POST /api/account/recover`. The worker builds the
+/// device-signed half of the ceremony from the stored link, submits both
+/// containers to the account service, replaces the local link, and
+/// converges spaces — so a single successful response means recovery is
+/// fully done, with nothing left for the caller to persist separately.
+pub async fn recover_account(
+    request: &AccountRecoverRequest,
+) -> Result<AccountStatus, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/account/recover", origin()))
+        .json(request)
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/account/recover returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -2,8 +2,8 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_worker_api::{
     AccountDevice, AccountLinkRequest, AccountRecoverRequest, AccountStatus, EvaluateResponse,
-    IdentifyResponse, JoinRequest, JoinResponse, QueryResponse, RepositoryInfo, RevokeDeviceRequest,
-    SyncResponse, SyncStatusResponse,
+    IdentifyResponse, JoinRequest, JoinResponse, QueryResponse, RepositoryInfo,
+    RevokeDeviceRequest, SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -16,6 +16,23 @@ pub struct AccountLinkRequest {
     pub succession_hex: Option<String>,
 }
 
+/// Recover an account onto a fresh root under a surviving device's
+/// authority, replacing the account's current root registration.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountRecoverRequest {
+    /// The root DID the account recovers onto.
+    pub new_root_did: String,
+    /// The credential id backing the new root's passkey.
+    pub new_credential_id: String,
+    /// Hex-encoded new-root-signed confirmation container, proving control
+    /// of `new_root_did`.
+    pub confirmation_hex: String,
+    /// Hex-encoded `newRoot → device` delegation the service installs on
+    /// this device once recovery succeeds.
+    pub device_delegation_hex: String,
+}
+
 /// Local account-link state.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
@@ -98,5 +115,24 @@ mod tests {
         let request: RevokeDeviceRequest =
             serde_json::from_value(serde_json::json!({ "did": "did:key:device" })).unwrap();
         assert_eq!(request.did, "did:key:device");
+    }
+
+    #[dialog_common::test]
+    fn it_serializes_account_recover_request_in_camel_case() {
+        let json = serde_json::to_value(AccountRecoverRequest {
+            new_root_did: "did:key:new-root".into(),
+            new_credential_id: "cred-new".into(),
+            confirmation_hex: "deadbeef".into(),
+            device_delegation_hex: "beefdead".into(),
+        })
+        .unwrap();
+        assert_eq!(json["newRootDid"], "did:key:new-root");
+        assert_eq!(json["newCredentialId"], "cred-new");
+        assert_eq!(json["confirmationHex"], "deadbeef");
+        assert_eq!(json["deviceDelegationHex"], "beefdead");
+
+        let request: AccountRecoverRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(request.new_root_did, "did:key:new-root");
+        assert_eq!(request.device_delegation_hex, "beefdead");
     }
 }

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -23,7 +23,9 @@ mod query;
 mod repository;
 mod sync;
 
-pub use account::{AccountDevice, AccountLinkRequest, AccountStatus, RevokeDeviceRequest};
+pub use account::{
+    AccountDevice, AccountLinkRequest, AccountRecoverRequest, AccountStatus, RevokeDeviceRequest,
+};
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};
 pub use evaluate::{CommitSummary, EvaluateResponse, QueryMatchBlock, QueryResult};

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -148,6 +148,7 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route("/api/account/link", post(account::link))
         .route("/api/account/devices", get(account_devices::list))
         .route("/api/account/devices/revoke", post(account_devices::revoke))
+        .route("/api/account/recover", post(account::recover))
         .route("/api/profile", get(profile::get_profile))
         // Profile-as-repository routes. The profile is its own
         // repository but lives outside the named-repo namespace

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -8,7 +8,7 @@ use dialog_ucan_core::DelegationChain;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_worker_api::{AccountLinkRequest, AccountStatus};
+use tonk_worker_api::{AccountLinkRequest, AccountRecoverRequest, AccountStatus};
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -231,6 +231,35 @@ pub(crate) async fn persist_link(
         }
     }
 
+    save_validated_link(state, chain, bytes).await
+}
+
+/// Validate and store a `root → current profile` delegation, unconditionally
+/// replacing whatever link is currently stored.
+///
+/// [`persist_link`] minus the same-issuer guard: recovery legitimately
+/// swaps the account onto a brand-new root under the recovering device's own
+/// authority, which is the entire point of the ceremony, so it cannot go
+/// through the guarded path. Only the recovery route may call this — the
+/// HTTP `link` route keeps calling [`persist_link`], which still refuses a
+/// bare relink onto a different root without a succession chain.
+pub(crate) async fn persist_link_replacing(
+    state: &crate::worker::TonkState,
+    request: &AccountLinkRequest,
+) -> Result<(), TonkWorkerError> {
+    let device_did = state.profile.did();
+    let (chain, bytes) = validate_link(request, &device_did).await?;
+    save_validated_link(state, chain, bytes).await
+}
+
+/// Shared tail of [`persist_link`] and [`persist_link_replacing`]: save the
+/// already-validated delegation as this profile's live account capability
+/// and persist its bytes as the local account link.
+async fn save_validated_link(
+    state: &crate::worker::TonkState,
+    chain: DelegationChain,
+    bytes: Vec<u8>,
+) -> Result<(), TonkWorkerError> {
     state
         .profile
         .access()
@@ -346,6 +375,163 @@ pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>
         })?;
     Ok(Json(AccountStatus::Unlinked {
         device_did: state.profile.did().to_string(),
+    }))
+}
+
+/// POST the two recovery containers to the account service and surface a
+/// non-2xx response as [`TonkWorkerError::Forbidden`], carrying the
+/// service's own error text — unlike `account_backup`'s POST helpers, which
+/// are best-effort and only ever log an [`TonkWorkerError::Internal`], a
+/// caller waiting on this route needs the real reason the ceremony was
+/// refused.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn post_recovery(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{Request, RequestInit, Response};
+
+    let init = RequestInit::new();
+    init.set_method("POST");
+    init.set_body(&js_sys::Uint8Array::from(body.as_slice()).into());
+    let request = Request::new_with_str_and_init(endpoint, &init)
+        .map_err(|e| TonkWorkerError::Internal(format!("recovery request: {e:?}")))?;
+    let global: web_sys::ServiceWorkerGlobalScope = js_sys::global()
+        .dyn_into()
+        .map_err(|_| TonkWorkerError::Internal("not in a service-worker scope".to_owned()))?;
+    let response: Response = JsFuture::from(global.fetch_with_request(&request))
+        .await
+        .and_then(|v| v.dyn_into())
+        .map_err(|e| TonkWorkerError::Internal(format!("recovery fetch: {e:?}")))?;
+    if !response.ok() {
+        let text = JsFuture::from(
+            response
+                .text()
+                .map_err(|e| TonkWorkerError::Internal(format!("recovery error body: {e:?}")))?,
+        )
+        .await
+        .ok()
+        .and_then(|value| value.as_string())
+        .unwrap_or_else(|| format!("account service returned HTTP {}", response.status()));
+        return Err(TonkWorkerError::Forbidden(text));
+    }
+    Ok(())
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn post_recovery(endpoint: &str, body: Vec<u8>) -> Result<(), TonkWorkerError> {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .body(body)
+        // Same reasoning as `account_backup`'s POST helpers: bound the
+        // wait so a wedged account service can't wedge the native caller.
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| TonkWorkerError::Internal(format!("recovery: {e}")))?;
+    if !response.status().is_success() {
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "account service returned an error".to_owned());
+        return Err(TonkWorkerError::Forbidden(text));
+    }
+    Ok(())
+}
+
+/// Recover an account onto a fresh root under this surviving device's
+/// authority: prove the old `root → device` link to the account service,
+/// swap its registry entry onto the new root, replace the local link, and
+/// converge every space this device holds onto the new root.
+///
+/// Mirrors [`link`]'s rotation arm for the convergence dispatch: the wasm
+/// build fires the migration sweep (`migrate::converge_after_rotation`,
+/// itself `wasm32`-only) detached under the write lock, then restore under
+/// the read lock; native has no sweep to run (there is nothing to migrate
+/// off the device DID that a worker-only sweep would touch) and just
+/// restores inline.
+#[wasm_compat]
+pub async fn recover(
+    State(state): State<AppState>,
+    Json(request): Json<AccountRecoverRequest>,
+) -> Result<Json<AccountStatus>, TonkWorkerError> {
+    // Keep the cloneable `AppState` handle around for the same reason
+    // `link` does: the wasm convergence dispatch below needs its own
+    // independent lock inside a detached task, after this handler's read
+    // guard has been dropped. Native awaits restore inline using the guard
+    // already held below, so it never needs this clone.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    let app_state = state.clone();
+    let state = state.read().await;
+    let device_did = state.profile.did();
+
+    let Some(link) = account_link(&state).await else {
+        return Err(TonkWorkerError::Router(
+            "profile has no account link".to_string(),
+        ));
+    };
+    // Only the wasm dispatch below acts on the old root; capturing it
+    // unconditionally would leave the native build with an unused binding.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    let old_root = link.issuer().clone();
+
+    let device = state.profile.signer().signer().clone();
+    let recovery_bytes = tonk_identity::request::build_recovery_invocation(
+        device,
+        &link,
+        request.new_root_did.clone(),
+        request.new_credential_id.clone(),
+        request.device_delegation_hex.clone(),
+    )
+    .await
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to build recovery invocation: {error}"))
+    })?;
+
+    let service = crate::router::account_backup::account_service_url().ok_or_else(|| {
+        TonkWorkerError::Internal("account service is unavailable for this host".to_string())
+    })?;
+    let body = serde_json::to_vec(&serde_json::json!({
+        "recovery": hex::encode(recovery_bytes),
+        "confirmation": request.confirmation_hex,
+    }))
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to serialize recovery request: {error}"))
+    })?;
+    let endpoint = format!("{}/accounts/recover", service.trim_end_matches('/'));
+    post_recovery(&endpoint, body).await?;
+
+    let link_request = AccountLinkRequest {
+        root_did: request.new_root_did.clone(),
+        delegation_hex: request.device_delegation_hex.clone(),
+        succession_hex: None,
+    };
+    persist_link_replacing(&state, &link_request).await?;
+
+    // Same write-then-read lock handoff as `link`'s rotation arm, and for
+    // the same reason: the sweep is a purely local storage sweep that must
+    // be mutually exclusive with handler-level writes (write lock), while
+    // restore awaits account-service round trips it must not stall every
+    // other handler behind it (read lock, acquired only after the sweep's
+    // write lock is released).
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            {
+                let tonk = app_state.write().await;
+                crate::router::migrate::converge_after_rotation(&tonk, &old_root).await;
+            }
+            let tonk = app_state.read().await;
+            crate::router::restore::restore_spaces(&tonk).await;
+        });
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        crate::router::restore::restore_spaces(&state).await;
+    }
+
+    Ok(Json(AccountStatus::Linked {
+        root_did: request.new_root_did,
+        device_did: device_did.to_string(),
     }))
 }
 
@@ -607,5 +793,26 @@ mod tests {
         }
         let Json(loaded) = get(State(state)).await.unwrap();
         assert!(matches!(loaded, AccountStatus::Linked { .. }));
+    }
+
+    // `recover`'s happy path needs a live account service to authorize the
+    // recovery/confirmation containers and flip the registry, so it is
+    // covered by the account service's own integration test and the manual
+    // staging pass, not here. This only exercises the local guard that
+    // runs before any service call.
+    #[dialog_common::test]
+    async fn it_refuses_recovery_when_unlinked() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let request = AccountRecoverRequest {
+            new_root_did: "did:key:z6Mkunreachable".to_string(),
+            new_credential_id: "cred-new".to_string(),
+            confirmation_hex: "deadbeef".to_string(),
+            device_delegation_hex: "deadbeef".to_string(),
+        };
+
+        assert!(matches!(
+            recover(State(state), Json(request)).await,
+            Err(TonkWorkerError::Router(_))
+        ));
     }
 }

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -518,7 +518,8 @@ pub async fn recover(
     // reports the flip as done and re-drives the local persist from that
     // state instead of re-running the whole ceremony — is a tracked
     // follow-up, not implemented here.
-    if let Err(_first_error) = persist_link_replacing(&state, &link_request).await {
+    if let Err(first_error) = persist_link_replacing(&state, &link_request).await {
+        log!("recovery persist failed once, retrying: {first_error}");
         persist_link_replacing(&state, &link_request).await?;
     }
 

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -505,7 +505,22 @@ pub async fn recover(
         delegation_hex: request.device_delegation_hex.clone(),
         succession_hex: None,
     };
-    persist_link_replacing(&state, &link_request).await?;
+    // The service registry is already flipped onto the new root by
+    // `post_recovery` above; if the local persist below fails now, retrying
+    // this handler from scratch is a dead end — it would rebuild the
+    // recovery invocation from the stored *old* link and get a 401 from a
+    // service that has already forgotten that root. Since the failure mode
+    // here is a local storage write (not a network round trip), retry it
+    // once in place before surfacing an error the caller cannot recover
+    // from.
+    //
+    // A fully idempotent `recover` — one that detects the service already
+    // reports the flip as done and re-drives the local persist from that
+    // state instead of re-running the whole ceremony — is a tracked
+    // follow-up, not implemented here.
+    if let Err(_first_error) = persist_link_replacing(&state, &link_request).await {
+        persist_link_replacing(&state, &link_request).await?;
+    }
 
     // Same write-then-read lock handoff as `link`'s rotation arm, and for
     // the same reason: the sweep is a purely local storage sweep that must
@@ -519,6 +534,10 @@ pub async fn recover(
             {
                 let tonk = app_state.write().await;
                 crate::router::migrate::converge_after_rotation(&tonk, &old_root).await;
+                // Recovery creates no device-keyed rows, so this sweep has
+                // nothing to migrate here — but it's idempotent, cheap, and
+                // keeps this arm symmetric with `link`'s rotation arm above.
+                crate::router::migrate::migrate_rosters(&tonk).await;
             }
             let tonk = app_state.read().await;
             crate::router::restore::restore_spaces(&tonk).await;

--- a/rust/tonk-worker/src/router/migrate.rs
+++ b/rust/tonk-worker/src/router/migrate.rs
@@ -53,6 +53,7 @@ pub(crate) async fn migrate_rosters(tonk: &TonkState) {
         return; // unlinked
     }
     if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        log!("roster migration sweep skipped: another sweep is already in flight");
         return;
     }
     for key in crate::router::profile_name::profile_space_keys(tonk).await {
@@ -75,6 +76,7 @@ pub(crate) async fn converge_after_rotation(tonk: &TonkState, old_root: &dialog_
         return;
     };
     if MIGRATE_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        log!("rotation convergence sweep skipped: another sweep is already in flight");
         return;
     }
     for key in crate::router::profile_name::profile_space_keys(tonk).await {


### PR DESCRIPTION
## Summary

Surviving-device recovery — passkey lost, but a linked device is still in hand — end to end (plan: `docs/superpowers/plans/2026-07-24-recovery-ceremonies.md`, Tasks 8–11; program spec: `docs/superpowers/specs/2026-07-24-account-system-completion-design.md`). Second of three recovery sub-stages.

**Stacked on #643** (deliberate rotation) — base is `feat/recovery-rotation`. Rebase onto `staging` once #643 merges.

## How it works

- **Ceremony (surviving device)**: create a new passkey, derive the NEW root scoped (`allowCredentials`) to the just-created credential — the same picker-ambiguity fix rotation uses. The surviving device signs a recovery container **under the OLD root** (proof: its still-valid `oldRoot → device` delegation) carrying `newRootDid`/`newCredentialId`/`deviceDelegation`, and the new root signs a confirmation naming the old root.
- **Service** (`POST /accounts/recover`): verifies the device container via `authorize` (must be an **active** device of the old-root account — a revoked/stolen device is rejected, and an `AND status = 'active'` guard on the delegation update closes the authorize-then-revoke TOCTOU), verifies the confirmation via `authorize_root`, cross-checks the two name each other (one negative test per arm), then flips `root_did` + `credential_id`. Replay is closed by the flip: the old containers no longer resolve an account (test-pinned).
- **Devices stay active**; only the credential is superseded.
- **Worker** (`POST /api/account/recover`): reuses the account-backup device signer and service URL, POSTs both containers, and on success replaces the local link via `persist_link_replacing` — `persist_link` minus the same-issuer guard. That unguarded path has exactly one caller (recover); the normal `/api/account/link` route keeps its guard, and `validate_link` (chain/signature checks) still runs. Then converges rosters (`converge_after_rotation` + `migrate_rosters` + `restore_spaces`, under the same write-lock discipline as the link rotation arm). A local persist failure after the service flip is retried once in place.
- **UI**: recovery panel reachable from both the choice and success panels (a `Linked` profile never sees `choice`, and recovery is only meaningful when linked).

## Deliberately deferred (this sub-stage)

- **Other-device reconnection**: after recovery the old root key is gone, so no succession can bridge the *other* previously-linked devices onto the new root — they keep their local data but need a service-confirmed replacing path (a device-signed probe under the new delegation) to reconnect. The panel copy says this honestly ("a separate step that isn't available yet"); the replacing path is a tracked follow-up.
- **Fully idempotent recover**: if the service flips but the local persist fails past the one retry, the ceremony device needs the same service-confirmed replacing path to finish; documented in a code comment as a follow-up.
- Total-loss re-anchor + CDP e2e are the remaining plan tasks (next PR).

## Testing

- Executed green: `cargo test -p tonk-account-service --features helpers` (49 unit + 8 integration, incl. recovery cross-check both arms, replay, revoked surviving device), `cargo test -p tonk-identity` (15), workspace `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, wasm `cargo check --tests` for tonk-worker and tonk-ui.
- wasm-gated worker/UI tests compile locally, execute in CI's web leg.
- Reviewed adversarially twice (whole-branch + fix-wave re-review): no composition — revoked device, foreign-account device, mixed containers, replayed pair, unscoped passkey pick — moves an account to an attacker's root; the worker route relaxes no service-side check.

## Suggested manual staging pass

Recover on staging with a real passkey → surviving device converges and stays signed in; then observe a *second* previously-linked device's behavior after recovery (demonstrates the deferred other-device reconnection).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces account recovery functionality, allowing users to recover their accounts onto a new root passkey using a surviving device. It includes new modules, routes, and request handling for the recovery process.

### Detailed summary
- Added `pub mod recovery;` in `core.rs`.
- Introduced `AccountRecoverRequest` struct in `account.rs`.
- Implemented `/accounts/recover` route in `handlers.rs`.
- Created `recover_account` function in `recovery.rs`.
- Updated SQL queries to handle active devices only.
- Added recovery handling in the UI and API.
- Implemented tests for recovery functionality.
- Enhanced error handling for recovery requests.

> The following files were skipped due to too many changes: `rust/tonk-account-service/tests/service.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->