### PR TITLE
ci(preview): deploy every service a pull request needs to test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [stable, staging]
 
+# Every job here mutates shared Cloudflare state, and two runs of one pull
+# request would race for the same `--preview-alias`. Superseding the in-flight
+# run is the wanted outcome: the newer commit is the one worth previewing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -33,15 +40,69 @@ jobs:
         run: |
           nix build --accept-flake-config .#tonk-cloudflare-artifacts
 
-      - name: Deploy preview
+      # A pull request gets the whole deployment, not just the access worker.
+      # The browser reads its account provider from the access worker's
+      # `/.well-known/tonk`, so previewing one against the released other tests
+      # a pairing that does not exist anywhere. Both go to the disposable
+      # `preview` environment, account worker first, because the access worker
+      # has to be told where that one landed.
+      - name: Apply preview account migrations
+        if: github.event_name == 'pull_request'
+        run: |
+          nix --accept-flake-config develop .#ci --command \
+            wrangler d1 migrations apply tonk-accounts-preview \
+              --remote --env preview -c wrangler.account.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy account preview
+        if: github.event_name == 'pull_request'
+        id: account-preview
+        run: |
+          set -o pipefail
+          preview_alias="pr-${{ github.event.pull_request.number }}"
+          log="$RUNNER_TEMP/account-preview.log"
+          nix --accept-flake-config develop .#ci --command \
+            wrangler versions upload --env preview -c wrangler.account.toml \
+              --preview-alias "$preview_alias" 2>&1 | tee "$log"
+          url="$(grep -Eo "https://$preview_alias-tonk-account-service-preview\.[a-z0-9-]+\.workers\.dev" "$log" | head -n 1 || true)"
+          if [ -z "$url" ]; then
+            echo "::error::wrangler printed no preview alias URL for the account worker; refusing to point the access preview at an unknown registry"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      # The two service URLs are the only configuration that cannot be checked
+      # in, because an alias URL exists only once its upload returns. Command
+      # line vars merge over the environment's, so the rest of `[env.preview]`
+      # still applies.
+      - name: Deploy access preview
         if: github.event_name == 'pull_request'
         id: deploy-preview
-        working-directory: rust/tonk-access-service
         run: |
+          set -o pipefail
+          preview_alias="pr-${{ github.event.pull_request.number }}"
+          account="${{ steps.account-preview.outputs.url }}"
+          log="$RUNNER_TEMP/access-preview.log"
+          nix --accept-flake-config develop .#ci --command \
+            wrangler versions upload --env preview -c wrangler.toml \
+              --preview-alias "$preview_alias" \
+              --var "ACCOUNT_SERVICE_URL:$account" \
+              --var "REVOCATION_RELAY_URL:$account/revocations" 2>&1 | tee "$log"
+          url="$(grep -Eo "https://$preview_alias-tonk-access-service-preview\.[a-z0-9-]+\.workers\.dev" "$log" | head -n 1 || true)"
+          if [ -z "$url" ]; then
+            echo "::error::wrangler printed no preview alias URL for the access worker"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
           {
-            echo 'command-output<<EOF'
-            nix --accept-flake-config develop .#ci --command wrangler versions upload --preview-alias pr-${{ github.event.pull_request.number }}
-            echo EOF
+            echo 'command-output<<WRANGLER_OUTPUT_EOF'
+            cat "$RUNNER_TEMP/account-preview.log" "$log"
+            echo WRANGLER_OUTPUT_EOF
           } >> "$GITHUB_OUTPUT"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -49,16 +110,14 @@ jobs:
 
       - name: Deploy staging
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
-        working-directory: rust/tonk-access-service
-        run: nix --accept-flake-config develop --command wrangler deploy --env staging
+        run: nix --accept-flake-config develop --command wrangler deploy --env staging -c wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy production
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
-        working-directory: rust/tonk-access-service
-        run: nix --accept-flake-config develop --command wrangler deploy
+        run: nix --accept-flake-config develop --command wrangler deploy -c wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -67,7 +126,30 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           message: |
-            Wrangler output for this change:
-            
+            Preview deployment for this change:
+
+            | Service | URL |
+            | --- | --- |
+            | App (`tonk-ui` + access worker) | ${{ steps.deploy-preview.outputs.url }} |
+            | Account registry | ${{ steps.account-preview.outputs.url }} |
+
+            The app serves that registry from its own `/.well-known/tonk`, so
+            browser ceremonies find it with no client configuration. The CLI
+            has to be told:
+
+            ```
+            tonk account link \
+              --service-url ${{ steps.account-preview.outputs.url }} \
+              --account-url ${{ steps.deploy-preview.outputs.url }}/account/link
+            ```
+
+            Passkeys minted here belong to the preview host and to nothing
+            else, so they are disposable and cannot reach a real account.
+
+            <details><summary>Wrangler output</summary>
+
+            ```
             ${{ steps.deploy-preview.outputs.command-output }}
-            
+            ```
+
+            </details>

