### PR TITLE
ci(cli-npm): allow manual npm publish runs

### DIFF
--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -4,10 +4,21 @@ name: 'CLI npm'
 # and publishes @tonk/cli (plus its platform packages) to npm. The
 # version comes from the tag and must match the Cargo workspace version;
 # nothing publishes on a normal push.
+#
+# Can also be run manually against any ref (`workflow_dispatch`), for
+# re-running a failed publish or shipping without cutting a tag. The
+# version still has to match the Cargo workspace version of the ref you
+# pick, so there is only ever one source of truth.
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish. Leave empty to use the ref Cargo workspace version.'
+        required: false
+        type: string
 
 concurrency:
   group: cli-npm-${{ github.ref }}
@@ -24,16 +35,27 @@ jobs:
       - uses: actions/checkout@v4
       - name: Derive and validate version
         id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          # Tag `v0.4.0` -> version `0.4.0`.
-          version="${GITHUB_REF_NAME#v}"
-          # Single source of truth: the Cargo workspace version must match the tag.
+          # Single source of truth: whatever we publish must match the
+          # Cargo workspace version of the checked-out ref.
           cargo_version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
             | grep -m1 '^version' \
             | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            # An empty input just means "publish what this ref says".
+            version="${INPUT_VERSION:-$cargo_version}"
+            version="${version#v}"
+            source="requested version $version"
+          else
+            # Tag `v0.4.0` -> version `0.4.0`.
+            version="${GITHUB_REF_NAME#v}"
+            source="tag $GITHUB_REF_NAME"
+          fi
           if [[ "$version" != "$cargo_version" ]]; then
-            echo "::error::tag v$version does not match Cargo workspace version $cargo_version"
+            echo "::error::$source does not match Cargo workspace version $cargo_version"
             exit 1
           fi
           # Prereleases (e.g. 0.4.1-rc.1) publish under `next`, releases under `latest`.

--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -143,17 +143,35 @@ jobs:
             }
             fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
           '
+      - name: Verify npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          # An expired or under-scoped token shows up as a bare `404 Not
+          # Found - PUT` partway through publishing, which reads like a
+          # missing package rather than an auth problem. Fail here first.
+          npm whoami
       - name: Publish
         working-directory: rust/tonk-cli/npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ needs.prepare.outputs.dist-tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
           # Platform packages first: the wrapper's optionalDependencies
           # point at them, so they must exist before it resolves.
           # The `./` prefix is required — a bare name like `darwin-arm64`
           # is parsed as a registry package spec, not a local directory.
-          npm publish ./darwin-arm64 --access public --tag "$TAG"
-          npm publish ./linux-x64    --access public --tag "$TAG"
-          npm publish ./cli          --access public --tag "$TAG"
+          for dir in darwin-arm64 linux-x64 cli; do
+            name="$(node -p "require('./$dir/package.json').name")"
+            # npm never allows a version to be republished, so a retry
+            # after a partial failure has to step over what already
+            # landed instead of dying on the first conflict.
+            if npm view "$name@$VERSION" version >/dev/null 2>&1; then
+              echo "$name@$VERSION already published, skipping"
+              continue
+            fi
+            npm publish "./$dir" --access public --tag "$TAG"
+          done


### PR DESCRIPTION
## What

`.github/workflows/cli-npm.yml` only triggered on a `v*` tag push, so pushing a tag was the only way to publish `@tonk/cli`. A publish that failed after the tag already existed could not be retried without cutting a new tag.

This adds `workflow_dispatch` with an optional `version` input:

- **Empty input** — publishes whatever `[workspace.package] version` says on the ref you select.
- **Supplied value** (`0.6.3` or `v0.6.3`) — only asserts it; a mismatch against the ref's Cargo workspace version still hard-fails.

The Cargo workspace version stays the single source of truth, and dist-tag routing is unchanged (hyphenated -> `next`, otherwise `latest`).

## Caveat

npm refuses to republish an existing version, so dispatch only rescues a partial failure where the failing package never landed. Otherwise a version bump is still required.

## Verification

- `actionlint .github/workflows/cli-npm.yml` — exit 0.
- Extracted the resolve script and ran it against the real `Cargo.toml` (0.6.3):
  - dispatch / empty input -> `0.6.3`, `latest`
  - dispatch / `v0.6.3` -> `0.6.3`, `latest`
  - dispatch / `9.9.9` -> fails with a version-mismatch error
  - tag push `v0.6.3` -> `0.6.3`, `latest`
  - tag push `v0.1.0` -> fails with a version-mismatch error

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the GitHub Actions workflow for publishing npm packages by adding a manual trigger option and improving version validation logic.

### Detailed summary
- Added `workflow_dispatch` to allow manual execution of the workflow.
- Introduced an `inputs.version` parameter for optional version specification.
- Improved version validation logic to handle manual and tag-based triggers.
- Added a verification step for npm authentication before publishing.
- Refactored the publishing process to skip already published packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->