### PR TITLE
fix: resolve sharing, account portability, and passkey errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,18 +2,27 @@ name: Deploy
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
+  # Cleanup must still run when a PR is closed with merge conflicts. This event
+  # uses the trusted base-branch workflow rather than checking out PR code.
+  pull_request_target:
+    types: [closed]
   push:
     branches: [stable, staging]
 
-# Every job here mutates shared Cloudflare state, and two runs of one pull
-# request would race for the same `--preview-alias`. Superseding the in-flight
-# run is the wanted outcome: the newer commit is the one worth previewing.
+# Two runs of one pull request would race for the same preview aliases and D1
+# database. Superseding the in-flight run is the wanted outcome: the newer
+# commit is the one worth previewing. Different pull requests use different
+# databases, so their migrations cannot invalidate each other's workers. PRs
+# are keyed by number because a merged `closed` event uses the target branch as
+# `github.ref` and must not cancel that branch's push deployment.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || format('pr-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:
   deploy:
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,12 +70,57 @@ jobs:
       # a pairing that does not exist anywhere. Both go to the disposable
       # `preview` environment, account worker first, because the access worker
       # has to be told where that one landed.
+      #
+      # Every PR needs its own D1 database. A shared database cannot safely
+      # serve immutable worker versions from branches with different migration
+      # histories: a newer PR schema can make an older PR's queries fail.
+      - name: Prepare preview account database
+        if: github.event_name == 'pull_request'
+        id: account-database
+        run: |
+          set -euo pipefail
+          database="tonk-accounts-pr-${{ github.event.pull_request.number }}"
+          # Wrangler resolves `main` and `migrations_dir` relative to the
+          # config file, so the generated config must stay in the repository
+          # root rather than `$RUNNER_TEMP`.
+          config="$PWD/wrangler.account.preview.toml"
+          database_id="$({
+            nix --accept-flake-config develop .#ci --command wrangler d1 list --json
+          } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
+          if [ -z "$database_id" ]; then
+            nix --accept-flake-config develop .#ci --command \
+              wrangler d1 create "$database" --location weur
+            database_id="$({
+              nix --accept-flake-config develop .#ci --command wrangler d1 list --json
+            } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
+          fi
+          if [ -z "$database_id" ]; then
+            echo "::error::Could not resolve the D1 database id for $database"
+            exit 1
+          fi
+          cp wrangler.account.toml "$config"
+          sed -i \
+            -e "s/database_name = \"tonk-accounts-preview\"/database_name = \"$database\"/" \
+            -e "s/database_id = \"323cb440-c356-4d1d-b238-2ffd11abedcc\"/database_id = \"$database_id\"/" \
+            "$config"
+          if ! grep -Fq "database_name = \"$database\"" "$config" \
+            || ! grep -Fq "database_id = \"$database_id\"" "$config"; then
+            echo "::error::Could not bind the account preview config to $database"
+            exit 1
+          fi
+          echo "database=$database" >> "$GITHUB_OUTPUT"
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Apply preview account migrations
         if: github.event_name == 'pull_request'
         run: |
           nix --accept-flake-config develop .#ci --command \
-            wrangler d1 migrations apply tonk-accounts-preview \
-              --remote --env preview -c wrangler.account.toml
+            wrangler d1 migrations apply \
+              "${{ steps.account-database.outputs.database }}" --remote \
+              --env preview -c "${{ steps.account-database.outputs.config }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -79,7 +133,8 @@ jobs:
           preview_alias="pr-${{ github.event.pull_request.number }}"
           log="$RUNNER_TEMP/account-preview.log"
           nix --accept-flake-config develop .#ci --command \
-            wrangler versions upload --env preview -c wrangler.account.toml \
+            wrangler versions upload --env preview \
+              -c "${{ steps.account-database.outputs.config }}" \
               --preview-alias "$preview_alias" 2>&1 | tee "$log"
           url="$(grep -Eo "https://$preview_alias-tonk-account-service-preview\.[a-z0-9-]+\.workers\.dev" "$log" | head -n 1 || true)"
           if [ -z "$url" ]; then
