### PR TITLE
fix(account): validate email before passkey creation

### DIFF
--- a/plan/account-creation-preflight.md
+++ b/plan/account-creation-preflight.md
@@ -1,0 +1,126 @@
+# Account creation preflight and passkey atomicity plan
+
+**Goal:** Verify that an email can create an account before prompting for or
+creating a passkey, while preserving email-enumeration resistance and making a
+retry with a different email deterministic.
+
+**Observed flow:**
+
+1. `POST /codes` sends a code without revealing whether the email is already
+   registered.
+2. The verification-panel submit handler creates and locally persists a
+   passkey root when none exists.
+3. The same handler asks for that passkey again to sign `POST /accounts`.
+4. `POST /accounts` verifies and consumes the code, then first checks the
+   unique email/root constraints while inserting the account and device.
+5. An existing email therefore leaves a newly created, unregistered local
+   passkey root behind. “Use a different email” clears only the visible error
+   and panel mode, so the next attempt inherits that intermediary root.
+
+**Approach:** Add a code-authenticated, non-consuming account preflight. A
+correct code proves control of the supplied address before the service reveals
+an email conflict; an available address retains the code for the existing
+atomic account-and-device insertion. Run this preflight before any WebAuthn
+ceremony. For a browser without a local root, combine passkey creation, root
+derivation, delegation, and account-invocation signing into one bridge call so
+the normal PRF-capable path uses one WebAuthn ceremony rather than create then
+assert. Keep the existing-root path intact for accountless passkey roots.
+
+**Residual boundary:** Availability can change between preflight and
+`POST /accounts`. The final unique constraint remains authoritative. Avoiding
+that race completely would require a server-side reservation lifecycle, which
+would add another durable intermediary state and a denial-of-service surface.
+
+## Tasks
+
+- [x] Add core and HTTP regression tests for a code-authenticated preflight:
+      wrong codes fail, existing emails return the safe conflict, and an
+      available-email preflight does not consume the code.
+- [x] Add a real-browser regression proving an existing-email attempt creates
+      no credential and a subsequent different-email attempt succeeds with one
+      credential.
+- [x] Implement the Worker and native-helper preflight routes and UI client.
+- [x] Add the combined fresh-root account ceremony and use it only after a
+      successful preflight.
+- [x] Reset verification-only form state when returning to email entry and
+      validate browser form constraints before network work.
+- [x] Consume the verified code in the same storage transaction as the account
+      and first-device inserts, and keep in-panel navigation disabled while an
+      asynchronous account transition is in flight.
+- [x] Run focused service, identity, UI, real-browser, formatting, and build
+      checks; record any unverified paths here.
+
+## Flow audit after the change
+
+- **Fresh browser account:** send code, preflight the verified email, create a
+  passkey and sign the account request in one identity bridge operation, submit
+  the authoritative account transaction, then attach the account locally. A
+  normal PRF-capable authenticator now needs one WebAuthn ceremony.
+- **Existing accountless root:** send code, preflight the verified email, use
+  the existing passkey to sign the request, submit the account transaction,
+  then attach the account locally. No new credential is created.
+- **Log in on another browser/device:** assert a discoverable passkey once,
+  atomically link the device remotely, then persist the returned account
+  locally. This flow does not ask for an email or verification code.
+- **Legacy account setup:** assert the existing passkey once, establish the
+  signed account repository descriptor with create-if-absent semantics, then
+  persist the winning descriptor locally.
+- **CLI handoff:** resolve the one-time handoff, assert the existing passkey
+  once, then complete the remote link. It does not mutate browser account state.
+
+## Remaining failure boundaries
+
+- Email availability can race between preflight and final insertion. The final
+  database uniqueness check is authoritative and returns the same clear
+  conflict. A durable reservation was rejected because it creates a new stale
+  state and denial-of-service surface.
+- Authenticators that do not return PRF output during credential creation need
+  the existing fallback assertion to recover it. That uncommon path can still
+  involve two WebAuthn prompts, but the credential and root remain reusable.
+- A passkey/root is saved locally before the remote account request so a
+  transient remote failure can be retried without creating another credential.
+  This is an intentional, valid accountless identity state.
+- Remote account creation and local browser attachment cannot share a database
+  transaction. If local attachment fails after an accepted response, the UI
+  says the account is ready and directs the user to log in. If the remote write
+  succeeds but its response is lost, the account is still recoverable through
+  login, but the transport error cannot prove whether the write committed; an
+  idempotent create acknowledgement remains future hardening.
+- A user can still leave `/account` through the top-level return link while work
+  is in flight; navigation destroys the page and its task. In-panel choices and
+  back buttons are disabled until the active transition settles, preventing a
+  stale completion from repainting a different panel.
+- The UI now requires `/accounts/preflight`, so rollout order is account worker
+  first and UI second. An older account worker returns an error and account
+  creation fails closed before WebAuthn rather than silently falling back to the
+  unsafe ordering.
+
+## Verification evidence
+
+- The new service regression failed with `404` before the preflight route was
+  implemented, then passed after the change.
+- The account-transaction regression failed because a root conflict had already
+  consumed the code, then passed after code deletion moved into the same SQLite
+  transaction and D1 batch as the account and first-device inserts.
+- The in-flight navigation regression failed because the choice/back buttons
+  remained enabled, then passed after `set_busy` covered every in-panel route.
+- `cargo fmt --all -- --check` and `git diff --check` passed.
+- `cargo check -p tonk-ui --target wasm32-unknown-unknown` passed in the Nix
+  development shell, as did the Worker-target check for
+  `tonk-account-service`.
+- All 34 `tonk-identity` Wasm unit tests passed.
+- All 65 account-service unit tests and all 10 HTTP integration tests passed;
+  the Cloudflare Worker package also compiled for Wasm.
+- All 28 `tonk-ui` Wasm tests passed, including 15 account UI tests and 5
+  identity bridge tests.
+- The isolated real-browser regression passed in Chrome: the existing-email
+  path created zero credentials; returning to email entry cleared the code;
+  the available-email retry completed with exactly one credential.
+- The first browser attempt stopped before Chrome because the Nix build volume
+  was full. Removing 11.9 GiB of this checkout's disposable Cargo artifacts
+  let the clean repository web-server derivation build and the unchanged test
+  pass.
+- No live Worker/D1 deployment or physical authenticator was exercised. The
+  native HTTP service, Worker Wasm build, and Chrome virtual authenticator cover
+  the implemented seams; the non-PRF-at-creation fallback remains unit-tested
+  rather than hardware-tested here.

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -24,8 +24,9 @@ instead signed directly by the passkey-derived root: successful verification,
 with issuer equal to subject, proves root-key control before the service writes
 the first account or another device. Account creation additionally consumes an
 email verification code. `POST /codes` and creation of a pending CLI handoff
