### PR TITLE
build(release): cut releases with cargo-release, tag in CI

### DIFF
--- a/.github/workflows/cli-npm-promote.yml
+++ b/.github/workflows/cli-npm-promote.yml
@@ -1,0 +1,59 @@
+name: 'CLI npm promote'
+
+# Promoting `stable` re-points the npm `stable` dist-tag at the version
+# stable now holds. It never publishes: because promotion is a
+# fast-forward, that version was already published from `staging` when
+# its `v*` tag fired `cli-npm.yml`. A dist-tag move is metadata only.
+#
+# This lives apart from `cli-npm.yml` deliberately. Adding a branch
+# trigger there would need `if:` guards on all three of its jobs, and one
+# missed guard means publishing on every push to stable.
+on:
+  push:
+    branches:
+      - stable
+  workflow_dispatch:
+
+concurrency:
+  group: cli-npm-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: 'Point @stable at the promoted version'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - name: Promote
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
+            | grep -m1 '^version' \
+            | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "stable holds $version"
+          # `stable` is only ever fast-forwarded to a final release. A
+          # prerelease here means the wrong commit was promoted.
+          if [[ "$version" == *-* ]]; then
+            echo "::error::stable holds prerelease $version; promote a final release instead"
+            exit 1
+          fi
+          # The version must already be on the registry. If it is not,
+          # stable holds a release that never published -- worth failing
+          # on rather than silently pointing the tag at nothing.
+          if ! npm view "@tonk/cli@$version" version >/dev/null 2>&1; then
+            echo "::error::@tonk/cli@$version is not published; nothing to promote"
+            exit 1
+          fi
+          # Only the wrapper needs the tag: its optionalDependencies pin
+          # exact platform versions, so `@tonk/cli@stable` resolves the
+          # right platform package on its own.
+          npm dist-tag add "@tonk/cli@$version" stable
+          npm dist-tag ls @tonk/cli

--- a/.github/workflows/cli-npm-promote.yml
+++ b/.github/workflows/cli-npm-promote.yml
@@ -1,9 +1,18 @@
 name: 'CLI npm promote'
 
 # Promoting `stable` re-points the npm `stable` dist-tag at the version
-# stable now holds. It never publishes: because promotion is a
-# fast-forward, that version was already published from `staging` when
-# its `v*` tag fired `cli-npm.yml`. A dist-tag move is metadata only.
+# stable now holds. It never publishes: `stable` is only fast-forwarded
+# to a commit that was already released from `staging`, so the version is
+# already on the registry and a dist-tag move is metadata only.
+#
+# The invariant this enforces: `stable`'s HEAD must be exactly the commit
+# `v<version>` points at. Promotion happens at milestones, so the
+# tempting fast-forward target is whatever staging HEAD looks good --
+# which is usually *past* the release commit. Promote there and `@stable`
+# would name a tarball that does not contain the code `stable` holds,
+# while `cli.yml`'s `publish-stable` builds `tonk-latest` from stable's
+# real HEAD. Two channels, same name, different binaries. So this fails
+# instead.
 #
 # This lives apart from `cli-npm.yml` deliberately. Adding a branch
 # trigger there would need `if:` guards on all three of its jobs, and one
@@ -26,6 +35,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The tag has to be resolvable locally to prove it points at
+          # this commit.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -35,6 +49,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+          # `workflow_dispatch` takes any ref. Dispatched against
+          # `staging` this would point @stable at a version stable does
+          # not hold, so the ref is checked rather than assumed.
+          if [[ "$GITHUB_REF" != "refs/heads/stable" ]]; then
+            echo "::error::@stable can only be promoted from the stable branch (got $GITHUB_REF)"
+            exit 1
+          fi
           version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
             | grep -m1 '^version' \
             | sed -E 's/.*"([^"]+)".*/\1/')"
@@ -45,11 +66,28 @@ jobs:
             echo "::error::stable holds prerelease $version; promote a final release instead"
             exit 1
           fi
-          # The version must already be on the registry. If it is not,
-          # stable holds a release that never published -- worth failing
-          # on rather than silently pointing the tag at nothing.
-          if ! npm view "@tonk/cli@$version" version >/dev/null 2>&1; then
-            echo "::error::@tonk/cli@$version is not published; nothing to promote"
+          # stable's HEAD must be the release commit itself, not a
+          # descendant of it.
+          if ! tag_sha="$(git rev-parse -q --verify "refs/tags/v$version^{commit}")"; then
+            echo "::error::tag v$version does not exist; stable holds a version that was never released"
+            exit 1
+          fi
+          if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::stable is at $GITHUB_SHA but v$version is $tag_sha; fast-forward stable to the release commit (git push origin v$version:refs/heads/stable) and promote again"
+            exit 1
+          fi
+          # The version must already be on the registry. A missing one
+          # means stable holds a release that never published -- worth
+          # failing on rather than pointing the tag at nothing. Distinguish
+          # that from a registry outage, which is not stable's fault and
+          # should not read as a broken release.
+          if ! npm_out="$(npm view "@tonk/cli@$version" version 2>&1)"; then
+            if grep -q 'code E404' <<<"$npm_out"; then
+              echo "::error::@tonk/cli@$version is not published; nothing to promote"
+            else
+              echo "::error::could not reach the registry to check @tonk/cli@$version; this is not a promotion failure, retry the run"
+            fi
+            echo "$npm_out"
             exit 1
           fi
           # Only the wrapper needs the tag: its optionalDependencies pin

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,155 @@
+name: 'Release tag'
+
+# Turns a merged version bump into the `v<version>` tag that publishes it.
+#
+# CI owns the tag because a maintainer cannot own it. Two active rulesets
+# cover `staging` (the default branch) and require a pull request, forbid
+# non-fast-forward, and require signed commits and status checks, with no
+# bypass actor -- so nothing pushes a commit straight to `staging`. Merge
+# commits are disabled as well, so a PR merge rewrites the SHA and a
+# locally created tag would point at a commit that never lands on the
+# branch. The rulesets cover branches, not tags, so CI can push the tag
+# once the bump is on `staging`.
+#
+# The predicate is a *change* to `[workspace.package] version` across the
+# pushed range -- never the mere absence of `v<version>`. Staging has sat
+# 21 commits past 0.6.3 with no `v0.6.3` tag; tagging on absence would
+# ship an arbitrary HEAD as a release, which is the exact failure this
+# whole change exists to remove.
+on:
+  push:
+    branches:
+      - staging
+
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: 'Tag a merged version bump'
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: write` pushes the tag. `actions: write` starts the
+      # publish: a tag pushed with GITHUB_TOKEN does not itself trigger
+      # any workflow -- GitHub suppresses events raised by the built-in
+      # token to stop workflows recursing -- so `cli-npm.yml` has to be
+      # dispatched explicitly. `workflow_dispatch` is one of the two
+      # event types exempt from that suppression.
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `github.event.before` is reachable, and the
+          # tags so an already-tagged release is a no-op.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 'Decide whether this push is a release'
+        id: decide
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # The same extraction `cli-npm.yml` uses, so one Cargo.toml
+          # shape feeds both. `|| true` stops a no-match from aborting
+          # the step under `pipefail`; every caller tests for an empty
+          # result instead.
+          workspace_version() {
+            git show "$1:Cargo.toml" 2>/dev/null \
+              | grep -A30 '^\[workspace.package\]' \
+              | grep -m1 '^version' \
+              | sed -E 's/.*"([^"]+)".*/\1/' || true
+          }
+
+          # Branch creation sends an all-zeroes `before`. There is no
+          # range to diff, so there is no evidence of a release.
+          if [[ -z "$BEFORE" || "$BEFORE" =~ ^0+$ ]]; then
+            echo "no previous commit on this push; nothing to tag"
+            exit 0
+          fi
+
+          # A force push can leave `before` unreachable. Same reasoning:
+          # without both endpoints we cannot prove a version changed, and
+          # guessing here would mint a release nobody asked for.
+          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "previous commit $BEFORE is unreachable (force push?); nothing to tag"
+            exit 0
+          fi
+
+          new="$(workspace_version "$GITHUB_SHA")"
+          old="$(workspace_version "$BEFORE")"
+
+          # An unreadable version at HEAD is a broken Cargo.toml or a
+          # broken pipeline, and either would disable releases silently
+          # from here on. Fail loudly instead.
+          if [[ -z "$new" ]]; then
+            echo "::error::could not read [workspace.package] version at $GITHUB_SHA"
+            exit 1
+          fi
+          if [[ -z "$old" ]]; then
+            echo "could not read the version at $BEFORE; nothing to tag"
+            exit 0
+          fi
+
+          if [[ "$old" == "$new" ]]; then
+            echo "version unchanged at $new; nothing to tag"
+            exit 0
+          fi
+          # Any change counts, in either direction. Reverting a release
+          # commit therefore looks like a release of the older version --
+          # but that version's tag almost always already exists, and the
+          # check below turns it into a no-op. Ordering is deliberately
+          # not enforced: no correct shell comparator gets 0.6.4-rc.2 ->
+          # 0.6.4 right (`sort -V` calls it backwards), and a broken one
+          # would block every real prerelease-to-final release.
+          echo "version changed $old -> $new"
+
+          # Re-running this workflow, or a push that lands after the tag
+          # already exists, must not fail and must not retag.
+          if git ls-remote --exit-code origin "refs/tags/v$new" >/dev/null 2>&1; then
+            echo "tag v$new already exists; nothing to tag"
+            exit 0
+          fi
+
+          echo "version=$new" >> "$GITHUB_OUTPUT"
+
+      - name: 'Create and push the tag'
+        if: steps.decide.outputs.version != ''
+        env:
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Anchored at the commit that landed, which is what the publish
+          # must build from.
+          git -c user.name='github-actions[bot]' \
+              -c 'user.email=41898282+github-actions[bot]@users.noreply.github.com' \
+              tag -a "v$VERSION" -m "chore: release $VERSION" "$GITHUB_SHA"
+          git push origin "refs/tags/v$VERSION"
+          echo "tagged v$VERSION at $GITHUB_SHA"
+
+      - name: 'Start the publish'
+        if: steps.decide.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          # `cli-npm.yml` resolves the version from the ref's Cargo
+          # workspace version and refuses a mismatch, so dispatching it
+          # against the tag publishes exactly the tagged code -- the same
+          # contract a tag push would have given us.
+          for attempt in 1 2 3; do
+            if gh workflow run cli-npm.yml --ref "v$VERSION"; then
+              echo "dispatched CLI npm for v$VERSION"
+              exit 0
+            fi
+            echo "dispatch attempt $attempt failed; retrying in 5s"
+            sleep 5
+          done
+          # The tag exists at this point, so recovery is a re-dispatch
+          # rather than another release.
+          echo "::error::could not start CLI npm for v$VERSION; re-run it with: gh workflow run cli-npm.yml --ref v$VERSION"
+          exit 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -64,34 +64,28 @@ jobs:
               | sed -E 's/.*"([^"]+)".*/\1/' || true
           }
 
-          # Branch creation sends an all-zeroes `before`. There is no
-          # range to diff, so there is no evidence of a release.
-          if [[ -z "$BEFORE" || "$BEFORE" =~ ^0+$ ]]; then
-            echo "no previous commit on this push; nothing to tag"
+          # Branch creation sends an all-zeroes `before`, and a force
+          # push can leave it unreachable; either way `workspace_version`
+          # comes back empty, as it does for an unreadable Cargo.toml.
+          # All three mean the same thing: without an old version we
+          # cannot prove one changed, and guessing would mint a release
+          # nobody asked for.
+          old=""
+          if [[ -n "$BEFORE" && ! "$BEFORE" =~ ^0+$ ]]; then
+            old="$(workspace_version "$BEFORE")"
+          fi
+          if [[ -z "$old" ]]; then
+            echo "no readable version at ${BEFORE:-the previous commit} (branch creation, force push, or unreadable Cargo.toml); nothing to tag"
             exit 0
           fi
-
-          # A force push can leave `before` unreachable. Same reasoning:
-          # without both endpoints we cannot prove a version changed, and
-          # guessing here would mint a release nobody asked for.
-          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            echo "previous commit $BEFORE is unreachable (force push?); nothing to tag"
-            exit 0
-          fi
-
-          new="$(workspace_version "$GITHUB_SHA")"
-          old="$(workspace_version "$BEFORE")"
 
           # An unreadable version at HEAD is a broken Cargo.toml or a
           # broken pipeline, and either would disable releases silently
           # from here on. Fail loudly instead.
+          new="$(workspace_version "$GITHUB_SHA")"
           if [[ -z "$new" ]]; then
             echo "::error::could not read [workspace.package] version at $GITHUB_SHA"
             exit 1
-          fi
-          if [[ -z "$old" ]]; then
-            echo "could not read the version at $BEFORE; nothing to tag"
-            exit 0
           fi
 
           if [[ "$old" == "$new" ]]; then

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ channel you installed from, so a `TONK_CHANNEL=staging` install keeps
 tracking staging.
 
 If `tonk` was installed some other way, `tonk update` says so instead
-of interfering: use `npm i -g @tonk/cli@latest` for an npm install, or
-your flake for a nix one. Re-running the install command also still
-works:
+of interfering: use `npm i -g @tonk/cli` for an npm install (or
+`@tonk/cli@stable` to pin to the last milestone), or your flake for a
+nix one. Re-running the install command also still works:
 
 ```sh
 curl -fsSL https://github.com/tonk-labs/tonk/releases/latest/download/install.sh | sh

