### PR TITLE
perf(access): let browsers cache the ucan preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "base58",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "async-trait",
  "base58",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "base58",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "async-trait",
  "base58",
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1419,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3#e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=e8bbe462a5ae5c7c71472d618c580b60ab87b88d#e8bbe462a5ae5c7c71472d618c580b60ab87b88d"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "base58",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "base58",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "base58",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "base58",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1063,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1245,7 +1245,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipld-core",
- "reqwest 0.12.28",
  "serde",
  "serde_bytes",
  "serde_ipld_dagcbor",
@@ -1260,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1297,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1326,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1373,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "async-trait",
  "base58",
@@ -1394,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1420,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?rev=dc40c522e8cf50004296cafa53faa9364d3164b1#dc40c522e8cf50004296cafa53faa9364d3164b1"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=18ef8d859bee393e52736a4abbc1cc83dec396b0#18ef8d859bee393e52736a4abbc1cc83dec396b0"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,22 +181,22 @@ wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,22 +181,22 @@ wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e3cf750a83b389a2a0ad5d9eee27bf788cffe9a3" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "e8bbe462a5ae5c7c71472d618c580b60ab87b88d" }
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,79 +1,78 @@
 [workspace]
-
-members = [
-    "rust/tonk-access-service",
-    "rust/tonk-account",
-    "rust/tonk-account-service",
-    "rust/tonk-analytics",
-    "rust/tonk-analyzer",
-    "rust/tonk-board",
-    "rust/tonk-code",
-    "rust/tonk-tree",
-    "rust/tonk-common",
-    "rust/tonk-core",
-    "rust/dialog-reactor",
-    "rust/tonk-display",
-    "rust/tonk-evaluator",
-    "rust/tonk-guest",
-    "rust/tonk-host",
-    "rust/tonk-invite",
-    "rust/tonk-identity",
-    "rust/tonk-inspector",
-    "rust/tonk-language-server",
-    "rust/tonk-macros",
-    "rust/tonk-notation",
-    "rust/tonk-fab",
-    "rust/tonk-portal",
-    "rust/tonk-prose",
-    "rust/tonk-table",
-    "rust/tonk-render",
-    "rust/tonk-router",
-    "rust/tonk-template",
-    "rust/tonk-cli",
-    "rust/tonk-schema",
-    "rust/tonk-sigil",
-    "rust/tonk-ui",
-    "rust/tonk-worker",
-    "rust/tonk-worker-api",
-    "rust/tonk-workspace",
-]
 resolver = "2"
+members = [
+  "rust/dialog-reactor",
+  "rust/tonk-access-service",
+  "rust/tonk-account",
+  "rust/tonk-account-service",
+  "rust/tonk-analytics",
+  "rust/tonk-analyzer",
+  "rust/tonk-board",
+  "rust/tonk-cli",
+  "rust/tonk-code",
+  "rust/tonk-common",
+  "rust/tonk-core",
+  "rust/tonk-display",
+  "rust/tonk-evaluator",
+  "rust/tonk-fab",
+  "rust/tonk-guest",
+  "rust/tonk-host",
+  "rust/tonk-identity",
+  "rust/tonk-inspector",
+  "rust/tonk-invite",
+  "rust/tonk-language-server",
+  "rust/tonk-macros",
+  "rust/tonk-notation",
+  "rust/tonk-portal",
+  "rust/tonk-prose",
+  "rust/tonk-render",
+  "rust/tonk-router",
+  "rust/tonk-schema",
+  "rust/tonk-sigil",
+  "rust/tonk-table",
+  "rust/tonk-template",
+  "rust/tonk-tree",
+  "rust/tonk-ui",
+  "rust/tonk-worker",
+  "rust/tonk-worker-api",
+  "rust/tonk-workspace",
+]
 
 [workspace.package]
 version = "0.6.3"
 authors = ["Tonk Labs"]
-license = "MIT"
 edition = "2024"
+license = "MIT"
 
 [workspace.dependencies]
