### PR TITLE
feat(account): add descriptive device names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1505,16 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
 ]
 
 [[package]]
@@ -2632,6 +2651,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2740,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,7 +2829,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2770,6 +2935,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2840,7 +3020,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f837924d5368f9f35a1c404699de3c074311358035c77d7164f5948c08b31382"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "windows",
 ]
@@ -4432,6 +4612,7 @@ dependencies = [
  "hex",
  "ipld-core",
  "lsp-types",
+ "os_info",
  "rand 0.9.5",
  "reqwest 0.12.28",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ keyring = "3.6"
 lsp-types = "0.97"
 matchit = "0.8"
 multibase = "0.9"
+os_info = { version = "3.15", default-features = false }
 parking_lot = "0.12"
 port_check = "0.3"
 proc-macro2 = "1"

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -133,6 +133,7 @@ futures-util = { workspace = true }
 reqwest = { workspace = true }
 ipld-core = { workspace = true }
 lsp-types = { workspace = true }
+os_info = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml = { workspace = true }

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -28,6 +28,33 @@ pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SI
 /// best-effort and must not leave the handoff command waiting indefinitely.
 const ACCOUNT_STATE_ENSURE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Descriptive registration name for a native CLI device.
+pub fn default_device_name() -> String {
+    let info = os_info::get();
+    format_device_name(info.os_type(), info.version())
+}
+
+fn format_device_name(os_type: os_info::Type, version: &os_info::Version) -> String {
+    let os_name = match os_type {
+        os_info::Type::Macos => "macOS".to_string(),
+        os_info::Type::Unknown => "unknown OS".to_string(),
+        os_type => os_type.to_string(),
+    };
+    let version = match version {
+        os_info::Version::Unknown => "(version unknown)".to_string(),
+        version => version.to_string(),
+    };
+    let mut name = format!("Tonk CLI on {os_name} {version}");
+    if name.len() > 100 {
+        let mut end = 100;
+        while !name.is_char_boundary(end) {
+            end -= 1;
+        }
+        name.truncate(end);
+    }
+    name
+}
+
 /// Current native profile account-link state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccountStatus {
@@ -782,6 +809,45 @@ pub async fn revoke(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn it_formats_the_cli_device_name_with_os_version() {
+        assert_eq!(
+            format_device_name(os_info::Type::Macos, &os_info::Version::Semantic(15, 6, 0)),
+            "Tonk CLI on macOS 15.6.0"
+        );
+        assert_eq!(
+            format_device_name(
+                os_info::Type::Ubuntu,
+                &os_info::Version::Custom("24.04 LTS".to_string())
+            ),
+            "Tonk CLI on Ubuntu 24.04 LTS"
+        );
+    }
+
+    #[test]
+    fn it_falls_back_for_unknown_cli_os_metadata() {
+        assert_eq!(
+            format_device_name(os_info::Type::Linux, &os_info::Version::Unknown),
+            "Tonk CLI on Linux (version unknown)"
+        );
+        assert_eq!(
+            format_device_name(os_info::Type::Unknown, &os_info::Version::Unknown),
+            "Tonk CLI on unknown OS (version unknown)"
+        );
+    }
+
+    #[test]
+    fn it_bounds_the_cli_device_name_without_splitting_utf8() {
+        let label = format_device_name(
+            os_info::Type::Linux,
+            &os_info::Version::Custom("é".repeat(100)),
+        );
+
+        assert!(label.starts_with("Tonk CLI on Linux "));
+        assert!(label.len() <= 100);
+        assert!(!label.is_empty());
+    }
 
     #[dialog_common::test]
     async fn it_logs_out_by_tombstoning_only_the_provider_attachment() {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -478,9 +478,9 @@ enum AccountCommand {
         after_help = "Examples:\n  tonk account link\n  tonk account link --name workstation"
     )]
     Link {
-        /// Device name shown on the browser confirmation screen.
-        #[arg(long, value_name = "NAME", default_value = "Tonk CLI")]
-        name: String,
+        /// Override the automatically generated OS/version device name.
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
         /// Account service base URL (for staging or local development).
         #[arg(
             long,
@@ -1236,7 +1236,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             &account::LinkOptions {
                 service_url,
                 account_url,
-                device_name: name,
+                device_name: name.unwrap_or_else(account::default_device_name),
                 open_browser: !no_open,
             },
         )
@@ -2775,6 +2775,31 @@ mod account_spots_parser_tests {
             }),
             "signed in: yes\nroot: did:root\nprovider: https://accounts.example\ndevice: did:device\naccount state: ready"
         );
