### PR TITLE
fix(account): share native handoff contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4626,6 +4626,7 @@ dependencies = [
  "ipld-core",
  "js-sys",
  "rand 0.9.5",
+ "serde-wasm-bindgen",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/tonk-account-service/src/core/links.rs
+++ b/rust/tonk-account-service/src/core/links.rs
@@ -3,21 +3,10 @@
 use crate::core::CeremonyError;
 use crate::core::delegation::check_device_delegation;
 use crate::store::{Device, DeviceStatus, LinkRequest, Store};
+use tonk_account::handoff::{ConsumedLink, ResolvedLink};
 
 /// Handoffs are deliberately short-lived bearer capabilities.
 pub const LINK_TTL_SECONDS: u64 = 5 * 60;
-
-/// Public device metadata returned to the browser after bearer resolution.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ResolvedLink {
-    /// Hash bound into the root-signed completion invocation.
-    pub token_hash: String,
-    /// CLI profile DID receiving the delegation.
-    pub device_did: String,
-    /// Human-readable device name shown before confirmation.
-    pub device_name: String,
-}
 
 /// Hash a raw 32-byte handoff secret for storage and lookup.
 pub fn hash_secret(secret: &str) -> Result<String, CeremonyError> {
@@ -167,18 +156,6 @@ pub async fn complete_link<S: Store>(
         ));
     }
     Ok(())
-}
-
-/// Provider-neutral local-root material returned by a completed handoff.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ConsumedLink {
-    /// Exact root-to-device delegation bytes, hex encoded.
-    pub delegation_hex: String,
-    /// Opaque credential identifier belonging to the root passkey.
-    pub credential_id: String,
-    /// Exact established account repository descriptor hex.
-    pub descriptor_hex: String,
 }
 
 /// Consume a completed delegation and descriptor once. `None` means the CLI

--- a/rust/tonk-account-service/src/handlers/links.rs
+++ b/rust/tonk-account-service/src/handlers/links.rs
@@ -1,25 +1,12 @@
 //! Native CLI browser-handoff endpoints.
 
