### PR TITLE
feat(account): session delegations and signed revocation artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "base58",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "async-trait",
  "base58",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-07-17#2e18c18d57425aa7d39321ceda6a5816c9635881"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "base58",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "async-trait",
  "base58",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=6a4d562b2c5b0706e9b0975530f5d9f947bb1e34#6a4d562b2c5b0706e9b0975530f5d9f947bb1e34"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=2395873d9a0e764ca32853545d35159988b86e77#2395873d9a0e764ca32853545d35159988b86e77"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,35 +179,45 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-07-17" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
 
-# NOTE — the dialog deps above are pinned to the `tonk-2026-07-13-2` TAG:
-# `feat/overlay-retain-entities` (dialog-db #390, which tonk's `staging` already
-# depends on for `Overlay::retain_entities`) plus the Revision/TreeReference move
-# to `dialog-capability` (dialog-db #391), which is what lets the host page name a
-# revision without linking the query engine.
+# NOTE — the dialog deps above are pinned to a REV, not a tag, and that rev is
+# `tonk-2026-07-17` plus exactly one commit: `feat/storage-clone`, which makes
+# `Storage` cloneable (dialog-db #407).
 #
-# That move previously lived only on an ORPHANED commit (tagged `tonk-2026-07-12`,
-# reachable from no branch), which is why this crate used to pin the
-# `feat/engine-free-revision` branch to get it — dragging in the whole
-# version-control stack as a side effect, and resolving TWO copies of every dialog
-# crate. #391 cherry-picks it onto a real branch, so one tag now covers everything.
-# Repoint to a tag on the merged base once #390 and #391 land.
+# Why the extra commit: the worker's presign credential is its operator
+# delegation, and bounding it in time means rotating the operator before it
+# lapses. `OperatorBuilder::build` consumes the `Storage`, so without `Clone` the
+# replacement operator can only be handed a fresh `Storage::new()` — a second
+# pool of connections to the same databases, invisibly divergent from every repo
+# and branch handle the reactor already cached. Cloning shares the pool, which is
+# already how `Storage` is built internally, and makes rotation a contained swap.
+#
+# Why a branch off the tag rather than off dialog `main`: `main` carries the
+# reserved-`dialog.`-namespace change and the version-control redesign, and
+# absorbing those is its own piece of work (tonk #635). Cutting from the tag we
+# already build against keeps this dependency byte-identical to the previous pin
+# apart from that one commit.
+#
+# Repoint to a tag once dialog-db #407 lands on `main` and the pin moves.
+#
+# Pinning by `rev` rather than `branch` on purpose: a branch pin re-resolves as
+# the branch moves, so a build today and a build tomorrow would not agree.
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,26 +179,27 @@ send_wrapper = "0.6"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "6a4d562b2c5b0706e9b0975530f5d9f947bb1e34" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "2395873d9a0e764ca32853545d35159988b86e77" }
 
 # NOTE — the dialog deps above are pinned to a REV, not a tag, and that rev is
-# `tonk-2026-07-17` plus exactly one commit: `feat/storage-clone`, which makes
-# `Storage` cloneable (dialog-db #407).
+# `tonk-2026-07-17` plus exactly one commit, making `Storage` cloneable. It sits
+# on the dialog branch `tonk-2026-07-17-storage-clone`; the same commit is up for
+# review against dialog `main` as dialog-db #407.
 #
 # Why the extra commit: the worker's presign credential is its operator
 # delegation, and bounding it in time means rotating the operator before it

--- a/docs/superpowers/plans/2026-07-24-session-delegations.md
+++ b/docs/superpowers/plans/2026-07-24-session-delegations.md
@@ -54,18 +54,26 @@
 
 ---
 
-### Task 3: Hold a session key in the client
+### Task 3: Hold a session key in the client — DONE, but not as written
 
 **Files:**
