### PR TITLE
ci: deploy the account worker with every release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,9 +182,50 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      # Both workers ship together, exactly as a pull request previews them.
+      # Only the preview path used to deploy the account worker, so every
+      # release moved the access worker against whichever account worker was
+      # last pushed by hand: routes the CLI depends on could be absent from
+      # the released service for as long as nobody noticed. Migrations run
+      # first, because code that queries a column the database does not have
+      # yet fails every request until the schema catches up.
+      - name: Apply staging account migrations
+        if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+        run: |
+          nix --accept-flake-config develop --command \
+            wrangler d1 migrations apply tonk-accounts-staging --remote \
+              --env staging -c wrangler.account.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy account staging
+        if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+        run: nix --accept-flake-config develop --command wrangler deploy --env staging -c wrangler.account.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy staging
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: nix --accept-flake-config develop --command wrangler deploy --env staging -c wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Apply production account migrations
+        if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+        run: |
+          nix --accept-flake-config develop --command \
+            wrangler d1 migrations apply tonk-accounts --remote \
+              -c wrangler.account.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy account production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+        run: nix --accept-flake-config develop --command wrangler deploy -c wrangler.account.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -147,6 +147,12 @@ worker containing `/accounts/preflight` before the UI that calls it. The UI
 fails closed if the route is absent rather than creating a passkey before email
 availability has been verified.
 
+Releases are not manual. `.github/workflows/publish.yml` applies this
+crate's migrations and deploys the worker on every push to `staging` and
+`stable`, alongside the access worker, so the two never drift apart. The
+steps below are the one-time bootstrap of the resources that deploy needs —
+database, buckets, secrets, and WAF rules — not a release procedure.
+
 First deploy, in order:
 
 1. `wrangler d1 create tonk-accounts` and paste the returned database id into


### PR DESCRIPTION
Stacked on #689.

Only the pull-request path deployed `wrangler.account.toml`. Pushes to
`staging` and `stable` deployed the access worker alone, so the account
service shipped whenever somebody last ran wrangler by hand, and the two
workers drifted apart silently.

The drift is live. `/devices/detach` merged in #675 and is absent from the
deployed service months later:

```
OPTIONS https://accounts.tonk.xyz/devices/detach -> 404
OPTIONS https://accounts.tonk.xyz/devices/list   -> 204
```

That 404 is what bricked `tonk account link` in #688. The CLI change makes
it survivable; this makes it stop happening.

## What changes

Migrations then deploy for the account worker on both release branches,
ahead of the access worker that advertises it at `/.well-known/tonk` —
the same order a PR preview already uses. Schema first, because code
querying a column the database does not have yet fails every request
until the schema catches up.

The account-service README no longer reads as if releases are manual; its
step list is now framed as the one-time resource bootstrap it actually is.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the deployment process for the `tonk-account-service` by adding specific steps for applying migrations and deploying both staging and production accounts. It ensures that the access worker and account worker are deployed together, preventing discrepancies.

### Detailed summary
- Added instructions for automatic releases via `.github/workflows/publish.yml`.
- Included steps for applying migrations and deploying the account worker for `staging` and `stable`.
- Separated deployment steps for `tonk-accounts-staging` and `tonk-accounts`.
- Ensured migrations run before deploying to avoid schema issues.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->