### PR TITLE
feat(account): redesign account dashboard

### DIFF
--- a/plan/account-panel-dashboard.md
+++ b/plan/account-panel-dashboard.md
@@ -1,0 +1,83 @@
+# Account panel dashboard implementation plan
+
+**Goal:** Replace the signed-in account interstitial and separate device screen with one legible, responsive dashboard using only data already available to the browser UI.
+**Approach:** Keep the existing `<tonk-account>` state machine and account authority operations, but author one `success` panel containing status, passkey guidance, the device list, and a clearly separated sign-out section. Load devices automatically whenever that panel is shown, and isolate its typography and controls from global Tonk document styles. Email, account creation time, passkey backup metadata, and passkey-provider inference are explicitly deferred because they need new authenticated data contracts.
+**Constraints:**
+- Keep WebAuthn ceremonies in the top-document `<tonk-account>` surface.
+- Preserve account creation, login, handoff, setup, revocation, deep-link, and local sign-out semantics.
+- Use only the existing `AccountStatus` and `AccountDevice` data contracts in this slice.
+- Preserve unrelated work and introduce no new dependencies.
+- Use familiar account language; keep authority terminology out of ordinary UI copy while retaining precise confirmation for permanent removal.
+- Maintain at least 44px interactive hit areas, reduced-motion behavior, and responsive mobile layout.
+
+## File map
+
+- `plan/account-panel-dashboard.md`: Durable scope, decisions, and verification state for this slice.
+- `rust/tonk-ui/src/account.html`: Signed-in dashboard semantics and newcomer-facing copy.
+- `rust/tonk-ui/src/account.rs`: Automatic device loading, device-row presentation, and confirmation/status copy.
+- `rust/tonk-ui/src/account.css`: Scoped heading reset, dashboard grid, consistent spacing, device rows, responsive rules, and interaction states.
+
+### Task 1: Author one signed-in account dashboard
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.html:account-success`
+- Modify: `rust/tonk-ui/src/account.rs:show_success, load_devices, bind`
+- Test: `rust/tonk-ui/src/account.rs:tests`
+
+**Interfaces:**
+- Consumes: existing `AccountStatus`, `AccountDevice`, `account_devices()`, `unlink_account()`, and revocation handlers.
+- Produces: the existing `success` mode as the sole signed-in dashboard; no wire-format changes.
+
+- [x] Add `it_authors_a_single_signed_in_dashboard` covering the visible `Account` title, passkey explanation, device list, sign-out explanation, absence of the `Manage devices` interstitial, and absence of technical grant/authority copy.
+- [x] Run the dashboard test against the old UI and observe the expected assertion failure on `Your Tonk account` versus `Account`.
+- [x] Move the device list and sign-out controls into `#account-success`, remove the separate devices panel and obsolete navigation buttons, and keep the status message as a transient notice.
+- [x] Make `show_success` and revoke deep links reveal the dashboard and load devices automatically without changing account or revocation authority behavior.
+- [x] Run the focused dashboard test and confirm success.
+
+### Task 2: Make device management legible without authority jargon
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.rs:render_devices, revocation_status, begin_revoke, bind`
+- Test: `rust/tonk-ui/src/account.rs:tests`
+
+**Interfaces:**
+- Consumes: unchanged `AccountDevice { name, status, created_at, this_device, ... }`.
+- Produces: device rows labelled with `Added <localized date>`, `This device`, `Access removed`, and `Remove access`; existing `data-*` revocation hooks remain intact.
+
+- [x] Extend the device-list regression test to require plain-language dates, state labels, current-device marker, removal action, and legacy relink guidance.
+- [x] Run the focused device-list test and observe the expected failure on the missing `This device` label.
+- [x] Render a semantic identity/meta group and plain-language status labels while retaining the existing target identifiers and safe revocation eligibility checks.
+- [x] Replace sign-out, revocation confirmation, and completion messages with plain language that distinguishes reversible local sign-out from permanent device-access removal.
+- [x] Run the focused account tests and confirm success.
+
+### Task 3: Isolate and polish the account layout
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.css`
+- Test: browser inspection of the mounted `/account` surface at desktop and mobile widths.
+
+**Interfaces:**
+- Consumes: the dashboard classes authored by Tasks 1 and 2 and existing Web Awesome colour tokens.
+- Produces: a centered responsive surface with a consistent 8px-derived spacing rhythm and no leaked global highlighted-heading treatment.
+
+- [x] Explicitly reset account headings (`display`, `background`, `color`, `padding`, and box-decoration behavior) so `styles.css` cannot apply the site-wide black highlight treatment.
+- [x] Add masthead, section, passkey-note, device-row, current-device badge, sign-out, and responsive grid styles; retain explicit transition properties, `scale: 0.96`, pretty/balanced wrapping, antialiasing, and 44px hit areas.
+- [x] Run formatting, focused tests, Wasm checking, and whitespace checks successfully (see verification evidence below).
+- [x] Build and serve the current UI, then inspect a disposable mounted dashboard in isolated headless Chrome at desktop and mobile widths. Confirm the heading reset, row alignment, responsive stacking, text wrapping, and 44px minimum hit areas. The static server predictably returns 404 for `/.well-known/tonk`; no authenticated provider or real device data was used.
+
+## Verification evidence
+
+- Red/green: the new dashboard test initially failed on the old title; the extended device test initially failed on the missing current-device label. Both passed after implementation.
+- `nix develop -c cargo test --target wasm32-unknown-unknown -p tonk-ui --lib account::tests -- --nocapture`: 12 passed, 0 failed.
+- `cargo fmt --package tonk-ui -- --check`: passed.
+- `cargo check -p tonk-ui --target wasm32-unknown-unknown`: passed.
+- `nix develop -c cargo test -p tonk-ui --no-run`: passed, compiling the updated real-browser flow assertions; one pre-existing unused-helper warning remains.
+- `nix develop -c build:web`: passed; the optional FlakeHub cache returned 401 and Nix built locally.
+- `git diff --check`: passed.
+- Browser QA: built CSS inspected at 1440px and the Chrome runner's 500px minimum width with a disposable fake device list. No horizontal overflow; headings had transparent backgrounds and zero padding; visible actions measured 44px, 44px, and 46px high. This was visual/layout verification, not a live authenticated revocation ceremony.
+
+## Deferred slices
+
+- Authenticated account summary exposing verified email and account creation time.
+- Versioned local passkey metadata for application-recorded creation time and browser-reported backup/attachment hints.
+- Device rename, last-used activity, or exact password-manager/provider claims.

