### PR TITLE
fix: repair a spot whose remote carries no revocation relay

### DIFF
--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -189,9 +189,14 @@ pub fn fab_html(space_did: &str) -> String {
   </form>
   <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Cancel</wa-button>
 </wa-dialog>
+<!-- One prompt, two repairs. Both end in the same `tonk:enable-sync` claim,
+     so they share a dialog — but every line of it is rewritten per refusal
+     (see `share.rs::Repair`), because a spot missing only its revocation
+     relay is already synced and "turn on sync" would be a lie. The markup
+     here is just the `not-synced` wording, which is also the default. -->
 <wa-dialog id="fab-enable-sync" label="Turn on sync?" class="fab__dialog" style="--width: 28rem">
   <p class="fab__prompt" data-enable-sync-detail>This spot only exists on this device.</p>
-  <p class="fab__prompt">Turn on sync so the people you share with can open it.</p>
+  <p class="fab__prompt" data-enable-sync-action>Turn on sync so the people you share with can open it.</p>
   <wa-button slot="footer" variant="primary" data-enable-sync-confirm>Turn on sync &amp; copy link</wa-button>
   <wa-button slot="footer" variant="neutral" appearance="plain" data-dialog="close">Not now</wa-button>
 </wa-dialog>
@@ -366,5 +371,9 @@ mod tests {
         assert!(html.contains("data-enable-sync-confirm"));
         assert!(html.contains("Turn on sync &amp; copy link"));
         assert!(html.contains("Not now"));
+        // The line `share.rs` rewrites per refusal class. Without the hook it
+        // is silently stuck on the `not-synced` wording, which is a lie for
+        // every other class the prompt serves.
+        assert!(html.contains("data-enable-sync-action"));
     }
 }

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -50,12 +50,19 @@
 //! subscription because a single predicate over both would resolve only when a
 //! refusal AND a link are present, which never happens.
 //!
-//! A refusal the prompt can repair (`not-synced`) abandons the clipboard write
-//! and opens the enable-sync dialog. Confirming it is a FRESH user activation,
-//! so a new clipboard write opens there and the attach-then-mint the worker
-//! runs settles it — one click, from refusal to link on the clipboard.
+//! A refusal the prompt can repair abandons the clipboard write and opens the
+//! enable-sync dialog. Confirming it is a FRESH user activation, so a new
+//! clipboard write opens there and the attach-then-mint the worker runs
+//! settles it — one click, from refusal to link on the clipboard.
 //!
-//! The other two classes (`unshareable-remote`, and `attach-failed` — an
+//! Two classes are repairable, and they share the claim but not the wording
+//! (see [`Repair`]). `not-synced` attaches a remote. `missing-revocation-relay`
+//! means the spot syncs fine but its remote carries no relay, so an invite
+//! could never be withdrawn — every spot whose remote predates in-band
+//! revocation is in that state; confirming upserts the relay onto the remote
+//! already there, leaving its address and its branch upstream untouched.
+//!
+//! The remaining classes (`unshareable-remote`, and `attach-failed` — an
 //! attach the user already approved that failed anyway) have no action the
 //! dialog could offer, but `detail` still has to reach the user: the button's
 //! "failed" label is a static string. `handle_blocked` re-opens the same
@@ -161,18 +168,75 @@ const BLOCKED_NEEDS_MEMBERSHIP: &str = tonk_worker_api::share::BLOCKED_NEEDS_MEM
 /// scaffolding can tell the two subscriptions' frames apart.
 const BLOCKED_TAG: &str = "tonk-share-blocked";
 
-/// The enable-sync prompt's id, and the attribute marking its confirm button
-/// and its reason slot. Authored in `markup.rs`; every lookup here is
-/// `Option`-guarded, so the element still shares (and still refuses) in a host
-/// that renders no dialog at all.
+/// The refusal class the same prompt repairs by attaching a relay rather than
+/// a remote: the spot syncs, but its remote carries no revocation relay, so a
+/// minted invite could never be withdrawn.
+const BLOCKED_MISSING_REVOCATION_RELAY: &str =
+    tonk_worker_api::share::BLOCKED_MISSING_REVOCATION_RELAY;
+
+/// The enable-sync prompt's id, and the attributes marking its confirm button,
+/// its reason slot, and the line describing what confirming does. Authored in
+/// `markup.rs`; every lookup here is `Option`-guarded, so the element still
+/// shares (and still refuses) in a host that renders no dialog at all.
 ///
 /// The dialog is not only for `not-synced`: [`handle_blocked`] re-opens it on
 /// every refusal so `detail` always lands somewhere visible, disabling the
