### PR TITLE
feat(account): add CLI logout

### DIFF
--- a/plan/account-logout-cli.md
+++ b/plan/account-logout-cli.md
@@ -1,0 +1,78 @@
+# CLI account logout implementation plan
+
+**Goal:** Add `tonk account logout` so the native CLI can disconnect its local provider attachment without erasing or rotating the profile, revoking the device, or losing local spot authority.
+
+**Approach:** Match the existing browser worker's `DELETE /api/account` / `unlink` semantics: write the account-provider credential's established empty-byte tombstone through the account-state operator, while leaving the local root, profile signer, account repository, trusted marker, spots, and delegations intact. Expose that operation from `tonk_cli::account`, wire it into the Clap command and telemetry descriptor, and document that remote revocation remains the separate `tonk account revoke` workflow.
+
+**Constraints:**
+- Implement against the current `feat/account-spots-cli` branch (HEAD `745ddeca2` when this plan was written) and preserve its account-spots listing, restore, and best-effort backup behavior.
+- `logout` means local provider detachment, matching `rust/tonk-worker/src/router/account.rs:unlink`; it must not call the account service, self-revoke the device, open a browser, reset the profile, rotate the device DID, remove the durable local root, delete the account repository, remove a trusted-base marker, or mutate any spot/site/registry/binding.
+- Keep `tonk account revoke <DID>` as the explicit server-side revocation operation. Logging out must remain usable offline and must leave the device active in the provider's device registry.
+- The dialog credential API has no delete operation. Clear only `tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE` by saving `Vec::<u8>::new()`, which `AccountProviderRecord::decode` already defines as the detach tombstone.
+- The operation is idempotent: an already-unregistered or root-missing profile may run `tonk account logout` successfully, and a second logout must remain successful.
+- After logout, `tonk account status` must report `provider: none` while retaining the same root DID and device DID when they existed. A later `tonk account link` may reattach provider services to that unchanged local authority.
+- Do not require an active spot or add `--spot` behavior, confirmation prompts, network options, dependencies, schema/storage migrations, a version bump, or `Cargo.lock` changes.
+- Preserve unrelated current-branch work and use the existing error/exit-code path (`anyhow::Result` into `print_failure`).
+
+## File map
+
+- `rust/tonk-cli/src/account.rs`: implement and unit-test provider tombstoning through the mounted account credential operator.
+- `rust/tonk-cli/src/bin/tonk.rs`: define and dispatch `account logout`, describe its non-destructive semantics in help, and classify it as the static `account`/`logout` telemetry descriptor.
+- `rust/tonk-cli/README.md`: add the command to account usage and distinguish logout from revocation and identity reset.
+- `plan/account-logout-cli.md`: durable implementation handoff; no production behavior.
+
+### Task 1: Detach the native provider without changing local authority
+
+**Files:**
+- Modify: `rust/tonk-cli/src/account.rs:stored_provider_with_operator, new logout/logout_with_operator functions, tests`
+- Test: `rust/tonk-cli/src/account.rs:tests`
+
+**Interfaces:**
+- Consumes: `account_state::credential_operator(profile)`, `ACCOUNT_LINK_SITE`, and the empty-byte tombstone contract in `tonk_account::AccountProviderRecord::decode`.
+- Produces:
+
+```rust
+/// Disconnect provider services while preserving this profile's root,
+/// delegations, account repository, and spots.
+pub async fn logout(profile: &dialog_operator::Profile) -> anyhow::Result<()>;
+
+// Private seam used by `logout` and isolated unit coverage.
+async fn logout_with_operator(
+    profile: &dialog_operator::Profile,
+    operator: &dialog_operator::Operator<dialog_storage::provider::storage::NativeSpace>,
+) -> anyhow::Result<()>;
+```
+
+- [ ] Add `it_logs_out_by_tombstoning_only_the_provider_attachment` in `account.rs`. Create a temp-rooted profile and `SpotStore`, build its operator with `account_state::credential_operator_for_store`, and persist: (1) a valid `LocalRoot` JSON record at `identity::LOCAL_ROOT_SITE`, (2) an encoded `AccountProviderRecord::attach_unconfigured(...)` at `ACCOUNT_LINK_SITE`, and (3) sentinel bytes at `tonk_account::TRUSTED_BASE_CREDENTIAL_SITE`. Also place a sentinel file under `store.account_dir()` and capture the profile DID. Assert `stored_provider_with_operator` is `Some` before logout.
+- [ ] In that test, call the not-yet-existing `logout_with_operator`; then assert `stored_provider_with_operator` is `None`, the raw `ACCOUNT_LINK_SITE` value is exactly empty, the `LocalRoot` record is byte-for-byte unchanged, the trusted-base marker is unchanged, the account-directory sentinel still exists, and `profile.did()` is unchanged. Run `cargo test -p tonk-cli --lib account::tests::it_logs_out_by_tombstoning_only_the_provider_attachment`; expect compilation failure because `logout_with_operator` does not exist.
+- [ ] Implement `logout_with_operator` as one credential save: `profile.credential().site(ACCOUNT_LINK_SITE).save(Vec::<u8>::new()).perform(operator).await`, with context `failed to clear the account provider`. Do not load a connection, issue an HTTP request, alter local-root/access credentials, or remove account-state files.
+- [ ] Implement public `logout` as the production adapter that obtains `account_state::credential_operator(profile)` and delegates to `logout_with_operator`. Keep it returning `Result<()>`: once the tombstone save succeeds, a later status-read problem must not turn the completed local mutation into a misleading logout failure.
+- [ ] Extend the same test (or add `it_allows_repeated_logout`) to call `logout_with_operator` a second time and assert success and the same preserved state. Run `cargo test -p tonk-cli --lib account::tests::it_logs_out_by_tombstoning_only_the_provider_attachment`; expect success.
+- [ ] Run `cargo test -p tonk-cli --lib account::tests`; expect all account link/device/revoke/logout unit tests to pass.
+
+### Task 2: Expose `tonk account logout` and document its boundary
+
+**Files:**
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:AccountCommand, descriptor, account_op, account parser tests`
+- Modify: `rust/tonk-cli/README.md:Usage account examples and account behavior note`
+- Test: `rust/tonk-cli/src/bin/tonk.rs:account parser tests`
+
+**Interfaces:**
+- Consumes: `account::logout(&Profile) -> anyhow::Result<()>` from Task 1 and the already-opened profile in `account_op`.
+- Produces: a no-argument `AccountCommand::Logout` parsed from `tonk account logout`, telemetry descriptor `("account", Some("logout"))`, success output `logged out\ndevice: <DID>`, and the usual non-zero `print_failure` path when the tombstone cannot be persisted.
+
+- [ ] Add `account_logout_is_a_no_argument_account_operation` beside the current account-spots parser tests. Parse `tonk account logout`, assert it yields `Command::Account { command: AccountCommand::Logout }`, and assert `descriptor` returns `("account", Some("logout"))`. Also assert `tonk account logout unexpected` is rejected by Clap. Run `cargo test -p tonk-cli --bin tonk account_logout_is_a_no_argument_account_operation`; expect compilation failure because the variant is absent.
+- [ ] Add `AccountCommand::Logout` with help that says it disconnects account services on this device, preserves local identity/root/spots, and does not revoke the device; direct users to `tonk account revoke <DID>` when they intend revocation. Do not add a confirmation or service URL argument because logout is local, reversible, and offline.
+- [ ] Add the exhaustive `descriptor` arm returning `"logout"`, so telemetry records only the static command name and no account identifiers.
+- [ ] Add the `account_op` arm. Call `account::logout(&profile)`; on success print exactly `logged out` and `device: {profile.did()}` on separate lines and return `ExitCode::Success`; on error use `print_failure(error)`. Do not invoke account-spots backup, status hydration, revocation, identity reset, or any active-spot path.
+- [ ] Rerun `cargo test -p tonk-cli --bin tonk account_logout_is_a_no_argument_account_operation`; expect success.
+- [ ] Update `rust/tonk-cli/README.md` account examples with `tonk account logout`. State that it writes only a local detach tombstone, keeps the root/device identity and spots available, works offline, and does not revoke the provider-side device; point to `tonk account devices` plus `tonk account revoke <DEVICE_DID>` for revocation and reserve `tonk identity --reset` for destructive identity rotation.
+- [ ] Run `cargo test -p tonk-cli --bin tonk`; expect all parser/dispatch helper tests to pass.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_spots`; expect current-branch account inventory, pull, and backup behavior to remain green.
+- [ ] Run `cargo fmt --all -- --check` and `cargo test -p tonk-cli`; expect formatting and all default CLI tests to pass. Confirm `git diff -- Cargo.lock` is empty.
+
+## Handoff verification
+
+- [ ] Run `rg -n "TBD|TODO|similar to|handle errors|write tests" plan/account-logout-cli.md`; expect no unresolved implementation placeholders (the command may match this verification sentence only).
+- [ ] Review the final diff and verify every production change is confined to `rust/tonk-cli/src/account.rs`, `rust/tonk-cli/src/bin/tonk.rs`, and `rust/tonk-cli/README.md`; no account-service, worker, identity-reset, spot-storage, dependency, lockfile, or version changes belong in this feature.
+- [ ] Verify the behavior matrix from tests and code: linked → provider tombstone; unlinked → success; repeated logout → success; local root/device/account directory/spots preserved; no network/revocation path reachable; telemetry descriptor is static `account/logout`.

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -63,6 +63,7 @@ tonk status       # synced | ahead | behind | diverged | no-upstream
 # Link this native profile to a passkey-backed account.
 tonk account status
 tonk account link --name workstation