-are unauthenticated and edge-rate-limited; resolving and consuming a handoff
-requires its 256-bit bearer secret.
+are unauthenticated and edge-rate-limited. Account preflight is authenticated
+by the submitted email code and edge-rate-limited; resolving and consuming a
+handoff requires its 256-bit bearer secret.
 
 ## RP ID invariants
 
@@ -54,6 +55,9 @@ permissive CORS headers).
 - `GET /`: service info as JSON (`service`, `version`).
 - `GET /health`: liveness check (`OK`).
 - `POST /codes`: request an email verification code. Body: `{ "email": string }`.
+- `POST /accounts/preflight`: verify a submitted `{ "email", "code" }` and
+  reject an already-registered address before WebAuthn. A successful check
+  does not consume the code; `POST /accounts` remains authoritative.
 - `POST /accounts`: create an account and register its first device, consuming
   a verification code. Body: a root-signed UCAN invocation container with
   command `["account", "create"]` and arguments `email`, `code`,
@@ -138,6 +142,11 @@ then the access worker, then the UI/service worker. Account acknowledgements
 are response supersets and clients accept both `CREDENTIAL_REVOKED` and legacy
 `DEVICE_REVOKED` during the mixed-version window.
 
+The preflight route is a hard dependency of this account UI: deploy the account
+worker containing `/accounts/preflight` before the UI that calls it. The UI
+fails closed if the route is absent rather than creating a passkey before email
+availability has been verified.
+
 First deploy, in order:
 
 1. `wrangler d1 create tonk-accounts` and paste the returned database id into