+dialog-reactor = { path = "./rust/dialog-reactor" }
 tonk-access-service = { path = "./rust/tonk-access-service" }
 tonk-account = { path = "./rust/tonk-account" }
 tonk-analytics = { path = "./rust/tonk-analytics" }
 tonk-analyzer = { path = "./rust/tonk-analyzer" }
 tonk-board = { path = "./rust/tonk-board" }
 tonk-code = { path = "./rust/tonk-code" }
-tonk-tree = { path = "./rust/tonk-tree" }
 tonk-common = { path = "./rust/tonk-common" }
 tonk-core = { path = "./rust/tonk-core" }
-dialog-reactor = { path = "./rust/dialog-reactor" }
 tonk-display = { path = "./rust/tonk-display" }
 tonk-evaluator = { path = "./rust/tonk-evaluator" }
+tonk-fab = { path = "./rust/tonk-fab" }
 tonk-host = { path = "./rust/tonk-host" }
+tonk-identity = { path = "./rust/tonk-identity" }
 tonk-inspector = { path = "./rust/tonk-inspector" }
 tonk-invite = { path = "./rust/tonk-invite" }
-tonk-identity = { path = "./rust/tonk-identity" }
 tonk-language-server = { path = "./rust/tonk-language-server" }
 tonk-macros = { path = "./rust/tonk-macros" }
 tonk-notation = { path = "./rust/tonk-notation" }
-tonk-fab = { path = "./rust/tonk-fab" }
 tonk-portal = { path = "./rust/tonk-portal" }
 tonk-prose = { path = "./rust/tonk-prose" }
-tonk-table = { path = "./rust/tonk-table" }
 tonk-render = { path = "./rust/tonk-render" }
 tonk-router = { path = "./rust/tonk-router" }
 tonk-schema = { path = "./rust/tonk-schema" }
-tonk-template = { path = "./rust/tonk-template" }
 tonk-sigil = { path = "./rust/tonk-sigil" }
+tonk-table = { path = "./rust/tonk-table" }
+tonk-template = { path = "./rust/tonk-template" }
+tonk-tree = { path = "./rust/tonk-tree" }
 tonk-ui = { path = "./rust/tonk-ui" }
 tonk-worker = { path = "./rust/tonk-worker" }
 tonk-worker-api = { path = "./rust/tonk-worker-api" }
@@ -85,18 +84,18 @@ axum = { version = "0.8", default-features = false }
 axum-wasm-macros = "0.1"
 base58 = "0.2"
 base64 = "0.22"
-multibase = "0.9"
 blake3 = "1.5"
 bs58 = "0.5"
-ciborium = "0.2"
+bytes = "1"
 chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "wasmbind",
+  "clock",
+  "wasmbind",
 ] }
+ciborium = "0.2"
 clap = { version = "4", features = ["derive"] }
 console_error_panic_hook = "0.1"
-custom-elements = "0.2"
 crypto-common = "=0.2.0-rc.5"
+custom-elements = "0.2"
 dialoguer = "0.11"
 digest = "=0.11.0-rc.4"
 dirs = "5"
@@ -105,24 +104,29 @@ flate2 = "1"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
+getrandom = { version = "0.4", features = ["wasm_js"] }
 getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom_0_3 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
-getrandom = { version = "0.4", features = ["wasm_js"] }
 hex = "0.4"
 hkdf = "0.12"
+html5gum = "0.7"
+http-body-util = "0.1"
+hyper = "1"
+hyper-util = "0.1"
 idb = "0.6"
+indexmap = { version = "2", features = ["serde"] }
 ipld-core = { version = "0.4", features = ["serde"] }
 keyring = "3.6"
 lsp-types = "0.97"
 matchit = "0.8"
-saphyr = "0.0.6"
-saphyr-parser = "0.0.6"
+multibase = "0.9"
 parking_lot = "0.12"
 port_check = "0.3"
+proc-macro2 = "1"
+quote = "1"
 rand = "0.9"
 rand_0_8 = { package = "rand", version = "0.8" }
 rand_core = "0.9"
-rusqlite = { version = "0.32", features = ["bundled"] }
 # Pinned to 0.12 to match dialog-db's transport crates (dialog-remote-ucan-s3 /
 # dialog-remote-s3) so Cargo unifies features into the same reqwest. `rustls-tls`
 # keeps the embedded webpki roots; `rustls-tls-native-roots` additionally trusts