+tonk account logout
 
 # Delegate access to the space.
 tonk invite                    # audience-open: anyone holding it can claim
@@ -118,6 +119,16 @@ distinct per failure stage (`ParseError`, `AnalyzeError`, `CommitError`,
 When an upstream is configured, a committing eval is wrapped with an automatic
 pull-before / push-after. `--no-sync` (or `TONK_NO_SYNC`) skips it; manual
 `tonk push` / `tonk pull` stay available either way.
+
+### Accounts
+
+`tonk account logout` writes only a local provider-detachment tombstone. It
+works offline and keeps the root and device identity, local spots, and account
+repository available for a later `tonk account link`. Logout does not revoke
+the provider-side device. To revoke one, find its DID with
+`tonk account devices` and run `tonk account revoke <DEVICE_DID>`. Use
+`tonk identity --reset` only when destructive local identity rotation is
+intended.
 
 ### Sync and sharing
 

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -139,6 +139,26 @@ async fn stored_provider(profile: &Profile) -> Result<Option<AccountProviderReco
     stored_provider_with_operator(profile, &operator).await
 }
 
+/// Disconnect provider services while preserving this profile's root,
+/// delegations, account repository, and spots.
+pub async fn logout(profile: &Profile) -> Result<()> {
+    let operator = crate::account_state::credential_operator(profile).await?;
+    logout_with_operator(profile, &operator).await
+}
+
+async fn logout_with_operator(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+) -> Result<()> {
+    profile
+        .credential()
+        .site(ACCOUNT_LINK_SITE)
+        .save(Vec::<u8>::new())
+        .perform(operator)
+        .await
+        .context("failed to clear the account provider")
+}
+
 fn parse_root_did(root_did: &str) -> Result<dialog_varsig::Did> {
     root_did.parse().context("stored local root DID is invalid")
 }