@@ -164,3 +219,29 @@ jobs:
             ```
 
             </details>
+
+  cleanup-account-preview:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wimpysworld/nothing-but-nix@main
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Delete preview account database
+        run: |
+          set -euo pipefail
+          database="tonk-accounts-pr-${{ github.event.pull_request.number }}"
+          database_id="$({
+            nix --accept-flake-config develop .#ci --command wrangler d1 list --json
+          } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
+          if [ -n "$database_id" ]; then
+            nix --accept-flake-config develop .#ci --command \
+              wrangler d1 delete "$database" --skip-confirmation
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/plan/bug-57-59.md
+++ b/plan/bug-57-59.md
@@ -16,7 +16,11 @@ fresh `tonk --spot tonk-team pull` on 2026-08-04.
   by those tasks, and the account-link response can complete before restore has
   populated the profile. The shared HTTP layer already applies a ten-second
   timeout to each upstream request, so awaiting this work has a bounded failure
-  mode.
+  mode. Manual preview acceptance then exposed a second cause: real invites
+  minted through an account begin with a Dialog powerline delegation
+  (`Subject::Any`), whose effective subject is its issuer. Account backup
+  validation rejected that valid shape before upload; creator prefixes use
+  `Subject::Specific`, explaining why only creator spots followed the account.
 - **BUG-59 — phone/QR passkey sign-in reports cancellation.** The WebAuthn
   ceremony allows discoverable credentials and therefore allows the browser's
   cross-device transport selection, but `identity_bridge` discards the rejected
@@ -69,7 +73,13 @@ Steps:
 4. Preserve per-space best-effort behavior when reconciling older local spots,
    while ensuring a just-joined spot's direct backup call completes before the
    join operation succeeds.
-5. Re-run account backup, account link, join, and restore tests.
+5. Accept Dialog powerline prefixes by deriving an `Any` root delegation's
+   effective subject from its issuer, while continuing to reject explicit
+   subject changes and account-root suffixes.
+6. Add a real-browser, real-service regression: create and share from one
+   account, claim from another, verify semantic inventory, erase the claiming
+   browser's local storage, sign the same account back in, restore, and pull.
+7. Re-run account backup, account link, join, restore, and end-to-end tests.
 
 ### 3. Preserve actionable WebAuthn failures across the UI boundary (BUG-59)
 
@@ -117,7 +127,9 @@ Implemented on 2026-08-04:
   validation and repair path.
 - BUG-58 now awaits account-service backup uploads and the account-link
   backup/restore sequence instead of detaching them from the service-worker
-  request lifetime.
+  request lifetime. Backup validation also accepts Dialog's root powerline
+  shape, deriving its stable subject from the root issuer while preserving the
+  existing signature, subject-change, validity, and account-root checks.
 - BUG-59 now preserves bounded browser/provider `name` and `message` details
   across both the passkey and UI bridge boundaries. Physical phone/provider
   completion remains a manual acceptance check.
@@ -130,6 +142,9 @@ Fresh verification:
 - Wasm tests pass: all 34 `tonk-identity`, all 19 `tonk-ui`, all 15 focused
   account tests, all 6 focused invite tests, and focused missing-relay and
   durable-join regressions.
+- The real-browser account regression passes against live native access and
+  account services: the claimed spot is uploaded, restored after complete
+  local-origin storage removal, and readable after pull on the clean device.
 - The aggregate 258-test wasm worker runner exceeded its 60-second harness
   timeout; all affected focused suites above pass independently.
 - The locally mounted app and account route load in isolated headless Chrome

--- a/plan/bug-57-59.md
+++ b/plan/bug-57-59.md
@@ -1,0 +1,138 @@
+# BUG-57 through BUG-59 implementation plan
+
+## Scope and observed evidence
+
+This plan covers the three active `Bug` issues in the `tonk-team` spot after a
+fresh `tonk --spot tonk-team pull` on 2026-08-04.
+
+- **BUG-57 — unusable share link.** The source browser logs `remote not
+  available`; the recipient browser cannot join. The invite resolver currently
+  treats a branch whose named dialog remote cannot be loaded as an internal
+  error, even when the replicated `xyz.tonk.remote` metadata still contains the
+  remote subject and address. That prevents the existing share-repair path from
+  producing a valid invite.
+- **BUG-58 — joined spots do not follow the account.** Spot backup and account
+  restore are spawned as detached wasm tasks. A service worker is not kept alive
+  by those tasks, and the account-link response can complete before restore has
+  populated the profile. The shared HTTP layer already applies a ten-second
+  timeout to each upstream request, so awaiting this work has a bounded failure
+  mode.
+- **BUG-59 — phone/QR passkey sign-in reports cancellation.** The WebAuthn
+  ceremony allows discoverable credentials and therefore allows the browser's
+  cross-device transport selection, but `identity_bridge` discards the rejected
+  JavaScript value. The displayed cancellation string is generated locally and
+  does not identify the browser/provider failure. Tonk's root derivation requires
+  WebAuthn PRF output, so an authenticator that returns no PRF cannot be treated
+  as a successful login.
+
+## Implementation
+
+### 1. Repair invite resolution from canonical remote metadata (BUG-57)
+
+Files:
+
+- `rust/tonk-worker/src/router/create_invite.rs`
+
+Steps:
+
+1. Add a regression test for resolving a configured upstream when the dialog
+   remote handle is unavailable but a matching `Remote` concept remains on the
+   meta branch.
+2. Query the meta branch before failing the dialog remote load.
+3. Validate the matching concept's subject DID and decode its stored
+   `SiteAddress`, then recreate only that named dialog remote and retry the
+   load. Do not substitute the current deployment origin or change a working
+   remote.
+4. Keep invalid/missing metadata as an explicit error; never mint an invite with
+   an invented endpoint.
+5. Re-run the invite and join regression tests, including missing-revocation
+   repair.
+
+### 2. Make account portability durable before reporting success (BUG-58)
+
+Files:
+
+- `rust/tonk-worker/src/router/account_backup.rs`
+- `rust/tonk-worker/src/router/account.rs`
+- relevant wasm tests in those modules
+
+Steps:
+
+1. Add tests showing a backup future remains pending until the mocked account
+   service accepts the artifact, and account linking does not report its final
+   status before backup/restore completes.
+2. Remove the wasm-only detached task in `dispatch_backup`; await the bounded
+   account-service upload and propagate its error to the caller.
+3. Remove the wasm-only detached account hydration task in `account::link`;
+   await account-state setup, existing-space backup, and restore before returning
+   the refreshed account status.
+4. Preserve per-space best-effort behavior when reconciling older local spots,
+   while ensuring a just-joined spot's direct backup call completes before the
+   join operation succeeds.
+5. Re-run account backup, account link, join, and restore tests.
+
+### 3. Preserve actionable WebAuthn failures across the UI boundary (BUG-59)
+
+Files:
+
+- `rust/tonk-ui/src/identity_bridge.rs`
+- `rust/tonk-identity/src/passkey.rs`
+
+Steps:
+
+1. Add bridge tests for both rejected `Error`/`DOMException` objects and rejected
+   strings, asserting that the error name and message survive.
+2. Replace the undifferentiated `Rejected` variant with a bounded textual reason
+   extracted from JavaScript without serializing arbitrary objects.
+3. Improve the passkey-side JavaScript error extraction so browser `name` and
+   `message` reach the bridge; keep the explicit no-PRF error intact.
+4. Do not force the `hybrid` hint globally: the reported browser already offers
+   a QR flow, and prioritizing it would alter local-authenticator selection
+   without evidence that transport selection is the fault.
+5. Re-run identity wasm tests. Record physical phone/provider validation as a
+   manual check because an automated browser cannot emulate that authenticator.
+
+## Verification
+
+1. Run `cargo fmt --all -- --check`.
+2. Run the focused Rust/wasm test targets for `tonk-worker`, `tonk-ui`, and
+   `tonk-identity` using the repository's Nix test commands.
+3. Run the invite-to-join end-to-end test and account restore test.
+4. Start an isolated local UI and use the repository browser harness plus an
+   isolated `chrome-devtools` session to inspect the mounted share and account
+   surfaces for console errors.
+5. Manual release acceptance:
+   - copy an invite from the original BUG-57 spot and join it in a clean browser;
+   - sign into the same account in a second clean browser and observe the joined
+     spot;
+   - repeat BUG-59's phone/QR ceremony and record the exact surfaced WebAuthn or
+     PRF result if the physical authenticator still refuses it.
+
+## Implementation status
+
+Implemented on 2026-08-04:
+
+- BUG-57 now reconstructs only a missing named dialog remote from matching
+  replica metadata before continuing through the existing revocation-relay
+  validation and repair path.
+- BUG-58 now awaits account-service backup uploads and the account-link
+  backup/restore sequence instead of detaching them from the service-worker
+  request lifetime.
+- BUG-59 now preserves bounded browser/provider `name` and `message` details
+  across both the passkey and UI bridge boundaries. Physical phone/provider
+  completion remains a manual acceptance check.
+
+Fresh verification:
+
+- `cargo fmt --all -- --check` and `git diff --check` pass.
+- Native tests pass: 24 `tonk-identity`, 2 `tonk-ui`, 71 `tonk-worker`, 5 FAB
+  drift, 11 standard-library, plus doc tests.
+- Wasm tests pass: all 34 `tonk-identity`, all 19 `tonk-ui`, all 15 focused
+  account tests, all 6 focused invite tests, and focused missing-relay and
+  durable-join regressions.
+- The aggregate 258-test wasm worker runner exceeded its 60-second harness
+  timeout; all affected focused suites above pass independently.
+- The locally mounted app and account route load in isolated headless Chrome
+  with no console errors. The account route shows the expected local-dev
+  deployment-configuration warning because no staged account provider is
+  configured.

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -4,8 +4,8 @@
 //! `src/handlers/`) onto native backends: a `SqliteStore::in_memory()`,
 //! a `MemoryChainStore`, and a shared `CapturedEmail`. Route paths,
 //! JSON field names, status codes, and CORS headers all match the
-//! worker exactly, except for the native-only `GET /_test/emails`
-//! captured-email snapshot used by out-of-process tests.
+//! worker exactly, except for native-only `GET /_test/*` inspection routes
+//! used by out-of-process tests.
 
 use std::sync::Arc;
 
@@ -137,6 +137,7 @@ async fn handle_request(
         (Method::GET, "/") => return Ok(info_response()),
         (Method::GET, "/health") => return Ok(health_response()),
         (Method::GET, "/_test/emails") => emails_route(&backends),
+        (Method::GET, "/_test/spots") => spots_route(req, &backends).await,
         (Method::POST, "/codes") => codes_route(req, &backends).await,
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
         (Method::POST, "/revocations") => revocations_route(req, &backends).await,
@@ -224,6 +225,36 @@ fn emails_route(backends: &Backends) -> Result<Response<Full<Bytes>>, ServiceErr
         .map(|(address, code)| serde_json::json!({ "address": address, "code": code }))
         .collect();
     Ok(json_response(StatusCode::OK, &snapshot))
+}
+
+/// `GET /_test/spots` → the semantic inventory for the root named by the
+/// `X-Test-Root` header, without a device invocation. Native test server only;
+/// lets browser integration tests inspect whether a prior browser actually
+/// uploaded an artifact before simulating a new device.
+async fn spots_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let root = req
+        .headers()
+        .get("x-test-root")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ServiceError::new(ErrorCode::InvalidArgument, "missing test root".to_string())
+        })?;
+    let account = backends
+        .store
+        .account_by_root(root)
+        .await
+        .map_err(|error| ServiceError::new(ErrorCode::InternalError, format!("{error:?}")))?
+        .ok_or_else(|| {
+            ServiceError::new(ErrorCode::NotFound, "unknown test account".to_string())
+        })?;
+    let spots = list_account_spots(&backends.chains, &account)
+        .await
+        .map_err(|error| ServiceError::new(ErrorCode::InternalError, format!("{error:?}")))?;
+    Ok(json_response(StatusCode::OK, &spots))
 }
 
 /// `POST /codes` → request a verification code.

--- a/rust/tonk-account/src/backup.rs
+++ b/rust/tonk-account/src/backup.rs
@@ -111,15 +111,21 @@ impl AccountSpotBackup {
             .proofs()
             .next()
             .ok_or_else(|| AccountSpotBackupError::InvalidChain("empty chain".to_string()))?;
+        // Dialog powerline delegations carry `Subject::Any`; for a root
+        // delegation their effective subject is the issuer. Repository invite
+        // chains minted through an account use that shape, while an owned
+        // space's direct `space -> root` prefix carries `Specific(space)`.
+        // Both name the same stable authority as long as an explicit root
+        // subject, when present, agrees with its issuer.
         let subject = match first.subject() {
-            dialog_ucan_core::subject::Subject::Specific(subject) => subject.clone(),
-            dialog_ucan_core::subject::Subject::Any => {
-                return Err(AccountSpotBackupError::MissingSubject);
+            dialog_ucan_core::subject::Subject::Specific(subject) => {
+                if subject != first.issuer() {
+                    return Err(AccountSpotBackupError::SubjectIssuerMismatch);
+                }
+                subject.clone()
             }
+            dialog_ucan_core::subject::Subject::Any => first.issuer().clone(),
         };
-        if &subject != first.issuer() {
-            return Err(AccountSpotBackupError::SubjectIssuerMismatch);
-        }
 
         let now = dialog_ucan_core::time::Timestamp::now();
         for (index, delegation) in chain.proofs().enumerate() {
@@ -129,9 +135,10 @@ impl AccountSpotBackup {
                 dialog_ucan_core::subject::Subject::Specific(_) => {
                     return Err(AccountSpotBackupError::SubjectChanged);
                 }
-                dialog_ucan_core::subject::Subject::Any => {
-                    return Err(AccountSpotBackupError::MissingSubject);
-                }
+                // A powerline proof preserves the root delegation's
+                // effective subject; it does not broaden this artifact to a
+                // different repository.
+                dialog_ucan_core::subject::Subject::Any => {}
             }
             if delegation.issuer() == account_root
                 || delegation.audience() == account_root && index + 1 != proof_count
@@ -272,7 +279,7 @@ mod tests {
         let space_did = space.did();
         let account = signer(2).await.did();
         let other = signer(3).await.did();
-        let valid_chain = space_chain(space, &account, &space_did).await;
+        let valid_chain = space_chain(space.clone(), &account, &space_did).await;
         let validated = artifact(&valid_chain).validate_for(&account).await.unwrap();
         assert_eq!(validated.subject, space_did);
         assert_eq!(validated.chain, valid_chain);
@@ -283,20 +290,19 @@ mod tests {
         };
         assert!(malformed.validate_for(&account).await.is_err());
 
-        let open = dialog_ucan_core::DelegationBuilder::new()
-            .issuer(signer(4).await)
+        let powerline = dialog_ucan_core::DelegationBuilder::new()
+            .issuer(space)
             .audience(&account)
             .subject(dialog_ucan_core::subject::Subject::Any)
             .command(vec![])
             .try_build()
             .await
             .unwrap();
-        assert!(
-            artifact(&dialog_ucan_core::DelegationChain::new(open))
-                .validate_for(&account)
-                .await
-                .is_err()
-        );
+        let powerline = artifact(&dialog_ucan_core::DelegationChain::new(powerline))
+            .validate_for(&account)
+            .await
+            .unwrap();
+        assert_eq!(powerline.subject, space_did);
 
         let wrong_subject_issuer = signer(5).await;
         let wrong_subject = space_chain(wrong_subject_issuer, &account, &other).await;

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -35,7 +35,24 @@ pub struct PasskeyCredential {
 }
 
 fn ceremony_error(context: &str, value: JsValue) -> anyhow::Error {
-    anyhow!("{context}: {value:?}")
+    let property = |name: &str| {
+        Reflect::get(&value, &name.into())
+            .ok()
+            .and_then(|value| value.as_string())
+            .filter(|value| !value.trim().is_empty())
+    };
+    let detail = if let Some(message) = value.as_string() {
+        message
+    } else {
+        match (property("name"), property("message")) {
+            (Some(name), Some(message)) => format!("{name}: {message}"),
+            (Some(name), None) => name,
+            (None, Some(message)) => message,
+            (None, None) => "unknown browser error".to_string(),
+        }
+    };
+    let detail: String = detail.chars().take(512).collect();
+    anyhow!("{context}: {detail}")
 }
 
 fn credentials() -> Result<CredentialsContainer> {
@@ -217,6 +234,17 @@ mod tests {
         let eval = Reflect::get(&prf, &"eval".into()).unwrap();
         let first = Reflect::get(&eval, &"first".into()).unwrap();
         assert_eq!(Uint8Array::new(&first).to_vec(), ROOT_KEY_CONTEXT);
+    }
+
+    #[dialog_common::test]
+    fn it_preserves_browser_error_names_and_messages() {
+        let error = js_sys::Error::new("phone authenticator returned no PRF");
+        error.set_name("NotSupportedError");
+
+        assert_eq!(
+            ceremony_error("passkey assertion failed", error.into()).to_string(),
+            "passkey assertion failed: NotSupportedError: phone authenticator returned no PRF"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -11,6 +11,7 @@ mod tests {
 
     use anyhow::{Context, Result, anyhow};
     use tempfile::TempDir;
+    use thirtyfour::extensions::cdp::ChromeDevTools;
     use thirtyfour::prelude::*;
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
     use tokio::process::{Child, Command};
@@ -349,12 +350,214 @@ mod tests {
         .await
     }
 
+    async fn post_json(
+        driver: &WebDriver,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let result = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                fetch(arguments[0], {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify(arguments[1]),
+                }).then(async response => done({
+                    status: response.status,
+                    body: await response.json(),
+                })).catch(error => done({ error: String(error) }));
+                "#,
+                vec![serde_json::json!(path), body],
+            )
+            .await?;
+        Ok(result.json().clone())
+    }
+
+    async fn get_json(driver: &WebDriver, path: &str) -> Result<serde_json::Value> {
+        let result = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                fetch(arguments[0]).then(async response => done({
+                    status: response.status,
+                    body: await response.json(),
+                })).catch(error => done({ error: String(error) }));
+                "#,
+                vec![serde_json::json!(path)],
+            )
+            .await?;
+        Ok(result.json().clone())
+    }
+
+    fn successful_body<'a>(
+        operation: &str,
+        result: &'a serde_json::Value,
+    ) -> &'a serde_json::Value {
+        assert!(
+            result.get("error").is_none(),
+            "{operation} transport failed: {result}"
+        );
+        assert!(
+            result["status"]
+                .as_u64()
+                .is_some_and(|status| (200..300).contains(&status)),
+            "{operation} failed: {result}"
+        );
+        &result["body"]
+    }
+
     fn did_for_device<'a>(output: &'a str, name: &str) -> Option<&'a str> {
         output.lines().find_map(|line| {
             let fields: Vec<_> = line.split('\t').collect();
             (fields.len() == 3 && fields[1] == name)
                 .then(|| fields[2].trim_end_matches(" (this device)"))
         })
+    }
+
+    #[dialog_common::test]
+    async fn it_backs_up_a_claimed_spot_for_another_account_device(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let creator = driver_with_prf(&env).await?;
+        sign_up(&creator, &env, "creator@example.com").await?;
+
+        let created = post_json(
+            &creator,
+            "/api/spaces",
+            serde_json::json!({
+                "name": "Shared Garden",
+                "remote": env.tonk_web.join("ucan/")?,
+                "revocation_url": env.account_service.join("revocations")?,
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let key = successful_body("create synced spot", &created)["key"]
+            .as_str()
+            .context("create response omitted the spot key")?
+            .to_string();
+        let pushed = post_json(
+            &creator,
+            &format!("/api/repository/{key}/branch/main/sync/push"),
+            serde_json::json!({}),
+        )
+        .await?;
+        successful_body("push synced spot", &pushed);
+        let invited = post_json(
+            &creator,
+            &format!("/api/repository/{key}/invite"),
+            serde_json::json!({ "baseUrl": env.tonk_web.join("join")? }),
+        )
+        .await?;
+        let invite_url = successful_body("mint invite", &invited)["url"]
+            .as_str()
+            .context("invite response omitted its URL")?
+            .to_string();
+        creator.quit().await?;
+
+        let claimer = driver_with_prf(&env).await?;
+        sign_up(&claimer, &env, "claimer@example.com").await?;
+        let visited = post_json(
+            &claimer,
+            "/api/profile/visit",
+            serde_json::json!({ "url": invite_url }),
+        )
+        .await?;
+        successful_body("visit shared spot", &visited);
+        let promoted = post_json(
+            &claimer,
+            &format!("/api/repository/{key}/membership"),
+            serde_json::json!({}),
+        )
+        .await?;
+        successful_body("promote guest membership", &promoted);
+
+        let account = get_json(&claimer, "/api/account").await?;
+        let root = successful_body("read claiming account", &account)["rootDid"]
+            .as_str()
+            .context("claiming account status omitted its root DID")?;
+        let snapshot: Vec<serde_json::Value> = reqwest::Client::new()
+            .get(env.account_service.join("_test/spots")?)
+            .header("X-Test-Root", root)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        assert!(
+            snapshot.iter().any(|spot| spot["subject"] == key),
+            "promotion completed without uploading the claimed spot: {snapshot:?}"
+        );
+
+        let devtools = ChromeDevTools::new(claimer.handle.clone());
+        devtools
+            .execute_cdp_with_params(
+                "Storage.clearDataForOrigin",
+                serde_json::json!({
+                    "origin": env.tonk_web.origin().ascii_serialization(),
+                    "storageTypes": "all",
+                }),
+            )
+            .await?;
+        claimer.goto(env.tonk_web.as_str()).await?;
+        claimer
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                navigator.serviceWorker.ready.then(() => {
+                    if (navigator.serviceWorker.controller) {
+                        done(true);
+                    } else {
+                        navigator.serviceWorker.addEventListener(
+                            "controllerchange",
+                            () => done(true),
+                            { once: true },
+                        );
+                    }
+                }).catch(error => done({ error: String(error) }));
+                "#,
+                vec![],
+            )
+            .await?;
+        claimer.goto(env.tonk_web.join("account")?.as_str()).await?;
+        element(&claimer, "tonk-account[data-mode=\"choice\"]").await?;
+        element(&claimer, "#account-choose-link")
+            .await?
+            .click()
+            .await?;
+        element(&claimer, "#account-link-submit")
+            .await?
+            .click()
+            .await?;
+        if let Err(wait_error) = element(&claimer, "tonk-account[data-mode=\"success\"]").await {
+            let host = element(&claimer, "tonk-account").await?;
+            let mode = host.attr("data-mode").await?.unwrap_or_default();
+            let error = element(&claimer, "#account-error").await?.text().await?;
+            return Err(wait_error).context(format!(
+                "second-device sign-in stopped in mode {mode:?}: {error:?}"
+            ));
+        }
+
+        let restored = get_json(&claimer, &format!("/api/repository/{key}")).await?;
+        let restored = successful_body("load claimed spot on second device", &restored);
+        assert_eq!(restored["subject"], key);
+
+        let pulled = post_json(
+            &claimer,
+            &format!("/api/repository/{key}/branch/main/sync/pull"),
+            serde_json::json!({}),
+        )
+        .await?;
+        successful_body("pull claimed spot on second device", &pulled);
+        let hydrated = get_json(&claimer, &format!("/api/repository/{key}")).await?;
+        assert_eq!(
+            successful_body("load pulled spot on second device", &hydrated)["label"],
+            "Shared Garden"
+        );
+
+        claimer.quit().await?;
+        Ok(())
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_wasm_bindgen::Serializer;
 use thiserror::Error;
 use tonk_account::handoff::{CompleteLinkCeremony, ResolvedLink};
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
 /// Input for creating or evaluating a root credential.
@@ -111,10 +111,39 @@ pub(crate) enum IdentityBridgeError {
     InvalidInput,
     #[error("identity ceremony did not return a promise")]
     NotPromise,
-    #[error("identity ceremony was cancelled or failed")]
-    Rejected,
+    #[error("identity ceremony failed: {0}")]
+    Rejected(String),
     #[error("identity ceremony returned an invalid response")]
     MalformedOutput,
+}
+
+const MAX_REJECTION_REASON_CHARS: usize = 512;
+
+/// Preserve the browser/provider reason without attempting to serialize an
+/// arbitrary rejected object. wasm-bindgen ceremonies reject with strings;
+/// browser APIs usually reject with an `Error` or `DOMException` carrying a
+/// stable `name` and human-readable `message`.
+fn rejection_reason(value: JsValue) -> String {
+    fn bounded(value: String) -> String {
+        value.chars().take(MAX_REJECTION_REASON_CHARS).collect()
+    }
+
+    if let Some(reason) = value.as_string() {
+        return bounded(reason);
+    }
+
+    let property = |name: &str| {
+        Reflect::get(&value, &name.into())
+            .ok()
+            .and_then(|value| value.as_string())
+            .filter(|value| !value.trim().is_empty())
+    };
+    match (property("name"), property("message")) {
+        (Some(name), Some(message)) => bounded(format!("{name}: {message}")),
+        (Some(name), None) => bounded(name),
+        (None, Some(message)) => bounded(message),
+        (None, None) => "unknown browser error".to_string(),
+    }
 }
 
 async fn call<I: Serialize, O: DeserializeOwned>(
@@ -140,12 +169,12 @@ async fn call<I: Serialize, O: DeserializeOwned>(
         .map_err(|_| IdentityBridgeError::InvalidInput)?;
     let promise: Promise = function
         .call1(&identity, &input)
-        .map_err(|_| IdentityBridgeError::Rejected)?
+        .map_err(|error| IdentityBridgeError::Rejected(rejection_reason(error)))?
         .dyn_into()
         .map_err(|_| IdentityBridgeError::NotPromise)?;
     let output = JsFuture::from(promise)
         .await
-        .map_err(|_| IdentityBridgeError::Rejected)?;
+        .map_err(|error| IdentityBridgeError::Rejected(rejection_reason(error)))?;
     serde_wasm_bindgen::from_value(output).map_err(|_| IdentityBridgeError::MalformedOutput)
 }
 
@@ -441,7 +470,10 @@ mod tests {
             IdentityBridgeError::NotPromise
         );
 
-        install_method("createRoot", "return Promise.reject(new Error('no')); ");
+        install_method(
+            "createRoot",
+            "return Promise.reject(new DOMException('phone authenticator returned no PRF', 'NotSupportedError')); ",
+        );
         assert_eq!(
             create_root(CreateRootInput {
                 device_did: "device".into(),
@@ -449,7 +481,23 @@ mod tests {
             })
             .await
             .unwrap_err(),
-            IdentityBridgeError::Rejected
+            IdentityBridgeError::Rejected(
+                "NotSupportedError: phone authenticator returned no PRF".into()
+            )
+        );
+
+        install_method(
+            "createRoot",
+            "return Promise.reject('provider unavailable'); ",
+        );
+        assert_eq!(
+            create_root(CreateRootInput {
+                device_did: "device".into(),
+                label: None,
+            })
+            .await
+            .unwrap_err(),
+            IdentityBridgeError::Rejected("provider unavailable".into())
         );
 
         install_method("createRoot", "return Promise.resolve({});");

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -333,14 +333,13 @@ pub(crate) async fn persist_link(
     Ok(())
 }
 
-/// Attach provider services and start best-effort backup/restore.
+/// Attach provider services and finish bounded backup/restore before reporting
+/// the account as linked.
 #[wasm_compat]
 pub async fn link(
     State(state): State<AppState>,
     Json(request): Json<AccountLinkRequest>,
 ) -> Result<Json<AccountStatus>, TonkWorkerError> {
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    let app_state = state.clone();
     let state = state.read().await;
     persist_link(&state, &request).await?;
     if request.initialize_name
@@ -349,20 +348,13 @@ pub async fn link(
         log!("new-account display-name seed did not complete: {error}");
     }
 
+    // Mount/hydrate the hidden account repository before touching user
+    // spaces. Each account-service request is bounded by the shared HTTP
+    // timeout, and awaiting the sequence keeps it inside the fetch lifetime.
+    super::account_state::ensure_account_state(&state).await;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    wasm_bindgen_futures::spawn_local(async move {
-        let state = app_state.read().await;
-        // Mount/hydrate the hidden account repository before touching user
-        // spaces. Remote failure leaves it retryable and unready.
-        super::account_state::ensure_account_state(&state).await;
-        crate::router::account_backup::back_up_existing_spaces(&state).await;
-        crate::router::restore::restore_spaces(&state).await;
-    });
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    {
-        super::account_state::ensure_account_state(&state).await;
-        crate::router::restore::restore_spaces(&state).await;
-    }
+    crate::router::account_backup::back_up_existing_spaces(&state).await;
+    crate::router::restore::restore_spaces(&state).await;
 
     Ok(Json(status(&state).await?))
 }

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -235,50 +235,25 @@ async fn dispatch_backup(
     remote_url: Option<String>,
     revocation_url: Option<String>,
     name: Option<String>,
-) {
+) -> Result<(), TonkWorkerError> {
     let Some(link) = crate::router::account::account_link(tonk).await else {
-        return;
+        return Ok(());
     };
     let Some(service) = account_service_url(tonk).await else {
-        return;
+        return Ok(());
     };
     let device = tonk.profile.signer().signer().clone();
-
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    {
-        wasm_bindgen_futures::spawn_local(async move {
-            if let Err(error) = run_backup(
-                device,
-                link,
-                service,
-                chain,
-                remote_url,
-                revocation_url,
-                name,
-            )
-            .await
-            {
-                log!("{context} backup failed: {error}");
-            }
-        });
-    }
-
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    {
-        if let Err(error) = run_backup(
-            device,
-            link,
-            service,
-            chain,
-            remote_url,
-            revocation_url,
-            name,
-        )
-        .await
-        {
-            log!("{context} backup failed: {error}");
-        }
-    }
+    run_backup(
+        device,
+        link,
+        service,
+        chain,
+        remote_url,
+        revocation_url,
+        name,
+    )
+    .await
+    .map_err(|error| TonkWorkerError::Internal(format!("{context} backup failed: {error}")))
 }
 
 async fn content_name<R>(tonk: &TonkState, repository: &Repository<R>) -> Option<String>
@@ -337,7 +312,7 @@ pub(crate) async fn back_up_subject(
         remote.revocation_url.map(|url| url.to_string()),
         name,
     )
-    .await;
+    .await?;
     Ok(())
 }
 
@@ -369,13 +344,13 @@ mod tests {
     use dialog_remote_ucan_s3::UcanAddress;
     use dialog_repository::SiteAddress;
     use tower::ServiceExt as _;
-    use wasm_bindgen::JsValue;
+    use wasm_bindgen::{JsCast as _, JsValue};
     use wasm_bindgen_test::wasm_bindgen_test_configure;
 
     use crate::router::repository::{
         BranchConfiguration, RemoteConfiguration, RepositoryConfiguration,
     };
-    use crate::router::tests::{GlobalPropertyGuard, put_repo, test_state};
+    use crate::router::tests::{GlobalPropertyGuard, attach_remote, put_repo, test_state};
     use crate::router::{api_router_with_state, tests};
 
     wasm_bindgen_test_configure!(run_in_service_worker);
@@ -390,6 +365,16 @@ mod tests {
             }
         }
         None
+    }
+
+    async fn next_task() {
+        let promise: js_sys::Promise =
+            js_sys::Function::new_no_args("return new Promise(resolve => setTimeout(resolve, 0));")
+                .call0(&JsValue::UNDEFINED)
+                .unwrap()
+                .dyn_into()
+                .unwrap();
+        wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
     }
 
     #[dialog_common::test]
@@ -537,6 +522,78 @@ mod tests {
             crate::router::identity::root_did(&tonk).await.unwrap()
         };
         assert_eq!(artifact.validate_for(&root).await.unwrap().subject, subject);
+    }
+
+    #[dialog_common::test]
+    async fn backup_does_not_finish_before_the_account_service_accepts_it() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let immediate = js_sys::Function::new_with_args(
+            "_request",
+            "return Promise.resolve(new Response('{}', { status: 200 }));",
+        );
+        let _initial_fetch = GlobalPropertyGuard::replace("fetch", immediate.as_ref());
+        let key = put_repo(&app, "backup-awaits-upload").await;
+        attach_remote(&app, &key, "https://sync.example.test/ucan/").await;
+
+        let started = JsValue::FALSE;
+        let _started = GlobalPropertyGuard::replace("__tonkUploadStarted", &started);
+        let resolver = JsValue::UNDEFINED;
+        let _resolver = GlobalPropertyGuard::replace("__tonkResolveUpload", &resolver);
+        let pending = js_sys::Function::new_with_args(
+            "_request",
+            r#"
+            globalThis.__tonkUploadStarted = true;
+            return new Promise(resolve => {
+                globalThis.__tonkResolveUpload = () =>
+                    resolve(new Response('{}', { status: 200 }));
+            });
+            "#,
+        );
+        let _pending_fetch = GlobalPropertyGuard::replace("fetch", pending.as_ref());
+
+        let completed = Rc::new(Cell::new(false));
+        let completed_task = Rc::clone(&completed);
+        let state_task = state.clone();
+        let subject: Did = key.parse().unwrap();
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = state_task.read().await;
+            back_up_subject(&tonk, &subject).await.unwrap();
+            completed_task.set(true);
+        });
+
+        let mut upload_started = false;
+        for _ in 0..100 {
+            next_task().await;
+            if js_sys::Reflect::get(&js_sys::global(), &"__tonkUploadStarted".into())
+                .unwrap()
+                .is_truthy()
+            {
+                upload_started = true;
+                break;
+            }
+        }
+        assert!(upload_started, "backup reached the mocked account service");
+        assert!(
+            !completed.get(),
+            "backup returned before its upload settled"
+        );
+
+        let resolve: js_sys::Function =
+            js_sys::Reflect::get(&js_sys::global(), &"__tonkResolveUpload".into())
+                .unwrap()
+                .dyn_into()
+                .unwrap();
+        resolve.call0(&JsValue::UNDEFINED).unwrap();
+        for _ in 0..100 {
+            next_task().await;
+            if completed.get() {
+                break;
+            }
+        }
+        assert!(completed.get(), "backup finishes after upload acceptance");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -21,9 +21,11 @@ use ::axum::{
 use axum_wasm_macros::wasm_compat;
 use dialog_credentials::{Ed25519Signer, key::KeyExport};
 use dialog_query::{Output as _, Query, Term};
-use dialog_repository::{RepositoryExt as _, SiteAddress, Upstream};
+use dialog_repository::{
+    LoadRemoteError, RemoteRepository, RepositoryExt as _, SiteAddress, Upstream,
+};
 use dialog_ucan::UcanDelegation;
-use dialog_varsig::Principal;
+use dialog_varsig::{Did, Principal};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_common::log;
@@ -443,31 +445,6 @@ where
         }
     };
 
-    let remote = repository
-        .remote(remote_name.as_str())
-        .load()
-        .perform(operator)
-        .await
-        .map_err(|e| {
-            TonkWorkerError::Internal(format!(
-                "branch 'main' upstream names remote '{remote_name}' but it failed to load: {e}"
-            ))
-        })?;
-
-    let access_url = match remote.address().site() {
-        SiteAddress::Ucan(ucan) => Url::parse(ucan.endpoint()).map_err(|e| {
-            TonkWorkerError::Internal(format!(
-                "remote '{remote_name}' has unparseable UCAN endpoint '{}': {e}",
-                ucan.endpoint()
-            ))
-        })?,
-        _ => {
-            return Ok(ConfiguredRemoteRequirement::Refused(
-                RemoteRefusal::UnshareableRemote,
-            ));
-        }
-    };
-
     let meta = repository
         .branch("meta")
         .open()
@@ -493,10 +470,32 @@ where
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to query remote metadata: {error:?}"))
         })?;
-    let remote_entity = remotes
+    let remote_concept = remotes
         .into_iter()
-        .find(|concept| concept.name.0 == remote_name)
-        .map(|concept| concept.this);
+        .find(|concept| concept.name.0 == remote_name);
+    let remote = load_or_recover_remote(
+        repository,
+        operator,
+        remote_name.as_str(),
+        remote_concept.as_ref(),
+    )
+    .await?;
+
+    let access_url = match remote.address().site() {
+        SiteAddress::Ucan(ucan) => Url::parse(ucan.endpoint()).map_err(|e| {
+            TonkWorkerError::Internal(format!(
+                "remote '{remote_name}' has unparseable UCAN endpoint '{}': {e}",
+                ucan.endpoint()
+            ))
+        })?,
+        _ => {
+            return Ok(ConfiguredRemoteRequirement::Refused(
+                RemoteRefusal::UnshareableRemote,
+            ));
+        }
+    };
+
+    let remote_entity = remote_concept.map(|concept| concept.this);
     let executions: Vec<RemoteExecution> = meta
         .query()
         .select(Query::<RemoteExecution> {
@@ -530,6 +529,60 @@ where
             revocation_url,
         },
     ))
+}
+
+/// Load the named dialog remote, rebuilding a missing address cell only from
+/// the replica's persisted remote concept. The metadata is the same signed
+/// configuration mirrored by `ensure_remote_config`; the current deployment
+/// origin is deliberately not used as a fallback.
+async fn load_or_recover_remote<R>(
+    repository: &dialog_repository::Repository<R>,
+    operator: &crate::worker::DefaultOperator,
+    remote_name: &str,
+    concept: Option<&RemoteConcept>,
+) -> Result<RemoteRepository, TonkWorkerError>
+where
+    R: Principal + Clone,
+{
+    match repository
+        .remote(remote_name)
+        .load()
+        .perform(operator)
+        .await
+    {
+        Ok(remote) => Ok(remote),
+        Err(LoadRemoteError::NotFound { .. }) => {
+            let concept = concept.ok_or_else(|| {
+                TonkWorkerError::Internal(format!(
+                    "branch 'main' upstream names missing remote '{remote_name}', and meta has no recovery record"
+                ))
+            })?;
+            let subject: Did = concept.subject.0.to_string().parse().map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "remote '{remote_name}' has an invalid subject in meta: {error}"
+                ))
+            })?;
+            let address = concept.address.decode().map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "remote '{remote_name}' has an invalid address in meta: {error:?}"
+                ))
+            })?;
+            repository
+                .remote(remote_name)
+                .create(address)
+                .subject(subject)
+                .perform(operator)
+                .await
+                .map_err(|error| {
+                    TonkWorkerError::Internal(format!(
+                        "failed to recover remote '{remote_name}' from meta: {error}"
+                    ))
+                })
+        }
+        Err(error) => Err(TonkWorkerError::Internal(format!(
+            "branch 'main' upstream names remote '{remote_name}' but it failed to load: {error}"
+        ))),
+    }
 }
 
 /// Probe `main` for an invite-ready endpoint. Unlike generic sync and account
@@ -576,7 +629,8 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use dialog_repository::RepositoryExt as _;
+    use dialog_remote_ucan_s3::UcanAddress;
+    use dialog_repository::{RepositoryExt as _, SiteAddress};
     use tower::ServiceExt;
 
     use tonk_invite::Invite;
@@ -586,6 +640,39 @@ mod tests {
     use crate::axum::RequestOrigin;
     use crate::router::tests::{attach_remote, content_invitations, put_repo, test_state};
     use crate::router::{CreateInviteResponse, api_router_with_state};
+
+    #[dialog_common::test]
+    async fn it_recovers_a_missing_dialog_remote_from_replica_metadata() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "recover-missing-dialog-remote").await;
+        let tonk = state.read().await;
+        let repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        let address = SiteAddress::from(UcanAddress::new("https://sync.example.test/ucan/"));
+        let replica = tonk_schema::Replica::new(tonk.profile.did(), repository.did());
+        let concept = replica.remote("origin", repository.did(), &address);
+
+        let recovered =
+            super::load_or_recover_remote(&repository, &tonk.operator, "origin", Some(&concept))
+                .await
+                .expect("signed replica metadata repairs the missing address cell");
+
+        assert_eq!(recovered.address().site(), &address);
+        assert_eq!(recovered.did(), repository.did());
+        assert!(
+            repository
+                .remote("origin")
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .is_ok()
+        );
+    }
 
     /// Minting an invite records an `Invitation` on the repo's content
     /// branch whose entity matches what a claimer derives from the


### PR DESCRIPTION
## Summary

- repair BUG-57 invite creation by reconstructing a missing named dialog remote only from matching replica metadata
- repair BUG-58 account portability by awaiting bounded backup, hydration, and restore work within the service-worker request lifetime
- improve BUG-59 by preserving bounded WebAuthn browser/provider error details across the Rust and UI bridge boundaries
- include the investigation, implementation plan, and acceptance checklist in plan/bug-57-59.md

## Verification

- nix develop -c cargo test -p tonk-worker -p tonk-ui -p tonk-identity --no-fail-fast
- nix develop -c cargo test -p tonk-identity -p tonk-ui --target wasm32-unknown-unknown
- nix develop -c cargo test -p tonk-worker --target wasm32-unknown-unknown router::account
- nix develop -c cargo test -p tonk-worker --target wasm32-unknown-unknown router::create_invite
- cargo fmt --all -- --check
- git diff --check
- mounted local app and account route inspected in isolated headless Chrome with no console errors

## Remaining manual acceptance

- exercise the original share link flow in two clean browsers
- sign into the same account in a second clean browser and confirm joined spots restore
- repeat the physical phone/QR passkey flow and capture the surfaced WebAuthn or PRF result if the authenticator still refuses it

The aggregate 258-test wasm worker invocation exceeded its 60-second harness timeout during implementation. The affected focused account and invite suites pass independently.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses multiple bugs related to account management and error handling in the `tonk` system, enhancing the robustness of the invite mechanism, account linking, and error reporting during WebAuthn ceremonies.

### Detailed summary
- Improved `ceremony_error` to extract and format browser error names and messages.
- Added tests for preserving browser error details.
- Ensured account backup completes before reporting success.
- Removed detached tasks for account linking and backup.
- Enhanced error handling for missing dialog remotes.
- Added functionality to recover missing dialog remotes from metadata.
- Introduced new routes for testing and inspecting account states.
- Updated CI workflow for better database management during PRs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->