### PR TITLE
fix(fab): heal the space-derived children when the space lands

### DIFF
--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -118,15 +118,19 @@ impl CustomElement for TonkFab {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &[]
+        &["space"]
     }
 
     /// Author the FAB's own DOM. The `space` attribute is stamped by the
     /// mounting view (`<tonk-fab with="main@profile:tonk" space={id}>`) and
-    /// is already resolved by the time `inject_children` runs — per the
+    /// is usually resolved by the time `inject_children` runs — per the
     /// `custom-elements` crate, this is deferred to (and runs before) the
     /// first `connectedCallback`, i.e. after HTML parsing has set the
-    /// element's attributes.
+    /// element's attributes. Usually, not always: the mounting view's first
+    /// projection can carry a blank `{id}` (the field lands a frame later),
+    /// in which case the subtree is authored around the blank and
+    /// [`attribute_changed_callback`](Self::attribute_changed_callback)
+    /// heals it when the real value arrives.
     fn inject_children(&mut self, this: &HtmlElement) {
         let space = this.get_attribute("space").unwrap_or_default();
         this.set_inner_html(&crate::markup::fab_html(&space));
@@ -198,11 +202,44 @@ impl CustomElement for TonkFab {
 
     fn attribute_changed_callback(
         &mut self,
-        _this: &HtmlElement,
-        _name: String,
-        _old: Option<String>,
-        _new: Option<String>,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
     ) {
+        if name != "space" || old == new {
+            return;
+        }
+        restamp_space(this, new.as_deref().unwrap_or(""));
+    }
+}
+
+/// Re-stamp the space onto every child [`crate::markup::fab_html`] derives
+/// from it.
+///
+/// The mounting view stamps `space={id}` on the host, but the subtree is
+/// authored ONCE, in `inject_children` — so a host whose `space` was blank at
+/// authoring time (an unsubstituted first projection) carries children
+/// pointed at nothing: a `main@` sync location, a share overlay with no
+/// space to subscribe against, an empty rename subject. The children are
+/// built to heal — each observes its own attribute and re-opens its
+/// subscriptions when it changes — but nothing ever re-delivered the space
+/// to them. This is that delivery. Attribute writes only, never a re-stamp
+/// of the subtree: every listener and observer bound at `connected_callback`
+/// stays live, and `setAttribute` fires each child's own changed callback.
+fn restamp_space(host: &HtmlElement, space: &str) {
+    let stamps = [
+        ("ui-sync-status", "with", crate::logic::space_with(space)),
+        ("ui-space-name", "space", space.to_owned()),
+        ("tonk-share", "space", space.to_owned()),
+        ("ui-member-roster", "space", space.to_owned()),
+        ("ui-dropdown", "exclude", space.to_owned()),
+        ("ui-space-switcher", "exclude", space.to_owned()),
+    ];
+    for (selector, attribute, value) in stamps {
+        if let Some(child) = host.query_selector(selector).ok().flatten() {
+            let _ = child.set_attribute(attribute, &value);
+        }
     }
 }
 
@@ -1745,6 +1782,47 @@ mod tests {
     use web_sys::window;
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    /// A blank-authored FAB heals every space-derived child attribute when
+    /// the space finally lands: the sync disc's location gets its repo half,
+    /// and the name/share/roster/switcher children get the space itself. The
+    /// subtree is NOT re-authored — the marker child proves the existing DOM
+    /// survives, which is what keeps every listener bound at connect alive.
+    #[wasm_bindgen_test]
+    fn it_restamps_the_space_onto_every_space_derived_child() {
+        let document = window().expect("window").document().expect("document");
+        let host: HtmlElement = document
+            .create_element("div")
+            .expect("create host")
+            .unchecked_into();
+        host.set_inner_html(&crate::markup::fab_html(""));
+        let marker = document.create_element("i").expect("create marker");
+        marker.set_id("survives-heal");
+        host.append_child(&marker).expect("append marker");
+
+        restamp_space(&host, "did:key:zHeal");
+
+        let attr = |selector: &str, name: &str| {
+            host.query_selector(selector)
+                .ok()
+                .flatten()
+                .and_then(|el| el.get_attribute(name))
+                .unwrap_or_default()
+        };
+        assert_eq!(attr("ui-sync-status", "with"), "main@did:key:zHeal");
+        assert_eq!(attr("ui-space-name", "space"), "did:key:zHeal");
+        assert_eq!(attr("tonk-share", "space"), "did:key:zHeal");
+        assert_eq!(attr("ui-member-roster", "space"), "did:key:zHeal");
+        assert_eq!(attr("ui-dropdown", "exclude"), "did:key:zHeal");
+        assert_eq!(attr("ui-space-switcher", "exclude"), "did:key:zHeal");
+        assert!(
+            host.query_selector("#survives-heal")
+                .ok()
+                .flatten()
+                .is_some(),
+            "healing must re-stamp attributes on the existing subtree, not re-author it"
+        );
+    }
 
     /// A FAB whose two dropdown segments are both open, plus the click-away
     /// curtain — the shape the profile view renders.

--- a/rust/tonk-fab/src/member_roster.rs
+++ b/rust/tonk-fab/src/member_roster.rs
@@ -58,6 +58,26 @@ impl CustomElement for UiMemberRosterElement {
         self.scaffold.connect(this, behaviour);
     }
 
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if name != "space" || old == new {
+            return;
+        }
+        // The space landed (or moved): the roster subscription was opened
+        // against the old value — or skipped entirely while it was blank.
+        // Drop it and subscribe against the space that is actually here.
+        self.scaffold.disconnect();
+        let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(MemberRosterBehaviour {
+            members: self.members.clone(),
+        });
+        self.scaffold.connect(this, behaviour);
+    }
+
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
         self.scaffold.disconnect();
     }

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -466,18 +466,29 @@ impl CustomElement for TonkShare {
     }
 
     fn connected_callback(&mut self, this: &HtmlElement) {
-        // Two subscriptions on one element: the minted link, and the refusal
-        // that says no link is coming. The scaffolding routes each frame back
-        // by the tag its behaviour subscribed under.
-        let link: Rc<dyn subscribing::Subscribing> = Rc::new(ShareLinkBehaviour {
-            state: Rc::clone(&self.state),
-            current_link: Rc::clone(&self.current_link),
-        });
-        let blocked: Rc<dyn subscribing::Subscribing> = Rc::new(ShareBlockedBehaviour {
-            state: Rc::clone(&self.state),
-        });
-        self.scaffold.connect_all(this, vec![link, blocked]);
+        self.connect_subscriptions(this);
         self.install_confirm_listener(this);
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if name != "space" || old == new {
+            return;
+        }
+        // The space landed (or moved). Any subscriptions were opened against
+        // the old value — or skipped entirely while it was blank
+        // (`resolve_with` returns `None` on an empty `space`, and
+        // `connect_all` no-ops). Drop them and subscribe against the space
+        // that is actually here; without this, a mint still fires on click
+        // but the link it produces has no subscription left to arrive on,
+        // and the copy can only time out.
+        self.scaffold.disconnect();
+        self.connect_subscriptions(this);
     }
 
     fn disconnected_callback(&mut self, this: &HtmlElement) {
@@ -523,6 +534,25 @@ impl CustomElement for TonkShare {
 }
 
 impl TonkShare {
+    /// Open the element's two subscriptions: the minted link, and the refusal
+    /// that says no link is coming. The scaffolding routes each frame back by
+    /// the tag its behaviour subscribed under.
+    ///
+    /// Run from `connected_callback`, and again from the `space` attribute
+    /// callback once a late-arriving space lands — `connect_all` is built to
+    /// be re-run (it no-ops while the routing context is unresolvable and
+    /// dedupes live tags).
+    fn connect_subscriptions(&self, this: &HtmlElement) {
+        let link: Rc<dyn subscribing::Subscribing> = Rc::new(ShareLinkBehaviour {
+            state: Rc::clone(&self.state),
+            current_link: Rc::clone(&self.current_link),
+        });
+        let blocked: Rc<dyn subscribing::Subscribing> = Rc::new(ShareBlockedBehaviour {
+            state: Rc::clone(&self.state),
+        });
+        self.scaffold.connect_all(this, vec![link, blocked]);
+    }
+
     /// Listen for the enable-sync prompt's confirm, wherever it is in the
     /// document.
     ///

--- a/rust/tonk-fab/src/space_name.rs
+++ b/rust/tonk-fab/src/space_name.rs
@@ -111,6 +111,39 @@ impl CustomElement for UiSpaceNameElement {
     }
 
     fn connected_callback(&mut self, this: &HtmlElement) {
+        self.wire(this);
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if name != "space" || old == new {
+            return;
+        }
+        // The space landed (or moved): the name subscription was opened
+        // against the old value — or skipped entirely while it was blank.
+        // Drop it and wire against the space that is actually here, which is
+        // what makes the rename chip come alive on a host whose first
+        // projection carried a blank `{id}`.
+        self.scaffold.disconnect();
+        self.wire(this);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        self.scaffold.disconnect();
+        self.change.borrow_mut().take();
+    }
+}
+
+impl UiSpaceNameElement {
+    /// Attach the commit listener and open the name subscription — the whole
+    /// of connecting, factored so the `space` attribute callback can re-run
+    /// it once a late-arriving space lands.
+    fn wire(&mut self, this: &HtmlElement) {
         if this
             .get_attribute("space")
             .filter(|s| !s.is_empty())
@@ -124,7 +157,11 @@ impl CustomElement for UiSpaceNameElement {
         // Attach the commit listener to the `<tonk-editable>` child. There is
         // no `tonk-display` event delegation here (this markup is Rust-owned,
         // not a resolved template), so the `change` binding is wired directly.
-        if let Some(editable) = this.query_selector("tonk-editable").ok().flatten() {
+        // Guarded: a re-wire from the attribute callback must not stack a
+        // second listener on the same child.
+        if self.change.borrow().is_none()
+            && let Some(editable) = this.query_selector("tonk-editable").ok().flatten()
+        {
             let claim_target = editable.clone();
             let current_name = self.current_name.clone();
             let host = this.clone();
@@ -140,11 +177,6 @@ impl CustomElement for UiSpaceNameElement {
             current_name: self.current_name.clone(),
         });
         self.scaffold.connect(this, behaviour);
-    }
-
-    fn disconnected_callback(&mut self, _this: &HtmlElement) {
-        self.scaffold.disconnect();
-        self.change.borrow_mut().take();
     }
 }
 

--- a/rust/tonk-workspace/src/ui_sync_status.rs
+++ b/rust/tonk-workspace/src/ui_sync_status.rs
@@ -64,7 +64,7 @@ impl CustomElement for UiSyncStatus {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &[]
+        &["with"]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -110,35 +110,27 @@ impl CustomElement for UiSyncStatus {
         let _ = Reflect::set(this, &"__tonkError".into(), error.as_ref());
         *self.error.borrow_mut() = Some(error);
 
-        // Subscribe on a microtask, NOT synchronously: when a render pass
-        // runs inside an outer custom-element reaction, the reaction queue
-        // delivers this callback only after that reaction finishes — by
-        // which time the diff may have detached this element again, and a
-        // dispatch from a detached tree never reaches the document
-        // listeners. By microtask time the DOM has settled; skip if no
-        // longer connected (a real re-connection re-runs this callback).
-        let subscription = self.subscription.clone();
-        let host = this.clone();
-        spawn_local(async move {
-            if !host.is_connected() || subscription.borrow().is_some() {
-                return;
-            }
-            let consumer: Element = host.into();
-            match status_query_body() {
-                Ok(body) => {
-                    let tag = JsValue::from_str(SUB_TAG);
-                    match consumer::subscribe(&consumer, &body, Some(&tag)) {
-                        Ok(sub) => *subscription.borrow_mut() = Some(sub),
-                        Err(err) => {
-                            // Dispatch failure: leave the pending disc;
-                            // nothing to subscribe to.
-                            tonk_common::log!("ui-sync-status: subscribe failed: {err:?}");
-                        }
-                    }
-                }
-                Err(err) => tonk_common::log!("ui-sync-status: query build failed: {err}"),
-            }
-        });
+        subscribe_status(this, self.subscription.clone());
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        this: &HtmlElement,
+        name: String,
+        old: Option<String>,
+        new: Option<String>,
+    ) {
+        if name != "with" || old == new {
+            return;
+        }
+        // The location landed (or moved): any subscription is addressed to
+        // the branch the OLD `with` named — or failed outright while the
+        // repo half was blank (`main@` is malformed, and the host refuses
+        // it). Drop it (its `Drop` cancels upstream) and subscribe against
+        // where `with` points now. This is how the disc comes alive on a
+        // host whose first projection stamped a blank space.
+        self.subscription.borrow_mut().take();
+        subscribe_status(this, self.subscription.clone());
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
@@ -148,6 +140,40 @@ impl CustomElement for UiSyncStatus {
         self.update.borrow_mut().take();
         self.error.borrow_mut().take();
     }
+}
+
+/// Open the status subscription for `this`, on a microtask.
+///
+/// NOT synchronously: when a render pass runs inside an outer custom-element
+/// reaction, the reaction queue delivers the calling callback only after that
+/// reaction finishes — by which time the diff may have detached this element
+/// again, and a dispatch from a detached tree never reaches the document
+/// listeners. By microtask time the DOM has settled; skip if no longer
+/// connected (a real re-connection re-runs `connected_callback`) or if a
+/// subscription is already live (a same-value attribute re-stamp must not
+/// double-subscribe).
+fn subscribe_status(this: &HtmlElement, subscription: Rc<RefCell<Option<Subscription>>>) {
+    let host = this.clone();
+    spawn_local(async move {
+        if !host.is_connected() || subscription.borrow().is_some() {
+            return;
+        }
+        let consumer: Element = host.into();
+        match status_query_body() {
+            Ok(body) => {
+                let tag = JsValue::from_str(SUB_TAG);
+                match consumer::subscribe(&consumer, &body, Some(&tag)) {
+                    Ok(sub) => *subscription.borrow_mut() = Some(sub),
+                    Err(err) => {
+                        // Dispatch failure: leave the pending disc;
+                        // nothing to subscribe to.
+                        tonk_common::log!("ui-sync-status: subscribe failed: {err:?}");
+                    }
+                }
+            }
+            Err(err) => tonk_common::log!("ui-sync-status: query build failed: {err}"),
+        }
+    });
 }
 
 /// Build the subscribe body for the `tonk:sync` status at `state:here`.


### PR DESCRIPTION
On a fresh spot, generating an invite link times out ("share: clipboard
write failed: share: timed out"), the rename chip is dead, and the sync
disc subscribes to a malformed `main@` location — while the worker mints
the invitation successfully on every click. Observed on the pr-664
preview and reproducible on any deployment: the failure is deterministic
for a page whose chrome projection renders before the site's `{id}`
fact, which is exactly the create-spot → navigate flow.

## Cause

The space chrome view stamps `<tonk-fab ... space={id}>`; the first
projection can carry a blank `{id}` (the fact lands a frame later), and
`<tonk-fab>` authors its subtree exactly once, around whatever it got:

- `<ui-sync-status with="main@">` — malformed, refused by the host
  ("host did not write detail.subscription")
- `<tonk-share space="">` — `resolve_with` returns `None`, so its
  link/refusal subscriptions are silently skipped
- `<ui-space-name space="">` — early-returns, rename never wires

The healing half of the design already exists on paper: the subscribing
children observe `space`, `<ui-space-name>`'s comment says "the
attribute callback re-runs this when it lands", and the scaffold's
`connect_all` documents that it no-ops while the context is unresolvable
and "the attribute-changed callback re-runs this once it lands". But
none of the attribute callbacks were implemented (all default no-ops),
and `<tonk-fab>` observed no attributes at all — so when the projection's
next frame delivers the real `{id}` to the FAB host attribute, nothing
propagates it. A later re-render heals `<tonk-site>` (it observes
`with`), which is why the space content loads while share/rename stay
dead forever.

## Fix

Complete the chain, exactly as the scaffold intended:

- `<tonk-fab>` observes `space`; on change it re-stamps the value onto
  every child the markup derives from it (`ui-sync-status`'s `with`,
  `space` on `ui-space-name`/`tonk-share`/`ui-member-roster`, `exclude`
  on `ui-dropdown`/`ui-space-switcher`). Attribute writes on the
  existing subtree, never a re-author — every listener/observer bound at
  `connected_callback` stays live, and `setAttribute` fires each child's
  own changed callback.
- `<tonk-share>`, `<ui-space-name>`, `<ui-member-roster>` implement
  their `space` callbacks: drop the scaffolded subscriptions and re-open
  them against the space that is actually there. (`ui-space-name` also
  wires its rename commit listener on the heal path, guarded so a
  re-wire never stacks a second listener.)
- `<ui-sync-status>` observes `with` and resubscribes when it changes,
  dropping the old subscription (its `Drop` cancels upstream).

Same-value re-stamps are filtered everywhere (`old == new` guards), so a
heal never double-subscribes.

## Tests

- `it_restamps_the_space_onto_every_space_derived_child` (wasm,
  browser-run in CI): a blank-authored FAB heals all six child
  attributes, and a marker child proves the subtree is not re-authored.
- Native suites of both touched crates pass (89 + 15); clippy
  `--all-targets --all-features` clean; wasm test targets compile.

Not covered here: driving the full subscription heal end-to-end needs
the host relay, which no local harness provides — the resubscribe path
is exercised structurally (guards, dedupe by tag in the scaffold) and
verified live on the preview once deployed. Also out of scope: why the
chrome view's first projection carries a blank `{id}` at all — this PR
makes the chrome converge on the value regardless, which the elements'
own docs say was always the contract.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `attribute_changed_callback` functionality across various components, ensuring that subscriptions and connections are properly managed when the `space` attribute changes. It introduces a new method for connecting subscriptions and improves the handling of attribute changes.

### Detailed summary
- Added `attribute_changed_callback` to `MemberRoster`, `SpaceName`, and `TonkShare` to manage space attribute changes.
- Introduced `connect_subscriptions` method in `TonkShare` to encapsulate subscription logic.
- Modified `disconnected_callback` methods to ensure proper disconnection and cleanup.
- Updated `restamp_space` function to re-apply attributes to child elements based on the new `space` value.
- Enhanced the `inject_children` method in `TonkFab` to handle cases where the `space` attribute is initially blank.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->