--- a/docs/superpowers/plans/2026-07-30-cargo-release.md
+++ b/docs/superpowers/plans/2026-07-30-cargo-release.md
@@ -2,24 +2,30 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the version bump and the `v*` tag a single act, and point npm's `stable` dist-tag at whatever `stable` holds.
+**Goal:** Make the version bump and the `v*` tag one causal chain rather than two acts a human can forget to connect, and point npm's `stable` dist-tag at the release commit `stable` holds.
 
-**Architecture:** A root `release.toml` overrides six cargo-release defaults that would misfire on a 34-crate workspace. `cargo-release` joins the flake devshell. A new workflow re-points the npm `stable` dist-tag on pushes to `stable` — a metadata move, never a publish.
+**Architecture:** A root `release.toml` overrides seven cargo-release defaults that would misfire on a 34-crate workspace behind branch rulesets. `cargo-release` joins the flake devshell — the devshell only, not the shared build inputs. A new workflow turns a merged version bump into a `v<version>` tag and starts the publish. A second new workflow re-points the npm `stable` dist-tag on pushes to `stable` — a metadata move, never a publish.
 
-**Tech Stack:** cargo-release 0.25.x (nixpkgs), GitHub Actions, npm CLI, nix flakes.
+**Tech Stack:** cargo-release 1.1.2 (nixpkgs), GitHub Actions, npm CLI, nix flakes.
 
 Spec: `docs/superpowers/specs/2026-07-30-cargo-release-design.md`.
 
 ## Global Constraints
 
+- **Nothing can push a commit to `staging`.** Two active rulesets target the default branch: `pull_request` + `non_fast_forward` with no bypass actor, and `deletion` + `non_fast_forward` + `required_signatures` + `required_status_checks`. `allow_merge_commit` is false, so a PR merge rewrites the SHA. A local `cargo release --execute` cannot push, and a locally created tag would point at a commit that never lands. The rulesets cover branches, not tags, so CI can push a tag.
 - Tag name must be exactly `v{{version}}` — `cli-npm.yml` triggers on the `v*` glob and would never fire on cargo-release's default `tonk-cli-v0.6.4`.
 - Commit message must be exactly `chore: release {{version}}` — matches the existing convention (lowercase "release", no crate name).
 - `publish = false` is mandatory. The default `true` targets all 34 crates and none are on crates.io.
-- `allow-branch = ["staging"]`. Version bumps happen only on `staging`; `stable` is only ever fast-forwarded.
+- `push = false` and `tag = false`. CI owns the tag; the push is a PR.
+- `allow-branch = ["staging", "release/*"]`. Version bumps happen on the way to `staging`; `stable` is only ever fast-forwarded.
+- The tag predicate is a version **change**, never the absence of a tag.
+- Do not modify `.github/workflows/cli-npm.yml`. It is the publish contract; the new workflows feed it.
 - No changelog generation. No crates.io publishing. No new platform targets.
 - No emojis in code, commits, or output.
 
-**Note on verification style:** this change is configuration and CI, not executable logic — there is no unit-testable function anywhere in it. Verification is therefore dry-runs, `actionlint`, and registry reads against real state. Do not manufacture unit tests for a TOML file; the checks below are the real ones.
+**Note on verification style:** this change is configuration and CI, not executable logic — the only Rust in it is one string. Verification is therefore dry-runs, `actionlint`, a local simulation of the tag predicate over real commits, and registry reads against real state. Do not manufacture unit tests for a TOML file; the checks below are the real ones.
+
+**Note on verification ordering:** cargo-release's dry run refuses to run against a dirty tree ("uncommitted changes detected"). Every dry-run step therefore comes *after* the commit step in its task, not before. Ordering them the other way produces a spurious error that looks like a config problem.
 
 ---
 
@@ -27,182 +33,147 @@ Spec: `docs/superpowers/specs/2026-07-30-cargo-release-design.md`.
 
 **Files:**
 - Create: `release.toml` (repo root)
-- Modify: `flake.nix:56` (insert into the alphabetized `commonBuildInputs` list, immediately after `cargo-nextest`)
+- Modify: `flake.nix` — `devShellBuildInputs`, not `commonBuildInputs`
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: the `cargo release <level>` command, available in `nix develop`, emitting one commit `chore: release <version>` and one annotated tag `v<version>`.
+- Produces: the `cargo release <level> --execute` command, available in `nix develop`, emitting exactly one commit `chore: release <version>` on the current branch and nothing else.
 
 - [ ] **Step 1: Create `release.toml`**
 
-```toml
-# Releases are cut with `cargo release <level>` from `staging` only. Each
-# run produces one commit and one `v<version>` tag, pushed together, so
-# the bump and the tag cannot drift apart the way 0.6.1 through 0.6.3 did.
-#
-# Every setting here overrides a default that misfires on this workspace.
-# See docs/superpowers/specs/2026-07-30-cargo-release-design.md.
-
-# The version is shared via `version.workspace`, so a release is one
-# commit for all 34 crates, not one commit each.
-consolidate-commits = true
-
-# `cli-npm.yml` triggers on the `v*` glob. The default of
-# `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which never matches.
-tag-name = "v{{version}}"
-
-pre-release-commit-message = "chore: release {{version}}"
-tag-message = "chore: release {{version}}"
-
-# None of these crates are on crates.io. Without this, a release attempts
-# `cargo publish` on all 34. Note that cargo-release still logs a
-# cosmetic `Publishing <crates>` line under this setting -- it is not
-# evidence of a registry attempt.
-publish = false
-
-# The guardrail against the original failure: a release cut from a
-# feature branch. Bumps belong on `staging`; `stable` only fast-forwards.
-allow-branch = ["staging"]
-```
+Settings and their justifications are the table in the spec's `release.toml` section. The file carries them as comments, plus a header explaining that a release is two acts because the ruleset makes it two acts.
 
 - [ ] **Step 2: Add cargo-release to the devshell**
 
-In `flake.nix`, inside `commonBuildInputs`, add `cargo-release` directly after `cargo-nextest` to keep the list alphabetized:
+In `flake.nix`, add `pkgs.cargo-release` to `devShellBuildInputs`.
 
-```nix
-            cargo-nextest
-            cargo-release
+**Not `commonBuildInputs`.** `flake.nix` passes `commonBuildInputs` to `nix/rust.nix` as `buildInputs`, which land as `nativeBuildInputs` on `buildDepsOnly` and all 34 crate derivations. A release tool there changes every crate hash, forces a cold cachix rebuild on both runners, and puts cargo-release in every build sandbox. `devShellBuildInputs` is `commonBuildInputs ++ [...]`, so `nix develop` still resolves it.
+
+`cargo-nextest` is already in `commonBuildInputs`. That is pre-existing; leave it.
+
+- [ ] **Step 3: Commit**
+
+Commit with Task 2's workflow (see Task 2, Step 4). The commit has to come before the dry runs regardless: cargo-release refuses to plan against an uncommitted tree.
+
+- [ ] **Step 4: Verify the tool resolves in the devshell**
+
+Run: `nix develop --command cargo release --version`
+
+Note the positional: cargo plugins are invoked as `cargo release`, so `cargo-release --version` is not the form to document even though the binary answers to it.
+
+Expected: `cargo-release 1.1.2` or later.
+
+- [ ] **Step 5: Verify the config is parsed as intended**
+
+Run: `nix develop --command cargo release config`
+
+Expected to include:
+
 ```
-
-- [ ] **Step 3: Verify the tool resolves in the devshell**
-
-Run: `nix develop --command cargo-release --version`
-Expected: a version string, `0.25.x` or later. If nix cannot evaluate, the flake edit is malformed.
-
-- [ ] **Step 4: Verify the config is parsed as intended**
-
-Run: `nix develop --command cargo release config | grep -E '^(publish|consolidate-commits|tag-name|pre-release-commit-message|allow-branch)'`
-Expected exactly:
-
-```
-allow-branch = ["staging"]
+allow-branch = ["staging", "release/*"]
 publish = false
+push = false
+tag = false
 consolidate-commits = true
 pre-release-commit-message = "chore: release {{version}}"
 tag-name = "v{{version}}"
+tag-message = "chore: release {{version}}"
 ```
 
-- [ ] **Step 5: Verify the branch guard rejects this branch**
+- [ ] **Step 6: Verify the branch guard rejects an unrelated branch**
 
-You are not on `staging`, so the guard must fire. Run:
+From a branch matching neither `staging` nor `release/*`:
 
-`nix develop --command cargo release rc --workspace --no-confirm`
+`nix develop --command cargo release patch --workspace --no-confirm`
 
-Expected: `error: cannot release from branch '<current>' as it doesn't match 'staging'`.
+Expected: `error: cannot release from branch '<current>' as it doesn't match ...`.
 
-Note: dry-run collects errors and keeps printing the plan, so a `Pushing ...` line still appears below the error. That is expected — only `--execute` aborts at the check. The error line is the assertion.
+Note: dry-run collects errors and keeps printing the plan, so lines still appear below the error. The error line is the assertion.
 
-- [ ] **Step 6: Verify the release plan itself, overriding the guard**
+- [ ] **Step 7: Verify the release plan itself**
 
-Run: `nix develop --command cargo release rc --workspace --no-confirm --allow-branch '*'`
+Run: `nix develop --command cargo release patch --workspace --no-confirm --allow-branch '*'`
 
 Expected, against a workspace at 0.6.3:
-- `Upgrading workspace to version 0.6.4-rc.1`
-- exactly one tag in the `Pushing` line: `v0.6.4-rc.1`
+- `Upgrading <crate> from 0.6.3 to 0.6.4` for every crate
+- **no** `Tagging` line and **no** `Pushing` line
 - no `error:` lines
 
 Do **not** pass `--execute`. This must not cut a real release.
 
-- [ ] **Step 7: Commit**
+---
+
+### Task 2: The release tag workflow
+
+**Files:**
+- Create: `.github/workflows/release-tag.yml`
+
+**Interfaces:**
+- Consumes: pushes to `staging`, and the `[workspace.package] version` at two commits.
+- Produces: the annotated tag `v<version>`, and a `cli-npm.yml` run against it.
+
+- [ ] **Step 1: Create the workflow**
+
+On push to `staging`, one job with `contents: write` and `actions: write`:
+
+1. `actions/checkout@v4` with `fetch-depth: 0` and `fetch-tags: true` — `github.event.before` must be reachable and the tag list must be present.
+2. Extract the workspace version at `github.event.before` and at `github.sha` using the same `grep`/`sed` pipeline as `cli-npm.yml`.
+3. Emit a `version` output only when all of these hold; otherwise print why and exit 0:
+   - `github.event.before` is non-empty and not all zeroes (branch creation);
+   - `github.event.before` is a reachable commit (force push);
+   - the version at `github.sha` is non-empty (this one is `exit 1` — an unreadable version at HEAD would silently disable releases forever);
+   - the version at `before` is non-empty;
+   - the two versions differ;
+   - `refs/tags/v<version>` does not already exist on the remote.
+4. Create the annotated tag at `github.sha` and push it.
+5. `gh workflow run cli-npm.yml --ref "v<version>"`.
+
+Step 5 is not optional. **A tag pushed with `GITHUB_TOKEN` does not trigger any workflow** — GitHub suppresses events raised by the built-in token to stop workflows recursing, with `workflow_dispatch` and `repository_dispatch` as the only exceptions. Without the dispatch this workflow would create tags and publish nothing. `cli-npm.yml` resolves the version from the ref's own `Cargo.toml` and refuses a mismatch, so dispatching it against the tag gives the same contract a tag push would have.
+
+`concurrency: release-tag` with `cancel-in-progress: false`, so two quick merges cannot interleave.
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `nix run nixpkgs#actionlint -- .github/workflows/release-tag.yml`
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Prove the predicate over real commits**
+
+The whole design rests on this predicate, so simulate it against staging history rather than reasoning about it. Pick two commit pairs: one across a real version bump, one across an ordinary merge. Run the same extraction the workflow runs, and show the predicate is true then false.
+
+Expected: `changed` for the bump pair, `unchanged` for the other. An empty version on either side means the pipeline is broken.
+
+- [ ] **Step 4: Commit**
+
+This belongs with Task 1: `push = false`/`tag = false` and this workflow are two halves of one decision, and either alone is broken — the config without the workflow never tags, the workflow without the config double-tags.
 
 ```bash
-git add release.toml flake.nix
-git commit -m "build: cut releases with cargo-release
-
-The workspace version and the v* tag were produced by separate acts, so
-they drifted -- 0.6.1 through 0.6.3 landed inside feature PRs with no
-tag. cargo-release makes the bump, the tag, and the push one command.
-
-Every setting in release.toml overrides a default that misfires on a
-34-crate workspace with a shared version: without them a release is 34
-commits, 34 tags named tonk-cli-v*, and 34 attempted crates.io
-publishes."
+git add release.toml flake.nix .github/workflows/release-tag.yml
+git commit -m "build(release): let CI cut the release tag"
 ```
 
 ---
 
-### Task 2: The stable promote workflow
+### Task 3: The stable promote workflow
 
 **Files:**
 - Create: `.github/workflows/cli-npm-promote.yml`
 
 **Interfaces:**
-- Consumes: the `v<version>` tags from Task 1, and the `@tonk/cli` versions that `cli-npm.yml` publishes from them.
-- Produces: the npm `stable` dist-tag, pointing at the version `stable` holds.
+- Consumes: the `v<version>` tags from Task 2, and the `@tonk/cli` versions `cli-npm.yml` publishes from them.
+- Produces: the npm `stable` dist-tag, pointing at the release commit `stable` holds.
 
 - [ ] **Step 1: Create the workflow**
 
-```yaml
-name: 'CLI npm promote'
+On push to `stable` and on `workflow_dispatch`, with `fetch-depth: 0` and `fetch-tags: true`, in order:
 
-# Promoting `stable` re-points the npm `stable` dist-tag at the version
-# stable now holds. It never publishes: because promotion is a
-# fast-forward, that version was already published from `staging` when
-# its `v*` tag fired `cli-npm.yml`. A dist-tag move is metadata only.
-#
-# This lives apart from `cli-npm.yml` deliberately. Adding a branch
-# trigger there would need `if:` guards on all three of its jobs, and one
-# missed guard means publishing on every push to stable.
-on:
-  push:
-    branches:
-      - stable
-  workflow_dispatch:
+1. Refuse unless `$GITHUB_REF` is `refs/heads/stable`. `workflow_dispatch` takes any ref, and dispatching against `staging` would point `@stable` at a version `stable` does not hold.
+2. Read the workspace version; refuse a prerelease.
+3. Require `refs/tags/v<version>^{commit}` to equal `$GITHUB_SHA`, with an error that names the fast-forward command. Without this, promoting to a staging commit *past* the release commit — which is the natural milestone target — makes `@stable` serve a tarball that does not contain the code `stable` holds, while `cli.yml` builds `tonk-latest` from stable's real HEAD.
+4. Require `@tonk/cli@<version>` to exist on the registry. Capture npm's output and branch on `code E404`, so a registry outage is not reported as an unpublished release.
+5. `npm dist-tag add @tonk/cli@<version> stable`, then `npm dist-tag ls`.
 
-concurrency:
-  group: cli-npm-promote
-  cancel-in-progress: false
-
-jobs:
-  promote:
-    name: 'Point @stable at the promoted version'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: 'https://registry.npmjs.org'
-      - name: Promote
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
-            | grep -m1 '^version' \
-            | sed -E 's/.*"([^"]+)".*/\1/')"
-          echo "stable holds $version"
-          # `stable` is only ever fast-forwarded to a final release. A
-          # prerelease here means the wrong commit was promoted.
-          if [[ "$version" == *-* ]]; then
-            echo "::error::stable holds prerelease $version; promote a final release instead"
-            exit 1
-          fi
-          # The version must already be on the registry. If it is not,
-          # stable holds a release that never published -- worth failing
-          # on rather than silently pointing the tag at nothing.
-          if ! npm view "@tonk/cli@$version" version >/dev/null 2>&1; then
-            echo "::error::@tonk/cli@$version is not published; nothing to promote"
-            exit 1
-          fi
-          # Only the wrapper needs the tag: its optionalDependencies pin
-          # exact platform versions, so `@tonk/cli@stable` resolves the
-          # right platform package on its own.
-          npm dist-tag add "@tonk/cli@$version" stable
-          npm dist-tag ls @tonk/cli
-```
+A separate file rather than a job inside `cli-npm.yml`: adding a branch trigger there would require `if:` guards on all three existing jobs, and a single missed guard means publishing on every stable push. The cost is that npm-registry mutations now live in two files.
 
 `node-version: 22` deviates from `cli-npm.yml`'s `20`, which the runners now flag as deprecated on every run. Bumping that file is a separate change; do not fold it in here.
 
@@ -213,8 +184,6 @@ Expected: exit 0, no output.
 
 - [ ] **Step 3: Verify the version extraction against real branches**
 
-The `grep`/`sed` pipeline is copied from `cli-npm.yml`, but confirm it against both branches:
-
 ```bash
 for ref in origin/staging origin/stable; do
   printf '%s: ' "$ref"