--- a/plan/passkey-account-summary.md
+++ b/plan/passkey-account-summary.md
@@ -1,0 +1,147 @@
+# Portable passkey account summary implementation plan
+
+**Goal:** Show the verified account email plus truthful passkey creation time and creation device on every linked account device, without inferring passkey facts from device-attachment history.
+**Approach:** Capture optional passkey metadata only when Tonk successfully creates a passkey, persist it with the provider-neutral local root, and bind it into the later root-signed account-creation invocation. Store the optional pair on the provider account row and expose it through a device-authorized summary endpoint proxied by the local worker. The dashboard renders the verified email on every account and renders either both passkey fields or an explicit legacy/unavailable state.
+**Constraints:**
+- A passkey may predate account attachment; account or device `created_at` values must never be relabelled as passkey creation time.
+- `created_on` describes the browser/OS where Tonk ran `navigator.credentials.create()`, not the current password-manager or storage provider.
+- Existing local-root records and account rows remain readable with absent metadata.
+- Passkey metadata is informational only and must not alter root derivation, delegation bytes/CIDs, authorization, revocation, or account-repository authority.
+- The account summary must require an active device invocation and must not expose whether an arbitrary email or root exists.
+- No new dependencies.
+
+## File map
+
+- `rust/tonk-worker-api/src/identity.rs`: optional local passkey metadata on root save/status DTOs.
+- `rust/tonk-worker-api/src/account.rs`: authenticated account-summary response DTO.
+- `rust/tonk-identity/src/ceremony.rs`: capture creation time and bind optional metadata into account creation.
+- `rust/tonk-identity/src/install.rs`: carry metadata across the top-document JavaScript ceremony boundary.
+- `rust/tonk-ui/src/identity_bridge.rs`: typed ceremony input/output metadata.
+- `rust/tonk-ui/src/account.rs`: persist creation metadata, request the account summary, and render honest fallback copy.
+- `rust/tonk-ui/src/api.rs`: local account-summary and metadata-aware root persistence clients.
+- `rust/tonk-ui/src/account.html`: account-email and passkey-fact markup.
+- `rust/tonk-ui/src/account.css`: aligned summary facts and responsive unavailable state.
+- `rust/tonk-account-service/migrations/0007_passkey_metadata.sql`: nullable passkey creation columns for legacy compatibility.
+- `rust/tonk-account-service/src/store.rs`: account model and atomic creation interface.
+- `rust/tonk-account-service/src/store/sqlite.rs`: native migration/query/binding support.
+- `rust/tonk-account-service/src/store/d1.rs`: Cloudflare D1 query/binding support.
+- `rust/tonk-account-service/src/core/accounts.rs`: validated optional metadata on account creation.
+- `rust/tonk-account-service/src/handlers/accounts.rs`: Worker account-create parsing and authenticated summary handler.
+- `rust/tonk-account-service/src/helpers/server.rs`: native helper equivalents for browser and HTTP tests.
+- `rust/tonk-account-service/src/lib.rs`: Worker route registration.
+- `rust/tonk-worker/src/router/account_devices.rs`: attached-provider lookup and device-signed summary proxy.
+- `rust/tonk-worker/src/router.rs`: local `GET /api/account/summary` route.
+- `rust/tonk-ui/src/account_flow.rs`: real-browser summary regression coverage.
+
+### Task 1: Preserve passkey metadata with the local root
+
+**Files:**
+- Modify: `rust/tonk-worker-api/src/identity.rs:RootStatus, SaveRootRequest`
+- Modify: `rust/tonk-worker/src/router/identity.rs:LocalRootRecord, status, persist_root`
+- Modify: `rust/tonk-identity/src/ceremony.rs:RootCeremony, create_root`
+- Modify: `rust/tonk-identity/src/install.rs:create_root, root_result`
+- Modify: `rust/tonk-ui/src/identity_bridge.rs:CreateRootInput, RootOutput`
+- Modify: `rust/tonk-ui/src/api.rs:save_root`
+- Test: `rust/tonk-worker/src/router/identity.rs:tests`
+- Test: `rust/tonk-ui/src/identity_bridge.rs:tests`
+
+**Interfaces:**
+- Produces: `PasskeyMetadata { created_at: u64, created_on: String }` and optional `passkey` fields on `RootStatus::Ready` and `SaveRootRequest`.
+- Compatibility: missing `passkey` deserializes as `None`; existing record version 1 remains valid.
+
+- [x] Add a local-root regression test that deserializes a save request containing passkey metadata, persists it, reloads it, and expects the same camelCase metadata in `RootStatus`; run it and observe failure because the metadata is currently discarded.
+- [x] Add optional metadata to the wire DTO and local record, rejecting blank creation-device labels and zero timestamps at the persistence boundary.
+- [x] Capture Unix seconds immediately after successful passkey creation when `createdOn` is provided, return it through the ceremony bridge, and pass the current browser/OS label from the account flow.
+- [x] Run the focused local-root and identity-bridge tests; expect success.
+
+### Task 2: Store and return portable account metadata
+
+**Files:**
+- Create: `rust/tonk-account-service/migrations/0007_passkey_metadata.sql`
+- Modify: `rust/tonk-account-service/src/store.rs:Account, Store::create_account_with_device, account queries`
+- Modify: `rust/tonk-account-service/src/store/sqlite.rs:in_memory, account mapping, account creation`
+- Modify: `rust/tonk-account-service/src/store/d1.rs:AccountRowD1, account creation`
+- Modify: `rust/tonk-account-service/src/core/accounts.rs:CreateAccount, create_account`
+- Modify: `rust/tonk-account-service/src/handlers/accounts.rs`
+- Modify: `rust/tonk-account-service/src/helpers/server.rs`
+- Modify: `rust/tonk-account-service/src/lib.rs`
+- Test: `rust/tonk-account-service/src/store/sqlite.rs:tests`
+- Test: `rust/tonk-account-service/src/core/accounts.rs:tests`
+- Test: `rust/tonk-account-service/tests/service.rs`
+
+**Interfaces:**
+- Consumes: optional root-signed `passkeyCreatedAt` integer and `passkeyCreatedOn` string arguments; either both must be present or both absent.
+- Produces: device-authorized `POST /account/summary` for command `account/summary`, returning `{ email, passkey: { createdAt, createdOn } | null }`.
+- Validation: `createdAt > 0`, no more than five minutes in the future relative to account creation; trimmed `createdOn` is 1–120 characters and contains no control characters.
+
+- [x] Add a migration/store test requiring nullable metadata columns and round-tripping both populated and legacy-null account rows; run it and observe the expected missing-column/value failure.
+- [x] Add an HTTP service test that creates an account with signed metadata, fetches the summary with its active device invocation, and asserts the verified email and exact metadata; run it and observe the expected 404/missing-route failure.
+- [x] Add migration, atomic store bindings, validation, Worker/native routes, and device authorization. Do not add a root- or email-lookup endpoint.
+- [x] Run focused account-service store, core, and HTTP tests; expect success.
+
+### Task 3: Carry metadata through account creation and the local worker
+
+**Files:**
+- Modify: `rust/tonk-worker-api/src/account.rs:AccountSummary`
+- Modify: `rust/tonk-worker-api/src/lib.rs`
+- Modify: `rust/tonk-identity/src/ceremony.rs:create_account`
+- Modify: `rust/tonk-identity/src/install.rs:create_account`
+- Modify: `rust/tonk-ui/src/identity_bridge.rs:CreateAccountInput`
+- Modify: `rust/tonk-worker/src/router/account_devices.rs`
+- Modify: `rust/tonk-worker/src/router.rs`
+- Modify: `rust/tonk-ui/src/api.rs:account_summary`
+- Test: adjacent serialization, ceremony, and worker-router tests.
+
+**Interfaces:**
+- Consumes: optional local `PasskeyMetadata` from `RootStatus` or a newly created `RootOutput`.
+- Produces: root-signed optional metadata on `POST /accounts`; local `GET /api/account/summary` returning `AccountSummary`.
+
+- [x] Extend the ceremony regression test to require exact optional metadata arguments and absence of both arguments for legacy creation; run it and observe failure because the current signature cannot carry metadata.
+- [x] Thread the optional value through account input, invocation signing, provider parsing, and storage without changing delegation construction.
+- [x] Add the local worker proxy using the profile's attached provider and existing device invocation chain; deserialize the complete provider response.
+- [x] Run focused worker-API, identity-ceremony, worker-router, and UI API compile/tests; expect success.
+
+### Task 4: Render the account summary clearly
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.html:account-passkey`
+- Modify: `rust/tonk-ui/src/account.css:account passkey facts`
+- Modify: `rust/tonk-ui/src/account.rs:show_success, summary rendering`
+- Modify: `rust/tonk-ui/src/account_flow.rs:it_signs_up_through_the_account_panels`
+- Test: `rust/tonk-ui/src/account.rs:tests`
+
+**Interfaces:**
+- Consumes: `AccountSummary` from the local worker.
+- Produces: `Account email`, `Created`, and `Created on` facts. Legacy or failed summary loads show `Unavailable` and never substitute account/device dates.
+
+- [x] Add a dashboard DOM test requiring the three labelled facts and explicit unavailable fallback; run it and observe failure because the facts are not authored.
+- [x] Add the semantic description list, compact three-column alignment, pretty wrapping, and responsive layout without changing existing interaction behavior.
+- [x] Load summary alongside devices; render localized creation date and the recorded browser/OS label. Treat a missing/older provider endpoint as unavailable metadata rather than hiding device management.
+- [x] Extend the real-browser signup test to require the verified email, a non-empty localized creation date, and `Chrome on …` creation label.
+- [x] Run focused Wasm account tests and compile the real-browser flow; expect success.
+
+### Task 5: Verify the complete slice
+
+- [x] Run `cargo fmt --all -- --check` and `git diff --check`.
+- [x] Run focused native account-service tests with `tonk-account-service/helpers`.
+- [x] Run focused Wasm tests for `tonk-worker-api`, `tonk-identity`, `tonk-worker`, and `tonk-ui` in the repository Nix environment.
+- [x] Run `nix develop -c cargo test -p tonk-ui --no-run` to compile the updated browser flow.
+- [x] Run `nix develop -c build:web`.
+- [x] Inspect the built account dashboard with disposable summary/device data at desktop and mobile widths; verify label/value alignment, wrapping, unavailable copy, and no new console/layout failures.
+- [x] Re-read the diff to confirm no account timestamp or device registration timestamp is presented as passkey creation time.
+
+## Verification evidence
+
+- Red/green: local-root metadata test failed with `left: Null`, then passed after persistence was implemented.
+- Red/green: migration test failed on missing `passkey_created_at`; signed HTTP test failed with `404` on `/account/summary`; both passed after implementation.
+- `nix develop -c cargo test -p tonk-account-service --features helpers`: 64 unit tests and 9 HTTP integration tests passed.
+- Affected Wasm suites: 34 identity, 25 UI, 260 worker, and 21 worker-API tests passed.
+- Affected native and Wasm compile checks passed; the updated real-browser signup flow compiles.
+- `nix develop -c build:web`: passed after moving the new worker handler into a tracked module so the flake source snapshot included it.
+- Mounted QA used disposable summary/device data at desktop and the Chrome runner's narrow viewport: three-column facts collapsed to one column and no horizontal overflow was observed. The already-running dev server retained a prior hot-reload build-error badge; the production build passed.
+
+## Explicitly deferred
+
+- Exact password-manager/provider naming; WebAuthn does not expose it reliably.
+- Backup eligibility/state and authenticator attachment; useful later, but require registration/assertion parsing and careful user-facing semantics.
+- Editing passkey metadata or backfilling legacy rows by inference.

--- a/rust/tonk-account-service/migrations/0007_passkey_metadata.sql
+++ b/rust/tonk-account-service/migrations/0007_passkey_metadata.sql
@@ -1,0 +1,5 @@
+-- Passkey ceremony facts recorded by Tonk at credential creation time.
+-- Nullable because accounts created before this migration have no reliable
+-- source for either value and must not be backfilled from account/device dates.
+ALTER TABLE accounts ADD COLUMN passkey_created_at INTEGER;
+ALTER TABLE accounts ADD COLUMN passkey_created_on TEXT;

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -16,7 +16,7 @@ use dialog_ucan_core::time::timestamp::{Duration, SystemTime, Timestamp};
 use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 
 use crate::core::CeremonyError;
-use crate::store::{Account, Device, Store};
+use crate::store::{Account, Device, PasskeyMetadata, Store};
 
 /// An authenticated caller: the account and device bound by a verified
 /// UCAN invocation, plus the invocation's arguments.
@@ -208,6 +208,47 @@ pub fn required_string(
     }
 }
 
+/// Extract optional passkey ceremony metadata, requiring the timestamp and
+/// browser/OS label to appear as one valid pair.
+pub fn optional_passkey_metadata(
+    arguments: &BTreeMap<String, Promised>,
+    now: u64,
+) -> Result<Option<PasskeyMetadata>, CeremonyError> {
+    match (
+        arguments.get("passkeyCreatedAt"),
+        arguments.get("passkeyCreatedOn"),
+    ) {
+        (None, None) => Ok(None),
+        (Some(Promised::Integer(created_at)), Some(Promised::String(created_on))) => {
+            let created_at = u64::try_from(*created_at).map_err(|_| {
+                CeremonyError::Invalid("passkeyCreatedAt must be a positive timestamp".into())
+            })?;
+            let created_on = created_on.trim();
+            if created_at == 0 || created_at > now.saturating_add(300) {
+                return Err(CeremonyError::Invalid(
+                    "passkeyCreatedAt is outside the allowed range".into(),
+                ));
+            }
+            if created_on.is_empty()
+                || created_on.chars().count() > 120
+                || created_on.chars().any(char::is_control)
+            {
+                return Err(CeremonyError::Invalid(
+                    "passkeyCreatedOn must be a short browser and operating system label".into(),
+                ));
+            }
+            Ok(Some(PasskeyMetadata {
+                created_at,
+                created_on: created_on.to_string(),
+            }))
+        }
+        _ => Err(CeremonyError::Invalid(
+            "passkey creation metadata must include both passkeyCreatedAt and passkeyCreatedOn"
+                .into(),
+        )),
+    }
+}
+
 /// Extract a required string argument.
 pub fn string_argument(caller: &Caller, name: &str) -> Result<String, CeremonyError> {
     required_string(&caller.arguments, name)
@@ -238,6 +279,45 @@ mod tests {
     use dialog_credentials::Ed25519Signer;
     use dialog_ucan_core::InvocationBuilder;
     use dialog_varsig::Principal;
+
+    #[dialog_common::test]
+    fn it_accepts_complete_passkey_creation_metadata() {
+        let arguments = [
+            ("passkeyCreatedAt".into(), Promised::Integer(100)),
+            (
+                "passkeyCreatedOn".into(),
+                Promised::String("  Chrome on macOS  ".into()),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            optional_passkey_metadata(&arguments, 200).unwrap(),
+            Some(PasskeyMetadata {
+                created_at: 100,
+                created_on: "Chrome on macOS".into(),
+            })
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_partial_or_future_passkey_creation_metadata() {
+        let partial = [("passkeyCreatedAt".into(), Promised::Integer(100))]
+            .into_iter()
+            .collect();
+        assert!(optional_passkey_metadata(&partial, 200).is_err());
+
+        let future = [
+            ("passkeyCreatedAt".into(), Promised::Integer(501)),
+            (
+                "passkeyCreatedOn".into(),
+                Promised::String("Chrome on macOS".into()),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        assert!(optional_passkey_metadata(&future, 200).is_err());
+    }
 
     const ROOT_PRF: [u8; 32] = [7u8; 32];
     const DEVICE_SEED: [u8; 32] = [8u8; 32];

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -6,7 +6,7 @@ use crate::core::CeremonyError;
 use crate::core::codes::verify_code;
 use crate::core::delegation::check_device_delegation;
 use crate::core::descriptor::validate_descriptor;
-use crate::store::{NewDevice, Store, StoreError};
+use crate::store::{NewDevice, PasskeyMetadata, Store, StoreError};
 
 /// Returned when the verified email address already belongs to an
 /// account under a different root DID.
@@ -33,6 +33,8 @@ pub struct CreateAccount {
     pub delegation_hex: String,
     /// Hex-encoded root-signed account repository descriptor.
     pub repository_descriptor_hex: String,
+    /// Facts recorded when Tonk created the passkey, if available.
+    pub passkey: Option<PasskeyMetadata>,
 }
 
 /// Create a new account and register its first device.
@@ -68,6 +70,7 @@ pub async fn create_account<S: Store>(
             &request.root_did,
             &request.credential_id,
             &repository_descriptor,
+            request.passkey.as_ref(),
             &NewDevice {
                 device_did: request.device_did.clone(),
                 attachment_id: crate::core::devices::random_attachment_id(),
@@ -188,10 +191,19 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: Some(PasskeyMetadata {
+                created_at: 150,
+                created_on: "Chrome on macOS".into(),
+            }),
         };
         let id = create_account(&store, &request, 200).await.unwrap();
         let account = store.account_by_root(&root_did).await.unwrap().unwrap();
         assert_eq!((account.id, account.email.as_str()), (id, "a@x.com"));
+        assert_eq!(account.passkey_created_at, Some(150));
+        assert_eq!(
+            account.passkey_created_on.as_deref(),
+            Some("Chrome on macOS")
+        );
         assert_eq!(store.devices(id).await.unwrap().len(), 1);
     }
 
@@ -222,6 +234,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: None,
         };
         assert!(matches!(
             create_account(&store, &request, 200).await,
@@ -242,6 +255,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: None,
         };
         assert!(matches!(
             create_account(&store, &request, 200).await,
@@ -269,6 +283,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: None,
         };
         let good_descriptor = request.repository_descriptor_hex.clone();
         request.repository_descriptor_hex = "not hex".into();
@@ -301,6 +316,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: None,
         };
         request.device_did = {
             use dialog_varsig::Principal;
@@ -337,6 +353,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex,
+            passkey: None,
         };
         create_account(&store, &first, 200).await.unwrap();
 
@@ -377,6 +394,7 @@ mod tests {
             device_name: "phone".into(),
             delegation_hex: hex::encode(chain2.to_bytes().unwrap()),
             repository_descriptor_hex: hex::encode(descriptor2.bytes()),
+            passkey: None,
         };
         // The message names the email, not the database's own
         // "UNIQUE constraint failed: accounts.email" text.
@@ -406,6 +424,7 @@ mod tests {
                 device_name: "laptop".into(),
                 delegation_hex: delegation_hex.clone(),
                 repository_descriptor_hex: descriptor_hex.clone(),
+                passkey: None,
             },
             200,
         )
@@ -424,6 +443,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex: descriptor_hex,
+            passkey: None,
         };
         let error = create_account(&store, &again, 500).await;
         assert!(matches!(&error, Err(CeremonyError::Conflict(msg)) if msg == ROOT_TAKEN));
@@ -449,6 +469,7 @@ mod tests {
             device_name: "laptop".into(),
             delegation_hex,
             repository_descriptor_hex: descriptor_hex,
+            passkey: None,
         };
         create_account(&store, &request, 200).await.unwrap();
 
@@ -517,6 +538,7 @@ mod tests {
                 device_name: "new registration".into(),
                 delegation_hex,
                 repository_descriptor_hex,
+                passkey: None,
             },
             200,
         )

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -6,7 +6,7 @@ use crate::core::CeremonyError;
 use crate::core::codes::verify_code;
 use crate::core::delegation::check_device_delegation;
 use crate::core::descriptor::validate_descriptor;
-use crate::store::{NewDevice, PasskeyMetadata, Store, StoreError};
+use crate::store::{NewAccount, NewDevice, PasskeyMetadata, Store, StoreError};
 
 /// Returned when the verified email address already belongs to an
 /// account under a different root DID.
@@ -64,23 +64,22 @@ pub async fn create_account<S: Store>(
     verify_code(store, &request.email, &request.code, now).await?;
 
     let email = request.email.to_lowercase();
-    let created = store
-        .create_account_with_device(
-            &email,
-            &request.root_did,
-            &request.credential_id,
-            &repository_descriptor,
-            request.passkey.as_ref(),
-            &NewDevice {
-                device_did: request.device_did.clone(),
-                attachment_id: crate::core::devices::random_attachment_id(),
-                delegation_cid,
-                delegation_hex: request.delegation_hex.clone(),
-                name: request.device_name.clone(),
-            },
-            now,
-        )
-        .await;
+    let account = NewAccount {
+        email: &email,
+        root_did: &request.root_did,
+        credential_id: &request.credential_id,
+        repository_descriptor: &repository_descriptor,
+        passkey: request.passkey.as_ref(),
+        created_at: now,
+    };
+    let device = NewDevice {
+        device_did: request.device_did.clone(),
+        attachment_id: crate::core::devices::random_attachment_id(),
+        delegation_cid,
+        delegation_hex: request.delegation_hex.clone(),
+        name: request.device_name.clone(),
+    };
+    let created = store.create_account_with_device(&account, &device).await;
 
     match created {
         Ok(account_id) => Ok(account_id),

--- a/rust/tonk-account-service/src/core/backup.rs
+++ b/rust/tonk-account-service/src/core/backup.rs
@@ -295,6 +295,8 @@ mod tests {
             root_did: root_did.to_string(),
             credential_id: "cred".to_string(),
             repository_descriptor: None,
+            passkey_created_at: None,
+            passkey_created_on: None,
             created_at: 100,
         }
     }

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -378,6 +378,8 @@ mod tests {
             root_did: root.did().to_string(),
             credential_id: "cred".into(),
             repository_descriptor: None,
+            passkey_created_at: None,
+            passkey_created_on: None,
             created_at: 1,
         };
         let device = Device {

--- a/rust/tonk-account-service/src/handlers/accounts.rs
+++ b/rust/tonk-account-service/src/handlers/accounts.rs
@@ -2,7 +2,7 @@
 
 use worker::*;
 
-use crate::auth::{authorize_root, required_string};
+use crate::auth::{authorize, authorize_root, optional_passkey_metadata, required_string};
 use crate::core::accounts::{CreateAccount, create_account};
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
@@ -11,6 +11,36 @@ use crate::store::Store;
 /// `OPTIONS /accounts` → CORS preflight.
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
     Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /account/summary` → verified email and passkey creation facts.