@@ -131,108 +135,68 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # strict superset, non-breaking. TLS deps are gated off wasm, so this is a no-op
 # for tonk-ui's wasm build. default-features = false avoids pulling in native-tls.
 reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
-    "rustls-tls-native-roots",
-    "json",
+  "json",
+  "rustls-tls",
+  "rustls-tls-native-roots",
 ] }
-serde = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
+saphyr = "0.0.6"
+saphyr-parser = "0.0.6"
 semver = "1"
+serde = "1"
 serde_bytes = "0.11"
-serde_json = "1"
-serde_yaml = "0.9"
 serde_ipld_dagcbor = "0.6"
 serde_ipld_dagjson = "0.2"
+serde_json = "1"
+serde-wasm-bindgen = "0.6"
+serde_yaml = "0.9"
+serial_test = "3"
 sha2_0_10 = { package = "sha2", version = "0.10" }
 syn = { version = "2", features = ["full"] }
-quote = "1"
-proc-macro2 = "1"
 tar = "0.4"
 tempfile = "3"
 thirtyfour = "0.36"
 thiserror = "2"
-html5gum = "0.7"
 tokio = "1"
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 tower-service = "0.3"
-hyper = "1"
-hyper-util = "0.1"
-bytes = "1"
-http-body-util = "0.1"
-indexmap = { version = "2", features = ["serde"] }
-serde-wasm-bindgen = "0.6"
+ulid = "1"
 url = "2"
 urlencoding = "2"
-ulid = "1"
 wasm-streams = "0.6"
 web-time = "1"
 webbrowser = "1.0"
 worker = "0.8.5"
 worker-macros = "0.8.5"
-serial_test = "3"
 zeroize = "1"
 
-# Bindgen
-wasm-bindgen = "=0.2.126"
-wasm-bindgen-test = "0.3"
-wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 send_wrapper = "0.6"
+# Bindgen
+wasm-bindgen = "=0.2.126"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "dc40c522e8cf50004296cafa53faa9364d3164b1" }
-
-# NOTE — the dialog deps above are pinned to the immutable head of
-# `fix/idb-upgrade-invalidates-sessions`, one commit past dialog-db #411.
-# That compatibility branch starts at `tonk-2026-07-17-storage-clone` and
-# adds structured service errors plus atomic staged installation without
-# taking the unrelated version-control/search-tree migration from dialog main.
-#
-# Why the IndexedDB commit: adding an object store reopens the database a
-# version higher, and the browser grants that only once every other
-# connection closes — so an upgrade destroys the connection every other
-# caller holds. A store session that outlived one upgrade was addressing a
-# closed connection, and the worker reported `Transaction error: idb error`
-# on ordinary reads whenever `POST /account/link`'s background restore grew
-# the schema underneath a request. Fold this into #411 when that PR next
-# moves.
-#
-# Why the extra commit: the worker's presign credential is its operator
-# delegation, and bounding it in time means rotating the operator before it
-# lapses. `OperatorBuilder::build` consumes the `Storage`, so without `Clone` the
-# replacement operator can only be handed a fresh `Storage::new()` — a second
-# pool of connections to the same databases, invisibly divergent from every repo
-# and branch handle the reactor already cached. Cloning shares the pool, which is
-# already how `Storage` is built internally, and makes rotation a contained swap.
-#
-# Why a branch off the tag rather than off dialog `main`: `main` carries the
-# reserved-`dialog.`-namespace change and the version-control redesign, and
-# absorbing those is its own piece of work (tonk #635). Cutting from the tag we
-# already build against keeps this dependency byte-identical to the previous pin
-# apart from that one commit.
-#
-# Repoint to a tag once dialog-db #407 and #410 land on `main` and Tonk is ready
-# to absorb the separately tracked dialog-main migration.
-#
-# Pinning by `rev` rather than `branch` on purpose: a branch pin re-resolves as
-# the branch moves, so a build today and a build tomorrow would not agree.
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "18ef8d859bee393e52736a4abbc1cc83dec396b0" }
 
 [profile.dev]
 opt-level = 1