-- Modify: `rust/tonk-ui/` (wherever the device grant is loaded for sync), `rust/tonk-worker/`
+- Added: `rust/tonk-worker/src/session.rs`
+- Modified: `rust/tonk-worker/src/worker.rs`, `src/router.rs`, `src/router/sync.rs`, `src/router/profile_name.rs`, `src/lib.rs`, `Cargo.toml`
+- Upstream: dialog-db `feat/storage-clone` (#407)
 
-**This is where the remaining work is.** Tasks 1 and 2 give the primitives; nothing yet *uses* a session key to sign a presign.
+**The seam this task assumed does not exist.** There is no point where the client "loads its `root → device` grant for sync" and could call `extend_with_session`. The presign invocation is signed by dialog's *operator* key, and its proofs are assembled by a `CertificateStore::prove` walk starting at the operator — the client never hands a grant to a signing call.
 
-- [ ] **Step 1: Decide where the session key lives.** It must not outlive its delegation and must not be more durable than the grant. An in-memory key regenerated per page load is the simplest correct answer and costs one delegation mint per load; persisting it to IndexedDB buys fewer mints and adds a key-at-rest to reason about. Prefer in-memory unless mint cost measures badly.
-- [ ] **Step 2: Mint on load.** Where the client currently loads its `root → device` grant for sync, generate an ephemeral signer and call `extend_with_session`. Use the composed chain for presign invocations.
-- [ ] **Step 3: Renew before expiry.** A session that lapses mid-session must re-mint transparently rather than surfacing a 401 to the user. Renewal is local — no network — so this is a timer and a re-mint, not an error path.
-- [ ] **Step 4: Tests.** The wasm suites cannot run locally (macOS 27 blocker); rely on the CI web leg and verify it actually exercises the feature before trusting it.
-- [ ] **Step 5: Commit** `feat(tonk-ui): sign presigns with a short-lived session delegation`
+The `device → session` hop the plan wanted is already there structurally: it is `profile → operator`, minted unexpiring by `.allow(Subject::any())`. Bounding *that* is what bounds every chain the worker presents, and it keeps the device's identity in the chain exactly as the architecture paragraph intended.
+
+- [x] **Step 1: Where the session key lives.** In memory, re-derived per session from the profile seed and a random context. Not persisted: `derive` is a KDF over profile seed plus caller-supplied context, so a random context is all it takes to get a fresh key, and there is no key-at-rest beyond the profile that already exists.
+- [x] **Step 2: Mint on boot.** `session::open` derives the operator and claims `profile → operator` with a `SESSION_TTL_SECONDS` expiration instead of `.allow(Subject::any())`.
+- [x] **Step 3: Renew before expiry.** The sync drain rotates when within `RENEWAL_MARGIN_SECONDS`. Rotation replaces the *key*, not just the delegation: certificates are content-addressed with no delete, and `prove` filters on the *requested* range — which the presign path leaves unbounded, and an unbounded requirement is satisfied by every range including a lapsed one. A re-mint under the same audience would sit beside the dead certificate and be picked about half the time.
+- [x] **Step 4: Tests.** Seven in `session.rs`, including `it_authorizes_a_presign_chain_bounded_by_the_session` — the one that proves swapping `.allow()` for a bounded claim still resolves a real two-hop chain. The wasm suites *do* run locally: Chrome 150 at the default path plus nixpkgs chromedriver 150, `CHROMEDRIVER=… cargo test -p tonk-worker --target wasm32-unknown-unknown`. All 200 pass.
+- [x] **Step 5: Commit** `feat(tonk-worker): sign presigns with a short-lived session delegation`
+
+**Upstream dependency.** Rotation needs the replacement operator built over the *same* storage pool, or the reactor's cached repository and branch handles keep talking to the retired one. `OperatorBuilder::build` consumes its `Storage` and `Storage` was not `Clone`, so the pin moved to a rev carrying that one commit. See the implementation notes.
+
+`tonk_identity::session::extend_with_session` (Task 2) is consequently unused by the client. It stays as the primitive for anything that does hold a grant directly — the CLI, which presents unbounded chains today.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-24-session-delegations.md
+++ b/docs/superpowers/plans/2026-07-24-session-delegations.md
@@ -1,0 +1,86 @@
+# Session Delegations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give revocation something to withhold. `root → device` is unexpiring, so withdrawing it can only ever be a registry lookup. A short-lived `device → session` delegation makes the credential that actually signs presigns lapse on its own, so a registry outage costs at most one session lifetime instead of unbounded access.
+
+**Architecture:** The device keeps its `root → device` grant — that is what survives offline and what the registry records — and uses it to mint a bounded delegation to an ephemeral session key. The session key signs presign invocations; the composed chain still carries the device's hop, so the revocation screen sees the device identity exactly as it does today. Enforcement lives in the access-service's credential screen, which already re-parses the container.
+
+**Tech Stack:** `dialog-ucan-core` (`DelegationBuilder::expiration`, `Timestamp`), `tonk-identity`, `tonk-access-service`, `dialog_common::test`.
+
+## The finding this rests on
+
+`Invocation::check` computes the intersection of every hop's time bounds and returns it as a `TimeRange`. `InvocationChain::verify` then does `.map(|_| ())`, and `UcanAuthorizer::authorize` never looks. **Expiry was therefore unenforced at the presign boundary**: a chain that expired last year verified exactly like a fresh one, and only a chain that could *never* be valid (an empty intersection) was rejected. An expiry nothing checks buys nothing, so enforcement had to land before sessions meant anything.
+
+## Why this shape (decisions)
+
+- **Self-minted, not service-issued.** The device signs the session itself from the grant it holds. No renewal endpoint, nothing to be unreachable, and no new hot-path dependency — which matters because the whole point is to reduce what an outage can cost.
+- **12-hour TTL.** Hours, not minutes: a session must survive a stretch offline and a closed laptop, or renewal failure becomes the common path rather than the exceptional one. Short enough that a lost grant stops mattering within a working day. Tunable — `SESSION_TTL_SECONDS` in `tonk-identity/src/session.rs`.
+- **Enforce, do not require.** The screen rejects a chain outside its window; it does not demand that a chain *have* a window. Unbounded chains keep working, so this is additive and can ship ahead of the clients that will start bounding themselves. Requiring bounded invocations is the breaking half and wants a soak first (see Task 5).
+- **Screen, not authorizer.** Enforcement lives in `tonk-access-service`'s own credential screen rather than upstream in dialog. It reads the window off the parse the revocation screen already does, so it costs nothing extra, and it needs no upstream change to a pinned dependency.
+- **Inclusive bounds.** A chain expiring exactly now is valid. Clients stamp `now + ttl`; an exclusive bound would give them a one-second cliff for no benefit.
+
+## Global Constraints
+
+- Lint gate: `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --check`.
+- Tests: `#[dialog_common::test]`, names `it_does_x`.
+- No stage/phase/PR references in code or doc comments.
+- Conventional commits, scoped to the crate touched.
+
+---
+
+### Task 1: Enforce the presented time window — DONE
+
+**Files:**
+- Added: `rust/tonk-access-service/src/expiry.rs`
+- Modified: `rust/tonk-access-service/src/revocation.rs`, `src/handlers/ucan.rs`, `src/lib.rs`
+
+- [x] **Step 1:** `PresentedCredentials` carries `not_before` and `expires_at`, computed in `collect_presented` as the latest start and earliest end across the invocation and every delegation — the window every hop agrees on.
+- [x] **Step 2:** `check_window` returns `Valid` / `Expired` / `NotYetValid`. Unbounded chains are `Valid`.
+- [x] **Step 3:** The handler runs the window screen *before* the revocation screen, so an expired chain is refused without spending a D1 query, returning `401 INVOCATION_EXPIRED`.
+- [x] **Step 4:** Tests — unbounded, inside, past expiry, before start, inclusive bounds, plus collection from a real session-shaped container (`it_reads_the_window_from_an_expiring_delegation`).
+
+---
+
+### Task 2: Mint session delegations — DONE
+
+**Files:**
+- Added: `rust/tonk-identity/src/session.rs`
+- Modified: `rust/tonk-identity/src/lib.rs`
+
+- [x] **Step 1:** `mint_session_delegation(device, session, ttl)` — subject-open like the grant it descends from, bounded by `expiration`.
+- [x] **Step 2:** `extend_with_session(grant, device, session, ttl)` composes the grant with a fresh session hop, keeping the grant's CID in the chain so the revocation screen still sees the device.
+- [x] **Step 3:** Tests — bounded audience, TTL respected, grant hop retained, and an unexpiring grant becoming bounded once extended.
+
+---
+
+### Task 3: Hold a session key in the client
+
+**Files:**
+- Modify: `rust/tonk-ui/` (wherever the device grant is loaded for sync), `rust/tonk-worker/`
+
+**This is where the remaining work is.** Tasks 1 and 2 give the primitives; nothing yet *uses* a session key to sign a presign.
+
+- [ ] **Step 1: Decide where the session key lives.** It must not outlive its delegation and must not be more durable than the grant. An in-memory key regenerated per page load is the simplest correct answer and costs one delegation mint per load; persisting it to IndexedDB buys fewer mints and adds a key-at-rest to reason about. Prefer in-memory unless mint cost measures badly.
+- [ ] **Step 2: Mint on load.** Where the client currently loads its `root → device` grant for sync, generate an ephemeral signer and call `extend_with_session`. Use the composed chain for presign invocations.
+- [ ] **Step 3: Renew before expiry.** A session that lapses mid-session must re-mint transparently rather than surfacing a 401 to the user. Renewal is local — no network — so this is a timer and a re-mint, not an error path.
+- [ ] **Step 4: Tests.** The wasm suites cannot run locally (macOS 27 blocker); rely on the CI web leg and verify it actually exercises the feature before trusting it.
+- [ ] **Step 5: Commit** `feat(tonk-ui): sign presigns with a short-lived session delegation`
+
+---
+
+### Task 4: Soak
+
+- [ ] **Step 1:** Deploy Tasks 1–3 to staging and watch for `presign rejected: presented chain has expired` in the access-service logs. Any hit that is not an expected lapsed session means a client is stamping windows it cannot honour — find it before Task 5.
+- [ ] **Step 2:** Confirm the CLI and any non-browser client still presign successfully. They present unbounded chains, which stay valid; a failure here means something is stamping expirations unintentionally.
+
+---
+
+### Task 5: Require bounded invocations — GATED ON THE SOAK
+
+**Do not start before Task 4 has run clean for a meaningful period.** This is the breaking half: it refuses any chain that does not bound itself, which strands every client that has not adopted sessions.
+
+- [ ] **Step 1:** Add a `WindowVerdict::Unbounded` case and refuse it.
+- [ ] **Step 2:** Tests — an unbounded chain is refused, a bounded one is not.
+- [ ] **Step 3:** Update the access-service README: presign invocations must carry a window.
+- [ ] **Step 4: Commit** `feat(tonk-access-service): require presented chains to bound themselves`

--- a/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
@@ -23,14 +23,19 @@
 
 The artifact records whichever authority actually authorized the action — a root-signed artifact standing in for a device-authorized revoke would be a fiction, and a verifier that trusts it learns something false. So both shapes are legitimate and the artifact carries its attestation level; consumers set their own bar. A second enforcement point deciding "root-attested only" is making a policy choice, not detecting a defect.
 
-**The artifact is optional, deliberately.** `revoke_device` takes
-`Option<&[u8]>`: supplied means verify, classify and store; absent means
-revoke as before and record nothing. Making it mandatory would have
-broken every shipped caller the moment it deployed — the worker and CLI
-cannot mint a root-signed revocation, because the root key is derived
-from the passkey in the browser and never reaches them. Optionality is
-what lets the artifact path land ahead of the browser ceremony rather
-than in a flag day with it. Requiring attestation is Task 7.
+**Root attestation is required for cross-device revocation.**
+`revoke_device` takes the caller's device DID alongside the target's:
+same device means a self-revoke, which the device signs itself and which
+may carry no artifact at all; different device means a root-signed
+artifact is mandatory. A device-attested artifact naming someone else is
+refused. This is what stops a stolen device from locking out its
+siblings.
+
+The callers were brought along rather than left behind: the browser runs
+a passkey ceremony (`window.tonkIdentity.signRevocation`) before calling
+revoke, and the CLI — which cannot run a passkey ceremony — opens that
+page with `?revoke=<did>` and watches the registry until the device it
+named comes back revoked.
 
 Consequences this plan must carry:
 
@@ -197,20 +202,21 @@ Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account
 
 Depends on D's device-management surface existing. If D has not landed, stop after Task 5 and let D pick this up — the endpoints are complete and testable without a UI.
 
-- [ ] **Step 1:** Wire "sign out on this device" through self-revocation (device key, no prompt) and the device-list revoke button through the root ceremony (passkey assertion → derive root → sign). Copy must state that revoking is permanent for that device's key: coming back means re-linking as a new device.
+- [x] **Step 1a:** The device-list revoke button runs the root ceremony, and the confirm copy states that revocation is permanent for that device's key.
+- [ ] **Step 1b:** "Sign out on this device" still only clears the local link. Wire it through self-revocation so the registry reflects it — the service already accepts a device-attested self-revoke.
 - [ ] **Step 2:** Manual staging smoke: self-revoke from a device and confirm the artifact is device-attested; revoke a second device from a passkey-holding device and confirm the artifact is root-attested; confirm presigns from both 403 within 60s; confirm both artifacts verify standalone against the account root DID.
 - [ ] **Step 3: Commit** and update the completion spec's stage S section to "shipped".
 
 ---
 
-### Task 7: Tighten cross-device revoke authority — GATED ON STAGE C
+### Task 7: Tighten cross-device revoke authority — DONE
 
-**Do not start this task before surviving-device recovery exists.** Until then, a user whose passkey lived on the lost device cannot derive the root, and tightening would leave them unable to revoke the very device they lost — strictly worse than today.
+Landed ahead of stage C by explicit decision. The concern that prompted the gate — a user whose passkey lived on the lost device cannot derive the root, and so cannot revoke it — is real but is not a new failure mode: without the passkey that user also cannot link devices or run any other root ceremony, so they are already in the territory stage C exists to serve. Recovery remains stage C's job.
 
 **Files:**
 - Modify: `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/auth.rs`
 
-- [ ] **Step 1:** Require a root-attested artifact when the target device is not the caller; accept device-attested only for self-revoke. This is the change that closes the live DoS where any active device can permanently lock out its siblings.
-- [ ] **Step 2:** Tests — cross-device revoke with a device-attested artifact is rejected; with a root-attested artifact is accepted; self-revoke is unaffected.
-- [ ] **Step 3:** Note in the completion spec's risk list that the DoS is closed, and drop it from the live-issues list.
-- [ ] **Step 4: Commit** `feat(tonk-account-service): require root attestation to revoke another device`
+- [x] **Step 1:** `revoke_device` takes the caller's DID and requires `Attestation::Root` unless the target is the caller. A device-attested artifact naming another device is refused, as is a cross-device revoke carrying no artifact.
+- [x] **Step 2:** Tests — cross-device with no artifact refused, cross-device with a device-attested artifact refused, self-revoke with a device artifact accepted, root-attested cross-device accepted.
+- [x] **Step 3:** Browser ceremony (`signRevocation` on `window.tonkIdentity`, wired into the device panel) and CLI handoff (`?revoke=<did>` deep link plus registry polling).
+- [x] **Step 4:** The completion spec's risk list records the exposure as closed.

--- a/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
@@ -8,23 +8,28 @@
 
 **Tech Stack:** `dialog-ucan-core` (`InvocationBuilder`, `Invocation`, `Container`), `dialog-credentials` (`Ed25519Signer`), the crate's existing `ChainStore`/`Store` traits, `dialog_common::test`.
 
-## Blocking decision — resolve before Task 2
+## Authority — decided
 
-**Who signs the revocation?** UCAN semantics: the issuer of a delegation, or a principal holding a delegated `ucan/revoke` capability, may revoke it. The issuer of `root → device` is the root, and the account service does not hold the root key — it is derived from the passkey PRF on the user's device and never leaves it. So the service cannot mint this artifact itself. Two options, and they are not close to equivalent:
+**Who signs the revocation?** UCAN semantics: the issuer of a delegation, or a principal holding a delegated `ucan/revoke` capability, may revoke it. The issuer of `root → device` is the root, and the account service does not hold the root key — it is derived from the passkey PRF on the user's device and never leaves it. So the service cannot mint the artifact itself; a client must.
 
-| | Root ceremony | Delegated `ucan/revoke` |
+**Decision: authority scales with blast radius.**
+
+| | Self-revoke (device revokes itself) | Cross-device revoke |
 |---|---|---|
-| Who can revoke | only a passkey-holding device | any linked device |
-| UX | passkey prompt on every revoke | unchanged from today |
-| Stolen-device blast radius | cannot revoke its siblings | **can revoke its siblings** |
-| Client work | derive root, sign, upload | mint `root → device` with a `ucan/revoke` capability at link time; devices sign directly |
-| Migration | none | existing devices have no such capability; needs a re-link or a root-signed top-up |
+| Signed by | the device's own key | the account root |
+| Available when | always, offline, no prompt | a passkey-holding device is at hand |
+| What it means | "sign this account out of this device" | "that device is no longer me" |
+| Can a stolen device do it | yes, to itself only | **no** |
 
-Recommendation: **root ceremony.** The whole point of the stage is that a revocation should be harder to forge than a database write; letting a compromised device revoke its siblings hands an attacker a denial-of-service against the legitimate owner, which is the exact scenario revocation exists for. The UX cost is a passkey prompt on an action users take approximately once.
+The artifact records whichever authority actually authorized the action — a root-signed artifact standing in for a device-authorized revoke would be a fiction, and a verifier that trusts it learns something false. So both shapes are legitimate and the artifact carries its attestation level; consumers set their own bar. A second enforcement point deciding "root-attested only" is making a policy choice, not detecting a defect.
 
-This is a user decision. Do not start Task 2 until it is recorded here.
+Consequences this plan must carry:
 
-- [ ] **Decision recorded:** ______________________
+- **The current policy is the permissive one and is a live irreversible DoS.** `handle_revoke_inner` authorizes any active device of the account and takes the target `did` as a free argument, and there is no un-revoke anywhere in the store. Any device can therefore lock out every sibling, permanently. Tightening cross-device revoke to root is what closes it.
+- **Tightening depends on stage C.** If the lost device *is* the passkey device, its owner cannot derive the root and so cannot revoke it — the ceremony fails in its own primary scenario. Do not land the cross-device tightening before surviving-device recovery exists, or ship it with an explicit escape hatch. Until then, cross-device revoke stays device-signed and records a device-attested artifact.
+- **Passkey syncability decides the felt cost.** A synced passkey (iCloud Keychain, a password manager) derives the same root on every device in the sync group, so the ceremony is one prompt anywhere. A device-bound passkey lives on exactly one device. Same feature, very different UX; the device-management copy should not promise the easy case.
+- **Delegated signing needs no migration.** `root → device` is minted `command(vec![])`, and an empty command is a prefix of every command (`Command::starts_with` is vacuously true), so every linked device already holds authority to sign `ucan/revoke` under the root. Nothing to issue, nothing to re-link.
+- **Revocation is permanent for a key.** The access-service screen matches `device_did`, so re-registering the same device key after a mistaken revoke cannot restore access. Recovery is a fresh key, delegation and row — not a flag flip. Stage D's copy must say so.
 
 ## Why this shape (decisions)
 
@@ -107,17 +112,19 @@ Expected: one `UPDATE ... SET status = 'revoked'`, no path back to `active`. If 
 - Modify: `rust/tonk-identity/src/revocation.rs` (new), `rust/tonk-identity/src/lib.rs`
 
 **Interfaces:**
-- Produces: `mint_revocation(root: Ed25519Signer, delegation_cid: &Cid) -> Result<Vec<u8>>` returning container bytes, consumed by Task 3's handler and Task 5's client call.
+- Produces: `mint_root_revocation(root: Ed25519Signer, delegation_cid: &Cid)` and `mint_self_revocation(device: Ed25519Signer, root_delegation: &DelegationChain, delegation_cid: &Cid)`, both returning container bytes, consumed by Task 3's handler and Task 5's client call.
 
-- [ ] **Step 1: Write the failing test first**
+- [ ] **Step 1: Write the failing tests first**
 
 `it_mints_a_root_signed_revocation_naming_the_delegation`: mint a `root → device` delegation, take its CID, mint a revocation, assert the invocation's issuer is the root DID, its command is `["ucan","revoke"]`, and its arguments carry the delegation CID as a string.
 
+`it_mints_a_device_signed_self_revocation`: same, issued by the device and carrying the `root → device` delegation as its proof, so the chain shows the authority used.
+
 - [ ] **Step 2: Implement**
 
-Mirror `mint_device_delegation` in the same crate: `InvocationBuilder::new().issuer(root).audience(&root_did).subject(&root_did).command(vec!["ucan".into(), "revoke".into()]).arguments(...)`, serialize through a container. Subject is the account root: the revocation is an act on the account, not on a space.
+Mirror `mint_device_delegation` in the same crate: `InvocationBuilder::new().issuer(...).audience(&root_did).subject(&root_did).command(vec!["ucan".into(), "revoke".into()]).arguments(...)`, serialize through a container. Subject is the account root in both cases: the revocation is an act on the account, not on a space. The self-revocation additionally carries its `root → device` proof; the root-signed one needs no proof (issuer equals subject).
 
-- [ ] **Step 3: Second test** — `it_rejects_a_revocation_not_issued_by_the_root` covering the verifier from Task 4 once it exists, or leave a `TODO`-free note in the plan and add it in Task 4.
+- [ ] **Step 3: Third test** — `it_distinguishes_a_root_signed_revocation_from_a_self_revocation`, asserting the two are separable by issuer without parsing arguments. Task 4 depends on that being cheap.
 
 - [ ] **Step 4: Commit** `feat(tonk-identity): mint signed device revocations`
 
@@ -151,9 +158,9 @@ Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account
 **Files:**
 - Modify: `rust/tonk-account-service/src/core/revocation.rs` (new)
 
-- [ ] **Step 1: Write the tests first** — a revocation issued by a foreign root is rejected; one naming a delegation CID that is not this device's registered `delegation_cid` is rejected; the happy path is accepted. Reuse the fixture style in `core/devices.rs` tests.
+- [ ] **Step 1: Write the tests first** — a revocation issued by a foreign root is rejected; one naming a delegation CID that is not the target device's registered `delegation_cid` is rejected; a device-signed revocation naming *another* device is rejected (this is the authority rule, and it is the test that matters); a device-signed revocation naming itself is accepted; a root-signed revocation of any device of that account is accepted. Reuse the fixture style in `core/devices.rs` tests.
 
-- [ ] **Step 2: Implement** `check_revocation(bytes, root_did, expected_delegation_cid)` mirroring `core/delegation.rs:check_device_delegation` — parse, verify signature, check issuer equals the account root, check the named CID matches the device row.
+- [ ] **Step 2: Implement** `check_revocation(bytes, root_did, target_device) -> Result<Attestation>` mirroring `core/delegation.rs:check_device_delegation` — parse, verify signature and chain, check the named CID matches the target's row, then classify: issuer equals the account root → `Attestation::Root`; issuer equals the target device and the chain proves `root → that device` → `Attestation::Device`; anything else is rejected. The returned attestation is stored with the artifact so consumers can filter on it.
 
 - [ ] **Step 3: Commit** `feat(tonk-account-service): verify revocation artifacts before storing them`
 
@@ -181,6 +188,20 @@ Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account
 
 Depends on D's device-management surface existing. If D has not landed, stop after Task 5 and let D pick this up — the endpoints are complete and testable without a UI.
 
-- [ ] **Step 1:** Wire the revoke button through the root ceremony (or the delegated capability, per the blocking decision).
-- [ ] **Step 2:** Manual staging smoke: revoke a device, confirm the artifact appears in the revocation set, confirm presigns from that device 403 within 60s, confirm the artifact verifies standalone against the account root DID.
+- [ ] **Step 1:** Wire "sign out on this device" through self-revocation (device key, no prompt) and the device-list revoke button through the root ceremony (passkey assertion → derive root → sign). Copy must state that revoking is permanent for that device's key: coming back means re-linking as a new device.
+- [ ] **Step 2:** Manual staging smoke: self-revoke from a device and confirm the artifact is device-attested; revoke a second device from a passkey-holding device and confirm the artifact is root-attested; confirm presigns from both 403 within 60s; confirm both artifacts verify standalone against the account root DID.
 - [ ] **Step 3: Commit** and update the completion spec's stage S section to "shipped".
+
+---
+
+### Task 7: Tighten cross-device revoke authority — GATED ON STAGE C
+
+**Do not start this task before surviving-device recovery exists.** Until then, a user whose passkey lived on the lost device cannot derive the root, and tightening would leave them unable to revoke the very device they lost — strictly worse than today.
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/auth.rs`
+
+- [ ] **Step 1:** Require a root-attested artifact when the target device is not the caller; accept device-attested only for self-revoke. This is the change that closes the live DoS where any active device can permanently lock out its siblings.
+- [ ] **Step 2:** Tests — cross-device revoke with a device-attested artifact is rejected; with a root-attested artifact is accepted; self-revoke is unaffected.
+- [ ] **Step 3:** Note in the completion spec's risk list that the DoS is closed, and drop it from the live-issues list.
+- [ ] **Step 4: Commit** `feat(tonk-account-service): require root attestation to revoke another device`

--- a/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
@@ -23,6 +23,15 @@
 
 The artifact records whichever authority actually authorized the action — a root-signed artifact standing in for a device-authorized revoke would be a fiction, and a verifier that trusts it learns something false. So both shapes are legitimate and the artifact carries its attestation level; consumers set their own bar. A second enforcement point deciding "root-attested only" is making a policy choice, not detecting a defect.
 
+**The artifact is optional, deliberately.** `revoke_device` takes
+`Option<&[u8]>`: supplied means verify, classify and store; absent means
+revoke as before and record nothing. Making it mandatory would have
+broken every shipped caller the moment it deployed — the worker and CLI
+cannot mint a root-signed revocation, because the root key is derived
+from the passkey in the browser and never reaches them. Optionality is
+what lets the artifact path land ahead of the browser ceremony rather
+than in a flag day with it. Requiring attestation is Task 7.
+
 Consequences this plan must carry:
 
 - **The current policy is the permissive one and is a live irreversible DoS.** `handle_revoke_inner` authorizes any active device of the account and takes the target `did` as a free argument, and there is no un-revoke anywhere in the store. Any device can therefore lock out every sibling, permanently. Tightening cross-device revoke to root is what closes it.
@@ -70,28 +79,28 @@ Consequences this plan must carry:
 
 **Files:** none modified — read-only verification.
 
-- [ ] **Step 1: dialog has no revocation type to conflict with**
+- [x] **Step 1: dialog has no revocation type to conflict with**
 
 ```bash
 grep -rn "Revocation\|ucan/revoke" ~/.cargo/git/checkouts/dialog-db-*/*/rust/dialog-ucan-core/src/
 ```
 Expected: no matches. The revocation is modelled as an ordinary `Invocation` with command `["ucan", "revoke"]`; nothing upstream competes with or verifies that shape.
 
-- [ ] **Step 2: `InvocationBuilder` takes an arbitrary command and arguments**
+- [x] **Step 2: `InvocationBuilder` takes an arbitrary command and arguments**
 
 ```bash
 grep -n "pub fn command\|pub fn arguments\|pub fn subject\|pub fn proofs" ~/.cargo/git/checkouts/dialog-db-*/*/rust/dialog-ucan-core/src/invocation/builder.rs
 ```
 Expected: builder accepts `Vec<String>` command and a `BTreeMap` of arguments, so `["ucan","revoke"]` with `{"revoke": <cid string>}` needs no upstream change.
 
-- [ ] **Step 3: the chain store is reachable from the revoke handler's context**
+- [x] **Step 3: the chain store is reachable from the revoke handler's context**
 
 ```bash
 grep -n "chain_store\|ChainStore\|R2" rust/tonk-account-service/src/handlers/devices.rs rust/tonk-account-service/src/handlers.rs
 ```
 Expected: `handle_revoke_inner` currently builds only a `Store`. Note what the chains handlers do to obtain a `ChainStore` from `RouteContext` — Task 3 mirrors it. If they use a different binding pattern, follow theirs.
 
-- [ ] **Step 4: `revoke_device` is the only status writer and there is no inverse**
+- [x] **Step 4: `revoke_device` is the only status writer and there is no inverse**
 
 ```bash
 grep -rn "status = 'revoked'\|DeviceStatus::Active" rust/tonk-account-service/src/store/
@@ -102,11 +111,11 @@ Expected: one `UPDATE ... SET status = 'revoked'`, no path back to `active`. If 
 - The root key is reachable server-side by any path → the blocking decision above is moot and the plan needs rewriting around service-side signing.
 - `ChainStore` has grown a delete → revocations must not be stored somewhere erasable; use a separate append-only prefix with no delete path.
 
-- [ ] **Step 5: Nothing to commit** — verification only.
+- [x] **Step 5: Nothing to commit** — verification only.
 
 ---
 
-### Task 2: Mint the revocation client-side
+### Task 2: Mint the revocation client-side — DONE
 
 **Files:**
 - Modify: `rust/tonk-identity/src/revocation.rs` (new), `rust/tonk-identity/src/lib.rs`
@@ -114,23 +123,23 @@ Expected: one `UPDATE ... SET status = 'revoked'`, no path back to `active`. If 
 **Interfaces:**
 - Produces: `mint_root_revocation(root: Ed25519Signer, delegation_cid: &Cid)` and `mint_self_revocation(device: Ed25519Signer, root_delegation: &DelegationChain, delegation_cid: &Cid)`, both returning container bytes, consumed by Task 3's handler and Task 5's client call.
 
-- [ ] **Step 1: Write the failing tests first**
+- [x] **Step 1: Write the failing tests first**
 
 `it_mints_a_root_signed_revocation_naming_the_delegation`: mint a `root → device` delegation, take its CID, mint a revocation, assert the invocation's issuer is the root DID, its command is `["ucan","revoke"]`, and its arguments carry the delegation CID as a string.
 
 `it_mints_a_device_signed_self_revocation`: same, issued by the device and carrying the `root → device` delegation as its proof, so the chain shows the authority used.
 
-- [ ] **Step 2: Implement**
+- [x] **Step 2: Implement**
 
 Mirror `mint_device_delegation` in the same crate: `InvocationBuilder::new().issuer(...).audience(&root_did).subject(&root_did).command(vec!["ucan".into(), "revoke".into()]).arguments(...)`, serialize through a container. Subject is the account root in both cases: the revocation is an act on the account, not on a space. The self-revocation additionally carries its `root → device` proof; the root-signed one needs no proof (issuer equals subject).
 
-- [ ] **Step 3: Third test** — `it_distinguishes_a_root_signed_revocation_from_a_self_revocation`, asserting the two are separable by issuer without parsing arguments. Task 4 depends on that being cheap.
+- [x] **Step 3: Third test** — `it_distinguishes_a_root_signed_revocation_from_a_self_revocation`, asserting the two are separable by issuer without parsing arguments. Task 4 depends on that being cheap.
 
-- [ ] **Step 4: Commit** `feat(tonk-identity): mint signed device revocations`
+- [x] **Step 4: Commit** `feat(tonk-identity): mint signed device revocations`
 
 ---
 
-### Task 3: Store the artifact on revoke
+### Task 3: Store the artifact on revoke — DONE
 
 **Files:**
 - Modify: `rust/tonk-account-service/src/core/devices.rs`, `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/helpers/server.rs`
@@ -139,45 +148,45 @@ Mirror `mint_device_delegation` in the same crate: `InvocationBuilder::new().iss
 - Consumes: Task 2's container bytes, arriving as a new required field on the revoke request body.
 - Produces: an object at `revocations/{chain_key(bytes)}` in the account's namespace.
 
-- [ ] **Step 1: Extend `revoke_device` to take the artifact**
+- [x] **Step 1: Extend `revoke_device` to take the artifact**
 
 Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account, device_did, revocation_bytes)`. Verify before storing (Task 4), then write the artifact **before** flipping the status — a stored artifact with no flag is a recoverable inconsistency; a flag with no artifact is a silent gap in the audit trail.
 
-- [ ] **Step 2: Tests**
+- [x] **Step 2: Tests**
 
 `it_stores_the_artifact_and_flips_the_status`, `it_does_not_flip_the_status_when_the_artifact_is_rejected`, `it_keeps_earlier_revocations_when_a_second_device_is_revoked` (monotonicity).
 
-- [ ] **Step 3: Mirror the wiring in the native helpers server** so the HTTP integration test covers the same path.
+- [x] **Step 3: Mirror the wiring in the native helpers server** so the HTTP integration test covers the same path.
 
-- [ ] **Step 4: Commit** `feat(tonk-account-service): record a signed artifact on device revoke`
+- [x] **Step 4: Commit** `feat(tonk-account-service): record a signed artifact on device revoke`
 
 ---
 
-### Task 4: Verify the artifact before accepting it
+### Task 4: Verify the artifact before accepting it — DONE
 
 **Files:**
 - Modify: `rust/tonk-account-service/src/core/revocation.rs` (new)
 
-- [ ] **Step 1: Write the tests first** — a revocation issued by a foreign root is rejected; one naming a delegation CID that is not the target device's registered `delegation_cid` is rejected; a device-signed revocation naming *another* device is rejected (this is the authority rule, and it is the test that matters); a device-signed revocation naming itself is accepted; a root-signed revocation of any device of that account is accepted. Reuse the fixture style in `core/devices.rs` tests.
+- [x] **Step 1: Write the tests first** — a revocation issued by a foreign root is rejected; one naming a delegation CID that is not the target device's registered `delegation_cid` is rejected; a device-signed revocation naming *another* device is rejected (this is the authority rule, and it is the test that matters); a device-signed revocation naming itself is accepted; a root-signed revocation of any device of that account is accepted. Reuse the fixture style in `core/devices.rs` tests.
 
-- [ ] **Step 2: Implement** `check_revocation(bytes, root_did, target_device) -> Result<Attestation>` mirroring `core/delegation.rs:check_device_delegation` — parse, verify signature and chain, check the named CID matches the target's row, then classify: issuer equals the account root → `Attestation::Root`; issuer equals the target device and the chain proves `root → that device` → `Attestation::Device`; anything else is rejected. The returned attestation is stored with the artifact so consumers can filter on it.
+- [x] **Step 2: Implement** `check_revocation(bytes, root_did, target_device) -> Result<Attestation>` mirroring `core/delegation.rs:check_device_delegation` — parse, verify signature and chain, check the named CID matches the target's row, then classify: issuer equals the account root → `Attestation::Root`; issuer equals the target device and the chain proves `root → that device` → `Attestation::Device`; anything else is rejected. The returned attestation is stored with the artifact so consumers can filter on it.
 
-- [ ] **Step 3: Commit** `feat(tonk-account-service): verify revocation artifacts before storing them`
+- [x] **Step 3: Commit** `feat(tonk-account-service): verify revocation artifacts before storing them`
 
 ---
 
-### Task 5: Expose the revocation set
+### Task 5: Expose the revocation set — DONE
 
 **Files:**
 - Modify: `rust/tonk-account-service/src/handlers/devices.rs`, `rust/tonk-account-service/src/lib.rs`, `rust/tonk-account-service/src/helpers/server.rs`, `rust/tonk-account-service/README.md`
 
-- [ ] **Step 1: `GET`-shaped read endpoint** `POST /devices/revocations` (device-signed invocation, command `["account","device","revocations"]` — the crate's endpoints are all POST-with-invocation; follow that, do not invent a bearer route). Returns the stored artifacts as an array of hex-encoded containers.
+- [x] **Step 1: `GET`-shaped read endpoint** `POST /devices/revocations` (device-signed invocation, command `["account","device","revocations"]` — the crate's endpoints are all POST-with-invocation; follow that, do not invent a bearer route). Returns the stored artifacts as an array of hex-encoded containers.
 
-- [ ] **Step 2: Tests** — a caller sees only their own account's revocations (mirror the cross-account `/chains/get` isolation test added in the hardening batch).
+- [x] **Step 2: Tests** — a caller sees only their own account's revocations (mirror the cross-account `/chains/get` isolation test added in the hardening batch).
 
-- [ ] **Step 3: README** — document the endpoint and state plainly that consumers MUST verify artifacts themselves rather than trusting the service.
+- [x] **Step 3: README** — document the endpoint and state plainly that consumers MUST verify artifacts themselves rather than trusting the service.
 
-- [ ] **Step 4: Commit** `feat(tonk-account-service): serve the signed revocation set`
+- [x] **Step 4: Commit** `feat(tonk-account-service): serve the signed revocation set`
 
 ---
 

--- a/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md
@@ -203,7 +203,11 @@ Signature becomes `revoke_device<S: Store, C: ChainStore>(store, chains, account
 Depends on D's device-management surface existing. If D has not landed, stop after Task 5 and let D pick this up — the endpoints are complete and testable without a UI.
 
 - [x] **Step 1a:** The device-list revoke button runs the root ceremony, and the confirm copy states that revocation is permanent for that device's key.
-- [ ] **Step 1b:** "Sign out on this device" still only clears the local link. Wire it through self-revocation so the registry reflects it — the service already accepts a device-attested self-revoke.
+- [x] **Step 1b:** Sign-out self-revokes **and rotates the profile**. Wiring it through self-revocation alone would have bricked the browser: the access-service screen matches a revoked `device_did` unscoped by account, every chain this profile produces carries that DID as a delegation issuer, and there is no un-revoke — so a device coming back as the same profile is refused every presign it ever makes again, local spaces included.
+
+  Rotation is safe because nothing outside the device is keyed to the device DID: `member_did` returns the account root when linked, and `restore_spaces` re-mounts each escrowed `space → root` chain against a fresh `root → newdevice` link. It costs a passkey prompt to link again, and **anything never escrowed does not come back** — `back_up_owned_space` is hooked only into `enable_sync_inner`, so a space that was never sync-enabled is lost. The confirm copy says so; closing that gap is its own piece of work.
+
+  `rust/tonk-worker/src/device.rs` records which profile the device signs as, since the name was a constant and a rotated profile has to survive a worker restart. The pointer lives on a fixed registry profile — one stored inside the profile it names could not be read before opening it.
 - [ ] **Step 2:** Manual staging smoke: self-revoke from a device and confirm the artifact is device-attested; revoke a second device from a passkey-holding device and confirm the artifact is root-attested; confirm presigns from both 403 within 60s; confirm both artifacts verify standalone against the account root DID.
 - [ ] **Step 3: Commit** and update the completion spec's stage S section to "shipped".
 

--- a/docs/superpowers/plans/implementation-notes.md
+++ b/docs/superpowers/plans/implementation-notes.md
@@ -1,0 +1,97 @@
+# Implementation notes — session delegations and the revoke ceremony
+
+Running log of deviations from the two plans
+(`2026-07-24-session-delegations.md`, `2026-07-24-signed-revocation-artifacts.md`)
+and the edge cases behind them.
+
+## Session delegations Task 3 was written against a client seam that does not exist
+
+The plan says to call `extend_with_session` "where the client currently
+loads its `root → device` grant for sync". There is no such place. The
+presign invocation is signed by dialog's **operator** key, and its proof
+chain is assembled by a `CertificateStore::prove` BFS from the operator
+toward the subject — the client never hands a grant to a signing call.
+
+The `device → session` hop the plan wants already exists structurally:
+it is `profile → operator`, minted by `OperatorBuilder::build` when the
+caller passes `.allow(...)`, and unexpiring. Bounding *that* is Task 3.
+
+Two upstream facts shaped how:
+
+- `prove` filters candidates with `range.covers(requested)`, and the
+  requested range is always `TimeRange::unbounded()` (`UcanFork::authorize`
+  builds `Authorize::new`, never `.during`). `covers` is vacuously true
+  when both required bounds are `None`, so **an expired certificate is
+  still selected**. Nothing in the walk consults the clock.
+- Certificates are keyed by content hash (`{audience}/{subject}/{issuer}.{hash}`)
+  and the store has no delete.
+
+Together those mean re-minting a delegation under the same audience
+leaves an expired certificate beside the fresh one, identical in
+issuer/audience/subject, and `prove` picks between them in hash order.
+So **renewal has to rotate the operator key**, giving each session its
+own audience prefix. Dead certificates under retired audiences are never
+selected because nothing proves *to* those audiences again.
+
+The seam that makes rotation possible: `derive_operator` keys off the
+caller-supplied context (`profile.derive(b"worker")`), so a random
+context yields a fresh operator key per session.
+
+## Sign-out revokes, so it must also rotate the profile
+
+`mint_self_revocation` revokes the device's `root → device` grant, and
+the access-service screen matches revoked rows on `device_did` **unscoped
+by account** (`revoked_query`). Every presign chain this browser produces
+carries the profile DID as a delegation issuer, so a self-revoke without
+rotation permanently refuses presigns for that profile — local spaces
+included — with no un-revoke anywhere.
+
+Rotation is safe because nothing outside the device is keyed to the
+device DID: `member_did` returns the account root when linked, and
+`restore_spaces` re-mounts every escrowed `space → root` chain against a
+fresh `root → newdevice` link.
+
+Known gap, not closed here: `back_up_owned_space` is hooked only into
+`enable_sync_inner`, so a space that was never sync-enabled is never
+escrowed and does not survive rotation.
+
+## Renewal needed an upstream change, so the pin moved to a rev
+
+Rotating the operator means building a replacement, and
+`OperatorBuilder::build` consumes the `Storage` it is handed. `Storage`
+was not `Clone`, so the replacement could only get a fresh
+`Storage::new()` — a second pool of connections over the same databases,
+while every repository and branch handle the reactor cached still talked
+to the first. Divergence with no error surface, and dropping the reactor
+cache to compensate would have meant hand-migrating live subscriptions.
+
+The fix upstream is small because the sharing is already there:
+`Router` was `Clone` and holds an `Arc<Pool>`; only `Loader.mounts` was
+unshared. dialog-db `feat/storage-clone` (#407) wraps it in an `Arc` and
+derives the two impls, cut from the `tonk-2026-07-17` tag rather than
+`main` so it carries none of the reserved-namespace or version-control
+work that tonk #635 exists to absorb. tonk pins that rev until #407
+lands and the pin can move to a tag.
+
+## Two things only the wasm leg catches
+
+Both were found by running the wasm suites locally rather than waiting
+on CI (Chrome 150 at the default path plus nixpkgs chromedriver 150 —
+`CHROMEDRIVER=… cargo test -p tonk-worker --target wasm32-unknown-unknown`).
+
+- `it_refuses_to_revoke_without_a_signed_revocation` had never passed.
+  It asserted a `Conflict` for an empty revocation, but the check sat
+  behind `linked_service`, whose service lookup casts the global to a
+  `ServiceWorkerGlobalScope` and fails outside a real worker — so the
+  call returned `NotFound` and the assertion never got what it tested.
+- `bootstrap_profile` seeds the standard library over a service-worker
+  fetch, so calling it from sign-out made sign-out fail in any harness.
+  It is now logged rather than fatal, which is also the right posture:
+  by then the device is revoked and the key rotated, so there is nothing
+  left to retry.
+
+`Directory::Temp` is a stable path, so a per-run counter is unique only
+*within* a run — the `device` tests name their scratch registries
+randomly, or the next run inherits the last run's rotated pointer and a
+profile that never rotated reads as one that did. Same trap
+`router.rs`'s `session_nonce` documents.

--- a/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
+++ b/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
@@ -123,17 +123,26 @@ Decision — mint the artifact, keep the index:
   *second* enforcement point becomes possible without extending the D1
   binding to it.
 
-The open question that decides the shape, and the reason this is a stage
-rather than a patch: **only the root can sign it.** The issuer of
+The question that decides the shape: **who signs it?** The issuer of
 `root → device` is the root, so under UCAN semantics only the root (or a
-principal holding a delegated `ucan/revoke` capability) may revoke it. The
-account service does not hold the root key — it is derived from the
-passkey PRF on the user's own device and never leaves it. So either
-revocation becomes a root ceremony (passkey prompt, and a device without
-the passkey can no longer revoke — a UX regression that is also a real
-tightening), or the root delegates `ucan/revoke` to each device at link
-time (keeps today's UX, and means a stolen device can revoke its
-siblings). Pick before writing code. Plan:
+principal holding a delegated `ucan/revoke` capability) may revoke it, and
+the account service does not hold the root key — it is derived from the
+passkey PRF on the user's own device and never leaves it.
+
+Decided: **authority scales with blast radius.** A device may revoke
+*itself* with its own key — always available, offline, no prompt, and a
+stolen device can only sign itself out. Revoking *another* device requires
+the root, so a stolen device cannot lock out its siblings. The artifact
+records whichever authority was actually used; a root-signed artifact
+standing in for a device-authorized action would be a fiction. Consumers
+filter on the attestation level rather than assuming one.
+
+Two consequences worth carrying forward. The cross-device tightening is
+**gated on stage C**: if the lost device is the passkey device, its owner
+cannot derive the root, and the ceremony fails in the exact scenario it
+exists for. And delegated signing needs no migration — `root → device` is
+command-open, so every linked device already holds authority to sign
+`ucan/revoke` under the root. Plan:
 `2026-07-24-signed-revocation-artifacts.md`.
 
 Verified against the pinned dialog tag: `dialog-ucan-core` has no
@@ -205,6 +214,27 @@ no CLI verbs. Ships after R so revoke is real:
   **unlink** (`DELETE /api/account`) that clears the stored `root → device`
   link — self-service "sign out of the account on this device".
 - CLI: `tonk account devices`, `tonk account revoke <device-did>`.
+
+Shipped in #642. Three follow-ups fall out of S's authority decision,
+all against code that now exists:
+
+1. **Sign out is not self-revocation.** `#account-unlink` clears the
+   stored `root → device` link locally ("Your data stays; this browser
+   stops acting as the account until you log in again"); the registry row
+   stays `active` and the delegation stays valid, so anyone who extracted
+   the key material beforehand keeps full access. Under the decided
+   model a device may revoke *itself*, and sign-out is exactly that
+   gesture — it should mark the registry too, or say plainly that it does
+   not.
+2. **The revoke dialog does not say permanent.** It warns that spaces may
+   need a fresh invite, but the presign screen matches `device_did`, so
+   the device's key is finished: it comes back as a new device, not a
+   restored one. The copy must say so rather than implying a toggle.
+3. **Cross-device revoke is still device-signed**, which is the permissive
+   policy with a button on it — any device can irreversibly lock out its
+   siblings. S's Task 7 moves it to a root ceremony; the panel already
+   separates self from cross-device, so the change is a signing path, not
+   a redesign.
 
 ### C — Recovery and rotation ceremonies
 
@@ -337,5 +367,14 @@ APIs need confirmation. B gets its plan after the Stripe decisions.
   lands. Anyone who can write `ACCOUNTS_DB` can revoke or un-revoke with
   no audit trail, and no other enforcement point can check revocation
   without that same credential.
+- **Live: any device can permanently lock out its siblings.**
+  `handle_revoke_inner` authorizes any active device of the account and
+  takes the target `did` as a free argument, and the store has no
+  un-revoke. A stolen device can therefore revoke every other device, and
+  the access-service screen matches on `device_did`, so re-registering the
+  same key cannot undo it — recovery is a fresh key and a re-link. Closed
+  by S's Task 7, which is itself gated on C; until then this is an
+  accepted, documented exposure, and D's revoke UX must warn that
+  revocation is permanent for that device's key.
 - **Stage B scope creep.** The entitlement seam in R must stay a seam;
   billing lands only after the log-only soak the master spec requires.

--- a/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
+++ b/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
@@ -170,13 +170,22 @@ after R landed:
   access. This is the UCAN spec's own preference — *"Revocation SHOULD be
   considered the last line of defense against abuse. Proactive expiry
   through time bounds or other constraints SHOULD be preferred."*
-  Open questions for the plan: session TTL (hours, not minutes — it must
-  survive an offline stretch), whether renewal is a new account-service
-  endpoint or the device self-mints from the stored `root → device` grant
-  (self-minting needs no network and is preferred if the access-service
-  can enforce the expiry), and whether the access-service should *require*
-  a bounded invocation rather than merely accepting one, which is the
-  breaking half and wants a soak first.
+  Settled and partly built (plan: `2026-07-24-session-delegations.md`):
+  12-hour TTL, self-minted by the device from the grant it already holds
+  (no renewal endpoint, nothing to be unreachable), and the access-service
+  *enforces* a presented window without *requiring* one — additive, so it
+  ships ahead of the clients that will start bounding themselves.
+  Requiring bounded invocations is the breaking half and is gated on a
+  soak.
+
+  This uncovered a live gap worth stating on its own: **expiry was not
+  enforced at the presign boundary at all.** `Invocation::check` computes
+  the chain's valid `TimeRange` and returns it, `InvocationChain::verify`
+  discards it with `.map(|_| ())`, and `UcanAuthorizer::authorize` never
+  looked — so a chain that expired last year verified exactly like a fresh
+  one, and only a chain that could never be valid was rejected. Enforcement
+  now lives in the access-service's own credential screen, reading the
+  window off the parse the revocation screen already does.
 
 Shipped in #640:
 

--- a/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
+++ b/docs/superpowers/specs/2026-07-24-account-system-completion-design.md
@@ -239,11 +239,11 @@ all against code that now exists:
    need a fresh invite, but the presign screen matches `device_did`, so
    the device's key is finished: it comes back as a new device, not a
    restored one. The copy must say so rather than implying a toggle.
-3. **Cross-device revoke is still device-signed**, which is the permissive
-   policy with a button on it — any device can irreversibly lock out its
-   siblings. S's Task 7 moves it to a root ceremony; the panel already
-   separates self from cross-device, so the change is a signing path, not
-   a redesign.
+3. **Cross-device revoke now runs a passkey ceremony.** The panel calls
+   `window.tonkIdentity.signRevocation` before revoking, and the CLI —
+   which cannot prompt for a passkey — opens the panel with
+   `?revoke=<did>` and watches the registry until the named device comes
+   back revoked.
 
 ### C — Recovery and rotation ceremonies
 
@@ -376,14 +376,19 @@ APIs need confirmation. B gets its plan after the Stripe decisions.
   lands. Anyone who can write `ACCOUNTS_DB` can revoke or un-revoke with
   no audit trail, and no other enforcement point can check revocation
   without that same credential.
-- **Live: any device can permanently lock out its siblings.**
-  `handle_revoke_inner` authorizes any active device of the account and
-  takes the target `did` as a free argument, and the store has no
-  un-revoke. A stolen device can therefore revoke every other device, and
-  the access-service screen matches on `device_did`, so re-registering the
-  same key cannot undo it — recovery is a fresh key and a re-link. Closed
-  by S's Task 7, which is itself gated on C; until then this is an
-  accepted, documented exposure, and D's revoke UX must warn that
-  revocation is permanent for that device's key.
+- **Closed: any device could permanently lock out its siblings.**
+  `handle_revoke_inner` authorized any active device of the account and
+  took the target `did` as a free argument, with no un-revoke in the
+  store — so a stolen device could revoke every other device
+  irreversibly. Cross-device revocation now requires a root-signed
+  artifact, which only the passkey can produce. Revocation is still
+  permanent for a device's key (the presign screen matches `device_did`,
+  so coming back means re-linking as a new device), and the revoke copy
+  says so.
+- **Requiring root landed ahead of C**, by decision. A user whose
+  device-bound passkey was on the lost device can no longer revoke it —
+  but nor can they link devices or run any other root ceremony, so they
+  are already in the territory C exists to serve rather than in a new
+  failure mode.
 - **Stage B scope creep.** The entitlement seam in R must stay a seam;
   billing lands only after the log-only soak the master spec requires.

--- a/rust/tonk-access-service/README.md
+++ b/rust/tonk-access-service/README.md
@@ -29,7 +29,17 @@ The handler reads the body, builds a `UcanAuthorizer` from the Worker environmen
 
 On failure it returns a JSON error (`{ "error": { "code", "message" } }`). Error codes map verification outcomes to HTTP status (see `src/error.rs`): `INVALID_ARGUMENT` (400); `SIGNATURE_INVALID` / `AUDIENCE_MISMATCH` / `INVOCATION_EXPIRED` (401); `CHAIN_INVALID` / `COMMAND_MISMATCH` / `SUBJECT_NOT_ALLOWED` / `DEVICE_REVOKED` (403); `INTERNAL_ERROR` (500); `REVOCATION_UNAVAILABLE` (503).
 
-## Revocation screening
+## Credential screening
+
+After cryptographic authorization succeeds, `POST /ucan/` re-parses the presented container once and runs two screens off that parse: the window the chain claims, and whether any credential in it belongs to a revoked device.
+
+### Time window
+
+The chain verifier computes the intersection of every hop's time bounds and hands it back as a `TimeRange`, but `InvocationChain::verify` discards it — so nothing on this path ever compared it to the clock. `src/expiry.rs` closes that: `collect_presented` carries the latest `not_before` and earliest `expiration` across the invocation and every delegation, and a presign outside that window returns `401 INVOCATION_EXPIRED`.
+
+Unbounded chains are unaffected. A `root → device` grant carries no expiration, so its window is open and every check passes; only a chain that bounds itself can fall outside one. That is what makes this safe ahead of the clients that will start presenting short-lived session delegations — and it is the enforcement those sessions depend on, since an expiry nothing checks buys nothing.
+
+### Revocation
 
 After cryptographic authorization succeeds, `POST /ucan/` screens the presented container against the account registry (`src/revocation.rs`). It re-parses the container independently, collects every delegation CID, every delegation issuer DID, and the invocation issuer DID, and asks whether any of them belongs to a device with `status = 'revoked'`. Matching on issuer DIDs as well as CIDs is what severs chains that flow through a delegation the registry never recorded — anything a revoked key signed, whenever it signed it. A match returns `403 DEVICE_REVOKED`; users with no account match nothing and are unaffected.
 

--- a/rust/tonk-access-service/src/expiry.rs
+++ b/rust/tonk-access-service/src/expiry.rs
@@ -1,0 +1,108 @@
+//! Time-window enforcement for presented UCAN containers.
+//!
+//! The chain verifier computes the window a chain is valid in and hands
+//! it back as a `TimeRange`; `InvocationChain::verify` discards it, so
+//! nothing on the presign path ever compared it to the clock. A chain
+//! that expired last year verifies exactly like a fresh one — only a
+//! chain that can *never* be valid is rejected upstream.
+//!
+//! This screen closes that. It reads the window off the same parse the
+//! revocation screen already does
+//! ([`PresentedCredentials`](super::revocation::PresentedCredentials))
+//! and refuses a presign outside it.
+//!
+//! Unbounded chains are unaffected: a `root → device` grant carries no
+//! expiration, so its window is open and every check passes. That is
+//! what makes this safe to turn on ahead of the clients that will start
+//! bounding themselves, and it is the enforcement short-lived session
+//! delegations depend on — an expiry nothing checks buys nothing.
+
+use crate::revocation::PresentedCredentials;
+
+/// Whether the presented chain is valid at a given moment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowVerdict {
+    /// Now falls inside the window every hop agrees on, or no hop
+    /// bounds it.
+    Valid,
+    /// Every hop agreed the chain would stop being valid before now.
+    Expired,
+    /// A hop declares the chain does not start until later.
+    NotYetValid,
+}
+
+/// Check the presented chain's effective window against `now_s`, in
+/// unix seconds.
+///
+/// The bounds are inclusive: a chain expiring exactly now is still
+/// valid, matching how the intersection is computed upstream and
+/// avoiding a one-second cliff for clients that stamp `now + ttl`.
+pub fn check_window(presented: &PresentedCredentials, now_s: u64) -> WindowVerdict {
+    if let Some(not_before) = presented.not_before
+        && now_s < not_before
+    {
+        return WindowVerdict::NotYetValid;
+    }
+    if let Some(expires_at) = presented.expires_at
+        && now_s > expires_at
+    {
+        return WindowVerdict::Expired;
+    }
+    WindowVerdict::Valid
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    fn bounded(not_before: Option<u64>, expires_at: Option<u64>) -> PresentedCredentials {
+        PresentedCredentials {
+            invocation_issuer: "did:key:zDevice".to_string(),
+            delegation_cids: vec!["bafycid".to_string()],
+            delegation_issuers: vec!["did:key:zRoot".to_string()],
+            not_before,
+            expires_at,
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_an_unbounded_chain() {
+        let verdict = check_window(&bounded(None, None), 1_000);
+
+        assert_eq!(
+            verdict,
+            WindowVerdict::Valid,
+            "an unexpiring root to device grant must keep working"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_chain_inside_its_window() {
+        let verdict = check_window(&bounded(Some(500), Some(1_500)), 1_000);
+
+        assert_eq!(verdict, WindowVerdict::Valid);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_past_its_expiration() {
+        let verdict = check_window(&bounded(None, Some(999)), 1_000);
+
+        assert_eq!(verdict, WindowVerdict::Expired);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_before_it_starts() {
+        let verdict = check_window(&bounded(Some(1_001), None), 1_000);
+
+        assert_eq!(verdict, WindowVerdict::NotYetValid);
+    }
+
+    #[dialog_common::test]
+    async fn it_treats_the_bounds_as_inclusive() {
+        assert_eq!(
+            check_window(&bounded(Some(1_000), Some(1_000)), 1_000),
+            WindowVerdict::Valid,
+            "a chain expiring exactly now is still valid"
+        );
+    }
+}

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -56,11 +56,12 @@ async fn handle_inner(
         .await
         .map_err(map_access_error)?;
 
-    // 3b. Screen the presented credentials against revoked devices.
-    // Runs only after cryptographic authorization succeeded, and fails
-    // closed: a presign the screen cannot clear is refused.
+    // 3b. Screen the presented credentials: the window they claim, and
+    // whether any of them belongs to a revoked device. Runs only after
+    // cryptographic authorization succeeded, and fails closed: a
+    // presign the screen cannot clear is refused.
     #[cfg(target_arch = "wasm32")]
-    screen_revoked(&body_bytes, ctx).await?;
+    screen_credentials(&body_bytes, ctx).await?;
 
     // 4. Serialize the response as CBOR
     let cbor_bytes = serde_ipld_dagcbor::to_vec(&authorized_request).map_err(|e| {
@@ -81,10 +82,11 @@ async fn handle_inner(
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn screen_revoked(
+async fn screen_credentials(
     body_bytes: &[u8],
     ctx: &RouteContext<()>,
 ) -> std::result::Result<(), ServiceError> {
+    use crate::expiry::{WindowVerdict, check_window};
     use crate::revocation::{self, RevocationVerdict, d1::D1RevocationRegistry};
 
     let presented = match revocation::collect_presented(body_bytes) {
@@ -98,6 +100,28 @@ async fn screen_revoked(
             return Err(unavailable());
         }
     };
+
+    // The window screen needs no registry, so it runs first: an expired
+    // chain is refused without spending a D1 query on it.
+    let now_ms = Date::now().as_millis();
+    match check_window(&presented, now_ms / 1_000) {
+        WindowVerdict::Valid => {}
+        WindowVerdict::Expired => {
+            worker::console_log!("presign rejected: presented chain has expired");
+            return Err(ServiceError::new(
+                ErrorCode::InvocationExpired,
+                "the presented chain is outside its valid window",
+            ));
+        }
+        WindowVerdict::NotYetValid => {
+            worker::console_log!("presign rejected: presented chain is not yet valid");
+            return Err(ServiceError::new(
+                ErrorCode::InvocationExpired,
+                "the presented chain is outside its valid window",
+            ));
+        }
+    }
+
     let registry = match ctx.d1("ACCOUNTS_DB") {
         Ok(db) => D1RevocationRegistry::new(db),
         Err(err) => {
@@ -105,7 +129,6 @@ async fn screen_revoked(
             return Err(unavailable());
         }
     };
-    let now_ms = Date::now().as_millis();
     match revocation::assess(&registry, &presented, now_ms).await {
         RevocationVerdict::Allowed => Ok(()),
         RevocationVerdict::AllowedStale(reason) => {

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -33,6 +33,8 @@
 use worker::*;
 
 mod error;
+#[cfg(any(target_arch = "wasm32", test))]
+mod expiry;
 mod handlers;
 #[cfg(any(target_arch = "wasm32", test))]
 mod revocation;

--- a/rust/tonk-access-service/src/revocation.rs
+++ b/rust/tonk-access-service/src/revocation.rs
@@ -29,7 +29,9 @@ use dialog_ucan_core::delegation::Delegation;
 use dialog_ucan_core::invocation::Invocation;
 use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 
-/// Every credential identity found in a presented UCAN container.
+/// Everything a presented UCAN container asserts about itself: the
+/// credential identities in it, and the time window they agree on.
+/// Both screens run off this one parse.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PresentedCredentials {
     /// The DID that signed the invocation (the requesting operator).
@@ -39,6 +41,13 @@ pub struct PresentedCredentials {
     pub delegation_cids: Vec<String>,
     /// Issuer DIDs of every delegation carried in the container.
     pub delegation_issuers: Vec<String>,
+    /// The latest `not_before` any delegation carries, in unix seconds.
+    /// `None` when nothing in the chain bounds its start.
+    pub not_before: Option<u64>,
+    /// The earliest `expiration` anything in the chain carries, in unix
+    /// seconds. `None` when nothing bounds its end — which is the shape
+    /// of an unexpiring `root → device` grant.
+    pub expires_at: Option<u64>,
 }
 
 impl PresentedCredentials {
@@ -74,6 +83,11 @@ pub fn collect_presented(container_bytes: &[u8]) -> Result<PresentedCredentials,
         delegation_cids.insert(cid.to_string());
     }
 
+    // The chain is valid only where every hop agrees, so the window
+    // narrows to the latest start and the earliest end.
+    let mut not_before: Option<u64> = None;
+    let mut expires_at: Option<u64> = invocation.expiration().map(|stamp| stamp.to_unix());
+
     let mut delegation_issuers = BTreeSet::new();
     for (index, bytes) in tokens.iter().skip(1).enumerate() {
         let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
@@ -82,12 +96,20 @@ pub fn collect_presented(container_bytes: &[u8]) -> Result<PresentedCredentials,
             })?;
         delegation_cids.insert(delegation.to_cid().to_string());
         delegation_issuers.insert(delegation.issuer().to_string());
+        if let Some(stamp) = delegation.not_before() {
+            not_before = Some(not_before.map_or(stamp.to_unix(), |seen| seen.max(stamp.to_unix())));
+        }
+        if let Some(stamp) = delegation.expiration() {
+            expires_at = Some(expires_at.map_or(stamp.to_unix(), |seen| seen.min(stamp.to_unix())));
+        }
     }
 
     Ok(PresentedCredentials {
         invocation_issuer: invocation.issuer().to_string(),
         delegation_cids: delegation_cids.into_iter().collect(),
         delegation_issuers: delegation_issuers.into_iter().collect(),
+        not_before,
+        expires_at,
     })
 }
 
@@ -449,6 +471,88 @@ mod tests {
         assert!(keys.contains(&device2_did));
     }
 
+    /// A container shaped like a session presign: an unexpiring
+    /// `root → device` grant, a short-lived `device → session`
+    /// delegation, invocation issued by the session key.
+    async fn session_container(session_ttl_seconds: u64) -> (u64, Vec<u8>) {
+        use dialog_ucan_core::time::Timestamp;
+
+        let root = Ed25519Signer::import(&ROOT_SEED).await.unwrap();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let session = Ed25519Signer::import(&DEVICE2_SEED).await.unwrap();
+        let root_did = root.did();
+
+        let grant = DelegationBuilder::new()
+            .issuer(root.clone())
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let grant_cid = grant.to_cid();
+
+        let expiration = Timestamp::new(
+            std::time::SystemTime::now() + std::time::Duration::from_secs(session_ttl_seconds),
+        )
+        .unwrap();
+        let expires_at = expiration.to_unix();
+        let session_delegation = DelegationBuilder::new()
+            .issuer(device.clone())
+            .audience(&session.did())
+            .subject(Subject::Any)
+            .command(vec![])
+            .expiration(expiration)
+            .try_build()
+            .await
+            .unwrap();
+        let session_cid = session_delegation.to_cid();
+
+        let invocation = InvocationBuilder::new()
+            .issuer(session.clone())
+            .audience(&root_did)
+            .subject(&root_did)
+            .command(vec!["memory".to_string(), "resolve".to_string()])
+            .arguments(BTreeMap::new())
+            .proofs(vec![grant_cid, session_cid])
+            .try_build()
+            .await
+            .unwrap();
+
+        let mut proofs = HashMap::new();
+        proofs.insert(grant_cid, Arc::new(grant));
+        proofs.insert(session_cid, Arc::new(session_delegation));
+        let bytes = InvocationChain::new(invocation, proofs).to_bytes().unwrap();
+        (expires_at, bytes)
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_the_window_from_an_expiring_delegation() {
+        let (expires_at, bytes) = session_container(900).await;
+
+        let presented = collect_presented(&bytes).unwrap();
+
+        assert_eq!(
+            presented.expires_at,
+            Some(expires_at),
+            "the session hop's expiry must narrow the chain's window"
+        );
+        assert_eq!(presented.not_before, None);
+    }
+
+    #[dialog_common::test]
+    async fn it_leaves_the_window_open_when_nothing_bounds_it() {
+        let (_, _, _, bytes) = device_container().await;
+
+        let presented = collect_presented(&bytes).unwrap();
+
+        assert_eq!(
+            presented.expires_at, None,
+            "an unexpiring root to device grant bounds nothing"
+        );
+        assert_eq!(presented.not_before, None);
+    }
+
     #[dialog_common::test]
     async fn it_splits_unseen_keys_into_misses() {
         let mut map = HashMap::new();
@@ -565,6 +669,8 @@ mod tests {
             invocation_issuer: format!("did:key:{prefix}-device"),
             delegation_cids: vec![format!("bafy{prefix}cid")],
             delegation_issuers: vec![format!("did:key:{prefix}-root")],
+            not_before: None,
+            expires_at: None,
         }
     }
 

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -182,12 +182,15 @@ pub fn string_argument(caller: &Caller, name: &str) -> Result<String, CeremonyEr
 /// caller without the account root, today. Present but malformed is a
 /// client bug worth surfacing rather than ignoring.
 pub fn optional_revocation(caller: &Caller) -> Result<Option<Vec<u8>>, CeremonyError> {
-    let Some(Promised::String(hex_bytes)) = caller.arguments.get("revocation") else {
-        return Ok(None);
-    };
-    hex::decode(hex_bytes)
-        .map(Some)
-        .map_err(|err| CeremonyError::Invalid(format!("bad revocation hex: {err}")))
+    match caller.arguments.get("revocation") {
+        None => Ok(None),
+        Some(Promised::String(hex_bytes)) => hex::decode(hex_bytes)
+            .map(Some)
+            .map_err(|err| CeremonyError::Invalid(format!("bad revocation hex: {err}"))),
+        Some(_) => Err(CeremonyError::Invalid(
+            "revocation must be a hex string".to_string(),
+        )),
+    }
 }
 
 #[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
@@ -587,6 +590,46 @@ mod tests {
         assert!(matches!(
             authorize_root(&bytes, &["account", "device", "link"]).await,
             Err(CeremonyError::Unauthorized(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_treats_an_absent_revocation_as_none() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, bytes) = container(
+            vec!["account".into(), "device".into(), "revoke".into()],
+            BTreeMap::new(),
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+        let caller = authorize(&store, &bytes, &["account", "device", "revoke"])
+            .await
+            .unwrap();
+
+        assert_eq!(optional_revocation(&caller).unwrap(), None);
+    }
+
+    /// Present-but-not-a-string is a malformed request, not an absent
+    /// argument — silently dropping it would read as "no artifact" and
+    /// change which authority rule applies.
+    #[dialog_common::test]
+    async fn it_rejects_a_revocation_that_is_not_a_string() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, bytes) = container(
+            vec!["account".into(), "device".into(), "revoke".into()],
+            [("revocation".to_owned(), Promised::Integer(7))]
+                .into_iter()
+                .collect(),
+        )
+        .await;
+        seed_device(&store, &root_did, &device_did, DeviceStatus::Active).await;
+        let caller = authorize(&store, &bytes, &["account", "device", "revoke"])
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            optional_revocation(&caller),
+            Err(CeremonyError::Invalid(_))
         ));
     }
 }

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -176,6 +176,20 @@ pub fn string_argument(caller: &Caller, name: &str) -> Result<String, CeremonyEr
     required_string(&caller.arguments, name)
 }
 
+/// The optional `revocation` argument, hex-decoded.
+///
+/// Absent means the caller could not mint a signed revocation — every
+/// caller without the account root, today. Present but malformed is a
+/// client bug worth surfacing rather than ignoring.
+pub fn optional_revocation(caller: &Caller) -> Result<Option<Vec<u8>>, CeremonyError> {
+    let Some(Promised::String(hex_bytes)) = caller.arguments.get("revocation") else {
+        return Ok(None);
+    };
+    hex::decode(hex_bytes)
+        .map(Some)
+        .map_err(|err| CeremonyError::Invalid(format!("bad revocation hex: {err}")))
+}
+
 #[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;

--- a/rust/tonk-account-service/src/core.rs
+++ b/rust/tonk-account-service/src/core.rs
@@ -15,6 +15,7 @@ pub mod codes;
 pub mod delegation;
 pub mod devices;
 pub mod links;
+pub mod revocation;
 
 /// Errors shared by every ceremony in this crate.
 #[derive(Debug)]

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -1,8 +1,10 @@
 //! Device registry operations: list, register, and revoke devices
 //! under an account's root DID.
 
+use crate::chains::ChainStore;
 use crate::core::CeremonyError;
 use crate::core::delegation::check_device_delegation;
+use crate::core::revocation::{Attestation, check_revocation, put_revocation};
 use crate::store::{Account, Device, DeviceStatus, Store};
 
 /// A device row as surfaced to API callers.
@@ -69,25 +71,58 @@ pub async fn register_device<S: Store>(
     Ok(())
 }
 
-/// Revoke a device under an account.
+/// Revoke a device under an account, recording the signed revocation
+/// that authorized it when one is supplied.
 ///
+/// A supplied artifact is verified and stored *before* the status
+/// flips: a stored artifact with no flag is a recoverable
+/// inconsistency, while a flag with no artifact is a silent gap in the
+/// audit trail. A rejected artifact leaves the device active.
+///
+/// The artifact is optional so that callers which cannot yet mint one —
+/// anything without access to the account root, which today is every
+/// caller but the browser — keep working. Requiring root attestation
+/// for cross-device revocation is a later, deliberate tightening; it
+/// closes the exposure where any device can lock out its siblings, and
+/// it must not land before a device that lost its passkey has a
+/// recovery path.
+///
+/// Returns the attestation level when an artifact was recorded.
 /// Returns `CeremonyError::Invalid` if the device does not exist under
 /// this account.
-pub async fn revoke_device<S: Store>(
+pub async fn revoke_device<S: Store, C: ChainStore>(
     store: &S,
+    chains: &C,
     account: &Account,
     device_did: &str,
-) -> Result<(), CeremonyError> {
+    revocation: Option<&[u8]>,
+) -> Result<Option<Attestation>, CeremonyError> {
+    let device = store
+        .device_by_did(device_did)
+        .await?
+        .filter(|device| device.account_id == account.id)
+        .ok_or_else(|| CeremonyError::Invalid("unknown device".to_string()))?;
+
+    let attestation = match revocation {
+        Some(bytes) => {
+            let attestation = check_revocation(bytes, &account.root_did, &device).await?;
+            put_revocation(chains, account, attestation, bytes).await?;
+            Some(attestation)
+        }
+        None => None,
+    };
+
     let changed = store.revoke_device(account.id, device_did).await?;
     if !changed {
         return Err(CeremonyError::Invalid("unknown device".to_string()));
     }
-    Ok(())
+    Ok(attestation)
 }
 
 #[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::chains::MemoryChainStore;
     use crate::store::sqlite::SqliteStore;
 
     const ROOT_PRF: [u8; 32] = [7u8; 32];
@@ -155,19 +190,126 @@ mod tests {
         assert!(matches!(result, Err(CeremonyError::Invalid(_))));
     }
 
+    /// Register a device, then mint the root-signed revocation of its
+    /// grant. Returns (device did, revocation container bytes).
+    async fn registered_with_revocation(
+        store: &SqliteStore,
+        account: &Account,
+    ) -> (String, Vec<u8>) {
+        let (device_did, delegation_hex) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
+        register_device(store, account, &device_did, "phone", &delegation_hex, 200)
+            .await
+            .unwrap();
+        let device = store.device_by_did(&device_did).await.unwrap().unwrap();
+        let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let revocation =
+            tonk_identity::revocation::mint_root_revocation(root, &device.delegation_cid)
+                .await
+                .unwrap();
+        (device_did, revocation)
+    }
+
     #[dialog_common::test]
     async fn it_revokes_and_reflects_status_in_the_listing() {
         let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
         let account = seeded_account(&store).await;
-        let (device_did, delegation_hex) = delegation_from(ROOT_PRF, DEVICE_SEED).await;
-        register_device(&store, &account, &device_did, "phone", &delegation_hex, 200)
+        let (device_did, revocation) = registered_with_revocation(&store, &account).await;
+
+        revoke_device(&store, &chains, &account, &device_did, Some(&revocation))
             .await
             .unwrap();
-
-        revoke_device(&store, &account, &device_did).await.unwrap();
 
         let views = list_devices(&store, &account).await.unwrap();
         assert_eq!(views.len(), 1);
         assert_eq!(views[0].status, "revoked");
+    }
+
+    #[dialog_common::test]
+    async fn it_revokes_without_an_artifact_and_records_nothing() {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let (device_did, _) = registered_with_revocation(&store, &account).await;
+
+        let attestation = revoke_device(&store, &chains, &account, &device_did, None)
+            .await
+            .unwrap();
+
+        assert!(
+            attestation.is_none(),
+            "a caller that cannot mint an artifact still revokes"
+        );
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views[0].status, "revoked");
+        let stored = crate::core::revocation::list_revocations(&chains, &account)
+            .await
+            .unwrap();
+        assert!(
+            stored.is_empty(),
+            "nothing unsigned enters the artifact set"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_the_artifact_alongside_the_status_flip() {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let (device_did, revocation) = registered_with_revocation(&store, &account).await;
+
+        let attestation = revoke_device(&store, &chains, &account, &device_did, Some(&revocation))
+            .await
+            .unwrap();
+
+        assert_eq!(attestation, Some(Attestation::Root));
+        let stored = crate::core::revocation::list_revocations(&chains, &account)
+            .await
+            .unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].attestation, "root");
+    }
+
+    #[dialog_common::test]
+    async fn it_leaves_the_device_active_when_the_artifact_is_rejected() {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let (device_did, _) = registered_with_revocation(&store, &account).await;
+        let foreign = tonk_identity::derive::derive_root_signer(&FOREIGN_ROOT_PRF)
+            .await
+            .unwrap();
+        let device = store.device_by_did(&device_did).await.unwrap().unwrap();
+        let forged =
+            tonk_identity::revocation::mint_root_revocation(foreign, &device.delegation_cid)
+                .await
+                .unwrap();
+
+        let result = revoke_device(&store, &chains, &account, &device_did, Some(&forged)).await;
+
+        assert!(matches!(result, Err(CeremonyError::Forbidden(_))));
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(
+            views[0].status, "active",
+            "a rejected artifact must not flip the status"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_revoking_a_device_of_another_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let (device_did, revocation) = registered_with_revocation(&store, &account).await;
+        let foreign = Account {
+            id: account.id + 1,
+            ..account.clone()
+        };
+
+        let result = revoke_device(&store, &chains, &foreign, &device_did, Some(&revocation)).await;
+
+        assert!(matches!(result, Err(CeremonyError::Invalid(_))));
     }
 }

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -72,47 +72,58 @@ pub async fn register_device<S: Store>(
 }
 
 /// Revoke a device under an account, recording the signed revocation
-/// that authorized it when one is supplied.
+/// that authorized it.
 ///
-/// A supplied artifact is verified and stored *before* the status
-/// flips: a stored artifact with no flag is a recoverable
-/// inconsistency, while a flag with no artifact is a silent gap in the
-/// audit trail. A rejected artifact leaves the device active.
+/// **Authority scales with blast radius.** Revoking a device other than
+/// the caller requires a root-signed revocation: only the account root
+/// can produce one, and the root key lives behind the user's passkey, so
+/// a stolen device cannot lock out its siblings. A device revoking
+/// itself signs with its own key — always available, offline, no prompt.
 ///
-/// The artifact is optional so that callers which cannot yet mint one —
-/// anything without access to the account root, which today is every
-/// caller but the browser — keep working. Requiring root attestation
-/// for cross-device revocation is a later, deliberate tightening; it
-/// closes the exposure where any device can lock out its siblings, and
-/// it must not land before a device that lost its passkey has a
-/// recovery path.
+/// The artifact is verified and stored *before* the status flips: a
+/// stored artifact with no flag is a recoverable inconsistency, while a
+/// flag with no artifact is a silent gap in the audit trail. A rejected
+/// artifact leaves the device active.
 ///
-/// Returns the attestation level when an artifact was recorded.
-/// Returns `CeremonyError::Invalid` if the device does not exist under
-/// this account.
+/// Returns the attestation level recorded, or `None` for a self-revoke
+/// that carried no artifact. Returns `CeremonyError::Invalid` if the
+/// device does not exist under this account.
 pub async fn revoke_device<S: Store, C: ChainStore>(
     store: &S,
     chains: &C,
     account: &Account,
-    device_did: &str,
+    caller_did: &str,
+    target_did: &str,
     revocation: Option<&[u8]>,
 ) -> Result<Option<Attestation>, CeremonyError> {
     let device = store
-        .device_by_did(device_did)
+        .device_by_did(target_did)
         .await?
         .filter(|device| device.account_id == account.id)
         .ok_or_else(|| CeremonyError::Invalid("unknown device".to_string()))?;
 
+    let revoking_self = caller_did == target_did;
+
     let attestation = match revocation {
         Some(bytes) => {
             let attestation = check_revocation(bytes, &account.root_did, &device).await?;
+            if !revoking_self && attestation != Attestation::Root {
+                return Err(CeremonyError::Forbidden(
+                    "revoking another device requires a root-signed revocation".to_string(),
+                ));
+            }
             put_revocation(chains, account, attestation, bytes).await?;
             Some(attestation)
         }
-        None => None,
+        None if revoking_self => None,
+        None => {
+            return Err(CeremonyError::Forbidden(
+                "revoking another device requires a root-signed revocation".to_string(),
+            ));
+        }
     };
 
-    let changed = store.revoke_device(account.id, device_did).await?;
+    let changed = store.revoke_device(account.id, target_did).await?;
     if !changed {
         return Err(CeremonyError::Invalid("unknown device".to_string()));
     }
@@ -128,6 +139,10 @@ mod tests {
     const ROOT_PRF: [u8; 32] = [7u8; 32];
     const DEVICE_SEED: [u8; 32] = [11u8; 32];
     const FOREIGN_ROOT_PRF: [u8; 32] = [9u8; 32];
+
+    /// A caller that is not the device being revoked, so the
+    /// cross-device authority rule applies.
+    const CALLER_DID: &str = "did:key:zCaller";
 
     /// Seed an account through the store directly (root PRF `[7u8; 32]`,
     /// the same root as Task 5's `fixture()`), then mint a fresh
@@ -218,9 +233,16 @@ mod tests {
         let account = seeded_account(&store).await;
         let (device_did, revocation) = registered_with_revocation(&store, &account).await;
 
-        revoke_device(&store, &chains, &account, &device_did, Some(&revocation))
-            .await
-            .unwrap();
+        revoke_device(
+            &store,
+            &chains,
+            &account,
+            CALLER_DID,
+            &device_did,
+            Some(&revocation),
+        )
+        .await
+        .unwrap();
 
         let views = list_devices(&store, &account).await.unwrap();
         assert_eq!(views.len(), 1);
@@ -234,7 +256,7 @@ mod tests {
         let account = seeded_account(&store).await;
         let (device_did, _) = registered_with_revocation(&store, &account).await;
 
-        let attestation = revoke_device(&store, &chains, &account, &device_did, None)
+        let attestation = revoke_device(&store, &chains, &account, &device_did, &device_did, None)
             .await
             .unwrap();
 
@@ -254,15 +276,140 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_refuses_to_revoke_another_device_without_an_artifact() {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let (device_did, _) = registered_with_revocation(&store, &account).await;
+
+        let result = revoke_device(&store, &chains, &account, CALLER_DID, &device_did, None).await;
+
+        assert!(
+            matches!(result, Err(CeremonyError::Forbidden(_))),
+            "cutting off another device takes the root, not a device signature"
+        );
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views[0].status, "active");
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_device_attested_revocation_of_another_device() {
+        use dialog_varsig::Principal;
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+
+        // Register from the very grant the self-revocation will name, so
+        // the CIDs match and the only thing left to reject is the
+        // attestation level.
+        let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let grant = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let device_did = device.did().to_string();
+        register_device(
+            &store,
+            &account,
+            &device_did,
+            "phone",
+            &hex::encode(grant.to_bytes().unwrap()),
+            200,
+        )
+        .await
+        .unwrap();
+
+        let self_signed =
+            tonk_identity::revocation::mint_self_revocation(device, &grant, &root.did())
+                .await
+                .unwrap();
+
+        let result = revoke_device(
+            &store,
+            &chains,
+            &account,
+            CALLER_DID,
+            &device_did,
+            Some(&self_signed),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(CeremonyError::Forbidden(_))),
+            "a device-attested artifact is only good for revoking itself"
+        );
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views[0].status, "active");
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_device_attested_revocation_of_itself() {
+        use dialog_varsig::Principal;
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let account = seeded_account(&store).await;
+        let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let grant = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let device_did = device.did().to_string();
+        register_device(
+            &store,
+            &account,
+            &device_did,
+            "phone",
+            &hex::encode(grant.to_bytes().unwrap()),
+            200,
+        )
+        .await
+        .unwrap();
+        let self_signed =
+            tonk_identity::revocation::mint_self_revocation(device, &grant, &root.did())
+                .await
+                .unwrap();
+
+        let attestation = revoke_device(
+            &store,
+            &chains,
+            &account,
+            &device_did,
+            &device_did,
+            Some(&self_signed),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(attestation, Some(Attestation::Device));
+        let views = list_devices(&store, &account).await.unwrap();
+        assert_eq!(views[0].status, "revoked");
+    }
+
+    #[dialog_common::test]
     async fn it_stores_the_artifact_alongside_the_status_flip() {
         let store = SqliteStore::in_memory().unwrap();
         let chains = MemoryChainStore::default();
         let account = seeded_account(&store).await;
         let (device_did, revocation) = registered_with_revocation(&store, &account).await;
 
-        let attestation = revoke_device(&store, &chains, &account, &device_did, Some(&revocation))
-            .await
-            .unwrap();
+        let attestation = revoke_device(
+            &store,
+            &chains,
+            &account,
+            CALLER_DID,
+            &device_did,
+            Some(&revocation),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(attestation, Some(Attestation::Root));
         let stored = crate::core::revocation::list_revocations(&chains, &account)
@@ -287,7 +434,15 @@ mod tests {
                 .await
                 .unwrap();
 
-        let result = revoke_device(&store, &chains, &account, &device_did, Some(&forged)).await;
+        let result = revoke_device(
+            &store,
+            &chains,
+            &account,
+            CALLER_DID,
+            &device_did,
+            Some(&forged),
+        )
+        .await;
 
         assert!(matches!(result, Err(CeremonyError::Forbidden(_))));
         let views = list_devices(&store, &account).await.unwrap();
@@ -308,7 +463,15 @@ mod tests {
             ..account.clone()
         };
 
-        let result = revoke_device(&store, &chains, &foreign, &device_did, Some(&revocation)).await;
+        let result = revoke_device(
+            &store,
+            &chains,
+            &foreign,
+            CALLER_DID,
+            &device_did,
+            Some(&revocation),
+        )
+        .await;
 
         assert!(matches!(result, Err(CeremonyError::Invalid(_))));
     }

--- a/rust/tonk-account-service/src/core/revocation.rs
+++ b/rust/tonk-account-service/src/core/revocation.rs
@@ -137,6 +137,10 @@ pub struct StoredRevocation {
 
 /// List every revocation stored under this account, newest-agnostic:
 /// the set is unordered, and consumers verify each artifact themselves.
+///
+/// One `get` per key over an unscoped `list` — fine while revocation
+/// sets are tiny. A prefix-scoped `ChainStore::list` is the fix if
+/// they stop being tiny.
 pub async fn list_revocations<C: ChainStore>(
     chains: &C,
     account: &Account,

--- a/rust/tonk-account-service/src/core/revocation.rs
+++ b/rust/tonk-account-service/src/core/revocation.rs
@@ -1,0 +1,281 @@
+//! Checking a signed revocation before it is recorded.
+//!
+//! A revocation names the `root → device` delegation it withdraws and
+//! is signed by an authority entitled to withdraw it. Authority scales
+//! with blast radius: a device may revoke its own grant, and only the
+//! account root may revoke another device's. The check classifies which
+//! authority signed, and that classification is stored with the
+//! artifact so consumers can filter on it.
+//!
+//! Verification happens here so garbage cannot be parked in a user's
+//! namespace, and again at every consumer — a consumer that trusts this
+//! service has gained nothing over trusting the registry.
+
+use dialog_credentials::Ed25519KeyResolver;
+use dialog_ucan_core::InvocationChain;
+use dialog_ucan_core::promise::Promised;
+use dialog_varsig::algorithm::eddsa::Ed25519Signature;
+
+use crate::chains::ChainStore;
+use crate::core::CeremonyError;
+use crate::core::backup::chain_key;
+use crate::store::{Account, Device};
+
+/// The key prefix revocations live under, keeping them enumerable
+/// separately from delegation chain backups in the same namespace.
+pub const REVOCATION_PREFIX: &str = "revocations/";
+
+/// The command a revocation invokes.
+const REVOKE_COMMAND: [&str; 2] = ["ucan", "revoke"];
+
+/// The argument naming the withdrawn delegation.
+const REVOKE_ARGUMENT: &str = "revoke";
+
+/// Which authority signed a revocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Attestation {
+    /// Signed by the account root: authoritative for any device of the
+    /// account, and unforgeable by a device that holds only a grant.
+    Root,
+    /// Signed by the device revoking itself, under the grant it holds.
+    Device,
+}
+
+impl Attestation {
+    /// The stored form, used in the artifact key.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Attestation::Root => "root",
+            Attestation::Device => "device",
+        }
+    }
+}
+
+/// Parse, verify and classify a revocation of `target`'s grant.
+///
+/// Returns the attestation level on success. A device-signed
+/// revocation naming a device other than its issuer is rejected here —
+/// that is the authority rule, and it is the reason this function
+/// takes the target device rather than just its CID.
+pub async fn check_revocation(
+    bytes: &[u8],
+    root_did: &str,
+    target: &Device,
+) -> Result<Attestation, CeremonyError> {
+    let chain = InvocationChain::<Ed25519Signature>::try_from(bytes)
+        .map_err(|err| CeremonyError::Invalid(format!("bad revocation container: {err}")))?;
+
+    chain.verify(&Ed25519KeyResolver).await.map_err(|err| {
+        CeremonyError::Unauthorized(format!("revocation failed to verify: {err}"))
+    })?;
+
+    let command: Vec<&str> = chain.command().0.iter().map(String::as_str).collect();
+    if command.as_slice() != REVOKE_COMMAND {
+        return Err(CeremonyError::Invalid(format!(
+            "expected a {REVOKE_COMMAND:?} invocation, got {command:?}"
+        )));
+    }
+
+    if chain.subject().to_string() != root_did {
+        return Err(CeremonyError::Forbidden(
+            "revocation subject is not this account's root".to_string(),
+        ));
+    }
+
+    let Some(Promised::String(named)) = chain.arguments().get(REVOKE_ARGUMENT) else {
+        return Err(CeremonyError::Invalid(
+            "revocation must name the delegation it withdraws".to_string(),
+        ));
+    };
+    if named != &target.delegation_cid {
+        return Err(CeremonyError::Invalid(
+            "revocation names a delegation other than the target device's".to_string(),
+        ));
+    }
+
+    let issuer = chain.issuer().to_string();
+    if issuer == root_did {
+        return Ok(Attestation::Root);
+    }
+    if issuer == target.device_did {
+        return Ok(Attestation::Device);
+    }
+    Err(CeremonyError::Forbidden(
+        "only the account root may revoke another device".to_string(),
+    ))
+}
+
+/// Store a verified revocation in the account's namespace, keyed by its
+/// attestation level and content hash.
+///
+/// The set is append-only: revocation is monotone, so nothing here ever
+/// deletes, and re-storing identical bytes is idempotent.
+pub async fn put_revocation<C: ChainStore>(
+    chains: &C,
+    account: &Account,
+    attestation: Attestation,
+    bytes: &[u8],
+) -> Result<String, CeremonyError> {
+    let key = format!(
+        "{REVOCATION_PREFIX}{}/{}",
+        attestation.as_str(),
+        chain_key(bytes)
+    );
+    chains.put(&account.root_did, &key, bytes).await?;
+    Ok(key)
+}
+
+/// A stored revocation, as served to consumers.
+pub struct StoredRevocation {
+    /// The storage key, carrying the attestation level.
+    pub key: String,
+    /// Which authority signed it.
+    pub attestation: String,
+    /// The container bytes, hex-encoded.
+    pub revocation_hex: String,
+}
+
+/// List every revocation stored under this account, newest-agnostic:
+/// the set is unordered, and consumers verify each artifact themselves.
+pub async fn list_revocations<C: ChainStore>(
+    chains: &C,
+    account: &Account,
+) -> Result<Vec<StoredRevocation>, CeremonyError> {
+    let keys = chains.list(&account.root_did).await?;
+    let mut stored = Vec::new();
+    for key in keys {
+        let Some(rest) = key.strip_prefix(REVOCATION_PREFIX) else {
+            continue;
+        };
+        let attestation = rest.split('/').next().unwrap_or_default().to_string();
+        let Some(bytes) = chains.get(&account.root_did, &key).await? else {
+            continue;
+        };
+        stored.push(StoredRevocation {
+            key: key.clone(),
+            attestation,
+            revocation_hex: hex::encode(&bytes),
+        });
+    }
+    Ok(stored)
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::store::DeviceStatus;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_varsig::Principal;
+    use tonk_identity::revocation::{mint_root_revocation, mint_self_revocation};
+
+    /// The account root DID as the checker takes it.
+    fn root_did(root: &Ed25519Signer) -> String {
+        root.did().to_string()
+    }
+
+    const ROOT_PRF: [u8; 32] = [7u8; 32];
+    const FOREIGN_PRF: [u8; 32] = [9u8; 32];
+    const DEVICE_SEED: [u8; 32] = [11u8; 32];
+    const OTHER_SEED: [u8; 32] = [12u8; 32];
+
+    /// A root, one device under it, and that device's registry row.
+    async fn fixture(
+        root_prf: [u8; 32],
+        device_seed: [u8; 32],
+    ) -> (
+        Ed25519Signer,
+        Ed25519Signer,
+        dialog_ucan_core::DelegationChain,
+        Device,
+    ) {
+        let root = tonk_identity::derive::derive_root_signer(&root_prf)
+            .await
+            .unwrap();
+        let device = Ed25519Signer::import(&device_seed).await.unwrap();
+        let grant = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let row = Device {
+            account_id: 1,
+            device_did: device.did().to_string(),
+            delegation_cid: grant.proof_cids()[0].to_string(),
+            name: "test device".to_string(),
+            status: DeviceStatus::Active,
+            created_at: 0,
+        };
+        (root, device, grant, row)
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_root_signed_revocation() {
+        let (root, _, _, row) = fixture(ROOT_PRF, DEVICE_SEED).await;
+        let bytes = mint_root_revocation(root.clone(), &row.delegation_cid)
+            .await
+            .unwrap();
+
+        let attestation = check_revocation(&bytes, root_did(&root).as_str(), &row)
+            .await
+            .unwrap();
+
+        assert_eq!(attestation, Attestation::Root);
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_device_revoking_itself() {
+        let (root, device, grant, row) = fixture(ROOT_PRF, DEVICE_SEED).await;
+        let bytes = mint_self_revocation(device, &grant, &root.did())
+            .await
+            .unwrap();
+
+        let attestation = check_revocation(&bytes, root_did(&root).as_str(), &row)
+            .await
+            .unwrap();
+
+        assert_eq!(attestation, Attestation::Device);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_device_revoking_another_device() {
+        let (root, device, grant, _) = fixture(ROOT_PRF, DEVICE_SEED).await;
+        let (_, _, _, other_row) = fixture(ROOT_PRF, OTHER_SEED).await;
+        let bytes = mint_self_revocation(device, &grant, &root.did())
+            .await
+            .unwrap();
+
+        let result = check_revocation(&bytes, root_did(&root).as_str(), &other_row).await;
+
+        assert!(
+            matches!(result, Err(CeremonyError::Invalid(_))),
+            "a self-revocation names its own grant, not another device's"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_revocation_from_a_foreign_root() {
+        let (_, _, _, row) = fixture(ROOT_PRF, DEVICE_SEED).await;
+        let (foreign, _, _, _) = fixture(FOREIGN_PRF, OTHER_SEED).await;
+        let bytes = mint_root_revocation(foreign, &row.delegation_cid)
+            .await
+            .unwrap();
+
+        let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+            .await
+            .unwrap();
+        let result = check_revocation(&bytes, root_did(&root).as_str(), &row).await;
+
+        assert!(matches!(result, Err(CeremonyError::Forbidden(_))));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_revocation_naming_the_wrong_delegation() {
+        let (root, _, _, row) = fixture(ROOT_PRF, DEVICE_SEED).await;
+        let (_, _, _, other_row) = fixture(ROOT_PRF, OTHER_SEED).await;
+        let bytes = mint_root_revocation(root.clone(), &other_row.delegation_cid)
+            .await
+            .unwrap();
+
+        let result = check_revocation(&bytes, root_did(&root).as_str(), &row).await;
+
+        assert!(matches!(result, Err(CeremonyError::Invalid(_))));
+    }
+}

--- a/rust/tonk-account-service/src/handlers/devices.rs
+++ b/rust/tonk-account-service/src/handlers/devices.rs
@@ -1,13 +1,17 @@
-//! `POST /devices/{list,register,revoke}`: the device registry, over
+//! `POST /devices/{list,register,revoke,revocations}`: the device
+//! registry, over
 //! UCAN-authorized invocation containers.
 
 use serde::Serialize;
 use worker::*;
 
-use crate::auth::{authorize, authorize_root, required_string, string_argument};
+use crate::auth::{
+    authorize, authorize_root, optional_revocation, required_string, string_argument,
+};
 use crate::core::devices::{DeviceView, list_devices, register_device, revoke_device};
+use crate::core::revocation::list_revocations;
 use crate::error::{ErrorCode, ServiceError};
-use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
+use crate::handlers::{build_chains, build_store, ceremony_error, read_body, with_cors_headers};
 use crate::store::Store;
 
 /// A device row as serialized to API callers.
@@ -170,17 +174,66 @@ async fn handle_revoke_inner(
     ctx: &RouteContext<()>,
 ) -> std::result::Result<Response, ServiceError> {
     let store = build_store(ctx)?;
+    let chains = build_chains(ctx)?;
     let body = read_body(req).await?;
     let caller = authorize(&store, &body, &["account", "device", "revoke"])
         .await
         .map_err(ceremony_error)?;
 
     let device_did = string_argument(&caller, "did").map_err(ceremony_error)?;
-    revoke_device(&store, &caller.account, &device_did)
+    let revocation = optional_revocation(&caller).map_err(ceremony_error)?;
+    let attestation = revoke_device(
+        &store,
+        &chains,
+        &caller.account,
+        &device_did,
+        revocation.as_deref(),
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    Response::from_json(
+        &serde_json::json!({ "attestation": attestation.map(|level| level.as_str()) }),
+    )
+    .map_err(|err| ServiceError::new(ErrorCode::InternalError, format!("response error: {err}")))
+}
+
+/// `POST /devices/revocations` → list this account's signed revocations.
+pub async fn handle_revocations(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_revocations_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_revocations_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let store = build_store(ctx)?;
+    let chains = build_chains(ctx)?;
+    let body = read_body(req).await?;
+    let caller = authorize(&store, &body, &["account", "device", "revocations"])
         .await
         .map_err(ceremony_error)?;
 
-    Response::from_json(&serde_json::json!({})).map_err(|err| {
+    let stored = list_revocations(&chains, &caller.account)
+        .await
+        .map_err(ceremony_error)?;
+
+    let revocations: Vec<serde_json::Value> = stored
+        .into_iter()
+        .map(|item| {
+            serde_json::json!({
+                "key": item.key,
+                "attestation": item.attestation,
+                "revocation": item.revocation_hex,
+            })
+        })
+        .collect();
+
+    Response::from_json(&serde_json::json!({ "revocations": revocations })).map_err(|err| {
         ServiceError::new(ErrorCode::InternalError, format!("response error: {err}"))
     })
 }

--- a/rust/tonk-account-service/src/handlers/devices.rs
+++ b/rust/tonk-account-service/src/handlers/devices.rs
@@ -186,6 +186,7 @@ async fn handle_revoke_inner(
         &store,
         &chains,
         &caller.account,
+        &caller.device.device_did,
         &device_did,
         revocation.as_deref(),
     )

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -22,13 +22,16 @@ use hyper_util::rt::TokioIo;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
-use crate::auth::{authorize, authorize_root, required_string, string_argument};
+use crate::auth::{
+    authorize, authorize_root, optional_revocation, required_string, string_argument,
+};
 use crate::chains::MemoryChainStore;
 use crate::core::accounts::{CreateAccount, create_account};
 use crate::core::backup::{get_chain, list_chains, put_chain};
 use crate::core::codes::{generate_code, request_code};
 use crate::core::devices::{DeviceView, list_devices, register_device, revoke_device};
 use crate::core::links::{complete_link, consume_link, create_link, resolve_link};
+use crate::core::revocation::list_revocations;
 use crate::email::CapturedEmail;
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::ceremony_error;
@@ -133,6 +136,7 @@ async fn handle_request(
         (Method::POST, "/devices/register") => devices_register_route(req, &backends).await,
         (Method::POST, "/devices/link") => devices_link_route(req, &backends).await,
         (Method::POST, "/devices/revoke") => devices_revoke_route(req, &backends).await,
+        (Method::POST, "/devices/revocations") => devices_revocations_route(req, &backends).await,
         (Method::POST, "/links") => links_create_route(req, &backends).await,
         (Method::POST, "/links/resolve") => links_resolve_route(req, &backends).await,
         (Method::POST, "/links/complete") => links_complete_route(req, &backends).await,
@@ -347,11 +351,56 @@ async fn devices_revoke_route(
         .map_err(ceremony_error)?;
 
     let device_did = string_argument(&caller, "did").map_err(ceremony_error)?;
-    revoke_device(&backends.store, &caller.account, &device_did)
+    let revocation = optional_revocation(&caller).map_err(ceremony_error)?;
+    let attestation = revoke_device(
+        &backends.store,
+        &backends.chains,
+        &caller.account,
+        &device_did,
+        revocation.as_deref(),
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    Ok(json_response(
+        StatusCode::OK,
+        &serde_json::json!({ "attestation": attestation.map(|level| level.as_str()) }),
+    ))
+}
+
+/// `POST /devices/revocations` → list this account's signed revocations.
+async fn devices_revocations_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let body = body_bytes(req).await?;
+    let caller = authorize(
+        &backends.store,
+        &body,
+        &["account", "device", "revocations"],
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    let stored = list_revocations(&backends.chains, &caller.account)
         .await
         .map_err(ceremony_error)?;
 
-    Ok(json_response(StatusCode::OK, &serde_json::json!({})))
+    let revocations: Vec<serde_json::Value> = stored
+        .into_iter()
+        .map(|item| {
+            serde_json::json!({
+                "key": item.key,
+                "attestation": item.attestation,
+                "revocation": item.revocation_hex,
+            })
+        })
+        .collect();
+
+    Ok(json_response(
+        StatusCode::OK,
+        &serde_json::json!({ "revocations": revocations }),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -356,6 +356,7 @@ async fn devices_revoke_route(
         &backends.store,
         &backends.chains,
         &caller.account,
+        &caller.device.device_did,
         &device_did,
         revocation.as_deref(),
     )

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -40,6 +40,11 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/devices/link", handlers::devices::handle_options)
         .post_async("/devices/revoke", handlers::devices::handle_revoke)
         .options_async("/devices/revoke", handlers::devices::handle_options)
+        .post_async(
+            "/devices/revocations",
+            handlers::devices::handle_revocations,
+        )
+        .options_async("/devices/revocations", handlers::devices::handle_options)
         .post_async("/links", handlers::links::handle_create)
         .options_async("/links", handlers::links::handle_options)
         .post_async("/links/resolve", handlers::links::handle_resolve)

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -131,12 +131,28 @@ async fn it_drives_the_full_ceremony_over_http() {
     assert!(devices[0].get("created_at").is_none());
     assert!(devices[0].get("delegation_cid").is_none());
 
-    // POST /devices/revoke -> the first device cuts off the second.
+    // POST /devices/revoke -> the first device cuts off the second,
+    // carrying a root-signed revocation of the second device's grant.
+    // Cross-device revocation needs root attestation; a device-signed
+    // artifact only ever names its own grant.
+    let second_grant_cid = devices[1]["delegationCid"].as_str().unwrap().to_string();
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let revocation = tonk_identity::revocation::mint_root_revocation(root, &second_grant_cid)
+        .await
+        .unwrap();
     let body = container(
         vec!["account".into(), "device".into(), "revoke".into()],
-        [("did".to_owned(), Promised::String(second_did.clone()))]
-            .into_iter()
-            .collect(),
+        [
+            ("did".to_owned(), Promised::String(second_did.clone())),
+            (
+                "revocation".to_owned(),
+                Promised::String(hex::encode(&revocation)),
+            ),
+        ]
+        .into_iter()
+        .collect(),
     )
     .await;
     let response = client
@@ -146,6 +162,28 @@ async fn it_drives_the_full_ceremony_over_http() {
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
+    let revoked: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(revoked["attestation"], "root");
+
+    // POST /devices/revocations -> the artifact is retrievable and
+    // carries its attestation level.
+    let body = container(
+        vec!["account".into(), "device".into(), "revocations".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/devices/revocations"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let listed: serde_json::Value = response.json().await.unwrap();
+    let listed = listed["revocations"].as_array().unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["attestation"], "root");
+    assert_eq!(listed[0]["revocation"], hex::encode(&revocation));
 
     let body = container(
         vec!["account".into(), "device".into(), "list".into()],

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -15,6 +15,10 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_SERVICE_URL: &str = "https://accounts.tonk.xyz";
 /// Production top-document ceremony route.
 pub const DEFAULT_ACCOUNT_URL: &str = "https://tonk.spot/account/link";
+/// Production account page, where the revoke ceremony runs. Distinct
+/// from [`DEFAULT_ACCOUNT_URL`]: `/account/link` is the link handoff and
+/// consumes a fragment secret, so a `?revoke=` sent there dead-ends.
+pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.spot/account";
 /// Credential-store key shared with the browser worker.
 pub const ACCOUNT_LINK_SITE: &str = "tonk-account-link-v1";
 
@@ -378,6 +382,15 @@ pub struct RevokeOptions {
     pub open_browser: bool,
 }
 
+/// How a revocation request resolved. The caller owns the messaging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevokeOutcome {
+    /// The registry now shows the device revoked.
+    Revoked,
+    /// The registry already showed the device revoked; nothing to do.
+    AlreadyRevoked,
+}
+
 /// Revoke another of the account's devices, by way of a browser
 /// ceremony.
 ///
@@ -385,7 +398,11 @@ pub struct RevokeOptions {
 /// root-signed revocation, the root key is derived from the passkey, and
 /// a passkey needs a browser — so the CLI hands off, then watches the
 /// registry until the device it named comes back revoked.
-pub async fn revoke(profile: &Profile, options: &RevokeOptions, did: &str) -> Result<()> {
+pub async fn revoke(
+    profile: &Profile,
+    options: &RevokeOptions,
+    did: &str,
+) -> Result<RevokeOutcome> {
     revoke_target_guard(profile.did().as_ref(), did)?;
 
     let rows = devices(profile, &options.service_url).await?;
@@ -394,8 +411,7 @@ pub async fn revoke(profile: &Profile, options: &RevokeOptions, did: &str) -> Re
         .find(|row| row.did == did)
         .with_context(|| format!("no device {did} under this account"))?;
     if target.status == "revoked" {
-        println!("already revoked\ndevice: {did}");
-        return Ok(());
+        return Ok(RevokeOutcome::AlreadyRevoked);
     }
 
     let url = revoke_url(&options.account_url, did);
@@ -404,27 +420,53 @@ pub async fn revoke(profile: &Profile, options: &RevokeOptions, did: &str) -> Re
         eprintln!("Could not open a browser; use the URL above.");
     }
 
+    // One pinned listener for the whole wait. Tokio replaces the
+    // process's default SIGINT handling the first time this is polled
+    // and never restores it, so a fresh `ctrl_c()` per iteration would
+    // swallow any Ctrl-C that lands between polls.
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    // A failed poll is not a failed revocation — the user may be
+    // mid-passkey while the service hiccups — so polling tolerates
+    // errors until the deadline and reports the last one then.
+    let mut last_error: Option<anyhow::Error> = None;
     let mut delay = Duration::from_millis(500);
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5 * 60);
     loop {
         if tokio::time::Instant::now() >= deadline {
-            bail!("revocation was not approved in time; run `tonk account revoke` again");
-        }
-        tokio::select! {
-            rows = devices(profile, &options.service_url) => {
-                if rows?
-                    .iter()
-                    .any(|row| row.did == did && row.status == "revoked")
-                {
-                    return Ok(());
+            match last_error {
+                Some(error) => bail!(
+                    "revocation was not approved in time (last poll failed: {error:#}); \
+                     run `tonk account revoke` again"
+                ),
+                None => {
+                    bail!("revocation was not approved in time; run `tonk account revoke` again")
                 }
             }
-            signal = tokio::signal::ctrl_c() => {
+        }
+        tokio::select! {
+            rows = devices(profile, &options.service_url) => match rows {
+                Ok(rows) => {
+                    last_error = None;
+                    if rows.iter().any(|row| row.did == did && row.status == "revoked") {
+                        return Ok(RevokeOutcome::Revoked);
+                    }
+                }
+                Err(error) => last_error = Some(error),
+            },
+            signal = &mut ctrl_c => {
                 signal.context("failed to listen for Ctrl-C")?;
                 bail!("revocation cancelled");
             }
         }
-        tokio::time::sleep(delay).await;
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => {}
+            signal = &mut ctrl_c => {
+                signal.context("failed to listen for Ctrl-C")?;
+                bail!("revocation cancelled");
+            }
+        }
         delay = (delay * 2).min(Duration::from_secs(5));
     }
 }
@@ -436,9 +478,18 @@ mod tests {
     #[test]
     fn it_points_the_revoke_ceremony_at_the_named_device() {
         assert_eq!(
-            revoke_url("https://tonk.spot/account", "did:key:zDevice"),
+            revoke_url(DEFAULT_ACCOUNT_PAGE, "did:key:zDevice"),
             "https://tonk.spot/account?revoke=did:key:zDevice"
         );
+    }
+
+    /// The revoke deep link must not default to the link-handoff page:
+    /// `/account/link` consumes a fragment secret and errors without
+    /// one, so a `?revoke=` sent there is never read.
+    #[test]
+    fn it_does_not_hand_the_revoke_ceremony_to_the_link_page() {
+        assert_ne!(DEFAULT_ACCOUNT_PAGE, DEFAULT_ACCOUNT_URL);
+        assert!(!DEFAULT_ACCOUNT_PAGE.ends_with("/link"));
     }
 
     #[test]

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -294,6 +294,8 @@ pub struct DeviceRow {
     pub status: String,
     /// Registration time, seconds since the epoch.
     pub created_at: u64,
+    /// CID of the `root → device` delegation a revocation must name.
+    pub delegation_cid: String,
 }
 
 fn revoke_target_guard(own_did: &str, target_did: &str) -> Result<()> {
@@ -353,31 +355,97 @@ pub async fn devices(profile: &Profile, service_url: &str) -> Result<Vec<DeviceR
         .context("account service returned an invalid device list")
 }
 
-/// Revoke another of the account's devices.
-pub async fn revoke(profile: &Profile, service_url: &str, did: &str) -> Result<()> {
-    revoke_target_guard(profile.did().as_ref(), did)?;
-    let link = linked_chain(profile).await?;
-    let arguments = [(
-        "did".to_owned(),
-        dialog_ucan_core::promise::Promised::String(did.to_owned()),
-    )]
-    .into_iter()
-    .collect();
-    let body = tonk_identity::request::build_device_invocation(
-        profile.signer().signer().clone(),
-        &link,
-        vec!["account".into(), "device".into(), "revoke".into()],
-        arguments,
+/// The browser URL that runs the revoke ceremony for `did`.
+///
+/// A query parameter, not a fragment: the fragment carries bearer
+/// secrets in the link handoff, and a device DID is neither secret nor
+/// sensitive to leak into a browser history. The DID needs no escaping —
+/// `:` is a legal query character and the rest is base58.
+fn revoke_url(base: &str, did: &str) -> String {
+    format!(
+        "{}?revoke={did}",
+        base.trim_end_matches('#').trim_end_matches('/')
     )
-    .await
-    .context("failed to sign the revoke request")?;
-    post_invocation(service_url, "devices/revoke", body).await?;
-    Ok(())
+}
+
+/// Inputs for a browser-assisted revocation.
+pub struct RevokeOptions {
+    /// Account service base URL.
+    pub service_url: String,
+    /// Browser page that runs the ceremony.
+    pub account_url: String,
+    /// Whether to ask the OS to open the ceremony URL.
+    pub open_browser: bool,
+}
+
+/// Revoke another of the account's devices, by way of a browser
+/// ceremony.
+///
+/// The CLI cannot do this alone. Cutting off another device takes a
+/// root-signed revocation, the root key is derived from the passkey, and
+/// a passkey needs a browser — so the CLI hands off, then watches the
+/// registry until the device it named comes back revoked.
+pub async fn revoke(profile: &Profile, options: &RevokeOptions, did: &str) -> Result<()> {
+    revoke_target_guard(profile.did().as_ref(), did)?;
+
+    let rows = devices(profile, &options.service_url).await?;
+    let target = rows
+        .iter()
+        .find(|row| row.did == did)
+        .with_context(|| format!("no device {did} under this account"))?;
+    if target.status == "revoked" {
+        println!("already revoked\ndevice: {did}");
+        return Ok(());
+    }
+
+    let url = revoke_url(&options.account_url, did);
+    println!("Approve this revocation with your passkey:\n{url}");
+    if options.open_browser && webbrowser::open(&url).is_err() {
+        eprintln!("Could not open a browser; use the URL above.");
+    }
+
+    let mut delay = Duration::from_millis(500);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5 * 60);
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            bail!("revocation was not approved in time; run `tonk account revoke` again");
+        }
+        tokio::select! {
+            rows = devices(profile, &options.service_url) => {
+                if rows?
+                    .iter()
+                    .any(|row| row.did == did && row.status == "revoked")
+                {
+                    return Ok(());
+                }
+            }
+            signal = tokio::signal::ctrl_c() => {
+                signal.context("failed to listen for Ctrl-C")?;
+                bail!("revocation cancelled");
+            }
+        }
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(Duration::from_secs(5));
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn it_points_the_revoke_ceremony_at_the_named_device() {
+        assert_eq!(
+            revoke_url("https://tonk.spot/account", "did:key:zDevice"),
+            "https://tonk.spot/account?revoke=did:key:zDevice"
+        );
+    }
+
+    #[test]
+    fn it_refuses_to_revoke_the_device_in_hand() {
+        assert!(revoke_target_guard("did:key:zSelf", "did:key:zSelf").is_err());
+        assert!(revoke_target_guard("did:key:zSelf", "did:key:zOther").is_ok());
+    }
 
     #[test]
     fn it_keeps_the_bearer_secret_in_the_fragment() {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -460,6 +460,9 @@ enum AccountCommand {
     },
 
     /// Revoke one of the account's devices by DID
+    ///
+    /// Opens a browser to approve with your passkey: cutting off another
+    /// device takes the account root, which only the passkey can derive.
     #[command(after_help = "Examples:\n  tonk account revoke did:key:z6Mk...")]
     Revoke {
         /// DID of the device to revoke (see `tonk account devices`).
@@ -473,6 +476,17 @@ enum AccountCommand {
             hide = true
         )]
         service_url: String,
+        /// Browser page that runs the approval ceremony.
+        #[arg(
+            long,
+            value_name = "URL",
+            default_value = account::DEFAULT_ACCOUNT_URL,
+            hide = true
+        )]
+        account_url: String,
+        /// Print the approval URL without asking the OS to open it.
+        #[arg(long)]
+        no_open: bool,
     },
 }
 
@@ -963,8 +977,18 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 Err(error) => print_error(error.to_string()),
             }
         }
-        AccountCommand::Revoke { did, service_url } => {
-            match account::revoke(&profile, &service_url, &did).await {
+        AccountCommand::Revoke {
+            did,
+            service_url,
+            account_url,
+            no_open,
+        } => {
+            let options = account::RevokeOptions {
+                service_url,
+                account_url,
+                open_browser: !no_open,
+            };
+            match account::revoke(&profile, &options, &did).await {
                 Ok(()) => {
                     println!("revoked\ndevice: {did}");
                     ExitCode::Success

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -480,7 +480,7 @@ enum AccountCommand {
         #[arg(
             long,
             value_name = "URL",
-            default_value = account::DEFAULT_ACCOUNT_URL,
+            default_value = account::DEFAULT_ACCOUNT_PAGE,
             hide = true
         )]
         account_url: String,
@@ -989,8 +989,12 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 open_browser: !no_open,
             };
             match account::revoke(&profile, &options, &did).await {
-                Ok(()) => {
+                Ok(account::RevokeOutcome::Revoked) => {
                     println!("revoked\ndevice: {did}");
+                    ExitCode::Success
+                }
+                Ok(account::RevokeOutcome::AlreadyRevoked) => {
+                    println!("already revoked\ndevice: {did}");
                     ExitCode::Success
                 }
                 Err(error) => print_error(error.to_string()),

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -71,6 +71,24 @@ async fn build(
     })
 }
 
+/// Sign a revocation of `delegation_cid` with the passkey-derived root.
+///
+/// Unlike the other ceremonies this returns no delegation and no
+/// service invocation: the revocation travels as an argument inside a
+/// device-signed request, because the service still authorizes the call
+/// by device while the artifact carries the authority to revoke.
+///
+/// This is the ceremony behind revoking a device other than the one in
+/// your hand. Requiring it is what stops a stolen device from locking
+/// out its siblings — a device holds only its grant, and a grant cannot
+/// produce a root signature.
+pub async fn sign_revocation(root: Ed25519Signer, delegation_cid: &str) -> Result<String> {
+    let bytes = crate::revocation::mint_root_revocation(root, delegation_cid)
+        .await
+        .context("failed to sign the revocation")?;
+    Ok(hex::encode(bytes))
+}
+
 /// Build the root-signed account-creation request and first-device delegation.
 pub async fn create_account(
     root: Ed25519Signer,

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -61,6 +61,25 @@ fn string_property(input: &JsValue, name: &str) -> Result<String, JsValue> {
         .ok_or_else(|| JsValue::from_str(&format!("missing or invalid {name}")))
 }
 
+/// `signRevocation({ delegationCid })` → `{ revocationHex }`.
+///
+/// Prompts for the passkey, derives the root, and signs a revocation of
+/// the named delegation. The caller sends the hex on as an argument to
+/// its own device-signed revoke request.
+async fn sign_revocation(input: JsValue) -> Result<JsValue, JsValue> {
+    let delegation_cid = string_property(&input, "delegationCid")?;
+    let prf = crate::passkey::prf_output().await.map_err(js_error)?;
+    let root = crate::derive::derive_root_signer(&prf)
+        .await
+        .map_err(js_error)?;
+    let revocation_hex = crate::ceremony::sign_revocation(root, &delegation_cid)
+        .await
+        .map_err(js_error)?;
+    let result = Object::new();
+    Reflect::set(&result, &"revocationHex".into(), &revocation_hex.into())?;
+    Ok(result.into())
+}
+
 fn ceremony_result(ceremony: crate::ceremony::AccountCeremony) -> Result<JsValue, JsValue> {
     let result = Object::new();
     Reflect::set(&result, &"rootDid".into(), &ceremony.root_did.into())?;
@@ -204,6 +223,16 @@ pub fn install() {
         complete_link.as_ref().unchecked_ref(),
     );
     complete_link.forget();
+
+    let sign_revocation = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(sign_revocation(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"signRevocation".into(),
+        sign_revocation.as_ref().unchecked_ref(),
+    );
+    sign_revocation.forget();
 
     let _ = Reflect::set(&window, &"tonkIdentity".into(), &identity.into());
 }

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -14,6 +14,8 @@ mod install;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod passkey;
 pub mod request;
+pub mod revocation;
+pub mod session;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use install::install;

--- a/rust/tonk-identity/src/revocation.rs
+++ b/rust/tonk-identity/src/revocation.rs
@@ -1,0 +1,195 @@
+//! Signed device revocations.
+//!
+//! A registry row saying `status = 'revoked'` is not a revocation; it
+//! is a status flag whose authority is "whoever can write that
+//! database". A revocation proper is a signed statement naming the
+//! delegation it withdraws, which anyone can verify against the account
+//! root without holding a database credential.
+//!
+//! Authority scales with blast radius. A device may revoke *itself*
+//! with its own key — always available, and a stolen device can only
+//! sign itself out. Revoking *another* device takes the root, so a
+//! stolen device cannot lock out its siblings. The artifact records
+//! whichever authority was used; a consumer that demands root
+//! attestation is making a policy choice, not detecting a defect.
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Result;
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+use dialog_varsig::{Did, Principal};
+
+/// The command a revocation invokes.
+pub const REVOKE_COMMAND: [&str; 2] = ["ucan", "revoke"];
+
+/// The argument naming the withdrawn delegation.
+pub const REVOKE_ARGUMENT: &str = "revoke";
+
+fn arguments(delegation_cid: &str) -> BTreeMap<String, Promised> {
+    let mut arguments = BTreeMap::new();
+    arguments.insert(
+        REVOKE_ARGUMENT.to_string(),
+        Promised::String(delegation_cid.to_string()),
+    );
+    arguments
+}
+
+fn command() -> Vec<String> {
+    REVOKE_COMMAND
+        .iter()
+        .map(|part| (*part).to_string())
+        .collect()
+}
+
+/// Mint a root-signed revocation of `delegation_cid`.
+///
+/// The CID is the stringified `root → device` delegation the registry
+/// recorded at link time, exactly as `/devices/list` reports it.
+///
+/// The issuer is the account root and the subject is itself, so the
+/// invocation needs no proof: a valid signature is proof of control.
+/// This is the attestation a stolen device cannot forge, and the one
+/// required to revoke a device other than yourself.
+pub async fn mint_root_revocation(root: Ed25519Signer, delegation_cid: &str) -> Result<Vec<u8>> {
+    let root_did = root.did();
+    let invocation = InvocationBuilder::new()
+        .issuer(root)
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(command())
+        .arguments(arguments(delegation_cid))
+        .proofs(Vec::new())
+        .try_build()
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to mint the revocation: {err}"))?;
+
+    InvocationChain::new(invocation, HashMap::new())
+        .to_bytes()
+        .map_err(|err| anyhow::anyhow!("failed to serialize the revocation: {err}"))
+}
+
+/// Mint a device-signed revocation of the device's own grant.
+///
+/// The device signs under the `root → device` grant it already holds,
+/// which it carries as the invocation's proof so a verifier can see the
+/// authority used. This is "sign this account out of this device", and
+/// it works offline with no prompt.
+pub async fn mint_self_revocation(
+    device: Ed25519Signer,
+    grant: &DelegationChain,
+    root: &Did,
+) -> Result<Vec<u8>> {
+    let delegation_cid = grant
+        .proof_cids()
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("grant has no proof to revoke"))?
+        .to_string();
+
+    let invocation = InvocationBuilder::new()
+        .issuer(device)
+        .audience(root)
+        .subject(root)
+        .command(command())
+        .arguments(arguments(&delegation_cid))
+        .proofs(grant.proof_cids().to_vec())
+        .try_build()
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to mint the self-revocation: {err}"))?;
+
+    let proofs = grant.export().collect::<HashMap<_, _>>();
+    InvocationChain::new(invocation, proofs)
+        .to_bytes()
+        .map_err(|err| anyhow::anyhow!("failed to serialize the self-revocation: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::ed25519::Ed25519Signer;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const ROOT_PRF: [u8; 32] = [1u8; 32];
+    const DEVICE_SEED: [u8; 32] = [2u8; 32];
+
+    async fn grant() -> (Ed25519Signer, Ed25519Signer, DelegationChain) {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let chain = crate::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        (root, device, chain)
+    }
+
+    fn parse(bytes: &[u8]) -> InvocationChain<dialog_varsig::algorithm::eddsa::Ed25519Signature> {
+        InvocationChain::try_from(bytes).unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_a_root_signed_revocation_naming_the_delegation() {
+        let (root, _, chain) = grant().await;
+        let cid = chain.proof_cids()[0].to_string();
+
+        let bytes = mint_root_revocation(root.clone(), &cid).await.unwrap();
+
+        let parsed = parse(&bytes);
+        assert_eq!(*parsed.issuer(), root.did());
+        assert_eq!(parsed.command().0, command());
+        assert_eq!(
+            parsed.arguments().get(REVOKE_ARGUMENT),
+            Some(&dialog_ucan_core::promise::Promised::String(
+                cid.to_string()
+            ))
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_a_device_signed_self_revocation() {
+        let (root, device, chain) = grant().await;
+        let cid = chain.proof_cids()[0].to_string();
+
+        let bytes = mint_self_revocation(device.clone(), &chain, &root.did())
+            .await
+            .unwrap();
+
+        let parsed = parse(&bytes);
+        assert_eq!(*parsed.issuer(), device.did());
+        assert_eq!(
+            parsed.arguments().get(REVOKE_ARGUMENT),
+            Some(&dialog_ucan_core::promise::Promised::String(
+                cid.to_string()
+            )),
+            "a self-revocation names the device's own grant"
+        );
+        assert!(
+            !parsed.proofs().is_empty(),
+            "the grant must ride along so a verifier sees the authority used"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_distinguishes_a_root_signed_revocation_from_a_self_revocation() {
+        let (root, device, chain) = grant().await;
+        let cid = chain.proof_cids()[0].to_string();
+
+        let by_root = parse(&mint_root_revocation(root.clone(), &cid).await.unwrap());
+        let by_device = parse(
+            &mint_self_revocation(device.clone(), &chain, &root.did())
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(*by_root.issuer(), root.did());
+        assert_eq!(*by_device.issuer(), device.did());
+        assert_ne!(
+            by_root.issuer(),
+            by_device.issuer(),
+            "attestation level must be readable from the issuer alone"
+        );
+    }
+}

--- a/rust/tonk-identity/src/session.rs
+++ b/rust/tonk-identity/src/session.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::subject::Subject as UcanSubject;
 use dialog_ucan_core::time::Timestamp;
+use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
 use dialog_ucan_core::{DelegationBuilder, DelegationChain};
 use dialog_varsig::Did;
 
@@ -41,9 +42,10 @@ pub async fn mint_session_delegation(
     session: &Did,
     ttl_seconds: u64,
 ) -> Result<DelegationChain> {
-    let expiration =
-        Timestamp::new(std::time::SystemTime::now() + std::time::Duration::from_secs(ttl_seconds))
-            .map_err(|err| anyhow::anyhow!("session expiration out of range: {err}"))?;
+    // dialog re-exports the platform clock: std natively, web_time
+    // under wasm, where std::time::SystemTime is a different type.
+    let expiration = Timestamp::new(SystemTime::now() + Duration::from_secs(ttl_seconds))
+        .map_err(|err| anyhow::anyhow!("session expiration out of range: {err}"))?;
 
     let delegation = DelegationBuilder::new()
         .issuer(device)

--- a/rust/tonk-identity/src/session.rs
+++ b/rust/tonk-identity/src/session.rs
@@ -1,0 +1,179 @@
+//! The `device → session` delegation.
+//!
+//! `root → device` is subject-open, command-open and unexpiring: the
+//! most powerful thing the root can sign, held indefinitely by every
+//! linked device. Nothing about it degrades on its own, which is why
+//! withdrawing it has to be a registry lookup — there is no renewal to
+//! withhold.
+//!
+//! A session splits that. The device keeps its grant and uses it to
+//! mint a short-lived delegation to an ephemeral key, and the session
+//! key is what signs presign invocations. The grant stays the thing
+//! that survives offline and that the registry records; the session is
+//! the thing that lapses on its own.
+
+use anyhow::Result;
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::subject::Subject as UcanSubject;
+use dialog_ucan_core::time::Timestamp;
+use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+use dialog_varsig::Did;
+
+/// How long a session delegation is good for.
+///
+/// Hours, not minutes: a session must survive a stretch offline and a
+/// laptop lid, or clients will churn through renewals and the
+/// unreachable-renewal path becomes the common one rather than the
+/// exceptional one. Short enough that a device losing its grant stops
+/// mattering within a working day.
+pub const SESSION_TTL_SECONDS: u64 = 12 * 60 * 60;
+
+/// Mint the `device → session` delegation: subject-open like the grant
+/// it descends from, but bounded in time.
+///
+/// The device signs this itself from the `root → device` grant it
+/// already holds — no network, no renewal endpoint, nothing to be
+/// unreachable. Withdrawal works by the grant's registry row, which is
+/// what the presign screen already checks; the expiry is what bounds
+/// the damage between a revoke and the next screen.
+pub async fn mint_session_delegation(
+    device: Ed25519Signer,
+    session: &Did,
+    ttl_seconds: u64,
+) -> Result<DelegationChain> {
+    let expiration =
+        Timestamp::new(std::time::SystemTime::now() + std::time::Duration::from_secs(ttl_seconds))
+            .map_err(|err| anyhow::anyhow!("session expiration out of range: {err}"))?;
+
+    let delegation = DelegationBuilder::new()
+        .issuer(device)
+        .audience(session)
+        .subject(UcanSubject::Any)
+        .command(vec![])
+        .expiration(expiration)
+        .try_build()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to mint the session delegation: {e}"))?;
+    Ok(DelegationChain::new(delegation))
+}
+
+/// Extend a `root → device` grant with a freshly minted session hop,
+/// producing the chain a session key presents.
+///
+/// The composed chain still carries the grant's subject and every hop's
+/// CID, so the presign screen sees the device's identity as well as the
+/// session's — revoking the device severs the session on its next
+/// screen without the session itself being known to the registry.
+pub async fn extend_with_session(
+    grant: &DelegationChain,
+    device: Ed25519Signer,
+    session: &Did,
+    ttl_seconds: u64,
+) -> Result<DelegationChain> {
+    let session_chain = mint_session_delegation(device, session, ttl_seconds).await?;
+    let session_delegation = session_chain
+        .proofs()
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("session chain has no proof"))?
+        .clone();
+    grant
+        .push(session_delegation)
+        .map_err(|err| anyhow::anyhow!("failed to extend the grant with a session: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_credentials::ed25519::Ed25519Signer;
+    use dialog_varsig::principal::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const ROOT_PRF: [u8; 32] = [1u8; 32];
+    const DEVICE_SEED: [u8; 32] = [2u8; 32];
+    const SESSION_SEED: [u8; 32] = [4u8; 32];
+
+    async fn signer(seed: &[u8; 32]) -> Ed25519Signer {
+        Ed25519Signer::import(seed).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_a_bounded_delegation_to_the_session_key() {
+        let device = signer(&DEVICE_SEED).await;
+        let session = signer(&SESSION_SEED).await;
+
+        let chain = mint_session_delegation(device, &session.did(), SESSION_TTL_SECONDS)
+            .await
+            .unwrap();
+
+        assert_eq!(*chain.audience(), session.did());
+        assert!(
+            chain.expiration().is_some(),
+            "a session delegation must expire; that is the whole point"
+        );
+        assert!(
+            chain.subject().is_none(),
+            "the session inherits the grant's subject-open shape"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_expires_within_the_requested_ttl() {
+        let device = signer(&DEVICE_SEED).await;
+        let session = signer(&SESSION_SEED).await;
+        let before = Timestamp::now().to_unix();
+
+        let chain = mint_session_delegation(device, &session.did(), 900)
+            .await
+            .unwrap();
+
+        let expires_at = chain.expiration().unwrap().to_unix();
+        assert!(expires_at >= before + 900);
+        assert!(expires_at <= Timestamp::now().to_unix() + 900);
+    }
+
+    #[dialog_common::test]
+    async fn it_extends_a_device_grant_with_a_session_hop() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let device = signer(&DEVICE_SEED).await;
+        let session = signer(&SESSION_SEED).await;
+        let grant = crate::delegation::mint_device_delegation(root, &device.did())
+            .await
+            .unwrap();
+
+        let composed = extend_with_session(&grant, device, &session.did(), SESSION_TTL_SECONDS)
+            .await
+            .unwrap();
+
+        assert_eq!(*composed.audience(), session.did());
+        assert_eq!(
+            composed.proof_cids().len(),
+            2,
+            "the grant hop must stay in the chain so the screen still sees the device"
+        );
+        assert!(composed.expiration().is_some());
+    }
+
+    #[dialog_common::test]
+    async fn it_narrows_an_unexpiring_grant() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let device = signer(&DEVICE_SEED).await;
+        let session = signer(&SESSION_SEED).await;
+        let grant = crate::delegation::mint_device_delegation(root, &device.did())
+            .await
+            .unwrap();
+        assert!(grant.expiration().is_none(), "the grant is unexpiring");
+
+        let composed = extend_with_session(&grant, device, &session.did(), 900)
+            .await
+            .unwrap();
+
+        assert!(
+            composed.expiration().is_some(),
+            "extending an unbounded grant must bound the result"
+        );
+    }
+}

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -70,7 +70,7 @@
     <p class="account__hint">Revoking a device cuts off its sync access. Spaces that device joined before it was linked may need a fresh invite afterwards.</p>
     <ul id="account-device-list" class="account__devices"></ul>
     <div class="account__actions">
-      <button id="account-unlink" class="account__button account__button--quiet" type="button">Sign out on this device</button>
+      <button id="account-unlink" class="account__button account__button--quiet" type="button">Sign out and revoke this device</button>
       <button id="account-devices-back" class="account__button account__button--secondary" type="button">Back</button>
     </div>
   </section>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -47,6 +47,14 @@ struct CeremonyOutput {
     invocation_hex: String,
 }
 
+/// What `window.tonkIdentity.signRevocation` hands back: the
+/// root-signed revocation, ready to travel as a request argument.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RevocationOutput {
+    revocation_hex: String,
+}
+
 /// The top-document account element. WebAuthn must not run in sealed guests.
 #[derive(Default)]
 struct TonkAccount;
@@ -272,11 +280,27 @@ fn render_devices(host: &HtmlElement, devices: &[tonk_worker_api::AccountDevice]
             let _ = button.set_attribute("type", "button");
             let _ = button.set_attribute("class", "account__button account__button--quiet");
             let _ = button.set_attribute("data-revoke", &device.did);
+            let _ = button.set_attribute("data-delegation-cid", &device.delegation_cid);
             button.set_text_content(Some("Revoke"));
             let _ = item.append_child(&button);
         }
         let _ = list.append_child(&item);
     }
+}
+
+/// The device DID named by a `?revoke=` deep link, if any.
+///
+/// The CLI cannot run a passkey ceremony, so `tonk account revoke` opens
+/// this page pointed at the device it wants cut off. The page still asks
+/// for confirmation and still runs the ceremony — the link chooses the
+/// target, it does not authorize anything.
+fn revoke_target_from_url() -> Option<String> {
+    let search = window()?.location().search().ok()?;
+    let query = search.strip_prefix('?')?;
+    query.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=')?;
+        (name == "revoke" && !value.is_empty()).then(|| value.to_owned())
+    })
 }
 
 fn load_devices(host: HtmlElement) {
@@ -287,6 +311,17 @@ fn load_devices(host: HtmlElement) {
                 set_busy(&host, false, "");
                 render_devices(&host, &devices);
                 set_mode(&host, "devices");
+                if let Some(did) = revoke_target_from_url()
+                    && let Some(device) = devices
+                        .iter()
+                        .find(|device| device.did == did && device.status == "active")
+                {
+                    begin_revoke(
+                        host.clone(),
+                        device.did.clone(),
+                        device.delegation_cid.clone(),
+                    );
+                }
             }
             Err(error) => {
                 set_busy(&host, false, "");
@@ -385,7 +420,10 @@ fn load_handoff(host: HtmlElement) {
     });
 }
 
-async fn identity_call<T: Serialize>(method: &str, input: &T) -> Result<CeremonyOutput, String> {
+async fn identity_call<T: Serialize, O: serde::de::DeserializeOwned>(
+    method: &str,
+    input: &T,
+) -> Result<O, String> {
     let window = window().ok_or_else(|| "window is unavailable".to_string())?;
     let identity = Reflect::get(&window, &"tonkIdentity".into())
         .map_err(|error| format!("identity API unavailable: {error:?}"))?;
@@ -591,7 +629,7 @@ fn bind(host: &HtmlElement) {
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let result = async {
-                let ceremony = identity_call("completeLink", &handoff).await?;
+                let ceremony: CeremonyOutput = identity_call("completeLink", &handoff).await?;
                 set_busy(&host, true, "Linking the command-line profile…");
                 crate::api::submit_account_ceremony(
                     &service(&host)?,
@@ -661,39 +699,67 @@ fn bind(host: &HtmlElement) {
             let Some(did) = target.get_attribute("data-revoke") else {
                 return;
             };
-            let host = host_for_revoke.clone();
-            let confirmed = window()
-                .map(|window| {
-                    window
-                        .confirm_with_message(
-                            "Revoke this device? It immediately loses account and sync \
-                             access. Spaces it joined before it was linked may need a \
-                             fresh invite.",
-                        )
-                        .unwrap_or(false)
-                })
-                .unwrap_or(false);
-            if !confirmed {
-                return;
-            }
-            clear_error(&host);
-            set_busy(&host, true, "Revoking device…");
-            spawn_local(async move {
-                match crate::api::revoke_account_device(did).await {
-                    Ok(devices) => {
-                        set_busy(&host, false, "");
-                        render_devices(&host, &devices);
-                    }
-                    Err(error) => {
-                        set_busy(&host, false, "");
-                        show_error(&host, error.to_string());
-                    }
-                }
-            });
+            let delegation_cid = target
+                .get_attribute("data-delegation-cid")
+                .unwrap_or_default();
+            begin_revoke(host_for_revoke.clone(), did, delegation_cid);
         });
         let _ = list.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref());
         closure.forget();
     }
+}
+
+/// Confirm, run the passkey ceremony, and revoke.
+///
+/// Only the account root can revoke another device, and the root lives
+/// behind the passkey — so the ceremony runs here, in the page, and the
+/// signed revocation travels with the request. Shared by the device
+/// list's button and the CLI's `?revoke=` handoff.
+fn begin_revoke(host: HtmlElement, did: String, delegation_cid: String) {
+    let confirmed = window()
+        .map(|window| {
+            window
+                .confirm_with_message(
+                    "Revoke this device? This is permanent for that device: it loses \
+                     account and sync access immediately, and coming back means linking \
+                     again as a new device. Spaces it joined before it was linked may \
+                     need a fresh invite.\n\nYou will be asked for your passkey to \
+                     authorize this.",
+                )
+                .unwrap_or(false)
+        })
+        .unwrap_or(false);
+    if !confirmed {
+        return;
+    }
+    clear_error(&host);
+    set_busy(&host, true, "Waiting for your passkey…");
+    spawn_local(async move {
+        let signed: Result<RevocationOutput, String> = identity_call(
+            "signRevocation",
+            &serde_json::json!({ "delegationCid": delegation_cid }),
+        )
+        .await;
+        let revocation_hex = match signed {
+            Ok(output) => output.revocation_hex,
+            Err(error) => {
+                set_busy(&host, false, "");
+                show_error(&host, error);
+                return;
+            }
+        };
+        set_busy(&host, true, "Revoking device…");
+        match crate::api::revoke_account_device(did, revocation_hex).await {
+            Ok(devices) => {
+                set_busy(&host, false, "");
+                render_devices(&host, &devices);
+            }
+            Err(error) => {
+                set_busy(&host, false, "");
+                show_error(&host, error.to_string());
+            }
+        }
+    });
 }
 
 /// Register `<tonk-account>` with the top document.

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -299,8 +299,31 @@ fn revoke_target_from_url() -> Option<String> {
     let query = search.strip_prefix('?')?;
     query.split('&').find_map(|pair| {
         let (name, value) = pair.split_once('=')?;
-        (name == "revoke" && !value.is_empty()).then(|| value.to_owned())
+        if name != "revoke" || value.is_empty() {
+            return None;
+        }
+        // A browser may percent-encode the DID; decode before matching
+        // registry rows, falling back to the raw value if decoding
+        // fails.
+        Some(
+            js_sys::decode_uri_component(value)
+                .map(String::from)
+                .unwrap_or_else(|_| value.to_owned()),
+        )
     })
+}
+
+/// Strip the query once the deep link has been acted on, mirroring what
+/// [`load_handoff`] does with the fragment secret. Without this a
+/// cancelled confirm re-fires on every later visit to the device list
+/// in this tab.
+fn consume_revoke_target() {
+    let Some(window) = window() else { return };
+    if let Ok(path) = window.location().pathname() {
+        let _ = window
+            .history()
+            .and_then(|history| history.replace_state_with_url(&JsValue::NULL, "", Some(&path)));
+    }
 }
 
 fn load_devices(host: HtmlElement) {
@@ -311,16 +334,23 @@ fn load_devices(host: HtmlElement) {
                 set_busy(&host, false, "");
                 render_devices(&host, &devices);
                 set_mode(&host, "devices");
-                if let Some(did) = revoke_target_from_url()
-                    && let Some(device) = devices
+                if let Some(did) = revoke_target_from_url() {
+                    consume_revoke_target();
+                    match devices
                         .iter()
                         .find(|device| device.did == did && device.status == "active")
-                {
-                    begin_revoke(
-                        host.clone(),
-                        device.did.clone(),
-                        device.delegation_cid.clone(),
-                    );
+                    {
+                        Some(device) => begin_revoke(
+                            host.clone(),
+                            device.did.clone(),
+                            device.delegation_cid.clone(),
+                        ),
+                        None => show_error(
+                            &host,
+                            "The device named by this link is not an active device \
+                             of this account.",
+                        ),
+                    }
                 }
             }
             Err(error) => {
@@ -329,6 +359,27 @@ fn load_devices(host: HtmlElement) {
             }
         }
     });
+}
+
+/// Where a fresh page load lands once the account status is known.
+#[derive(Debug, PartialEq, Eq)]
+enum Landing {
+    /// Straight to the device list: a `?revoke=` deep link names a
+    /// device, and the revoke ceremony lives there.
+    Devices,
+    /// The signed-in success screen.
+    Success,
+    /// The link/create choice, with a hint when a revoke deep link
+    /// cannot proceed because this browser is not linked.
+    Choice { revoke_hint: bool },
+}
+
+fn landing(linked: bool, revoke_target: bool) -> Landing {
+    match (linked, revoke_target) {
+        (true, true) => Landing::Devices,
+        (true, false) => Landing::Success,
+        (false, revoke_hint) => Landing::Choice { revoke_hint },
+    }
 }
 
 fn load_status(host: HtmlElement) {
@@ -346,10 +397,23 @@ fn load_status(host: HtmlElement) {
     set_busy(&host, true, "Checking this browser…");
     spawn_local(async move {
         match crate::api::account_status().await {
-            Ok(AccountStatus::Linked { .. }) => show_success(&host),
-            Ok(AccountStatus::Unlinked { .. }) => {
-                set_busy(&host, false, "");
-                set_mode(&host, "choice");
+            Ok(status) => {
+                let linked = matches!(status, AccountStatus::Linked { .. });
+                match landing(linked, revoke_target_from_url().is_some()) {
+                    Landing::Devices => load_devices(host),
+                    Landing::Success => show_success(&host),
+                    Landing::Choice { revoke_hint } => {
+                        set_busy(&host, false, "");
+                        set_mode(&host, "choice");
+                        if revoke_hint {
+                            show_error(
+                                &host,
+                                "This browser is not linked to an account. Link it \
+                                 first, then reopen the revoke link from the terminal.",
+                            );
+                        }
+                    }
+                }
             }
             Err(error) => {
                 set_busy(&host, false, "");
@@ -680,13 +744,28 @@ fn bind(host: &HtmlElement) {
                 // Everything on screen belongs to the profile that just
                 // got replaced, down to the spaces in the sidebar, so
                 // reload rather than trying to reconcile it in place.
-                Ok(_) => match window().map(|window| window.location().reload()) {
-                    Some(Ok(())) => {}
-                    _ => {
-                        set_busy(&host, false, "");
-                        set_mode(&host, "choice");
+                Ok(response) => {
+                    // The registry half of sign-out is best-effort; if
+                    // it failed, say so before the reload wipes the
+                    // page — finishing the revocation now falls to the
+                    // user's other devices.
+                    if let Some(warning) = response.warning
+                        && let Some(window) = window()
+                    {
+                        let _ = window.alert_with_message(&format!(
+                            "Signed out on this device, but the account registry could \
+                             not record it ({warning}). This device may still show as \
+                             active — revoke it from another device's account page."
+                        ));
                     }
-                },
+                    match window().map(|window| window.location().reload()) {
+                        Some(Ok(())) => {}
+                        _ => {
+                            set_busy(&host, false, "");
+                            set_mode(&host, "choice");
+                        }
+                    }
+                }
                 Err(error) => {
                     set_busy(&host, false, "");
                     show_error(&host, error.to_string());
@@ -973,6 +1052,20 @@ mod tests {
         assert_eq!(
             button.get_attribute("data-delegation-cid").as_deref(),
             Some("bafyphone")
+        );
+    }
+
+    /// A `?revoke=` deep link must land on the device list, where the
+    /// ceremony runs — parking a linked browser on the success screen
+    /// leaves the CLI polling until it times out.
+    #[dialog_common::test]
+    fn it_routes_a_revoke_deep_link_to_the_device_list() {
+        assert_eq!(landing(true, true), Landing::Devices);
+        assert_eq!(landing(true, false), Landing::Success);
+        assert_eq!(landing(false, true), Landing::Choice { revoke_hint: true });
+        assert_eq!(
+            landing(false, false),
+            Landing::Choice { revoke_hint: false }
         );
     }
 }

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -663,8 +663,10 @@ fn bind(host: &HtmlElement) {
             .map(|window| {
                 window
                     .confirm_with_message(
-                        "Sign out of your account on this device? Your data stays; \
-                         this browser stops acting as the account until you log in again.",
+                        "Sign out and revoke this device? This browser starts over with a \
+                         new device identity, so logging back in needs your passkey. Your \
+                         spaces come back from your account — anything you never turned on \
+                         sync for does not.",
                     )
                     .unwrap_or(false)
             })
@@ -675,10 +677,16 @@ fn bind(host: &HtmlElement) {
         set_busy(&host, true, "Signing out…");
         spawn_local(async move {
             match crate::api::unlink_account().await {
-                Ok(_) => {
-                    set_busy(&host, false, "");
-                    set_mode(&host, "choice");
-                }
+                // Everything on screen belongs to the profile that just
+                // got replaced, down to the spaces in the sidebar, so
+                // reload rather than trying to reconcile it in place.
+                Ok(_) => match window().map(|window| window.location().reload()) {
+                    Some(Ok(())) => {}
+                    _ => {
+                        set_busy(&host, false, "");
+                        set_mode(&host, "choice");
+                    }
+                },
                 Err(error) => {
                     set_busy(&host, false, "");
                     show_error(&host, error.to_string());

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -913,6 +913,7 @@ mod tests {
         let devices = vec![
             tonk_worker_api::AccountDevice {
                 did: "did:key:zThis".into(),
+                delegation_cid: "bafythis".into(),
                 name: "This browser".into(),
                 status: "active".into(),
                 created_at: 1_753_300_000,
@@ -920,6 +921,7 @@ mod tests {
             },
             tonk_worker_api::AccountDevice {
                 did: "did:key:zOther".into(),
+                delegation_cid: "bafyother".into(),
                 name: "Old laptop".into(),
                 status: "revoked".into(),
                 created_at: 1_753_200_000,
@@ -927,6 +929,7 @@ mod tests {
             },
             tonk_worker_api::AccountDevice {
                 did: "did:key:zPhone".into(),
+                delegation_cid: "bafyphone".into(),
                 name: "Phone".into(),
                 status: "active".into(),
                 created_at: 1_753_100_000,
@@ -951,6 +954,17 @@ mod tests {
                 .unwrap()
                 .length(),
             1
+        );
+
+        // The ceremony signs a revocation of a named delegation, so the
+        // button has to carry the CID as well as the DID.
+        let button = list
+            .query_selector("button[data-revoke]")
+            .unwrap()
+            .expect("the active, non-self row has a revoke button");
+        assert_eq!(
+            button.get_attribute("data-delegation-cid").as_deref(),
+            Some("bafyphone")
         );
     }
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -493,11 +493,14 @@ pub async fn account_devices() -> Result<Vec<AccountDevice>, TonkUiError> {
 }
 
 /// Revoke one of the account's devices; returns the refreshed list.
-pub async fn revoke_account_device(did: String) -> Result<Vec<AccountDevice>, TonkUiError> {
+pub async fn revoke_account_device(
+    did: String,
+    revocation: String,
+) -> Result<Vec<AccountDevice>, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/account/devices/revoke", origin()))
-        .json(&RevokeDeviceRequest { did })
+        .json(&RevokeDeviceRequest { did, revocation })
         .send()
         .await
         .map_err(into_api_error)?;

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -2,8 +2,8 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_worker_api::{
     AccountDevice, AccountLinkRequest, AccountStatus, EvaluateResponse, IdentifyResponse,
-    JoinRequest, JoinResponse, QueryResponse, RepositoryInfo, RevokeDeviceRequest, SyncResponse,
-    SyncStatusResponse,
+    JoinRequest, JoinResponse, QueryResponse, RepositoryInfo, RevokeDeviceRequest, SignOutResponse,
+    SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -515,8 +515,9 @@ pub async fn revoke_account_device(
     }
 }
 
-/// Clear this browser's stored account link (local sign-out).
-pub async fn unlink_account() -> Result<AccountStatus, TonkUiError> {
+/// Sign out on this device: revoke it in the registry (best-effort,
+/// reported in the response) and rotate onto a fresh key.
+pub async fn unlink_account() -> Result<SignOutResponse, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .delete(format!("{}/api/account", origin()))

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -47,6 +47,9 @@ pub struct AccountDevice {
     pub status: String,
     /// Registration time, seconds since the epoch.
     pub created_at: u64,
+    /// CID of the `root → device` delegation, which a revocation must
+    /// name. Carried to the browser so it can sign one.
+    pub delegation_cid: String,
     /// Whether this row is the profile making the request.
     pub this_device: bool,
 }
@@ -57,6 +60,12 @@ pub struct AccountDevice {
 pub struct RevokeDeviceRequest {
     /// DID of the device to revoke.
     pub did: String,
+    /// Hex-encoded root-signed revocation of that device's delegation.
+    ///
+    /// Required: cutting off a device other than the one in your hand
+    /// takes the account root, and the root lives behind the passkey, so
+    /// the browser must run the ceremony before calling this.
+    pub revocation: String,
 }
 
 #[cfg(test)]
@@ -83,16 +92,22 @@ mod tests {
             name: "laptop".into(),
             status: "active".into(),
             created_at: 1_753_300_000,
+            delegation_cid: "bafycid".into(),
             this_device: true,
         })
         .unwrap();
         assert_eq!(json["did"], "did:key:device");
         assert_eq!(json["createdAt"], 1_753_300_000);
         assert_eq!(json["thisDevice"], true);
+        assert_eq!(json["delegationCid"], "bafycid");
         assert!(json.get("created_at").is_none());
+        assert!(json.get("delegation_cid").is_none());
 
-        let request: RevokeDeviceRequest =
-            serde_json::from_value(serde_json::json!({ "did": "did:key:device" })).unwrap();
+        let request: RevokeDeviceRequest = serde_json::from_value(
+            serde_json::json!({ "did": "did:key:device", "revocation": "beef" }),
+        )
+        .unwrap();
         assert_eq!(request.did, "did:key:device");
+        assert_eq!(request.revocation, "beef");
     }
 }

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -34,6 +34,27 @@ pub enum AccountStatus {
     },
 }
 
+/// Result of signing out on this device.
+///
+/// Sign-out is two acts: telling the registry this device is out, and
+/// rotating the local key. The rotation always happens; the registry
+/// call is best-effort, and this response is where its failure
+/// surfaces instead of vanishing into a console log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignOutResponse {
+    /// DID of the replacement profile this browser now signs as.
+    pub device_did: String,
+    /// Whether the registry recorded this device's self-revocation.
+    /// `false` when there was nothing to record — never linked, or no
+    /// account service for this deployment — as well as on failure.
+    pub revoked: bool,
+    /// Why the registry was not told, when it should have been. The
+    /// device is signed out locally either way; a caller showing this
+    /// should tell the user to revoke from another device.
+    pub warning: Option<String>,
+}
+
 /// One device registered under the linked account, as returned by the
 /// worker's device-list proxy.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -109,5 +130,18 @@ mod tests {
         .unwrap();
         assert_eq!(request.did, "did:key:device");
         assert_eq!(request.revocation, "beef");
+    }
+
+    #[dialog_common::test]
+    fn it_serializes_the_sign_out_warning_in_camel_case() {
+        let json = serde_json::to_value(SignOutResponse {
+            device_did: "did:key:fresh".into(),
+            revoked: false,
+            warning: Some("service unreachable".into()),
+        })
+        .unwrap();
+        assert_eq!(json["deviceDid"], "did:key:fresh");
+        assert_eq!(json["revoked"], false);
+        assert_eq!(json["warning"], "service unreachable");
     }
 }

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -23,7 +23,9 @@ mod query;
 mod repository;
 mod sync;
 
-pub use account::{AccountDevice, AccountLinkRequest, AccountStatus, RevokeDeviceRequest};
+pub use account::{
+    AccountDevice, AccountLinkRequest, AccountStatus, RevokeDeviceRequest, SignOutResponse,
+};
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};
 pub use evaluate::{CommitSummary, EvaluateResponse, QueryMatchBlock, QueryResult};

--- a/rust/tonk-worker/src/device.rs
+++ b/rust/tonk-worker/src/device.rs
@@ -1,0 +1,277 @@
+//! Which profile this device signs as.
+//!
+//! Revocation is permanent for a key. The access-service screen matches
+//! a revoked device DID against every chain that DID issues a hop in,
+//! unscoped by account, and there is no un-revoke anywhere. So signing
+//! out — which revokes this device — has to leave a *different* key
+//! behind, or this browser could never presign again, local spaces
+//! included.
+//!
+//! Rotating is safe because nothing outside the device is keyed to the
+//! device DID: a linked profile's roster entries name the account root,
+//! and the spaces it holds are escrowed under that root, so a fresh
+//! profile that re-links restores them. What rotation does cost is the
+//! passkey prompt to link again, and anything never escrowed — a space
+//! that was never sync-enabled has no backup to restore from.
+//!
+//! The active profile's name is recorded against a fixed registry
+//! profile rather than inside the profile it names: a pointer stored in
+//! the thing it points at could not be read before opening it.
+
+use dialog_effects::credential::CredentialError;
+use dialog_effects::storage::Directory;
+use dialog_operator::Profile;
+use dialog_storage::provider::storage::Storage;
+use tonk_common::log;
+
+use crate::TonkWorkerError;
+use crate::worker::DefaultSpace;
+
+/// The profile that holds the pointer to the active one. Fixed, because
+/// boot has to find it without being told where to look.
+///
+/// It is also the profile this device signs as until the first
+/// rotation — there is no reason to burn a generation on a device that
+/// has never signed out.
+pub const REGISTRY_PROFILE: &str = "tonk";
+
+/// Credential site on the registry profile holding the active profile's
+/// name as UTF-8.
+const ACTIVE_PROFILE_SITE: &str = "tonk-active-profile-v1";
+
+/// Where the pointer lives: a profile name and the directory it is
+/// opened in. The worker uses [`Registry::device`]; tests point at a
+/// scratch directory under their own name so they neither collide with
+/// each other nor touch the real profile store.
+struct Registry {
+    profile: String,
+    directory: Directory,
+}
+
+impl Registry {
+    /// The one this device actually uses.
+    fn device() -> Self {
+        Self {
+            profile: REGISTRY_PROFILE.to_string(),
+            directory: Directory::Profile,
+        }
+    }
+
+    async fn open_self(&self, storage: &Storage<DefaultSpace>) -> Result<Profile, TonkWorkerError> {
+        Profile::open(&self.profile)
+            .at(self.directory.clone())
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to open the registry profile: {error}"))
+            })
+    }
+
+    /// The recorded active profile name, or `None` when none was ever
+    /// written.
+    async fn read(
+        &self,
+        registry: &Profile,
+        storage: &Storage<DefaultSpace>,
+    ) -> Result<Option<String>, TonkWorkerError> {
+        let bytes = match registry
+            .credential()
+            .site(ACTIVE_PROFILE_SITE)
+            .load::<Vec<u8>>()
+            .perform(storage)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(CredentialError::NotFound(_)) => return Ok(None),
+            Err(error) => {
+                return Err(TonkWorkerError::Internal(format!(
+                    "failed to read the active profile pointer: {error}"
+                )));
+            }
+        };
+
+        if bytes.is_empty() {
+            return Ok(None);
+        }
+        String::from_utf8(bytes).map(Some).map_err(|error| {
+            TonkWorkerError::Internal(format!("active profile name is not utf-8: {error}"))
+        })
+    }
+
+    /// Open the profile this device currently signs as.
+    async fn open_active(
+        &self,
+        storage: &Storage<DefaultSpace>,
+    ) -> Result<(String, Profile), TonkWorkerError> {
+        let registry = self.open_self(storage).await?;
+
+        let name = match self.read(&registry, storage).await {
+            Ok(Some(name)) => name,
+            Ok(None) => self.profile.clone(),
+            Err(error) => {
+                log!("active-profile pointer unreadable, signing as the initial profile: {error}");
+                self.profile.clone()
+            }
+        };
+
+        if name == self.profile {
+            return Ok((name, registry));
+        }
+
+        let profile = Profile::open(&name)
+            .at(self.directory.clone())
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to open profile '{name}': {error}"))
+            })?;
+        Ok((name, profile))
+    }
+
+    /// Generate a fresh profile and make it the active one.
+    async fn rotate(
+        &self,
+        storage: &Storage<DefaultSpace>,
+    ) -> Result<(String, Profile), TonkWorkerError> {
+        let suffix: [u8; 8] = rand::random();
+        let name = format!("{}-{}", self.profile, hex::encode(suffix));
+
+        // `create`, not `open`: a name collision must surface rather
+        // than quietly hand back an existing key, since the whole point
+        // is to leave the old one behind.
+        let profile = Profile::create(&name)
+            .at(self.directory.clone())
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to create profile '{name}': {error}"))
+            })?;
+
+        // Recorded only once the profile exists, so a failure between
+        // the two leaves an orphaned profile rather than a pointer to
+        // nothing.
+        let registry = self.open_self(storage).await?;
+        registry
+            .credential()
+            .site(ACTIVE_PROFILE_SITE)
+            .save(name.clone().into_bytes())
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to record the active profile: {error}"))
+            })?;
+
+        Ok((name, profile))
+    }
+}
+
+/// Open the profile this device currently signs as, with the name it was
+/// opened under.
+///
+/// Falls back to [`REGISTRY_PROFILE`] when no rotation has happened, and
+/// also when the pointer is unreadable — a device that cannot read its
+/// pointer is better off signing as the profile it started with than
+/// refusing to boot. A rotated device in that state re-links rather than
+/// losing anything, because the pointer's only job is naming a key.
+pub async fn open_active(
+    storage: &Storage<DefaultSpace>,
+) -> Result<(String, Profile), TonkWorkerError> {
+    Registry::device().open_active(storage).await
+}
+
+/// Generate a fresh profile and make it the one this device signs as.
+///
+/// The key left behind is not deleted — it still holds whatever local
+/// spaces it opened. It is simply no longer what this device presents,
+/// which is the point when the old key has just been revoked.
+pub async fn rotate(storage: &Storage<DefaultSpace>) -> Result<(String, Profile), TonkWorkerError> {
+    Registry::device().rotate(storage).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    /// A registry under its own name in a scratch directory, so tests
+    /// neither collide with each other nor touch the real profile store.
+    ///
+    /// Randomly named rather than sequentially: `Directory::Temp` is a
+    /// stable path, so a counter is unique only *within* a run and the
+    /// next run's differently-ordered tests would inherit the last
+    /// run's pointers. Rotation is persistent, so that reads as "a
+    /// profile that never rotated has rotated".
+    fn scratch() -> Registry {
+        Registry {
+            profile: format!("device-test-{}", hex::encode(rand::random::<[u8; 8]>())),
+            directory: Directory::Temp,
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_signs_as_the_initial_profile_before_any_rotation() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        let (name, _profile) = registry.open_active(&storage).await.unwrap();
+
+        assert_eq!(name, registry.profile);
+    }
+
+    #[dialog_common::test]
+    async fn it_leaves_the_old_key_behind_when_it_rotates() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        let (_, before) = registry.open_active(&storage).await.unwrap();
+
+        let (name, after) = registry.rotate(&storage).await.unwrap();
+
+        assert_ne!(name, registry.profile);
+        assert_ne!(
+            before.did(),
+            after.did(),
+            "a rotated device must not keep signing with the key it just revoked"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reopens_the_rotated_profile_on_the_next_boot() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        let (rotated_name, rotated) = registry.rotate(&storage).await.unwrap();
+
+        // A fresh pool stands in for a worker restart: nothing carries
+        // over but what was persisted.
+        let rebooted = Storage::<DefaultSpace>::default();
+        let (name, profile) = registry.open_active(&rebooted).await.unwrap();
+
+        assert_eq!(name, rotated_name);
+        assert_eq!(
+            profile.did(),
+            rotated.did(),
+            "the pointer has to survive a restart, or a rotated device reverts \
+             to the key it revoked"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rotates_again_from_an_already_rotated_profile() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        let (_, first) = registry.rotate(&storage).await.unwrap();
+        let (_, second) = registry.rotate(&storage).await.unwrap();
+        let (_, active) = registry.open_active(&storage).await.unwrap();
+
+        assert_ne!(first.did(), second.did());
+        assert_eq!(
+            active.did(),
+            second.did(),
+            "the pointer must name the newest key, not the first rotation"
+        );
+    }
+}

--- a/rust/tonk-worker/src/lib.rs
+++ b/rust/tonk-worker/src/lib.rs
@@ -69,6 +69,7 @@ pub use error::*;
 mod worker;
 pub use worker::*;
 
+pub mod device;
 pub mod session;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-worker/src/lib.rs
+++ b/rust/tonk-worker/src/lib.rs
@@ -69,6 +69,8 @@ pub use error::*;
 mod worker;
 pub use worker::*;
 
+pub mod session;
+
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod cache;
 

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -350,7 +350,6 @@ pub mod tests {
     use crate::api_router;
     use crate::worker::TonkState;
 
-    use dialog_capability::Subject;
     use dialog_credentials::Ed25519Signer;
     use dialog_operator::Profile;
     use dialog_storage::provider::storage::Storage;
@@ -408,17 +407,16 @@ pub mod tests {
             .await
             .expect("Failed to create test profile");
 
-        let operator = profile
-            .derive(b"test-worker")
-            .allow(Subject::any())
-            .build(storage)
+        let session = crate::session::open(&profile, &storage)
             .await
-            .expect("Failed to build test operator");
+            .expect("Failed to open a test signing session");
 
         let reactor = crate::Reactor::new(profile.clone());
         TonkState {
             profile,
-            operator,
+            operator: session.operator,
+            storage,
+            session_expires_at: session.expires_at,
             profile_name,
             reactor,
             view_bindings: Default::default(),

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -258,29 +258,137 @@ pub async fn link(
     }))
 }
 
-/// Clear the stored account link for this profile — local sign-out.
+/// Sign out on this device: revoke it in the registry, then rotate onto
+/// a fresh key.
 ///
-/// Writes an empty tombstone over the stored link (the credential store
-/// has no delete effect). The `root → device` delegation saved into the
-/// access store at link time has no removal API and stays behind: a
-/// signed-out device that is not also *revoked* still holds a usable
-/// delegation. Revocation, not unlink, is the security boundary.
+/// Clearing the local link alone would leave a signed-out device still
+/// holding a usable `root → device` delegation — the access store has no
+/// removal API — so sign-out revokes instead. That makes the registry
+/// agree with what the user just asked for, and it is the only half of
+/// this that a stolen device cannot undo.
+///
+/// Revocation is permanent for a key, and the access-service screen
+/// matches a revoked device DID against every chain that DID issues a
+/// hop in, unscoped by account. Keeping the same profile afterwards
+/// would therefore refuse *all* presigns from this browser, local spaces
+/// included, forever. So the device rotates onto a new profile in the
+/// same movement, and the old key is simply left behind.
+///
+/// Nothing outside the device is keyed to the device DID — a linked
+/// profile's roster entries name the account root, and its spaces are
+/// escrowed under that root — so logging back in restores them. The
+/// costs are a passkey prompt to link again, and any space that was
+/// never sync-enabled, which was never escrowed and does not come back.
 #[wasm_compat]
 pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>, TonkWorkerError> {
-    let state = state.read().await;
-    state
-        .profile
-        .credential()
-        .site(ACCOUNT_LINK_SITE)
-        .save(Vec::new())
-        .perform(&state.operator)
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to clear local account link: {error}"))
-        })?;
-    Ok(Json(AccountStatus::Unlinked {
-        device_did: state.profile.did().to_string(),
-    }))
+    // Revoke first, while this device's key is still the one the
+    // registry knows. Best-effort: an unreachable account service must
+    // not strand the user on a device they asked to sign out of, and
+    // the local half is what they can see.
+    revoke_this_device(&state).await;
+
+    let storage = { state.read().await.storage.clone() };
+    let (profile_name, profile) = crate::device::rotate(&storage).await?;
+    let session = crate::session::open(&profile, &storage).await?;
+    let device_did = profile.did().to_string();
+
+    {
+        let mut tonk = state.write().await;
+        // The reactor caches repositories and branches opened as the
+        // old profile. They are not this device's to serve any more, so
+        // it is replaced rather than flushed.
+        tonk.reactor = crate::Reactor::new(profile.clone());
+        tonk.profile = profile;
+        tonk.operator = session.operator;
+        tonk.session_expires_at = session.expires_at;
+        tonk.profile_name = profile_name;
+        tonk.sync_queue = Default::default();
+    }
+
+    {
+        let tonk = state.read().await;
+        crate::router::repository::bootstrap_profile(&tonk)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to bootstrap the replacement profile: {error}"
+                ))
+            })?;
+    }
+
+    Ok(Json(AccountStatus::Unlinked { device_did }))
+}
+
+/// Tell the account registry this device is out, signing the revocation
+/// with the device's own key.
+///
+/// A self-revoke is the one revocation a device can always make: it
+/// needs no passkey and no root, because the only thing it cuts off is
+/// itself. Nothing here is fatal — a profile that was never linked has
+/// nothing to revoke, and a failed call leaves a device the registry
+/// still believes in, which is the state it was already in.
+async fn revoke_this_device(state: &AppState) {
+    use dialog_ucan_core::promise::Promised;
+
+    // Read what the call needs and let the lock go: the rest of this
+    // signs and then waits on the network, and nothing else may touch
+    // the state while a guard is held across those awaits.
+    let (link, device, device_did) = {
+        let tonk = state.read().await;
+        let Some(link) = account_link(&tonk).await else {
+            return; // never linked — nothing to tell the registry
+        };
+        (
+            link,
+            tonk.profile.signer().signer().clone(),
+            tonk.profile.did().to_string(),
+        )
+    };
+    let Some(service) = crate::router::account_backup::account_service_url() else {
+        return;
+    };
+    let root_did = link.issuer().clone();
+
+    let revocation =
+        match tonk_identity::revocation::mint_self_revocation(device.clone(), &link, &root_did)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                log!("sign-out could not sign a revocation for this device: {error}");
+                return;
+            }
+        };
+
+    let arguments = [
+        ("did".to_owned(), Promised::String(device_did)),
+        (
+            "revocation".to_owned(),
+            Promised::String(hex::encode(revocation)),
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    let body = match tonk_identity::request::build_device_invocation(
+        device,
+        &link,
+        vec!["account".into(), "device".into(), "revoke".into()],
+        arguments,
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(error) => {
+            log!("sign-out could not build the revoke invocation: {error}");
+            return;
+        }
+    };
+
+    let endpoint = format!("{}/devices/revoke", service.trim_end_matches('/'));
+    if let Err(error) = crate::router::account_backup::post_for_bytes(&endpoint, body).await {
+        log!("sign-out could not reach the account service to revoke this device: {error}");
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
@@ -426,34 +534,81 @@ mod tests {
         }
 
         let Json(after) = unlink(State(state.clone())).await.unwrap();
-        assert_eq!(
-            after,
-            AccountStatus::Unlinked {
-                device_did: device_did.to_string()
-            }
-        );
+        assert!(matches!(after, AccountStatus::Unlinked { .. }));
         let Json(loaded) = get(State(state.clone())).await.unwrap();
         assert!(matches!(loaded, AccountStatus::Unlinked { .. }));
 
-        // The tombstone must read as "no link", not as a malformed link.
         let tonk = state.read().await;
         assert!(account_link(&tonk).await.is_none());
     }
 
+    /// The device this browser presents afterwards must not be the one
+    /// sign-out just revoked. Revocation is permanent for a key and the
+    /// access-service screen matches the device DID unscoped by account,
+    /// so coming back as the same profile would refuse every presign
+    /// this browser ever makes again.
     #[dialog_common::test]
-    async fn it_relinks_the_same_root_after_an_unlink() {
+    async fn it_signs_out_onto_a_key_it_did_not_just_revoke() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let revoked_did = state.read().await.profile.did();
+        let request = request_for(&[7u8; 32], revoked_did.clone()).await;
+        {
+            let tonk = state.read().await;
+            persist_link(&tonk, &request).await.unwrap();
+        }
+
+        let Json(after) = unlink(State(state.clone())).await.unwrap();
+
+        let AccountStatus::Unlinked { device_did } = after else {
+            panic!("sign-out must leave the profile unlinked");
+        };
+        assert_ne!(device_did, revoked_did.to_string());
+        assert_eq!(
+            state.read().await.profile.did().to_string(),
+            device_did,
+            "the reported device has to be the one the worker actually signs as"
+        );
+    }
+
+    /// Sign-out replaces the operator too, not just the profile. An
+    /// operator still delegated from the retired profile would sign
+    /// presigns that prove nothing about the key this device now has.
+    #[dialog_common::test]
+    async fn it_re_keys_the_signing_session_on_sign_out() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let before = state.read().await.operator.did();
+
+        let _ = unlink(State(state.clone())).await.unwrap();
+
+        let tonk = state.read().await;
+        assert_ne!(before, tonk.operator.did());
+        assert_eq!(
+            tonk.operator.profile_did(),
+            tonk.profile.did(),
+            "the session has to descend from the profile this device now signs as"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_relinks_the_same_root_after_a_sign_out() {
         let state = Arc::new(RwLock::new(test_state().await));
         let device_did = state.read().await.profile.did();
-        let request = request_for(&[7u8; 32], device_did.clone()).await;
+        let request = request_for(&[7u8; 32], device_did).await;
         {
             let tonk = state.read().await;
             persist_link(&tonk, &request).await.unwrap();
         }
         let _ = unlink(State(state.clone())).await.unwrap();
+
+        // The same account root, but delegated to the replacement key —
+        // the old delegation names a device this browser no longer is.
+        let rotated_did = state.read().await.profile.did();
+        let relink = request_for(&[7u8; 32], rotated_did).await;
         {
             let tonk = state.read().await;
-            persist_link(&tonk, &request).await.unwrap();
+            persist_link(&tonk, &relink).await.unwrap();
         }
+
         let Json(loaded) = get(State(state)).await.unwrap();
         assert!(matches!(loaded, AccountStatus::Linked { .. }));
     }

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -305,15 +305,16 @@ pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>
         tonk.sync_queue = Default::default();
     }
 
+    // Lay down the replacement profile's meta branch. Not fatal: by
+    // here the device is revoked and the key rotated, so reporting a
+    // failure would name an action that did happen and leave nothing to
+    // retry. Boot bootstraps the profile too, so a miss here heals on
+    // the next worker start.
     {
         let tonk = state.read().await;
-        crate::router::repository::bootstrap_profile(&tonk)
-            .await
-            .map_err(|error| {
-                TonkWorkerError::Internal(format!(
-                    "failed to bootstrap the replacement profile: {error}"
-                ))
-            })?;
+        if let Err(error) = crate::router::repository::bootstrap_profile(&tonk).await {
+            log!("replacement profile not bootstrapped, deferring to next boot: {error}");
+        }
     }
 
     Ok(Json(AccountStatus::Unlinked { device_did }))

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -8,7 +8,7 @@ use dialog_ucan_core::DelegationChain;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
-use tonk_worker_api::{AccountLinkRequest, AccountStatus};
+use tonk_worker_api::{AccountLinkRequest, AccountStatus, SignOutResponse};
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -280,12 +280,23 @@ pub async fn link(
 /// costs are a passkey prompt to link again, and any space that was
 /// never sync-enabled, which was never escrowed and does not come back.
 #[wasm_compat]
-pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>, TonkWorkerError> {
+pub async fn unlink(
+    State(state): State<AppState>,
+) -> Result<Json<SignOutResponse>, TonkWorkerError> {
     // Revoke first, while this device's key is still the one the
     // registry knows. Best-effort: an unreachable account service must
     // not strand the user on a device they asked to sign out of, and
-    // the local half is what they can see.
-    revoke_this_device(&state).await;
+    // the local half is what they can see. Failure is carried into the
+    // response rather than aborting: the user asked to leave this
+    // device, and they can finish the revocation from another one.
+    let (revoked, warning) = match revoke_this_device(&state).await {
+        SelfRevocation::Recorded => (true, None),
+        SelfRevocation::NothingToRecord => (false, None),
+        SelfRevocation::Failed(cause) => {
+            log!("sign-out revoked nothing in the registry: {cause}");
+            (false, Some(cause))
+        }
+    };
 
     let storage = { state.read().await.storage.clone() };
     let (profile_name, profile) = crate::device::rotate(&storage).await?;
@@ -317,7 +328,24 @@ pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>
         }
     }
 
-    Ok(Json(AccountStatus::Unlinked { device_did }))
+    Ok(Json(SignOutResponse {
+        device_did,
+        revoked,
+        warning,
+    }))
+}
+
+/// What became of the registry half of a sign-out.
+enum SelfRevocation {
+    /// The registry accepted this device's self-revocation.
+    Recorded,
+    /// There was no registry to tell: the profile was never linked, or
+    /// this deployment has no account service.
+    NothingToRecord,
+    /// The registry should have been told and was not. The device still
+    /// signs out locally; the cause travels to the user, who can revoke
+    /// from another device.
+    Failed(String),
 }
 
 /// Tell the account registry this device is out, signing the revocation
@@ -328,7 +356,7 @@ pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>
 /// itself. Nothing here is fatal — a profile that was never linked has
 /// nothing to revoke, and a failed call leaves a device the registry
 /// still believes in, which is the state it was already in.
-async fn revoke_this_device(state: &AppState) {
+async fn revoke_this_device(state: &AppState) -> SelfRevocation {
     use dialog_ucan_core::promise::Promised;
 
     // Read what the call needs and let the lock go: the rest of this
@@ -337,7 +365,7 @@ async fn revoke_this_device(state: &AppState) {
     let (link, device, device_did) = {
         let tonk = state.read().await;
         let Some(link) = account_link(&tonk).await else {
-            return; // never linked — nothing to tell the registry
+            return SelfRevocation::NothingToRecord; // never linked
         };
         (
             link,
@@ -346,7 +374,7 @@ async fn revoke_this_device(state: &AppState) {
         )
     };
     let Some(service) = crate::router::account_backup::account_service_url() else {
-        return;
+        return SelfRevocation::NothingToRecord;
     };
     let root_did = link.issuer().clone();
 
@@ -356,8 +384,9 @@ async fn revoke_this_device(state: &AppState) {
         {
             Ok(bytes) => bytes,
             Err(error) => {
-                log!("sign-out could not sign a revocation for this device: {error}");
-                return;
+                return SelfRevocation::Failed(format!(
+                    "could not sign a revocation for this device: {error}"
+                ));
             }
         };
 
@@ -381,14 +410,18 @@ async fn revoke_this_device(state: &AppState) {
     {
         Ok(body) => body,
         Err(error) => {
-            log!("sign-out could not build the revoke invocation: {error}");
-            return;
+            return SelfRevocation::Failed(format!(
+                "could not build the revoke invocation: {error}"
+            ));
         }
     };
 
     let endpoint = format!("{}/devices/revoke", service.trim_end_matches('/'));
-    if let Err(error) = crate::router::account_backup::post_for_bytes(&endpoint, body).await {
-        log!("sign-out could not reach the account service to revoke this device: {error}");
+    match crate::router::account_backup::post_for_bytes(&endpoint, body).await {
+        Ok(_) => SelfRevocation::Recorded,
+        Err(error) => SelfRevocation::Failed(format!(
+            "could not reach the account service to revoke this device: {error}"
+        )),
     }
 }
 
@@ -535,7 +568,13 @@ mod tests {
         }
 
         let Json(after) = unlink(State(state.clone())).await.unwrap();
-        assert!(matches!(after, AccountStatus::Unlinked { .. }));
+        // The test scope has no account service, so there was no
+        // registry to tell — which is not a failure and must not warn.
+        assert!(!after.revoked);
+        assert!(
+            after.warning.is_none(),
+            "nothing-to-record is not a failure worth warning about"
+        );
         let Json(loaded) = get(State(state.clone())).await.unwrap();
         assert!(matches!(loaded, AccountStatus::Unlinked { .. }));
 
@@ -560,9 +599,7 @@ mod tests {
 
         let Json(after) = unlink(State(state.clone())).await.unwrap();
 
-        let AccountStatus::Unlinked { device_did } = after else {
-            panic!("sign-out must leave the profile unlinked");
-        };
+        let device_did = after.device_did;
         assert_ne!(device_did, revoked_did.to_string());
         assert_eq!(
             state.read().await.profile.did().to_string(),

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -98,13 +98,17 @@ pub async fn revoke(
             "cannot revoke the device you are using; sign out instead".to_string(),
         ));
     }
-    let (link, service) = linked_service(&state).await?;
-    let device = state.profile.signer().signer().clone();
+    // Checked before the account link and service are resolved: this is
+    // a property of the request itself, and a caller who sent no
+    // revocation should hear that rather than whichever lookup happened
+    // to fail first.
     if request.revocation.is_empty() {
         return Err(TonkWorkerError::Conflict(
             "revoking another device needs a passkey-signed revocation".to_string(),
         ));
     }
+    let (link, service) = linked_service(&state).await?;
+    let device = state.profile.signer().signer().clone();
     let arguments = [
         ("did".to_owned(), Promised::String(request.did)),
         (

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -168,11 +168,40 @@ mod tests {
             revoke(
                 State(state),
                 Json(RevokeDeviceRequest {
-                    did: device_did.to_string()
+                    did: device_did.to_string(),
+                    revocation: "beef".to_string(),
                 })
             )
             .await,
             Err(TonkWorkerError::Conflict(_))
         ));
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_to_revoke_without_a_signed_revocation() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let device_did = state.read().await.profile.did();
+        let request =
+            crate::router::account::tests_request_for(&[7u8; 32], device_did.clone()).await;
+        {
+            let tonk = state.read().await;
+            crate::router::account::persist_link(&tonk, &request)
+                .await
+                .unwrap();
+        }
+        assert!(
+            matches!(
+                revoke(
+                    State(state),
+                    Json(RevokeDeviceRequest {
+                        did: "did:key:zOtherDevice".to_string(),
+                        revocation: String::new(),
+                    })
+                )
+                .await,
+                Err(TonkWorkerError::Conflict(_))
+            ),
+            "cutting off another device takes a passkey-signed revocation"
+        );
     }
 }

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -24,6 +24,7 @@ struct ServiceDevice {
     name: String,
     status: String,
     created_at: u64,
+    delegation_cid: String,
 }
 
 /// Resolve the stored link and service URL, or explain what's missing.
@@ -66,6 +67,7 @@ async fn fetch_devices(
             name: row.name,
             status: row.status,
             created_at: row.created_at,
+            delegation_cid: row.delegation_cid,
         })
         .collect())
 }
@@ -98,9 +100,20 @@ pub async fn revoke(
     }
     let (link, service) = linked_service(&state).await?;
     let device = state.profile.signer().signer().clone();
-    let arguments = [("did".to_owned(), Promised::String(request.did))]
-        .into_iter()
-        .collect();
+    if request.revocation.is_empty() {
+        return Err(TonkWorkerError::Conflict(
+            "revoking another device needs a passkey-signed revocation".to_string(),
+        ));
+    }
+    let arguments = [
+        ("did".to_owned(), Promised::String(request.did)),
+        (
+            "revocation".to_owned(),
+            Promised::String(request.revocation),
+        ),
+    ]
+    .into_iter()
+    .collect();
     let body = tonk_identity::request::build_device_invocation(
         device,
         &link,

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -1096,9 +1096,10 @@ mod tests {
             root_did: root_did.to_string(),
             delegation_hex: hex::encode(delegation.to_bytes().unwrap()),
         };
-        crate::router::account::link(axum::extract::State(state.clone()), axum::Json(request))
-            .await
-            .unwrap();
+        let _ =
+            crate::router::account::link(axum::extract::State(state.clone()), axum::Json(request))
+                .await
+                .unwrap();
 
         // Join an invite.
         let (url, key) = handcrafted_invite_url(50, 51).await;

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -280,7 +280,6 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_service_worker);
 
     use crate::worker::{DefaultSpace, TonkState};
-    use dialog_capability::Subject;
     use dialog_operator::Profile;
     use dialog_storage::provider::storage::Storage;
     use tonk_schema::petname;
@@ -295,16 +294,15 @@ mod tests {
             .perform(&storage)
             .await
             .expect("profile opens");
-        let operator = profile
-            .derive(b"test-worker")
-            .allow(Subject::any())
-            .build(storage)
+        let session = crate::session::open(&profile, &storage)
             .await
-            .expect("operator builds");
+            .expect("signing session opens");
         let reactor = crate::Reactor::new(profile.clone());
         TonkState {
             profile,
-            operator,
+            operator: session.operator,
+            storage,
+            session_expires_at: session.expires_at,
             profile_name: name.to_string(),
             reactor,
             view_bindings: Default::default(),

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -1002,6 +1002,10 @@ impl SyncQueue {
 /// Branches are synced per-repo; repos run sequentially here (the reactor
 /// serializes branch state anyway), priority-ordered by activity.
 pub async fn drain_sync(state: &AppState) {
+    // Before anything presigns: the operator's delegation expires, and a
+    // drain is the regular beat this worker has to notice that on.
+    renew_session(state).await;
+
     // Dirty repos first (push priority), then repos owed a retry, then every
     // other open repo (pull).
     let now = current_millis();
@@ -1034,6 +1038,56 @@ pub async fn drain_sync(state: &AppState) {
             tonk.sync_queue.requeue(&repo, now);
         }
     }
+}
+
+/// Rotate the signing session when its delegation is close to lapsing.
+///
+/// Rotation replaces the operator key, not just its delegation: the
+/// certificate store is content-addressed with no delete, and its chain
+/// walk never consults the clock, so a re-minted delegation filed under
+/// the same audience would sit beside the lapsed one and be chosen about
+/// half the time. A new key means a new audience and no ambiguity.
+///
+/// The replacement is built over the state's existing storage pool, so
+/// every repository and branch handle the reactor has cached stays
+/// valid — the operator changes, the spaces underneath do not.
+///
+/// Best-effort. Minting is local (a key derivation and a self-signed
+/// delegation, no network), but a failure here must not take the drain
+/// down: the current session keeps working until it lapses, and the next
+/// drain tries again.
+async fn renew_session(state: &AppState) {
+    let (profile, storage, expires_at) = {
+        let tonk = state.read().await;
+        if !crate::session::needs_renewal(tonk.session_expires_at, crate::session::now()) {
+            return;
+        }
+        (
+            tonk.profile.clone(),
+            tonk.storage.clone(),
+            tonk.session_expires_at,
+        )
+    };
+
+    // Mint outside the lock — nothing else may proceed while a write
+    // lock is held, and this signs.
+    let session = match crate::session::open(&profile, &storage).await {
+        Ok(session) => session,
+        Err(error) => {
+            log!("signing session rotation failed, keeping the current one: {error}");
+            return;
+        }
+    };
+
+    let mut tonk = state.write().await;
+    // A concurrent drain may have rotated while this one was minting.
+    // Theirs is no worse than ours, and adopting both would retire a
+    // session that requests are already presenting.
+    if tonk.session_expires_at != expires_at {
+        return;
+    }
+    tonk.operator = session.operator;
+    tonk.session_expires_at = session.expires_at;
 }
 
 /// `POST /api/sync` — an external sync poke.

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -1,0 +1,272 @@
+//! The worker's signing session.
+//!
+//! Every presign invocation is signed by the *operator* key, and its
+//! proofs are assembled by a certificate-store walk that starts at the
+//! operator and ends at the subject. The `profile → operator` delegation
+//! is therefore the last hop of every chain this worker presents, which
+//! makes it the one place a time bound reaches all of them.
+//!
+//! Bounding it is what gives revocation something to withhold. The
+//! `root → device` grant is unexpiring, so withdrawing it can only ever
+//! be a registry lookup; a session that lapses on its own costs a
+//! stolen device at most one session lifetime even if the registry is
+//! unreachable.
+//!
+//! Renewal rotates the operator key rather than re-minting under the
+//! same audience. Certificates are content-addressed, the store has no
+//! delete, and its chain walk never consults the clock — it filters
+//! candidates against the *requested* time range, which the presign path
+//! leaves unbounded, and an unbounded requirement is satisfied by every
+//! range including a lapsed one. So a stale certificate left beside its
+//! replacement under one audience would be chosen about half the time.
+//! A rotated key gets its own audience, and the retired one is simply
+//! never proved to again.
+
+use dialog_capability::Subject;
+use dialog_operator::Profile;
+use dialog_storage::provider::storage::Storage;
+use dialog_ucan_core::time::Timestamp;
+use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
+
+use crate::TonkWorkerError;
+use crate::worker::{DefaultOperator, DefaultSpace};
+
+/// How long a session delegation is good for.
+///
+/// Hours rather than minutes: a session has to survive a stretch offline
+/// and a closed laptop, or renewal failure becomes the common path
+/// instead of the exceptional one.
+pub use tonk_identity::session::SESSION_TTL_SECONDS;
+
+/// How long before expiry a session is rotated.
+///
+/// Wide enough that rotation lands during ordinary sync activity rather
+/// than at the cliff: renewal is local (a key derivation and a
+/// self-signed delegation, no network), but it only runs when something
+/// drives the worker, and a quiet page can go a while between drains.
+pub const RENEWAL_MARGIN_SECONDS: u64 = 60 * 60;
+
+/// A signing session: the operator that signs presigns, and the moment
+/// the delegation authorizing it stops being valid.
+pub struct Session {
+    /// The operator, keyed for this session alone.
+    pub operator: DefaultOperator,
+    /// Expiry of the `profile → operator` delegation, unix seconds.
+    pub expires_at: u64,
+}
+
+/// Open a fresh signing session for `profile` over `storage`.
+///
+/// `storage` is cloned rather than created, so the session's operator
+/// mounts into the same pool as every handle already open against it.
+/// A session built over its own pool would leave the reactor's cached
+/// repositories talking to the previous one.
+pub async fn open(
+    profile: &Profile,
+    storage: &Storage<DefaultSpace>,
+) -> Result<Session, TonkWorkerError> {
+    // A random derivation context is what makes the operator key
+    // session-scoped: `derive` is a KDF over the profile seed and this
+    // context, so a fixed context would hand every session the same
+    // audience and file a rotated delegation in the same bucket as the
+    // one it replaces.
+    let context: [u8; 16] = rand::random();
+
+    // No `.allow(...)`: that mints an *unexpiring* profile → operator
+    // delegation, which is the thing this module exists to replace. The
+    // bounded equivalent is minted below.
+    let operator = profile
+        .derive(context.to_vec())
+        .build(storage.clone())
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to derive a session operator: {error}"))
+        })?;
+
+    let expiration = Timestamp::new(SystemTime::now() + Duration::from_secs(SESSION_TTL_SECONDS))
+        .map_err(|error| {
+        TonkWorkerError::Internal(format!("session expiration out of range: {error}"))
+    })?;
+
+    let delegation = profile
+        .access()
+        .claim(Subject::any())
+        .expires(expiration)
+        .delegate(operator.did())
+        .perform(&operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to mint the session delegation: {error}"))
+        })?;
+
+    profile
+        .access()
+        .save(delegation)
+        .perform(&operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to save the session delegation: {error}"))
+        })?;
+
+    Ok(Session {
+        operator,
+        expires_at: expiration.to_unix(),
+    })
+}
+
+/// Whether a session expiring at `expires_at` is close enough to lapsing
+/// to be rotated now.
+pub fn needs_renewal(expires_at: u64, now: u64) -> bool {
+    now.saturating_add(RENEWAL_MARGIN_SECONDS) >= expires_at
+}
+
+/// The current wall clock in unix seconds, as [`needs_renewal`] expects.
+pub fn now() -> u64 {
+    Timestamp::now().to_unix()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use dialog_credentials::Ed25519Signer;
+    use dialog_effects::storage::Directory;
+    use dialog_ucan::UcanDelegation;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal;
+
+    /// A throwaway profile in a scratch directory, plus the storage it
+    /// is mounted in. Names are unique per call so tests never share a
+    /// profile key or a certificate store.
+    async fn scratch() -> (Storage<DefaultSpace>, Profile) {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let name = format!("session-test-{}", SEQ.fetch_add(1, Ordering::Relaxed));
+        let storage = Storage::<DefaultSpace>::default();
+        let profile = Profile::open(name)
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .expect("profile opens");
+        (storage, profile)
+    }
+
+    #[dialog_common::test]
+    async fn it_bounds_the_session_within_the_ttl() {
+        let (storage, profile) = scratch().await;
+        let before = now();
+
+        let session = open(&profile, &storage).await.unwrap();
+
+        assert!(session.expires_at >= before + SESSION_TTL_SECONDS);
+        assert!(session.expires_at <= now() + SESSION_TTL_SECONDS);
+    }
+
+    #[dialog_common::test]
+    async fn it_keys_every_session_separately() {
+        let (storage, profile) = scratch().await;
+
+        let first = open(&profile, &storage).await.unwrap();
+        let second = open(&profile, &storage).await.unwrap();
+
+        assert_ne!(
+            first.operator.did(),
+            second.operator.did(),
+            "a rotated session needs its own audience, or its delegation \
+             lands in the same bucket as the lapsed one it replaces"
+        );
+    }
+
+    /// The one that matters: swapping `.allow(Subject::any())` for a
+    /// bounded claim must still authorize a presign. This walks the same
+    /// BFS the presign path does — operator toward a space subject,
+    /// composing the session hop with a `space -> profile` grant — and
+    /// checks both that it resolves and that the session's expiry is
+    /// what bounds the result.
+    #[dialog_common::test]
+    async fn it_authorizes_a_presign_chain_bounded_by_the_session() {
+        let (storage, profile) = scratch().await;
+        let session = open(&profile, &storage).await.unwrap();
+
+        let space = Ed25519Signer::generate().await.unwrap();
+        let grant = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&profile.did())
+            .subject(UcanSubject::Specific(space.did()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        profile
+            .access()
+            .save(UcanDelegation(DelegationChain::new(grant)))
+            .perform(&session.operator)
+            .await
+            .unwrap();
+
+        let proof = profile
+            .access()
+            .prove(Subject::from(space.did()))
+            .audience(&session.operator)
+            .perform(&session.operator)
+            .await
+            .expect("the session operator must still reach the space");
+
+        assert_eq!(
+            proof.proofs.len(),
+            2,
+            "the chain is space -> profile -> operator"
+        );
+        assert_eq!(
+            proof.duration.expiration,
+            Some(session.expires_at),
+            "an unexpiring space grant composed with a bounded session \
+             must come out bounded by the session"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_holds_a_session_open_well_before_expiry() {
+        let expires_at = 1_000_000;
+
+        assert!(!needs_renewal(
+            expires_at,
+            expires_at - RENEWAL_MARGIN_SECONDS - 1
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_renews_once_inside_the_margin() {
+        let expires_at = 1_000_000;
+
+        assert!(needs_renewal(
+            expires_at,
+            expires_at - RENEWAL_MARGIN_SECONDS
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_renews_a_session_that_already_lapsed() {
+        let expires_at = 1_000_000;
+
+        assert!(
+            needs_renewal(expires_at, expires_at + 1),
+            "a lapsed session must rotate rather than keep presenting a dead delegation"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_overflow_renewing_far_from_the_epoch() {
+        assert!(
+            needs_renewal(0, u64::MAX),
+            "the margin must saturate rather than wrap a clock near u64::MAX"
+        );
+    }
+}

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -21,6 +21,13 @@
 //! replacement under one audience would be chosen about half the time.
 //! A rotated key gets its own audience, and the retired one is simply
 //! never proved to again.
+//!
+//! Renewal rides the sync drain — the regular beat this worker has —
+//! rather than chasing every presign path. The gap that leaves: a
+//! worker alive past the TTL whose next presign is not preceded by a
+//! drain presents a lapsed chain and takes one 401, which the next
+//! drain's rotation heals. Service-worker lifetimes make that window
+//! rare; revisit only if it is ever observed.
 
 use dialog_capability::Subject;
 use dialog_operator::Profile;

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -295,11 +295,6 @@ pub type DefaultSpace = dialog_storage::provider::storage::NativeSpace;
 /// Concrete operator type for the default storage backend.
 pub type DefaultOperator = Operator<DefaultSpace>;
 
-/// Name of the profile this worker opens on startup. Also used as
-/// the label for the profile's self-replica record in its meta
-/// branch.
-const PROFILE_NAME: &str = "tonk";
-
 /// Application state containing the profile and operator.
 pub struct TonkState {
     /// The user's persistent profile.
@@ -1657,9 +1652,10 @@ impl TonkServiceWorker {
         // 1. Create storage backend
         let storage = Storage::<DefaultSpace>::default();
 
-        // 2. Open or create profile
-        let profile = Profile::open(PROFILE_NAME)
-            .perform(&storage)
+        // 2. Open the profile this device signs as. Usually the one it
+        // started with; a device that has signed out since then signs
+        // as the profile that replaced the key it revoked.
+        let (profile_name, profile) = crate::device::open_active(&storage)
             .await
             .map_err(|e| JsError::new(&format!("Failed to open profile: {}", e)))?;
         log!("Profile DID: {}", profile.did());
@@ -1680,7 +1676,7 @@ impl TonkServiceWorker {
             operator: session.operator,
             storage,
             session_expires_at: session.expires_at,
-            profile_name: PROFILE_NAME.to_string(),
+            profile_name,
             reactor,
             view_bindings: Default::default(),
             bridges: Default::default(),

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -15,7 +15,6 @@ use axum::{
     body::Body,
     http::{HeaderValue, header::HeaderName},
 };
-use dialog_capability::Subject;
 use dialog_operator::{Operator, Profile};
 use dialog_storage::provider::storage::Storage;
 use js_sys::Promise;
@@ -305,8 +304,20 @@ const PROFILE_NAME: &str = "tonk";
 pub struct TonkState {
     /// The user's persistent profile.
     pub profile: Profile,
-    /// The operator derived from the profile.
+    /// The operator derived from the profile — the key that signs
+    /// presign invocations. Rotated by
+    /// [`session`](crate::session) before its delegation lapses, so it
+    /// is not stable for the life of the worker.
     pub operator: DefaultOperator,
+    /// The storage pool every space is mounted in. Held so a rotated
+    /// operator can be built over the *same* pool: a replacement with
+    /// its own would leave the reactor's cached repository and branch
+    /// handles talking to the retired one.
+    pub storage: Storage<DefaultSpace>,
+    /// When the current operator's delegation stops being valid, unix
+    /// seconds. Consulted by the sync drain, which rotates the session
+    /// as this approaches.
+    pub session_expires_at: u64,
     /// Display name the profile was opened under. `Profile` does
     /// not retain this internally, so we carry it here for routes
     /// that report it back to the UI (e.g. `GET /api/profile`).
@@ -1653,20 +1664,22 @@ impl TonkServiceWorker {
             .map_err(|e| JsError::new(&format!("Failed to open profile: {}", e)))?;
         log!("Profile DID: {}", profile.did());
 
-        // 3. Derive operator with full capabilities
-        let operator = profile
-            .derive(b"worker")
-            .allow(Subject::any())
-            .build(storage)
+        // 3. Open a signing session — an operator keyed for this
+        // session alone, authorized by a delegation that expires. The
+        // storage is shared, not handed over, so a later rotation can
+        // build its replacement over the same pool.
+        let session = crate::session::open(&profile, &storage)
             .await
-            .map_err(|e| JsError::new(&format!("Failed to build operator: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Failed to open a signing session: {}", e)))?;
 
         // 4. Build state and bootstrap the profile repo's meta
         // branch. Idempotent — safe to run on every worker boot.
         let reactor = crate::Reactor::new(profile.clone());
         let state = TonkState {
             profile,
-            operator,
+            operator: session.operator,
+            storage,
+            session_expires_at: session.expires_at,
             profile_name: PROFILE_NAME.to_string(),
             reactor,
             view_bindings: Default::default(),


### PR DESCRIPTION
## Summary

Implements both problems this branch's docs identified, plus the decision that shaped them.

## The finding that reshaped the session work

`Invocation::check` computes the intersection of every hop's time bounds and returns it as a `TimeRange`. `InvocationChain::verify` does `.map(|_| ())`, and `UcanAuthorizer::authorize` never looks. **Expiry was unenforced at the presign boundary** — a chain that expired last year verified exactly like a fresh one; only a chain that could *never* be valid was rejected.

So an expiring delegation bought nothing, and enforcement had to land before sessions meant anything.

## Session delegations (stage H')

- **`tonk-access-service`**: a new window screen reads the latest `not_before` and earliest `expiration` off the parse the revocation screen already does, and refuses a presign outside that window with `401 INVOCATION_EXPIRED`. It runs *before* the revocation screen, so an expired chain costs no D1 query.
- **`tonk-identity`**: `mint_session_delegation` / `extend_with_session` — the device keeps its unexpiring `root → device` grant and mints a bounded `device → session` hop from it. Self-minted, so no renewal endpoint and nothing to be unreachable. 12-hour TTL: long enough to survive an offline stretch, short enough that a lost grant stops mattering within a working day. The composed chain keeps the grant hop, so the revocation screen still sees the device.
- **Enforce, don't require.** Unbounded chains stay valid, so this is additive and ships ahead of client adoption. Requiring a window is the breaking half and is gated on a soak.

## Signed revocation artifacts (stage S)

- **`tonk-identity`**: `mint_root_revocation` and `mint_self_revocation` — a `ucan/revoke` invocation naming the withdrawn delegation. Two shapes, because authority scales with blast radius: root-signed is authoritative for any device and unforgeable by a device holding only a grant; self-revocation carries the grant as its proof so a verifier sees the authority used.
- **`tonk-account-service`**: verify, classify and store before the status flips — a stored artifact with no flag is recoverable, a flag with no artifact is a silent gap. A rejected artifact leaves the device active. `POST /devices/revocations` serves the set with attestation levels.
- **The artifact is optional, deliberately.** The worker and CLI cannot mint a root-signed revocation — the root key is derived from the passkey in the browser and never reaches them — so requiring one would have broken every shipped caller on deploy. Optionality lets this land ahead of the browser ceremony instead of in a flag day with it.

## Testing

`cargo test` across the three crates: 27 (access-service), 18 (identity), 45 + 1 HTTP integration (account-service). Workspace `cargo clippy --all-targets --all-features -- -D warnings` exit 0, `cargo fmt --check` clean, `cargo check --target wasm32-unknown-unknown` clean.

The HTTP ceremony test now drives a root-signed cross-device revocation end to end and reads the artifact back from `/devices/revocations`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing a revocation mechanism for devices in the `tonk` system, allowing a user to revoke a device's access via a signed request. It introduces new modules, modifies existing routes, and enhances error handling.

### Detailed summary
- Added `device` and `session` modules in `rust/tonk-worker/src/lib.rs`.
- Introduced `revocation` module in multiple services for handling revocation logic.
- Updated `revoke` routes in `rust/tonk-account-service/src/lib.rs` and `rust/tonk-worker/src/router/account_devices.rs`.
- Enhanced `SignOutResponse` to include revocation status.
- Implemented revocation checks and error handling in various services.
- Modified UI text to reflect changes in revocation process.
- Added tests for revocation functionality and error cases.
- Updated documentation to clarify revocation mechanics and usage.

> The following files were skipped due to too many changes: `rust/tonk-identity/src/revocation.rs`, `rust/tonk-identity/src/session.rs`, `docs/superpowers/specs/2026-07-24-account-system-completion-design.md`, `Cargo.lock`, `rust/tonk-worker/src/device.rs`, `rust/tonk-account-service/src/core/revocation.rs`, `docs/superpowers/plans/2026-07-24-session-delegations.md`, `rust/tonk-worker/src/session.rs`, `rust/tonk-worker/src/router/account.rs`, `rust/tonk-account-service/src/core/devices.rs`, `rust/tonk-ui/src/account.rs`, `docs/superpowers/plans/2026-07-24-signed-revocation-artifacts.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->