### PR TITLE
fix(cli): stop an undeliverable detach from bricking account link

### DIFF
--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -133,6 +133,16 @@ other access-service requests are denied before HTTP. Logout queues a
 signed, generation-specific detach intent; the device list may remain stale
 until a later account operation reaches the provider and flushes that outbox.
 
+A detach intent is signed once and never edited, so a client-error response
+is a permanent verdict on it: an unknown attachment, a payload the service
+disagrees with, or a service with no detach route can never accept that
+intent, and the CLI drops it rather than retrying forever. Timeouts, rate
+limits, and server errors are retried instead, and while one is still
+queued for a provider, linking to that same provider is refused because its
+one-active-generation rule would reject the activation. `tonk account link
+--abandon-detach` drops those undelivered intents and links anyway; the
+earlier device can stay listed until `tonk account revoke` removes it.
+
 Detach is not revocation. It hides the exact attachment and permits a later
 fresh handoff without publishing an immutable revocation. `tonk account revoke
 <DEVICE_DID>` permanently revokes the selected grant, which can never be

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -95,6 +95,8 @@ pub struct LinkOptions {
     pub device_name: String,
     /// Whether to ask the OS to open the handoff URL.
     pub open_browser: bool,
+    /// Whether to drop undeliverable detach intents and link anyway.
+    pub abandon_detach: bool,
 }
 
 /// Successful browser handoff.
@@ -485,6 +487,44 @@ async fn activate_remote(
     Ok(())
 }
 