+    }
+
+    #[test]
+    fn account_link_name_is_none_when_omitted() {
+        let cli = Cli::try_parse_from(["tonk", "account", "link"]).unwrap();
+        let Some(Command::Account {
+            command: AccountCommand::Link { name, .. },
+        }) = cli.command
+        else {
+            panic!("expected account link");
+        };
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn account_link_name_preserves_an_explicit_override() {
+        let cli =
+            Cli::try_parse_from(["tonk", "account", "link", "--name", "workstation"]).unwrap();
+        let Some(Command::Account {
+            command: AccountCommand::Link { name, .. },
+        }) = cli.command
+        else {
+            panic!("expected account link");
+        };
+        assert_eq!(name.as_deref(), Some("workstation"));
     }
 
     #[test]

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -92,6 +92,7 @@ features = [
     "HtmlScriptElement",
     "Location",
     "MessageEvent",
+    "Navigator",
     "Node",
     "ServiceWorkerContainer",
     "Storage",

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -37,7 +37,6 @@
       <label>Verification code
         <input id="account-code" name="Verification code" type="text" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
       </label>
-      <input id="account-create-device-name" name="Device name" type="hidden" value="This browser">
       <button id="account-create-submit" class="account__button" type="submit">Create account</button>
       <button id="account-verify-back" class="account__button account__button--quiet" type="button">Use a different email</button>
     </form>
@@ -46,7 +45,6 @@
   <section id="account-link" class="account__panel" hidden>
     <h2>Log in</h2>
     <form class="account__form">
-      <input id="account-link-device-name" name="Device name" type="hidden" value="This browser">
       <button id="account-link-submit" class="account__button" type="submit">Log in</button>
       <button id="account-link-back" class="account__button account__button--quiet" type="button">Back</button>
     </form>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -833,14 +833,12 @@ fn bind(host: &HtmlElement) {
         let fields = (
             input(&host, "#account-email"),
             input(&host, "#account-code"),
-            input(&host, "#account-create-device-name"),
         );
-        let (email, code, device_name) = match fields {
-            (Ok(email), Ok(code), Ok(name)) => (email, code, name),
-            (Err(error), _, _) | (_, Err(error), _) | (_, _, Err(error)) => {
-                return show_error(&host, error);
-            }
+        let (email, code) = match fields {
+            (Ok(email), Ok(code)) => (email, code),
+            (Err(error), _) | (_, Err(error)) => return show_error(&host, error),
         };
+        let device_name = crate::device_name::current();
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let result = async {
@@ -919,10 +917,7 @@ fn bind(host: &HtmlElement) {
 
     on_click(host, "#account-link-submit", |host| {
         clear_error(&host);
-        let device_name = match input(&host, "#account-link-device-name") {
-            Ok(value) => value,
-            Err(error) => return show_error(&host, error),
-        };
+        let device_name = crate::device_name::current();
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let result = async {
@@ -1301,6 +1296,22 @@ mod tests {
     }
 
     #[dialog_common::test]
+    fn it_does_not_author_fixed_browser_registration_names() {
+        let host = host();
+        assert!(
+            host.query_selector("#account-create-device-name")
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            host.query_selector("#account-link-device-name")
+                .unwrap()
+                .is_none()
+        );
+        assert!(!host.inner_html().contains("This browser"));
+    }
+
+    #[dialog_common::test]
     fn it_distinguishes_publication_from_projection_and_self_revocation() {
         let stale = RevokeDeviceAcknowledgement {
             target_did: "did:key:device".into(),
@@ -1409,6 +1420,8 @@ mod tests {
     #[dialog_common::test]
     async fn it_renders_the_device_list_with_a_this_device_marker() {
         let host = mounted_account_host().await;
+        // A legacy persisted label must still render verbatim; this change only
+        // affects names generated for new registrations.
         let devices = vec![
             tonk_worker_api::AccountDevice {
                 did: "did:key:zThis".into(),

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -162,7 +162,7 @@ mod tests {
             .click()
             .await?;
         element(&driver, "tonk-account[data-mode=\"devices\"]").await?;
-        wait_for_text_containing(&driver, "#account-device-list", "This browser").await?;
+        wait_for_text_containing(&driver, "#account-device-list", "Chrome on ").await?;
 
         driver.quit().await?;
         Ok(())
@@ -384,7 +384,11 @@ mod tests {
             "devices failed: {}",
             devices.stderr
         );
-        assert!(devices.stdout.contains("active\tThis browser\t"));
+        assert!(
+            devices.stdout.contains("active\tChrome on "),
+            "{}",
+            devices.stdout
+        );
         assert!(devices.stdout.contains("active\te2e terminal\t"));
         assert!(devices.stdout.contains(" (this device)"));
 

--- a/rust/tonk-ui/src/device_name.rs
+++ b/rust/tonk-ui/src/device_name.rs
@@ -1,0 +1,169 @@
+//! Best-effort browser device labels for account registration.
+
+use web_sys::window;
+
+/// Derive the current browser's descriptive account device label.
+pub(crate) fn current() -> String {
+    let Some(window) = window() else {
+        return from_navigator("", "", 0);
+    };
+    let navigator = window.navigator();
+    from_navigator(
+        &navigator.user_agent().unwrap_or_default(),
+        &navigator.platform().unwrap_or_default(),
+        navigator.max_touch_points(),
+    )
+}
+
+fn from_navigator(user_agent: &str, platform: &str, max_touch_points: i32) -> String {
+    let browser = if ["Edg/", "EdgA/", "EdgiOS/"]
+        .iter()
+        .any(|token| user_agent.contains(token))
+    {
+        "Edge"
+    } else if user_agent.contains("OPR/") {
+        "Opera"
+    } else if user_agent.contains("SamsungBrowser/") {
+        "Samsung Internet"
+    } else if user_agent.contains("Chrome/") || user_agent.contains("CriOS/") {
+        "Chrome"
+    } else if user_agent.contains("Firefox/") || user_agent.contains("FxiOS/") {
+        "Firefox"
+    } else if user_agent.contains("Safari/") {
+        "Safari"
+    } else {
+        "Browser"
+    };
+
+    let is_ipad_desktop = platform.contains("MacIntel") && max_touch_points > 1;
+    let os = if is_ipad_desktop
+        || ["iPhone", "iPad", "iPod"]
+            .iter()
+            .any(|token| user_agent.contains(token) || platform.contains(token))
+    {
+        "iOS"
+    } else if user_agent.contains("Android") || platform.contains("Android") {
+        "Android"
+    } else if user_agent.contains("Windows") || platform.contains("Win") {
+        "Windows"
+    } else if user_agent.contains("CrOS") || platform.contains("CrOS") {
+        "Chrome OS"
+    } else if ["Macintosh", "Mac OS", "MacIntel"]
+        .iter()
+        .any(|token| user_agent.contains(token) || platform.contains(token))
+    {
+        "macOS"
+    } else if user_agent.contains("Linux") || platform.contains("Linux") {
+        "Linux"
+    } else {
+        "Unknown OS"
+    };
+
+    format!("{browser} on {os}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::from_navigator;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_browser_and_os_families_from_navigator_metadata() {
+        let cases = [
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0 Safari/537.36",
+                "MacIntel",
+                0,
+                "Chrome on macOS",
+            ),
+            (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/138.0 Safari/537.36 Edg/138.0",
+                "Win32",
+                0,
+                "Edge on Windows",
+            ),
+            (
+                "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
+                "Linux x86_64",
+                0,
+                "Firefox on Linux",
+            ),
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15",
+                "MacIntel",
+                0,
+                "Safari on macOS",
+            ),
+            (
+                "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/138.0 Mobile Safari/537.36",
+                "Linux armv8l",
+                5,
+                "Chrome on Android",
+            ),
+            (
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 Version/18.5 Mobile Safari/604.1",
+                "iPhone",
+                5,
+                "Safari on iOS",
+            ),
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 Version/18.0 Mobile Safari/604.1",
+                "MacIntel",
+                5,
+                "Safari on iOS",
+            ),
+            ("", "", 0, "Browser on Unknown OS"),
+        ];
+
+        for (user_agent, platform, touch_points, expected) in cases {
+            assert_eq!(
+                from_navigator(user_agent, platform, touch_points),
+                expected,
+                "user agent: {user_agent}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_applies_embedded_browser_token_precedence() {
+        let cases = [
+            ("Chrome/120 Edg/120", "Edge"),
+            ("Chrome/120 EdgA/120", "Edge"),
+            ("CriOS/120 EdgiOS/120", "Edge"),
+            ("Chrome/120 OPR/106", "Opera"),
+            ("Chrome/120 SamsungBrowser/25", "Samsung Internet"),
+            ("CriOS/120 Mobile", "Chrome"),
+            ("FxiOS/120 Mobile", "Firefox"),
+        ];
+
+        for (user_agent, browser) in cases {
+            assert_eq!(
+                from_navigator(user_agent, "", 0),
+                format!("{browser} on Unknown OS"),
+                "user agent: {user_agent}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_applies_os_token_precedence() {
+        let cases = [
+            ("iPhone Android Windows CrOS Macintosh Linux", "iOS"),
+            ("Android Windows CrOS Macintosh Linux", "Android"),
+            ("Windows CrOS Macintosh Linux", "Windows"),
+            ("CrOS Macintosh Linux", "Chrome OS"),
+            ("Macintosh Linux", "macOS"),
+            ("Linux", "Linux"),
+        ];
+
+        for (metadata, os) in cases {
+            assert_eq!(
+                from_navigator(metadata, metadata, 0),
+                format!("Browser on {os}"),
+                "metadata: {metadata}"
+            );
+        }
+    }
+}

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -24,6 +24,9 @@ pub mod analytics;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod deployment;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod device_name;
+
 /// Error types for the Tonk UI.
 pub mod error;
 


### PR DESCRIPTION
## Summary

- derive best-effort browser registration labels such as `Chrome on macOS`, including browser/OS precedence and safe fallbacks
- default bare CLI account links to `Tonk CLI on <OS> <version>` with UTF-8-safe 100-byte bounds
- preserve explicit `tonk account link --name ...` overrides and legacy persisted device labels unchanged

## Testing

- `nix --accept-flake-config develop .#ci -c lint`
- `nix develop --accept-flake-config .#ci --command test:native:debug` (1,342 passed, 3 skipped)
- `nix develop --accept-flake-config .#ci --command test:native:release` (1,342 passed, 3 skipped)
- `nix develop --accept-flake-config .#ci --command test:web:debug` (1,240 passed, 1 skipped)
- `nix develop --accept-flake-config .#ci --command test:web:release` (1,240 passed, 1 skipped)
- `nix build .#tonk-ui`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the device name handling in the `tonk` application, particularly for browser and CLI environments, by introducing a new module for device name generation and updating related tests and UI elements.

### Detailed summary
- Added a new module `device_name` for generating device names based on browser info.
- Updated `Cargo.toml` to include `os_info` dependency.
- Replaced hardcoded device names in the UI with dynamic generation.
- Updated tests to verify device name behavior.
- Modified CLI argument handling for device names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->