@@ -242,12 +206,12 @@ strip = "debuginfo"
 opt-level = 3
 
 [profile.release]
+strip = "debuginfo"
 lto = "thin"
 codegen-units = 1
-strip = "debuginfo"
 
 [profile.wasm-release]
+inherits = "release"
 opt-level = "s"
 debug = 0
-inherits = "release"
 strip = "debuginfo"

--- a/rust/tonk-access-service/src/handlers/shortcut.rs
+++ b/rust/tonk-access-service/src/handlers/shortcut.rs
@@ -30,8 +30,12 @@ fn with_cors_headers(response: Response) -> Response {
 
 /// OPTIONS → Handle CORS preflight
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
-    let response = Response::empty()?.with_status(204);
-    Ok(with_cors_headers(response))
+    let response = with_cors_headers(Response::empty()?.with_status(204));
+    // Only the preflight can be cached, so the lifetime is set here
+    // rather than on every response.
+    let headers = response.headers().clone();
+    let _ = headers.set("Access-Control-Max-Age", crate::PREFLIGHT_MAX_AGE);
+    Ok(response.with_headers(headers))
 }
 
 /// PUT /@ → store a shortcut target, respond with its hash

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -164,8 +164,31 @@ fn unavailable() -> ServiceError {
     )
 }
 
-/// Create UcanAuthorizer from environment configuration.
+thread_local! {
+    /// The authorizer built by this isolate, if it has built one.
+    static AUTHORIZER: std::cell::OnceCell<UcanAuthorizer> =
+        const { std::cell::OnceCell::new() };
+}
+
+/// The UcanAuthorizer for this isolate.
+///
+/// It is built from deployment configuration — vars and secrets that
+/// an isolate cannot see change — so reading the bindings once and
+/// reusing the result costs nothing in freshness. A failed build is
+/// not cached: the next request tries again.
 fn create_authorizer(ctx: &RouteContext<()>) -> std::result::Result<UcanAuthorizer, ServiceError> {
+    AUTHORIZER.with(|cached| {
+        if let Some(authorizer) = cached.get() {
+            return Ok(authorizer.clone());
+        }
+        let authorizer = build_authorizer(ctx)?;
+        let _ = cached.set(authorizer.clone());
+        Ok(authorizer)
+    })
+}
+
+/// Create UcanAuthorizer from environment configuration.
+fn build_authorizer(ctx: &RouteContext<()>) -> std::result::Result<UcanAuthorizer, ServiceError> {
     // Get R2 configuration from environment
     let account_id = ctx
         .var("R2_ACCOUNT_ID")

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -22,8 +22,12 @@ fn with_cors_headers(response: Response) -> Response {
 
 /// OPTIONS /ucan/ → Handle CORS preflight
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
-    let response = Response::empty()?.with_status(204);
-    Ok(with_cors_headers(response))
+    let response = with_cors_headers(Response::empty()?.with_status(204));
+    // Only the preflight can be cached, so the lifetime is set here
+    // rather than on every response.
+    let headers = response.headers().clone();
+    let _ = headers.set("Access-Control-Max-Age", crate::PREFLIGHT_MAX_AGE);
+    Ok(response.with_headers(headers))
 }
 
 /// POST /ucan/ → Authorize UCAN invocation and return presigned S3 request

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -13,7 +13,8 @@ use dialog_remote_ucan_s3::UcanAuthorizer;
 use hyper::body::Incoming;
 use hyper::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_EXPOSE_HEADERS, CACHE_CONTROL, CONTENT_TYPE, LOCATION,
+    ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE, CACHE_CONTROL, CONTENT_TYPE,
+    HeaderValue, LOCATION,
 };
 use hyper::server::conn::http1;
 use hyper::{Method, Request, Response, StatusCode};
