### PR TITLE
fix(cli): recover and adopt a spot's account authority

### DIFF
--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -87,6 +87,11 @@ name = "account_interrupt"
 path = "tests/account_interrupt.rs"
 required-features = ["integration-tests"]
 
+[[test]]
+name = "account_authority"
+path = "tests/account_authority.rs"
+required-features = ["integration-tests"]
+
 [features]
 integration-tests = []
 

--- a/rust/tonk-cli/src/account_authority.rs
+++ b/rust/tonk-cli/src/account_authority.rs
@@ -141,31 +141,21 @@ impl AccountBoundOperator {
         let mut chain = if subject == root {
             grant
         } else {
-            let bytes = self
-                .profile
-                .credential()
-                .site(tonk_account::backup::space_root_site(&subject, &root))
-                .load::<Vec<u8>>()
-                .perform(&self.inner)
-                .await
-                .map_err(|error| {
-                    AuthorizeError::Denied(format!(
-                        "spot is not delegated to the active account: {error}"
-                    ))
-                })?;
-            let backup = tonk_account::backup::AccountSpotBackup {
-                chain_hex: hex::encode(bytes),
-                remote_url: None,
-                revocation_url: None,
-                name: None,
-            };
-            let prefix = backup.validate_for(&root).await.map_err(|error| {
-                AuthorizeError::Denied(format!(
-                    "spot is not delegated to the active account: {error}"
-                ))
-            })?;
+            // Resolving rather than reading: a spot predating this account,
+            // or created by a release that stored no prefix, still has to
+            // reach its own remote. Recovery is the same one every other
+            // account path uses, so the authority a spot syncs with is the
+            // authority it gets backed up with.
+            let prefix =
+                crate::site::account_root_prefix_for(&self.profile, &self.inner, &subject, &root)
+                    .await
+                    .map_err(|error| {
+                        AuthorizeError::Denied(format!(
+                            "spot is not delegated to the active account: {error:#}"
+                        ))
+                    })?;
             let active_proof = grant.proofs().next().unwrap().clone();
-            prefix.chain.push(active_proof).map_err(|error| {
+            prefix.push(active_proof).map_err(|error| {
                 AuthorizeError::Denied(format!("account authority chain is invalid: {error}"))
             })?
         };

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -450,106 +450,157 @@ async fn mount_delegated_inner(
 /// Load the exact reusable prefix for a site, recovering it from pre-feature
 /// profile authority when the dedicated credential is absent.
 pub async fn account_root_prefix(site: &TonkSite, account_root: &Did) -> Result<DelegationChain> {
-    let credential = site
-        .profile
-        .credential()
-        .site(space_root_site(&site.repository.did(), account_root));
-    match credential.load::<Vec<u8>>().perform(&site.operator).await {
-        Ok(bytes) if !bytes.is_empty() => {
-            let backup = AccountSpotBackup {
-                chain_hex: hex::encode(bytes),
-                remote_url: None,
-                revocation_url: None,
-                name: None,
-            };
-            return Ok(backup
-                .validate_for(account_root)
-                .await
-                .context("stored account-root prefix is invalid")?
-                .chain);
-        }
-        Ok(_) => {}
-        Err(error) if crate::account_state::credential_is_missing(&error) => {}
-        Err(error) => return Err(error).context("failed to load the account-root prefix"),
-    }
+    account_root_prefix_for(
+        &site.profile,
+        site.operator.local(),
+        &site.repository.did(),
+        account_root,
+    )
+    .await
+}
 
-    // A v1 credential is copied only when its signatures and terminal root
-    // validate for the explicitly requested account.
-    let legacy = site
-        .profile
-        .credential()
-        .site(format!("{SPACE_ROOT_SITE_PREFIX}{}", site.repository.did()));
-    match legacy.load::<Vec<u8>>().perform(&site.operator).await {
-        Ok(bytes) if !bytes.is_empty() => {
-            let backup = AccountSpotBackup {
-                chain_hex: hex::encode(&bytes),
-                remote_url: None,
-                revocation_url: None,
-                name: None,
-            };
-            if let Ok(validated) = backup.validate_for(account_root).await {
-                site.profile
-                    .credential()
-                    .site(space_root_site(&site.repository.did(), account_root))
-                    .save(bytes)
-                    .perform(&site.operator)
-                    .await
-                    .context("failed to migrate the account-root prefix")?;
-                return Ok(validated.chain);
-            }
-        }
-        Ok(_) => {}
-        Err(error) if crate::account_state::credential_is_missing(&error) => {}
-        Err(error) => return Err(error).context("failed to load the legacy account-root prefix"),
-    }
-
-    let proof = site
-        .profile
-        .access()
-        .prove(&site.repository)
-        .perform(&site.operator)
-        .await
-        .context("failed to recover repository authority")?;
-    let mut delegations = Vec::new();
-    let mut reached_root = false;
-    for certificate in proof.proofs {
-        let delegation = certificate.0;
-        reached_root = delegation.audience() == account_root;
-        delegations.push(delegation);
-        if reached_root {
-            break;
-        }
-    }
-    if !reached_root {
-        anyhow::bail!("repository authority does not pass through the account root");
-    }
-    let chain = DelegationChain::try_from(delegations)
-        .context("recovered repository authority is not a valid chain")?;
-    let validated = AccountSpotBackup {
-        chain_hex: hex::encode(
-            chain
-                .to_bytes()
-                .context("failed to serialize recovered prefix")?,
-        ),
+/// Decode a stored prefix artifact for `account_root`.
+async fn validate_prefix(bytes: Vec<u8>, account_root: &Did) -> Result<DelegationChain> {
+    Ok(AccountSpotBackup {
+        chain_hex: hex::encode(bytes),
         remote_url: None,
         revocation_url: None,
         name: None,
     }
     .validate_for(account_root)
-    .await
-    .context("recovered account-root prefix is invalid")?;
-    let bytes = validated
-        .chain
-        .to_bytes()
-        .context("failed to serialize recovered prefix")?;
-    site.profile
+    .await?
+    .chain)
+}
+
+/// Read one credential site, treating absence and emptiness alike.
+async fn optional_credential(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    site: String,
+) -> Result<Option<Vec<u8>>> {
+    match profile
         .credential()
-        .site(space_root_site(&site.repository.did(), account_root))
-        .save(bytes)
-        .perform(&site.operator)
+        .site(site)
+        .load::<Vec<u8>>()
+        .perform(operator)
         .await
-        .context("failed to persist recovered account-root prefix")?;
-    Ok(validated.chain)
+    {
+        Ok(bytes) if bytes.is_empty() => Ok(None),
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if crate::account_state::credential_is_missing(&error) => Ok(None),
+        Err(error) => Err(error).context("failed to load a stored authority prefix"),
+    }
+}
+
+/// Resolve the reusable `subject → … → account_root` prefix, minting it
+/// when this profile holds the subject's authority but no chain to the
+/// account reaches it yet.
+///
+/// Every path that authorizes a remote request for a spot needs this exact
+/// prefix, so all of them recover the same way. A spot created before the
+/// account existed — or by a release that stored no prefix at all — has
+/// repository authority that stops at the profile, and refusing it would
+/// strand data the device demonstrably owns. Extending that authority to
+/// the account root is local bookkeeping: it delegates to the root this
+/// profile already holds a grant from, and publishes nothing.
+pub(crate) async fn account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain> {
+    let current = space_root_site(subject, account_root);
+    if let Some(bytes) = optional_credential(profile, operator, current.clone()).await? {
+        return validate_prefix(bytes, account_root)
+            .await
+            .context("stored account-root prefix is invalid");
+    }
+
+    // A v1 credential is copied only when its signatures and terminal root
+    // validate for the explicitly requested account.
+    let legacy = format!("{SPACE_ROOT_SITE_PREFIX}{subject}");
+    if let Some(bytes) = optional_credential(profile, operator, legacy).await?
+        && let Ok(chain) = validate_prefix(bytes.clone(), account_root).await
+    {
+        save_prefix(profile, operator, &current, bytes)
+            .await
+            .context("failed to migrate the account-root prefix")?;
+        return Ok(chain);
+    }
+
+    let chain = match recover_prefix(profile, operator, subject, account_root).await? {
+        Some(chain) => chain,
+        None => mint_prefix(profile, operator, subject, account_root).await?,
+    };
+    let bytes = chain
+        .to_bytes()
+        .context("failed to serialize the account-root prefix")?;
+    let validated = validate_prefix(bytes.clone(), account_root)
+        .await
+        .context("recovered account-root prefix is invalid")?;
+    save_prefix(profile, operator, &current, bytes)
+        .await
+        .context("failed to persist the account-root prefix")?;
+    Ok(validated)
+}
+
+async fn save_prefix(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    site: &str,
+    bytes: Vec<u8>,
+) -> Result<()> {
+    profile
+        .credential()
+        .site(site.to_string())
+        .save(bytes)
+        .perform(operator)
+        .await?;
+    Ok(())
+}
+
+/// Rebuild the prefix from certificates this profile already holds.
+async fn recover_prefix(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<Option<DelegationChain>> {
+    let proof = profile
+        .access()
+        .prove(Subject::from(subject.clone()))
+        .perform(operator)
+        .await
+        .context("failed to recover repository authority")?;
+    let mut delegations = Vec::new();
+    for certificate in proof.proofs {
+        let delegation = certificate.0;
+        let reached_root = delegation.audience() == account_root;
+        delegations.push(delegation);
+        if reached_root {
+            return DelegationChain::try_from(delegations)
+                .context("recovered repository authority is not a valid chain")
+                .map(Some);
+        }
+    }
+    Ok(None)
+}
+
+/// Extend held authority over `subject` to the account root.
+async fn mint_prefix(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain> {
+    let delegation: UcanDelegation = profile
+        .access()
+        .claim(Subject::from(subject.clone()))
+        .delegate(account_root.clone())
+        .perform(operator)
+        .await
+        .context("this profile cannot delegate the spot to the account root")?;
+    Ok(delegation.into_chain())
 }
 
 /// Knobs for [`TonkSite::open_with`] / [`TonkSite::init_with`].

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -1,0 +1,84 @@
+//! Live coverage for authorizing a spot's remote under an account.
+
+mod common;
+
+use anyhow::Result;
+use tonk_access_service::helpers::AccessServiceAddress;
+use tonk_account::backup::space_root_site;
+use tonk_cli::site::{SiteConfig, TonkSite};
+
+/// Open sites the way a real install does, with the account boundary in
+/// front of every remote fork. The shared fixture config leaves it off so
+/// that tests without an account can still run.
+fn account_config(fixture: &common::AccountFixture) -> SiteConfig {
+    SiteConfig {
+        require_account: true,
+        ..fixture.config.clone()
+    }
+}
+
+async fn configure_upstream(site: &TonkSite, endpoint: &str) -> Result<()> {
+    tonk_cli::remote::add(site, "origin", endpoint, Some(site.repository.did())).await?;
+    tonk_cli::remote::set_upstream(site, "origin").await?;
+    Ok(())
+}
+
+/// Releases before the account-root prefix existed stored no such
+/// credential, so upgrading left every spot they created with nothing under
+/// that key. Authorization has to rebuild the prefix from the certificates
+/// the profile already holds instead of reporting the spot as undelegated.
+#[dialog_common::test]
+async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let fixture = common::AccountFixture::new().await?;
+    let site = TonkSite::init_at_with(
+        &fixture.tmp.path().join("upgraded"),
+        account_config(&fixture),
+    )
+    .await?;
+    let prefix_site = space_root_site(&site.repository.did(), fixture.link.issuer());
+    fixture
+        .profile
+        .credential()
+        .site(prefix_site.clone())
+        .save(Vec::<u8>::new())
+        .perform(&site.operator)
+        .await?;
+    configure_upstream(&site, &env.access_service_url).await?;
+
+    tonk_cli::sync::push(&site).await?;
+
+    let restored = fixture
+        .profile
+        .credential()
+        .site(prefix_site)
+        .load::<Vec<u8>>()
+        .perform(&site.operator)
+        .await?;
+    assert!(
+        !restored.is_empty(),
+        "authorizing a remote must leave the recovered prefix stored"
+    );
+    Ok(())
+}
+
+/// A spot created before the account existed chains to the device root this
+/// profile held at the time and reaches no account root at all. Linking an
+/// account must adopt it rather than strand it offline.
+#[dialog_common::test]
+async fn it_pushes_a_spot_created_before_the_account_existed(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let fixture = common::AccountFixture::new().await?;
+    let path = fixture.pre_account_site.root.clone();
+    let site = TonkSite::open_with(&path, account_config(&fixture)).await?;
+    configure_upstream(&site, &env.access_service_url).await?;
+
+    tonk_cli::sync::push(&site).await?;
+
+    let prefix = tonk_cli::site::account_root_prefix(&site, fixture.link.issuer()).await?;
+    assert_eq!(prefix.subject(), Some(&site.repository.did()));
+    assert_eq!(prefix.audience(), fixture.link.issuer());
+    Ok(())
+}

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -67,6 +67,9 @@ pub fn isolated_config(parent: &std::path::Path) -> Result<SiteConfig> {
 
 #[cfg(feature = "integration-tests")]
 pub struct AccountFixture {
+    /// A site this profile created before the account existed, so its
+    /// repository authority reaches no account root.
+    pub pre_account_site: TonkSite,
     pub server: tonk_account_service::helpers::AccountServer,
     pub profile: dialog_operator::Profile,
     pub store: tonk_cli::spot::SpotStore,
@@ -138,6 +141,7 @@ impl AccountFixture {
         )
         .await?;
         Ok(Self {
+            pre_account_site: test.site,
             server,
             profile,
             store,

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1383,4 +1383,44 @@ mod when_mounting_account_authority {
         assert_eq!(persisted, recovered.to_bytes()?);
         Ok(())
     }
+
+    /// A spot created before this account existed has repository authority
+    /// that stops at the profile and reaches no account root at all. The
+    /// profile holds that authority, so it can extend it rather than
+    /// stranding the spot with nothing that can authorize its remote.
+    #[dialog_common::test]
+    async fn it_adopts_a_spot_whose_authority_reaches_no_account_root() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        let account_root = Ed25519Signer::import(&[73; 32]).await?.did();
+        assert_ne!(local_root(&test.site).await?, account_root);
+
+        let adopted = site::account_root_prefix(&test.site, &account_root).await?;
+
+        assert_eq!(adopted.subject(), Some(&test.site.repository.did()));
+        assert_eq!(adopted.audience(), &account_root);
+        let persisted = test
+            .site
+            .profile
+            .credential()
+            .site(space_root_site(&test.site.repository.did(), &account_root))
+            .load::<Vec<u8>>()
+            .perform(&test.site.operator)
+            .await?;
+        assert_eq!(persisted, adopted.to_bytes()?);
+        Ok(())
+    }
+
+    /// Adoption happens once: the second call must read the stored prefix
+    /// rather than mint a second, differently-signed one.
+    #[dialog_common::test]
+    async fn it_reuses_an_adopted_prefix_on_later_authorizations() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        let account_root = Ed25519Signer::import(&[74; 32]).await?.did();
+
+        let first = site::account_root_prefix(&test.site, &account_root).await?;
+        let second = site::account_root_prefix(&test.site, &account_root).await?;
+
+        assert_eq!(first.to_bytes()?, second.to_bytes()?);
+        Ok(())
+    }
 }


### PR DESCRIPTION
Stacked on #688.

Reported after upgrading 0.6.5 → 0.6.6: every `tonk pull` on an existing
spot fails with

```
Authorization denied: spot is not delegated to the active account:
Storage error: Filesystem I/O error: No such file or directory (os error 2)
```

## Why

`AccountBoundOperator::authorize_guarded` read the account-root prefix
credential (`tonk-space-root-v2/<repo>/<root>`) and mapped *any* error to
`Denied`, including the file simply not existing. No release before 0.6.6
wrote that credential — `git grep tonk-space-root v0.6.5` only hits
`tonk-worker`, and 0.6.5's `bootstrap_repository` stored no prefix at all.
So upgrading denied every pre-existing spot its own remote.

The recovery already existed one module over, in
`site::account_root_prefix`, but authorization never called it.

Two populations are affected, and only one of them recovery alone can fix:

- **Spot created while linked.** Its authority already reaches the account
  root, so rebuilding the prefix from held certificates is enough.
- **Spot created before the account existed.** It chains to the device
  root this profile held at the time and reaches no account root at all.
  Nothing re-keys existing spots at link time, so recovery bails with
  `repository authority does not pass through the account root`.

## What changes

Authorization resolves the prefix instead of reading it, through one
shared path: stored prefix → v1 credential → held certificates → mint.

The last step is new. A spot that reaches no account root gets the
authority this profile already holds over that subject extended to the
account root. The device can already read, write, and `tonk invite` that
spot to any audience, so delegating it to the account root is within what
it can do and matches what linking an account means. It is stored locally
and published nowhere. The prefix a spot syncs with is now the prefix it
gets backed up with.

The denial message also carries the full error chain now, instead of a
bare `No such file or directory`.

## Verification

Two live tests in `tests/account_authority.rs`, one per population, that
push to a real access service. With the change stashed both fail with the
reported error verbatim:

```
spot is not delegated to the active account: Storage error:
Filesystem I/O error: No such file or directory (os error 2)
```

An earlier version of these tests passed with *and* without the fix: the
shared `AccountFixture` config sets `require_account: false`, which
switches the whole account boundary off. They now build sites with the
gate on, which is what caught it.

Also: 2 new unit tests for adoption and its idempotence in `tests/site.rs`;
`--test site` (47), `--test account_spots` (11), `--lib` (134) all pass;
clippy `--all-targets --all-features` and `fmt --check` clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces integration tests for account authority management, enhancing the handling of spots created before an account existed and ensuring proper authority delegation and recovery mechanisms.

### Detailed summary
- Added `account_authority` test configuration in `Cargo.toml`.
- Introduced `pre_account_site` field in `AccountFixture` struct.
- Implemented tests for adopting spots with no account root authority.
- Updated methods for account root prefix recovery and validation.
- Improved error handling and delegation logic in authority management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->