-/// confirm button (see `open_enable_sync_dialog`) on the two classes it
-/// cannot repair.
+/// confirm button (see `open_enable_sync_dialog`) on the one class it cannot
+/// repair.
 const DIALOG_ID: &str = "fab-enable-sync";
 const DIALOG_CONFIRM: &str = "[data-enable-sync-confirm]";
 const DIALOG_DETAIL: &str = "[data-enable-sync-detail]";
+const DIALOG_ACTION: &str = "[data-enable-sync-action]";
+
+/// Heading and confirm label for a refusal with no repair. The button stays
+/// visible but disabled, so it needs wording that doesn't promise an action —
+/// "Turn on sync & copy link" greyed out reads as a broken control rather than
+/// an answer.
+const TERMINAL_LABEL: &str = "Can't share this spot";
+const TERMINAL_CONFIRM: &str = "Copy link";
+
+/// What confirming the prompt is offering to do, for one refusal class.
+///
+/// The prompt serves two repairs that share a claim but not a sentence, plus
+/// a terminal class it only reports. Holding the whole wording per class —
+/// rather than swapping `detail` alone, as it used to — is what keeps a
+/// synced spot from being told to turn on sync: before this, EVERY refusal
+/// re-used the `not-synced` copy, so a missing relay showed a greyed-out
+/// "Turn on sync & copy link" under a sentence about a device-only spot.
+///
+/// `None` from [`Repair::for_code`] is the terminal case: report `detail`,
+/// no action line, confirm disabled.
+struct Repair {
+    /// The dialog's `label` attribute — its heading.
+    label: &'static str,
+    /// The line under `detail` saying what confirming does.
+    action: &'static str,
+    /// The confirm button's text.
+    confirm: &'static str,
+}
+
+impl Repair {
+    /// The repair for a refusal class, or `None` when there is none to offer.
+    fn for_code(code: &str) -> Option<Self> {
+        match code {
+            BLOCKED_NOT_SYNCED => Some(Self {
+                label: "Turn on sync?",
+                action: "Turn on sync so the people you share with can open it.",
+                confirm: "Turn on sync & copy link",
+            }),
+            // The spot already syncs — this repair upserts the relay onto the
+            // remote that is there. Every spot whose remote predates in-band
+            // revocation lands here, so the wording explains a gap the user
+            // never chose rather than asking them to configure anything.
+            BLOCKED_MISSING_REVOCATION_RELAY => Some(Self {
+                label: "Finish setting up sharing?",
+                action: "Add a revocation relay so you can take access back later.",
+                confirm: "Add relay & copy link",
+            }),
+            _ => None,
+        }
+    }
+}
 
 /// The join prompt, shown for [`BLOCKED_NEEDS_MEMBERSHIP`]. Its own dialog
 /// rather than the sync one with substituted copy: the two refusals have
@@ -861,7 +925,7 @@ fn handle_blocked(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, block
         return;
     }
 
-    if blocked.code != BLOCKED_NOT_SYNCED {
+    let Some(repair) = Repair::for_code(&blocked.code) else {
         // Nothing the prompt could fix — including an attach that failed after
         // the user already accepted it. Say so rather than leaving the button
         // spinning until the timeout. Through `fail_copy`, not bare `settle`,
@@ -874,16 +938,16 @@ fn handle_blocked(host: &HtmlElement, state: &Rc<RefCell<ShareStateCell>>, block
         // user just approved already failed), so the confirm button is
         // disabled rather than absent — visible, but not a second attempt at
         // something that cannot help.
-        open_enable_sync_dialog(&blocked.detail, false);
+        open_enable_sync_dialog(&blocked.detail, None);
         return;
-    }
+    };
 
     // Repairable: abandon the copy and ask. `settle` would stamp `Failed` and
     // arm the revert timer, which is wrong while a question is on screen — the
     // control would quietly flip back to "share" underneath the dialog.
     abandon(state, &blocked.detail);
     set_state(host, ShareState::Blocked);
-    open_enable_sync_dialog(&blocked.detail, true);
+    open_enable_sync_dialog(&blocked.detail, Some(repair));
 }
 
 /// Drop a pending clipboard write without moving the control's state. The