@@ -121,14 +122,20 @@ async fn handle_request(
     use bytes::Bytes;
     use http_body_util::Full;
 
-    // Handle CORS preflight
+    // Handle CORS preflight. Like the Worker handlers, the preflight
+    // carries its own cache lifetime; only the preflight can be cached.
     if req.method() == Method::OPTIONS {
-        return Ok(cors_response(
+        let mut response = cors_response(
             Response::builder()
                 .status(StatusCode::NO_CONTENT)
                 .body(Full::new(Bytes::new()))
                 .unwrap(),
-        ));
+        );
+        response.headers_mut().insert(
+            ACCESS_CONTROL_MAX_AGE,
+            HeaderValue::from_static(crate::PREFLIGHT_MAX_AGE),
+        );
+        return Ok(response);
     }
 
     if req.method() == Method::PUT && req.uri().path() == "/@" {

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -32,6 +32,16 @@
 
 use worker::*;
 
+/// How long a browser may cache a CORS preflight for this service, in
+/// seconds.
+///
+/// Every content-addressed fetch is a `POST` carrying
+/// `Content-Type: application/cbor`, which is not CORS-safelisted, so
+/// each one is preflighted. Without a `Max-Age`, Chrome discards the
+/// preflight result after five seconds and re-issues `OPTIONS`
+/// mid-load, roughly doubling the requests a cold load pays for.
+pub(crate) const PREFLIGHT_MAX_AGE: &str = "86400";
+
 mod error;
 #[cfg(any(target_arch = "wasm32", test))]
 mod expiry;

--- a/rust/tonk-access-service/tests/shortcut.rs
+++ b/rust/tonk-access-service/tests/shortcut.rs
@@ -170,6 +170,35 @@ mod http {
         Ok(())
     }
 
+    /// The shortcut routes are preflighted too, and their preflight
+    /// carries the same cache lifetime as the UCAN one.
+    #[dialog_common::test]
+    async fn it_caches_the_shortcut_preflight(env: AccessServiceAddress) -> anyhow::Result<()> {
+        let client = reqwest::Client::new();
+        let hash = Shortcut::new(b"/join?access=abc").unwrap().hash_str();
+
+        for path in ["/@", &format!("/@/{hash}")] {
+            let response = client
+                .request(
+                    reqwest::Method::OPTIONS,
+                    format!("{}{path}", env.access_service_url),
+                )
+                .send()
+                .await?;
+            assert_eq!(response.status(), 204, "{path}");
+            assert_eq!(
+                response
+                    .headers()
+                    .get("Access-Control-Max-Age")
+                    .and_then(|value| value.to_str().ok()),
+                Some("86400"),
+                "{path} preflight must carry a cache lifetime",
+            );
+        }
+
+        Ok(())
+    }
+
     /// A `ttl=0` shortcut is stored already-expired: the logical
     /// expiry check makes the very next read a 404.
     #[dialog_common::test]

--- a/rust/tonk-access-service/tests/ucan_integration.rs
+++ b/rust/tonk-access-service/tests/ucan_integration.rs
@@ -331,3 +331,29 @@ async fn it_syncs_blobs_via_ucan(env: AccessServiceAddress) -> anyhow::Result<()
 
     Ok(())
 }
+
+/// Every `POST /ucan/` carries a non-safelisted `Content-Type`, so the
+/// browser preflights it. The preflight must say how long it stays
+/// good, or a cold load re-issues `OPTIONS` between batches of fetches.
+#[dialog_common::test]
+async fn it_caches_the_ucan_preflight(env: AccessServiceAddress) -> anyhow::Result<()> {
+    let response = reqwest::Client::new()
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/ucan/", env.access_service_url),
+        )
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 204);
+    assert_eq!(
+        response
+            .headers()
+            .get("Access-Control-Max-Age")
+            .and_then(|value| value.to_str().ok()),
+        Some("86400"),
+        "the preflight must carry a cache lifetime",
+    );
+
+    Ok(())
+}

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -3255,14 +3255,17 @@ name!:
     ///
     /// Asserted as a ratio rather than an absolute: node counts depend on
     /// the tree's fan-out, but the whole point is that the big tree costs