--- a/rust/tonk-access-service/README.md
+++ b/rust/tonk-access-service/README.md
@@ -78,6 +78,10 @@ The S3 address uses region `auto`, as R2 requires.
 
 As a Cloudflare Worker, build and deploy with `worker-build` / `wrangler` like any `worker`-based crate (the `cdylib` target).
 
+`wrangler.toml` at the repo root carries three environments. The top level is production on `hub.tonk.xyz`, `[env.staging]` is `staging.tonk.xyz`, and `[env.preview]` is on no route: the deploy workflow uploads one version of it per pull request under a `pr-<number>` preview alias, reached at a workers.dev URL. Each has its own R2 buckets, because this Worker presigns writes into whichever bucket it is bound to and a preview must not be able to write into a real one.
+
+`ACCOUNT_SERVICE_URL` and `REVOCATION_RELAY_URL` are checked in for production and staging but overridden per pull request for preview, since the account worker's own alias URL is not known until its upload returns. The checked-in preview values point at an unresolvable host on purpose: a preview that failed to wire itself has to break rather than serve a real registry through `/.well-known/tonk` to browsers that trust it. Bootstrapping the preview environment is described in `tonk-account-service`'s README.
+
 For local development and integration tests, the `helpers` feature builds a native HTTP server that mirrors the Worker behavior without deploying to Cloudflare. The `tonk-access-local` binary (`src/bin/local.rs`, requires `--features helpers`) starts that server against a local backing S3 and prints its URL:
 
 ```sh

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -180,6 +180,58 @@ tonk account link \
   --account-url https://staging.tonk.xyz/account/link
 ```
 
+### Preview
+
+Preview is a third wrangler environment, on no route at all: `.github/workflows/publish.yml`
+uploads one version of it per pull request under a `pr-<number>` preview alias
+and reads back the workers.dev URL that alias resolves to. The access worker's
+`ACCOUNT_SERVICE_URL` is then overridden with that URL, so a pull request's
+browser reaches the same pull request's registry rather than a released one.
+
+The environment exists so continuous integration can apply an unreviewed
+migration to a real D1 database. That is exactly what must never happen to
+staging, and it is why preview holds its own database and buckets rather than
+borrowing staging's. Resetting or recreating any of them is safe, and is the
+right first move whenever two open pull requests have left the schema in a
+state neither of them expects.
+
+Bootstrap covers both workers, because a preview is only testable as a pair.
+Do it once, in order; after this, pull requests need no manual step.
+
+State:
+
+1. `wrangler d1 create tonk-accounts-preview` and paste the returned id into
+   `database_id` under `[[env.preview.d1_databases]]`.
+2. `wrangler r2 bucket create tonk-account-chains-preview`.
+3. `wrangler r2 bucket create tonk-revocations-preview`. Both workers bind this
+   one: this service publishes revocation artifacts into it and the access
+   service reads them back, so a preview that split them would enforce nothing.
+4. `wrangler r2 bucket create tonk-spaces-preview`, bound by the access service
+   as `BUCKET`.
+
+Secrets, which are per-environment and so have to be set explicitly:
+
+5. `wrangler secret put RESEND_API_KEY -c wrangler.account.toml --env preview`.
+   Preview sends from the same verified domain as staging and production, so it
+   inherits the same email fan-out exposure and wants the matching rate limiting
+   rule.
+6. `wrangler secret put R2_ACCESS_KEY_ID -c wrangler.toml --env preview` and
+   `wrangler secret put R2_SECRET_ACCESS_KEY -c wrangler.toml --env preview`,
+   from an R2 API token granting object read and write on `tonk-spaces-preview`.
+   That is the only bucket these credentials presign; `BUCKET` and `REVOCATIONS`
+   are native bindings and need none.
+
+Workers. `wrangler versions upload` versions an existing Worker and fails when
+there is none, so each needs one deploy by hand before the workflow has anything
+to attach its uploads to:
+
+7. `wrangler deploy -c wrangler.account.toml --env preview`.
+8. `wrangler deploy -c wrangler.toml --env preview`.
+
+The API token the workflow authenticates with needs D1 edit permission, not just
+Workers deployment. Without it the run fails at the migration step, before
+either upload.
+
 ## Abuse controls
 
 Application-level throttles live in `src/core/codes.rs`: per-email 60 s