@@ -902,27 +966,45 @@ fn abandon(state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
 /// dialog is absent, so the element still works in a host that does not
 /// render it.
 ///
-/// `offer_confirm` distinguishes the one refusal the dialog can act on
-/// (`not-synced`) from the two it can only report (`unshareable-remote`,
-/// `attach-failed`): `false` disables the confirm button — there is no
-/// attach to retry — while leaving the dialog open so `detail` stays
-/// visible. The button is reused across refusals rather than replaced, so a
-/// later repairable refusal must re-enable it: `true` clears both attributes
-/// back off.
-fn open_enable_sync_dialog(detail: &str, offer_confirm: bool) {
+/// `repair` is the refusal's offer, or `None` for a class the dialog can only
+/// report (`unshareable-remote`, `attach-failed`): that disables the confirm
+/// button — there is no attach to retry — while leaving the dialog open so
+/// `detail` stays visible, and blanks the action line, which would otherwise
+/// promise something the greyed-out button cannot do.
+///
+/// Every slot is written on every open, never left at its markup default: the
+/// dialog is one element reused across refusal classes, so anything not
+/// rewritten here is the *previous* refusal's wording. That is the bug this
+/// signature exists to make hard — a repairable refusal must also restore
+/// what a terminal one disabled.
+fn open_enable_sync_dialog(detail: &str, repair: Option<Repair>) {
     let Some(dialog) = enable_sync_dialog() else {
         return;
     };
     if let Ok(Some(slot)) = dialog.query_selector(DIALOG_DETAIL) {
         slot.set_text_content(Some(detail));
     }
+    // The terminal wording, used wherever `repair` is `None`.
+    let label = repair
+        .as_ref()
+        .map_or(TERMINAL_LABEL, |repair| repair.label);
+    let action = repair.as_ref().map_or("", |repair| repair.action);
+    let confirm_label = repair
+        .as_ref()
+        .map_or(TERMINAL_CONFIRM, |repair| repair.confirm);
+
+    if let Ok(Some(slot)) = dialog.query_selector(DIALOG_ACTION) {
+        slot.set_text_content(Some(action));
+    }
+    let _ = dialog.set_attribute("label", label);
     if let Ok(Some(confirm)) = dialog.query_selector(DIALOG_CONFIRM) {
+        confirm.set_text_content(Some(confirm_label));
         // Visible either way — an unrepairable refusal greys the button rather
         // than removing it, so the dialog reads as an answer and not as a form
         // with a button missing. `disabled` is the whole mechanism: the click
         // handler checks it explicitly, since nothing native backs the
         // attribute on a custom-element button.
-        if offer_confirm {
+        if repair.is_some() {
             let _ = confirm.remove_attribute("disabled");
         } else {
             let _ = confirm.set_attribute("disabled", "");
@@ -1181,10 +1263,13 @@ mod tests {
     }
 
     /// A stand-in for `markup.rs`'s `#fab-enable-sync` dialog: just enough
-    /// structure (the id, the detail slot, the confirm button) for
-    /// `open_enable_sync_dialog`'s lookups to find something. Attached to
-    /// `document.body` — `enable_sync_dialog` reads through
+    /// structure (the id, the detail slot, the action line, the confirm
+    /// button) for `open_enable_sync_dialog`'s lookups to find something.
+    /// Attached to `document.body` — `enable_sync_dialog` reads through
     /// `document.get_element_by_id`, not a passed-in root.
+    ///
+    /// The action line is not returned: only the tests about per-refusal
+    /// wording read it, and they do so through [`action_text`].
     fn dialog_stub() -> (Element, Element, Element) {
         let document = window().expect("window").document().expect("document");
         let dialog = document.create_element("div").expect("create dialog");
@@ -1193,11 +1278,16 @@ mod tests {
         detail
             .set_attribute("data-enable-sync-detail", "")
             .expect("mark detail");
+        let action = document.create_element("p").expect("create action");
+        action
+            .set_attribute("data-enable-sync-action", "")
+            .expect("mark action");
         let confirm = document.create_element("button").expect("create confirm");
         confirm
             .set_attribute("data-enable-sync-confirm", "")
             .expect("mark confirm");
         dialog.append_child(&detail).expect("attach detail");
+        dialog.append_child(&action).expect("attach action");
         dialog.append_child(&confirm).expect("attach confirm");
         document
             .body()
@@ -1205,6 +1295,16 @@ mod tests {
             .append_child(&dialog)
             .expect("attach dialog");
         (dialog, detail, confirm)
+    }
+
+    /// The prompt's action line — what confirming is being offered as.
+    fn action_text(dialog: &Element) -> String {
+        dialog
+            .query_selector(DIALOG_ACTION)
+            .expect("query action")
+            .expect("action slot")
+            .text_content()
+            .unwrap_or_default()
     }
 
     #[wasm_bindgen_test]
@@ -1491,7 +1591,7 @@ mod tests {
     fn it_keeps_an_unrepairable_refusals_confirm_visible_and_inert() {
         let bar = mounted_bar();
 
-        open_enable_sync_dialog("This spot's sync server can't be shared.", false);
+        open_enable_sync_dialog("This spot's sync server can't be shared.", None);
 
         let confirm = window()
             .and_then(|w| w.document())
@@ -1742,6 +1842,117 @@ mod tests {
         );
 
         dialog.remove();
+    }
+
+    /// A spot whose remote carries no revocation relay is repairable, not
+    /// terminal: it syncs, so the mint is refused only because the invite
+    /// could never be withdrawn, and confirming upserts the relay.
+    ///
+    /// The regression this pins: every spot whose remote predates in-band
+    /// revocation lands here, and the class used to fall through to the
+    /// terminal branch — a dead, greyed-out confirm with no way forward.
+    #[dialog_common::test]
+    fn it_offers_the_relay_repair_when_the_remote_has_no_revocation_relay() {
+        let (dialog, detail, confirm) = dialog_stub();
+        let host = fresh_host();
+        let state = Rc::new(RefCell::new(ShareStateCell::default()));
+        state.borrow_mut().pending_time = Some(7.0);
+        open_clipboard_write(Rc::clone(&state), None).expect("clipboard write opens");
+        set_state(&host, ShareState::Copying);
+
+        handle_blocked(
+            &host,
+            &state,
+            Blocked {
+                code: BLOCKED_MISSING_REVOCATION_RELAY.to_owned(),
+                detail: "Invites to this spot can't be withdrawn yet.".to_owned(),
+                time: 7.0,
+            },
+        );
+
+        assert_eq!(read_state(&host), ShareState::Blocked);
+        assert!(
+            !confirm.has_attribute("disabled"),
+            "the relay repair must offer a working confirm button",
+        );
+        assert_eq!(
+            detail.text_content().as_deref(),
+            Some("Invites to this spot can't be withdrawn yet.")
+        );
+        assert!(
+            state.borrow().pending.is_none(),
+            "the clipboard write is abandoned while the question is on screen",
+        );
+
+        dialog.remove();
+    }
+
+    /// The prompt is one element reused across refusal classes, so the wording
+    /// has to be rewritten per class and not merely appended to. A spot that
+    /// already syncs must never be told to turn on sync — the bug that made a
+    /// missing relay show "Turn on sync so the people you share with can open
+    /// it." above a button offering the same.
+    #[dialog_common::test]
+    fn it_rewrites_the_whole_prompt_for_each_refusal_class() {
+        let (dialog, _detail, confirm) = dialog_stub();
+
+        open_enable_sync_dialog(
+            "This spot only exists on this device.",
+            Repair::for_code(BLOCKED_NOT_SYNCED),
+        );
+        let synced_action = action_text(&dialog);
+        let synced_confirm = confirm.text_content().unwrap_or_default();
+        let synced_label = dialog.get_attribute("label").unwrap_or_default();
+
+        open_enable_sync_dialog(
+            "Invites to this spot can't be withdrawn yet.",
+            Repair::for_code(BLOCKED_MISSING_REVOCATION_RELAY),
+        );
+        let relay_action = action_text(&dialog);
+        let relay_confirm = confirm.text_content().unwrap_or_default();
+        let relay_label = dialog.get_attribute("label").unwrap_or_default();
+
+        dialog.remove();
+
+        assert!(synced_action.contains("Turn on sync"));
+        assert!(synced_confirm.contains("Turn on sync"));
+        assert_eq!(synced_label, "Turn on sync?");
+
+        assert!(
+            !relay_action.contains("Turn on sync"),
+            "a synced spot is not asked to turn on sync, got {relay_action:?}",
+        );
+        assert!(
+            !relay_confirm.contains("Turn on sync"),
+            "nor offered it on the button, got {relay_confirm:?}",
+        );
+        assert!(
+            !relay_label.contains("Turn on sync"),
+            "nor in the heading, got {relay_label:?}",
+        );
+    }
+
+    /// A terminal refusal must not leave the previous repair's promise on
+    /// screen beside a button that can no longer keep it.
+    #[dialog_common::test]
+    fn it_clears_the_action_line_on_an_unrepairable_refusal() {
+        let (dialog, _detail, confirm) = dialog_stub();
+
+        open_enable_sync_dialog(
+            "This spot only exists on this device.",
+            Repair::for_code(BLOCKED_NOT_SYNCED),
+        );
+        assert!(!action_text(&dialog).is_empty(), "the repair promises one");
+
+        open_enable_sync_dialog("This spot's sync server can't be shared.", None);
+        let action = action_text(&dialog);
+        let confirm_label = confirm.text_content().unwrap_or_default();
+        let disabled = confirm.has_attribute("disabled");
+        dialog.remove();
+
+        assert_eq!(action, "", "a terminal refusal promises nothing");
+        assert_eq!(confirm_label, TERMINAL_CONFIRM);
+        assert!(disabled);
     }
 
     /// A copy nothing ever answered gives the button back, whether or not a

--- a/rust/tonk-worker-api/src/share.rs
+++ b/rust/tonk-worker-api/src/share.rs
@@ -20,7 +20,9 @@ pub const BLOCKED_NOT_SYNCED: &str = "not-synced";
 pub const BLOCKED_UNSHAREABLE_REMOTE: &str = "unshareable-remote";
 
 /// The remote carries no revocation relay, so a minted invite would have
-/// nowhere to publish its revocation. Terminal.
+/// nowhere to publish its revocation. Repairable: the bar offers to attach
+/// the relay the spot's own sync server advertises, which is an upsert onto
+/// the existing remote rather than a second one.
 pub const BLOCKED_MISSING_REVOCATION_RELAY: &str = "missing-revocation-relay";
 
 /// This replica is a guest visit: it holds bounded invite authority, not the

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -317,19 +317,26 @@ async fn put_shortcut(endpoint: &str, target: String) -> Result<String, TonkWork
 
 /// Why a spot cannot produce a shareable invite.
 ///
-/// Both variants mean the same thing to the recipient — an invite that can
-/// never sync, so they land in a spot that stays permanently empty — but
-/// only [`Self::NotSynced`] is repairable by attaching a remote, so only it
-/// offers the prompt.
+/// Every variant means an invite that would fail its recipient — one that
+/// can never sync, or one that could never be withdrawn. Only
+/// [`Self::UnshareableRemote`] is terminal; the other two name something the
+/// share prompt can attach, so they offer it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RemoteRefusal {
-    /// `main` has no upstream at all. Repairable.
+    /// `main` has no upstream at all. Repairable by attaching a remote.
     NotSynced,
     /// `main` tracks something that is not a remote, or a remote whose site
     /// address is not a UCAN endpoint. An invite URL has no way to express
     /// either, so there is nothing to offer.
     UnshareableRemote,
-    /// A UCAN remote exists, but no explicit revocation relay was stored.
+    /// A UCAN remote exists, but no explicit revocation relay was stored —
+    /// so an invite could be minted and never revoked.
+    ///
+    /// Repairable, and separately from [`Self::NotSynced`]: the spot is
+    /// already synced, so the repair is an upsert of the relay onto the
+    /// remote that is there, not an attach. Reached by every spot whose
+    /// remote predates in-band revocation, and by any caller that attached
+    /// a remote without naming a relay.
     MissingRevocationRelay,
 }
 
@@ -351,9 +358,7 @@ impl RemoteRefusal {
         match self {
             Self::NotSynced => "This spot only exists on this device.",
             Self::UnshareableRemote => "This spot's sync server can't be shared.",
-            Self::MissingRevocationRelay => {
-                "This spot's sync server needs an explicit revocation relay."
-            }
+            Self::MissingRevocationRelay => "Invites to this spot can't be withdrawn yet.",
         }
     }
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2138,6 +2138,47 @@ async fn create_space_inner(
     Ok(key)
 }
 
+/// The relay the access service behind `remote` publishes revocations to,
+/// read from its `/.well-known/tonk`.
+///
+/// The fallback for a caller that named a remote but no relay. Resolved
+/// against the *remote's* origin rather than this worker's, because the
+/// relay belongs to the access service the spot actually syncs through —
+/// which is not necessarily the deployment serving this page.
+///
+/// Best-effort: `None` on any failure, so a blip leaves the spot synced
+/// but unshareable rather than not synced at all. That state is no longer
+/// a dead end — the share prompt offers to attach a relay to an existing
+/// remote (see [`RemoteRefusal::MissingRevocationRelay`]).
+///
+/// [`RemoteRefusal::MissingRevocationRelay`]: super::create_invite::RemoteRefusal::MissingRevocationRelay
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn deployment_revocation_url(remote: &str) -> Option<String> {
+    use wasm_bindgen::JsCast as _;
+    use wasm_bindgen_futures::JsFuture;
+
+    let endpoint = Url::parse(remote).ok()?.join("/.well-known/tonk").ok()?;
+    let global: web_sys::ServiceWorkerGlobalScope = js_sys::global().dyn_into().ok()?;
+    let response: web_sys::Response = JsFuture::from(global.fetch_with_str(endpoint.as_str()))
+        .await
+        .and_then(|value| value.dyn_into())
+        .ok()?;
+    if !response.ok() {
+        log!(
+            "deployment config at {} returned HTTP {}",
+            endpoint,
+            response.status()
+        );
+        return None;
+    }
+    let body = JsFuture::from(response.text().ok()?)
+        .await
+        .ok()?
+        .as_string()?;
+    let config: tonk_worker_api::DeploymentConfig = serde_json::from_str(&body).ok()?;
+    Some(config.revocation_relay_url.to_string())
+}
+
 /// Attach a sync remote to a space, idempotently, via
 /// [`ensure_remote_config`] — the same helper [`attach_remote`] uses, so
 /// the in-app path and the HTTP route converge on one implementation.
@@ -2146,6 +2187,12 @@ async fn create_space_inner(
 /// or pre-existing), for both the Hub "New space" and topbar "Enable
 /// sync" forms. A missing repository or empty URL is a no-op (logged),
 /// not an error.
+///
+/// A caller that names no relay gets the remote's own
+/// ([`deployment_revocation_url`]) rather than a remote with none. The
+/// create wizard is exactly that caller: its hidden `revocation` input is
+/// filled by an async fetch that a fast submit can beat, and an omitted
+/// relay used to produce a spot that could sync but never be shared.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 async fn enable_sync_inner(
     state: &AppState,
@@ -2158,7 +2205,21 @@ async fn enable_sync_inner(
         log!("enable sync '{}': empty remote, nothing to attach", key);
         return Ok(());
     }
-    let configuration = space_config(remote, revocation_url)?;
+    let relay = match revocation_url.filter(|url| !url.trim().is_empty()) {
+        Some(url) => Some(url.to_owned()),
+        None => {
+            let resolved = deployment_revocation_url(remote).await;
+            if resolved.is_none() {
+                log!(
+                    "enable sync '{}': no relay given and none advertised by {}",
+                    key,
+                    remote
+                );
+            }
+            resolved
+        }
+    };
+    let configuration = space_config(remote, relay.as_deref())?;
 
     let tonk = state.write().await;
     // A missing repository is a no-op, not an error — defensive against a
@@ -2188,8 +2249,16 @@ async fn enable_sync_inner(
     // Escrow this owned space's delegation so the account's other devices
     // can restore it. Best-effort; no-op for unlinked profiles or for a
     // repository that doesn't hold its signer (i.e. wasn't created here).
-    crate::router::account_backup::back_up_owned_space(&tonk, &repository, remote, revocation_url)
-        .await;
+    // The resolved relay, not the caller's: an escrowed space restored on
+    // another device has to come back shareable, which the omitted-relay
+    // record it used to carry would not.
+    crate::router::account_backup::back_up_owned_space(
+        &tonk,
+        &repository,
+        remote,
+        relay.as_deref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -3781,13 +3850,24 @@ where
             .clone()
             .unwrap_or_else(|| repository.did());
 
-        match repository
+        // What the meta mirror should describe. An existing remote is left
+        // alone at the dialog layer, so the mirror has to follow the remote
+        // that is really there and not the one the request asked for —
+        // otherwise a caller that names a remote only to reach the
+        // `revocationUrl` beside it (the share prompt's relay repair) would
+        // silently rewrite its address to whatever origin that caller
+        // happened to be served from.
+        let (subject, address) = match repository
             .remote(remote_name.as_str())
             .load()
             .perform(&tonk.operator)
             .await
         {
-            Ok(_) => log!("Remote '{}' already present; left as-is", remote_name),
+            Ok(existing) => {
+                log!("Remote '{}' already present; left as-is", remote_name);
+                let address = existing.address();
+                (address.subject().clone(), address.site().clone())
+            }
             Err(_) => {
                 let mut create = repository
                     .remote(remote_name.as_str())
@@ -3802,10 +3882,11 @@ where
                     ))
                 })?;
                 log!("Remote '{}' created", remote_name);
+                (subject, remote_config.address.clone())
             }
-        }
+        };
 
-        let concept = replica.remote(remote_name.as_str(), subject, &remote_config.address);
+        let concept = replica.remote(remote_name.as_str(), subject, &address);
         transaction = transaction.assert(concept.clone());
         if let Some(revocation_url) = &remote_config.revocation_url {
             transaction =
@@ -5470,6 +5551,96 @@ mod tests {
         assert!(
             invitations.is_empty(),
             "a refused mint records no invitation"
+        );
+    }
+
+    /// POST a remote config to `key`, exactly as the topbar and the share
+    /// prompt's confirm do. Unlike [`attach_remote`] it names no relay
+    /// unless asked, so a test can produce the pre-in-band-revocation shape:
+    /// a spot that syncs but cannot mint.
+    async fn post_remote(
+        app: &Router,
+        key: &str,
+        endpoint: &str,
+        relay: Option<&str>,
+    ) -> RepositoryInfo {
+        use dialog_remote_ucan_s3::UcanAddress;
+
+        let mut remote = RemoteConfiguration::new(SiteAddress::from(UcanAddress::new(endpoint)));
+        if let Some(relay) = relay {
+            remote = remote.revocation_url(relay.parse().unwrap());
+        }
+        let config = RepositoryConfiguration::default()
+            .remote("origin", remote)
+            .branch(
+                "main",
+                BranchConfiguration::default().upstream("origin", "main"),
+            );
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/repository/{key}/remote"))
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&config).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "remote attach succeeds");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// A synced spot whose remote carries no relay refuses the mint, and a
+    /// second attach naming the relay repairs it — the path the share
+    /// prompt's confirm drives for every spot created before in-band
+    /// revocation landed.
+    ///
+    /// The repair names a DIFFERENT endpoint on purpose. The prompt builds it
+    /// from the page's origin, which need not be the origin the spot actually
+    /// syncs through, and an existing remote is left as-is at the dialog
+    /// layer — so the meta mirror has to keep describing the remote that is
+    /// really there rather than adopting the caller's.
+    #[dialog_common::test]
+    async fn it_repairs_a_remote_that_carries_no_revocation_relay() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "test-relay-repair").await;
+        let _ = post_remote(&app, &key, "https://access.example.test/ucan/", None).await;
+
+        run_invite_with_time(&state, &key, 11.0).await;
+
+        let blocked = share_blocked_rows(&state, &key).await;
+        assert_eq!(blocked.len(), 1, "one refusal recorded");
+        assert_eq!(blocked[0].0, "missing-revocation-relay");
+        assert!(
+            content_invitations(&state, &key).await.is_empty(),
+            "a refused mint records no invitation",
+        );
+
+        let info = post_remote(
+            &app,
+            &key,
+            "https://a-different-origin.example.test/ucan/",
+            Some("https://relay.example.test/revocations"),
+        )
+        .await;
+
+        run_invite_with_time(&state, &key, 12.0).await;
+
+        assert_eq!(
+            content_invitations(&state, &key).await.len(),
+            1,
+            "the repaired spot mints",
+        );
+
+        let address = serde_json::to_string(&info.remote["origin"].address).unwrap();
+        assert!(
+            address.contains("https://access.example.test/ucan/"),
+            "the repair must not repoint the remote, got {address}",
         );
     }
 


### PR DESCRIPTION
Sharing a spot created before in-band revocation (#653) fails with a dead
button: the mint refuses `missing-revocation-relay`, and the prompt that
opens says "Turn on sync so the people you share with can open it" above a
greyed-out "Turn on sync & copy link" — for a spot that is already synced.

```
worker.js  Invite for repo 'did:key:z6Mkjd…' refused: missing-revocation-relay
share: clipboard write failed: JsValue("This spot's sync server needs an explicit revocation relay.")
```

Two bugs.

## The refusal was misclassified as terminal

`handle_blocked` treated every class except `not-synced` and
`needs-membership` as unrepairable, re-opening the dialog with its confirm
disabled purely so the detail sentence reached the user. Because only
`detail` was ever swapped, the surrounding copy stayed on the `not-synced`
wording for every other class.

It was never terminal. `ensure_remote_config` already upserts the relay onto
a remote that exists — it loads the dialog-side remote and leaves it as-is,
and the branch loop skips a branch already tracking its upstream — so the
repair is the same `tonk:enable-sync` claim the prompt already dispatches.
Reclassified, and routed through the same confirm.

The prompt now rewrites heading, action line, and button label per class from
a `Repair` table, so no class can inherit another's wording. The terminal case
gets its own inert copy instead of a greyed-out offer.

## New spots could hit the same state

The create wizard's hidden `revocation` input is filled by an async fetch of
`/.well-known/tonk`; `remote` is filled synchronously and the relay is not, so
a submit that beats the fetch sent no relay and the empty string was dropped
rather than sent. `enable_sync_inner` now resolves the relay itself when the
caller names none, against the remote's own origin — the relay belongs to the
access service the spot syncs through, not necessarily the deployment serving
the page. Best-effort: a failed fetch logs and leaves the spot synced but
unshareable, which is no longer a dead end. The resolved relay also reaches
`back_up_owned_space`, so an escrowed space restores shareable.

## One hazard found while wiring the repair

`ensure_remote_config` left an existing remote alone at the dialog layer but
still mirrored the *request's* address onto meta. The relay repair sends
page-origin + `/ucan/`, so repairing a spot whose remote pointed elsewhere
would have silently repointed its recorded address. The mirror now describes
the remote that is really there.

## Testing

- `it_repairs_a_remote_that_carries_no_revocation_relay` drives the whole
  path: relay-less attach → mint refuses → second attach naming a *different*
  endpoint plus the relay → mint succeeds, address unchanged. Reverting the
  `ensure_remote_config` fix fails it on exactly that assertion.
- Three `tonk-fab` tests: the relay repair, per-class rewriting, and the
  terminal action-line clear.
- tonk-worker 233, tonk-fab 50/16/2/2 (wasm), 89/25 native. `cargo fmt --check`
  and workspace `clippy --all-targets --all-features` clean.
- Verified against the reporting spot on staging: the equivalent
  `POST /api/repository/{did}/remote` upsert made it shareable.

Existing spots are repaired by sharing them once and confirming the prompt.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of revocation relays in the `tonk` application, particularly in scenarios where invites cannot be shared due to missing relays. It enhances user prompts and repairs related to invite sharing.

### Detailed summary
- Updated comments in `share.rs` to clarify revocation relay scenarios.
- Added markup in `markup.rs` for improved user prompts on syncing.
- Modified `RemoteRefusal` enum in `create_invite.rs` to better describe repairable states.
- Enhanced `deployment_revocation_url` function to fetch relays more effectively.
- Updated `enable_sync_inner` function to handle relay resolutions.
- Improved dialog handling for user prompts in `share.rs` to offer clearer actions.
- Added tests to verify proper behavior for missing revocation relays and ensure correct dialog actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->