+/// Deliver queued detach intents before a handoff opens on `provider`.
+///
+/// Only an undelivered detach at the same provider can block a handoff:
+/// the service's one-active-generation rule rejects activation while an
+/// earlier generation of this device is still active there. A detach
+/// queued for a different provider says nothing about this one, and one
+/// the provider can never accept is dropped by the flush itself.
+async fn clear_detach_for(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    provider: &str,
+    abandon: bool,
+) -> Result<()> {
+    let flushed = crate::account_session::flush_pending(profile, operator).await?;
+    if !flushed.retains(provider) {
+        if let Some(warning) = flushed.warning {
+            eprintln!("warning: {warning}");
+        }
+        return Ok(());
+    }
+    if abandon {
+        let abandoned = crate::account_session::abandon_pending(profile, operator).await?;
+        eprintln!(
+            "warning: abandoned {abandoned} undelivered detach intent(s); \
+             earlier devices may still be listed on the account page"
+        );
+        return Ok(());
+    }
+    bail!(
+        "cannot link while a detach for {provider} is undelivered: {}\n\
+         retry once the account service is reachable, or run \
+         `tonk account link --abandon-detach` to link anyway",
+        flushed
+            .warning
+            .unwrap_or_else(|| "provider retry required".to_string())
+    );
+}
+
 /// Start or resume a browser handoff and activate its fresh generation.
 pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcome> {
     let operator = crate::account_state::credential_operator(profile).await?;
@@ -500,17 +540,14 @@ pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcom
     if state.active.is_some() {
         bail!("an account is already active; run `tonk account logout` before linking another");
     }
-    if !state.pending_detaches.is_empty() {
-        let flushed = crate::account_session::flush_pending(profile, &operator).await?;
-        if flushed.pending > 0 {
-            bail!(
-                "cannot resume account linking while a prior detach is pending: {}",
-                flushed
-                    .warning
-                    .unwrap_or_else(|| "provider retry required".to_string())
-            );
+    let target_provider = match &state.pending_login {
+        Some(crate::account_session::PendingLogin::Waiting { provider, .. }) => provider.clone(),
+        Some(crate::account_session::PendingLogin::Activating { account, .. }) => {
+            account.provider.clone()
         }
-    }
+        None => options.service_url.trim_end_matches('/').to_string(),
+    };
+    clear_detach_for(profile, &operator, &target_provider, options.abandon_detach).await?;
     let device_did = profile.did().to_string();
     let client = reqwest::Client::new();
     let (service_url, secret, token_hash, activating) = match state.pending_login {
@@ -537,15 +574,6 @@ pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcom
             (account.provider.clone(), secret, token_hash, Some(account))
         }
         None => {
-            let flushed = crate::account_session::flush_pending(profile, &operator).await?;
-            if flushed.pending > 0 {
-                bail!(
-                    "cannot start a new account handoff while a prior detach is pending: {}",
-                    flushed
-                        .warning
-                        .unwrap_or_else(|| "provider retry required".to_string())
-                );
-            }
             let (secret, token_hash) = new_secret();
             crate::account_session::begin_login(
                 profile,

--- a/rust/tonk-cli/src/account_session.rs
+++ b/rust/tonk-cli/src/account_session.rs
@@ -447,11 +447,118 @@ pub(crate) async fn install_for_integration_test(
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FlushOutcome {
     /// Number of entries removed after terminal provider outcomes.
-    pub flushed: usize,
-    /// Number retained for a later retry.
-    pub pending: usize,
-    /// Bounded warning for the first retained failure.
+    pub delivered: usize,
+    /// Number dropped because the provider can never accept them.
+    pub abandoned: usize,
+    /// Providers whose detach is still queued after this attempt.
+    pub retained: Vec<String>,
+    /// Bounded warning for the first entry that was not delivered.
     pub warning: Option<String>,
+}
+
+impl FlushOutcome {
+    /// Whether a detach for `provider` is still undelivered.
+    pub fn retains(&self, provider: &str) -> bool {
+        let provider = provider.trim_end_matches('/');
+        self.retained
+            .iter()
+            .any(|queued| queued.trim_end_matches('/') == provider)
+    }
+}
+
+/// What one delivery attempt proved about a queued detach.
+enum Disposition {
+    /// The provider confirmed a terminal lifecycle outcome.
+    Delivered,
+    /// The provider can never accept this intent, so keeping it only
+    /// blocks the device. The account row may stay visible until the
+    /// account page revokes it.
+    Abandoned(String),
+    /// The attempt was inconclusive: the generation may still be active.
+    Retained(String),
+}
+
+/// Classify one provider response.
+///
+/// A detach intent is immutable and signed once, so a `4xx` is a permanent
+/// verdict on this exact payload rather than a transient condition: the
+/// service reports an unknown attachment as `404`, a payload disagreeing
+/// with the stored row as `409`, and a malformed or forged intent as
+/// `400`/`403`. Retrying any of those forever cannot change the answer, and
+/// a queue that never drains blocks `tonk account link` permanently. The
+/// timeout and rate-limit statuses are the exceptions: they describe the
+/// attempt, not the payload.
+fn classify(status: reqwest::StatusCode) -> Option<Disposition> {
+    if status.is_client_error()
+        && !matches!(
+            status,
+            reqwest::StatusCode::REQUEST_TIMEOUT | reqwest::StatusCode::TOO_MANY_REQUESTS
+        )
+    {
+        return Some(Disposition::Abandoned(format!(
+            "gave up delivering a device detach after provider status {status}; \
+             the device may still be listed on the account page"
+        )));
+    }
+    if !status.is_success() {
+        return Some(Disposition::Retained(format!(
+            "detach retry retained after provider status {status}"
+        )));
+    }
+    None
+}
+
+/// Whether a success response names a terminal lifecycle outcome.
+async fn terminal_outcome(response: reqwest::Response) -> bool {
+    response
+        .json::<serde_json::Value>()
+        .await
+        .ok()
+        .and_then(|value| {
+            value
+                .get("outcome")
+                .and_then(|value| value.as_str())
+                .map(str::to_owned)
+        })
+        .is_some_and(|value| {
+            matches!(
+                value.as_str(),
+                "detached"
+                    | "alreadyDetached"
+                    | "cancelledPendingActivation"
+                    | "superseded"
+                    | "revoked"
+            )
+        })
+}
+
+/// Drop every undelivered detach intent under the exclusive transition
+/// lock, returning how many were dropped.
+///
+/// The escape hatch for a provider whose failures never resolve. Delivery
+/// is best effort already, and an outbox that cannot drain otherwise blocks
+/// every later login on this device with no way out.
+pub async fn abandon_pending(profile: &Profile, operator: &Operator<NativeSpace>) -> Result<usize> {
+    let store = SpotStore::open().context("failed to locate account state")?;
+    abandon_pending_for_store(profile, operator, &store).await
+}
+
+pub(crate) async fn abandon_pending_for_store(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    store: &SpotStore,
+) -> Result<usize> {
+    let guard = exclusive_transition_guard(store)?;
+    ensure_initialized(profile, operator, &guard).await?;
+    let mut state = load_raw(profile, operator, store)
+        .await?
+        .unwrap_or_default();
+    let abandoned = state.pending_detaches.len();
+    if abandoned > 0 {
+        state.pending_detaches.clear();
+        save_raw(profile, operator, store, &state).await?;
+    }
+    Ok(abandoned)
 }
 
 /// Retry detach outbox entries under the exclusive transition lock.
@@ -488,49 +595,280 @@ pub(crate) async fn flush_pending_for_store(
             .timeout(std::time::Duration::from_secs(10))
             .send()
             .await;
-        let terminal = match result {
-            Ok(response) if response.status().is_success() => response
-                .json::<serde_json::Value>()
-                .await
-                .ok()
-                .and_then(|value| {
-                    value
-                        .get("outcome")
-                        .and_then(|value| value.as_str())
-                        .map(str::to_owned)
-                })
-                .is_some_and(|value| {
-                    matches!(
-                        value.as_str(),
-                        "detached"
-                            | "alreadyDetached"
-                            | "cancelledPendingActivation"
-                            | "superseded"
-                            | "revoked"
-                    )
-                }),
+        let disposition = match result {
             Ok(response) => {
-                let status = response.status();
-                outcome.warning.get_or_insert_with(|| {
-                    format!("detach retry retained after provider status {status}")
-                });
-                false
+                if let Some(disposition) = classify(response.status()) {
+                    disposition
+                } else if terminal_outcome(response).await {
+                    // A success status still has to name a terminal lifecycle
+                    // outcome; anything else leaves this generation's fate
+                    // unknown, which is a retry rather than a delivery.
+                    Disposition::Delivered
+                } else {
+                    Disposition::Retained(
+                        "detach retry retained after an unrecognized provider outcome".to_string(),
+                    )
+                }
             }
-            Err(error) => {
-                outcome
-                    .warning
-                    .get_or_insert_with(|| format!("detach retry retained: {error}"));
-                false
-            }
+            Err(error) => Disposition::Retained(format!("detach retry retained: {error}")),
         };
-        if terminal {
-            outcome.flushed += 1;
-        } else {
-            retained.push(pending);
+        match disposition {
+            Disposition::Delivered => outcome.delivered += 1,
+            Disposition::Abandoned(warning) => {
+                outcome.abandoned += 1;
+                outcome.warning.get_or_insert(warning);
+            }
+            Disposition::Retained(warning) => {
+                outcome.warning.get_or_insert(warning);
+                outcome.retained.push(pending.provider.clone());
+                retained.push(pending);
+            }
         }
     }
-    outcome.pending = retained.len();
     state.pending_detaches = retained;
     save_raw(profile, operator, store, &state).await?;
     Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+
+    use dialog_capability::Subject;
+    use dialog_effects::storage::Directory;
+    use dialog_storage::provider::storage::Storage;
+
+    use super::*;
+
+    /// Answer every detach request with one fixed status and body.
+    fn detach_server(status: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind detach service");
+        let endpoint = format!("http://{}", listener.local_addr().expect("service address"));
+        std::thread::spawn(move || {
+            for incoming in listener.incoming() {
+                let Ok(mut stream) = incoming else { return };
+                let mut buffer = [0u8; 4096];
+                let _ = stream.read(&mut buffer);
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.flush();
+            }
+        });
+        endpoint
+    }
+
+    /// A port nothing is listening on, so delivery cannot even connect.
+    fn unreachable_provider() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve a port");
+        let endpoint = format!(
+            "http://{}",
+            listener.local_addr().expect("reserved address")
+        );
+        drop(listener);
+        endpoint
+    }
+
+    struct Fixture {
+        profile: Profile,
+        operator: Operator<NativeSpace>,
+        store: SpotStore,
+        _directory: tempfile::TempDir,
+    }
+
+    async fn fixture() -> Fixture {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let store = SpotStore::at(directory.path().join("state"));
+        let storage = Storage::<NativeSpace>::default();
+        let profile = Profile::open(format!("cli-detach-outbox-{}", rand::random::<u64>()))
+            .at(Directory::At(
+                directory.path().join("profiles").to_string_lossy().into(),
+            ))
+            .perform(&storage)
+            .await
+            .expect("open profile");
+        std::fs::create_dir_all(store.account_dir()).expect("create account directory");
+        let account_dir = store.account_dir().canonicalize().expect("account path");
+        let operator = profile
+            .derive(b"tonk/account-state/v1")
+            .allow(Subject::any())
+            .base(Directory::At(account_dir.to_string_lossy().into()))
+            .build(storage)
+            .await
+            .expect("derive operator");
+        Fixture {
+            profile,
+            operator,
+            store,
+            _directory: directory,
+        }
+    }
+
+    /// Queue one detach intent addressed to `provider`.
+    async fn queue(fixture: &Fixture, provider: &str) {
+        let intent = SignedDetachIntent::sign(
+            fixture.profile.signer(),
+            &fixture.profile.did(),
+            "attachment",
+            "delegation",
+            1,
+        )
+        .await
+        .expect("sign detach intent");
+        let state = AccountSessionState {
+            pending_detaches: vec![PendingDetach {
+                provider: provider.to_string(),
+                intent,
+            }],
+            ..AccountSessionState::default()
+        };
+        save_raw(&fixture.profile, &fixture.operator, &fixture.store, &state)
+            .await
+            .expect("seed the outbox");
+    }
+
+    async fn outbox(fixture: &Fixture) -> Vec<PendingDetach> {
+        load_raw(&fixture.profile, &fixture.operator, &fixture.store)
+            .await
+            .expect("load state")
+            .unwrap_or_default()
+            .pending_detaches
+    }
+
+    async fn flush(fixture: &Fixture) -> FlushOutcome {
+        flush_pending_for_store(&fixture.profile, &fixture.operator, &fixture.store)
+            .await
+            .expect("flush the outbox")
+    }
+
+    #[dialog_common::test]
+    async fn it_removes_a_detach_the_provider_terminally_confirmed() {
+        let fixture = fixture().await;
+        let provider = detach_server("200 OK", r#"{"outcome":"alreadyDetached"}"#);
+        queue(&fixture, &provider).await;
+
+        let outcome = flush(&fixture).await;
+
+        assert_eq!(outcome.delivered, 1);
+        assert_eq!(outcome.abandoned, 0);
+        assert!(outcome.retained.is_empty());
+        assert_eq!(outcome.warning, None);
+        assert!(outbox(&fixture).await.is_empty());
+    }
+
+    /// A `2xx` whose body names no lifecycle outcome leaves the generation's
+    /// fate unknown, so the intent has to survive for a later attempt.
+    #[dialog_common::test]
+    async fn it_retains_a_detach_after_an_unrecognized_success_body() {
+        let fixture = fixture().await;
+        let provider = detach_server("200 OK", r#"{"outcome":"somethingElse"}"#);
+        queue(&fixture, &provider).await;
+
+        let outcome = flush(&fixture).await;
+
+        assert_eq!(outcome.delivered, 0);
+        assert!(outcome.retains(&provider));
+        assert_eq!(outbox(&fixture).await.len(), 1);
+    }
+
+    /// The lockout this prevents: an account service with no detach route
+    /// (or no such attachment) answers `404` forever, and a retained entry
+    /// blocks every later `tonk account link` on the device.
+    #[dialog_common::test]
+    async fn it_abandons_a_detach_the_provider_can_never_accept() {
+        let fixture = fixture().await;
+        let provider = detach_server("404 Not Found", "{}");
+        queue(&fixture, &provider).await;
+
+        let outcome = flush(&fixture).await;
+
+        assert_eq!(outcome.abandoned, 1);
+        assert_eq!(outcome.delivered, 0);
+        assert!(!outcome.retains(&provider));
+        assert!(
+            outcome
+                .warning
+                .as_deref()
+                .is_some_and(|warning| warning.contains("may still be listed")),
+            "an abandoned detach must say the device can remain listed: {:?}",
+            outcome.warning
+        );
+        assert!(outbox(&fixture).await.is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_abandons_a_detach_whose_payload_the_provider_rejects() {
+        let fixture = fixture().await;
+        let provider = detach_server("409 Conflict", "{}");
+        queue(&fixture, &provider).await;
+
+        assert_eq!(flush(&fixture).await.abandoned, 1);
+        assert!(outbox(&fixture).await.is_empty());
+    }
+
+    /// Retryable failures describe the attempt rather than the signed
+    /// payload, so these must outlive the attempt even though two of them
+    /// are client-error statuses.
+    #[dialog_common::test]
+    async fn it_retains_a_detach_after_a_retryable_failure() {
+        for status in [
+            "503 Service Unavailable",
+            "429 Too Many Requests",
+            "408 Request Timeout",
+        ] {
+            let fixture = fixture().await;
+            let provider = detach_server(status, "{}");
+            queue(&fixture, &provider).await;
+
+            let outcome = flush(&fixture).await;
+
+            assert_eq!(outcome.abandoned, 0, "{status} must not be abandoned");
+            assert!(outcome.retains(&provider), "{status} must be retried");
+            assert_eq!(outbox(&fixture).await.len(), 1, "{status} must persist");
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_a_detach_the_provider_never_answered() {
+        let fixture = fixture().await;
+        let provider = unreachable_provider();
+        queue(&fixture, &provider).await;
+
+        let outcome = flush(&fixture).await;
+
+        assert!(outcome.retains(&provider));
+        assert_eq!(outbox(&fixture).await.len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_abandons_every_queued_detach_on_demand() {
+        let fixture = fixture().await;
+        queue(&fixture, &unreachable_provider()).await;
+
+        let abandoned =
+            abandon_pending_for_store(&fixture.profile, &fixture.operator, &fixture.store)
+                .await
+                .expect("abandon the outbox");
+
+        assert_eq!(abandoned, 1);
+        assert!(outbox(&fixture).await.is_empty());
+    }
+
+    /// A detach queued for one provider says nothing about linking to
+    /// another, so it must not report itself as blocking that handoff.
+    #[dialog_common::test]
+    async fn it_reports_a_retained_detach_only_for_its_own_provider() {
+        let fixture = fixture().await;
+        let provider = detach_server("503 Service Unavailable", "{}");
+        queue(&fixture, &provider).await;
+
+        let outcome = flush(&fixture).await;
+
+        assert!(outcome.retains(&format!("{provider}/")));
+        assert!(!outcome.retains("https://accounts.example"));
+    }
 }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -500,6 +500,10 @@ enum AccountCommand {
         /// Print the approval URL without asking the OS to open it.
         #[arg(long)]
         no_open: bool,
+        /// Link even though an earlier logout's detach never reached the
+        /// account service. Those devices may stay listed until revoked.
+        #[arg(long)]
+        abandon_detach: bool,
     },
 
     /// Disconnect account services on this device
@@ -1231,6 +1235,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             service_url,
             account_url,
             no_open,
+            abandon_detach,
         } => match account::link(
             &profile,
             &account::LinkOptions {
@@ -1238,6 +1243,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 account_url,
                 device_name: name.unwrap_or_else(account::default_device_name),
                 open_browser: !no_open,
+                abandon_detach,
             },
         )
         .await


### PR DESCRIPTION
Reported after upgrading 0.6.5 → 0.6.6: `tonk account logout` warned
`detach retry retained after provider status 404 Not Found`, and every
later `tonk account link` then failed with `cannot resume account linking
while a prior detach is pending`. There is no way out of that state.

## Why it locks

A detach intent is signed once and never edited, so a client-error
response is a permanent verdict on that exact payload: the service
answers `404` for an unknown attachment (`core/devices.rs:164`), `409`
for a payload disagreeing with the stored row, and `400`/`403` for a
malformed or forged intent. `flush_pending` retried all of them forever,
`link` refused to start while any entry was queued, and nothing else ever
cleared the outbox.

The 404 is real today, not hypothetical: the deployed account service has
no detach route at all.

```
OPTIONS https://accounts.tonk.xyz/devices/detach -> 404
OPTIONS https://accounts.tonk.xyz/devices/list   -> 204
```

That gap is fixed separately, at the end of this stack.

## What changes

- Classify each delivery attempt: **deliver** on a terminal outcome,
  **abandon** on a client error that can never change, **retain** only
  what describes the attempt (timeout, 429, 5xx, transport failure).
- Scope link's refusal to the provider actually holding an undelivered
  detach. Another provider's queue says nothing about this handoff.
- Add `tonk account link --abandon-detach` for a provider whose failures
  never resolve, so a queue that cannot drain is never terminal.

An abandoned detach can leave the device listed on the account page until
`tonk account revoke` removes it; the warning says so.

This deviates from `plan/account-logout-cli.md`, which specified
retaining `unknownAttachment` and `payloadMismatch`. That plan did not
account for the retained entry also being a hard block on linking, which
turns a stale device row into a bricked device.

## Verification

`cargo test -p tonk-cli --lib` — 134 pass, including 8 new tests driving
a stub detach service through terminal, unrecognized-success, 404, 409,
503/429/408, and unreachable-provider outcomes. `clippy --all-targets
--all-features` and `fmt --check` clean.

Users already stuck can clear it by hand until this ships:
`rm ~/Library/Application\ Support/tonk/account/tonk-account-session-v1-*.json`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature in the `tonk` CLI that allows users to link accounts while abandoning undeliverable detach intents. This enhances the user experience by preventing blocks caused by previous detach requests.

### Detailed summary
- Added `abandon_detach` option to the `tonk` CLI for linking accounts.
- Implemented logic in `account_op` to handle `abandon_detach`.
- Created `clear_detach_for` function to manage queued detach intents.
- Updated `FlushOutcome` to track abandoned detach intents.
- Enhanced error handling for undeliverable detach intents.
- Added tests for various scenarios regarding detach intent handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->