@@ -749,6 +769,120 @@ pub async fn revoke(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[dialog_common::test]
+    async fn it_logs_out_by_tombstoning_only_the_provider_attachment() {
+        use dialog_capability::Subject;
+        use dialog_effects::storage::Directory;
+        use dialog_storage::provider::storage::Storage;
+
+        let temp = tempfile::tempdir().unwrap();
+        let store = crate::spot::SpotStore::at(temp.path().join("state"));
+        let profile_dir = Directory::At(temp.path().join("profiles").to_string_lossy().into());
+        let profile_name = format!("cli-account-logout-test-{}", rand::random::<u64>());
+        let storage = Storage::<NativeSpace>::default();
+        let profile = Profile::open(&profile_name)
+            .at(profile_dir)
+            .perform(&storage)
+            .await
+            .unwrap();
+        std::fs::create_dir_all(store.account_dir()).unwrap();
+        let account_dir = store.account_dir().canonicalize().unwrap();
+        let operator = profile
+            .derive(b"tonk/account-state/v1")
+            .allow(Subject::any())
+            .base(Directory::At(account_dir.to_string_lossy().into()))
+            .build(storage)
+            .await
+            .unwrap();
+        let device_did = profile.did();
+        let local_root = crate::identity::LocalRoot {
+            credential_id: "credential".to_string(),
+            root_did: device_did.to_string(),
+            delegation_cid: "delegation".to_string(),
+            delegation_hex: "00".to_string(),
+        };
+        let local_root_bytes = serde_json::to_vec(&local_root).unwrap();
+        let provider = AccountProviderRecord::attach_unconfigured("https://accounts.example", 1)
+            .unwrap()
+            .encode()
+            .unwrap();
+        let trusted_base = b"trusted-base".to_vec();
+        profile
+            .credential()
+            .site(crate::identity::LOCAL_ROOT_SITE)
+            .save(local_root_bytes.clone())
+            .perform(&operator)
+            .await
+            .unwrap();
+        profile
+            .credential()
+            .site(ACCOUNT_LINK_SITE)
+            .save(provider)
+            .perform(&operator)
+            .await
+            .unwrap();
+        profile
+            .credential()
+            .site(tonk_account::TRUSTED_BASE_CREDENTIAL_SITE)
+            .save(trusted_base.clone())
+            .perform(&operator)
+            .await
+            .unwrap();
+        let sentinel = store.account_dir().join("sentinel");
+        std::fs::write(&sentinel, b"keep").unwrap();
+
+        assert!(
+            stored_provider_with_operator(&profile, &operator)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        logout_with_operator(&profile, &operator).await.unwrap();
+
+        assert!(
+            stored_provider_with_operator(&profile, &operator)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        logout_with_operator(&profile, &operator).await.unwrap();
+
+        assert_eq!(
+            profile
+                .credential()
+                .site(ACCOUNT_LINK_SITE)
+                .load::<Vec<u8>>()
+                .perform(&operator)
+                .await
+                .unwrap(),
+            Vec::<u8>::new()
+        );
+        assert_eq!(
+            profile
+                .credential()
+                .site(crate::identity::LOCAL_ROOT_SITE)
+                .load::<Vec<u8>>()
+                .perform(&operator)
+                .await
+                .unwrap(),
+            local_root_bytes
+        );
+        assert_eq!(
+            profile
+                .credential()
+                .site(tonk_account::TRUSTED_BASE_CREDENTIAL_SITE)
+                .load::<Vec<u8>>()
+                .perform(&operator)
+                .await
+                .unwrap(),
+            trusted_base
+        );
+        assert_eq!(std::fs::read(&sentinel).unwrap(), b"keep");
+        assert_eq!(profile.did(), device_did);
+    }
 
     #[test]
     fn it_points_the_revoke_ceremony_at_the_named_device() {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1192,6 +1192,27 @@ fn account_state_label(status: tonk_account::AccountStateStatus) -> &'static str
     }
 }
 
+fn render_account_status(status: account::AccountStatus) -> String {
+    match status {
+        account::AccountStatus::MissingRoot { device_did } => {
+            format!("signed in: no\nroot: missing\nprovider: none\ndevice: {device_did}")
+        }
+        account::AccountStatus::Unregistered {
+            root_did,
+            device_did,
+        } => format!("signed in: no\nroot: {root_did}\nprovider: none\ndevice: {device_did}"),
+        account::AccountStatus::Registered {
+            root_did,
+            device_did,
+            provider,
+            account_state,
+        } => format!(
+            "signed in: yes\nroot: {root_did}\nprovider: {provider}\ndevice: {device_did}\naccount state: {}",
+            account_state_label(account_state)
+        ),
+    }
+}
+
 async fn account_op(command: AccountCommand) -> ExitCode {
     let profile = match identity::open().await {
         Ok(profile) => profile,
@@ -1199,27 +1220,8 @@ async fn account_op(command: AccountCommand) -> ExitCode {
     };
     match command {
         AccountCommand::Status => match account::status(&profile).await {
-            Ok(account::AccountStatus::MissingRoot { device_did }) => {
-                println!("root: missing\nprovider: none\ndevice: {device_did}");
-                ExitCode::Success
-            }
-            Ok(account::AccountStatus::Unregistered {
-                root_did,
-                device_did,
-            }) => {
-                println!("root: {root_did}\nprovider: none\ndevice: {device_did}");
-                ExitCode::Success
-            }
-            Ok(account::AccountStatus::Registered {
-                root_did,
-                device_did,
-                provider,
-                account_state,
-            }) => {
-                println!(
-                    "root: {root_did}\nprovider: {provider}\ndevice: {device_did}\naccount state: {}",
-                    account_state_label(account_state)
-                );
+            Ok(status) => {
+                println!("{}", render_account_status(status));
                 ExitCode::Success
             }
             Err(error) => print_failure(error),
@@ -2748,6 +2750,32 @@ fn classify(err: &EvalError) -> ExitCode {
 #[cfg(test)]
 mod account_spots_parser_tests {
     use super::*;
+
+    #[test]
+    fn account_status_makes_sign_in_state_explicit() {
+        assert_eq!(
+            render_account_status(account::AccountStatus::MissingRoot {
+                device_did: "did:device".to_string(),
+            }),
+            "signed in: no\nroot: missing\nprovider: none\ndevice: did:device"
+        );
+        assert_eq!(
+            render_account_status(account::AccountStatus::Unregistered {
+                root_did: "did:root".to_string(),
+                device_did: "did:device".to_string(),
+            }),
+            "signed in: no\nroot: did:root\nprovider: none\ndevice: did:device"
+        );
+        assert_eq!(
+            render_account_status(account::AccountStatus::Registered {
+                root_did: "did:root".to_string(),
+                device_did: "did:device".to_string(),
+                provider: "https://accounts.example".to_string(),
+                account_state: tonk_account::AccountStateStatus::Ready,
+            }),
+            "signed in: yes\nroot: did:root\nprovider: https://accounts.example\ndevice: did:device\naccount state: ready"
+        );
+    }
 
     #[test]
     fn account_logout_is_a_no_argument_account_operation() {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -502,6 +502,12 @@ enum AccountCommand {
         no_open: bool,
     },
 
+    /// Disconnect account services on this device
+    ///
+    /// Preserves the local identity, root, and spots without revoking this
+    /// device. Use `tonk account revoke <DID>` to revoke a device instead.
+    Logout,
+
     /// List or pull the spots backed up under this account
     Spots {
         #[command(subcommand)]
@@ -847,6 +853,7 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
             Some(match command {
                 AccountCommand::Status => "status",
                 AccountCommand::Link { .. } => "link",
+                AccountCommand::Logout => "logout",
                 AccountCommand::Spots { command } => match command {
                     None | Some(AccountSpotsCommand::List) => "spots-list",
                     Some(AccountSpotsCommand::Pull { .. }) => "spots-pull",
@@ -1244,6 +1251,13 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                     eprintln!("warning: account repository is not synchronized: {warning}");
                 }
                 back_up_all_best_effort(&profile).await;
+                ExitCode::Success
+            }
+            Err(error) => print_failure(error),
+        },
+        AccountCommand::Logout => match account::logout(&profile).await {
+            Ok(()) => {
+                println!("logged out\ndevice: {}", profile.did());
                 ExitCode::Success
             }
             Err(error) => print_failure(error),
@@ -2734,6 +2748,20 @@ fn classify(err: &EvalError) -> ExitCode {
 #[cfg(test)]
 mod account_spots_parser_tests {
     use super::*;
+
+    #[test]
+    fn account_logout_is_a_no_argument_account_operation() {
+        let cli = Cli::try_parse_from(["tonk", "account", "logout"]).unwrap();
+        let command = cli.command.as_ref().expect("account command");
+        assert!(matches!(
+            command,
+            Command::Account {
+                command: AccountCommand::Logout
+            }
+        ));
+        assert_eq!(descriptor(command), ("account", Some("logout")));
+        assert!(Cli::try_parse_from(["tonk", "account", "logout", "unexpected"]).is_err());
+    }
 
     #[test]
     fn account_spots_bare_and_list_are_the_same_operation() {


### PR DESCRIPTION
## Summary

- add `tonk account logout` as an offline, idempotent provider-detachment command
- preserve the local root, device identity, delegations, account repository, trusted marker, and spots
- document the boundary between logout, provider-side device revocation, and destructive identity reset

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tonk-cli`
- `cargo test -p tonk-cli --features integration-tests --test account_spots`

## Stack

This PR targets `feat/account-spots-cli` and is stacked on #674.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `tonk account logout` command to the CLI, allowing users to disconnect their local provider attachment while preserving their profile and account data. It does not revoke the device or require an internet connection.

### Detailed summary
- Added `tonk account logout` command to the CLI.
- Implemented `logout` function to clear the account provider credential.
- Preserved local identity, root, and spots during logout.
- Updated `README.md` with usage instructions for the new command.
- Created tests for logout functionality and account status rendering.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->