+pub async fn handle_summary(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_summary_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_summary_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let store = build_store(ctx)?;
+    let body = read_body(req).await?;
+    let caller = authorize(&store, &body, &["account", "summary"])
+        .await
+        .map_err(ceremony_error)?;
+
+    Response::from_json(&serde_json::json!({
+        "email": caller.account.email,
+        "passkey": caller.account.passkey_created_at.zip(caller.account.passkey_created_on)
+            .map(|(created_at, created_on)| serde_json::json!({
+                "createdAt": created_at,
+                "createdOn": created_on,
+            })),
+    }))
+    .map_err(|err| ServiceError::new(ErrorCode::InternalError, format!("response error: {err}")))
 }
 
 /// `POST /accounts` → create a new account.
@@ -30,6 +60,8 @@ async fn handle_inner(
     let caller = authorize_root(&body, &["account", "create"])
         .await
         .map_err(ceremony_error)?;
+    let now = Date::now().as_millis() / 1000;
+    let passkey = optional_passkey_metadata(&caller.arguments, now).map_err(ceremony_error)?;
     let request = CreateAccount {
         email: required_string(&caller.arguments, "email").map_err(ceremony_error)?,
         code: required_string(&caller.arguments, "code").map_err(ceremony_error)?,
@@ -41,9 +73,9 @@ async fn handle_inner(
         repository_descriptor_hex: required_string(&caller.arguments, "repositoryDescriptor")
             .map_err(ceremony_error)?,
         root_did: caller.root_did,
+        passkey,
     };
     let store = build_store(ctx)?;
-    let now = Date::now().as_millis() / 1000;
     let account_id = create_account(&store, &request, now)
         .await
         .map_err(ceremony_error)?;

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -25,8 +25,8 @@ use tonk_account::backup::{ACCOUNT_SPOTS_CAPABILITY_HEADER, ACCOUNT_SPOTS_CAPABI
 use tonk_account::handoff::{LinkCreateRequest, LinkSecretRequest};
 
 use crate::auth::{
-    authorize, authorize_link_activation, authorize_root, optional_revocation, required_string,
-    string_argument,
+    authorize, authorize_link_activation, authorize_root, optional_passkey_metadata,
+    optional_revocation, required_string, string_argument,
 };
 use crate::chains::MemoryChainStore;
 use crate::core::accounts::{CreateAccount, create_account};
@@ -143,6 +143,7 @@ async fn handle_request(
         (Method::GET, "/_test/spots") => spots_route(req, &backends).await,
         (Method::POST, "/codes") => codes_route(req, &backends).await,
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
+        (Method::POST, "/account/summary") => account_summary_route(req, &backends).await,
         (Method::POST, "/revocations") => revocations_route(req, &backends).await,
         (Method::POST, "/account/repository/establish") => {
             repository_establish_route(req, &backends).await
@@ -171,6 +172,28 @@ async fn handle_request(
         Ok(response) => response,
         Err(err) => error_response(err),
     }))
+}
+
+/// `POST /account/summary` → verified account facts for an active device.
+async fn account_summary_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let body = body_bytes(req).await?;
+    let caller = authorize(&backends.store, &body, &["account", "summary"])
+        .await
+        .map_err(ceremony_error)?;
+    Ok(json_response(
+        StatusCode::OK,
+        &serde_json::json!({
+            "email": caller.account.email,
+            "passkey": caller.account.passkey_created_at.zip(caller.account.passkey_created_on)
+                .map(|(created_at, created_on)| serde_json::json!({
+                    "createdAt": created_at,
+                    "createdOn": created_on,
+                })),
+        }),
+    ))
 }
 
 /// `GET /` → service info. Not CORS-wrapped, matching the worker.
@@ -298,6 +321,8 @@ async fn accounts_route(
     let caller = authorize_root(&body, &["account", "create"])
         .await
         .map_err(ceremony_error)?;
+    let now = unix_now();
+    let passkey = optional_passkey_metadata(&caller.arguments, now).map_err(ceremony_error)?;
     let request = CreateAccount {
         email: required_string(&caller.arguments, "email").map_err(ceremony_error)?,
         code: required_string(&caller.arguments, "code").map_err(ceremony_error)?,
@@ -309,8 +334,9 @@ async fn accounts_route(
         repository_descriptor_hex: required_string(&caller.arguments, "repositoryDescriptor")
             .map_err(ceremony_error)?,
         root_did: caller.root_did,
+        passkey,
     };
-    let account_id = create_account(&backends.store, &request, unix_now())
+    let account_id = create_account(&backends.store, &request, now)
         .await
         .map_err(ceremony_error)?;
     let account = backends

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -33,6 +33,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/codes", handlers::codes::handle_options)
         .post_async("/accounts", handlers::accounts::handle)
         .options_async("/accounts", handlers::accounts::handle_options)
+        .post_async("/account/summary", handlers::accounts::handle_summary)
+        .options_async("/account/summary", handlers::accounts::handle_options)
         .post_async("/revocations", handlers::revocations::handle)
         .options_async("/revocations", handlers::revocations::handle_options)
         .post_async(

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -20,8 +20,21 @@ pub struct Account {
     pub credential_id: String,
     /// Exact root-signed account repository descriptor, when established.
     pub repository_descriptor: Option<Vec<u8>>,
+    /// Passkey ceremony time, when Tonk recorded it.
+    pub passkey_created_at: Option<u64>,
+    /// Browser and operating system where the passkey ceremony ran.
+    pub passkey_created_on: Option<String>,
     /// Creation time, as a unix timestamp in seconds.
     pub created_at: u64,
+}
+
+/// Facts Tonk recorded during a passkey creation ceremony.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasskeyMetadata {
+    /// Ceremony time, as a unix timestamp in seconds.
+    pub created_at: u64,
+    /// Browser and operating system where the ceremony ran.
+    pub created_on: String,
 }
 
 /// A device delegated under an account's root DID.
@@ -264,6 +277,7 @@ pub trait Store {
         root_did: &str,
         credential_id: &str,
         repository_descriptor: &[u8],
+        passkey: Option<&PasskeyMetadata>,
         device: &NewDevice,
         created_at: u64,
     ) -> Result<i64, StoreError>;
@@ -371,12 +385,12 @@ pub const INSERT_ACCOUNT: &str =
 
 /// SQL: insert a new account with its repository descriptor.
 pub const INSERT_ACCOUNT_WITH_DESCRIPTOR: &str = "INSERT INTO accounts \
-    (email, root_did, credential_id, repository_descriptor, created_at) \
-    VALUES (?1, ?2, ?3, ?4, ?5)";
+    (email, root_did, credential_id, repository_descriptor, passkey_created_at, passkey_created_on, created_at) \
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
 
 /// SQL: look up an account by root DID.
 pub const SELECT_ACCOUNT_BY_ROOT: &str = "SELECT id, email, root_did, credential_id, \
-    repository_descriptor, created_at FROM accounts WHERE root_did = ?1";
+    repository_descriptor, passkey_created_at, passkey_created_on, created_at FROM accounts WHERE root_did = ?1";
 
 /// SQL: install a descriptor only while the account has none.
 pub const ESTABLISH_REPOSITORY_DESCRIPTOR: &str = "UPDATE accounts \
@@ -389,7 +403,7 @@ pub const SELECT_REPOSITORY_DESCRIPTOR: &str =
 
 /// SQL: look up an account by email address.
 pub const SELECT_ACCOUNT_BY_EMAIL: &str = "SELECT id, email, root_did, credential_id, \
-    repository_descriptor, created_at FROM accounts WHERE email = ?1";
+    repository_descriptor, passkey_created_at, passkey_created_on, created_at FROM accounts WHERE email = ?1";
 
 /// SQL: register a device under an account.
 pub const INSERT_DEVICE: &str = "INSERT INTO devices (account_id, device_did, attachment_id, delegation_cid, delegation_hex, name, status, created_at) \

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -37,6 +37,23 @@ pub struct PasskeyMetadata {
     pub created_on: String,
 }
 
+/// An account to insert as part of atomically creating its first device.
+#[derive(Debug, Clone, Copy)]
+pub struct NewAccount<'a> {
+    /// Verified, normalized email address.
+    pub email: &'a str,
+    /// Root DID controlled by the passkey.
+    pub root_did: &'a str,
+    /// Opaque WebAuthn credential identifier.
+    pub credential_id: &'a str,
+    /// Exact root-signed account repository descriptor.
+    pub repository_descriptor: &'a [u8],
+    /// Facts Tonk recorded during passkey creation, when available.
+    pub passkey: Option<&'a PasskeyMetadata>,
+    /// Account creation time, as a Unix timestamp in seconds.
+    pub created_at: u64,
+}
+
 /// A device delegated under an account's root DID.
 #[derive(Debug, Clone)]
 pub struct Device {
@@ -273,13 +290,8 @@ pub trait Store {
     /// in that case.
     async fn create_account_with_device(
         &self,
-        email: &str,
-        root_did: &str,
-        credential_id: &str,
-        repository_descriptor: &[u8],
-        passkey: Option<&PasskeyMetadata>,
+        account: &NewAccount<'_>,
         device: &NewDevice,
-        created_at: u64,
     ) -> Result<i64, StoreError>;
 
     /// Establish one immutable repository descriptor and return `(winner, created)`.

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -16,7 +16,7 @@ use crate::store::{
     Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
     DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
     INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK,
-    LinkCompletion, LinkRequest, NewDevice, PasskeyMetadata, SELECT_ACCOUNT_BY_EMAIL,
+    LinkCompletion, LinkRequest, NewAccount, NewDevice, SELECT_ACCOUNT_BY_EMAIL,
     SELECT_ACCOUNT_BY_ROOT, SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE,
     SELECT_DEVICE_FOR_ACCOUNT, SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
     SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
@@ -252,35 +252,32 @@ impl Store for D1Store {
 
     async fn create_account_with_device(
         &self,
-        email: &str,
-        root_did: &str,
-        credential_id: &str,
-        repository_descriptor: &[u8],
-        passkey: Option<&PasskeyMetadata>,
+        account: &NewAccount<'_>,
         device: &NewDevice,
-        created_at: u64,
     ) -> Result<i64, StoreError> {
         // D1 batches run as a single transaction: either every statement
         // commits or none does. The device insert reaches back for the
         // account id it needs via SQLite's `last_insert_rowid()` rather
         // than a value threaded in from Rust, since the account id isn't
         // known until the first statement in this same batch executes.
-        let descriptor = js_sys::Uint8Array::from(repository_descriptor);
+        let descriptor = js_sys::Uint8Array::from(account.repository_descriptor);
         let insert_account = self
             .0
             .prepare(INSERT_ACCOUNT_WITH_DESCRIPTOR)
             .bind(&[
-                JsValue::from(email),
-                JsValue::from(root_did),
-                JsValue::from(credential_id),
+                JsValue::from(account.email),
+                JsValue::from(account.root_did),
+                JsValue::from(account.credential_id),
                 descriptor.into(),
-                passkey
+                account
+                    .passkey
                     .map(|metadata| JsValue::from_f64(metadata.created_at as f64))
                     .unwrap_or(JsValue::NULL),
-                passkey
+                account
+                    .passkey
                     .map(|metadata| JsValue::from(metadata.created_on.as_str()))
                     .unwrap_or(JsValue::NULL),
-                JsValue::from_f64(created_at as f64),
+                JsValue::from_f64(account.created_at as f64),
             ])
             .map_err(map_err)?;
         let insert_device = self
@@ -292,7 +289,7 @@ impl Store for D1Store {
                 JsValue::from(device.delegation_cid.as_str()),
                 JsValue::from(device.delegation_hex.as_str()),
                 JsValue::from(device.name.as_str()),
-                JsValue::from_f64(created_at as f64),
+                JsValue::from_f64(account.created_at as f64),
             ])
             .map_err(map_err)?;
         let results = self

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -16,9 +16,9 @@ use crate::store::{
     Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
     DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
     INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK,
-    LinkCompletion, LinkRequest, NewDevice, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
-    SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT,
-    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
+    LinkCompletion, LinkRequest, NewDevice, PasskeyMetadata, SELECT_ACCOUNT_BY_EMAIL,
+    SELECT_ACCOUNT_BY_ROOT, SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE,
+    SELECT_DEVICE_FOR_ACCOUNT, SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
     SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
     UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
 };
@@ -75,6 +75,8 @@ struct AccountRowD1 {
     root_did: String,
     credential_id: String,
     repository_descriptor: Option<Vec<u8>>,
+    passkey_created_at: Option<f64>,
+    passkey_created_on: Option<String>,
     created_at: f64,
 }
 
@@ -86,6 +88,8 @@ impl From<AccountRowD1> for Account {
             root_did: row.root_did,
             credential_id: row.credential_id,
             repository_descriptor: row.repository_descriptor,
+            passkey_created_at: row.passkey_created_at.map(|value| value as u64),
+            passkey_created_on: row.passkey_created_on,
             created_at: row.created_at as u64,
         }
     }
@@ -252,6 +256,7 @@ impl Store for D1Store {
         root_did: &str,
         credential_id: &str,
         repository_descriptor: &[u8],
+        passkey: Option<&PasskeyMetadata>,
         device: &NewDevice,
         created_at: u64,
     ) -> Result<i64, StoreError> {
@@ -269,6 +274,12 @@ impl Store for D1Store {
                 JsValue::from(root_did),
                 JsValue::from(credential_id),
                 descriptor.into(),
+                passkey
+                    .map(|metadata| JsValue::from_f64(metadata.created_at as f64))
+                    .unwrap_or(JsValue::NULL),
+                passkey
+                    .map(|metadata| JsValue::from(metadata.created_on.as_str()))
+                    .unwrap_or(JsValue::NULL),
                 JsValue::from_f64(created_at as f64),
             ])
             .map_err(map_err)?;

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -10,7 +10,7 @@ use super::{
     Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
     DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
     INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_LINK, LinkCompletion, LinkRequest,
-    NewDevice, PasskeyMetadata, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
+    NewAccount, NewDevice, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
     SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT,
     SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
     SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
@@ -210,26 +210,21 @@ impl Store for SqliteStore {
 
     async fn create_account_with_device(
         &self,
-        email: &str,
-        root_did: &str,
-        credential_id: &str,
-        repository_descriptor: &[u8],
-        passkey: Option<&PasskeyMetadata>,
+        account: &NewAccount<'_>,
         device: &NewDevice,
-        created_at: u64,
     ) -> Result<i64, StoreError> {
         let mut conn = self.0.lock().expect("store mutex poisoned");
         let tx = conn.transaction().map_err(map_err)?;
         tx.execute(
             INSERT_ACCOUNT_WITH_DESCRIPTOR,
             params![
-                email,
-                root_did,
-                credential_id,
-                repository_descriptor,
-                passkey.map(|metadata| metadata.created_at as i64),
-                passkey.map(|metadata| metadata.created_on.as_str()),
-                created_at as i64
+                account.email,
+                account.root_did,
+                account.credential_id,
+                account.repository_descriptor,
+                account.passkey.map(|metadata| metadata.created_at as i64),
+                account.passkey.map(|metadata| metadata.created_on.as_str()),
+                account.created_at as i64
             ],
         )
         .map_err(map_err)?;
@@ -244,7 +239,7 @@ impl Store for SqliteStore {
                 device.delegation_hex,
                 device.name,
                 DeviceStatus::Active.as_str(),
-                created_at as i64,
+                account.created_at as i64,
             ],
         )
         .map_err(map_err)?;

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -10,10 +10,11 @@ use super::{
     Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
     DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
     INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_LINK, LinkCompletion, LinkRequest,
-    NewDevice, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT, SELECT_ACTIVE_DEVICE_BY_DID,
-    SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT, SELECT_DEVICES_BY_ACCOUNT,
-    SELECT_LINK, SELECT_LINK_BY_ATTACHMENT, SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError,
-    UPDATE_DEVICE_REVOKE, UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
+    NewDevice, PasskeyMetadata, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
+    SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT,
+    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
+    SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
+    UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -53,6 +54,8 @@ impl SqliteStore {
             "../../migrations/0006_device_attachment_lifecycle.sql"
         ))
         .map_err(map_err)?;
+        conn.execute_batch(include_str!("../../migrations/0007_passkey_metadata.sql"))
+            .map_err(map_err)?;
         Ok(Self(Mutex::new(conn)))
     }
 }
@@ -211,6 +214,7 @@ impl Store for SqliteStore {
         root_did: &str,
         credential_id: &str,
         repository_descriptor: &[u8],
+        passkey: Option<&PasskeyMetadata>,
         device: &NewDevice,
         created_at: u64,
     ) -> Result<i64, StoreError> {
@@ -223,6 +227,8 @@ impl Store for SqliteStore {
                 root_did,
                 credential_id,
                 repository_descriptor,
+                passkey.map(|metadata| metadata.created_at as i64),
+                passkey.map(|metadata| metadata.created_on.as_str()),
                 created_at as i64
             ],
         )
@@ -255,7 +261,9 @@ impl Store for SqliteStore {
                 root_did: row.get(2)?,
                 credential_id: row.get(3)?,
                 repository_descriptor: row.get(4)?,
-                created_at: row.get::<_, i64>(5)? as u64,
+                passkey_created_at: row.get::<_, Option<i64>>(5)?.map(|value| value as u64),
+                passkey_created_on: row.get(6)?,
+                created_at: row.get::<_, i64>(7)? as u64,
             })
         })
         .optional()
@@ -271,7 +279,9 @@ impl Store for SqliteStore {
                 root_did: row.get(2)?,
                 credential_id: row.get(3)?,
                 repository_descriptor: row.get(4)?,
-                created_at: row.get::<_, i64>(5)? as u64,
+                passkey_created_at: row.get::<_, Option<i64>>(5)?.map(|value| value as u64),
+                passkey_created_on: row.get(6)?,
+                created_at: row.get::<_, i64>(7)? as u64,
             })
         })
         .optional()
