### PR TITLE
fix(deploy): point staging at the recreated accounts d1

### DIFF
--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -34,7 +34,7 @@ routes = [{ pattern = "accounts-staging.tonk.xyz", custom_domain = true }]
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "tonk-accounts-staging"
-database_id = "d82a5715-d210-4bca-bd9d-4ab64e909566"
+database_id = "e1f11539-c01c-4c48-a27b-988609ad3fe1"
 migrations_dir = "rust/tonk-account-service/migrations"
 
 [[env.staging.r2_buckets]]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,7 +40,7 @@ bucket_name = "tonk-spaces-staging"
 [[env.staging.d1_databases]]
 binding = "ACCOUNTS_DB"
 database_name = "tonk-accounts-staging"
-database_id = "d82a5715-d210-4bca-bd9d-4ab64e909566"
+database_id = "e1f11539-c01c-4c48-a27b-988609ad3fe1"
 
 [env.staging.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"


### PR DESCRIPTION
## Why

Every staging deploy has been failing:

```
D1 binding 'ACCOUNTS_DB' references database
'd82a5715-d210-4bca-bd9d-4ab64e909566' which was not found. [code: 10181]
```

`tonk-accounts-staging` was deleted and recreated on 2026-07-28 21:04Z, which gave it a new uuid. Both wrangler configs still pinned the old one. No commit changed the binding; the database changed underneath it.

| | uuid |
| --- | --- |
| pinned in both configs | `d82a5715-…` (gone) |
| actually exists | `e1f11539-c01c-4c48-a27b-988609ad3fe1` |

## What

Point both at the live database. One id, two files: `wrangler.toml` holds the access service's read-only `ACCOUNTS_DB` view of the registry that `wrangler.account.toml`'s `DB` binding owns and migrates. Each pins the id independently and nothing checks they agree — which is why this could rot silently.

## Verification

- `wrangler d1 info tonk-accounts-staging` resolves through both configs (it errored `code: 7404` through either one before).
- The database is live and needs no re-migration: 15 accounts, 32 devices, 4 link requests; 1,232 reads and 109 writes in the last 24h.

## Unrelated, but found on the way and worth a separate look

The recreated staging database has five migrations applied where `staging` has two. The extra three come from unmerged branches, including two different `0003`s:

| Migration | Branch | Applied |
| --- | --- | --- |
| `0003_account_repository_descriptor.sql` | `feat/root-owned-account-state` | Jul 29 14:18 |
| `0004_normalize_devices.sql` | `feat/root-owned-account-state` | Jul 29 14:51 |
| `0003_device_delegation_path.sql` | `feat/in-band-revocation` (#653) | Jul 29 21:07 |

All three are harmless to the code on `staging` today. The duplicate numbering is not harmless to production: `0004_normalize_devices.sql` rebuilds `devices` with an explicit column list that omits `delegation_hex`, the column `0003_device_delegation_path.sql` adds. Staging survived only because it applied them chronologically, with `0003_device_delegation_path` last. A fresh database applies in name order — `0003_device_delegation_path` then `0004_normalize_devices` — and silently drops the column, losing every device's delegation bytes. Production has neither migration yet, so it takes exactly that path once both branches land.

Renumbering alone does not fix it: `0004`'s `INSERT ... SELECT` has to carry `delegation_hex`, or be ordered above the migration that adds it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `database_id` for the `tonk-accounts-staging` configuration in both the `wrangler.toml` and `wrangler.account.toml` files, ensuring that the correct database identifier is used for the environment.

### Detailed summary
- Updated `database_id` in `wrangler.toml` from `d82a5715-d210-4bca-bd9d-4ab64e909566` to `e1f11539-c01c-4c48-a27b-988609ad3fe1`
- Updated `database_id` in `wrangler.account.toml` from `d82a5715-d210-4bca-bd9d-4ab64e909566` to `e1f11539-c01c-4c48-a27b-988609ad3fe1`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->