@@ -223,116 +192,52 @@ for ref in origin/staging origin/stable; do
 done
 ```
 
-Expected: `origin/staging: 0.6.3` and `origin/stable: 0.6.0` (or later values, but two distinct parseable versions — an empty result means the pipeline is broken).
+Expected: two distinct parseable versions. An empty result means the pipeline is broken.
 
-- [ ] **Step 4: Verify both guards fire correctly against live registry state**
+- [ ] **Step 4: Verify the guards against live state**
 
-Simulate the two failure paths and the success path locally:
+Confirm the prerelease guard fires on a hyphenated version; that `npm view @tonk/cli@<stable's version>` reports `code E404`; and that a published version resolves. Confirm the tag guard would fire today, since no `v0.6.0` tag exists for the version `stable` holds.
 
-```bash
-# Prerelease guard
-v=0.6.4-rc.1; [[ "$v" == *-* ]] && echo "guard fires: prerelease rejected"
-# Unpublished guard: stable is at 0.6.0, which was never published
-npm view "@tonk/cli@0.6.0" version >/dev/null 2>&1 \
-  && echo "0.6.0 published" || echo "guard fires: 0.6.0 unpublished, promote would fail"
-# Success path: 0.4.0 is published
-npm view "@tonk/cli@0.4.0" version >/dev/null 2>&1 \
-  && echo "success path: 0.4.0 resolvable, dist-tag move would proceed"
-```
-
-Expected: all three lines print. The middle one confirms a real and useful property — promoting `stable` **today** would correctly fail, because stable holds 0.6.0 and 0.6.0 was never published.
+Expected: promoting `stable` **today** correctly fails, twice over — no `v0.6.0` tag and 0.6.0 unpublished. That is by design and self-heals after one full cycle. Do not add a workaround.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add .github/workflows/cli-npm-promote.yml
-git commit -m "ci(cli-npm): point the npm stable dist-tag at promoted versions
-
-stable moves on milestones, so it can sit well behind staging. Mapping
-npm's latest onto stable would mean the default install serves
-increasingly old code -- which is the situation today, with latest at
-0.4.0 against a 0.6.3 workspace.
-
-So latest tracks staging finals and stable gets its own dist-tag. Since
-promotion is a fast-forward, the version is already published and this
-only re-points a tag; it never publishes. Both guards fail loudly rather
-than pointing the tag at nothing."
+git commit -m "ci(cli-npm): require stable to sit on the release commit before promoting"
 ```
 
 ---
 
-### Task 3: Documentation
+### Task 4: Documentation
 
 **Files:**
-- Modify: `rust/tonk-cli/npm/README.md:25-60` (the "Publishing (maintainers)" section runs from line 25 to the end of the 60-line file; keep the local `npm pack` recipe near the end intact)
-- Modify: `README.md:93-95` (the install line)
+- Modify: `rust/tonk-cli/npm/README.md` (the "Publishing (maintainers)" section and the closing paragraph)
+- Modify: `README.md` (the install line)
+- Modify: `rust/tonk-cli/src/update/swap.rs` (the npm remedy string)
 
 **Interfaces:**
-- Consumes: the commands from Tasks 1 and 2.
+- Consumes: the commands from Tasks 1-3.
 - Produces: nothing consumed by later tasks.
 
 - [ ] **Step 1: Rewrite the publishing section**
 
-Replace the numbered steps and the paragraph beginning "The tag is the source of the version" in `rust/tonk-cli/npm/README.md` with:
+Four numbered steps: the one-time `NPM_TOKEN` note; cut the bump on a `release/*` branch with `cargo release <level> --execute`; PR it and let `release-tag.yml` tag the merge; promote by fast-forwarding `stable` to the release commit.
 
-```markdown
-Publishing runs in CI so every platform binary is built reproducibly —
-you cannot build the Linux binary from a Mac. It is **tag-driven**;
-nothing publishes on a normal push.
+Must state, because each is a trap a maintainer would otherwise hit:
 
-1. One-time: add an `NPM_TOKEN` repository secret — an npm automation
-   token with read-write on the whole **`@tonk` scope**, not a package
-   subset, so platform packages added later keep working. A token
-   scoped too narrowly still passes `npm whoami` and then fails with a
-   bare `404 Not Found - PUT`, which reads like a missing package.
-2. From `staging`, cut the release. This is one command; it bumps the
-   workspace version, commits, tags, and pushes together:
+- which level cuts a final (`patch`/`minor`/`major`), and that `release` only strips an existing prerelease — from a final it writes no commit and still exits 0;
+- that `release.toml` disables the push and the tag, so `--execute` produces only a commit;
+- that promoting must target the release commit, with the exact `git push origin v<version>:refs/heads/stable`;
+- that the `CLI npm` run on the tag must finish before promoting, that the resulting `is not published; nothing to promote` means "not yet", and that `gh workflow run cli-npm-promote.yml --ref stable` re-runs a promote.
 
-   ```sh
-   cargo release rc        # 0.6.3 -> 0.6.4-rc.1, publishes to @next
-   cargo release release   # 0.6.4-rc.2 -> 0.6.4, publishes to @latest
-   ```
+Also fix the local `npm pack` recipe: it installs `./tonk-cli-0.5.0.tgz` while `cli/package.json` says `0.6.0`, so it fails as written. Glob it (`./tonk-cli-[0-9]*.tgz`) — the committed versions are placeholders CI stamps over, so any literal filename rots.
 
-   Dry-run is the default — add `--execute` to act. Releases are
-   refused from any branch but `staging`.
-
-3. Promote by fast-forwarding `stable`. That re-points the `stable`
-   dist-tag; it does not publish again.
-
-The first `rc` fixes the target version, and there is no combined
-level-plus-prerelease flag, so if scope grows mid-cycle, re-target
-explicitly: `cargo release 0.7.0-rc.1`.
-
-### Dist-tags
-
-| Tag | Points at | Install |
-| --- | --- | --- |
-| `next` | prereleases from `staging` | `npx @tonk/cli@next` |
-| `latest` | finals from `staging` | `npx @tonk/cli` |
-| `stable` | the version `stable` holds | `npx @tonk/cli@stable` |
-
-`latest` tracks staging finals rather than `stable` on purpose. `stable`
-moves on milestones, so mapping `latest` onto it would make the default
-install progressively more stale.
-
-The workflow **refuses to publish if the tag disagrees with the Cargo
-workspace version**, and `cargo release` keeps them in step by
-construction. `cli-npm.yml` can also be run manually
-(`gh workflow run cli-npm.yml --ref staging`) to retry a failed publish
-without cutting a new tag; it skips any version already on the registry.
-```
+Replace the closing "Bump both together" paragraph. It survives from the manual era and now contradicts the section above it: CI stamps the `package.json`s and cargo-release owns the workspace bump.
 
 - [ ] **Step 2: Update the root README install line**
 
-`README.md:93-95` currently reads:
-
-```
-If `tonk` was installed some other way, `tonk update` says so instead
-of interfering: use `npm i -g @tonk/cli@latest` for an npm install, or
-your flake for a nix one.
-```
-
-Replace with — note `@latest` is dropped, since it is now the default and naming it invites confusion with `@stable`:
+Drop `@latest` — it is the default, and naming it invites confusion with `@stable`:
 
 ```
 If `tonk` was installed some other way, `tonk update` says so instead
@@ -343,20 +248,27 @@ nix one.
 
 The clause is mid-sentence; the `or your flake for a nix one` tail must still parse.
 
-- [ ] **Step 3: Verify no stale instructions remain**
+- [ ] **Step 3: Fix the npm remedy string**
 
-Run: `grep -rn "git tag v\|push origin v" rust/tonk-cli/npm/README.md README.md`
-Expected: no output. Any hit is a leftover manual-tagging instruction that Task 1 replaced.
+`ForeignInstall::Npm` in `rust/tonk-cli/src/update/swap.rs` says `run \`npm i -g @tonk/cli@latest\``. Under this model `@latest` means staging finals, so that moves a `@stable`-pinned user onto a faster channel. Mirror the root README instead: no explicit tag, with `@stable` offered beside it.
 
-- [ ] **Step 4: Commit**
+Run `cargo build -p tonk-cli` so the edit is proven to compile.
+
+- [ ] **Step 4: Verify no stale instructions remain**
 
 ```bash
-git add rust/tonk-cli/npm/README.md README.md
-git commit -m "docs(cli): document cargo-release and the three dist-tags
+grep -rn "git tag v\|push origin v[0-9]\|--no-push\|atomic" rust/tonk-cli/npm/README.md README.md release.toml
+```
 
-Replaces the manual bump-then-tag steps, which are what drifted, and
-spells out the token scope: a token narrow enough to pass npm whoami and
-still fail on PUT has now cost two releases."
+Expected: only the deliberate `git push origin v0.6.4:refs/heads/stable` promote line. Anything else is a leftover from the manual or the atomic-push model.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rust/tonk-cli/src/update/swap.rs
+git commit -m "fix(cli): stop the npm update remedy pinning @latest"
+git add rust/tonk-cli/npm/README.md README.md
+git commit -m "docs(cli): document the two-act release"
 ```
 
 ---
@@ -367,16 +279,18 @@ still fail on PUT has now cost two releases."
 
 | Spec section | Task |
 | --- | --- |
-| `release.toml` (six overrides) | 1 |
-| Devshell addition | 1 |
-| Stable promote workflow | 2 |
-| Docs — npm README, root README | 3 |
-| Model, version flow, ordering wart | documented in 3, enforced by 1 and 2 |
+| Constraint: nothing can push to `staging` | 1 (config), 2 (workflow) |
+| `release.toml` (seven overrides) | 1 |
+| Devshell addition, devshell-only | 1 |
+| Why CI owns the tag | 2 |
+| Stable promote workflow + promote-target invariant | 3 |
+| Ordering dependency | 4 |
+| Docs — npm README, root README, remedy string | 4 |
 | Out of scope: changelog, crates.io, platforms | absent by construction |
-| Blocked: npm token | called out in 3, Step 1 |
+| Blocked: npm token | called out in 4, Step 1 |
 
-**Placeholders:** none. Every step has literal content.
+**Placeholders:** none.
 
-**Type consistency:** the version-extraction pipeline is byte-identical between `cli-npm.yml` and the new promote workflow, and Task 2 Step 3 verifies it against both branches. Tag format `v{{version}}` in Task 1 matches the `v*` glob `cli-npm.yml` already uses.
+**Type consistency:** the version-extraction pipeline is byte-identical across `cli-npm.yml`, `release-tag.yml`, and `cli-npm-promote.yml`. The tag `release-tag.yml` creates matches `release.toml`'s `tag-name` and `cli-npm.yml`'s `v*` glob.
 
-**Known gap, deliberate:** nothing here can be end-to-end verified until the npm token is fixed, since every path terminates in a registry write. Task 2 Step 4 gets as close as read-only checks allow.
+**Known gap, deliberate:** nothing here can be end-to-end verified until the npm token is fixed, since every path terminates in a registry write. And `release-tag.yml`'s trigger cannot be exercised without a real merge to `staging`; Task 2 Step 3 simulates the predicate, which is the part that decides whether a release happens.

--- a/docs/superpowers/plans/2026-07-30-cargo-release.md
+++ b/docs/superpowers/plans/2026-07-30-cargo-release.md
@@ -1,0 +1,382 @@
+# cargo-release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the version bump and the `v*` tag a single act, and point npm's `stable` dist-tag at whatever `stable` holds.
+
+**Architecture:** A root `release.toml` overrides six cargo-release defaults that would misfire on a 34-crate workspace. `cargo-release` joins the flake devshell. A new workflow re-points the npm `stable` dist-tag on pushes to `stable` — a metadata move, never a publish.
+
+**Tech Stack:** cargo-release 0.25.x (nixpkgs), GitHub Actions, npm CLI, nix flakes.
+
+Spec: `docs/superpowers/specs/2026-07-30-cargo-release-design.md`.
+
+## Global Constraints
+
+- Tag name must be exactly `v{{version}}` — `cli-npm.yml` triggers on the `v*` glob and would never fire on cargo-release's default `tonk-cli-v0.6.4`.
+- Commit message must be exactly `chore: release {{version}}` — matches the existing convention (lowercase "release", no crate name).
+- `publish = false` is mandatory. The default `true` targets all 34 crates and none are on crates.io.
+- `allow-branch = ["staging"]`. Version bumps happen only on `staging`; `stable` is only ever fast-forwarded.
+- No changelog generation. No crates.io publishing. No new platform targets.
+- No emojis in code, commits, or output.
+
+**Note on verification style:** this change is configuration and CI, not executable logic — there is no unit-testable function anywhere in it. Verification is therefore dry-runs, `actionlint`, and registry reads against real state. Do not manufacture unit tests for a TOML file; the checks below are the real ones.
+
+---
+
+### Task 1: release.toml and the devshell
+
+**Files:**
+- Create: `release.toml` (repo root)
+- Modify: `flake.nix:56` (insert into the alphabetized `commonBuildInputs` list, immediately after `cargo-nextest`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the `cargo release <level>` command, available in `nix develop`, emitting one commit `chore: release <version>` and one annotated tag `v<version>`.
+
+- [ ] **Step 1: Create `release.toml`**
+
+```toml
+# Releases are cut with `cargo release <level>` from `staging` only. Each
+# run produces one commit and one `v<version>` tag, pushed together, so
+# the bump and the tag cannot drift apart the way 0.6.1 through 0.6.3 did.
+#
+# Every setting here overrides a default that misfires on this workspace.
+# See docs/superpowers/specs/2026-07-30-cargo-release-design.md.
+
+# The version is shared via `version.workspace`, so a release is one
+# commit for all 34 crates, not one commit each.
+consolidate-commits = true
+
+# `cli-npm.yml` triggers on the `v*` glob. The default of
+# `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which never matches.
+tag-name = "v{{version}}"
+
+pre-release-commit-message = "chore: release {{version}}"
+tag-message = "chore: release {{version}}"
+
+# None of these crates are on crates.io. Without this, a release attempts
+# `cargo publish` on all 34. Note that cargo-release still logs a
+# cosmetic `Publishing <crates>` line under this setting -- it is not
+# evidence of a registry attempt.
+publish = false
+
+# The guardrail against the original failure: a release cut from a
+# feature branch. Bumps belong on `staging`; `stable` only fast-forwards.
+allow-branch = ["staging"]
+```
+
+- [ ] **Step 2: Add cargo-release to the devshell**
+
+In `flake.nix`, inside `commonBuildInputs`, add `cargo-release` directly after `cargo-nextest` to keep the list alphabetized:
+
+```nix
+            cargo-nextest
+            cargo-release
+```
+
+- [ ] **Step 3: Verify the tool resolves in the devshell**
+
+Run: `nix develop --command cargo-release --version`
+Expected: a version string, `0.25.x` or later. If nix cannot evaluate, the flake edit is malformed.
+
+- [ ] **Step 4: Verify the config is parsed as intended**
+
+Run: `nix develop --command cargo release config | grep -E '^(publish|consolidate-commits|tag-name|pre-release-commit-message|allow-branch)'`
+Expected exactly:
+
+```
+allow-branch = ["staging"]
+publish = false
+consolidate-commits = true
+pre-release-commit-message = "chore: release {{version}}"
+tag-name = "v{{version}}"
+```
+
+- [ ] **Step 5: Verify the branch guard rejects this branch**
+
+You are not on `staging`, so the guard must fire. Run:
+
+`nix develop --command cargo release rc --workspace --no-confirm`
+
+Expected: `error: cannot release from branch '<current>' as it doesn't match 'staging'`.
+
+Note: dry-run collects errors and keeps printing the plan, so a `Pushing ...` line still appears below the error. That is expected — only `--execute` aborts at the check. The error line is the assertion.
+
+- [ ] **Step 6: Verify the release plan itself, overriding the guard**
+
+Run: `nix develop --command cargo release rc --workspace --no-confirm --allow-branch '*'`
+
+Expected, against a workspace at 0.6.3:
+- `Upgrading workspace to version 0.6.4-rc.1`
+- exactly one tag in the `Pushing` line: `v0.6.4-rc.1`
+- no `error:` lines
+
+Do **not** pass `--execute`. This must not cut a real release.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add release.toml flake.nix
+git commit -m "build: cut releases with cargo-release
+
+The workspace version and the v* tag were produced by separate acts, so
+they drifted -- 0.6.1 through 0.6.3 landed inside feature PRs with no
+tag. cargo-release makes the bump, the tag, and the push one command.
+
+Every setting in release.toml overrides a default that misfires on a
+34-crate workspace with a shared version: without them a release is 34
+commits, 34 tags named tonk-cli-v*, and 34 attempted crates.io
+publishes."
+```
+
+---
+
+### Task 2: The stable promote workflow
+
+**Files:**
+- Create: `.github/workflows/cli-npm-promote.yml`
+
+**Interfaces:**
+- Consumes: the `v<version>` tags from Task 1, and the `@tonk/cli` versions that `cli-npm.yml` publishes from them.
+- Produces: the npm `stable` dist-tag, pointing at the version `stable` holds.
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: 'CLI npm promote'
+
+# Promoting `stable` re-points the npm `stable` dist-tag at the version
+# stable now holds. It never publishes: because promotion is a
+# fast-forward, that version was already published from `staging` when
+# its `v*` tag fired `cli-npm.yml`. A dist-tag move is metadata only.
+#
+# This lives apart from `cli-npm.yml` deliberately. Adding a branch
+# trigger there would need `if:` guards on all three of its jobs, and one
+# missed guard means publishing on every push to stable.
+on:
+  push:
+    branches:
+      - stable
+  workflow_dispatch:
+
+concurrency:
+  group: cli-npm-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: 'Point @stable at the promoted version'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - name: Promote
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
+            | grep -m1 '^version' \
+            | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "stable holds $version"
+          # `stable` is only ever fast-forwarded to a final release. A
+          # prerelease here means the wrong commit was promoted.
+          if [[ "$version" == *-* ]]; then
+            echo "::error::stable holds prerelease $version; promote a final release instead"
+            exit 1
+          fi
+          # The version must already be on the registry. If it is not,
+          # stable holds a release that never published -- worth failing
+          # on rather than silently pointing the tag at nothing.
+          if ! npm view "@tonk/cli@$version" version >/dev/null 2>&1; then
+            echo "::error::@tonk/cli@$version is not published; nothing to promote"
+            exit 1
+          fi
+          # Only the wrapper needs the tag: its optionalDependencies pin
+          # exact platform versions, so `@tonk/cli@stable` resolves the
+          # right platform package on its own.
+          npm dist-tag add "@tonk/cli@$version" stable
+          npm dist-tag ls @tonk/cli
+```
+
+`node-version: 22` deviates from `cli-npm.yml`'s `20`, which the runners now flag as deprecated on every run. Bumping that file is a separate change; do not fold it in here.
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `nix run nixpkgs#actionlint -- .github/workflows/cli-npm-promote.yml`
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Verify the version extraction against real branches**
+
+The `grep`/`sed` pipeline is copied from `cli-npm.yml`, but confirm it against both branches:
+
+```bash
+for ref in origin/staging origin/stable; do
+  printf '%s: ' "$ref"
+  git show "$ref:Cargo.toml" | grep -A30 '^\[workspace.package\]' \
+    | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'
+done
+```
+
+Expected: `origin/staging: 0.6.3` and `origin/stable: 0.6.0` (or later values, but two distinct parseable versions — an empty result means the pipeline is broken).
+
+- [ ] **Step 4: Verify both guards fire correctly against live registry state**
+
+Simulate the two failure paths and the success path locally:
+
+```bash
+# Prerelease guard
+v=0.6.4-rc.1; [[ "$v" == *-* ]] && echo "guard fires: prerelease rejected"
+# Unpublished guard: stable is at 0.6.0, which was never published
+npm view "@tonk/cli@0.6.0" version >/dev/null 2>&1 \
+  && echo "0.6.0 published" || echo "guard fires: 0.6.0 unpublished, promote would fail"
+# Success path: 0.4.0 is published
+npm view "@tonk/cli@0.4.0" version >/dev/null 2>&1 \
+  && echo "success path: 0.4.0 resolvable, dist-tag move would proceed"
+```
+
+Expected: all three lines print. The middle one confirms a real and useful property — promoting `stable` **today** would correctly fail, because stable holds 0.6.0 and 0.6.0 was never published.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/cli-npm-promote.yml
+git commit -m "ci(cli-npm): point the npm stable dist-tag at promoted versions
+
+stable moves on milestones, so it can sit well behind staging. Mapping
+npm's latest onto stable would mean the default install serves
+increasingly old code -- which is the situation today, with latest at
+0.4.0 against a 0.6.3 workspace.
+
+So latest tracks staging finals and stable gets its own dist-tag. Since
+promotion is a fast-forward, the version is already published and this
+only re-points a tag; it never publishes. Both guards fail loudly rather
+than pointing the tag at nothing."
+```
+
+---
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `rust/tonk-cli/npm/README.md:25-60` (the "Publishing (maintainers)" section runs from line 25 to the end of the 60-line file; keep the local `npm pack` recipe near the end intact)
+- Modify: `README.md:93-95` (the install line)
+
+**Interfaces:**
+- Consumes: the commands from Tasks 1 and 2.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Rewrite the publishing section**
+
+Replace the numbered steps and the paragraph beginning "The tag is the source of the version" in `rust/tonk-cli/npm/README.md` with:
+
+```markdown
+Publishing runs in CI so every platform binary is built reproducibly —
+you cannot build the Linux binary from a Mac. It is **tag-driven**;
+nothing publishes on a normal push.
+
+1. One-time: add an `NPM_TOKEN` repository secret — an npm automation
+   token with read-write on the whole **`@tonk` scope**, not a package
+   subset, so platform packages added later keep working. A token
+   scoped too narrowly still passes `npm whoami` and then fails with a
+   bare `404 Not Found - PUT`, which reads like a missing package.
+2. From `staging`, cut the release. This is one command; it bumps the
+   workspace version, commits, tags, and pushes together:
+
+   ```sh
+   cargo release rc        # 0.6.3 -> 0.6.4-rc.1, publishes to @next
+   cargo release release   # 0.6.4-rc.2 -> 0.6.4, publishes to @latest
+   ```
+
+   Dry-run is the default — add `--execute` to act. Releases are
+   refused from any branch but `staging`.
+
+3. Promote by fast-forwarding `stable`. That re-points the `stable`
+   dist-tag; it does not publish again.
+
+The first `rc` fixes the target version, and there is no combined
+level-plus-prerelease flag, so if scope grows mid-cycle, re-target
+explicitly: `cargo release 0.7.0-rc.1`.
+
+### Dist-tags
+
+| Tag | Points at | Install |
+| --- | --- | --- |
+| `next` | prereleases from `staging` | `npx @tonk/cli@next` |
+| `latest` | finals from `staging` | `npx @tonk/cli` |
+| `stable` | the version `stable` holds | `npx @tonk/cli@stable` |
+
+`latest` tracks staging finals rather than `stable` on purpose. `stable`
+moves on milestones, so mapping `latest` onto it would make the default
+install progressively more stale.
+
+The workflow **refuses to publish if the tag disagrees with the Cargo
+workspace version**, and `cargo release` keeps them in step by
+construction. `cli-npm.yml` can also be run manually
+(`gh workflow run cli-npm.yml --ref staging`) to retry a failed publish
+without cutting a new tag; it skips any version already on the registry.
+```
+
+- [ ] **Step 2: Update the root README install line**
+
+`README.md:93-95` currently reads:
+
+```
+If `tonk` was installed some other way, `tonk update` says so instead
+of interfering: use `npm i -g @tonk/cli@latest` for an npm install, or
+your flake for a nix one.
+```
+
+Replace with — note `@latest` is dropped, since it is now the default and naming it invites confusion with `@stable`:
+
+```
+If `tonk` was installed some other way, `tonk update` says so instead
+of interfering: use `npm i -g @tonk/cli` for an npm install (or
+`@tonk/cli@stable` to pin to the last milestone), or your flake for a
+nix one.
+```
+
+The clause is mid-sentence; the `or your flake for a nix one` tail must still parse.
+
+- [ ] **Step 3: Verify no stale instructions remain**
+
+Run: `grep -rn "git tag v\|push origin v" rust/tonk-cli/npm/README.md README.md`
+Expected: no output. Any hit is a leftover manual-tagging instruction that Task 1 replaced.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rust/tonk-cli/npm/README.md README.md
+git commit -m "docs(cli): document cargo-release and the three dist-tags
+
+Replaces the manual bump-then-tag steps, which are what drifted, and
+spells out the token scope: a token narrow enough to pass npm whoami and
+still fail on PUT has now cost two releases."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| `release.toml` (six overrides) | 1 |
+| Devshell addition | 1 |
+| Stable promote workflow | 2 |
+| Docs — npm README, root README | 3 |
+| Model, version flow, ordering wart | documented in 3, enforced by 1 and 2 |
+| Out of scope: changelog, crates.io, platforms | absent by construction |
+| Blocked: npm token | called out in 3, Step 1 |
+
+**Placeholders:** none. Every step has literal content.
+
+**Type consistency:** the version-extraction pipeline is byte-identical between `cli-npm.yml` and the new promote workflow, and Task 2 Step 3 verifies it against both branches. Tag format `v{{version}}` in Task 1 matches the `v*` glob `cli-npm.yml` already uses.
+
+**Known gap, deliberate:** nothing here can be end-to-end verified until the npm token is fixed, since every path terminates in a registry write. Task 2 Step 4 gets as close as read-only checks allow.

--- a/docs/superpowers/plans/2026-07-30-cargo-release.md
+++ b/docs/superpowers/plans/2026-07-30-cargo-release.md
@@ -53,7 +53,25 @@ In `flake.nix`, add `pkgs.cargo-release` to `devShellBuildInputs`.
 
 - [ ] **Step 3: Commit**
 
-Commit with Task 2's workflow (see Task 2, Step 4). The commit has to come before the dry runs regardless: cargo-release refuses to plan against an uncommitted tree.
+Commit before verifying. The dry runs in Steps 4-7 need a clean tree: cargo-release checks for uncommitted changes *before* it reaches the branch guard, so on a dirty tree it aborts with `uncommitted changes detected` and never prints the release plan you are trying to inspect.
+
+```bash
+git add release.toml flake.nix
+git commit -m "build(release): let CI cut the release tag
+
+cargo-release cannot push to staging. Two active rulesets cover the
+default branch and require a pull request with no bypass actor, and
+merge commits are disabled, so a PR merge rewrites the SHA and a
+locally created tag could never point at a commit that lands. The bump
+stays local; CI owns the tag.
+
+The remaining settings each override a default that misfires on a
+34-crate shared-version workspace: without them a release is 34
+commits, 34 tags named tonk-cli-v*, and 34 attempted crates.io
+publishes."
+```
+
+Task 2 adds the tag workflow to *this* commit rather than a second one — see Task 2, Step 4.
 
 - [ ] **Step 4: Verify the tool resolves in the devshell**
 
@@ -143,13 +161,13 @@ The whole design rests on this predicate, so simulate it against staging history
 
 Expected: `changed` for the bump pair, `unchanged` for the other. An empty version on either side means the pipeline is broken.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Amend Task 1's commit**
 
-This belongs with Task 1: `push = false`/`tag = false` and this workflow are two halves of one decision, and either alone is broken — the config without the workflow never tags, the workflow without the config double-tags.
+This belongs with Task 1: `push = false`/`tag = false` and this workflow are two halves of one decision, and either alone is broken — the config without the workflow never tags, the workflow without the config double-tags. Task 1 already committed the config so its dry runs had a clean tree to plan against, so add the workflow to that commit instead of creating a second one.
 
 ```bash
-git add release.toml flake.nix .github/workflows/release-tag.yml
-git commit -m "build(release): let CI cut the release tag"
+git add .github/workflows/release-tag.yml
+git commit --amend --no-edit
 ```
 
 ---

--- a/docs/superpowers/specs/2026-07-30-cargo-release-design.md
+++ b/docs/superpowers/specs/2026-07-30-cargo-release-design.md
@@ -1,0 +1,191 @@
+# Release process: cargo-release and channel mapping
+
+## Problem
+
+The workspace version and the `v*` tag are produced by separate acts, so
+they drift. `chore: release 0.6.1`, `0.6.2`, and `0.6.3` each landed
+*inside* an unrelated feature PR (#632, #647, #651) as ordinary commits.
+No `v0.6.x` tag exists. There is no point in the process where anyone
+would think "and now tag", because there is no release moment — the bump
+is a side effect of shipping a feature.
+
+The result: npm `@tonk/cli` latest is **0.4.0** while the workspace is at
+**0.6.3**, so `npx @tonk/cli` serves code from two minors ago.
+
+A separate, compounding failure: every `CLI npm` run has failed on npm
+auth, so even the tagged releases (`v0.4.0`, `v0.5.0`) never published
+from CI. 0.4.0 reached npm by hand, ~40 minutes after its run failed.
+That is out of scope here (see Blocked below) but it is why the drift
+went unnoticed.
+
+## Model
+
+Deploying and releasing are already separate systems in this repo. The
+mistake is treating a staging push as a release. `cli.yml:74` says so
+directly: the rolling channel carries `commit` in `manifest.json`
+because "a rolling tag cannot identify a build". Staging builds are
+already identified by commit, not by version.
+
+So staging deploys continuously and unversioned. Versions stay scarce.
+
+| Event | Trigger | Channel | Cadence |
+| --- | --- | --- | --- |
+| staging push | branch | `tonk-staging` + CF staging | every merge, unversioned |
+| `cargo release rc` | `v*-rc.N` tag | npm `@next` | on demand |
+| `cargo release release` | `v*` tag | npm `@latest` | once per cycle |
+| stable promote | branch | `tonk-latest` + CF prod, npm `@stable` | at milestones |
+
+An rc exists for when someone needs a citable, installable artifact — a
+tester, a pinned bug report. Not one per merge.
+
+### Version flow
+
+```
+staging  cargo release rc        0.6.3 -> 0.6.4-rc.1   tag v0.6.4-rc.1 -> npm @next
+         cargo release rc              -> 0.6.4-rc.2   tag v0.6.4-rc.2 -> npm @next
+         cargo release release         -> 0.6.4        tag v0.6.4      -> npm @latest
+             |
+         promote (fast-forward)
+             v
+stable   0.6.4                        -> tonk-latest, npm @stable
+```
+
+All version changes happen on `staging`. `stable` only ever
+fast-forwards.
+
+**Why bump on staging rather than stable.** If stable gets its own
+version commit it stops being a strict ancestor of staging, and every
+future promote needs a merge instead of a fast-forward. Bumping on
+staging preserves the ff, and stable still ends up holding exactly
+0.6.4. Today staging is +21 on stable and stable is +0 on staging, so
+the ff property currently holds and is worth keeping.
+
+**Why `@latest` tracks staging finals, not stable.** Stable moves on
+milestones, so it can sit many versions behind. If `@latest` meant
+stable, the default `npm install @tonk/cli` would serve increasingly
+ancient code — which is the observed situation now (0.4.0 vs 0.6.3),
+structurally rather than accidentally. Vetted installs use
+`npx @tonk/cli@stable`.
+
+**No change to the existing dist-tag derivation.** `cli-npm.yml` already
+routes a hyphenated version to `next` and anything else to `latest`,
+which is exactly this model, and its `v*` tag glob already matches
+`v0.6.4-rc.1`. The only registry-facing addition is `@stable`.
+
+**`@stable` is a dist-tag move, not a publish.** Because promotion is a
+fast-forward, the release commit is identical on both branches and the
+version is already on the registry. Promoting runs
+`npm dist-tag add @tonk/cli@<version> stable`, which repoints a tag
+without republishing. Only the wrapper needs it: its
+`optionalDependencies` pin exact platform versions, so resolving
+`@tonk/cli@stable` pulls the correct platform packages automatically.
+
+### Ordering wart
+
+The final tag fires npm `@latest` before stable is fast-forwarded, so
+for the interval between the two, `@latest` describes a commit that is
+not yet on stable. The commit is bit-identical either way, so the skew
+is cosmetic. Accepted. If it ever matters, the zero-skew form is
+`cargo release release --no-push`, ff stable, then push the tag.
+
+## release.toml
+
+At the workspace root. Every line overrides a default that would
+otherwise do damage.
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| `publish` | `false` | Default `true` attempts `cargo publish` on all 34 crates. None are on crates.io. |
+| `consolidate-commits` | `true` | Default `false` produces 34 separate commits, one per crate. |
+| `tag-name` | `"v{{version}}"` | Default `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which does not match `cli-npm.yml`'s `v*` glob and would never trigger a publish. |
+| `pre-release-commit-message` | `"chore: release {{version}}"` | Matches the existing convention; the default injects a crate name and a capital R. |
+| `tag-message` | `"chore: release {{version}}"` | Same reason. |
+| `allow-branch` | `["staging"]` | Default `["*"]`. This is the guardrail against the actual failure mode: a release cut from the wrong branch. |
+
+`push` keeps its default of `true`. Atomicity is the entire point — bump,
+tag, and push as one act, leaving no window in which the tag can be
+forgotten.
+
+Dry-run is cargo-release's default; `--execute` is required to act.
+
+## Devshell
+
+Add `cargo-release` to `devShellBuildInputs` in `flake.nix`. Declarative,
+no imperative install.
+
+## Stable promote workflow
+
+New file `.github/workflows/cli-npm-promote.yml`, triggered on push to
+`stable`:
+
+1. Read the workspace version from the stable checkout.
+2. Verify `@tonk/cli@<version>` exists on the registry. If it does not,
+   fail loudly — it means stable holds a version that was never
+   released, which is a real problem worth surfacing rather than
+   silently tagging nothing.
+3. `npm dist-tag add @tonk/cli@<version> stable`.
+
+A separate file rather than a job inside `cli-npm.yml`: adding a branch
+trigger there would require `if:` guards on all three existing jobs, and
+a single missed guard means publishing on every stable push. The cost is
+that npm-registry mutations now live in two files.
+
+## Docs
+
+- `rust/tonk-cli/npm/README.md`, "Publishing (maintainers)": replace the
+  manual bump-then-tag steps with the cargo-release commands, and
+  document all three dist-tags. The existing text already specifies the
+  correct token shape ("an npm automation token for the `@tonk` scope
+  with publish rights"), which is what the live token is not. Keep the
+  local `npm pack` verification recipe as-is.
+- Root `README.md` line 94 references `@tonk/cli@latest`. Add `@stable`
+  and say which is which.
+
+## Verification
+
+All mechanics below were confirmed empirically in an isolated two-crate
+workspace with an inherited `version.workspace`, before writing this
+spec:
+
+| Claim | Evidence |
+| --- | --- |
+| `rc` from 0.6.3 gives `0.6.4-rc.1`; repeating gives `rc.2` | executed both |
+| `release` strips the prerelease to `0.6.4` | executed |
+| One consolidated commit per release, `Cargo.toml` + `Cargo.lock` only | `2 files changed` |
+| One annotated tag named `v<version>` | `git tag -l` = 1 entry; `git cat-file -t` = `tag` |
+| `publish = false` genuinely skips the registry | crates absent from crates.io, no token configured, exit 0, no registry error |
+| `allow-branch` blocks a wrong-branch release | `error: cannot release from branch 'feat/something' as it doesn't match 'staging'` |
+
+Two gotchas found in the process, recorded so nobody re-derives them:
+
+- cargo-release prints `Publishing <all crates>` **even with
+  `publish = false` and `--no-publish`**. The line is cosmetic. Do not
+  read it as evidence of a crates.io attempt.
+- In dry-run mode cargo-release collects errors and continues printing
+  the plan, so a blocked release still shows a `Pushing ...` line before
+  failing at the end. Only `--execute` aborts at the check.
+
+Remaining verification during implementation:
+
+- `cargo release rc` dry run from `staging` in the real workspace: expect
+  one commit, one tag `v0.6.4-rc.1`, no crates.io attempt.
+- `actionlint` on the new promote workflow.
+
+## Out of scope
+
+- Changelog generation. There is no changelog today, and
+  conventional-commit changelogs are a separate argument.
+- crates.io publishing. `publish = false` covers cargo-release; a
+  Cargo-level `publish = false` per crate would be strictly stronger but
+  is 34 edits for a risk that requires a crates.io token to materialise.
+- New platform targets.
+
+## Blocked
+
+Nothing publishes until the npm token is fixed. `npm whoami` succeeds as
+`tonk-labs`, and `tonk-labs` owns all three packages, but
+`PUT @tonk/cli-darwin-arm64` returns 404 — npm's response for an
+unauthorised publish. The token needs read-write on the whole `@tonk`
+scope, not a package subset, so newly added platform packages keep
+working. This spec is implementable and mergeable regardless; it just
+cannot produce a published artifact yet.

--- a/docs/superpowers/specs/2026-07-30-cargo-release-design.md
+++ b/docs/superpowers/specs/2026-07-30-cargo-release-design.md
@@ -18,6 +18,40 @@ from CI. 0.4.0 reached npm by hand, ~40 minutes after its run failed.
 That is out of scope here (see Blocked below) but it is why the drift
 went unnoticed.
 
+## Constraint: nothing can push to `staging`
+
+Checked against the GitHub rulesets API, after an earlier draft of this
+spec claimed staging was unprotected. **That claim was wrong**: it was
+checked against the classic branch-protection endpoint
+(`/branches/staging/protection`), which returns 404 for a branch governed
+only by rulesets. Rulesets are a separate API and a separate object, and
+`staging` has two active ones:
+
+- Ruleset 3652307 "Require PR approval before merging to main branch":
+  targets `~DEFAULT_BRANCH`, rules `pull_request` + `non_fast_forward`,
+  `bypass_actors: []`, `current_user_can_bypass: never`.
+- Ruleset 12020040 "Stable branch rules": targets `~DEFAULT_BRANCH`,
+  rules `deletion`, `non_fast_forward`, `required_signatures`,
+  `required_status_checks`. Bypass is one team, `bypass_mode:
+  pull_request` — which is not a bypass of the PR requirement.
+
+`staging` is the default branch, so both apply to it. Additionally
+`allow_merge_commit: false`: only squash and rebase are enabled, so a PR
+merge always produces a **new SHA**.
+
+Two consequences that shape the whole design:
+
+1. A local `cargo release --execute` cannot work. It ends in a push to
+   the current branch, which is rejected, after the commit already
+   exists.
+2. A locally created tag is useless even if the push were separate. It
+   points at the pre-merge commit, and squash-merging produces a
+   different SHA — so the tag would name a commit that is not on
+   `staging` and never will be.
+
+Tags themselves are unaffected: the rulesets target branches, so CI can
+push a `v*` tag freely.
+
 ## Model
 
 Deploying and releasing are already separate systems in this repo. The
@@ -31,8 +65,8 @@ So staging deploys continuously and unversioned. Versions stay scarce.
 | Event | Trigger | Channel | Cadence |
 | --- | --- | --- | --- |
 | staging push | branch | `tonk-staging` + CF staging | every merge, unversioned |
-| `cargo release rc` | `v*-rc.N` tag | npm `@next` | on demand |
-| `cargo release release` | `v*` tag | npm `@latest` | once per cycle |
+| release PR merged with an `-rc.N` version | `v*-rc.N` tag, cut by CI | npm `@next` | on demand |
+| release PR merged with a final version | `v*` tag, cut by CI | npm `@latest` | once per cycle |
 | stable promote | branch | `tonk-latest` + CF prod, npm `@stable` | at milestones |
 
 An rc exists for when someone needs a citable, installable artifact — a
@@ -40,18 +74,59 @@ tester, a pinned bug report. Not one per merge.
 
 ### Version flow
 
+A release is two acts. `cargo release` makes the bump commit locally;
+CI makes the tag once that commit lands on `staging`.
+
 ```
-staging  cargo release rc        0.6.3 -> 0.6.4-rc.1   tag v0.6.4-rc.1 -> npm @next
-         cargo release rc              -> 0.6.4-rc.2   tag v0.6.4-rc.2 -> npm @next
-         cargo release release         -> 0.6.4        tag v0.6.4      -> npm @latest
-             |
-         promote (fast-forward)
-             v
-stable   0.6.4                        -> tonk-latest, npm @stable
+release/*   cargo release rc --execute        0.6.3 -> 0.6.4-rc.1
+                | PR, squash-merge
+                v
+staging     release-tag.yml sees the version change
+              -> tag v0.6.4-rc.1 -> dispatch cli-npm.yml -> npm @next
+
+release/*   cargo release rc --execute        -> 0.6.4-rc.2   (repeatable)
+                ... same path ...             -> npm @next
+
+release/*   cargo release release --execute   -> 0.6.4
+                ... same path ...             -> npm @latest
+                |
+            promote: git push origin v0.6.4:refs/heads/stable
+                v
+stable      0.6.4                -> tonk-latest, npm @stable
 ```
 
+`patch`, `minor`, or `major` in place of `rc` cuts a final without going
+through a prerelease at all.
+
 All version changes happen on `staging`. `stable` only ever
-fast-forwards.
+fast-forwards, and only to a commit a `v*` tag names.
+
+### Why CI owns the tag
+
+`.github/workflows/release-tag.yml`, on push to `staging`:
+
+1. Extract `[workspace.package] version` at `github.event.before` and at
+   `github.sha`.
+2. If they differ, and `v<version>` does not already exist, create an
+   annotated tag `v<version>` at `github.sha` and push it.
+3. Start `cli-npm.yml` against that tag.
+
+The predicate must be a version **change**, not the absence of a tag.
+Staging is currently at 0.6.3 with no `v0.6.3`; a tag-absence predicate
+would tag an arbitrary HEAD 21 commits past the last release, which is
+the failure this spec exists to remove. Where the range cannot be
+diffed — `github.event.before` all-zeroes on branch creation, or
+unreachable after a force push — the workflow does nothing rather than
+guess.
+
+Step 3 is not redundant. A tag pushed with `GITHUB_TOKEN` does not
+trigger any workflow: GitHub suppresses events raised by the built-in
+token to stop workflows recursing, with `workflow_dispatch` and
+`repository_dispatch` as the only exceptions. So the tag push alone
+would create a tag and publish nothing. Dispatching `cli-npm.yml`
+against the tag ref reaches the same contract by the permitted route,
+and needs no new secret — the alternative is a PAT or GitHub App token
+whose only job is to launder the push event.
 
 **Why bump on staging rather than stable.** If stable gets its own
 version commit it stops being a strict ancestor of staging, and every
@@ -67,26 +142,51 @@ ancient code — which is the observed situation now (0.4.0 vs 0.6.3),
 structurally rather than accidentally. Vetted installs use
 `npx @tonk/cli@stable`.
 
-**No change to the existing dist-tag derivation.** `cli-npm.yml` already
-routes a hyphenated version to `next` and anything else to `latest`,
-which is exactly this model, and its `v*` tag glob already matches
-`v0.6.4-rc.1`. The only registry-facing addition is `@stable`.
+**No change to `cli-npm.yml`.** It already routes a hyphenated version to
+`next` and anything else to `latest`, which is exactly this model. Its
+`v*` tag glob still covers a hand-pushed tag; the CI path reaches it by
+`workflow_dispatch` instead, for the GITHUB_TOKEN reason above, and both
+entry points resolve the version from the ref's own `Cargo.toml`. The
+only registry-facing addition is `@stable`.
 
-**`@stable` is a dist-tag move, not a publish.** Because promotion is a
-fast-forward, the release commit is identical on both branches and the
-version is already on the registry. Promoting runs
+**`@stable` is a dist-tag move, not a publish.** `stable` is only
+fast-forwarded to a commit a `v*` tag names, so the version is already on
+the registry. Promoting runs
 `npm dist-tag add @tonk/cli@<version> stable`, which repoints a tag
 without republishing. Only the wrapper needs it: its
 `optionalDependencies` pin exact platform versions, so resolving
 `@tonk/cli@stable` pulls the correct platform packages automatically.
 
-### Ordering wart
+### The promote target is an invariant, not a convention
 
-The final tag fires npm `@latest` before stable is fast-forwarded, so
-for the interval between the two, `@latest` describes a commit that is
-not yet on stable. The commit is bit-identical either way, so the skew
-is cosmetic. Accepted. If it ever matters, the zero-skew form is
-`cargo release release --no-push`, ff stable, then push the tag.
+Promotion happens at milestones, so the natural fast-forward target is
+whatever staging HEAD looks good — which is normally *past* the release
+commit. That breaks `@stable`. The workspace version at that later
+commit is still `<version>`, so the promote workflow would point
+`@stable` at the `<version>` tarball, which was built from the release
+commit and does not contain the extra commits. Meanwhile `cli.yml`'s
+`publish-stable` builds the `tonk-latest` GitHub release from stable's
+real HEAD. Two channels claiming to be stable, different binaries, no
+error anywhere.
+
+So `cli-npm-promote.yml` requires `v<version>` to resolve to exactly
+`$GITHUB_SHA` and fails with the fast-forward command if it does not.
+The documented promote is `git push origin v<version>:refs/heads/stable`,
+which satisfies it by construction.
+
+An earlier draft of this spec called the equivalent skew "cosmetic" on
+the grounds that the release commit is bit-identical on both branches.
+That only held while promotion was assumed to target the release commit;
+it is an invariant now rather than an assumption.
+
+### Ordering dependency
+
+The tag's publish run must finish before `stable` is promoted, because
+promoting checks the registry. Promote early and it fails with
+`@tonk/cli@<version> is not published; nothing to promote`, which reads
+like a design violation but means "not yet". Documented in the README,
+along with `gh workflow run cli-npm-promote.yml --ref stable` to re-run
+one.
 
 ## release.toml
 
@@ -97,49 +197,83 @@ otherwise do damage.
 | --- | --- | --- |
 | `publish` | `false` | Default `true` attempts `cargo publish` on all 34 crates. None are on crates.io. |
 | `consolidate-commits` | `true` | Default `false` produces 34 separate commits, one per crate. |
-| `tag-name` | `"v{{version}}"` | Default `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which does not match `cli-npm.yml`'s `v*` glob and would never trigger a publish. |
+| `push` | `false` | Default `true`. The ruleset rejects a push to `staging`, and cargo-release hits it *after* writing the commit, leaving a half-done release and a confusing error. |
+| `tag` | `false` | Default `true`. A tag cut locally points at the pre-merge commit, and the squash merge produces a different SHA. `release-tag.yml` owns the tag. |
+| `tag-name` | `"v{{version}}"` | Retained under `tag = false` for the manual escape hatch (`--tag` plus a hand push) and as the name `release-tag.yml` must match. Default `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which does not match `cli-npm.yml`'s `v*` glob and would never trigger a publish. |
 | `pre-release-commit-message` | `"chore: release {{version}}"` | Matches the existing convention; the default injects a crate name and a capital R. |
 | `tag-message` | `"chore: release {{version}}"` | Same reason. |
-| `allow-branch` | `["staging"]` | Default `["*"]`. This is the guardrail against the actual failure mode: a release cut from the wrong branch. |
+| `allow-branch` | `["staging", "release/*"]` | Default `["*", "!HEAD"]`. The guardrail against a release cut from an unrelated feature branch. `release/*` is the normal path, since the bump needs a PR anyway; `staging` stays allowed for a maintainer who already has it checked out. `stable` is absent on purpose. |
 
-`push` keeps its default of `true`. Atomicity is the entire point — bump,
-tag, and push as one act, leaving no window in which the tag can be
-forgotten.
+Dry-run is cargo-release's default; `--execute` is required to act. Under
+`push = false` and `tag = false`, `--execute` produces exactly one
+artifact: the commit `chore: release <version>` on the current branch.
 
-Dry-run is cargo-release's default; `--execute` is required to act.
+`cargo release release` deserves a warning in the docs: it only strips an
+existing pre-version. Run from a final version it has nothing to strip,
+changes no version, writes no commit, and exits 0 — a silent no-op that
+reads as success. `patch`, `minor`, and `major` are the levels that cut a
+final directly.
 
 ## Devshell
 
 Add `cargo-release` to `devShellBuildInputs` in `flake.nix`. Declarative,
 no imperative install.
 
+Specifically **not** `commonBuildInputs`: `flake.nix` passes that to
+`nix/rust.nix` as `buildInputs`, which become `nativeBuildInputs` on
+`buildDepsOnly` and all 34 crate derivations. Adding a tool there changes
+every crate hash, forces a cold cachix rebuild on both runners, and puts
+a release tool in every build sandbox. `devShellBuildInputs` is
+`commonBuildInputs ++ [...]`, so `nix develop` still gets it.
+
 ## Stable promote workflow
 
 New file `.github/workflows/cli-npm-promote.yml`, triggered on push to
-`stable`:
+`stable` and on `workflow_dispatch`:
 
-1. Read the workspace version from the stable checkout.
-2. Verify `@tonk/cli@<version>` exists on the registry. If it does not,
+1. Refuse unless the ref is `refs/heads/stable`. `workflow_dispatch`
+   accepts any ref, and dispatching against `staging` would point
+   `@stable` at a version `stable` does not hold.
+2. Read the workspace version from the stable checkout, and refuse a
+   prerelease.
+3. Require `v<version>` to resolve to exactly `$GITHUB_SHA` — see "The
+   promote target is an invariant" above. The error names the
+   fast-forward command.
+4. Verify `@tonk/cli@<version>` exists on the registry. If it does not,
    fail loudly — it means stable holds a version that was never
    released, which is a real problem worth surfacing rather than
-   silently tagging nothing.
-3. `npm dist-tag add @tonk/cli@<version> stable`.
+   silently tagging nothing. Capture npm's output and distinguish
+   `code E404` from any other failure, so a registry outage does not get
+   reported as an unpublished release.
+5. `npm dist-tag add @tonk/cli@<version> stable`.
 
 A separate file rather than a job inside `cli-npm.yml`: adding a branch
 trigger there would require `if:` guards on all three existing jobs, and
 a single missed guard means publishing on every stable push. The cost is
 that npm-registry mutations now live in two files.
 
+Note that the first promote after this lands will fail by design.
+`stable` holds 0.6.0, npm's highest version is 0.4.0, and there is no
+`v0.6.0` tag. It self-heals after one full cycle; no workaround.
+
 ## Docs
 
 - `rust/tonk-cli/npm/README.md`, "Publishing (maintainers)": replace the
-  manual bump-then-tag steps with the cargo-release commands, and
-  document all three dist-tags. The existing text already specifies the
-  correct token shape ("an npm automation token for the `@tonk` scope
-  with publish rights"), which is what the live token is not. Keep the
-  local `npm pack` verification recipe as-is.
+  manual bump-then-tag steps with the four-step flow — cut the bump on
+  `release/*`, PR it, let CI tag, promote to the release commit — and
+  document all three dist-tags. State which level cuts a final and that
+  `release` is a no-op from one. State that promoting has to wait for the
+  tag's publish run. The existing text already specifies the correct
+  token shape ("an npm automation token for the `@tonk` scope with
+  publish rights"), which is what the live token is not. Keep the local
+  `npm pack` verification recipe, but glob the wrapper tarball rather
+  than naming a version — the committed `package.json` versions are
+  placeholders that CI stamps over, so a literal filename rots.
 - Root `README.md` line 94 references `@tonk/cli@latest`. Add `@stable`
-  and say which is which.
+  and say which is which. Same for the npm remedy string in
+  `rust/tonk-cli/src/update/swap.rs`: under this model `@latest` means
+  staging finals, so telling an npm user to install `@latest` moves a
+  `@stable`-pinned install onto a faster channel.
 
 ## Verification
 
@@ -156,20 +290,33 @@ spec:
 | `publish = false` genuinely skips the registry | crates absent from crates.io, no token configured, exit 0, no registry error |
 | `allow-branch` blocks a wrong-branch release | `error: cannot release from branch 'feat/something' as it doesn't match 'staging'` |
 
+That prototype ran with `push = true` and `tag = true`, so the tag rows
+describe cargo-release's capability rather than this repo's
+configuration. Under `tag = false` no local tag is produced at all; the
+`v<version>` name lives on in `release-tag.yml`.
+
 Two gotchas found in the process, recorded so nobody re-derives them:
 
 - cargo-release prints `Publishing <all crates>` **even with
   `publish = false` and `--no-publish`**. The line is cosmetic. Do not
   read it as evidence of a crates.io attempt.
 - In dry-run mode cargo-release collects errors and continues printing
-  the plan, so a blocked release still shows a `Pushing ...` line before
-  failing at the end. Only `--execute` aborts at the check.
+  the plan, so a blocked release still prints the rest of its plan below
+  the error. Only `--execute` aborts at the check. Read the `error:` line,
+  not the absence of one.
 
-Remaining verification during implementation:
+Confirmed in this workspace, with cargo-release 1.1.2, after the config
+landed:
 
-- `cargo release rc` dry run from `staging` in the real workspace: expect
-  one commit, one tag `v0.6.4-rc.1`, no crates.io attempt.
-- `actionlint` on the new promote workflow.
+| Claim | Evidence |
+| --- | --- |
+| all seven settings parse | `cargo release config` shows `push = false`, `tag = false`, `allow-branch = ["staging", "release/*"]`, `publish = false`, `consolidate-commits = true`, `tag-name`, `tag-message`, `pre-release-commit-message` |
+| the branch guard fires | ``error: cannot release from branch `build/cargo-release` as it doesn't match `staging`, `release/*` `` |
+| `patch` bumps to 0.6.4 with no tag and no push | 35 `Upgrading ... 0.6.3 to 0.6.4` lines, zero `Tagging`/`Pushing`/`error:` lines |
+| `rc` bumps to 0.6.4-rc.1 | `Upgrading tonk-cli from 0.6.3 to 0.6.4-rc.1` |
+| `release` from a final is a silent no-op | zero `Upgrading` lines, exits on the dry-run abort alone |
+| the tag predicate discriminates | over real staging commits: `dbb9b9c4c..65d105b52` (0.6.2 → 0.6.3) yields `TAG v0.6.3`; `7875f6427..dbb9b9c4c` yields `no tag (version unchanged at 0.6.2)`; all-zeroes and unreachable `before` both yield no tag |
+| both workflows lint | `actionlint` exit 0, no output |
 
 ## Out of scope
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
             caddy
             cachix
             cargo-nextest
+            cargo-release
             esbuild
             imagemagick
             jq

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
             caddy
             cachix
             cargo-nextest
-            cargo-release
             esbuild
             imagemagick
             jq
@@ -116,6 +115,10 @@
         # Include the Rust toolchain in build inputs for dev shells
         devShellBuildInputs = commonBuildInputs ++ [
           pkgs.cachix
+          # Devshell only: `commonBuildInputs` becomes nativeBuildInputs
+          # for every crate derivation, so a release tool in there would
+          # change 34 hashes and force a cold cache rebuild.
+          pkgs.cargo-release
           wrangler
           rustToolchain
           wasm-bindgen-cli

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,27 @@
+# Releases are cut with `cargo release <level>` from `staging` only. Each
+# run produces one commit and one `v<version>` tag, pushed together, so
+# the bump and the tag cannot drift apart the way 0.6.1 through 0.6.3 did.
+#
+# Every setting here overrides a default that misfires on this workspace.
+# See docs/superpowers/specs/2026-07-30-cargo-release-design.md.
+
+# The version is shared via `version.workspace`, so a release is one
+# commit for all 34 crates, not one commit each.
+consolidate-commits = true
+
+# `cli-npm.yml` triggers on the `v*` glob. The default of
+# `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which never matches.
+tag-name = "v{{version}}"
+
+pre-release-commit-message = "chore: release {{version}}"
+tag-message = "chore: release {{version}}"
+
+# None of these crates are on crates.io. Without this, a release attempts
+# `cargo publish` on all 34. Note that cargo-release still logs a
+# cosmetic `Publishing <crates>` line under this setting -- it is not
+# evidence of a registry attempt.
+publish = false
+
+# The guardrail against the original failure: a release cut from a
+# feature branch. Bumps belong on `staging`; `stable` only fast-forwards.
+allow-branch = ["staging"]

--- a/release.toml
+++ b/release.toml
@@ -1,15 +1,9 @@
 # A release is two acts, split across two machines, because it has to be.
 # `cargo release <level>` makes the version bump commit and stops. The
 # tag is created in CI by `.github/workflows/release-tag.yml` once that
-# commit lands on `staging`, and the tag is what publishes.
-#
-# Why it cannot be one local act: two active rulesets cover `staging`
-# (the default branch) and require a pull request, forbid
-# non-fast-forward, and require signed commits and status checks, with no
-# bypass actor. So nothing can push a commit directly to `staging`.
-# Merge commits are disabled too, so a PR merge rewrites the SHA -- a tag
-# created locally would point at a commit that never lands on the branch.
-# The rulesets cover branches, not tags, which is why CI can push one.
+# commit lands on `staging`, and the tag is what publishes. That
+# workflow's header explains why the split is forced; the `push` and
+# `tag` settings below say what it means here.
 #
 # Every setting here overrides a default that misfires on this workspace.
 # See docs/superpowers/specs/2026-07-30-cargo-release-design.md.

--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,15 @@
-# Releases are cut with `cargo release <level>` from `staging` only. Each
-# run produces one commit and one `v<version>` tag, pushed together, so
-# the bump and the tag cannot drift apart the way 0.6.1 through 0.6.3 did.
+# A release is two acts, split across two machines, because it has to be.
+# `cargo release <level>` makes the version bump commit and stops. The
+# tag is created in CI by `.github/workflows/release-tag.yml` once that
+# commit lands on `staging`, and the tag is what publishes.
+#
+# Why it cannot be one local act: two active rulesets cover `staging`
+# (the default branch) and require a pull request, forbid
+# non-fast-forward, and require signed commits and status checks, with no
+# bypass actor. So nothing can push a commit directly to `staging`.
+# Merge commits are disabled too, so a PR merge rewrites the SHA -- a tag
+# created locally would point at a commit that never lands on the branch.
+# The rulesets cover branches, not tags, which is why CI can push one.
 #
 # Every setting here overrides a default that misfires on this workspace.
 # See docs/superpowers/specs/2026-07-30-cargo-release-design.md.
@@ -9,7 +18,19 @@
 # commit for all 34 crates, not one commit each.
 consolidate-commits = true
 
-# `cli-npm.yml` triggers on the `v*` glob. The default of
+# The ruleset forbids pushing to `staging`, so cargo-release must not
+# try. It exits non-zero on the rejected push, after the commit exists,
+# leaving a confusing half-done state.
+push = false
+
+# CI owns the tag. A tag cut here would point at the local commit, and
+# the squash merge that lands it on `staging` produces a different SHA.
+tag = false
+
+# Kept even though `tag = false`: it names the tag for the escape hatch
+# where a maintainer cuts one by hand (`--tag` plus a manual push), and
+# it must stay in step with the tag `release-tag.yml` creates.
+# `cli-npm.yml` triggers on the `v*` glob, and cargo-release's default of
 # `{{prefix}}v{{version}}` yields `tonk-cli-v0.6.4`, which never matches.
 tag-name = "v{{version}}"
 
@@ -22,6 +43,9 @@ tag-message = "chore: release {{version}}"
 # evidence of a registry attempt.
 publish = false
 
-# The guardrail against the original failure: a release cut from a
-# feature branch. Bumps belong on `staging`; `stable` only fast-forwards.
-allow-branch = ["staging"]
+# The guardrail against the original failure: a release cut from an
+# unrelated feature branch. `release/*` is the normal path -- the bump
+# needs a PR anyway, so it starts life on its own branch -- and
+# `staging` is allowed for the case where a maintainer already has it
+# checked out. `stable` is absent on purpose: it only fast-forwards.
+allow-branch = ["staging", "release/*"]

--- a/rust/tonk-cli/npm/README.md
+++ b/rust/tonk-cli/npm/README.md
@@ -28,28 +28,86 @@ Publishing runs in CI so every platform binary is built reproducibly —
 you cannot build the Linux binary from a Mac. It is **tag-driven**;
 nothing publishes on a normal push.
 
+The bump and the tag are separate acts on separate machines, and have to
+be. Rulesets on `staging` require a pull request and forbid
+non-fast-forward with no bypass, so nobody can push a release commit
+directly; and because merge commits are disabled, merging rewrites the
+SHA, so a tag created locally would point at a commit that never lands.
+So `cargo release` makes only the commit, and `release-tag.yml` creates
+the `v<version>` tag in CI once that commit is on `staging`.
+
 1. One-time: add an `NPM_TOKEN` repository secret — an npm automation
    token with read-write on the whole **`@tonk` scope**, not a package
    subset, so platform packages added later keep working. A token
    scoped too narrowly still passes `npm whoami` and then fails with a
    bare `404 Not Found - PUT`, which reads like a missing package.
-2. From `staging`, cut the release. This is one command; it bumps the
-   workspace version, commits, tags, and pushes together:
+
+2. Cut the bump on a `release/*` branch off current `staging`:
 
    ```sh
-   cargo release rc        # 0.6.3 -> 0.6.4-rc.1, publishes to @next
-   cargo release release   # 0.6.4-rc.2 -> 0.6.4, publishes to @latest
+   git fetch origin && git switch -c release/0.6.4 origin/staging
+   nix develop            # cargo-release lives in the devshell
+   cargo release patch --execute   # 0.6.3 -> 0.6.4
    ```
 
-   Dry-run is the default — add `--execute` to act. Releases are
-   refused from any branch but `staging`.
+   Dry-run is the default; `--execute` acts. `release.toml` sets
+   `push = false` and `tag = false`, so this writes exactly one commit,
+   `chore: release 0.6.4` (`Cargo.toml` plus `Cargo.lock`), and touches
+   nothing else. A release is refused from any branch but `staging` or
+   `release/*`, and refused outright if the tree is dirty.
 
-3. Promote by fast-forwarding `stable`. That re-points the `stable`
-   dist-tag; it does not publish again.
+   Which level to use:
 
-The first `rc` fixes the target version, and there is no combined
-level-plus-prerelease flag, so if scope grows mid-cycle, re-target
-explicitly: `cargo release 0.7.0-rc.1`.
+   | Command | From | To | Ends up on |
+   | --- | --- | --- | --- |
+   | `cargo release patch` (also `minor`, `major`) | 0.6.3 | 0.6.4 | `@latest` |
+   | `cargo release rc` | 0.6.3 | 0.6.4-rc.1 | `@next` |
+   | `cargo release rc` | 0.6.4-rc.1 | 0.6.4-rc.2 | `@next` |
+   | `cargo release release` | 0.6.4-rc.2 | 0.6.4 | `@latest` |
+
+   `release` **only strips an existing prerelease**. Run from a final
+   version it has nothing to strip, so it changes no version and makes
+   no commit while still exiting 0 — which reads as success. To cut a
+   final directly, use `patch`, `minor`, or `major`.
+
+   The first `rc` fixes the target version and there is no combined
+   level-plus-prerelease flag, so if scope grows mid-cycle, re-target
+   explicitly: `cargo release 0.7.0-rc.1 --execute`.
+
+3. Open a PR for that one commit and merge it to `staging`. On the
+   merge, `release-tag.yml` notices that `[workspace.package] version`
+   changed across the pushed range, creates the annotated tag
+   `v0.6.4` at the merged commit, and starts `cli-npm.yml` — which
+   builds both platform binaries and publishes them.
+
+   It tags on a version *change* only. A missing `v<version>` is never
+   on its own a reason to tag, which is why staging can sit well past
+   0.6.3 with no `v0.6.3` and nothing fires.
+
+4. At a milestone, promote by fast-forwarding `stable` **to the release
+   commit itself**:
+
+   ```sh
+   git push origin v0.6.4:refs/heads/stable
+   ```
+
+   `stable` is always an ancestor of `staging`, so that is a
+   fast-forward. If it is rejected as non-fast-forward, something put a
+   commit on `stable` that is not on `staging` — sort that out rather
+   than forcing it.
+
+   `cli-npm-promote.yml` then re-points the `stable` dist-tag; it never
+   publishes. It requires `stable`'s HEAD to be exactly the commit
+   `v<version>` names and fails otherwise: fast-forwarding to some later
+   staging commit would leave `@stable` serving a tarball that does not
+   contain the code `stable` holds, while `cli.yml` builds the
+   `tonk-latest` GitHub release from stable's real HEAD.
+
+   Wait for the `CLI npm` run on the tag to finish before promoting.
+   Promote too early and it fails with
+   `@tonk/cli@<version> is not published; nothing to promote`, which
+   means "not yet" rather than a broken release. Re-run a promote with
+   `gh workflow run cli-npm-promote.yml --ref stable`.
 
 ### Dist-tags
 
@@ -57,16 +115,16 @@ explicitly: `cargo release 0.7.0-rc.1`.
 | --- | --- | --- |
 | `next` | prereleases from `staging` | `npx @tonk/cli@next` |
 | `latest` | finals from `staging` | `npx @tonk/cli` |
-| `stable` | the version `stable` holds | `npx @tonk/cli@stable` |
+| `stable` | the release commit `stable` holds | `npx @tonk/cli@stable` |
 
 `latest` tracks staging finals rather than `stable` on purpose. `stable`
 moves on milestones, so mapping `latest` onto it would make the default
 install progressively more stale.
 
 The workflow **refuses to publish if the tag disagrees with the Cargo
-workspace version**, and `cargo release` keeps them in step by
-construction. `cli-npm.yml` can also be run manually
-(`gh workflow run cli-npm.yml --ref staging`) to retry a failed publish
+workspace version**, and `release-tag.yml` derives the tag from that
+version, so they cannot diverge. `cli-npm.yml` can also be run manually
+(`gh workflow run cli-npm.yml --ref v0.6.4`) to retry a failed publish
 without cutting a new tag; it skips any version already on the registry.
 
 To verify locally without publishing, from `rust/tonk-cli/npm`:
@@ -76,11 +134,16 @@ To verify locally without publishing, from `rust/tonk-cli/npm`:
 nix build --accept-flake-config ../../..#tonk-cli
 install -Dm0755 ../../../result/bin/tonk darwin-arm64/bin/tonk
 npm pack ./darwin-arm64 ./cli            # produces .tgz tarballs
-# smoke-test the launcher against the packed tarballs:
-tmp=$(mktemp -d) && npm --prefix "$tmp" install ./tonk-cli-darwin-arm64-*.tgz ./tonk-cli-0.5.0.tgz
+# smoke-test the launcher against the packed tarballs. The glob avoids
+# hardcoding a version: the committed package.json versions are stale by
+# design (see below), so a literal filename here rots.
+tmp=$(mktemp -d) && npm --prefix "$tmp" install ./tonk-cli-darwin-arm64-*.tgz ./tonk-cli-[0-9]*.tgz
 "$tmp/node_modules/.bin/tonk" --help
 ```
 
-The npm package version tracks the Rust workspace version
-(`version.workspace` in the root `Cargo.toml`), so `tonk --version`
-matches the published `@tonk/cli` version. Bump both together.
+There is one version in this repo: `version.workspace` in the root
+`Cargo.toml`, which `cargo release` bumps. CI stamps it into all three
+`package.json`s at publish time, so `tonk --version` always matches the
+published `@tonk/cli` version. The versions committed in those
+`package.json`s are placeholders — nothing reads them, and hand-editing
+them to "keep up" is the manual step this process removed.

--- a/rust/tonk-cli/npm/README.md
+++ b/rust/tonk-cli/npm/README.md
@@ -28,20 +28,46 @@ Publishing runs in CI so every platform binary is built reproducibly —
 you cannot build the Linux binary from a Mac. It is **tag-driven**;
 nothing publishes on a normal push.
 
-1. One-time: add an `NPM_TOKEN` repository secret (an npm automation
-   token for the `@tonk` scope with publish rights).
-2. Bump the version (see below) and land it.
-3. Push a `v<version>` tag matching the Cargo workspace version, e.g.
-   `git tag v0.5.0 && git push origin v0.5.0`. That fires
-   `.github/workflows/cli-npm.yml`, which builds both binaries, stamps
-   the version across all three package.jsons, and publishes the
-   platform packages first, then the wrapper.
+1. One-time: add an `NPM_TOKEN` repository secret — an npm automation
+   token with read-write on the whole **`@tonk` scope**, not a package
+   subset, so platform packages added later keep working. A token
+   scoped too narrowly still passes `npm whoami` and then fails with a
+   bare `404 Not Found - PUT`, which reads like a missing package.
+2. From `staging`, cut the release. This is one command; it bumps the
+   workspace version, commits, tags, and pushes together:
 
-The tag is the source of the version, and the workflow **refuses to
-publish if it disagrees with the Cargo workspace version** — so the
-bump has to land before the tag. The dist-tag is derived, not chosen:
-a prerelease version (`0.5.1-rc.1`) publishes under `next`, anything
-else under `latest`.
+   ```sh
+   cargo release rc        # 0.6.3 -> 0.6.4-rc.1, publishes to @next
+   cargo release release   # 0.6.4-rc.2 -> 0.6.4, publishes to @latest
+   ```
+
+   Dry-run is the default — add `--execute` to act. Releases are
+   refused from any branch but `staging`.
+
+3. Promote by fast-forwarding `stable`. That re-points the `stable`
+   dist-tag; it does not publish again.
+
+The first `rc` fixes the target version, and there is no combined
+level-plus-prerelease flag, so if scope grows mid-cycle, re-target
+explicitly: `cargo release 0.7.0-rc.1`.
+
+### Dist-tags
+
+| Tag | Points at | Install |
+| --- | --- | --- |
+| `next` | prereleases from `staging` | `npx @tonk/cli@next` |
+| `latest` | finals from `staging` | `npx @tonk/cli` |
+| `stable` | the version `stable` holds | `npx @tonk/cli@stable` |
+
+`latest` tracks staging finals rather than `stable` on purpose. `stable`
+moves on milestones, so mapping `latest` onto it would make the default
+install progressively more stale.
+
+The workflow **refuses to publish if the tag disagrees with the Cargo
+workspace version**, and `cargo release` keeps them in step by
+construction. `cli-npm.yml` can also be run manually
+(`gh workflow run cli-npm.yml --ref staging`) to retry a failed publish
+without cutting a new tag; it skips any version already on the registry.
 
 To verify locally without publishing, from `rust/tonk-cli/npm`:
 

--- a/rust/tonk-cli/src/update/swap.rs
+++ b/rust/tonk-cli/src/update/swap.rs
@@ -23,10 +23,18 @@ pub enum ForeignInstall {
 
 impl ForeignInstall {
     /// The command that actually updates this kind of install.
+    ///
+    /// The npm remedy names no dist-tag by default and offers `@stable`
+    /// beside it, matching the root README: `@latest` now means staging
+    /// finals, so telling a `@stable`-pinned user to install it would
+    /// silently move them onto a faster channel.
     pub fn remedy(self) -> &'static str {
         match self {
             ForeignInstall::Nix => "update it through nix (e.g. `nix flake update`)",
-            ForeignInstall::Npm => "run `npm i -g @tonk/cli@latest`",
+            ForeignInstall::Npm => {
+                "reinstall it through npm (`npm i -g @tonk/cli`, or `@tonk/cli@stable` \
+                 to stay on the last milestone)"
+            }
         }
     }
 


### PR DESCRIPTION
## Why

The workspace version and the `v*` tag were produced by separate acts, so they drifted. `chore: release 0.6.1`, `0.6.2`, and `0.6.3` each landed *inside* an unrelated feature PR (#632, #647, #651) as ordinary commits, and no `v0.6.x` tag exists. There is no release moment in the current process, so nothing prompts anyone to tag.

Result: npm `@tonk/cli` latest is **0.4.0** against a **0.6.3** workspace, so `npx @tonk/cli` serves code two minors old.

## What

`cargo release <level>` becomes the single release act, and CI turns a merged bump into the tag that publishes it.

```
local:  cargo release <level> --execute --no-push --no-tag   (on a release/* branch)
          └> commit "chore: release 0.7.0"
        PR ──────> staging  (squash)
                     │
CI (release-tag.yml): workspace version changed across the pushed range
                      && v0.7.0 absent
          └> tag v0.7.0 at the merged SHA, then dispatch cli-npm.yml
```

CI owns the tag because a maintainer cannot. Two active rulesets cover `staging` and require a pull request with no bypass actor; merge commits are disabled, so a PR merge rewrites the SHA and a locally created tag could never point at a commit that lands. The rulesets cover branches, not tags.

### Dist-tags

| Tag | Points at |
| --- | --- |
| `next` | prereleases from `staging` |
| `latest` | finals from `staging` |
| `stable` | the release commit `stable` sits on |

`latest` tracks staging finals rather than `stable` deliberately: `stable` moves on milestones, so mapping `latest` onto it would make the default install progressively staler — which is the situation today.

`@stable` is a dist-tag move, not a publish. `cli-npm-promote.yml` requires `v$version` to resolve to exactly the pushed SHA, so `npx @tonk/cli@stable` and `install.sh` cannot ship different binaries.

## Notable decisions

- **The tag predicate is a version *change* across the pushed range, never the absence of a tag.** With the workspace at 0.6.3 and no `v0.6.3` tag, tagging on absence would ship an arbitrary staging HEAD — 21 commits past the last release — as a release. That is the exact defect this PR removes.
- **A tag pushed with `GITHUB_TOKEN` triggers no workflow.** GitHub suppresses events raised by the built-in token, so `release-tag.yml` pushes the tag and then explicitly dispatches `cli-npm.yml` against the tag ref; `workflow_dispatch` is one of the two events exempt from that suppression. `cli-npm.yml` is invoked, not modified, and its dispatch path resolves the version from the tagged ref's own `Cargo.toml` and hard-fails on a mismatch.
- **`cargo release release` only strips an existing prerelease.** Run from a final it writes no commit and still tags. The README documents `patch|minor|major` for cutting a final directly.
- Each `release.toml` setting overrides a default that misfires on 34 crates sharing one version: without them a release is 34 commits, 34 tags named `tonk-cli-v*`, and 34 attempted crates.io publishes.

## Verification

- 289/289 `tonk-cli` tests pass (1 skipped).
- `cargo clippy --workspace --all-targets --all-features` exit 0; `cargo fmt --all --check` clean.
- `actionlint` exit 0 on all three workflows; `cli-npm.yml` byte-identical to `staging`.
- `cargo release config` confirms `push = false`, `tag = false`, `allow-branch = ["staging", "release/*"]`.
- `cargo release patch` dry run bumps to 0.6.4 with no tag and no push; `release` from 0.6.3 confirmed a silent no-op.
- The tag predicate was simulated over real staging commits where the version differs and where it does not, plus the all-zeroes, unreachable-`before`, and tag-already-exists paths.
- Flake still evaluates after moving `cargo-release` to `devShellBuildInputs` — it was in `commonBuildInputs`, which feeds all 34 crate derivations and would have forced a cold cachix rebuild.

`nix flake check` was not run: nix builds on this machine hit an unrelated macOS 27 libffi break, so a failure there would not be attributable to this branch.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restructuring the release process for the `tonk` CLI tool by integrating `cargo-release` and enhancing the CI workflows to ensure proper tagging and promotion without manual errors.

### Detailed summary
- Added `pkgs.cargo-release` to `devShellBuildInputs` in `flake.nix`.
- Updated README instructions for installation and usage.
- Revised the `remedy` string in `rust/tonk-cli/src/update/swap.rs`.
- Created `.github/workflows/release-tag.yml` for automated tagging.
- Created `.github/workflows/cli-npm-promote.yml` for npm dist-tag promotion.
- Configured `release.toml` to manage versioning and tagging settings.
- Enhanced documentation for the release process in multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->