@@ -836,6 +846,22 @@ mod tests {
             )
             .unwrap();
         assert_eq!(registrations, 2);
+    }
+
+    #[dialog_common::test]
+    fn it_migrates_nullable_passkey_creation_metadata() {
+        let store = SqliteStore::in_memory().unwrap();
+        let conn = store.0.lock().expect("store mutex poisoned");
+        let columns = conn
+            .prepare("PRAGMA table_info(accounts)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(columns.contains(&"passkey_created_at".to_string()));
+        assert!(columns.contains(&"passkey_created_on".to_string()));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -123,6 +123,7 @@ async fn account_creation(email: &str, code: &str) -> Vec<u8> {
         "laptop".to_string(),
         hex::encode(grant.to_bytes().unwrap()),
         "http://127.0.0.1:8080/ucan/".to_string(),
+        None,
     )
     .await
     .unwrap();
@@ -385,6 +386,7 @@ async fn it_explains_an_already_registered_email_over_http() {
             "laptop".into(),
             hex::encode(grant.to_bytes().unwrap()),
             "http://127.0.0.1:8080/ucan/".into(),
+            None,
         )
         .await
         .unwrap();
@@ -463,6 +465,10 @@ async fn it_drives_the_full_ceremony_over_http() {
         "laptop".into(),
         hex::encode(first_grant.to_bytes().unwrap()),
         "http://127.0.0.1:8080/ucan/".into(),
+        Some(tonk_identity::ceremony::PasskeyCreationMetadata {
+            created_at: 1_754_380_800,
+            created_on: "Chrome on macOS".into(),
+        }),
     )
     .await
     .unwrap();
@@ -478,6 +484,28 @@ async fn it_drives_the_full_ceremony_over_http() {
     let created: serde_json::Value = response.json().await.unwrap();
     assert!(created["accountId"].is_i64());
     assert_eq!(created["descriptorHex"], expected_descriptor);
+
+    // The account summary reveals verified account facts only to an active
+    // device. Passkey facts are the values witnessed at credential creation,
+    // not inferred from this account or device registration time.
+    let body = container_with_link(
+        &device,
+        &first_grant,
+        vec!["account".into(), "summary".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{base}/account/summary"))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let summary: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(summary["email"], "person@example.com");
+    assert_eq!(summary["passkey"]["createdAt"], 1_754_380_800_u64);
+    assert_eq!(summary["passkey"]["createdOn"], "Chrome on macOS");
 
     // Establishment is set-if-absent: a later valid candidate receives
     // the stored creation winner, never its own bytes.
@@ -1021,6 +1049,7 @@ async fn it_drives_the_full_ceremony_over_http() {
         "other-device".to_string(),
         hex::encode(other_grant.to_bytes().unwrap()),
         "http://127.0.0.1:8080/ucan/".to_string(),
+        None,
     )
     .await
     .unwrap();

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -112,6 +112,7 @@ impl AccountFixture {
             "fixture-device".to_string(),
             hex::encode(link.to_bytes()?),
             "http://127.0.0.1:9/ucan/".to_string(),
+            None,
         )
         .await?;
         reqwest::Client::new()

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -56,6 +56,17 @@ pub struct RootCeremony {
     pub delegation_cid: String,
     /// Exact hex-encoded root → device delegation bytes.
     pub delegation_hex: String,
+    /// Creation details when this ceremony created the passkey.
+    pub passkey: Option<PasskeyCreationMetadata>,
+}
+
+/// Informational metadata captured by the browser that created a passkey.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasskeyCreationMetadata {
+    /// Browser-reported Unix time immediately after credential creation.
+    pub created_at: u64,
+    /// Browser and operating-system label where creation ran.
+    pub created_on: String,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -63,6 +74,7 @@ async fn root_ceremony(
     root: Ed25519Signer,
     credential_id: String,
     device_did: dialog_varsig::Did,
+    passkey: Option<PasskeyCreationMetadata>,
 ) -> Result<RootCeremony> {
     let root_did = root.did().to_string();
     let delegation = mint_device_delegation(root, &device_did).await?;
@@ -78,6 +90,7 @@ async fn root_ceremony(
         credential_id,
         delegation_cid,
         delegation_hex,
+        passkey,
     })
 }
 
@@ -91,15 +104,20 @@ async fn root_ceremony(
 pub async fn create_root(
     device_did: dialog_varsig::Did,
     label: Option<&str>,
+    created_on: Option<&str>,
 ) -> Result<RootCeremony> {
     let created = crate::passkey::create_passkey(label).await?;
     let credential_id = hex::encode(created.id);
+    let passkey = created_on.map(|created_on| PasskeyCreationMetadata {
+        created_at: (js_sys::Date::now() / 1000.0) as u64,
+        created_on: created_on.to_string(),
+    });
     let prf = match created.prf_output {
         Some(output) => output,
         None => crate::passkey::prf_output().await?,
     };
     let root = crate::derive::derive_root_signer(&prf).await?;
-    root_ceremony(root, credential_id, device_did).await
+    root_ceremony(root, credential_id, device_did, passkey).await
 }
 
 /// Evaluate an existing discoverable passkey and delegate its root to `device_did`.
@@ -111,7 +129,7 @@ pub async fn evaluate_root(device_did: dialog_varsig::Did) -> Result<RootCeremon
         .prf_output
         .context("the authenticator returned no PRF output")?;
     let root = crate::derive::derive_root_signer(&prf).await?;
-    root_ceremony(root, credential_id, device_did).await
+    root_ceremony(root, credential_id, device_did, None).await
 }
 
 fn strings(values: impl IntoIterator<Item = (&'static str, String)>) -> BTreeMap<String, Promised> {
@@ -185,6 +203,7 @@ pub async fn create_account(
     device_name: String,
     delegation_hex: String,
     remote: String,
+    passkey: Option<PasskeyCreationMetadata>,
 ) -> Result<AccountCeremony> {
     let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(&root, &remote)
         .await
@@ -197,18 +216,29 @@ pub async fn create_account(
     if delegation.issuer() != &root.did() || delegation.audience() != &device_did {
         anyhow::bail!("existing delegation does not match the evaluated root and device");
     }
+    let mut arguments = strings([
+        ("email", email),
+        ("code", code),
+        ("credentialId", credential_id),
+        ("deviceDid", device_did.to_string()),
+        ("deviceName", device_name),
+        ("delegation", delegation_hex.clone()),
+        ("repositoryDescriptor", descriptor_hex.clone()),
+    ]);
+    if let Some(passkey) = passkey {
+        arguments.insert(
+            "passkeyCreatedAt".into(),
+            Promised::Integer(passkey.created_at as i128),
+        );
+        arguments.insert(
+            "passkeyCreatedOn".into(),
+            Promised::String(passkey.created_on),
+        );
+    }
     build(
         root,
         vec!["account".into(), "create".into()],
-        strings([
-            ("email", email),
-            ("code", code),
-            ("credentialId", credential_id),
-            ("deviceDid", device_did.to_string()),
-            ("deviceName", device_name),
-            ("delegation", delegation_hex.clone()),
-            ("repositoryDescriptor", descriptor_hex.clone()),
-        ]),
+        arguments,
         device_did_string,
         delegation_hex,
         Some(descriptor_hex),
@@ -340,6 +370,10 @@ mod tests {
             "laptop".into(),
             delegation_hex,
             "https://accounts.example/ucan/".into(),
+            Some(PasskeyCreationMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".into(),
+            }),
         )
         .await
         .unwrap();
@@ -364,6 +398,14 @@ mod tests {
             chain.arguments().get("email"),
             Some(&Promised::String("a@x.com".into()))
         );
+        assert_eq!(
+            chain.arguments().get("passkeyCreatedAt"),
+            Some(&Promised::Integer(1_754_380_800))
+        );
+        assert_eq!(
+            chain.arguments().get("passkeyCreatedOn"),
+            Some(&Promised::String("Chrome on macOS".into()))
+        );
         let descriptor_hex = output.descriptor_hex.unwrap();
         assert_eq!(
             chain.arguments().get("repositoryDescriptor"),
@@ -375,6 +417,28 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(descriptor.account_subject(), &expected_root);
+
+        let (root, device) = fixture().await;
+        let delegation = crate::delegation::mint_device_delegation(root.clone(), &device)
+            .await
+            .unwrap();
+        let legacy = create_account(
+            root,
+            "legacy@x.com".into(),
+            "123456".into(),
+            "legacy-credential".into(),
+            device,
+            "old browser".into(),
+            hex::encode(delegation.to_bytes().unwrap()),
+            "https://accounts.example/ucan/".into(),
+            None,
+        )
+        .await
+        .unwrap();
+        let bytes = hex::decode(legacy.invocation_hex).unwrap();
+        let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
+        assert!(!chain.arguments().contains_key("passkeyCreatedAt"));
+        assert!(!chain.arguments().contains_key("passkeyCreatedOn"));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -130,6 +130,16 @@ fn root_result(ceremony: crate::ceremony::RootCeremony) -> Result<JsValue, JsVal
         &"delegationHex".into(),
         &ceremony.delegation_hex.into(),
     )?;
+    if let Some(passkey) = ceremony.passkey {
+        let metadata = Object::new();
+        Reflect::set(
+            &metadata,
+            &"createdAt".into(),
+            &JsValue::from_f64(passkey.created_at as f64),
+        )?;
+        Reflect::set(&metadata, &"createdOn".into(), &passkey.created_on.into())?;
+        Reflect::set(&result, &"passkey".into(), &metadata)?;
+    }
     Ok(result.into())
 }
 
@@ -141,8 +151,9 @@ async fn create_root(input: JsValue) -> Result<JsValue, JsValue> {
     // sends the address it just verified; a spot creating a root sends
     // nothing, because no account exists to name.
     let label = optional_string_property(&input, "label");
+    let created_on = optional_string_property(&input, "createdOn");
     root_result(
-        crate::ceremony::create_root(device_did, label.as_deref())
+        crate::ceremony::create_root(device_did, label.as_deref(), created_on.as_deref())
             .await
             .map_err(js_error)?,
     )
@@ -189,6 +200,21 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     let expected_root = string_property(&input, "rootDid")?;
     let credential_id = string_property(&input, "credentialId")?;
     let delegation_hex = string_property(&input, "delegationHex")?;
+    let passkey = Reflect::get(&input, &"passkey".into())
+        .ok()
+        .filter(|value| !value.is_null() && !value.is_undefined())
+        .map(|value| {
+            let created_at = Reflect::get(&value, &"createdAt".into())?
+                .as_f64()
+                .ok_or_else(|| JsValue::from_str("passkey.createdAt must be a timestamp"))?
+                as u64;
+            let created_on = string_property(&value, "createdOn")?;
+            Ok::<_, JsValue>(crate::ceremony::PasskeyCreationMetadata {
+                created_at,
+                created_on,
+            })
+        })
+        .transpose()?;
     let evaluated = crate::passkey::evaluate_passkey().await.map_err(js_error)?;
     if hex::encode(evaluated.id) != credential_id {
         return Err(JsValue::from_str(
@@ -218,6 +244,7 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
             device_name,
             delegation_hex,
             remote,
+            passkey,
         )
         .await
         .map_err(js_error)?,

--- a/rust/tonk-ui/src/account.css
+++ b/rust/tonk-ui/src/account.css
@@ -3,34 +3,45 @@ tonk-account {
     --account-muted: var(--wa-color-text-quiet, light-dark(#62646b, #a4a5aa));
     --account-surface: var(--wa-color-surface-raised, light-dark(#ffffff, #191a1d));
     --account-field: var(--wa-color-surface-default, light-dark(#f5f5f6, #101113));
+    --account-divider: color-mix(in oklab, var(--account-ink) 11%, transparent);
+    --account-shadow:
+        0 0 0 1px rgb(0 0 0 / 6%),
+        0 1px 2px -1px rgb(0 0 0 / 6%),
+        0 12px 32px rgb(0 0 0 / 7%);
     display: grid;
     min-height: 100dvh;
     place-items: center;
-    padding: 32px 20px;
+    padding: 40px 24px;
     box-sizing: border-box;
     background: var(--wa-color-surface-default, light-dark(#ffffff, #101113));
     color: var(--account-ink);
     font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
 }
 
 .account {
-    width: min(100%, 620px);
-    padding: 34px;
+    width: min(100%, 760px);
+    padding: 40px;
     box-sizing: border-box;
     background: var(--account-surface);
-    box-shadow:
-        0 0 0 1px rgb(0 0 0 / 6%),
-        0 1px 2px -1px rgb(0 0 0 / 6%),
-        0 12px 32px rgb(0 0 0 / 7%);
+    box-shadow: var(--account-shadow);
+}
+
+.account__masthead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
 }
 
 .account__brand {
     display: inline-flex;
     align-items: center;
+    min-height: 44px;
     gap: 9px;
     color: inherit;
     text-decoration: none;
-    min-height: 44px;
 }
 
 .account__wordmark {
@@ -48,29 +59,62 @@ tonk-account {
     font-weight: 600;
 }
 
-.account h1 {
-    margin: 42px 0 10px;
-    font-family: "Gestalte", Georgia, serif;
-    font-size: clamp(34px, 7vw, 52px);
-    line-height: 0.98;
-    letter-spacing: -0.035em;
+.account__return {
+    display: grid;
+    min-height: 44px;
+    place-items: center;
+    color: var(--account-muted);
+    font-size: 14px;
+    font-weight: 600;
+    text-underline-offset: 3px;
+}
+
+/* Account pages are a settings surface, not editorial content. Reset every
+   property from the app-wide highlighted heading treatment explicitly. */
+.account h1,
+.account h2 {
+    display: block;
+    padding: 0;
+    background: transparent;
+    color: var(--account-ink);
+    -webkit-box-decoration-break: slice;
+    box-decoration-break: slice;
     text-wrap: balance;
 }
 
+.account h1 {
+    margin: 44px 0 28px;
+    font-family: "Gestalte", Georgia, serif;
+    font-size: clamp(36px, 7vw, 52px);
+    font-weight: 400;
+    line-height: 1;
+    letter-spacing: -0.035em;
+}
+
 .account h2 {
-    margin: 0 0 18px;
+    margin: 0 0 16px;
     font-family: "Gestalte", Georgia, serif;
     font-size: 26px;
     font-weight: 400;
     line-height: 1.1;
     letter-spacing: -0.02em;
-    text-wrap: balance;
+}
+
+.account__dashboard h2 {
+    margin: 0;
+    font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.015em;
 }
 
 .account__lede,
 .account__message,
 .account__hint,
-.account__error {
+.account__error,
+.account__section p,
+.account__signout p {
     text-wrap: pretty;
 }
 
@@ -118,7 +162,7 @@ tonk-account {
     display: grid;
     gap: 1px;
     margin: 0 0 16px;
-    background: color-mix(in oklab, var(--account-ink) 10%, transparent);
+    background: var(--account-divider);
 }
 
 .account__device div {
@@ -173,9 +217,9 @@ tonk-account {
 
 .account__button {
     display: grid;
-    place-items: center;
     min-height: 46px;
     padding: 11px 16px;
+    place-items: center;
     border: 0;
     border-radius: 0;
     background: var(--account-ink);
@@ -196,6 +240,13 @@ tonk-account {
         0 4px 12px rgb(0 0 0 / 10%);
 }
 
+.account__button:focus-visible,
+.account__return:focus-visible,
+.account__brand:focus-visible {
+    outline: 3px solid color-mix(in oklab, #deff1a 70%, var(--account-ink));
+    outline-offset: 3px;
+}
+
 .account__button:active:not(:disabled) {
     scale: 0.96;
 }
@@ -210,13 +261,25 @@ tonk-account {
     color: var(--account-ink);
 }
 
-.account__button--quiet {
+.account__button--quiet,
+.account__button--remove {
     justify-self: start;
     min-height: 44px;
     padding-inline: 0;
     background: transparent;
     color: var(--account-muted);
     box-shadow: none;
+}
+
+.account__button--quiet:hover:not(:disabled),
+.account__button--remove:hover:not(:disabled) {
+    color: var(--account-ink);
+    box-shadow: none;
+}
+
+.account__button--compact {
+    justify-self: end;
+    min-width: 104px;
 }
 
 .account__hint {
@@ -235,41 +298,156 @@ tonk-account {
     line-height: 1.45;
 }
 
+.account__dashboard {
+    display: grid;
+    gap: 24px;
+}
+
 .account__status {
-    margin: 0 0 18px;
+    margin: -16px 0 0;
     color: var(--account-muted);
+    font-size: 15px;
+    line-height: 1.5;
+}
+
+.account__section {
+    padding: 24px;
+    background: var(--account-surface);
+    box-shadow:
+        0 0 0 1px rgb(0 0 0 / 6%),
+        0 1px 2px -1px rgb(0 0 0 / 6%),
+        0 2px 4px rgb(0 0 0 / 4%);
+}
+
+.account__section p,
+.account__signout p {
+    margin: 8px 0 0;
+    color: var(--account-muted);
+    font-size: 14px;
+    line-height: 1.55;
+}
+
+.account__passkey {
+    background: color-mix(in oklab, #deff1a 9%, var(--account-surface));
+}
+
+.account__passkey .account__hint {
+    margin-top: 8px;
+}
+
+.account__facts {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin: 18px 0 0;
+    border-block: 1px solid var(--account-divider);
+}
+
+.account__facts > div {
+    min-width: 0;
+    padding: 15px 16px 15px 0;
+}
+
+.account__facts > div + div {
+    padding-left: 16px;
+    border-left: 1px solid var(--account-divider);
+}
+
+.account__facts dt {
+    margin-bottom: 5px;
+    color: var(--account-muted);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.account__facts dd {
+    min-height: 1.45em;
+    margin: 0;
+    overflow-wrap: anywhere;
+    font-size: 14px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.45;
+}
+
+.account__section-heading {
+    margin-bottom: 18px;
 }
 
 .account__devices {
     display: grid;
-    gap: 8px;
-    margin: 0 0 18px;
+    margin: 0;
     padding: 0;
+    border-top: 1px solid var(--account-divider);
     list-style: none;
 }
 
 .account__device-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 10px 14px;
-    border: 1px solid color-mix(in oklab, var(--account-ink) 12%, transparent);
+    column-gap: 24px;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--account-divider);
+}
+
+.account__device-identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 10px;
+}
+
+.account__device-name {
+    overflow: hidden;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.account__device-current {
+    flex: none;
+    padding: 3px 8px;
     background: var(--account-field);
+    color: var(--account-muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
 }
 
 .account__device-meta {
+    grid-column: 1;
+    min-width: 0;
+    margin-top: 4px;
     color: var(--account-muted);
     font-size: 13px;
+    line-height: 1.45;
+    text-wrap: pretty;
+}
+
+.account__device-row .account__button--remove {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+}
+
+.account__signout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 24px;
+    padding-top: 24px;
+    border-top: 1px solid var(--account-divider);
 }
 
 @media (prefers-color-scheme: dark) {
-    .account {
+    tonk-account {
+        --account-shadow: 0 0 0 1px rgb(255 255 255 / 8%);
+    }
+
+    .account__section {
         box-shadow: 0 0 0 1px rgb(255 255 255 / 8%);
     }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 620px) {
     tonk-account {
         place-items: stretch;
         padding: 0;
@@ -277,8 +455,55 @@ tonk-account {
 
     .account {
         min-height: 100dvh;
-        padding: 26px 22px;
+        padding: 24px 20px 32px;
         box-shadow: none;
+    }
+
+    .account__masthead {
+        gap: 16px;
+    }
+
+    .account__return {
+        font-size: 13px;
+    }
+
+    .account h1 {
+        margin: 36px 0 24px;
+    }
+
+    .account__section {
+        padding: 20px;
+    }
+
+    .account__facts {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .account__facts > div,
+    .account__facts > div + div {
+        padding: 12px 0;
+        border-left: 0;
+    }
+
+    .account__facts > div + div {
+        border-top: 1px solid var(--account-divider);
+    }
+
+    .account__device-row,
+    .account__signout {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 8px;
+    }
+
+    .account__device-row .account__button--remove {
+        grid-column: 1;
+        grid-row: auto;
+    }
+
+    .account__button--compact {
+        width: 100%;
+        justify-self: stretch;
+        margin-top: 8px;
     }
 }
 

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -1,10 +1,13 @@
 <main class="account">
-  <a class="account__brand" href="/" data-return aria-label="Back to Tonk">
-    <span class="account__wordmark">tonk</span>
-    <span class="account__badge">account</span>
-  </a>
+  <header class="account__masthead">
+    <a class="account__brand" href="/" aria-label="Tonk home">
+      <span class="account__wordmark">tonk</span>
+      <span class="account__badge">account</span>
+    </a>
+    <a class="account__return" href="/" data-return>Back to Tonk</a>
+  </header>
 
-  <h1>Your Tonk account</h1>
+  <h1>Account</h1>
 
   <section id="account-choice" class="account__panel" hidden>
     <p class="account__lede">Create an account to keep your spots and access them on any device.</p>
@@ -69,21 +72,48 @@
     <p class="account__hint">The first accepted setup chooses one repository location for every device. Retries always recover that same choice.</p>
   </section>
 
-  <section id="account-success" class="account__panel" hidden>
-    <p id="account-success-message" class="account__status">You're logged in.</p>
-    <button id="account-manage-devices" class="account__button account__button--secondary" type="button">Manage devices</button>
-    <a class="account__button account__button--secondary" href="/" data-return>Back to Tonk</a>
-  </section>
+  <div id="account-success" class="account__panel account__dashboard" hidden>
+    <p id="account-success-message" class="account__status">Signed in on this device.</p>
 
-  <section id="account-devices" class="account__panel" hidden>
-    <h2>Your devices</h2>
-    <p class="account__hint">Revoking a device permanently cuts off authority through that device grant. Disconnecting account services leaves local space authority unchanged.</p>
-    <ul id="account-device-list" class="account__devices"></ul>
-    <div class="account__actions">
-      <button id="account-unlink" class="account__button account__button--quiet" type="button">Disconnect account services on this device</button>
-      <button id="account-devices-back" class="account__button account__button--secondary" type="button">Back</button>
-    </div>
-  </section>
+    <section class="account__section account__passkey" aria-labelledby="account-passkey-title">
+      <div class="account__section-heading">
+        <h2 id="account-passkey-title">Account and passkey</h2>
+        <p>Your passkey replaces a password and may be saved to a device, browser profile, or password manager.</p>
+      </div>
+      <dl class="account__facts" aria-label="Account and passkey details">
+        <div>
+          <dt>Account email</dt>
+          <dd id="account-email-value">Loading…</dd>
+        </div>
+        <div>
+          <dt>Passkey created</dt>
+          <dd id="account-passkey-created-value">Loading…</dd>
+        </div>
+        <div>
+          <dt>Created on</dt>
+          <dd id="account-passkey-device-value">Loading…</dd>
+        </div>
+      </dl>
+      <p id="account-passkey-detail" class="account__hint">“Created on” identifies the browser and operating system used to make this passkey. Browsers do not tell Tonk which passkey manager currently stores it.</p>
+      <p class="account__hint">Before using Tonk on another device or browser, check that the passkey is available there.</p>
+    </section>
+
+    <section class="account__section account__device-section" aria-labelledby="account-devices-title">
+      <div class="account__section-heading">
+        <h2 id="account-devices-title">Devices</h2>
+        <p>These devices can open and sync your Tonk spots. Remove any device you no longer use or recognise.</p>
+      </div>
+      <ul id="account-device-list" class="account__devices"></ul>
+    </section>
+
+    <section class="account__signout" aria-labelledby="account-signout-title">
+      <div>
+        <h2 id="account-signout-title">Sign out on this device</h2>
+        <p>Your existing spots will stay on this device, but syncing will stop until you sign in again.</p>
+      </div>
+      <button id="account-unlink" class="account__button account__button--secondary account__button--compact" type="button">Sign out</button>
+    </section>
+  </div>
 
   <p id="account-working" class="account__hint" role="status" aria-live="polite">Checking this browser…</p>
   <p id="account-error" class="account__error" role="alert" hidden></p>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -116,7 +116,6 @@ fn set_mode(host: &HtmlElement, mode: &str) {
         ("handoff", "#account-handoff"),
         ("setup", "#account-setup"),
         ("success", "#account-success"),
-        ("devices", "#account-devices"),
     ] {
         if let Ok(Some(panel)) = host.query_selector(selector) {
             if name == mode {
@@ -135,7 +134,6 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-link-submit",
         "#account-handoff-submit",
         "#account-setup-submit",
-        "#account-manage-devices",
         "#account-unlink",
     ] {
         if let Ok(Some(button)) = host.query_selector(selector)
@@ -175,6 +173,53 @@ fn show_success(host: &HtmlElement) {
     clear_error(host);
     set_busy(host, false, "");
     set_mode(host, "success");
+    load_summary(host.clone());
+    load_devices(host.clone());
+}
+
+fn set_text(host: &HtmlElement, selector: &str, value: &str) {
+    if let Ok(Some(element)) = host.query_selector(selector) {
+        element.set_text_content(Some(value));
+    }
+}
+
+fn render_summary(host: &HtmlElement, summary: &tonk_worker_api::AccountSummary) {
+    set_text(host, "#account-email-value", &summary.email);
+    match &summary.passkey {
+        Some(passkey) => {
+            let date = js_sys::Date::new(&JsValue::from_f64(passkey.created_at as f64 * 1000.0))
+                .to_locale_date_string("default", &JsValue::UNDEFINED);
+            set_text(host, "#account-passkey-created-value", &String::from(date));
+            set_text(host, "#account-passkey-device-value", &passkey.created_on);
+        }
+        None => {
+            set_text(host, "#account-passkey-created-value", "Unavailable");
+            set_text(host, "#account-passkey-device-value", "Unavailable");
+            set_text(
+                host,
+                "#account-passkey-detail",
+                "This passkey was made before Tonk started recording creation details. Tonk cannot reliably reconstruct them.",
+            );
+        }
+    }
+}
+
+fn load_summary(host: HtmlElement) {
+    spawn_local(async move {
+        match crate::api::account_summary().await {
+            Ok(summary) => render_summary(&host, &summary),
+            Err(error) => {
+                for selector in [
+                    "#account-email-value",
+                    "#account-passkey-created-value",
+                    "#account-passkey-device-value",
+                ] {
+                    set_text(&host, selector, "Unavailable");
+                }
+                web_sys::console::warn_1(&format!("account summary unavailable: {error}").into());
+            }
+        }
+    });
 }
 
 /// Land a signed-in device where it was going.
@@ -192,7 +237,7 @@ fn settle(host: &HtmlElement) {
     settle_with(host, crate::account_gate::finish());
 }
 
-/// Show the account page to a device that already had an account.
+/// Show the account dashboard to a device that already had an account.
 ///
 /// Same shape as [`settle`], minus the return-to-`next` step. A gated user who
 /// signed in on another tab still gets their interrupted operation replayed;
@@ -244,26 +289,44 @@ fn render_devices(host: &HtmlElement, devices: &[tonk_worker_api::AccountDevice]
         };
         let _ = item.set_attribute("class", "account__device-row");
 
+        let Ok(identity) = document.create_element("div") else {
+            continue;
+        };
+        let _ = identity.set_attribute("class", "account__device-identity");
+
         let Ok(name) = document.create_element("span") else {
             continue;
         };
+        let _ = name.set_attribute("class", "account__device-name");
         name.set_text_content(Some(&device.name));
+        let _ = identity.append_child(&name);
+
+        if device.this_device {
+            let Ok(marker) = document.create_element("span") else {
+                continue;
+            };
+            let _ = marker.set_attribute("class", "account__device-current");
+            marker.set_text_content(Some("This device"));
+            let _ = identity.append_child(&marker);
+        }
 
         let Ok(meta) = document.create_element("span") else {
             continue;
         };
         let _ = meta.set_attribute("class", "account__device-meta");
-        let registered = js_sys::Date::new(&JsValue::from_f64(device.created_at as f64 * 1000.0))
+        let date = js_sys::Date::new(&JsValue::from_f64(device.created_at as f64 * 1000.0))
             .to_locale_date_string("default", &JsValue::UNDEFINED);
-        let mut details = format!("{} · {}", device.status, String::from(registered));
-        if device.this_device {
-            details.push_str(" · this device");
-        } else if device.status == "active" && device.delegation_hex.is_none() {
-            details.push_str(" · relink required to revoke");
+        let mut details = if device.status == "revoked" {
+            format!("Access removed · Added {}", String::from(date))
+        } else {
+            format!("Added {}", String::from(date))
+        };
+        if !device.this_device && device.status == "active" && device.delegation_hex.is_none() {
+            details.push_str(" · Sign in again on this device to enable removal");
         }
         meta.set_text_content(Some(&details));
 
-        let _ = item.append_child(&name);
+        let _ = item.append_child(&identity);
         let _ = item.append_child(&meta);
 
         if device.status == "active" && (device.this_device || device.delegation_hex.is_some()) {
@@ -271,17 +334,19 @@ fn render_devices(host: &HtmlElement, devices: &[tonk_worker_api::AccountDevice]
                 continue;
             };
             let _ = button.set_attribute("type", "button");
-            let _ = button.set_attribute("class", "account__button account__button--quiet");
+            let _ = button.set_attribute("class", "account__button account__button--remove");
             let _ = button.set_attribute("data-revoke", &device.did);
             let _ = button.set_attribute("data-attachment-id", &device.attachment_id);
             let _ = button.set_attribute("data-delegation-cid", &device.delegation_cid);
+            let _ =
+                button.set_attribute("aria-label", &format!("Remove access for {}", device.name));
             if let Some(delegation_hex) = &device.delegation_hex {
                 let _ = button.set_attribute("data-delegation-hex", delegation_hex);
             }
             if device.this_device {
                 let _ = button.set_attribute("data-self-revoke", "true");
             }
-            button.set_text_content(Some("Revoke"));
+            button.set_text_content(Some("Remove access"));
             let _ = item.append_child(&button);
         }
         let _ = list.append_child(&item);
@@ -293,11 +358,11 @@ fn revocation_status(
     self_revoke: bool,
 ) -> &'static str {
     if self_revoke {
-        "This device has been revoked. Its remote authority is permanently withdrawn."
+        "Access removed from this device."
     } else if acknowledgement.projection == RevocationProjection::Stale {
-        "Device revoked. The account device list has not caught up yet."
+        "Access removed. The device list may take a moment to update."
     } else {
-        "Device revoked."
+        "Access removed."
     }
 }
 
@@ -349,7 +414,7 @@ fn revoke_attachment_from_url() -> Option<String> {
 
 /// Strip the query once the deep link has been acted on, mirroring what
 /// [`load_handoff`] does with the fragment secret. Without this a
-/// cancelled confirm re-fires on every later visit to the device list
+/// cancelled confirm re-fires on every later dashboard visit
 /// in this tab.
 fn consume_revoke_target() {
     let Some(window) = window() else { return };
@@ -361,13 +426,13 @@ fn consume_revoke_target() {
 }
 
 fn load_devices(host: HtmlElement) {
+    set_mode(&host, "success");
     set_busy(&host, true, "Loading devices…");
     spawn_local(async move {
         match crate::api::account_devices().await {
             Ok(devices) => {
                 set_busy(&host, false, "");
                 render_devices(&host, &devices);
-                set_mode(&host, "devices");
                 if let Some(did) = revoke_target_from_url() {
                     let attachment_id = revoke_attachment_from_url();
                     consume_revoke_target();
@@ -390,13 +455,12 @@ fn load_devices(host: HtmlElement) {
                         }
                         Some(_) => show_error(
                             &host,
-                            "This device was registered before revocation evidence was retained. \
-                             Relink it before revoking it from another device.",
+                            "This device was added before remote removal was supported. \
+                             Sign in again on that device, then try removing it here.",
                         ),
                         None => show_error(
                             &host,
-                            "The device named by this link is not an active device \
-                             of this account.",
+                            "The device in this link is no longer connected to this account.",
                         ),
                     }
                 }
@@ -412,12 +476,12 @@ fn load_devices(host: HtmlElement) {
 /// Where a fresh page load lands once the account status is known.
 #[derive(Debug, PartialEq, Eq)]
 enum Landing {
-    /// Straight to the device list: a `?revoke=` deep link names a
-    /// device, and the revoke ceremony lives there.
+    /// Straight to the dashboard and load its devices: a `?revoke=` deep link
+    /// names a device, and the removal ceremony lives there.
     Devices,
     /// Explicit one-time descriptor ceremony for a legacy raw link.
     Setup,
-    /// The signed-in success screen.
+    /// The signed-in dashboard.
     Success,
     /// The link/create choice, with a hint when a revoke deep link
     /// cannot proceed because this browser is not linked.
@@ -570,6 +634,7 @@ async fn persist(
             crate::api::save_root(
                 ceremony.credential_id.clone(),
                 ceremony.delegation_hex.clone(),
+                None,
             )
             .await
             .map_err(|error| error.to_string())?;
@@ -856,14 +921,15 @@ fn bind(host: &HtmlElement) {
                 let status = crate::api::root_status()
                     .await
                     .map_err(|error| error.to_string())?;
-                let (root_did, device_did, credential_id, delegation_hex) = match status {
+                let (root_did, device_did, credential_id, delegation_hex, passkey) = match status {
                     tonk_worker_api::RootStatus::Ready {
                         root_did,
                         device_did,
                         credential_id,
                         delegation_hex,
+                        passkey,
                         ..
-                    } => (root_did, device_did, credential_id, delegation_hex),
+                    } => (root_did, device_did, credential_id, delegation_hex, passkey),
                     tonk_worker_api::RootStatus::Missing { device_did } => {
                         // This ceremony is what creates the passkey, and it
                         // knows the address the code just verified — so the
@@ -874,12 +940,14 @@ fn bind(host: &HtmlElement) {
                         let created = create_root(CreateRootInput {
                             device_did,
                             label: Some(email.clone()),
+                            created_on: Some(device_name.clone()),
                         })
                         .await
                         .map_err(|error| error.to_string())?;
                         crate::api::save_root(
                             created.credential_id.clone(),
                             created.delegation_hex.clone(),
+                            created.passkey.clone(),
                         )
                         .await
                         .map_err(|error| error.to_string())?;
@@ -888,6 +956,7 @@ fn bind(host: &HtmlElement) {
                             created.device_did,
                             created.credential_id,
                             created.delegation_hex,
+                            created.passkey,
                         )
                     }
                 };
@@ -899,6 +968,7 @@ fn bind(host: &HtmlElement) {
                     root_did,
                     credential_id,
                     delegation_hex,
+                    passkey,
                     remote: proposed_remote()?,
                 })
                 .await
@@ -989,21 +1059,13 @@ fn bind(host: &HtmlElement) {
         });
     });
 
-    on_click(host, "#account-manage-devices", |host| {
-        clear_error(&host);
-        load_devices(host);
-    });
-    on_click(host, "#account-devices-back", |host| {
-        clear_error(&host);
-        set_mode(&host, "success");
-    });
     on_click(host, "#account-unlink", |host| {
         clear_error(&host);
         let confirmed = window()
             .map(|window| {
                 window
                     .confirm_with_message(
-                        "Disconnect account services on this device? Your local identity and space authority remain available.",
+                        "Sign out on this device? Your existing spots will stay here, but account syncing will stop until you sign in again.",
                     )
                     .unwrap_or(false)
             })
@@ -1080,9 +1142,9 @@ fn begin_revoke(
     self_revoke: bool,
 ) {
     let message = if self_revoke {
-        "Revoke this device? This permanently withdraws its remote access. Returning requires provisioning a new device grant."
+        "Remove access for this device? This permanently disconnects it from your Tonk account. To use it again, sign in to add it as a new device."
     } else {
-        "Revoke this device? This permanently withdraws its root grant and remote access. Returning requires provisioning a new device grant.\n\nYou will be asked for your passkey to authorize this."
+        "Remove access for this device? This permanently disconnects it from your Tonk account. To use it again, sign in to add a new device.\n\nYou will be asked to confirm with your passkey."
     };
     let confirmed = window()
         .map(|window| window.confirm_with_message(message).unwrap_or(false))
@@ -1249,7 +1311,7 @@ mod tests {
         bind_return_links(&host);
 
         let back = host
-            .query_selector("#account-success [data-return]")
+            .query_selector(".account__masthead [data-return]")
             .unwrap()
             .expect("the success panel offers a way back");
         assert_eq!(
@@ -1271,7 +1333,7 @@ mod tests {
         bind_return_links(&host);
 
         assert_eq!(
-            host.query_selector("#account-success [data-return]")
+            host.query_selector(".account__masthead [data-return]")
                 .unwrap()
                 .expect("the success panel offers a way back")
                 .get_attribute("href")
@@ -1312,6 +1374,120 @@ mod tests {
     }
 
     #[dialog_common::test]
+    fn it_authors_a_single_signed_in_dashboard() {
+        let host = host();
+        assert_eq!(
+            host.query_selector(".account > h1")
+                .unwrap()
+                .expect("account heading")
+                .text_content()
+                .as_deref(),
+            Some("Account")
+        );
+
+        let dashboard = host
+            .query_selector("#account-success")
+            .unwrap()
+            .expect("signed-in dashboard");
+        for selector in [
+            "#account-device-list",
+            "#account-unlink",
+            "#account-email-value",
+            "#account-passkey-created-value",
+            "#account-passkey-device-value",
+            ".account__passkey",
+            ".account__signout",
+        ] {
+            assert!(
+                dashboard.query_selector(selector).unwrap().is_some(),
+                "the signed-in dashboard is missing {selector}"
+            );
+        }
+        assert!(
+            host.query_selector(".account__masthead [data-return]")
+                .unwrap()
+                .is_some(),
+            "the account masthead should offer a conventional return link"
+        );
+
+        let copy = dashboard.text_content().unwrap();
+        assert!(copy.contains("device, browser profile, or password manager"));
+        assert!(copy.contains("do not tell Tonk which passkey manager currently stores it"));
+        assert!(copy.contains("syncing will stop until you sign in again"));
+        for technical in ["authority", "grant", "relink required"] {
+            assert!(
+                !copy.contains(technical),
+                "signed-in copy exposes technical term {technical}"
+            );
+        }
+        assert!(
+            host.query_selector("#account-manage-devices")
+                .unwrap()
+                .is_none(),
+            "device management should not sit behind an interstitial"
+        );
+        assert!(
+            host.query_selector("#account-devices").unwrap().is_none(),
+            "the signed-in dashboard should be the only device-management surface"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_renders_recorded_and_legacy_passkey_facts_without_guessing() {
+        let host = host();
+        render_summary(
+            &host,
+            &tonk_worker_api::AccountSummary {
+                email: "person@example.com".into(),
+                passkey: Some(tonk_worker_api::PasskeyMetadata {
+                    created_at: 1_754_380_800,
+                    created_on: "Chrome on macOS".into(),
+                }),
+            },
+        );
+        assert_eq!(
+            host.query_selector("#account-email-value")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("person@example.com")
+        );
+        assert_eq!(
+            host.query_selector("#account-passkey-device-value")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Chrome on macOS")
+        );
+
+        render_summary(
+            &host,
+            &tonk_worker_api::AccountSummary {
+                email: "legacy@example.com".into(),
+                passkey: None,
+            },
+        );
+        assert_eq!(
+            host.query_selector("#account-passkey-created-value")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Unavailable")
+        );
+        assert!(
+            host.query_selector("#account-passkey-detail")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .unwrap()
+                .contains("cannot reliably reconstruct")
+        );
+    }
+
+    #[dialog_common::test]
     fn it_does_not_author_fixed_browser_registration_names() {
         let host = host();
         assert!(
@@ -1337,11 +1513,11 @@ mod tests {
         };
         assert_eq!(
             revocation_status(&stale, false),
-            "Device revoked. The account device list has not caught up yet."
+            "Access removed. The device list may take a moment to update."
         );
         assert_eq!(
             revocation_status(&stale, true),
-            "This device has been revoked. Its remote authority is permanently withdrawn."
+            "Access removed from this device."
         );
     }
 
@@ -1490,9 +1666,10 @@ mod tests {
         assert_eq!(items.length(), 4);
         let text = list.text_content().unwrap();
         assert!(text.contains("This browser"));
-        assert!(text.contains("this device"));
-        assert!(text.contains("revoked"));
-        assert!(text.contains("relink required to revoke"));
+        assert!(text.contains("This device"));
+        assert!(text.contains("Access removed"));
+        assert!(text.contains("Added"));
+        assert!(text.contains("Sign in again on this device to enable removal"));
         // Self-revocation is device-signed and the current row does not need
         // provider path bytes. Another device needs retained path evidence;
         // the legacy row remains visible but has no unsafe revoke action.
@@ -1514,6 +1691,7 @@ mod tests {
             .query_selector("button[data-revoke=\"did:key:zPhone\"]")
             .unwrap()
             .expect("the active, non-self row has a revoke button");
+        assert_eq!(button.text_content().as_deref(), Some("Remove access"));
         assert_eq!(
             button.get_attribute("data-delegation-cid").as_deref(),
             Some("bafyphone")

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -158,11 +158,13 @@ mod tests {
         let driver = driver_with_prf(&env).await?;
         sign_up(&driver, &env, EMAIL).await?;
 
-        element(&driver, "#account-manage-devices")
+        wait_for_text_containing(&driver, "#account-email-value", EMAIL).await?;
+        let created = element(&driver, "#account-passkey-created-value")
             .await?
-            .click()
+            .text()
             .await?;
-        element(&driver, "tonk-account[data-mode=\"devices\"]").await?;
+        assert!(!created.is_empty() && created != "Loading…" && created != "Unavailable");
+        wait_for_text_containing(&driver, "#account-passkey-device-value", "Chrome on ").await?;
         wait_for_text_containing(&driver, "#account-device-list", "Chrome on ").await?;
 
         driver.quit().await?;
@@ -612,15 +614,11 @@ mod tests {
 
         driver.goto(env.tonk_web.join("account")?.as_str()).await?;
         element(&driver, "tonk-account[data-mode=\"success\"]").await?;
-        element(&driver, "#account-manage-devices")
-            .await?
-            .click()
-            .await?;
-        element(&driver, "tonk-account[data-mode=\"devices\"]").await?;
+        wait_for_text_containing(&driver, "#account-device-list", "e2e terminal").await?;
         let selector = format!("#account-device-list button[data-revoke=\"{cli_did}\"]");
         element(&driver, &selector).await?.click().await?;
         driver.accept_alert().await?;
-        wait_for_text_containing(&driver, "#account-working", "Device revoked").await?;
+        wait_for_text_containing(&driver, "#account-working", "Access removed").await?;
 
         let rejected = devices(&linked.profile, &env).await?;
         assert_eq!(rejected.status.code(), Some(4), "{}", rejected.stderr);

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -3,9 +3,9 @@ use serde::Deserialize;
 use tonk_account::handoff::{LinkSecretRequest, ResolvedLink};
 use tonk_worker_api::{
     AccountDevice, AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus,
-    EvaluateResponse, IdentifyResponse, JoinRequest, JoinResponse, MembershipResponse,
-    QueryResponse, RepositoryInfo, RevokeDeviceAcknowledgement, RevokeDeviceRequest, RootStatus,
-    SaveRootRequest, SyncResponse, SyncStatusResponse,
+    AccountSummary, EvaluateResponse, IdentifyResponse, JoinRequest, JoinResponse,
+    MembershipResponse, QueryResponse, RepositoryInfo, RevokeDeviceAcknowledgement,
+    RevokeDeviceRequest, RootStatus, SaveRootRequest, SyncResponse, SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -495,6 +495,7 @@ pub async fn root_status() -> Result<RootStatus, TonkUiError> {
 pub async fn save_root(
     credential_id: String,
     delegation_hex: String,
+    passkey: Option<tonk_worker_api::PasskeyMetadata>,
 ) -> Result<RootStatus, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
@@ -502,6 +503,7 @@ pub async fn save_root(
         .json(&SaveRootRequest {
             credential_id,
             delegation_hex,
+            passkey,
         })
         .send()
         .await
@@ -603,6 +605,25 @@ pub async fn account_devices() -> Result<Vec<AccountDevice>, TonkUiError> {
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "GET /api/account/devices returned {status}: {text}"
+        )))
+    }
+}
+
+/// Load verified account and passkey facts for the linked account.
+pub async fn account_summary() -> Result<AccountSummary, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/account/summary", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "GET /api/account/summary returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/identity.rs
+++ b/rust/tonk-ui/src/identity.rs
@@ -287,6 +287,7 @@ mod tests {
             "competing device".to_string(),
             hex::encode(delegation.to_bytes()?),
             env.tonk_web.join("ucan/")?.to_string(),
+            None,
         )
         .await?;
         let response = client

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -19,6 +19,9 @@ pub(crate) struct CreateRootInput {
     /// metadata only — no delegation depends on it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// Browser/OS label recorded only for a newly created passkey.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_on: Option<String>,
 }
 
 /// Input for creating an account and its first device registration.
@@ -32,6 +35,9 @@ pub(crate) struct CreateAccountInput {
     pub root_did: String,
     pub credential_id: String,
     pub delegation_hex: String,
+    /// Creation facts retained with the local root, when this browser made it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passkey: Option<tonk_worker_api::PasskeyMetadata>,
     /// Account repository remote this browser proposes for the new account.
     pub remote: String,
 }
@@ -79,6 +85,8 @@ pub(crate) struct RootOutput {
     pub device_did: String,
     pub credential_id: String,
     pub delegation_hex: String,
+    #[serde(default)]
+    pub passkey: Option<tonk_worker_api::PasskeyMetadata>,
 }
 
 /// Account ceremony output sent to the account service.
@@ -246,6 +254,7 @@ mod tests {
         let output = create_root(CreateRootInput {
             device_did: "did:key:device".into(),
             label: None,
+            created_on: None,
         })
         .await
         .unwrap();
@@ -279,6 +288,7 @@ mod tests {
         create_root(CreateRootInput {
             device_did: "did:key:labelled".into(),
             label: Some("someone@example.com".into()),
+            created_on: Some("Chrome on macOS".into()),
         })
         .await
         .expect("an account ceremony sends its verified address");
@@ -286,6 +296,7 @@ mod tests {
         create_root(CreateRootInput {
             device_did: "did:key:plain".into(),
             label: None,
+            created_on: None,
         })
         .await
         .expect("a spot-created root sends no label at all");
@@ -307,6 +318,8 @@ mod tests {
                     || input.deviceDid !== "did:key:device" || input.deviceName !== "Browser"
                     || input.rootDid !== "did:key:root" || input.credentialId !== "credential"
                     || input.delegationHex !== "delegation"
+                    || input.passkey.createdAt !== 1754380800
+                    || input.passkey.createdOn !== "Chrome on macOS"
                     || input.remote !== "https://tonk.spot/ucan/")
                     return Promise.reject(new Error("property"));
                 return Promise.resolve({{
@@ -324,6 +337,10 @@ mod tests {
                 root_did: "did:key:root".into(),
                 credential_id: "credential".into(),
                 delegation_hex: "delegation".into(),
+                passkey: Some(tonk_worker_api::PasskeyMetadata {
+                    created_at: 1_754_380_800,
+                    created_on: "Chrome on macOS".into(),
+                }),
                 remote: "https://tonk.spot/ucan/".into(),
             })
             .await
@@ -429,6 +446,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -440,6 +458,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -453,6 +472,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -464,6 +484,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -478,6 +499,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -494,6 +516,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),
@@ -505,6 +528,7 @@ mod tests {
             create_root(CreateRootInput {
                 device_did: "device".into(),
                 label: None,
+                created_on: None,
             })
             .await
             .unwrap_err(),

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -2,6 +2,18 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::PasskeyMetadata;
+
+/// Verified facts shown on the linked account dashboard.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSummary {
+    /// Email address verified when the account was created.
+    pub email: String,
+    /// Facts Tonk recorded during passkey creation, absent for legacy roots.
+    pub passkey: Option<PasskeyMetadata>,
+}
+
 /// Attach provider services to an already persisted local root, naming the
 /// account repository this root owns.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -158,6 +170,21 @@ pub struct RevokeDeviceAcknowledgement {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[dialog_common::test]
+    fn it_serializes_account_summary_passkey_facts_in_camel_case() {
+        let json = serde_json::to_value(AccountSummary {
+            email: "person@example.com".into(),
+            passkey: Some(PasskeyMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".into(),
+            }),
+        })
+        .unwrap();
+        assert_eq!(json["email"], "person@example.com");
+        assert_eq!(json["passkey"]["createdAt"], 1_754_380_800_u64);
+        assert_eq!(json["passkey"]["createdOn"], "Chrome on macOS");
+    }
 
     #[dialog_common::test]
     fn it_serializes_repository_setup_requests_in_camel_case() {

--- a/rust/tonk-worker-api/src/identity.rs
+++ b/rust/tonk-worker-api/src/identity.rs
@@ -4,6 +4,16 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+/// Informational metadata recorded when Tonk creates a passkey.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasskeyMetadata {
+    /// Browser-reported Unix time immediately after credential creation.
+    pub created_at: u64,
+    /// Browser and operating-system label where creation ran.
+    pub created_on: String,
+}
+
 /// Current local passkey-root state.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
@@ -29,6 +39,9 @@ pub enum RootStatus {
         delegation_cid: String,
         /// Exact hex-encoded delegation bytes.
         delegation_hex: String,
+        /// Creation details when this Tonk client created the passkey.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        passkey: Option<PasskeyMetadata>,
     },
 }
 
@@ -40,6 +53,9 @@ pub struct SaveRootRequest {
     pub credential_id: String,
     /// Exact hex-encoded root → device delegation bytes.
     pub delegation_hex: String,
+    /// Creation details when this request follows passkey creation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passkey: Option<PasskeyMetadata>,
 }
 
 /// Request to create a durable space through the local root.

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -29,8 +29,8 @@ mod sync;
 
 pub use account::{
     AccountConvergenceReport, AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse,
-    AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus, RevocationProjection,
-    RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+    AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus, AccountSummary,
+    RevocationProjection, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
 };
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};
@@ -38,8 +38,8 @@ pub use deployment::DeploymentConfig;
 pub use evaluate::{CommitSummary, EvaluateResponse, QueryMatchBlock, QueryResult};
 pub use identify::IdentifyResponse;
 pub use identity::{
-    ACCOUNT_REQUIRED, AccountRequired, CreateSpaceRequest, CreateSpaceResponse, PendingIntent,
-    RootStatus, SaveRootRequest,
+    ACCOUNT_REQUIRED, AccountRequired, CreateSpaceRequest, CreateSpaceResponse, PasskeyMetadata,
+    PendingIntent, RootStatus, SaveRootRequest,
 };
 pub use invite::{
     CreateInviteRequest, CreateInviteResponse, InvitationKind, InvitationSummary,

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -238,6 +238,7 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
             post(account::establish_repository),
         )
         .route("/api/account/devices", get(account_devices::list))
+        .route("/api/account/summary", get(account_devices::summary))
         .route("/api/account/devices/revoke", post(account_devices::revoke))
         .route("/api/profile", get(profile::get_profile))
         // Profile-as-repository routes. The profile is its own
@@ -649,6 +650,7 @@ pub mod tests {
             tonk_worker_api::SaveRootRequest {
                 credential_id: "test-credential".to_string(),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
+                passkey: None,
             },
         )
         .await

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -8,7 +8,9 @@ use dialog_ucan_core::{DelegationChain, promise::Promised};
 use serde::Deserialize;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
-use tonk_worker_api::{AccountDevice, RevokeDeviceAcknowledgement, RevokeDeviceRequest};
+use tonk_worker_api::{
+    AccountDevice, AccountSummary, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+};
 
 use super::AppState;
 use super::account_backup::account_service_url;
@@ -29,7 +31,7 @@ struct ServiceDevice {
 }
 
 /// Resolve the stored link and service URL, or explain what's missing.
-async fn linked_service(
+pub(super) async fn linked_service(
     state: &TonkState,
 ) -> Result<(dialog_ucan_core::DelegationChain, String), TonkWorkerError> {
     let link = super::account::account_link(state).await.ok_or_else(|| {
@@ -86,6 +88,34 @@ pub async fn list(
     let state = state.read().await;
     let (link, service) = linked_service(&state).await?;
     Ok(Json(fetch_devices(&state, &link, &service).await?))
+}
+
+/// Return verified account facts authorized by this profile's active grant.
+#[wasm_compat]
+pub async fn summary(
+    State(state): State<AppState>,
+) -> Result<Json<AccountSummary>, TonkWorkerError> {
+    let state = state.read().await;
+    let (link, service) = linked_service(&state).await?;
+    let body = tonk_identity::request::build_device_invocation(
+        state.profile.signer().signer().clone(),
+        &link,
+        vec!["account".into(), "summary".into()],
+        BTreeMap::new(),
+    )
+    .await
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("build account-summary invocation: {error}"))
+    })?;
+    let endpoint = url::Url::parse(&format!(
+        "{}/account/summary",
+        service.trim_end_matches('/')
+    ))
+    .map_err(|error| TonkWorkerError::Internal(format!("invalid account provider URL: {error}")))?;
+    let response = super::http::post_cbor(&endpoint, &body).await?;
+    let summary = serde_json::from_slice(&response.body)
+        .map_err(|error| TonkWorkerError::Internal(format!("parse account summary: {error}")))?;
+    Ok(Json(summary))
 }
 
 async fn self_revocation(
@@ -187,6 +217,15 @@ mod tests {
         let state = Arc::new(RwLock::new(test_state_without_account().await));
         assert!(matches!(
             list(State(state)).await,
+            Err(TonkWorkerError::NotFound(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_summary_for_an_unlinked_profile() {
+        let state = Arc::new(RwLock::new(test_state_without_account().await));
+        assert!(matches!(
+            summary(State(state)).await,
             Err(TonkWorkerError::NotFound(_))
         ));
     }

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1156,6 +1156,7 @@ mod tests {
             tonk_worker_api::SaveRootRequest {
                 credential_id: credential_id.clone(),
                 delegation_hex: delegation_hex.clone(),
+                passkey: None,
             },
         )
         .await

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -7,7 +7,7 @@ use dialog_ucan_core::DelegationChain;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
-use tonk_worker_api::{RootStatus, SaveRootRequest};
+use tonk_worker_api::{PasskeyMetadata, RootStatus, SaveRootRequest};
 
 use super::AppState;
 use crate::TonkWorkerError;
@@ -20,6 +20,8 @@ struct LocalRootRecord {
     version: u8,
     credential_id: String,
     delegation: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    passkey: Option<PasskeyMetadata>,
 }
 
 /// A validated local root record.
@@ -35,6 +37,8 @@ pub(crate) struct LocalRoot {
     pub delegation: DelegationChain,
     /// Exact serialized delegation bytes.
     pub bytes: Vec<u8>,
+    /// Informational creation details recorded by the creating browser.
+    pub passkey: Option<PasskeyMetadata>,
 }
 
 pub(crate) async fn validate_grant(
@@ -115,6 +119,7 @@ pub(crate) async fn local_root(state: &TonkState) -> Result<LocalRoot, TonkWorke
         credential_id: record.credential_id,
         delegation,
         bytes: record.delegation,
+        passkey: record.passkey,
     })
 }
 
@@ -131,6 +136,7 @@ fn status(root: LocalRoot) -> RootStatus {
         credential_id: root.credential_id,
         delegation_cid: root.delegation.proof_cids()[0].to_string(),
         delegation_hex: hex::encode(root.bytes),
+        passkey: root.passkey,
     }
 }
 
@@ -155,6 +161,26 @@ pub(crate) async fn persist_root(
             "credentialId must not be empty".to_string(),
         ));
     }
+    let passkey = request
+        .passkey
+        .map(|mut metadata| {
+            metadata.created_on = metadata.created_on.trim().to_string();
+            if metadata.created_at == 0 {
+                return Err(TonkWorkerError::Router(
+                    "passkey createdAt must be greater than zero".to_string(),
+                ));
+            }
+            if metadata.created_on.is_empty()
+                || metadata.created_on.chars().count() > 120
+                || metadata.created_on.chars().any(char::is_control)
+            {
+                return Err(TonkWorkerError::Router(
+                    "passkey createdOn must be a readable device label".to_string(),
+                ));
+            }
+            Ok(metadata)
+        })
+        .transpose()?;
     let bytes = hex::decode(&request.delegation_hex)
         .map_err(|error| TonkWorkerError::Router(format!("invalid delegation hex: {error}")))?;
     let chain = validate_grant(bytes.clone(), &state.profile.did()).await?;
@@ -162,6 +188,7 @@ pub(crate) async fn persist_root(
         version: 1,
         credential_id: request.credential_id,
         delegation: bytes.clone(),
+        passkey,
     };
     if let Some(existing) = load_record(state).await? {
         if existing != record {
@@ -201,6 +228,7 @@ pub(crate) async fn persist_root(
         credential_id: record.credential_id,
         delegation: chain,
         bytes,
+        passkey: record.passkey,
     }))
 }
 
@@ -239,6 +267,7 @@ mod tests {
             SaveRootRequest {
                 credential_id: format!("credential-{root_seed}"),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
+                passkey: None,
             },
             grant,
         )
@@ -261,6 +290,25 @@ mod tests {
         let Json(result) = get(State(state)).await.unwrap();
         assert!(matches!(result, RootStatus::Ready { delegation_cid, .. }
             if delegation_cid == grant.proof_cids()[0].to_string()));
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_passkey_creation_metadata_with_the_local_root() {
+        let state = Arc::new(RwLock::new(test_state_without_root().await));
+        let device = state.read().await.profile.did();
+        let (request, _) = request_for(1, &device).await;
+        let mut request = serde_json::to_value(request).unwrap();
+        request["passkey"] = serde_json::json!({
+            "createdAt": 1_754_380_800,
+            "createdOn": "Chrome on macOS",
+        });
+        let request = serde_json::from_value(request).unwrap();
+
+        let _ = save(State(state.clone()), Json(request)).await.unwrap();
+        let Json(result) = get(State(state)).await.unwrap();
+        let result = serde_json::to_value(result).unwrap();
+        assert_eq!(result["passkey"]["createdAt"], 1_754_380_800u64);
+        assert_eq!(result["passkey"]["createdOn"], "Chrome on macOS");
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## Summary
- replace the signed-in interstitial and separate device page with one responsive account dashboard
- show the verified account email and passkey creation date/browser-OS when Tonk recorded them
- add an active-device-authorized account summary endpoint and nullable D1 migration for legacy compatibility
- use plain-language device removal and sign-out copy without changing revocation authority

## Passkey semantics
- metadata is recorded only when Tonk successfully creates a new passkey
- legacy accounts show Unavailable rather than inferring from account or device timestamps
- Created on identifies the browser and operating system used for creation, not the current password manager

## Verification
- nix develop -c cargo test -p tonk-account-service --features helpers
- affected Wasm suites: 34 identity, 25 UI, 260 worker, and 21 worker-API tests
- nix develop -c cargo test -p tonk-ui --no-run
- nix develop -c cargo check -p tonk-cli --tests
- nix develop -c build:web
- cargo fmt and git diff checks
- responsive desktop/mobile and accessibility inspection with disposable account data

## Deployment note
Apply migration 0007_passkey_metadata.sql before testing newly created passkey metadata on the Cloudflare preview. Existing accounts remain compatible and display unavailable metadata.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces passkey metadata handling across various components of the Tonk application, enhancing account management and device interactions. It includes new structures for passkey creation details and updates to account summaries, device management, and related database migrations.

### Detailed summary
- Added `PasskeyMetadata` structure for passkey creation details.
- Updated account creation and management to include passkey metadata.
- Enhanced account summary retrieval to return passkey creation facts.
- Modified database schema to store passkey creation timestamps.
- Updated UI to display passkey creation information.
- Implemented tests to validate passkey metadata handling.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/account.css`, `plan/passkey-account-summary.md`, `rust/tonk-ui/src/account.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->