### PR TITLE
fix(cli): mount the profile before touching account credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account-service"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "dialog-common",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "bs58",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dialog-capability",
  "dialog-common",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use dialog_operator::Profile;
-use dialog_storage::provider::storage::{NativeSpace, Storage};
+use dialog_storage::provider::storage::NativeSpace;
 use dialog_ucan_core::DelegationChain;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -98,10 +98,6 @@ struct ConsumeResponse {
     descriptor_hex: String,
 }
 
-fn storage() -> Storage<NativeSpace> {
-    Storage::<NativeSpace>::default()
-}
-
 async fn decode_provider(
     root_did: &dialog_varsig::Did,
     bytes: Result<Vec<u8>, dialog_effects::credential::CredentialError>,
@@ -157,17 +153,8 @@ pub(crate) async fn require_account_with_operator(
 }
 
 async fn stored_provider(profile: &Profile) -> Result<Option<AccountProviderRecord>> {
-    let Some(root) = crate::identity::local_root(profile).await? else {
-        return Ok(None);
-    };
-    let root_did = parse_root_did(&root.root_did)?;
-    let bytes = profile
-        .credential()
-        .site(ACCOUNT_LINK_SITE)
-        .load::<Vec<u8>>()
-        .perform(&storage())
-        .await;
-    decode_provider(&root_did, bytes).await
+    let operator = crate::account_state::credential_operator(profile).await?;
+    stored_provider_with_operator(profile, &operator).await
 }
 
 fn parse_root_did(root_did: &str) -> Result<dialog_varsig::Did> {
@@ -228,6 +215,7 @@ async fn persist(
     let record = AccountProviderRecord::attach(service_url, &descriptor, &root_did, now)
         .await
         .context("account service returned an unusable repository descriptor")?;
+    let operator = crate::account_state::credential_operator(profile).await?;
     profile
         .credential()
         .site(ACCOUNT_LINK_SITE)
@@ -236,7 +224,7 @@ async fn persist(
                 .encode()
                 .context("failed to serialize account provider")?,
         )
-        .perform(&storage())
+        .perform(&operator)
         .await
         .context("failed to attach the account provider")?;
     Ok(root.root_did)

--- a/rust/tonk-cli/src/identity.rs
+++ b/rust/tonk-cli/src/identity.rs
@@ -47,23 +47,14 @@ fn missing_credential(error: &CredentialError) -> bool {
 }
 
 /// Load the provider-neutral local root, if one has been provisioned.
+///
+/// Mounts the profile's account operator first: a bare
+/// `Storage::default()` has no mounts, so performing a credential load
+/// against one fails with "no mount for {did}" before it ever reaches
+/// the store — on every machine, provisioned or not.
 pub async fn local_root(profile: &Profile) -> Result<Option<LocalRoot>> {
-    let storage = Storage::<NativeSpace>::default();
-    let bytes = match profile
-        .credential()
-        .site(LOCAL_ROOT_SITE)
-        .load::<Vec<u8>>()
-        .perform(&storage)
-        .await
-    {
-        Ok(bytes) if bytes.is_empty() => return Ok(None),
-        Ok(bytes) => bytes,
-        Err(error) if missing_credential(&error) => return Ok(None),
-        Err(error) => return Err(error).context("failed to load the local root"),
-    };
-    let record: LocalRoot =
-        serde_json::from_slice(&bytes).context("stored local root is malformed")?;
-    Ok(Some(record))
+    let operator = crate::account_state::credential_operator(profile).await?;
+    local_root_with_operator(profile, &operator).await
 }
 
 /// Load the local root through an already-mounted site operator.
@@ -122,17 +113,17 @@ pub async fn save_local_root(
     {
         bail!("this device already has a different local root");
     }
-    let storage = Storage::<NativeSpace>::default();
+    let operator = crate::account_state::credential_operator(profile).await?;
     profile
         .save(UcanDelegation(chain))
-        .perform(&storage)
+        .perform(&operator)
         .await
         .context("failed to install the local-root delegation")?;
     profile
         .credential()
         .site(LOCAL_ROOT_SITE)
         .save(serde_json::to_vec(&record).context("failed to serialize the local root")?)
-        .perform(&storage)
+        .perform(&operator)
         .await
         .context("failed to persist the local root")?;
     Ok(record)


### PR DESCRIPTION
`tonk account link` fails immediately with "error: failed to load the
local root" — on every native machine, linked or not, since #653. With
the error chain surfaced (`{err:#}`), the cause reads:

```
failed to load the local root: Storage error: Storage error:
no mount for did:key:z6Mkmr...   <- the device DID
```

## Cause

Mounts are registered per `Storage` instance: `Profile::open`/`load`
inserts the profile space into the pool of the storage it was performed
against, and dialog's router answers "no mount" for any other instance.
The local-root machinery introduced in #653 performed every credential
load and save against a fresh `Storage::<NativeSpace>::default()` — an
instance with an empty pool — so `local_root`, `save_local_root`,
`stored_provider`, and the provider attach all failed before reaching
the store. The `missing_credential` mapping that distinguishes "no
record yet" from a broken store never ran, and the whole native account
surface (`status`, `link`, `devices`, `revoke`, plus every
`require_account` gate) was dead on arrival.

The mounted path already existed and works: `credential_operator`
builds the account-state operator by loading the profile into the
storage it returns, and the `_with_operator` read variants use it
(that's how `account_state::status` functions).

## Fix

Route the operator-less conveniences through `credential_operator`:

- `identity::local_root` → delegates to `local_root_with_operator`
- `identity::save_local_root` → performs both saves via the operator
- `account::stored_provider` → delegates to
  `stored_provider_with_operator`
- `account::persist`'s provider attach → performs via the operator
- the orphaned bare-`storage()` helper is deleted

## Verification

- Before: `tonk identity` → `error: failed to load the local root`.
  After: `device: did:key:z6Mk…` / `root: missing (run `tonk account
  link`)`.
- `tonk account link --no-open --service-url <preview> --account-url
  <preview>` prints the browser approval URL and polls (ceremony not
  completed in the test).
- `cargo test -p tonk-cli` — 134 passed, 0 failed; clippy
  `--all-targets --all-features` clean; fmt clean.

## Not covered

No automated test pins "a fresh CLI on a fresh machine can read its
missing root as missing" — the existing account tests all construct
mounted operators explicitly, which is exactly why this shipped broken.
A test that calls the public `identity::local_root` against a temp
profile would have caught it and is worth adding when the account test
harness next moves.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the project and refactoring the `local_root` and `save_local_root` functions in the `rust/tonk-cli/src/identity.rs` file to utilize an operator for credential management instead of a default storage instance.

### Detailed summary
- Updated version in `Cargo.toml` and `Cargo.lock` from `0.6.3` to `0.6.4`.
- Refactored `local_root` function to use `local_root_with_operator`.
- Refactored `save_local_root` function to use `operator` instead of `storage`.
- Removed unnecessary storage function in `rust/tonk-cli/src/account.rs`.
- Updated `stored_provider` to use `stored_provider_with_operator`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->