-use serde::Deserialize;
+use tonk_account::handoff::{LinkCreateRequest, LinkSecretRequest};
 use worker::*;
 
 use crate::auth::{authorize_root, required_string};
 use crate::core::links::{complete_link, consume_link, create_link, resolve_link};
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CreateRequest {
-    token_hash: String,
-    device_did: String,
-    device_name: String,
-}
-
-#[derive(Deserialize)]
-struct SecretRequest {
-    secret: String,
-}
 
 /// CORS preflight for every `/links/*` endpoint.
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
@@ -29,7 +16,7 @@ pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Res
 /// Create a pending CLI browser handoff.
 pub async fn handle_create(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
     let response = match async {
-        let body: CreateRequest = req.json().await.map_err(json_error)?;
+        let body: LinkCreateRequest = req.json().await.map_err(json_error)?;
         let store = build_store(&ctx)?;
         create_link(
             &store,
@@ -53,7 +40,7 @@ pub async fn handle_create(mut req: Request, ctx: RouteContext<()>) -> Result<Re
 /// Resolve a pending handoff using its raw bearer secret.
 pub async fn handle_resolve(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
     let response = match async {
-        let body: SecretRequest = req.json().await.map_err(json_error)?;
+        let body: LinkSecretRequest = req.json().await.map_err(json_error)?;
         let store = build_store(&ctx)?;
         let link = resolve_link(&store, &body.secret, now())
             .await
@@ -100,7 +87,7 @@ pub async fn handle_complete(mut req: Request, ctx: RouteContext<()>) -> Result<
 /// Consume a completed delegation once, or return `202` while pending.
 pub async fn handle_consume(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
     let response = match async {
-        let body: SecretRequest = req.json().await.map_err(json_error)?;
+        let body: LinkSecretRequest = req.json().await.map_err(json_error)?;
         let store = build_store(&ctx)?;
         match consume_link(&store, &body.secret, now())
             .await

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -21,6 +21,7 @@ use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
+use tonk_account::handoff::{LinkCreateRequest, LinkSecretRequest};
 
 use crate::auth::{
     authorize, authorize_root, optional_revocation, required_string, string_argument,
@@ -508,19 +509,6 @@ async fn devices_revoke_route(
             "stored": outcome.stored,
         }),
     ))
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct LinkCreateRequest {
-    token_hash: String,
-    device_did: String,
-    device_name: String,
-}
-
-#[derive(Deserialize)]
-struct LinkSecretRequest {
-    secret: String,
 }
 
 async fn links_create_route(

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
 use dialog_varsig::Principal;
+use tonk_account::handoff::{ConsumedLink, LinkCreateRequest, LinkSecretRequest, ResolvedLink};
 use tonk_account_service::helpers::AccountServer;
 
 const ROOT_PRF: [u8; 32] = [7u8; 32];
@@ -337,25 +338,28 @@ async fn it_drives_the_full_ceremony_over_http() {
     let cli_did = cli.did().to_string();
     let response = client
         .post(format!("{base}/links"))
-        .json(&serde_json::json!({
-            "tokenHash": token_hash,
-            "deviceDid": cli_did,
-            "deviceName": "terminal"
-        }))
+        .json(&LinkCreateRequest {
+            token_hash: token_hash.clone(),
+            device_did: cli_did.clone(),
+            device_name: "terminal".to_string(),
+        })
         .send()
         .await
         .unwrap();
     assert_eq!(response.status(), 201);
     let response = client
         .post(format!("{base}/links/resolve"))
-        .json(&serde_json::json!({ "secret": secret }))
+        .json(&LinkSecretRequest {
+            secret: secret.to_string(),
+        })
         .send()
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
-    let pending: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(pending["deviceDid"], cli_did);
-    assert_eq!(pending["deviceName"], "terminal");
+    let pending: ResolvedLink = response.json().await.unwrap();
+    assert_eq!(pending.token_hash, token_hash);
+    assert_eq!(pending.device_did, cli_did);
+    assert_eq!(pending.device_name, "terminal");
 
     let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
         .await
@@ -374,17 +378,22 @@ async fn it_drives_the_full_ceremony_over_http() {
     assert_eq!(response.status(), 200);
     let response = client
         .post(format!("{base}/links/consume"))
-        .json(&serde_json::json!({ "secret": secret }))
+        .json(&LinkSecretRequest {
+            secret: secret.to_string(),
+        })
         .send()
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
-    let consumed: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(consumed["delegationHex"], expected_delegation);
-    assert_eq!(consumed["descriptorHex"], expected_descriptor);
+    let consumed: ConsumedLink = response.json().await.unwrap();
+    assert_eq!(consumed.delegation_hex, expected_delegation);
+    assert_eq!(consumed.credential_id, "cred-1");
+    assert_eq!(consumed.descriptor_hex, expected_descriptor);
     let response = client
         .post(format!("{base}/links/consume"))
-        .json(&serde_json::json!({ "secret": secret }))
+        .json(&LinkSecretRequest {
+            secret: secret.to_string(),
+        })
         .send()
         .await
         .unwrap();

--- a/rust/tonk-account/src/handoff.rs
+++ b/rust/tonk-account/src/handoff.rs
@@ -1,0 +1,143 @@
+//! Shared contracts for one-time native account handoffs.
+
+/// Request to create a pending native account handoff.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkCreateRequest {
+    /// Hash of the bearer secret bound into the completion invocation.
+    pub token_hash: String,
+    /// Native device DID that will receive the account delegation.
+    pub device_did: String,
+    /// Human-readable native device name shown before confirmation.
+    pub device_name: String,
+}
+
+/// Bearer-secret request used to resolve or consume an account handoff.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LinkSecretRequest {
+    /// Raw one-time bearer secret for the handoff.
+    pub secret: String,
+}
+
+/// Pending native device metadata resolved for the browser ceremony.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedLink {
+    /// Hash bound into the root-signed completion invocation.
+    pub token_hash: String,
+    /// Native device DID that will receive the account delegation.
+    pub device_did: String,
+    /// Human-readable native device name shown before confirmation.
+    pub device_name: String,
+}
+
+/// Root-signed browser ceremony result submitted to the account service.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompleteLinkCeremony {
+    /// Hex-encoded signed account-link completion invocation.
+    pub invocation_hex: String,
+}
+
+/// Provider-neutral local-root material returned by a completed handoff.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsumedLink {
+    /// Exact root-to-device delegation bytes, hex encoded.
+    pub delegation_hex: String,
+    /// Opaque credential identifier belonging to the root passkey.
+    pub credential_id: String,
+    /// Exact established account repository descriptor, hex encoded.
+    pub descriptor_hex: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_round_trips_each_handoff_phase_in_camel_case() {
+        let create = LinkCreateRequest {
+            token_hash: "hash".to_string(),
+            device_did: "did:key:device".to_string(),
+            device_name: "terminal".to_string(),
+        };
+        let create_json = serde_json::to_value(&create).unwrap();
+        assert_eq!(
+            create_json.as_object().unwrap().keys().collect::<Vec<_>>(),
+            vec!["deviceDid", "deviceName", "tokenHash"]
+        );
+        assert_eq!(
+            serde_json::from_value::<LinkCreateRequest>(create_json).unwrap(),
+            create
+        );
+
+        let secret = LinkSecretRequest {
+            secret: "secret".to_string(),
+        };
+        let secret_json = serde_json::to_value(&secret).unwrap();
+        assert_eq!(
+            secret_json.as_object().unwrap().keys().collect::<Vec<_>>(),
+            vec!["secret"]
+        );
+        assert_eq!(
+            serde_json::from_value::<LinkSecretRequest>(secret_json).unwrap(),
+            secret
+        );
+
+        let resolved = ResolvedLink {
+            token_hash: "hash".to_string(),
+            device_did: "did:key:device".to_string(),
+            device_name: "terminal".to_string(),
+        };
+        let resolved_json = serde_json::to_value(&resolved).unwrap();
+        assert_eq!(
+            resolved_json
+                .as_object()
+                .unwrap()
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["deviceDid", "deviceName", "tokenHash"]
+        );
+        assert_eq!(
+            serde_json::from_value::<ResolvedLink>(resolved_json).unwrap(),
+            resolved
+        );
+
+        let ceremony = CompleteLinkCeremony {
+            invocation_hex: "invocation".to_string(),
+        };
+        let ceremony_json = serde_json::to_value(&ceremony).unwrap();
+        assert_eq!(
+            ceremony_json
+                .as_object()
+                .unwrap()
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["invocationHex"]
+        );
+        assert_eq!(
+            serde_json::from_value::<CompleteLinkCeremony>(ceremony_json).unwrap(),
+            ceremony
+        );
+
+        let consumed = ConsumedLink {
+            delegation_hex: "delegation".to_string(),
+            credential_id: "credential".to_string(),
+            descriptor_hex: "descriptor".to_string(),
+        };
+        let consumed_json = serde_json::to_value(&consumed).unwrap();
+        assert_eq!(
+            consumed_json
+                .as_object()
+                .unwrap()
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["credentialId", "delegationHex", "descriptorHex"]
+        );
+        assert_eq!(
+            serde_json::from_value::<ConsumedLink>(consumed_json).unwrap(),
+            consumed
+        );
+    }
+}

--- a/rust/tonk-account/src/handoff.rs
+++ b/rust/tonk-account/src/handoff.rs
@@ -55,6 +55,17 @@ pub struct ConsumedLink {
 mod tests {
     use super::*;
 
+    fn sorted_keys(value: &serde_json::Value) -> Vec<&str> {
+        let mut keys = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        keys.sort_unstable();
+        keys
+    }
+
     #[test]
     fn it_round_trips_each_handoff_phase_in_camel_case() {
         let create = LinkCreateRequest {
@@ -64,7 +75,7 @@ mod tests {
         };
         let create_json = serde_json::to_value(&create).unwrap();
         assert_eq!(
-            create_json.as_object().unwrap().keys().collect::<Vec<_>>(),
+            sorted_keys(&create_json),
             vec!["deviceDid", "deviceName", "tokenHash"]
         );
         assert_eq!(
@@ -76,10 +87,7 @@ mod tests {
             secret: "secret".to_string(),
         };
         let secret_json = serde_json::to_value(&secret).unwrap();
-        assert_eq!(
-            secret_json.as_object().unwrap().keys().collect::<Vec<_>>(),
-            vec!["secret"]
-        );
+        assert_eq!(sorted_keys(&secret_json), vec!["secret"]);
         assert_eq!(
             serde_json::from_value::<LinkSecretRequest>(secret_json).unwrap(),
             secret
@@ -92,11 +100,7 @@ mod tests {
         };
         let resolved_json = serde_json::to_value(&resolved).unwrap();
         assert_eq!(
-            resolved_json
-                .as_object()
-                .unwrap()
-                .keys()
-                .collect::<Vec<_>>(),
+            sorted_keys(&resolved_json),
             vec!["deviceDid", "deviceName", "tokenHash"]
         );
         assert_eq!(
@@ -108,14 +112,7 @@ mod tests {
             invocation_hex: "invocation".to_string(),
         };
         let ceremony_json = serde_json::to_value(&ceremony).unwrap();
-        assert_eq!(
-            ceremony_json
-                .as_object()
-                .unwrap()
-                .keys()
-                .collect::<Vec<_>>(),
-            vec!["invocationHex"]
-        );
+        assert_eq!(sorted_keys(&ceremony_json), vec!["invocationHex"]);
         assert_eq!(
             serde_json::from_value::<CompleteLinkCeremony>(ceremony_json).unwrap(),
             ceremony
@@ -128,11 +125,7 @@ mod tests {
         };
         let consumed_json = serde_json::to_value(&consumed).unwrap();
         assert_eq!(
-            consumed_json
-                .as_object()
-                .unwrap()
-                .keys()
-                .collect::<Vec<_>>(),
+            sorted_keys(&consumed_json),
             vec!["credentialId", "delegationHex", "descriptorHex"]
         );
         assert_eq!(

--- a/rust/tonk-account/src/lib.rs
+++ b/rust/tonk-account/src/lib.rs
@@ -5,6 +5,8 @@
 //! mounting and projection policy remains with the worker and CLI adapters.
 
 mod descriptor;
+/// Shared wire and browser-ceremony contracts for native account handoffs.
+pub mod handoff;
 mod provider;
 
 pub use descriptor::{AccountRepositoryDescriptorV1, DescriptorError};

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -7,7 +7,8 @@ use dialog_operator::Profile;
 use dialog_storage::provider::storage::NativeSpace;
 use dialog_ucan_core::DelegationChain;
 use rand::RngCore;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use tonk_account::handoff::{ConsumedLink, LinkCreateRequest, LinkSecretRequest};
 use tonk_account::{AccountProviderRecord, AccountStateStatus};
 
 /// Production account API used unless explicitly overridden.
@@ -75,27 +76,6 @@ pub struct LinkOutcome {
     pub account_state: AccountStateStatus,
     /// Diagnostic when the persisted link remains unhydrated.
     pub warning: Option<String>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CreateLinkRequest<'a> {
-    token_hash: &'a str,
-    device_did: &'a str,
-    device_name: &'a str,
-}
-
-#[derive(Serialize)]
-struct SecretRequest<'a> {
-    secret: &'a str,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ConsumeResponse {
-    delegation_hex: String,
-    credential_id: String,
-    descriptor_hex: String,
 }
 
 async fn decode_provider(
@@ -251,10 +231,10 @@ async fn create_remote(
 ) -> Result<()> {
     let response = client
         .post(format!("{}/links", service_url.trim_end_matches('/')))
-        .json(&CreateLinkRequest {
-            token_hash,
-            device_did,
-            device_name,
+        .json(&LinkCreateRequest {
+            token_hash: token_hash.to_string(),
+            device_did: device_did.to_string(),
+            device_name: device_name.to_string(),
         })
         .send()
         .await
@@ -271,13 +251,15 @@ async fn consume_once(
     client: &reqwest::Client,
     service_url: &str,
     secret: &str,
-) -> Result<Option<ConsumeResponse>> {
+) -> Result<Option<ConsumedLink>> {
     let response = client
         .post(format!(
             "{}/links/consume",
             service_url.trim_end_matches('/')
         ))
-        .json(&SecretRequest { secret })
+        .json(&LinkSecretRequest {
+            secret: secret.to_string(),
+        })
         .send()
         .await
         .context("failed to poll account link request")?;
@@ -289,7 +271,7 @@ async fn consume_once(
         let body = response.text().await.unwrap_or_default();
         bail!("account service rejected the link poll ({status}): {body}");
     }
-    Ok(Some(response.json::<ConsumeResponse>().await.context(
+    Ok(Some(response.json::<ConsumedLink>().await.context(
         "account service returned an invalid link response",
     )?))
 }

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -23,6 +23,7 @@ zeroize = { workspace = true }
 getrandom_0_3 = { workspace = true }
 js-sys = { workspace = true }
 rand = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -272,20 +272,45 @@ async fn establish_account_repository(input: JsValue) -> Result<JsValue, JsValue
     Ok(result.into())
 }
 
+fn parse_complete_link_input(
+    input: JsValue,
+) -> Result<tonk_account::handoff::ResolvedLink, JsValue> {
+    let input = serde_wasm_bindgen::from_value::<tonk_account::handoff::ResolvedLink>(input)
+        .map_err(|_| JsValue::from_str("malformed completeLink input"))?;
+    if input.token_hash.is_empty() {
+        return Err(JsValue::from_str("missing or invalid tokenHash"));
+    }
+    if input.device_name.is_empty() {
+        return Err(JsValue::from_str("missing or invalid deviceName"));
+    }
+    if input.device_did.is_empty() {
+        return Err(JsValue::from_str("missing or invalid deviceDid"));
+    }
+    input
+        .device_did
+        .parse::<dialog_varsig::Did>()
+        .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
+    Ok(input)
+}
+
 async fn complete_link(input: JsValue) -> Result<JsValue, JsValue> {
-    let token_hash = string_property(&input, "tokenHash")?;
-    let device_did = string_property(&input, "deviceDid")?
+    let input = parse_complete_link_input(input)?;
+    let device_did = input
+        .device_did
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
-    let device_name = string_property(&input, "deviceName")?;
     let prf = crate::passkey::prf_output().await.map_err(js_error)?;
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
-    let ceremony = crate::ceremony::complete_link(root, token_hash, device_did, device_name)
-        .await
-        .map_err(js_error)?;
-    ceremony_result(ceremony)
+    let ceremony =
+        crate::ceremony::complete_link(root, input.token_hash, device_did, input.device_name)
+            .await
+            .map_err(js_error)?;
+    serde_wasm_bindgen::to_value(&tonk_account::handoff::CompleteLinkCeremony {
+        invocation_hex: ceremony.invocation_hex,
+    })
+    .map_err(|_| JsValue::from_str("failed to serialize completeLink output"))
 }
 
 /// Install `window.tonkIdentity` on the page. Idempotent; a no-op
@@ -391,6 +416,80 @@ mod tests {
     use js_sys::Reflect;
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     wasm_bindgen_test_configure!(run_in_browser);
+
+    fn complete_link_input(
+        token_hash: JsValue,
+        device_did: JsValue,
+        device_name: JsValue,
+    ) -> JsValue {
+        let input = Object::new();
+        Reflect::set(&input, &"tokenHash".into(), &token_hash).unwrap();
+        Reflect::set(&input, &"deviceDid".into(), &device_did).unwrap();
+        Reflect::set(&input, &"deviceName".into(), &device_name).unwrap();
+        input.into()
+    }
+
+    fn parse_error(input: JsValue) -> String {
+        parse_complete_link_input(input)
+            .unwrap_err()
+            .as_string()
+            .expect("parser errors are stable strings")
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_invalid_complete_link_input_before_the_ceremony() {
+        use dialog_varsig::Principal;
+
+        assert_eq!(
+            parse_error(Object::new().into()),
+            "malformed completeLink input"
+        );
+        assert_eq!(
+            parse_error(complete_link_input(
+                "".into(),
+                "did:key:unused".into(),
+                "terminal".into(),
+            )),
+            "missing or invalid tokenHash"
+        );
+        assert_eq!(
+            parse_error(complete_link_input(
+                "hash".into(),
+                "did:key:unused".into(),
+                "".into(),
+            )),
+            "missing or invalid deviceName"
+        );
+        assert_eq!(
+            parse_error(complete_link_input(
+                "hash".into(),
+                "".into(),
+                "terminal".into(),
+            )),
+            "missing or invalid deviceDid"
+        );
+        assert!(
+            parse_error(complete_link_input(
+                "hash".into(),
+                "not a DID".into(),
+                "terminal".into(),
+            ))
+            .starts_with("invalid deviceDid: ")
+        );
+
+        let device = dialog_credentials::Ed25519Signer::import(&[8u8; 32])
+            .await
+            .unwrap();
+        let valid = tonk_account::handoff::ResolvedLink {
+            token_hash: "hash".to_string(),
+            device_did: device.did().to_string(),
+            device_name: "terminal".to_string(),
+        };
+        assert_eq!(
+            parse_complete_link_input(serde_wasm_bindgen::to_value(&valid).unwrap()).unwrap(),
+            valid
+        );
+    }
 
     #[dialog_common::test]
     fn it_installs_ceremony_functions_on_window_tonk_identity() {

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -7,14 +7,13 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement, window};
 
-use tonk_account::AccountStateStatus;
+use tonk_account::{AccountStateStatus, handoff::ResolvedLink};
 use tonk_worker_api::{AccountStatus, RevocationProjection, RevokeDeviceAcknowledgement};
 
 use crate::identity_bridge::{
-    CeremonyOutput, CompleteLinkInput, CreateAccountInput, CreateRootInput,
-    EstablishRepositoryInput, LinkDeviceInput, RevocationOutput, SignRevocationInput,
-    complete_link, create_account, create_root, establish_account_repository, link_device,
-    sign_revocation,
+    CeremonyOutput, CreateAccountInput, CreateRootInput, EstablishRepositoryInput, LinkDeviceInput,
+    RevocationOutput, SignRevocationInput, complete_link, create_account, create_root,
+    establish_account_repository, link_device, sign_revocation,
 };
 
 const STYLE_ID: &str = "tonk-account-styles";
@@ -524,12 +523,7 @@ fn load_handoff(host: HtmlElement) {
             }
         };
         match crate::api::resolve_account_link(&service_url, &secret).await {
-            Ok(link) => {
-                let handoff = CompleteLinkInput {
-                    token_hash: link.token_hash,
-                    device_did: link.device_did,
-                    device_name: link.device_name,
-                };
+            Ok(handoff) => {
                 if let Ok(value) = serde_wasm_bindgen::to_value(&handoff) {
                     let _ = Reflect::set(host.as_ref(), &HANDOFF.into(), &value);
                 }
@@ -957,7 +951,7 @@ fn bind(host: &HtmlElement) {
         clear_error(&host);
         let handoff = Reflect::get(host.as_ref(), &HANDOFF.into())
             .ok()
-            .and_then(|value| serde_wasm_bindgen::from_value::<CompleteLinkInput>(value).ok());
+            .and_then(|value| serde_wasm_bindgen::from_value::<ResolvedLink>(value).ok());
         let Some(handoff) = handoff else {
             return show_error(
                 &host,

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -1,5 +1,6 @@
 use reqwest::StatusCode;
 use serde::Deserialize;
+use tonk_account::handoff::{LinkSecretRequest, ResolvedLink};
 use tonk_worker_api::{
     AccountDevice, AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus,
     EvaluateResponse, IdentifyResponse, JoinRequest, JoinResponse, MembershipResponse,
@@ -8,18 +9,6 @@ use tonk_worker_api::{
 };
 
 use crate::error::TonkUiError;
-
-/// Pending native device metadata resolved through a handoff secret.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PendingAccountLink {
-    /// Hash the root ceremony binds into its signed completion.
-    pub token_hash: String,
-    /// Native profile DID that will receive the delegation.
-    pub device_did: String,
-    /// Native device name shown for confirmation.
-    pub device_name: String,
-}
 
 /// Mirrors the worker's error envelope so we can decode
 /// structured rejections (analyzer code + range) instead of
@@ -741,10 +730,12 @@ pub async fn submit_account_ceremony(
 pub async fn resolve_account_link(
     service: &str,
     secret: &str,
-) -> Result<PendingAccountLink, TonkUiError> {
+) -> Result<ResolvedLink, TonkUiError> {
     let response = reqwest::Client::new()
         .post(format!("{}/links/resolve", service.trim_end_matches('/')))
-        .json(&serde_json::json!({ "secret": secret }))
+        .json(&LinkSecretRequest {
+            secret: secret.to_string(),
+        })
         .send()
         .await
         .map_err(into_api_error)?;

--- a/rust/tonk-ui/src/identity.rs
+++ b/rust/tonk-ui/src/identity.rs
@@ -124,13 +124,20 @@ mod tests {
             .execute_async(
                 r#"
                 const done = arguments[arguments.length - 1];
-                window.tonkIdentity.createAccount({
-                    email: "person@example.com",
-                    code: "123456",
+                window.tonkIdentity.createRoot({
                     deviceDid: arguments[0],
-                    deviceName: "test browser",
-                    remote: "https://accounts.example/ucan/",
+                    label: "person@example.com",
                 })
+                    .then((root) => window.tonkIdentity.createAccount({
+                        email: "person@example.com",
+                        code: "123456",
+                        deviceDid: arguments[0],
+                        deviceName: "test browser",
+                        rootDid: root.rootDid,
+                        credentialId: root.credentialId,
+                        delegationHex: root.delegationHex,
+                        remote: "https://accounts.example/ucan/",
+                    }))
                     .then((result) => done({ ok: result }))
                     .catch((error) => done({ error: String(error) }));
                 "#,
@@ -166,27 +173,51 @@ mod tests {
             ))
         );
 
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_root_signed_cli_handoff(env: TestEnvironment) -> Result<()> {
+        use dialog_credentials::Ed25519Signer;
+        use dialog_ucan_core::principal::Principal;
+        use dialog_ucan_core::promise::Promised;
+        use dialog_ucan_core::{DelegationChain, InvocationChain};
+        use tonk_account::handoff::CompleteLinkCeremony;
+
+        let driver = driver_with_prf(env).await?;
+        let browser = Ed25519Signer::import(&[8u8; 32]).await?;
         let cli = Ed25519Signer::import(&[9u8; 32]).await?;
+        let browser_did = browser.did().to_string();
         let cli_did = cli.did().to_string();
         let output = driver
             .execute_async(
                 r#"
                 const done = arguments[arguments.length - 1];
-                window.tonkIdentity.completeLink({
-                    tokenHash: "handoff-hash",
-                    deviceDid: arguments[0],
-                    deviceName: "test terminal",
-                })
+                window.tonkIdentity.createRoot({ deviceDid: arguments[0] })
+                    .then(() => window.tonkIdentity.completeLink({
+                        tokenHash: "handoff-hash",
+                        deviceDid: arguments[1],
+                        deviceName: "test terminal",
+                    }))
                     .then((result) => done({ ok: result }))
                     .catch((error) => done({ error: String(error) }));
                 "#,
-                vec![serde_json::Value::String(cli_did.clone())],
+                vec![
+                    serde_json::Value::String(browser_did),
+                    serde_json::Value::String(cli_did.clone()),
+                ],
             )
             .await?;
         let output = output.json().clone();
         assert!(output.get("error").is_none(), "handoff failed: {output:?}");
-        let ceremony = &output["ok"];
-        let invocation = hex::decode(ceremony["invocationHex"].as_str().unwrap())?;
+        let raw = output["ok"].as_object().expect("ceremony is an object");
+        assert_eq!(
+            raw.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["invocationHex"]
+        );
+        let ceremony: CompleteLinkCeremony = serde_json::from_value(output["ok"].clone())?;
+        let invocation = hex::decode(ceremony.invocation_hex)?;
         let invocation = InvocationChain::try_from(invocation.as_slice())?;
         invocation
             .verify(&dialog_credentials::Ed25519KeyResolver)
@@ -203,7 +234,11 @@ mod tests {
             invocation.arguments().get("tokenHash"),
             Some(&Promised::String("handoff-hash".into()))
         );
-        let delegation = hex::decode(ceremony["delegationHex"].as_str().unwrap())?;
+        let delegation_hex = match invocation.arguments().get("delegation") {
+            Some(Promised::String(delegation_hex)) => delegation_hex,
+            other => panic!("expected delegation argument, got {other:?}"),
+        };
+        let delegation = hex::decode(delegation_hex)?;
         let delegation = DelegationChain::try_from(delegation.as_slice())?;
         assert_eq!(delegation.audience().to_string(), cli_did);
 

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -4,6 +4,7 @@ use js_sys::{Function, Promise, Reflect};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_wasm_bindgen::Serializer;
 use thiserror::Error;
+use tonk_account::handoff::{CompleteLinkCeremony, ResolvedLink};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
@@ -58,15 +59,6 @@ pub(crate) struct EstablishCeremonyOutput {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LinkDeviceInput {
-    pub device_did: String,
-    pub device_name: String,
-}
-
-/// Input for completing a command-line device handoff.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct CompleteLinkInput {
-    pub token_hash: String,
     pub device_did: String,
     pub device_name: String,
 }
@@ -180,8 +172,8 @@ pub(crate) async fn link_device(
 }
 
 pub(crate) async fn complete_link(
-    input: CompleteLinkInput,
-) -> Result<CeremonyOutput, IdentityBridgeError> {
+    input: ResolvedLink,
+) -> Result<CompleteLinkCeremony, IdentityBridgeError> {
     call("completeLink", input).await
 }
 
@@ -337,19 +329,21 @@ mod tests {
                 if (input.tokenHash !== "token" || input.deviceDid !== "did:key:device"
                     || input.deviceName !== "CLI")
                     return Promise.reject(new Error("property"));
-                return Promise.resolve({{
-                    rootDid: "did:key:root", credentialId: "credential",
-                    delegationHex: "delegation", invocationHex: "invocation"
-                }});"#
+                return Promise.resolve({{ invocationHex: "invocation" }});"#
             ),
         );
-        complete_link(CompleteLinkInput {
-            token_hash: "token".into(),
-            device_did: "did:key:device".into(),
-            device_name: "CLI".into(),
-        })
-        .await
-        .unwrap();
+        assert_eq!(
+            complete_link(ResolvedLink {
+                token_hash: "token".into(),
+                device_did: "did:key:device".into(),
+                device_name: "CLI".into(),
+            })
+            .await
+            .unwrap(),
+            CompleteLinkCeremony {
+                invocation_hex: "invocation".into(),
+            }
+        );
 
         install_method(
             "signRevocation",
@@ -370,6 +364,32 @@ mod tests {
             .revocation_hex,
             "revocation"
         );
+    }
+
+    /// Completing a CLI handoff only submits the root-signed invocation. The
+    /// account service, not this browser response, supplies the durable passkey
+    /// credential id when the CLI consumes the completed handoff.
+    #[dialog_common::test]
+    async fn it_accepts_the_actual_complete_link_output() {
+        install_method(
+            "completeLink",
+            r#"
+            return Promise.resolve({
+                rootDid: "did:key:root", deviceDid: input.deviceDid,
+                delegationHex: "delegation", invocationHex: "invocation"
+            });
+            "#,
+        );
+
+        let output = complete_link(ResolvedLink {
+            token_hash: "token".into(),
+            device_did: "did:key:device".into(),
+            device_name: "CLI".into(),
+        })
+        .await
+        .expect("the real completeLink response is a valid bridge output");
+
+        assert_eq!(output.invocation_hex, "invocation");
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## Summary
- add phase-specific native handoff DTOs under `tonk_account::handoff`
- migrate the account service, CLI, UI, and identity bridge to the shared contract
- make `completeLink` return only the signed `invocationHex` and preserve pre-passkey input validation
- retain the missing-`credentialId` regression coverage and add dedicated CLI handoff integration coverage

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p tonk-account`
- `cargo test -p tonk-account-service --features helpers --test service`
- `cargo check -p tonk-account-service --target wasm32-unknown-unknown`
- `cargo test -p tonk-cli --lib account::tests`
- `cargo test -p tonk-identity --target wasm32-unknown-unknown --lib -- --nocapture`
- `cargo test -p tonk-ui --target wasm32-unknown-unknown --lib -- --nocapture`
- `cargo check -p tonk-ui --target wasm32-unknown-unknown`
- `cargo clippy -p tonk-ui --target wasm32-unknown-unknown --all-targets --no-deps -- -D warnings`
- `nix build .#tonk-account-service --no-link`
- `nix build .#tonk-ui --no-link`
- `cargo test -p tonk-ui --features web-integration-tests --no-run`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `handoff` module to facilitate native account handoffs, incorporating new request structures and modifying existing functions to utilize these structures for better handling of link creation and resolution processes.

### Detailed summary
- Added `handoff` module in `rust/tonk-account/src/lib.rs`.
- Introduced `LinkCreateRequest`, `LinkSecretRequest`, `ResolvedLink`, and `CompleteLinkCeremony` structs in `rust/tonk-account/src/handoff.rs`.
- Updated various functions to use new request/response types.
- Removed obsolete structs and references related to link handling.
- Enhanced error handling and validation for link-related operations.
- Updated tests to cover new structures and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->