@@ -156,7 +165,7 @@ First deploy, in order:
 7. Add a WAF rate limiting rule for unauthenticated request creation (zone `tonk.xyz`,
    Security > WAF > Rate limiting rules): expression
    `(http.host eq "accounts.tonk.xyz" and http.request.method eq "POST" and
-   (http.request.uri.path eq "/codes" or http.request.uri.path eq "/links"))`,
+   http.request.uri.path in {"/codes" "/accounts/preflight" "/links"})`,
    counting by IP, 3 requests per 10 seconds, action Block. The service
    enforces a per-email cooldown but nothing per-IP, so without this rule an
    unauthenticated caller can fan out email sends or pending D1 rows.
@@ -255,17 +264,18 @@ resend cooldown, 10-minute code TTL, five verification attempts per code.
 Everything IP-shaped is enforced at the Cloudflare edge, not in code:
 
 - **Rate rule** (zone `tonk.xyz`, and the staging host): one rate-limiting
-  rule per environment covering the two unauthenticated write paths.
-  Each rule's expression should match both `/codes` and `/links`:
+  rule per environment covering the unauthenticated and code-authenticated
+  bootstrap paths. Each rule's expression should match `/codes`,
+  `/accounts/preflight`, and `/links`:
 
   ```
   (http.host eq "accounts.tonk.xyz" and http.request.method eq "POST" and
-   http.request.uri.path in {"/codes" "/links"})
+   http.request.uri.path in {"/codes" "/accounts/preflight" "/links"})
   ```
 
   Deployed threshold: 3 requests per 10 seconds per IP, action Block.
-  Verify each environment's existing rule covers both paths in the expression,
-  and extend the path set if `/links` is missing.
+  Verify each environment's existing rule covers all three paths in the
+  expression.
   `/links/resolve|complete|consume` need no rule: they demand the 256-bit
   bearer secret and cheap lookups fail closed.
 - **Turnstile**: deliberately not deployed. Revisit only if the rate rule

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -3,7 +3,7 @@
 //! register the account and its first device.
 
 use crate::core::CeremonyError;
-use crate::core::codes::verify_code;
+use crate::core::codes::check_code;
 use crate::core::delegation::check_device_delegation;
 use crate::core::descriptor::validate_descriptor;
 use crate::store::{NewDevice, PasskeyMetadata, Store, StoreError};
@@ -14,6 +14,28 @@ pub const EMAIL_TAKEN: &str = "an account already exists for this email address"
 
 /// Returned when the calling root DID already has an account.
 pub const ROOT_TAKEN: &str = "an account already exists for this passkey";
+
+/// Prove control of an email address and reject a known uniqueness conflict
+/// before the browser creates or evaluates a passkey.
+///
+/// A correct code is deliberately not consumed when the address is available:
+/// [`create_account`] remains the authoritative boundary that consumes it and
+/// atomically inserts the account and first device. A known conflict consumes
+/// the code because no account can be created from that attempt.
+pub async fn preflight_account<S: Store>(
+    store: &S,
+    email: &str,
+    code: &str,
+    now: u64,
+) -> Result<(), CeremonyError> {
+    check_code(store, email, code, now).await?;
+    let email = email.to_lowercase();
+    if store.account_by_email(&email).await?.is_some() {
+        store.delete_code(&email).await?;
+        return Err(CeremonyError::Conflict(EMAIL_TAKEN.to_string()));
+    }
+    Ok(())
+}
 
 /// A request to create a new account and register its first device.
 pub struct CreateAccount {
@@ -61,7 +83,7 @@ pub async fn create_account<S: Store>(
         &request.device_did,
     )
     .await?;
-    verify_code(store, &request.email, &request.code, now).await?;
+    check_code(store, &request.email, &request.code, now).await?;
 
     let email = request.email.to_lowercase();
     let created = store
@@ -129,7 +151,7 @@ async fn explain_conflict<S: Store>(
 #[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
-    use crate::core::codes::request_code;
+    use crate::core::codes::{request_code, verify_code};
     use crate::email::CapturedEmail;
     use crate::store::sqlite::SqliteStore;
     use crate::store::{Device, DeviceStatus};
@@ -205,6 +227,42 @@ mod tests {
             Some("Chrome on macOS")
         );
         assert_eq!(store.devices(id).await.unwrap().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_preflights_only_after_email_control_and_preserves_an_available_code() {
+        let store = SqliteStore::in_memory().unwrap();
+        let sender = CapturedEmail::default();
+        store
+            .create_account("taken@x.com", "did:key:zTaken", "credential", 1)
+            .await
+            .unwrap();
+
+        request_code(&store, &sender, "taken@x.com", "123456", 100)
+            .await
+            .unwrap();
+        let conflict = preflight_account(&store, "TAKEN@x.com", "123456", 200).await;
+        assert!(
+            matches!(&conflict, Err(CeremonyError::Conflict(message)) if message == EMAIL_TAKEN)
+        );
+        assert!(matches!(
+            verify_code(&store, "taken@x.com", "123456", 200).await,
+            Err(CeremonyError::CodeInvalid)
+        ));
+
+        request_code(&store, &sender, "available@x.com", "654321", 100)
+            .await
+            .unwrap();
+        assert!(matches!(
+            preflight_account(&store, "available@x.com", "000000", 200).await,
+            Err(CeremonyError::CodeInvalid)
+        ));
+        preflight_account(&store, "AVAILABLE@x.com", "654321", 200)
+            .await
+            .unwrap();
+        verify_code(&store, "available@x.com", "654321", 200)
+            .await
+            .unwrap();
     }
 
     #[dialog_common::test]
@@ -447,6 +505,10 @@ mod tests {
         };
         let error = create_account(&store, &again, 500).await;
         assert!(matches!(&error, Err(CeremonyError::Conflict(msg)) if msg == ROOT_TAKEN));
+
+        verify_code(&store, "b@x.com", "654321", 500)
+            .await
+            .expect("a rejected account transaction must not consume the email code");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/src/core/codes.rs
+++ b/rust/tonk-account-service/src/core/codes.rs
@@ -63,14 +63,14 @@ pub async fn request_code<S: Store, E: EmailSender>(
     Ok(())
 }
 
-/// Verify a previously requested code, consuming it on success.
+/// Check a previously requested code without consuming it.
 ///
 /// Returns [`CeremonyError::CodeInvalid`] uniformly when there is no
 /// pending code, the code has expired, attempts are exhausted, or the
 /// supplied code does not match — so responses don't reveal which
 /// check failed. The email address is lowercased before every store
 /// access.
-pub async fn verify_code<S: Store>(
+pub async fn check_code<S: Store>(
     store: &S,
     email: &str,
     code: &str,
@@ -87,6 +87,18 @@ pub async fn verify_code<S: Store>(
         store.bump_attempts(&email).await?;
         return Err(CeremonyError::CodeInvalid);
     }
+    Ok(())
+}
+
+/// Verify a previously requested code, consuming it on success.
+pub async fn verify_code<S: Store>(
+    store: &S,
+    email: &str,
+    code: &str,
+    now: u64,
+) -> Result<(), CeremonyError> {
+    check_code(store, email, code, now).await?;
+    let email = email.to_lowercase();
     store.delete_code(&email).await?;
     Ok(())
 }

--- a/rust/tonk-account-service/src/handlers/accounts.rs
+++ b/rust/tonk-account-service/src/handlers/accounts.rs
@@ -2,8 +2,10 @@
 
 use worker::*;
 
+use serde::Deserialize;
+
 use crate::auth::{authorize, authorize_root, optional_passkey_metadata, required_string};
-use crate::core::accounts::{CreateAccount, create_account};
+use crate::core::accounts::{CreateAccount, create_account, preflight_account};
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
 use crate::store::Store;
@@ -11,6 +13,41 @@ use crate::store::Store;
 /// `OPTIONS /accounts` → CORS preflight.
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
     Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+#[derive(Deserialize)]
+struct PreflightRequest {
+    email: String,
+    code: String,
+}
+
+/// `POST /accounts/preflight` → verify email control and availability.
+pub async fn handle_preflight(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_preflight_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_preflight_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let input: PreflightRequest = req.json().await.map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("failed to parse request body: {error}"),
+        )
+    })?;
+    let store = build_store(ctx)?;
+    let now = Date::now().as_millis() / 1000;
+    preflight_account(&store, &input.email, &input.code, now)
+        .await
+        .map_err(ceremony_error)?;
+    Response::from_json(&serde_json::json!({})).map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
 }
 
 /// `POST /account/summary` → verified email and passkey creation facts.

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -29,7 +29,7 @@ use crate::auth::{
     optional_revocation, required_string, string_argument,
 };
 use crate::chains::MemoryChainStore;
-use crate::core::accounts::{CreateAccount, create_account};
+use crate::core::accounts::{CreateAccount, create_account, preflight_account};
 use crate::core::backup::{get_chain, list_account_spots, list_chains, put_chain_and_index_spot};
 use crate::core::codes::{generate_code, request_code};
 use crate::core::descriptor::establish_descriptor;
@@ -143,6 +143,7 @@ async fn handle_request(
         (Method::GET, "/_test/spots") => spots_route(req, &backends).await,
         (Method::POST, "/codes") => codes_route(req, &backends).await,
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
+        (Method::POST, "/accounts/preflight") => accounts_preflight_route(req, &backends).await,
         (Method::POST, "/account/summary") => account_summary_route(req, &backends).await,
         (Method::POST, "/revocations") => revocations_route(req, &backends).await,
         (Method::POST, "/account/repository/establish") => {
@@ -357,6 +358,24 @@ async fn accounts_route(
             "descriptorHex": descriptor_hex,
         }),
     ))
+}
+
+/// `POST /accounts/preflight` → verify email control and availability.
+async fn accounts_preflight_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    #[derive(Deserialize)]
+    struct PreflightRequest {
+        email: String,
+        code: String,
+    }
+
+    let body: PreflightRequest = parse_json(req).await?;
+    preflight_account(&backends.store, &body.email, &body.code, unix_now())
+        .await
+        .map_err(ceremony_error)?;
+    Ok(json_response(StatusCode::OK, &serde_json::json!({})))
 }
 
 /// `POST /account/repository/establish` → establish one descriptor winner.

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -33,6 +33,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/codes", handlers::codes::handle_options)
         .post_async("/accounts", handlers::accounts::handle)
         .options_async("/accounts", handlers::accounts::handle_options)
+        .post_async("/accounts/preflight", handlers::accounts::handle_preflight)
+        .options_async("/accounts/preflight", handlers::accounts::handle_options)
         .post_async("/account/summary", handlers::accounts::handle_summary)
         .options_async("/account/summary", handlers::accounts::handle_options)
         .post_async("/revocations", handlers::revocations::handle)

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -272,6 +272,7 @@ pub trait Store {
     /// whole operation, including code consumption, so a failed transaction
     /// cannot strand either a zero-device account or a spent verification
     /// code. Returns `StoreError::Conflict` in that case.
+    #[allow(clippy::too_many_arguments)]
     async fn create_account_with_device(
         &self,
         email: &str,

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -264,13 +264,14 @@ pub trait Store {
     /// [`crate::core::accounts::create_account`].
     async fn account_by_email(&self, email: &str) -> Result<Option<Account>, StoreError>;
 
-    /// Atomically create a new account and register its first device.
+    /// Atomically create a new account, register its first device, and consume
+    /// the email's verified code.
     ///
     /// Either both rows are created or neither is: a conflict on the
-    /// email, root DID, or account-scoped device registration rolls back
-    /// the whole operation, so a device-registration failure can never
-    /// strand an account with zero devices. Returns `StoreError::Conflict`
-    /// in that case.
+    /// email, root DID, or account-scoped device registration rolls back the
+    /// whole operation, including code consumption, so a failed transaction
+    /// cannot strand either a zero-device account or a spent verification
+    /// code. Returns `StoreError::Conflict` in that case.
     async fn create_account_with_device(
         &self,
         email: &str,

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -295,9 +295,14 @@ impl Store for D1Store {
                 JsValue::from_f64(created_at as f64),
             ])
             .map_err(map_err)?;
+        let consume_code = self
+            .0
+            .prepare(DELETE_CODE)
+            .bind(&[JsValue::from(email)])
+            .map_err(map_err)?;
         let results = self
             .0
-            .batch(vec![insert_account, insert_device])
+            .batch(vec![insert_account, insert_device, consume_code])
             .await
             .map_err(map_err)?;
         results

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -248,6 +248,7 @@ impl Store for SqliteStore {
             ],
         )
         .map_err(map_err)?;
+        tx.execute(DELETE_CODE, params![email]).map_err(map_err)?;
         tx.commit().map_err(map_err)?;
         Ok(account_id)
     }

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -249,6 +249,102 @@ async fn it_exhausts_verification_attempts_over_http() {
 }
 
 #[dialog_common::test]
+async fn it_checks_email_availability_only_after_a_valid_code() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let existing = "existing@example.com";
+
+    client
+        .post(format!("{}/codes", server.endpoint))
+        .json(&serde_json::json!({ "email": existing }))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let first_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    let created = client
+        .post(format!("{}/accounts", server.endpoint))
+        .header("Content-Type", "application/cbor")
+        .body(account_creation(existing, &first_code).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 201);
+
+    client
+        .post(format!("{}/codes", server.endpoint))
+        .json(&serde_json::json!({ "email": existing }))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let existing_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    let conflict = client
+        .post(format!("{}/accounts/preflight", server.endpoint))
+        .json(&serde_json::json!({
+            "email": existing,
+            "code": existing_code,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), 409);
+    let error: serde_json::Value = conflict.json().await.unwrap();
+    assert_eq!(error["error"]["code"], "CONFLICT");
+    assert_eq!(
+        error["error"]["message"],
+        tonk_account_service::core::accounts::EMAIL_TAKEN
+    );
+
+    let available = "available@example.com";
+    client
+        .post(format!("{}/codes", server.endpoint))
+        .json(&serde_json::json!({ "email": available }))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let available_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    for _ in 0..2 {
+        let response = client
+            .post(format!("{}/accounts/preflight", server.endpoint))
+            .json(&serde_json::json!({
+                "email": available,
+                "code": available_code,
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            200,
+            "a successful preflight must not consume the code"
+        );
+    }
+
+    let wrong_code = if available_code == "000000" {
+        "111111"
+    } else {
+        "000000"
+    };
+    let wrong = client
+        .post(format!("{}/accounts/preflight", server.endpoint))
+        .json(&serde_json::json!({
+            "email": available,
+            "code": wrong_code,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), 401);
+
+    server.stop().await;
+}
+
+#[dialog_common::test]
 async fn it_rejects_a_mismatched_command() {
     let server = AccountServer::start().await;
     let body = container(

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -60,6 +60,16 @@ pub struct RootCeremony {
     pub passkey: Option<PasskeyCreationMetadata>,
 }
 
+/// A fresh passkey root and its account-creation invocation, produced from
+/// one in-memory root signer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FreshAccountCeremony {
+    /// Material the browser persists only after credential creation succeeds.
+    pub root: RootCeremony,
+    /// Root-signed request submitted to the account service.
+    pub account: AccountCeremony,
+}
+
 /// Informational metadata captured by the browser that created a passkey.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PasskeyCreationMetadata {
@@ -94,6 +104,25 @@ async fn root_ceremony(
     })
 }
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn create_root_material(
+    label: Option<&str>,
+    created_on: Option<&str>,
+) -> Result<(Ed25519Signer, String, Option<PasskeyCreationMetadata>)> {
+    let created = crate::passkey::create_passkey(label).await?;
+    let credential_id = hex::encode(created.id);
+    let passkey = created_on.map(|created_on| PasskeyCreationMetadata {
+        created_at: (js_sys::Date::now() / 1000.0) as u64,
+        created_on: created_on.to_string(),
+    });
+    let prf = match created.prf_output {
+        Some(output) => output,
+        None => crate::passkey::prf_output().await?,
+    };
+    let root = crate::derive::derive_root_signer(&prf).await?;
+    Ok((root, credential_id, passkey))
+}
+
 /// Create a passkey root and delegate it to `device_did`.
 ///
 /// `label` names the credential in the user's passkey manager: the account
@@ -106,17 +135,7 @@ pub async fn create_root(
     label: Option<&str>,
     created_on: Option<&str>,
 ) -> Result<RootCeremony> {
-    let created = crate::passkey::create_passkey(label).await?;
-    let credential_id = hex::encode(created.id);
-    let passkey = created_on.map(|created_on| PasskeyCreationMetadata {
-        created_at: (js_sys::Date::now() / 1000.0) as u64,
-        created_on: created_on.to_string(),
-    });
-    let prf = match created.prf_output {
-        Some(output) => output,
-        None => crate::passkey::prf_output().await?,
-    };
-    let root = crate::derive::derive_root_signer(&prf).await?;
+    let (root, credential_id, passkey) = create_root_material(label, created_on).await?;
     root_ceremony(root, credential_id, device_did, passkey).await
 }
 
@@ -244,6 +263,44 @@ pub async fn create_account(
         Some(descriptor_hex),
     )
     .await
+}
+
+/// Create a passkey root and sign its account request without immediately
+/// asking the new passkey for a second assertion.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[allow(clippy::too_many_arguments)]
+pub async fn create_fresh_account(
+    email: String,
+    code: String,
+    device_did: dialog_varsig::Did,
+    device_name: String,
+    remote: String,
+    created_on: Option<&str>,
+) -> Result<FreshAccountCeremony> {
+    let (root, credential_id, passkey) = create_root_material(Some(&email), created_on).await?;
+    let root_ceremony = root_ceremony(
+        root.clone(),
+        credential_id.clone(),
+        device_did.clone(),
+        passkey.clone(),
+    )
+    .await?;
+    let account = create_account(
+        root,
+        email,
+        code,
+        credential_id,
+        device_did,
+        device_name,
+        root_ceremony.delegation_hex.clone(),
+        remote,
+        passkey,
+    )
+    .await?;
+    Ok(FreshAccountCeremony {
+        root: root_ceremony,
+        account,
+    })
 }
 
 /// Build the root-signed request that links a new device to an existing account.

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -253,6 +253,37 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     Ok(result)
 }
 
+async fn create_fresh_account(input: JsValue) -> Result<JsValue, JsValue> {
+    let email = string_property(&input, "email")?;
+    let code = string_property(&input, "code")?;
+    let device_did = string_property(&input, "deviceDid")?
+        .parse()
+        .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
+    let device_name = string_property(&input, "deviceName")?;
+    let remote = string_property(&input, "remote")?;
+    let created_on = optional_string_property(&input, "createdOn");
+    let ceremony = crate::ceremony::create_fresh_account(
+        email,
+        code,
+        device_did,
+        device_name,
+        remote,
+        created_on.as_deref(),
+    )
+    .await
+    .map_err(js_error)?;
+    let result = root_result(ceremony.root)?;
+    Reflect::set(
+        &result,
+        &"invocationHex".into(),
+        &ceremony.account.invocation_hex.into(),
+    )?;
+    if let Some(descriptor_hex) = ceremony.account.descriptor_hex {
+        Reflect::set(&result, &"descriptorHex".into(), &descriptor_hex.into())?;
+    }
+    Ok(result)
+}
+
 async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
     let device_did = string_property(&input, "deviceDid")?
         .parse()
@@ -393,6 +424,16 @@ pub fn install() {
         create_account.as_ref().unchecked_ref(),
     );
     create_account.forget();
+
+    let create_fresh_account = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(create_fresh_account(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"createFreshAccount".into(),
+        create_fresh_account.as_ref().unchecked_ref(),
+    );
+    create_fresh_account.forget();
 
     let link_device = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
         future_to_promise(link_device(input))

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -11,9 +11,9 @@ use tonk_account::{AccountStateStatus, handoff::ResolvedLink};
 use tonk_worker_api::{AccountStatus, RevocationProjection, RevokeDeviceAcknowledgement};
 
 use crate::identity_bridge::{
-    CeremonyOutput, CreateAccountInput, CreateRootInput, EstablishRepositoryInput, LinkDeviceInput,
-    RevocationOutput, SignRevocationInput, complete_link, create_account, create_root,
-    establish_account_repository, link_device, sign_revocation,
+    CeremonyOutput, CreateAccountInput, CreateFreshAccountInput, EstablishRepositoryInput,
+    LinkDeviceInput, RevocationOutput, SignRevocationInput, complete_link, create_account,
+    create_fresh_account, establish_account_repository, link_device, sign_revocation,
 };
 
 const STYLE_ID: &str = "tonk-account-styles";
@@ -101,6 +101,12 @@ fn input(host: &HtmlElement, selector: &str) -> Result<String, String> {
     let value = input.value().trim().to_string();
     if value.is_empty() {
         Err(format!("{} is required", input.name()))
+    } else if !input.check_validity() {
+        Err(input
+            .validation_message()
+            .ok()
+            .filter(|message| !message.is_empty())
+            .unwrap_or_else(|| format!("{} is invalid", input.name())))
     } else {
         Ok(value)
     }
@@ -129,9 +135,14 @@ fn set_mode(host: &HtmlElement, mode: &str) {
 
 fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
     for selector in [
+        "#account-choose-create",
+        "#account-choose-link",
         "#account-send-code",
         "#account-create-submit",
+        "#account-create-back",
+        "#account-verify-back",
         "#account-link-submit",
+        "#account-link-back",
         "#account-handoff-submit",
         "#account-setup-submit",
         "#account-unlink",
@@ -862,6 +873,14 @@ fn bind(host: &HtmlElement) {
     on_click(host, "#account-verify-back", |host| {
         clear_error(&host);
         set_busy(&host, false, "");
+        if let Ok(Some(code)) = host.query_selector("#account-code")
+            && let Ok(code) = code.dyn_into::<HtmlInputElement>()
+        {
+            code.set_value("");
+        }
+        if let Ok(Some(destination)) = host.query_selector("#account-code-email") {
+            destination.set_text_content(None);
+        }
         set_mode(&host, "create");
         focus_input(&host, "#account-email");
     });
@@ -915,13 +934,18 @@ fn bind(host: &HtmlElement) {
             (Err(error), _) | (_, Err(error)) => return show_error(&host, error),
         };
         let device_name = crate::device_name::current();
-        set_busy(&host, true, "Waiting for your passkey…");
+        set_busy(&host, true, "Checking verification code…");
         spawn_local(async move {
             let result = async {
+                let service_url = service(&host).await?;
+                crate::api::preflight_account(&service_url, &email, &code)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                set_busy(&host, true, "Waiting for your passkey…");
                 let status = crate::api::root_status()
                     .await
                     .map_err(|error| error.to_string())?;
-                let (root_did, device_did, credential_id, delegation_hex, passkey) = match status {
+                let ceremony = match status {
                     tonk_worker_api::RootStatus::Ready {
                         root_did,
                         device_did,
@@ -929,50 +953,45 @@ fn bind(host: &HtmlElement) {
                         delegation_hex,
                         passkey,
                         ..
-                    } => (root_did, device_did, credential_id, delegation_hex, passkey),
+                    } => create_account(CreateAccountInput {
+                        email,
+                        code,
+                        device_did,
+                        device_name,
+                        root_did,
+                        credential_id,
+                        delegation_hex,
+                        passkey,
+                        remote: proposed_remote()?,
+                    })
+                    .await
+                    .map_err(|error| error.to_string())?,
                     tonk_worker_api::RootStatus::Missing { device_did } => {
-                        // This ceremony is what creates the passkey, and it
-                        // knows the address the code just verified — so the
-                        // credential gets a name its owner will recognise in a
-                        // passkey manager instead of an opaque handle. Only
-                        // here: a root created by anything else has no account
-                        // to name.
-                        let created = create_root(CreateRootInput {
+                        let created = create_fresh_account(CreateFreshAccountInput {
+                            email,
+                            code,
                             device_did,
-                            label: Some(email.clone()),
-                            created_on: Some(device_name.clone()),
+                            device_name,
+                            remote: proposed_remote()?,
+                            created_on: crate::device_name::current(),
                         })
                         .await
                         .map_err(|error| error.to_string())?;
                         crate::api::save_root(
                             created.credential_id.clone(),
                             created.delegation_hex.clone(),
-                            created.passkey.clone(),
+                            Some(created.passkey.clone()),
                         )
                         .await
                         .map_err(|error| error.to_string())?;
-                        (
-                            created.root_did,
-                            created.device_did,
-                            created.credential_id,
-                            created.delegation_hex,
-                            created.passkey,
-                        )
+                        CeremonyOutput {
+                            root_did: created.root_did,
+                            credential_id: created.credential_id,
+                            delegation_hex: created.delegation_hex,
+                            invocation_hex: created.invocation_hex,
+                        }
                     }
                 };
-                let ceremony = create_account(CreateAccountInput {
-                    email,
-                    code,
-                    device_did,
-                    device_name,
-                    root_did,
-                    credential_id,
-                    delegation_hex,
-                    passkey,
-                    remote: proposed_remote()?,
-                })
-                .await
-                .map_err(|error| error.to_string())?;
                 set_busy(&host, true, "Creating your account…");
                 complete_remote(&host, "/accounts", ceremony, true).await
             }
@@ -1370,6 +1389,88 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "local persistence recovery must not be exposed in the account UI"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_invalid_authored_fields_before_network_work() {
+        let host = host();
+        let email: HtmlInputElement = host
+            .query_selector("#account-email")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+        email.set_value("not-an-email");
+        assert!(input(&host, "#account-email").is_err());
+        email.set_value("person@example.com");
+        assert_eq!(
+            input(&host, "#account-email").as_deref(),
+            Ok("person@example.com")
+        );
+
+        let code: HtmlInputElement = host
+            .query_selector("#account-code")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+        code.set_value("12");
+        assert!(input(&host, "#account-code").is_err());
+        code.set_value("123456");
+        assert_eq!(input(&host, "#account-code").as_deref(), Ok("123456"));
+    }
+
+    #[dialog_common::test]
+    fn it_disables_in_panel_navigation_while_account_work_is_in_flight() {
+        let host = host();
+        set_busy(&host, true, "Checking verification code…");
+
+        for selector in [
+            "#account-choose-create",
+            "#account-choose-link",
+            "#account-create-back",
+            "#account-verify-back",
+            "#account-link-back",
+        ] {
+            let button: HtmlButtonElement = host
+                .query_selector(selector)
+                .unwrap()
+                .unwrap()
+                .unchecked_into();
+            assert!(button.disabled(), "{selector} remained interactive");
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_clears_verification_state_before_trying_another_email() {
+        let host = host();
+        bind(&host);
+        let code: HtmlInputElement = host
+            .query_selector("#account-code")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+        code.set_value("123456");
+        host.query_selector("#account-code-email")
+            .unwrap()
+            .unwrap()
+            .set_text_content(Some("old@example.com"));
+        set_mode(&host, "verify");
+
+        let back: HtmlElement = host
+            .query_selector("#account-verify-back")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+        back.click();
+
+        assert_eq!(host.get_attribute("data-mode").as_deref(), Some("create"));
+        assert_eq!(code.value(), "");
+        assert_eq!(
+            host.query_selector("#account-code-email")
+                .unwrap()
+                .unwrap()
+                .text_content(),
+            Some(String::new())
         );
     }
 

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -16,7 +16,7 @@ mod tests {
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
     use tokio::process::{Child, Command};
 
-    use crate::helpers::{TestEnvironment, driver_with_prf};
+    use crate::helpers::{TestEnvironment, driver_with_prf, driver_with_prf_authenticator};
 
     const EMAIL: &str = "person@example.com";
 
@@ -95,6 +95,20 @@ mod tests {
         }
     }
 
+    async fn credential_count(driver: &WebDriver, authenticator_id: &str) -> Result<usize> {
+        let devtools = ChromeDevTools::new(driver.handle.clone());
+        let result = devtools
+            .execute_cdp_with_params(
+                "WebAuthn.getCredentials",
+                serde_json::json!({ "authenticatorId": authenticator_id }),
+            )
+            .await?;
+        result["credentials"]
+            .as_array()
+            .map(Vec::len)
+            .ok_or_else(|| anyhow!("Chrome omitted the virtual authenticator credentials"))
+    }
+
     pub(crate) async fn sign_up(
         driver: &WebDriver,
         env: &TestEnvironment,
@@ -166,6 +180,102 @@ mod tests {
         assert!(!created.is_empty() && created != "Loading…" && created != "Unavailable");
         wait_for_text_containing(&driver, "#account-passkey-device-value", "Chrome on ").await?;
         wait_for_text_containing(&driver, "#account-device-list", "Chrome on ").await?;
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_existing_email_before_creating_a_passkey_and_can_retry(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let existing_email = "existing@example.com";
+        let available_email = "available@example.com";
+
+        let creator = driver_with_prf(&env).await?;
+        sign_up(&creator, &env, existing_email).await?;
+        creator.quit().await?;
+
+        let (driver, authenticator_id) = driver_with_prf_authenticator(&env).await?;
+        driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                navigator.serviceWorker.ready.then(() => {
+                    if (navigator.serviceWorker.controller) {
+                        done(true);
+                    } else {
+                        navigator.serviceWorker.addEventListener(
+                            "controllerchange",
+                            () => done(true),
+                            { once: true },
+                        );
+                    }
+                }).catch(error => done({ error: String(error) }));
+                "#,
+                vec![],
+            )
+            .await?;
+        driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        element(&driver, "#account-choose-create")
+            .await?
+            .click()
+            .await?;
+        element(&driver, "#account-email")
+            .await?
+            .send_keys(existing_email)
+            .await?;
+        element(&driver, "#account-send-code")
+            .await?
+            .click()
+            .await?;
+        element(&driver, "tonk-account[data-mode=\"verify\"]").await?;
+        element(&driver, "#account-code")
+            .await?
+            .send_keys(captured_code(&env, existing_email).await?)
+            .await?;
+        element(&driver, "#account-create-submit")
+            .await?
+            .click()
+            .await?;
+
+        wait_for_text(
+            &driver,
+            "#account-error",
+            "an account already exists for this email address",
+        )
+        .await?;
+        assert_eq!(
+            credential_count(&driver, &authenticator_id).await?,
+            0,
+            "email conflicts must be reported before WebAuthn creates a credential"
+        );
+
+        element(&driver, "#account-verify-back")
+            .await?
+            .click()
+            .await?;
+        let code = element(&driver, "#account-code").await?;
+        assert_eq!(code.prop("value").await?.as_deref(), Some(""));
+        let email = element(&driver, "#account-email").await?;
+        email.clear().await?;
+        email.send_keys(available_email).await?;
+        element(&driver, "#account-send-code")
+            .await?
+            .click()
+            .await?;
+        element(&driver, "tonk-account[data-mode=\"verify\"]").await?;
+        element(&driver, "#account-code")
+            .await?
+            .send_keys(captured_code(&env, available_email).await?)
+            .await?;
+        element(&driver, "#account-create-submit")
+            .await?
+            .click()
+            .await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        assert_eq!(credential_count(&driver, &authenticator_id).await?, 1);
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -724,6 +724,24 @@ pub async fn request_account_code(service: &str, email: &str) -> Result<(), Tonk
     }
 }
 
+/// Verify control of an available account email before starting WebAuthn.
+pub async fn preflight_account(service: &str, email: &str, code: &str) -> Result<(), TonkUiError> {
+    let path = "/accounts/preflight";
+    let response = reqwest::Client::new()
+        .post(format!("{}{}", service.trim_end_matches('/'), path))
+        .json(&serde_json::json!({ "email": email, "code": code }))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    let status = response.status();
+    let text = response.text().await.map_err(into_api_error)?;
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(account_service_error(path, status, &text))
+    }
+}
+
 /// Submit a signed ceremony container to the account service.
 pub async fn submit_account_ceremony(
     service: &str,

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -97,10 +97,19 @@ mod native {
     /// Creates a WebDriver with a PRF-capable virtual authenticator.
     #[cfg(test)]
     pub(crate) async fn driver_with_prf(env: &TestEnvironment) -> Result<WebDriver> {
+        Ok(driver_with_prf_authenticator(env).await?.0)
+    }
+
+    /// Creates a WebDriver and returns the PRF-capable virtual authenticator's
+    /// id so tests can inspect credential side effects.
+    #[cfg(test)]
+    pub(crate) async fn driver_with_prf_authenticator(
+        env: &TestEnvironment,
+    ) -> Result<(WebDriver, String)> {
         let driver = env.driver().await?;
         let devtools = ChromeDevTools::new(driver.handle.clone());
         devtools.execute_cdp("WebAuthn.enable").await?;
-        devtools
+        let authenticator = devtools
             .execute_cdp_with_params(
                 "WebAuthn.addVirtualAuthenticator",
                 serde_json::json!({
@@ -117,6 +126,10 @@ mod native {
                 }),
             )
             .await?;
+        let authenticator_id = authenticator["authenticatorId"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Chrome omitted the virtual authenticator id"))?
+            .to_string();
         driver
             .execute_async(
                 r#"
@@ -128,7 +141,7 @@ mod native {
                 vec![],
             )
             .await?;
-        Ok(driver)
+        Ok((driver, authenticator_id))
     }
 
     /// Manages test server processes for integration testing.

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
 /// Input for creating or evaluating a root credential.
+#[cfg(test)]
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CreateRootInput {
@@ -40,6 +41,18 @@ pub(crate) struct CreateAccountInput {
     pub passkey: Option<tonk_worker_api::PasskeyMetadata>,
     /// Account repository remote this browser proposes for the new account.
     pub remote: String,
+}
+
+/// Input for a fresh account whose passkey root does not exist yet.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CreateFreshAccountInput {
+    pub email: String,
+    pub code: String,
+    pub device_did: String,
+    pub device_name: String,
+    pub remote: String,
+    pub created_on: String,
 }
 
 /// Input for the one-time account repository establishment ceremony.
@@ -78,6 +91,7 @@ pub(crate) struct SignRevocationInput {
 }
 
 /// Root ceremony output persisted by the service worker.
+#[cfg(test)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RootOutput {
@@ -96,6 +110,19 @@ pub(crate) struct CeremonyOutput {
     pub root_did: String,
     pub credential_id: String,
     pub delegation_hex: String,
+    pub invocation_hex: String,
+}
+
+/// Fresh-root account output, carrying both local persistence and remote
+/// submission material from one passkey ceremony.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FreshAccountOutput {
+    pub root_did: String,
+    pub device_did: String,
+    pub credential_id: String,
+    pub delegation_hex: String,
+    pub passkey: tonk_worker_api::PasskeyMetadata,
     pub invocation_hex: String,
 }
 
@@ -186,6 +213,7 @@ async fn call<I: Serialize, O: DeserializeOwned>(
     serde_wasm_bindgen::from_value(output).map_err(|_| IdentityBridgeError::MalformedOutput)
 }
 
+#[cfg(test)]
 pub(crate) async fn create_root(input: CreateRootInput) -> Result<RootOutput, IdentityBridgeError> {
     call("createRoot", input).await
 }
@@ -194,6 +222,12 @@ pub(crate) async fn create_account(
     input: CreateAccountInput,
 ) -> Result<CeremonyOutput, IdentityBridgeError> {
     call("createAccount", input).await
+}
+
+pub(crate) async fn create_fresh_account(
+    input: CreateFreshAccountInput,
+) -> Result<FreshAccountOutput, IdentityBridgeError> {
+    call("createFreshAccount", input).await
 }
 
 pub(crate) async fn establish_account_repository(
@@ -309,6 +343,36 @@ mod tests {
             if (!(Object.getPrototypeOf(input) === Object.prototype || Object.getPrototypeOf(input) === null))
                 return Promise.reject(new Error("prototype"));
         "#;
+
+        install_method(
+            "createFreshAccount",
+            &format!(
+                r#"{plain_object_guard}
+                if (input.email !== "fresh@example.test" || input.code !== "123456"
+                    || input.deviceDid !== "did:key:device" || input.deviceName !== "Browser"
+                    || input.createdOn !== "Chrome on macOS"
+                    || input.remote !== "https://tonk.spot/ucan/")
+                    return Promise.reject(new Error("property"));
+                return Promise.resolve({{
+                    rootDid: "did:key:root", deviceDid: input.deviceDid,
+                    credentialId: "credential", delegationHex: "delegation",
+                    passkey: {{ createdAt: 1754380800, createdOn: input.createdOn }},
+                    invocationHex: "invocation"
+                }});"#
+            ),
+        );
+        let fresh = create_fresh_account(CreateFreshAccountInput {
+            email: "fresh@example.test".into(),
+            code: "123456".into(),
+            device_did: "did:key:device".into(),
+            device_name: "Browser".into(),
+            remote: "https://tonk.spot/ucan/".into(),
+            created_on: "Chrome on macOS".into(),
+        })
+        .await
+        .unwrap();
+        assert_eq!(fresh.invocation_hex, "invocation");
+        assert_eq!(fresh.passkey.created_at, 1_754_380_800);
 
         install_method(
             "createAccount",


### PR DESCRIPTION
## Summary

- verify email control and availability before starting WebAuthn without exposing account existence to unverified callers
- create a fresh passkey root and signed account request in one ceremony, while preserving existing accountless-root behavior
- consume the verification code atomically with account and first-device creation, clear retry state, and lock in-panel navigation during async transitions
- document remaining race, recovery, and deployment-order boundaries

## Verification

- `cargo test -p tonk-account-service --features helpers` (65 unit tests passed; HTTP tests rerun serially below)
- `cargo test -p tonk-account-service --features helpers --test service -- --test-threads=1 --nocapture` (10 passed)
- `nix develop -c cargo test --target wasm32-unknown-unknown -p tonk-ui --lib` (28 passed)
- `nix develop -c cargo test --target wasm32-unknown-unknown -p tonk-identity --lib` (34 passed)
- isolated real-browser existing-email then different-email retry regression (passed; zero credentials before conflict, one after successful retry)
- `nix develop -c cargo check -p tonk-ui --target wasm32-unknown-unknown`
- `nix develop -c cargo check -p tonk-account-service --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
- `git diff --check`

## Rollout

Deploy the account worker containing `/accounts/preflight` before the UI. The UI deliberately fails closed when the endpoint is unavailable.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an account preflight check that verifies email control and availability before creating a passkey account. It ensures that existing emails are not reused and that valid codes do not get consumed during the preflight process.

### Detailed summary
- Added `POST /accounts/preflight` endpoint to verify email and code without consuming the code.
- Updated `create_account_with_device` to include email code consumption on conflict.
- Refactored `verify_code` to `check_code` for clarity.
- Enhanced tests for email availability and conflict scenarios.
- Updated UI to reflect changes in account creation flow.
- Introduced `create_fresh_account` to handle fresh account creation with passkey.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->