### PR TITLE
chore(staging): retire staging.tonk.spot

### DIFF
--- a/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
+++ b/docs/superpowers/plans/2026-07-22-cli-invite-remote-origin.md
@@ -930,11 +930,11 @@ Expected: the link starts with `https://tonk.spot/join?access=` after Task 7 (be
 export TONK_SPOTS_STATE="$(mktemp -d)"
 export TONK_SPOT=probe-staging
 cargo run -q -p tonk-cli --bin tonk -- spot new probe-staging 2>&1 | tail -2
-cargo run -q -p tonk-cli --bin tonk -- remote add origin https://staging.tonk.spot/ucan/ 2>&1 | tail -2
+cargo run -q -p tonk-cli --bin tonk -- remote add origin https://staging.tonk.xyz/ucan/ 2>&1 | tail -2
 cargo run -q -p tonk-cli --bin tonk -- invite 2>&1 | tail -4
 ```
 
-Expected: a short link of the form `https://staging.tonk.spot/@/<base58>#<seed>`, and **no** shorten warning. This is the whole point of the change — if the warning is still there, stop and diagnose before continuing.
+Expected: a short link of the form `https://staging.tonk.xyz/@/<base58>#<seed>`, and **no** shorten warning. This is the whole point of the change — if the warning is still there, stop and diagnose before continuing.
 
 Note this makes a real `PUT` to the staging shortcut service, storing a delegation for a throwaway local repo with no data on it.
 
@@ -947,7 +947,7 @@ cargo run -q -p tonk-cli --bin tonk -- invite --remote origin 2>&1 | tail -3
 cargo run -q -p tonk-cli --bin tonk -- invite --no-remote 2>&1 | tail -3
 ```
 
-Expected: the bare `invite` errors naming both remotes; `--remote origin` mints a short `staging.tonk.spot` link; `--no-remote` mints against the fallback base with a shorten warning.
+Expected: the bare `invite` errors naming both remotes; `--remote origin` mints a short `staging.tonk.xyz` link; `--no-remote` mints against the fallback base with a shorten warning.
 
 - [ ] **Step 8: Commit**
 
@@ -1322,4 +1322,4 @@ Neither PR makes production shorten. `https://tonk.spot/@` returns 404 because t
 curl -s -X PUT https://tonk.spot/@ --data-binary "/join?access=probe" -w " [%{http_code}]\n"
 ```
 
-Expected after the deploy: a base58 hash and `[200]`, matching `staging.tonk.spot` today.
+Expected after the deploy: a base58 hash and `[200]`, matching `staging.tonk.xyz` today.

--- a/docs/superpowers/specs/2026-07-22-cli-invite-remote-origin-design.md
+++ b/docs/superpowers/specs/2026-07-22-cli-invite-remote-origin-design.md
@@ -23,7 +23,7 @@ Measured, 2026-07-22:
 | origin | `PUT /@` |
 | --- | --- |
 | `tonk.spot` (= `hub.tonk.xyz`, prod) | 404 Not Found |
-| `staging.tonk.spot` (= `staging.tonk.xyz`) | 200, returns a base58 hash |
+| `staging.tonk.xyz` | 200, returns a base58 hash |
 
 `wrangler.toml` gates the routes on `run_worker_first = ["/@", "/@/*",
 ...]` under `[assets]`; the production deploy predates that, so the asset
@@ -149,5 +149,5 @@ access service via `AccessServiceAddress`. Extend it to mint without an
 explicit `--base-url` and assert the link's origin matches the harness
 remote's, which is the regression this whole change is about.
 
-Manual check against staging: register a `staging.tonk.spot` remote,
+Manual check against staging: register a `staging.tonk.xyz` remote,
 run `tonk invite`, confirm a short link with no warning.

--- a/plan/invite-origin-followups.md
+++ b/plan/invite-origin-followups.md
@@ -109,8 +109,7 @@ remotes where one fails to decode resolves the other implicitly.
 
 **Analytics classified CLI invitees as `dev`.**
 `rust/tonk-analytics/src/web.rs` knew only `hub.tonk.xyz` and
-`staging.tonk.xyz`. It now maps `tonk.spot` and `staging.tonk.spot` to
-the same environments.
+`staging.tonk.xyz`. It now maps the production alias `tonk.spot` too.
 
 **Stale command names.** `tonk concepts` → `tonk concept ls` in
 `.claude/skills/tonk-bug/SKILL.md` (agent-facing, so a live footgun)

--- a/rust/tonk-analytics/src/web.rs
+++ b/rust/tonk-analytics/src/web.rs
@@ -64,15 +64,14 @@ export function ph_init(key, host) {
         // staging, dev, and the marketing site (which registers
         // environment = "website" in its own repo) apart within the
         // shared PostHog project.
-        // Each deployment answers on both its tonk.xyz and its
-        // tonk.spot name. tonk.spot is the canonical one the CLI
-        // builds invite links against, so a recipient arriving from
-        // `tonk invite` lands here on tonk.spot — matching only the
-        // tonk.xyz names would file every CLI invitee under "dev".
+        // Production answers on both hub.tonk.xyz and tonk.spot.
+        // tonk.spot is the canonical one the CLI builds invite links
+        // against, so a recipient arriving from `tonk invite` lands
+        // there. Staging has only its staging.tonk.xyz origin.
         var host = location.hostname;
         var environment =
             (host === "hub.tonk.xyz" || host === "tonk.spot") ? "production"
-            : (host === "staging.tonk.xyz" || host === "staging.tonk.spot") ? "staging"
+            : host === "staging.tonk.xyz" ? "staging"
             : "dev";
         window.posthog.register({ environment: environment });
         return true;

--- a/rust/tonk-host/src/space_origin.rs
+++ b/rust/tonk-host/src/space_origin.rs
@@ -9,7 +9,7 @@
 //! resolution; classification then reduces to an origin comparison.
 //!
 //! It is an ILLUSION. The document is really served from the host origin
-//! (`staging.tonk.spot`) at `/space/{did}/...`; the host translates a
+//! (`staging.tonk.xyz`) at `/space/{did}/...`; the host translates a
 //! guest-world path back to the real route at the bridge. Only the guest's
 //! internal coordinate system is the per-space origin.
 //!

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -61,8 +61,8 @@ fn prf_extensions() -> AuthenticationExtensionsClientInputs {
 /// boundary — any origin allowed to use it can silently derive a visiting
 /// user's root key with one discoverable-credential assertion — so it is
 /// pinned to this exact origin and nothing else. Every other host under
-/// `tonk.spot`, including staging and any wildcard hostname, is its own
-/// relying party with its own disjoint credentials. Widening later is
+/// `tonk.spot`, including any wildcard hostname, is its own relying party
+/// with its own disjoint credentials. Widening later is
 /// possible via Related Origin Requests; narrowing never is.
 const RP_APEX: &str = "tonk.spot";
 
@@ -295,7 +295,6 @@ mod tests {
         // cannot derive an apex root key from a visiting user's passkey.
         assert_eq!(apex_rp_id("www.tonk.spot"), None);
         assert_eq!(apex_rp_id("hub.tonk.spot"), None);
-        assert_eq!(apex_rp_id("staging.tonk.spot"), None);
         assert_eq!(apex_rp_id("a.b.tonk.spot"), None);
         assert_eq!(apex_rp_id("staging.tonk.xyz"), None);
         assert_eq!(apex_rp_id("localhost"), None);


### PR DESCRIPTION
## Summary

- stop classifying `staging.tonk.spot` as the staging web deployment
- use only `staging.tonk.xyz` in current comments and historical verification docs
- retain the unrelated synthetic per-space `*.tonk.spot` guest origins

## Testing

- `cargo test -p tonk-identity -p tonk-analytics -p tonk-host`
- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown -p tonk-analytics -p tonk-host -p tonk-identity`
- verified no tracked `staging.tonk.spot` references remain

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates references from `tonk.spot` and `staging.tonk.spot` to `tonk.xyz` and `staging.tonk.xyz`, reflecting changes in the hosting environment and ensuring consistency in the handling of remote origins.

### Detailed summary
- Updated documentation to reflect `staging.tonk.xyz` as the new staging origin.
- Changed mappings in analytics to include `tonk.spot` and `staging.tonk.xyz`.
- Adjusted code comments and assertions to use `staging.tonk.xyz`.
- Modified expected outputs in tests and examples to reference `staging.tonk.xyz`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->