-    /// about what the small one does. Measured at the sizes below, a
-    /// correct diff copies 4 nodes either way while a baseless one copies
-    /// 74 — so the bound discriminates with room to spare, and the 750x
-    /// size gap is what buys that room.
+    /// about what the small one does. A correct diff copies a handful of
+    /// nodes either way while a baseless one copies the tree, so the bound
+    /// discriminates with room to spare, and the 375x size gap is what buys
+    /// that room. The large side is sized to discriminate, not to impress:
+    /// in the browser harness this test runs against Chrome's 30-second
+    /// renderer-liveness check, and a bigger fixture proves nothing more
+    /// while drifting toward that cliff on a loaded runner.
     #[dialog_common::test]
     async fn it_installs_a_claim_without_copying_the_space() {
         let small = claim_install_cost(8).await;
-        let large = claim_install_cost(6000).await;
+        let large = claim_install_cost(3000).await;
 
         assert!(
             small > 0,
@@ -3270,7 +3273,7 @@ name!:
         );
         assert!(
             large <= small * 3,
-            "installing a claim onto a 6000-fact space cost {large} nodes \
+            "installing a claim onto a 3000-fact space cost {large} nodes \
              against {small} for an 8-fact one — the copy is scaling with \
              the space, so the diff has lost its base",
         );


### PR DESCRIPTION
Cold-load follow-up to #661. After a lazy join, every locally-missing tree
node is one authorized read: an OPTIONS preflight, a `POST /ucan/`, and a
presigned R2 GET. The POST's `Content-Type: application/cbor` is not
CORS-safelisted, so the preflight is mandatory — and the access service sent
no `Access-Control-Max-Age`, so Chrome fell back to its 5-second default and
re-preflighted for the whole load. On the cold walk that roughly doubles the
request count on the authorization path.

## Fix

`Access-Control-Max-Age: 86400` on the preflight responses of `/ucan/` and
`/@`, via one crate-private constant so the worker handlers and the native
mirror server cannot drift. The header goes on the OPTIONS response only —
it means nothing on the POST. Browsers clamp the value (Chrome to 2h,
Firefox to 24h); either covers a full load.

Rider: `create_authorizer` rebuilt the S3 credential from env bindings on
every request — four JS-interop reads and a URL parse. The authorizer is now
built once per isolate (`thread_local` + `OnceCell`); a failed build is not
cached, so a misconfigured isolate retries rather than pinning an error. The
cached values are deployment config an isolate cannot see change: a secret
or var update rolls a new deployment, which starts new isolates.

## Tests

New `it_caches_the_ucan_preflight` (tests/ucan_integration.rs) and
`it_caches_the_shortcut_preflight` (tests/shortcut.rs) assert the header on
the OPTIONS responses. Both sit behind the crate's existing
`integration-tests` feature — the worker handlers cannot run outside
workerd, so the native server is the only exerciseable OPTIONS path. Both
verified red by removing the header insert.

- `cargo test -p tonk-access-service` and `--features integration-tests` —
  all green (10 lib, 19 integration)
- `cargo clippy -p tonk-access-service --all-targets --all-features` — clean
- `cargo check --target wasm32-unknown-unknown` — clean (the only
  compile-level check of the worker handler edits; no workerd run happened)

## Not covered

The wasm handlers themselves are exercised only through the native mirror
plus the type check. `tonk-account-service` has the identical CORS shape and
the same missing `Max-Age`; untouched here since it is not on the cold-load
path.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing CORS preflight responses by introducing a `PREFLIGHT_MAX_AGE` constant, which specifies how long browsers can cache these preflights, thus improving performance. 

### Detailed summary
- Added `PREFLIGHT_MAX_AGE` constant to specify CORS preflight cache duration.
- Updated `handle_options` functions in `shortcut.rs` and `ucan.rs` to set `Access-Control-Max-Age` header.
- Added integration tests to verify preflight caching for `/ucan/` and shortcut routes.
- Adjusted comments for clarity and updated dependency versions in `Cargo.toml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

## Dialog pin — testing the full cold-read stack

This PR follows the tip of the stacked dialog PRs: dialog-db#414
(single-flight node fetches, range-scan read-ahead) is based on
dialog-db#413 (memoized delegation chains, once-computed delegation
encodings, per-thread HTTP client), so its head carries both. The
preview deployment therefore exercises every layer of the cold-read
work at once, and the join-to-interactive measurement can run against
a real remote before anything merges.

Merge order: dialog #413, then #414 (which retargets to the lineage
branch), then repoint this pin at the resulting lineage tip.