@@ -212,6 +264,10 @@ Migrations must be applied to both environments (wrangler reads
 wrangler d1 migrations list tonk-accounts --remote -c wrangler.account.toml
 wrangler d1 migrations list tonk-accounts-staging --remote -c wrangler.account.toml --env staging
 ```
+
+Preview is not on this list: its migrations are applied by the deploy workflow
+on every pull request, so its schema is whatever the branch under review says it
+is, and drift there is the expected state rather than a fault.
 
 Both must show `0001_init.sql`, `0002_link_requests.sql`, and
 `0003_device_delegation_path.sql` as applied; apply any pending ones with the

--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -51,3 +51,38 @@ bucket_name = "tonk-revocations-staging"
 
 [env.staging.vars]
 EMAIL_FROM = "tonk <accounts@tonk.xyz>"
+
+# Preview. Disjoint from staging for the same reason staging is disjoint from
+# production, and more urgently: continuous integration applies each pull
+# request's migrations to this database before uploading that request's worker,
+# so the schema here tracks whatever is under review rather than what is
+# released. Resetting it costs nothing, which is the point.
+#
+# `routes = []` prevents the named environment from inheriting the top-level
+# `accounts.tonk.xyz` custom domain; each pull request is reached at its own
+# `--preview-alias` workers.dev URL instead.
+[env.preview]
+workers_dev = true
+routes = []
+
+# Ships empty: the id is minted by `wrangler d1 create` on whichever account
+# hosts this, and is filled in once at bootstrap. Blank is the safe default,
+# because the preview job applies migrations before it uploads anything — a
+# forgotten bootstrap fails there, rather than anywhere near a database that
+# holds real accounts.
+[[env.preview.d1_databases]]
+binding = "DB"
+database_name = "tonk-accounts-preview"
+database_id = "323cb440-c356-4d1d-b238-2ffd11abedcc"
+migrations_dir = "rust/tonk-account-service/migrations"
+
+[[env.preview.r2_buckets]]
+binding = "CHAINS"
+bucket_name = "tonk-account-chains-preview"
+
+[[env.preview.r2_buckets]]
+binding = "REVOCATIONS"
+bucket_name = "tonk-revocations-preview"
+
+[env.preview.vars]
+EMAIL_FROM = "tonk <accounts@tonk.xyz>"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -46,3 +46,36 @@ R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
 R2_BUCKET_NAME = "tonk-spaces-staging"
 ACCOUNT_SERVICE_URL = "https://accounts-staging.tonk.xyz"
 REVOCATION_RELAY_URL = "https://accounts-staging.tonk.xyz/revocations"
+
+# Preview. Every pull request uploads a version of this environment under a
+# `--preview-alias` and is reached at its own workers.dev URL, so the
+# environment holds no route of its own. `routes = []` is load-bearing: a named
+# environment inherits the top-level `routes`, and deploying it with that
+# inherited entry would reassign the `hub.tonk.xyz` custom domain away from
+# production.
+#
+# Its state is disjoint from staging as well as production. A pull request
+# applies its own account-service migrations and writes real objects through
+# this worker's presigned URLs, and neither of those belongs in an environment
+# someone else is testing against.
+[env.preview]
+workers_dev = true
+routes = []
+
+[[env.preview.r2_buckets]]
+binding = "BUCKET"
+bucket_name = "tonk-spaces-preview"
+
+[[env.preview.r2_buckets]]
+binding = "REVOCATIONS"
+bucket_name = "tonk-revocations-preview"
+
+[env.preview.vars]
+R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
+R2_BUCKET_NAME = "tonk-spaces-preview"
+# Replaced per pull request with the account worker's own preview alias, which
+# is only known once that upload returns. The checked-in values are deliberately
+# unresolvable: a preview that failed to wire itself has to break visibly rather
+# than quietly serve a real registry to browsers that trust `/.well-known/tonk`.
+ACCOUNT_SERVICE_URL = "https://accounts-preview.invalid"
+REVOCATION_RELAY_URL = "https://accounts-preview.invalid/revocations"


### PR DESCRIPTION
## Summary

- give pull requests a `preview` environment holding its own D1 database and R2 buckets, so continuous integration can apply an unreviewed migration without touching anything anyone else is testing against
- deploy the account worker alongside the access worker, applying the branch's migrations first and wiring the access worker's `ACCOUNT_SERVICE_URL` to the alias URL the account upload returns
- fail the run when wrangler prints no alias URL, rather than letting a preview fall through to a checked-in registry
- comment both URLs on the pull request, with the CLI invocation that reaches them

## The bug this fixes

The preview job ran one `wrangler versions upload` with no `--env`. That resolves the **top-level** config, so every preview so far bound the production `tonk-spaces` bucket and served `https://accounts.tonk.xyz` through `/.well-known/tonk`. Browsers testing a pull request were talking to the real account registry, and no version of the account worker under review was ever reachable — which is why #652 cannot be tested end to end today: its flows need migrations that only exist on its branch.

## Why a separate environment

Staging would have needed no provisioning, but the migration step is the whole point and it would have applied each pull request's schema to the database staging serves from. `tonk-account-service`'s README already says results from a mixed-version staging are not end-to-end evidence. Per-PR ephemeral databases were the other option; they isolate concurrent pull requests properly but need generated configs and a cleanup path that leaks databases when it fails. Preview state is shared and disposable instead: resetting it costs nothing and is the documented first move when two open pull requests leave the schema confused.

`routes = []` is load-bearing in both configs. A named environment inherits the top-level `routes`, and wrangler warns that deploying it that way "will reassign these custom domains away from the top-level Worker" — without it, a preview deploy would take over `hub.tonk.xyz` and `accounts.tonk.xyz`.

Passkeys need no special handling: `apex_rp_id` returns `None` off `tonk.spot`, so each preview host is its own relying party with disposable credentials that cannot reach a real account.

## Testing

- `actionlint` (with its shellcheck pass over the `run:` scripts) is clean
- `wrangler versions upload --dry-run` resolves the expected bindings for all six environment/config pairs: production, staging, and preview across both configs, with no route-inheritance warning
- verified against wrangler 4.110.0 rather than assumed: `--var` splits on the first colon only, so a URL survives intact and lands as `plain_text`; `[assets]` inherits into a named environment; `d1 migrations apply` skips its confirmation prompt in a non-interactive shell

The preview job itself cannot run until this merges, since a `pull_request` workflow is taken from the merge ref.

## Deploy prerequisites

The D1 database and all three preview buckets already exist. Still outstanding before the job can pass:

1. `wrangler secret put RESEND_API_KEY -c wrangler.account.toml --env preview`
2. `wrangler secret put R2_ACCESS_KEY_ID -c wrangler.toml --env preview` and `wrangler secret put R2_SECRET_ACCESS_KEY -c wrangler.toml --env preview`
3. one `wrangler deploy --env preview` per config, since `versions upload` versions an existing Worker and fails when there is none
4. `CLOUDFLARE_API_TOKEN` needs D1 edit permission, not just Workers deployment

Full list in `rust/tonk-account-service/README.md` under *Preview*.

Staging and production account-service deploys stay manual, exactly as documented. Automating those means auto-migrating the production database from CI, which is a separate decision.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `preview` environment for the Cloudflare Worker deployment process, enabling continuous integration to apply unreviewed migrations safely. It ensures that pull requests can be tested without affecting production or staging environments.

### Detailed summary
- Added a `preview` environment in `wrangler.toml` and `wrangler.account.toml`.
- Configured separate R2 buckets and D1 database for `preview`.
- Updated deployment workflow to handle migrations and URLs for `preview`.
- Documented the setup process for `preview` in `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->