### PR TITLE
feat(worker): renew guest session authority from the retained invite

### DIFF
--- a/plan/guest-session-renewal.md
+++ b/plan/guest-session-renewal.md
@@ -1,0 +1,149 @@
+# Renewable guest sessions implementation plan
+
+**Goal:** Keep an accountless guest's remote pull, push, and status operations authorized for as long as the retained open invite remains valid, without weakening the one-hour bound on any individual guest delegation.
+
+**Approach:** Treat the retained open-invite URL as the renewable bearer authority and persist which ephemeral operator each guest delegation targets plus its effective expiry. Before any sync path presigns, rotate to a fresh operator when either the normal signing session or any renewable guest delegation is due, replay every current guest invite onto that operator, persist the replacement chains and metadata, and only then swap the worker state to the new operator.
+
+**Constraints:**
+
+- Guest access remains accountless and full read/write; this fix must not add a passkey, root membership, account-service request, or account attachment.
+- `Invite::visit` remains bounded to `VISIT_TTL_SECONDS` (one hour). Renewal mints another bounded delegation from the retained bearer invite; it must not turn a guest into durable membership or extend beyond an expiry already present in the original invite chain.
+- The access service remains the enforcement boundary for expiry and revocation. No account-service, access-service, invite URL, or remote wire-protocol change is required.
+- Never save a replacement guest delegation under the same operator audience. The certificate store retains old chains and its proof walk does not reject expired candidates, so same-audience renewal would intermittently present the stale chain.
+- One operator is shared by all mounted repositories. Any operator rotation must therefore replay every still-valid guest invite, not only the guest that triggered renewal; durable spaces continue through their existing `space -> root -> device -> operator` proof path.
+- A service-worker restart creates a new operator. A retained guest record whose recorded audience differs from the current operator is due immediately, regardless of its recorded expiry.
+- Existing `tonk-guest-invite-v1:<repo-key>` records must remain readable. Missing audience/expiry metadata is interpreted as legacy state and forces one immediate refresh; successful refresh rewrites the record in the new format.
+- Refresh is local: parsing the retained URL, importing its embedded invite signer, minting the delegation, and retaining it must not contact the account or access service. The next ordinary remote operation still performs the normal expiry and revocation checks.
+- Rotation must be state-safe. Re-read the guest set while holding the exclusive `TonkState` lock so a guest join that completed after the initial due check is included before the operator swap. Prepare and retain every replacement chain before swapping `tonk.operator`.
+- If opening the candidate session or retaining any replacement chain fails, leave the current operator and guest metadata unchanged and retry on a later sync trigger. Partially retained chains for an unused candidate audience are harmless. If metadata persistence fails partway, do not swap; the candidate-audience mismatch in any written record keeps the next attempt due.
+- A malformed retained record is existing local corruption, not a reason to delete credentials or invent authority. Report it through the existing error/logging path and preserve it; do not let it authorize a remote request.
+- Do not add sleeps to tests. Drive the pure expiry predicate with explicit timestamps and force stored metadata into the renewal margin for integration coverage.
+- Do not change `Cargo.lock`; the required signing, parsing, storage, and query APIs are already present.
+- The current filesystem is at 100% usage and the access-service check already failed with `No space left on device`. Reclaim space with the user's approval before running the full native/WASM verification matrix; do not silently delete build artifacts.
+
+## File map
+
+- `rust/tonk-worker/src/router/join.rs`: versioned retained-guest record, guest enumeration, centralized bounded grant mint/retain helpers, and initial-visit metadata persistence.
+- `rust/tonk-worker/src/router/sync.rs`: due detection, batch operator rotation, synchronous renewal at every remote sync/status boundary, and renewal integration tests.
+- `rust/tonk-worker/README.md`: document that guest grants are locally renewed from the retained open invite and remain independently expiry/revocation checked.
+- `rust/tonk-invite/src/lib.rs`: unchanged source of the one-hour `VISIT_TTL_SECONDS` bound and `Invite::visit` implementation.
+- `rust/tonk-access-service/src/expiry.rs`: unchanged expiry enforcement; its existing tests remain part of broader verification.
+
+### Task 1: Persist enough guest-session metadata to renew safely
+
+**Files:**
+
+- Modify: `rust/tonk-worker/src/router/join.rs:GuestRecord, save_guest, guest_url, save_authority`
+- Test: `rust/tonk-worker/src/router/join.rs:tests`
+
+**Interfaces:**
+
+- Consumes: the existing `tonk-guest-invite-v1:<repo-key>` credential site, `PreparedJoin.url`, `PreparedJoin.invite`, `Invite::visit`, and the current `tonk.operator.did()`.
+- Produces:
+
+```rust
+pub(crate) struct GuestLease {
+    pub subject: Did,
+    pub url: String,
+    pub audience: Option<Did>,
+    pub expires_at: Option<u64>,
+}
+
+pub(crate) struct GuestGrant {
+    pub chain: DelegationChain,
+    pub audience: Did,
+    pub expires_at: u64,
+}
+
+pub(crate) async fn guest_leases(
+    tonk: &TonkState,
+) -> Result<Vec<GuestLease>, TonkWorkerError>;
+
+pub(crate) async fn mint_guest_grant(
+    invite: Invite,
+    audience: &Did,
+) -> Result<GuestGrant, JoinFailure>;
+
+pub(crate) async fn retain_guest_grant(
+    tonk: &TonkState,
+    operator: &DefaultOperator,
+    grant: &GuestGrant,
+) -> Result<(), JoinFailure>;
+
+pub(crate) async fn save_guest(
+    tonk: &TonkState,
+    operator: &DefaultOperator,
+    subject: &Did,
+    url: &str,
+    grant: &GuestGrant,
+) -> Result<(), JoinFailure>;
+```
+
+- [ ] Add `it_reads_a_v1_guest_record_as_a_legacy_lease`. Save the current `{version: 1, url}` bytes, load them through the production decoder, and assert the URL survives while `audience` and `expires_at` are `None`; unsupported versions and a v2 record missing either field must return a typed internal/claim failure rather than panic.
+- [ ] Add `it_persists_the_guest_grants_actual_audience_and_expiry`. Visit an open invite, commit it through the existing guest path, reload the credential record, and assert version 2, the exact current operator DID, and the delegation chain's effective expiration rather than an independently calculated `now + 3600` value.
+- [ ] Add `it_enumerates_only_repository_replicas_with_guest_records`. Seed two guest replicas, one durable replica, the profile replica, and the account replica; assert `guest_leases` returns the two guest subjects in stable subject order and never treats an absent/cleared guest site as a guest.
+- [ ] Run `nix develop path:. -c test:web:debug`; expect the new tests to fail because the v2 metadata and helper interfaces do not exist. If disk pressure prevents the run, record `No space left on device` as an environmental block rather than treating it as the expected red result.
+- [ ] Replace the write-only `GuestRecord { version: 1, url }` shape with a decoder that accepts version 1 as missing metadata and writes version 2 as `{version, url, audience, expires_at}`. Parse the audience string as a `Did` on load and reject unsupported versions or incomplete v2 records.
+- [ ] Refactor `guest_url` to project from the shared record loader so membership status and promotion preserve their current behavior. `clear_guest` continues to write empty bytes and remains the only way promotion removes guest state.
+- [ ] Implement `guest_leases` by querying the profile `main` branch for `Replica::repository_kind()` rows belonging to `tonk.profile.did()`, loading each subject's guest credential site, dropping absent/cleared sites, and sorting by subject DID for deterministic batch behavior.
+- [ ] Centralize guest minting in `mint_guest_grant`: call `Invite::visit(audience)`, require an effective chain expiration, and return the exact audience and expiration alongside the chain. Initial visit staging and durable commit must use the same helper so tests and renewal cannot drift in TTL or chain construction.
+- [ ] Change `save_authority` to return `Option<GuestGrant>` after the chain is retained. Pass that result to `save_guest`, which writes the matching v2 record only for `JoinMode::GuestVisit`; durable join/promotion behavior remains unchanged.
+- [ ] Implement `retain_guest_grant` as the chain-retention half and `save_guest` as the metadata-persistence half. Initial visit calls them in that order. Renewal can retain the complete batch first and write the complete metadata batch second, avoiding a state swap while any guest still lacks a chain for the candidate audience. Do not log or return the bearer URL.
+- [ ] Run `cargo test -p tonk-invite it_visits_with_bounded_session_authority_without_changing_the_invite`; expect the unchanged one-hour bound test to pass.
+- [ ] Run `nix develop path:. -c test:web:debug`; expect all guest join, promotion, and new metadata tests to pass.
+
+### Task 2: Renew all guest authority before any remote sync operation
+
+**Files:**
+
+- Modify: `rust/tonk-worker/src/router/sync.rs:drain_sync, renew_session, pull, push, sync, sync_status`
+- Test: `rust/tonk-worker/src/router/sync.rs:tests and overlay_tests`
+- Modify: `rust/tonk-worker/README.md:Browser contracts or a new Guest authority subsection`
+
+**Interfaces:**
+
+- Consumes: `session::needs_renewal`, `session::open`, `session::now`, `join::guest_leases`, `join::mint_guest_grant`, `join::retain_guest_grant`, and `join::save_guest` from Task 1.
+- Produces:
+
+```rust
+pub(crate) const GUEST_RENEWAL_MARGIN_SECONDS: u64 = 5 * 60;
+
+pub(crate) fn guest_needs_renewal(
+    lease: &GuestLease,
+    current_audience: &Did,
+    now: u64,
+) -> bool;
+
+pub(crate) async fn ensure_session_authority(
+    state: &AppState,
+) -> Result<(), TonkWorkerError>;
+```
+
+- [ ] Add pure predicate tests: `it_keeps_a_guest_outside_the_five_minute_margin`, `it_renews_a_guest_inside_the_margin`, `it_renews_legacy_guest_metadata`, and `it_renews_an_audience_mismatch_after_worker_restart`. Use fixed timestamps and assert the exact inclusive boundary `now + GUEST_RENEWAL_MARGIN_SECONDS >= expires_at`.
+- [ ] Add `it_rotates_and_rebinds_a_guest_before_expiry` in the service-worker test module. Create a local open-invite guest, rewrite only its stored v2 expiry into the margin, call `ensure_session_authority`, and assert: the operator DID changed; the guest record names the new DID; its expiry moved forward; and `profile.access().prove(subject).audience(new_operator)` succeeds with a chain whose effective expiry equals the rewritten record.
+- [ ] Add `it_rebinds_a_fresh_guest_after_operator_restart`. Create a guest, open a new session over the same profile/storage and install that operator into the test state without touching the guest record, call `ensure_session_authority`, and assert the audience mismatch forces replay even though the recorded guest expiry is still far away.
+- [ ] Add `it_rebinds_every_guest_when_one_guest_forces_rotation`. Create two guests plus one durable space, put only the first guest inside the margin, renew once, and assert both guest records target the same new operator and all three subjects can produce proofs for it. Assert exactly one operator rotation, not one per guest.
+- [ ] Add `it_does_not_rotate_a_healthy_operator_or_guest`. Call the ensure function twice with all expiries outside their margins and assert the operator DID and guest record bytes remain identical.
+- [ ] Add `it_keeps_the_current_operator_when_guest_replay_fails`. Create a valid guest, rewrite its retained v2 record with a syntactically invalid invite URL and an expiry inside the margin, call `ensure_session_authority`, and assert it returns an error without changing `tonk.operator`, `session_expires_at`, or the stored guest bytes. Preserve the malformed record for diagnosis; do not add a generic storage abstraction solely to inject a later write failure.
+- [ ] Run `nix develop path:. -c test:web:debug`; expect the renewal tests to fail because current `renew_session` only considers `session_expires_at` and never replays retained guest invites.
+- [ ] Implement `guest_needs_renewal`: return true for v1 metadata, an audience different from the current operator, or an expiry inside the five-minute margin. When deciding whether a valid invite can trigger automatic renewal, respect an earlier expiration in the original invite chain; an already expired parent invite cannot be made valid by another guest hop.
+- [ ] Replace `renew_session` with `ensure_session_authority`. Its initial read phase loads all guest leases and returns immediately unless the normal session or at least one renewable guest is due. Open the candidate `Session` outside the state lock.
+- [ ] Acquire the exclusive state lock, verify `session_expires_at` still matches the snapshot, and re-read the full current guest set under that lock. Parse and mint a `GuestGrant` for every still-valid guest against the candidate operator, including guests that were not individually due, because the operator is global.
+- [ ] Retain every candidate chain first. Then persist every matching v2 record. Swap `tonk.operator` and `tonk.session_expires_at` only after both phases complete successfully. On any storage failure, keep the old operator; do not delete the old chains or guest records.
+- [ ] Keep the current best-effort drain behavior: `drain_sync` logs a renewal failure and continues with the still-current session, allowing a later trigger to retry. Also call `ensure_session_authority` synchronously before the first presign in each direct remote boundary: `pull`, `push`, `sync`, and `sync_status`. This closes the service-worker-restart race instead of relying on a debounced drain to win against the request.
+- [ ] Preserve offline and paused behavior. Local renewal may run while offline, but no new network request is introduced; a paused branch still performs no remote fetch/pull/push.
+- [ ] Document the resulting chain and lifecycle in `rust/tonk-worker/README.md`: each guest hop is one-hour bounded, the retained open invite is replayed locally onto rotated operators, expiry/revocation remain enforced remotely, and explicit promotion is still the only transition to durable membership.
+- [ ] Run `cargo fmt --all -- --check`; expect success.
+- [ ] Run `cargo test -p tonk-invite`; expect success.
+- [ ] Run `cargo test -p tonk-access-service --features helpers expiry`; expect the existing expired-chain rejection tests to pass.
+- [ ] Run `cargo test -p tonk-worker`; expect native worker tests to pass.
+- [ ] Run `nix develop path:. -c test:web:debug`; expect all WASM worker tests, including guest join/promotion and renewal coverage, to pass.
+- [ ] Run `nix flake check 'path:.'`; expect the repository-defined formatting, lint, native, and build checks to pass. Report any remaining disk-, browser-, Nix-daemon-, or sandbox-bound check separately from code failures.
+
+## Acceptance evidence
+
+- A guest proof is never presented after its recorded one-hour delegation expires: before a remote operation reaches presign, it either uses a freshly rotated operator with a freshly bounded guest chain or reports a renewal/storage failure while retaining the previous state.
+- A worker restart followed immediately by `sync`, `pull`, `push`, or `sync_status` replays the retained invite before that operation presigns.
+- Rotating for one guest preserves every other guest and every durable space under the single new operator.
+- Promotion still clears the guest record only after durable authority commits; a promoted space is not replayed as a guest on later rotations.
+- No account-service request, account attachment, new root, permanent guest grant, wire-format change, or lock-file change appears in the diff.

--- a/rust/tonk-worker/README.md
+++ b/rust/tonk-worker/README.md
@@ -67,6 +67,38 @@ The router's shared state is `Arc<RwLock<TonkState>>`. `TonkState` owns:
 re-exported here as `tonk_worker::reactor` (and flattened), so `Reactor`,
 `CommandRegistry`, and friends are usable directly off this crate.
 
+## Guest authority
+
+An accountless guest holds no membership. What it holds is an audience-open
+invite URL, retained locally, and one bounded delegation minted from it —
+`subject -> ... -> operator`, capped at `VISIT_TTL_SECONDS` (one hour) by
+`Invite::visit`. That bound never moves.
+
+Because the bound never moves, the delegation is renewed rather than extended.
+Before any remote operation presigns (`pull`, `push`, `sync`, `sync_status`, and
+the sync drain), `ensure_session_authority` checks the signing session and every
+retained guest record. If the session or any guest is due, it rotates the
+operator once and replays every still-valid guest invite onto the new one: a
+fresh key means a fresh audience, which is what keeps the retired chain from
+being picked out of a content-addressed store that never deletes and never
+consults the clock. Durable spaces need no replay — they reach the operator
+through `space -> root -> device -> operator`, whose last hop the rotation
+re-mints anyway.
+
+Each guest record therefore stores which operator its live chain is addressed to
+and when that chain lapses, alongside the URL. A record naming any other
+operator is due immediately, whatever its expiry says, which is what makes a
+service-worker restart heal on the next request instead of taking a 401. An
+invite that has itself expired is not replayed: a guest hop cannot outlive the
+chain it extends.
+
+Renewal is local — parse, mint, retain — and adds no request to the account or
+access service. Expiry and revocation stay where they were: the access service
+checks them on the next ordinary remote call. Renewal only decides which
+credential that call presents. And it is still not membership: explicit
+promotion (`POST /api/repository/{repo}/membership`) remains the only path from
+a guest to a durable member.
+
 ## Host/guest routing model
 
 A view is rendered in a sandboxed iframe. Routing policy lives entirely in

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1261,6 +1261,85 @@ pub mod tests {
         );
     }
 
+    /// Hand-craft an audience-open invite URL for a synthetic repository
+    /// subject. The subject signer doubles as root issuer. Distinct tag
+    /// bytes give distinct subjects/ephemerals. Returns the URL plus the
+    /// subject's routing key (the repo a join mounts the claimer's
+    /// replica under).
+    ///
+    /// `remote` advertises an access service. Every host used in tests
+    /// is unresolvable, so a staged pull against one fails the way a
+    /// remote outage does; `None` makes the invite local-only.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub(crate) async fn open_invite_url(
+        subject_tag: u8,
+        ephemeral_tag: u8,
+        remote: Option<&str>,
+    ) -> (String, String) {
+        use dialog_credentials::ed25519::Ed25519Signer;
+        use dialog_ucan_core::subject::Subject as UcanSubject;
+        use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+        use dialog_varsig::Principal as _;
+        use tonk_invite::{Invite, InviteAudience};
+        use tonk_schema::prelude::DidExt as _;
+
+        let subject_signer = Ed25519Signer::import(&[subject_tag; 32]).await.unwrap();
+        let subject = subject_signer.did();
+        let key = subject.repo_key().to_owned();
+        let ephemeral_seed = [ephemeral_tag; 32];
+        let ephemeral = Ed25519Signer::import(&ephemeral_seed).await.unwrap();
+        let delegation = DelegationBuilder::new()
+            .issuer(subject_signer)
+            .audience(&ephemeral.did())
+            .subject(UcanSubject::Specific(subject.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let invite = Invite::new(
+            DelegationChain::new(delegation),
+            InviteAudience::Open {
+                seed: ephemeral_seed,
+            },
+            remote.map(|url| url::Url::parse(url).unwrap()),
+        )
+        .await
+        .unwrap()
+        .with_revocation_url(
+            remote.map(|_| "https://relay.example.test/revocations/".parse().unwrap()),
+        );
+        (invite.to_url("https://hub.tonk.xyz/join").unwrap(), key)
+    }
+
+    /// `POST /api/profile/visit` — an accountless guest visit.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub(crate) async fn visit_invite(app: &Router, url: &str) -> StatusCode {
+        post_invite_url(app, "/api/profile/visit", url).await
+    }
+
+    /// `POST /api/profile/join` — a durable claim to the local root.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub(crate) async fn join_invite_url(app: &Router, url: &str) -> StatusCode {
+        post_invite_url(app, "/api/profile/join", url).await
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    async fn post_invite_url(app: &Router, path: &str, url: &str) -> StatusCode {
+        let body = serde_json::json!({ "url": url }).to_string();
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
     /// Drive the `tonk:invite` command end to end on a fresh, synced repo
     /// and return the minted invite. Attaches a remote before minting —
     /// a local-only repo now refuses to mint at all.

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -98,7 +98,10 @@ use super::repository::{
     UpstreamConfiguration, build_repository_info, record_initialized_replica_in_profile,
     record_replica_local_meta,
 };
-use crate::{TonkWorkerError, worker::TonkState};
+use crate::{
+    TonkWorkerError,
+    worker::{DefaultOperator, TonkState},
+};
 
 /// The single branch the profile repository lives on (`main`; the
 /// profile has no content/meta split).
@@ -644,57 +647,121 @@ pub(crate) struct JoinOutcome {
     pub renewed: bool,
 }
 
+/// The record shape written today: the retained bearer URL plus which
+/// operator the live guest delegation was minted for and when it lapses.
+///
+/// Version 1 carried the URL alone. That was enough to replay an invite
+/// on demand, but not to tell whether the delegation currently in the
+/// certificate store is still usable — which is what renewal has to
+/// decide before every remote operation. A v1 record is therefore read
+/// as "metadata unknown", which forces one refresh and rewrites it in
+/// this shape.
+const GUEST_RECORD_VERSION: u8 = 2;
+
+/// The on-disk form. Both metadata fields are absent in version 1 and
+/// required in version 2; [`decode_guest_record`] is what enforces that,
+/// so nothing downstream has to re-check the pairing.
 #[derive(Serialize, Deserialize)]
 struct GuestRecord {
     version: u8,
     url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    audience: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+}
+
+/// A retained guest record, decoded.
+///
+/// `audience` and `expires_at` are `None` only for a legacy version 1
+/// record. They are read together or not at all: an audience without an
+/// expiry says nothing about whether the delegation is still good, and an
+/// expiry without an audience says nothing about which chain it describes.
+pub(crate) struct GuestLease {
+    /// The subject whose replica this guest holds.
+    pub subject: Did,
+    /// The retained open-invite URL. Bearer authority — never logged.
+    pub url: String,
+    /// Operator the live delegation was minted for.
+    pub audience: Option<Did>,
+    /// Effective expiry of that delegation, unix seconds.
+    pub expires_at: Option<u64>,
+}
+
+impl std::fmt::Debug for GuestLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GuestLease")
+            .field("subject", &self.subject)
+            .field("audience", &self.audience)
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A freshly minted guest delegation, with the two facts the retained
+/// record has to agree with: who it is addressed to, and when it lapses.
+///
+/// The expiry is read off the chain rather than computed as `now + TTL`,
+/// so an invite that expires sooner than the guest hop would carries
+/// through instead of being overstated.
+pub(crate) struct GuestGrant {
+    /// The bounded `subject -> ... -> operator` chain.
+    pub chain: DelegationChain,
+    /// The operator the chain terminates at.
+    pub audience: Did,
+    /// Effective expiration of the chain, unix seconds.
+    pub expires_at: u64,
 }
 
 fn guest_site(subject: &Did) -> String {
     format!("tonk-guest-invite-v1:{}", subject.repo_key())
 }
 
-/// Retain the invite a guest visit was opened with, so an explicit
-/// promotion can replay it without the page holding the URL.
-pub(crate) async fn save_guest(
+/// Decode a stored guest record into its URL and, when the record
+/// carries them, the audience and expiry of the delegation it describes.
+///
+/// A record this cannot read is local corruption, not authority to
+/// invent: it comes back as an error and the caller preserves the bytes.
+fn decode_guest_record(
+    subject: &Did,
+    bytes: &[u8],
+) -> Result<(String, Option<Did>, Option<u64>), TonkWorkerError> {
+    let record: GuestRecord = serde_json::from_slice(bytes).map_err(|error| {
+        TonkWorkerError::Internal(format!("stored guest record is invalid: {error}"))
+    })?;
+    match record.version {
+        // Legacy: the URL is all it kept. Treated as "metadata unknown",
+        // which reads as due on the next check.
+        1 => Ok((record.url, None, None)),
+        GUEST_RECORD_VERSION => {
+            let (Some(audience), Some(expires_at)) = (record.audience, record.expires_at) else {
+                return Err(TonkWorkerError::Internal(format!(
+                    "stored guest record for {subject} is missing its delegation metadata"
+                )));
+            };
+            let audience = audience.parse::<Did>().map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "stored guest record for {subject} names an unparseable audience: {error}"
+                ))
+            })?;
+            Ok((record.url, Some(audience), Some(expires_at)))
+        }
+        version => Err(TonkWorkerError::Internal(format!(
+            "stored guest record for {subject} has unsupported version {version}"
+        ))),
+    }
+}
+
+/// Read the retained guest record for `subject`, if there is one.
+///
+/// An absent or cleared site is not a guest — promotion clears by
+/// writing empty bytes, which has to read the same as never having
+/// visited.
+pub(crate) async fn guest_lease(
     tonk: &TonkState,
     subject: &Did,
-    url: &str,
-) -> Result<(), JoinFailure> {
-    let record = serde_json::to_vec(&GuestRecord {
-        version: 1,
-        url: url.to_string(),
-    })
-    .map_err(|error| {
-        JoinFailure::claim_failed(format!("failed to serialize the guest record: {error}"))
-    })?;
-    tonk.profile
-        .credential()
-        .site(guest_site(subject))
-        .save(record)
-        .perform(&tonk.operator)
-        .await
-        .map_err(|error| {
-            JoinFailure::claim_failed(format!("failed to save the guest record: {error}"))
-        })
-}
-
-/// Drop the retained guest invite. Part of the durable commit, never a
-/// preflight write: until it runs, a promotion that fails still leaves
-/// the guest with working bounded access.
-async fn clear_guest(tonk: &TonkState, subject: &Did) -> Result<(), JoinFailure> {
-    tonk.profile
-        .credential()
-        .site(guest_site(subject))
-        .save(Vec::<u8>::new())
-        .perform(&tonk.operator)
-        .await
-        .map_err(|error| {
-            JoinFailure::claim_failed(format!("failed to clear the guest record: {error}"))
-        })
-}
-
-async fn guest_url(tonk: &TonkState, subject: &Did) -> Result<Option<String>, TonkWorkerError> {
+) -> Result<Option<GuestLease>, TonkWorkerError> {
     let bytes = match tonk
         .profile
         .credential()
@@ -714,10 +781,362 @@ async fn guest_url(tonk: &TonkState, subject: &Did) -> Result<Option<String>, To
     if bytes.is_empty() {
         return Ok(None);
     }
-    let record: GuestRecord = serde_json::from_slice(&bytes).map_err(|error| {
-        TonkWorkerError::Internal(format!("stored guest record is invalid: {error}"))
+    let (url, audience, expires_at) = decode_guest_record(subject, &bytes)?;
+    Ok(Some(GuestLease {
+        subject: subject.clone(),
+        url,
+        audience,
+        expires_at,
+    }))
+}
+
+/// Every guest this profile currently holds, in subject order.
+///
+/// The operator is shared by all mounted repositories, so rotating it
+/// invalidates every guest delegation at once — which makes the whole
+/// set, not the one guest that triggered a rotation, the unit renewal
+/// works on. Sorted so that batch behaves the same on every pass.
+pub(crate) async fn guest_leases(tonk: &TonkState) -> Result<Vec<GuestLease>, TonkWorkerError> {
+    let profile_meta = tonk
+        .reactor
+        .profile_repository()
+        .branch(PROFILE_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to open profile meta branch: {error}"))
+        })?;
+
+    let rows: Vec<Replica> = profile_meta
+        .handle()
+        .query()
+        .select(Query::<Replica> {
+            this: Term::var("this"),
+            subject: Term::var("subject"),
+            profile: Term::from(tonk_schema::domain::replica::Profile(
+                tonk.profile.did().this(),
+            )),
+            kind: Term::from(Replica::repository_kind()),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("replica query on profile meta failed: {error:?}"))
+        })?;
+
+    let mut subjects: Vec<Did> = Vec::with_capacity(rows.len());
+    for row in rows {
+        match row.subject.0.to_string().parse::<Did>() {
+            Ok(subject) => subjects.push(subject),
+            // A single unreadable index row is not a reason to refuse to
+            // renew every other guest; the profile route skips it the
+            // same way.
+            Err(error) => log!(
+                "replica subject {:?} is unparseable: {error:?}",
+                row.subject.0
+            ),
+        }
+    }
+    subjects.sort_by_key(|subject| subject.to_string());
+    subjects.dedup();
+
+    let mut leases = Vec::new();
+    for subject in subjects {
+        if let Some(lease) = guest_lease(tonk, &subject).await? {
+            leases.push(lease);
+        }
+    }
+    Ok(leases)
+}
+
+/// Parse a lease's retained invite, unless replaying it could not
+/// produce usable authority.
+///
+/// `Ok(None)` means the invite itself has lapsed. A guest hop is bounded
+/// by the chain it extends, so replaying an expired invite would mint a
+/// chain that is already dead — and, because the record would then name
+/// an audience whose delegation is inside the renewal margin forever, it
+/// would ask for a rotation on every single sync boundary. Declining
+/// here is what keeps a dead invite from becoming a rotation loop; the
+/// guest simply stays as it is until someone hands it a live link.
+///
+/// A URL that does not parse is a different thing: local corruption. It
+/// comes back as an error so the caller can refuse to rotate and leave
+/// the record in place for diagnosis.
+pub(crate) async fn renewable_invite(
+    lease: &GuestLease,
+    now: u64,
+) -> Result<Option<Invite>, JoinFailure> {
+    let invite = Invite::parse_url(&lease.url).await.map_err(|error| {
+        JoinFailure::malformed(format!(
+            "retained guest invite for {} did not parse: {error}",
+            lease.subject
+        ))
     })?;
-    Ok(Some(record.url))
+    if invite
+        .chain
+        .expiration()
+        .is_some_and(|expiration| expiration.to_unix() <= now)
+    {
+        return Ok(None);
+    }
+    Ok(Some(invite))
+}
+
+/// Mint one bounded guest delegation from `invite` to `audience`.
+///
+/// The single place a guest hop is created: staging, the initial visit,
+/// and renewal all come through here, so the TTL and chain shape cannot
+/// drift between what a test exercises and what renewal replays. The
+/// expiry returned is the chain's effective one — an invite that lapses
+/// before the guest hop would bounds the result, and no hop can extend
+/// past it.
+pub(crate) async fn mint_guest_grant(
+    invite: Invite,
+    audience: &Did,
+) -> Result<GuestGrant, JoinFailure> {
+    let chain = invite
+        .visit(audience)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("invite did not extend to a guest: {error}"))
+        })?
+        .chain;
+    let expires_at = chain
+        .expiration()
+        .ok_or_else(|| JoinFailure::claim_failed("a guest delegation must expire"))?
+        .to_unix();
+    Ok(GuestGrant {
+        chain,
+        audience: audience.clone(),
+        expires_at,
+    })
+}
+
+/// Install a minted guest chain in the durable certificate store.
+///
+/// Split from [`save_guest`] so a batch renewal can retain every
+/// replacement chain before it writes any metadata: the operator swap
+/// then happens with no guest left holding a record that names an
+/// audience it has no chain for.
+pub(crate) async fn retain_guest_grant(
+    tonk: &TonkState,
+    operator: &DefaultOperator,
+    grant: &GuestGrant,
+) -> Result<(), JoinFailure> {
+    tonk.profile
+        .access()
+        .save(UcanDelegation(grant.chain.clone()))
+        .perform(operator)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("failed to save the guest authority: {error}"))
+        })
+}
+
+/// Retain the invite a guest visit was opened with, together with the
+/// audience and expiry of the delegation currently standing on it.
+///
+/// The URL is the renewable half: it is what a promotion replays, and
+/// what renewal replays onto a rotated operator. The metadata is the
+/// half that says whether replaying is due.
+pub(crate) async fn save_guest(
+    tonk: &TonkState,
+    operator: &DefaultOperator,
+    subject: &Did,
+    url: &str,
+    grant: &GuestGrant,
+) -> Result<(), JoinFailure> {
+    write_guest_record(
+        tonk,
+        operator,
+        subject,
+        url,
+        &grant.audience,
+        grant.expires_at,
+    )
+    .await
+}
+
+async fn write_guest_record(
+    tonk: &TonkState,
+    operator: &DefaultOperator,
+    subject: &Did,
+    url: &str,
+    audience: &Did,
+    expires_at: u64,
+) -> Result<(), JoinFailure> {
+    let record = serde_json::to_vec(&GuestRecord {
+        version: GUEST_RECORD_VERSION,
+        url: url.to_string(),
+        audience: Some(audience.to_string()),
+        expires_at: Some(expires_at),
+    })
+    .map_err(|error| {
+        JoinFailure::claim_failed(format!("failed to serialize the guest record: {error}"))
+    })?;
+    tonk.profile
+        .credential()
+        .site(guest_site(subject))
+        .save(record)
+        .perform(operator)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("failed to save the guest record: {error}"))
+        })
+}
+
+/// Overwrite a retained guest record with chosen metadata, bypassing the
+/// mint that normally produces it.
+///
+/// Test-only. Renewal is driven entirely by what is stored, so the
+/// alternative to writing that directly is waiting an hour for a real
+/// delegation to approach its expiry.
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn store_guest_record(
+    tonk: &TonkState,
+    subject: &Did,
+    url: &str,
+    audience: &Did,
+    expires_at: u64,
+) -> Result<(), JoinFailure> {
+    write_guest_record(tonk, &tonk.operator, subject, url, audience, expires_at).await
+}
+
+/// The raw retained bytes for `subject`, for tests that assert a failed
+/// renewal left the record exactly as it found it.
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn guest_record_bytes(tonk: &TonkState, subject: &Did) -> Option<Vec<u8>> {
+    tonk.profile
+        .credential()
+        .site(guest_site(subject))
+        .load::<Vec<u8>>()
+        .perform(&tonk.operator)
+        .await
+        .ok()
+        .filter(|bytes| !bytes.is_empty())
+}
+
+/// The stored record is the only thing renewal reads before it decides
+/// whether a guest's authority is still good, so decoding it is pure
+/// data and runs on both targets.
+#[cfg(test)]
+mod guest_record {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use dialog_credentials::ed25519::Ed25519Signer;
+    use dialog_varsig::{Did, Principal as _};
+
+    use super::{GUEST_RECORD_VERSION, decode_guest_record};
+
+    async fn subject() -> Did {
+        Ed25519Signer::import(&[9u8; 32]).await.unwrap().did()
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_a_v1_guest_record_as_a_legacy_lease() {
+        let subject = subject().await;
+        let bytes = serde_json::json!({ "version": 1, "url": "https://hub.tonk.xyz/join?x=1#s" })
+            .to_string()
+            .into_bytes();
+
+        let (url, audience, expires_at) = decode_guest_record(&subject, &bytes).unwrap();
+
+        assert_eq!(
+            url, "https://hub.tonk.xyz/join?x=1#s",
+            "the retained URL is what a legacy record still carries",
+        );
+        assert!(
+            audience.is_none() && expires_at.is_none(),
+            "a v1 record knows nothing about the live delegation, which is \
+             what makes it due for one refresh",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_a_v2_guest_record_with_its_delegation_metadata() {
+        let subject = subject().await;
+        let audience = Ed25519Signer::import(&[11u8; 32]).await.unwrap().did();
+        let bytes = serde_json::json!({
+            "version": GUEST_RECORD_VERSION,
+            "url": "https://hub.tonk.xyz/join?x=1#s",
+            "audience": audience.to_string(),
+            "expires_at": 1_700_000_000u64,
+        })
+        .to_string()
+        .into_bytes();
+
+        let decoded = decode_guest_record(&subject, &bytes).unwrap();
+
+        assert_eq!(
+            decoded,
+            (
+                "https://hub.tonk.xyz/join?x=1#s".to_string(),
+                Some(audience),
+                Some(1_700_000_000),
+            )
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_v2_guest_record_missing_its_metadata() {
+        let subject = subject().await;
+        for partial in [
+            serde_json::json!({
+                "version": GUEST_RECORD_VERSION,
+                "url": "https://hub.tonk.xyz/join",
+                "expires_at": 1_700_000_000u64,
+            }),
+            serde_json::json!({
+                "version": GUEST_RECORD_VERSION,
+                "url": "https://hub.tonk.xyz/join",
+                "audience": "did:key:z6MkeTG3bFFSLYVU7VqhgZxqr6YzpaGrQtFMh1uvqGy1vDnP",
+            }),
+        ] {
+            assert!(
+                decode_guest_record(&subject, partial.to_string().as_bytes()).is_err(),
+                "half the metadata says nothing about whether the stored \
+                 delegation is still usable, so it must not be read as if it did",
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_a_guest_record_from_an_unsupported_version() {
+        let subject = subject().await;
+        let bytes = serde_json::json!({ "version": 99, "url": "https://hub.tonk.xyz/join" })
+            .to_string()
+            .into_bytes();
+
+        assert!(
+            decode_guest_record(&subject, &bytes).is_err(),
+            "a record this build cannot read is corruption to report, not \
+             authority to guess at",
+        );
+    }
+}
+
+/// Drop the retained guest invite. Part of the durable commit, never a
+/// preflight write: until it runs, a promotion that fails still leaves
+/// the guest with working bounded access.
+async fn clear_guest(tonk: &TonkState, subject: &Did) -> Result<(), JoinFailure> {
+    tonk.profile
+        .credential()
+        .site(guest_site(subject))
+        .save(Vec::<u8>::new())
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("failed to clear the guest record: {error}"))
+        })
+}
+
+async fn guest_url(tonk: &TonkState, subject: &Did) -> Result<Option<String>, TonkWorkerError> {
+    Ok(guest_lease(tonk, subject).await?.map(|lease| lease.url))
 }
 
 /// Whether this replica is a guest visit rather than a durable member.
@@ -959,14 +1378,8 @@ async fn stage_join(tonk: &TonkState, prepared: PreparedJoin) -> Result<StagedJo
         // attempt gets its own bounded delegation and the real operator
         // only receives one once this stage has passed.
         None => {
-            prepared
-                .invite
-                .clone()
-                .visit(&staging.operator().did())
-                .await
-                .map_err(|error| {
-                    JoinFailure::claim_failed(format!("invite did not extend to a guest: {error}"))
-                })?
+            mint_guest_grant(prepared.invite.clone(), &staging.operator().did())
+                .await?
                 .chain
         }
     };
@@ -1142,7 +1555,7 @@ async fn commit_join(tonk: &TonkState, staged: StagedJoin) -> Result<JoinOutcome
         .await?;
     }
 
-    save_authority(tonk, &prepared, chain).await?;
+    let grant = save_authority(tonk, &prepared, chain).await?;
 
     if prepared.installs_replica() {
         record_initialized_replica_in_profile(tonk, &prepared.subject)
@@ -1153,7 +1566,19 @@ async fn commit_join(tonk: &TonkState, staged: StagedJoin) -> Result<JoinOutcome
     }
 
     match prepared.mode {
-        JoinMode::GuestVisit => save_guest(tonk, &prepared.subject, &prepared.url).await?,
+        JoinMode::GuestVisit => {
+            let grant = grant.ok_or_else(|| {
+                JoinFailure::claim_failed("a guest visit installed no bounded authority")
+            })?;
+            save_guest(
+                tonk,
+                &tonk.operator,
+                &prepared.subject,
+                &prepared.url,
+                &grant,
+            )
+            .await?;
+        }
         JoinMode::Durable => {
             if prepared.guest {
                 clear_guest(tonk, &prepared.subject).await?;
@@ -1192,27 +1617,27 @@ async fn commit_join(tonk: &TonkState, staged: StagedJoin) -> Result<JoinOutcome
 /// Idempotent at the dialog layer — re-saving the same chain is a no-op,
 /// re-saving an extended one adds a fresh proof. Either way the
 /// recipient's effective access can only grow, never shrink, by joining.
+///
+/// Returns the minted grant for a guest visit, so the caller writes a
+/// retained record that describes the chain actually installed rather
+/// than an independently recomputed one.
 async fn save_authority(
     tonk: &TonkState,
     prepared: &PreparedJoin,
     staged_chain: DelegationChain,
-) -> Result<(), JoinFailure> {
-    let chain = match prepared.mode {
-        JoinMode::Durable => staged_chain,
-        // The staged guest delegation is addressed to the staging
-        // operator and dies with it, so the durable one is minted here —
-        // after staging proved the invite is good for it.
+) -> Result<Option<GuestGrant>, JoinFailure> {
+    // The staged guest delegation is addressed to the staging operator
+    // and dies with it, so the durable one is minted here — after
+    // staging proved the invite is good for it.
+    let grant = match prepared.mode {
+        JoinMode::Durable => None,
         JoinMode::GuestVisit => {
-            prepared
-                .invite
-                .clone()
-                .visit(&tonk.operator.did())
-                .await
-                .map_err(|error| {
-                    JoinFailure::claim_failed(format!("guest authority did not mint: {error}"))
-                })?
-                .chain
+            Some(mint_guest_grant(prepared.invite.clone(), &tonk.operator.did()).await?)
         }
+    };
+    let chain = match &grant {
+        Some(grant) => grant.chain.clone(),
+        None => staged_chain,
     };
 
     let prefix_bytes = match prepared.mode {
@@ -1244,7 +1669,7 @@ async fn save_authority(
                 ))
             })?;
     }
-    Ok(())
+    Ok(grant)
 }
 
 /// Give the durable repository the staged revision, then publish it as the
@@ -2085,58 +2510,23 @@ mod tests {
     };
 
     /// Hand-craft an audience-open invite URL for a synthetic
-    /// repository subject. The subject signer doubles as root issuer.
-    /// Distinct tag bytes give distinct subjects/ephemerals. Returns
-    /// the URL plus the subject's routing key (the repo the join
-    /// mounts the claimer's replica under).
+    /// repository subject. Distinct tag bytes give distinct
+    /// subjects/ephemerals. Returns the URL plus the subject's routing
+    /// key (the repo the join mounts the claimer's replica under).
     async fn handcrafted_invite_url(subject_tag: u8, ephemeral_tag: u8) -> (String, String) {
-        open_invite_url(subject_tag, ephemeral_tag, None).await
+        crate::router::tests::open_invite_url(subject_tag, ephemeral_tag, None).await
     }
 
     /// The same open invite, but advertising an access service. The host
     /// does not exist, so any staged pull against it fails the way a
     /// remote outage does.
     async fn unreachable_invite_url(subject_tag: u8, ephemeral_tag: u8) -> (String, String) {
-        open_invite_url(
+        crate::router::tests::open_invite_url(
             subject_tag,
             ephemeral_tag,
             Some("https://sync.invalid.test/ucan/"),
         )
         .await
-    }
-
-    async fn open_invite_url(
-        subject_tag: u8,
-        ephemeral_tag: u8,
-        remote: Option<&str>,
-    ) -> (String, String) {
-        let subject_signer = Ed25519Signer::import(&[subject_tag; 32]).await.unwrap();
-        let subject = subject_signer.did();
-        let key = subject.repo_key().to_owned();
-        let ephemeral_seed = [ephemeral_tag; 32];
-        let ephemeral = Ed25519Signer::import(&ephemeral_seed).await.unwrap();
-        let delegation = DelegationBuilder::new()
-            .issuer(subject_signer)
-            .audience(&ephemeral.did())
-            .subject(UcanSubject::Specific(subject.clone()))
-            .command(vec![])
-            .try_build()
-            .await
-            .unwrap();
-        let chain = DelegationChain::new(delegation);
-        let invite = Invite::new(
-            chain,
-            InviteAudience::Open {
-                seed: ephemeral_seed,
-            },
-            remote.map(|url| url::Url::parse(url).unwrap()),
-        )
-        .await
-        .unwrap()
-        .with_revocation_url(
-            remote.map(|_| "https://relay.example.test/revocations/".parse().unwrap()),
-        );
-        (invite.to_url("https://hub.tonk.xyz/join").unwrap(), key)
     }
 
     /// Hand-craft an audience-scoped invite: only `audience` can redeem
@@ -3048,6 +3438,102 @@ mod tests {
         assert!(
             memberships.iter().any(|row| row.member.0 == root_entity),
             "a promoted guest is recorded by root DID",
+        );
+    }
+
+    /// Renewal decides whether a guest's authority is still good from the
+    /// retained record alone, so the record has to describe the chain that
+    /// was actually installed — the operator it names and the expiry the
+    /// chain really carries, not a separately recomputed `now + TTL`.
+    #[dialog_common::test]
+    async fn it_persists_the_guest_grants_actual_audience_and_expiry() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (url, key) = handcrafted_invite_url(74, 75).await;
+        assert_eq!(post_visit(&app, &url).await, StatusCode::CREATED);
+        let subject: dialog_varsig::Did = key.parse().unwrap();
+
+        let tonk = state.read().await;
+        let lease = super::guest_lease(&tonk, &subject)
+            .await
+            .expect("the guest record reads")
+            .expect("a visit retains one");
+
+        let bytes = super::guest_record_bytes(&tonk, &subject)
+            .await
+            .expect("the record is on disk");
+        let raw: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(raw["version"], serde_json::json!(2));
+
+        assert_eq!(
+            lease.audience.as_ref(),
+            Some(&tonk.operator.did()),
+            "the record must name the operator the chain was minted for, or \
+             renewal cannot tell a live delegation from a retired one",
+        );
+
+        let proof = tonk
+            .profile
+            .access()
+            .prove(dialog_capability::Subject::from(subject.clone()))
+            .audience(&tonk.operator)
+            .perform(&tonk.operator)
+            .await
+            .expect("the guest chain proves");
+        assert_eq!(
+            proof.duration.expiration, lease.expires_at,
+            "the recorded expiry is the chain's effective one",
+        );
+    }
+
+    /// The operator is shared by every mounted repository, so renewal
+    /// works on the whole guest set. Which means enumerating it has to
+    /// find exactly the guests: not the durable spaces beside them, and
+    /// not a replica whose guest site was cleared by promotion.
+    #[dialog_common::test]
+    async fn it_enumerates_only_repository_replicas_with_guest_records() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (first_url, first_key) = handcrafted_invite_url(76, 77).await;
+        let (second_url, second_key) = handcrafted_invite_url(78, 79).await;
+        let (durable_url, durable_key) = handcrafted_invite_url(80, 81).await;
+        assert_eq!(post_visit(&app, &first_url).await, StatusCode::CREATED);
+        assert_eq!(post_visit(&app, &second_url).await, StatusCode::CREATED);
+        assert_eq!(post_join(&app, &durable_url).await, StatusCode::CREATED);
+
+        let mut expected = vec![first_key.clone(), second_key.clone()];
+        expected.sort();
+
+        let leases = {
+            let tonk = state.read().await;
+            super::guest_leases(&tonk).await.expect("leases enumerate")
+        };
+        assert_eq!(
+            leases
+                .iter()
+                .map(|lease| lease.subject.to_string())
+                .collect::<Vec<_>>(),
+            expected,
+            "only the two guests, in subject order, and never the durable \
+             space or the profile and account replicas beside them",
+        );
+        assert!(
+            !expected.contains(&durable_key),
+            "the durable join is not a guest",
+        );
+
+        // Promotion clears the site by writing empty bytes, which has to
+        // read the same as never having visited.
+        assert_eq!(promote(&app, &first_key).await.0, StatusCode::OK);
+        let leases = {
+            let tonk = state.read().await;
+            super::guest_leases(&tonk).await.expect("leases enumerate")
+        };
+        assert_eq!(
+            leases
+                .iter()
+                .map(|lease| lease.subject.to_string())
+                .collect::<Vec<_>>(),
+            vec![second_key],
+            "a promoted replica must not be replayed as a guest",
         );
     }
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -5751,8 +5751,9 @@ mod tests {
         let key = put_repo(&app, "test-refuse-guest").await;
         attach_remote(&app, &key, "https://access.example.test/ucan/").await;
 
-        // Marked a guest through the writer the visit path itself uses, so the
-        // fixture states no opinion about how guest state is stored.
+        // Marked a guest through the record writer itself, so the fixture
+        // states no opinion about how guest state is stored beyond the
+        // metadata every retained record carries.
         {
             use dialog_repository::{Repository, RepositoryExt as _};
             let tonk = state.read().await;
@@ -5763,10 +5764,13 @@ mod tests {
                 .perform(&tonk.operator)
                 .await
                 .expect("repo loads");
-            crate::router::join::save_guest(
+            let audience = tonk.operator.did();
+            crate::router::join::store_guest_record(
                 &tonk,
                 &repository.did(),
                 "https://staging.example.test/join?access=fixture",
+                &audience,
+                crate::session::now() + 3600,
             )
             .await
             .expect("guest record stores");

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use ::axum::{Json, extract::Path, extract::State};
 use axum_wasm_macros::wasm_compat;
 use dialog_repository::{PublishError, PullError, Revision};
+use dialog_varsig::Did;
 use serde::Deserialize;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
@@ -24,6 +25,7 @@ pub use tonk_worker_api::{SyncResponse, SyncStatusResponse};
 use super::{AppState, BranchConfiguration};
 use crate::TonkWorkerError;
 use crate::broadcast::{Notification, broadcast};
+use crate::router::join::GuestLease;
 
 /// Announce on the branch's broadcast channel that its head may have
 /// moved, so subscribed UIs refresh their revision and sync-state
@@ -520,6 +522,11 @@ pub async fn pull(
         params.branch
     );
 
+    // Before the lock, because renewal takes one of its own — and before
+    // the presign below, because a worker that has just restarted holds
+    // guest chains addressed to an operator that no longer exists.
+    ensure_session_authority(&state).await?;
+
     let tonk_state = state.write().await;
 
     let session = tonk_state
@@ -599,6 +606,8 @@ pub async fn push(
         params.branch
     );
 
+    ensure_session_authority(&state).await?;
+
     let tonk_state = state.write().await;
 
     let session = tonk_state
@@ -654,6 +663,12 @@ pub async fn sync_status(
     State(state): State<AppState>,
     Path(params): Path<SyncPath>,
 ) -> Result<Json<SyncStatusResponse>, TonkWorkerError> {
+    // Renewal first: it takes the write lock, so it cannot run under the
+    // read lock this route then holds for its duration. The fetch below
+    // presigns, so a lapsed or restarted-worker credential has to be
+    // replaced before it, not by whichever drain happens to run next.
+    ensure_session_authority(&state).await?;
+
     // Read-only: status acquires a branch and does a remote fetch but never
     // mutates `TonkState`. A read lock lets concurrent queries proceed instead
     // of blocking on the (network-bound) status request.
@@ -836,6 +851,12 @@ pub async fn sync(
         )
         .await;
     }
+
+    // Everything above this point is local — an offline or paused branch
+    // returns without touching the network — so renewal waits until a
+    // remote operation is actually going to happen. It has to happen
+    // before the read lock below, which is held across both directions.
+    ensure_session_authority(&state).await?;
 
     // A READ lock, not a write lock. Pull/push reach the reactor and operator
     // by shared reference (the reactor owns its own interior locks for the
@@ -1087,7 +1108,13 @@ impl SyncQueue {
 pub async fn drain_sync(state: &AppState) {
     // Before anything presigns: the operator's delegation expires, and a
     // drain is the regular beat this worker has to notice that on.
-    renew_session(state).await;
+    // Best-effort here — a failed rotation must not take the drain down.
+    // The current session keeps working until it lapses, the remote
+    // boundaries below renew synchronously anyway, and the next drain
+    // tries again.
+    if let Err(error) = ensure_session_authority(state).await {
+        log!("session authority renewal failed, keeping the current one: {error}");
+    }
 
     // Dirty repos first (push priority), then repos owed a retry, then every
     // other open repo (pull).
@@ -1123,7 +1150,41 @@ pub async fn drain_sync(state: &AppState) {
     }
 }
 
-/// Rotate the signing session when its delegation is close to lapsing.
+/// How long before a guest delegation lapses it is replayed.
+///
+/// Much tighter than the session's own margin, because the two are
+/// bounded differently: a session lasts
+/// [`SESSION_TTL_SECONDS`](crate::session::SESSION_TTL_SECONDS) and can
+/// afford to rotate an hour early, while a guest hop is capped at
+/// [`VISIT_TTL_SECONDS`](tonk_invite::VISIT_TTL_SECONDS) — one hour
+/// total. An hour-wide margin there would mean every guest is due from
+/// the moment it is minted. Five minutes is wide enough to cover a sync
+/// that starts just under the wire and reaches the remote just over it.
+pub(crate) const GUEST_RENEWAL_MARGIN_SECONDS: u64 = 5 * 60;
+
+/// Whether the guest delegation `lease` describes has to be replayed
+/// before it is used again.
+///
+/// Three ways to be due, and the first two are not about the clock:
+///
+/// - Legacy metadata. A version 1 record kept only the URL, so nothing
+///   is known about the chain standing on it. Refresh once and it
+///   rewrites itself in the current shape.
+/// - A different audience. Every worker restart derives a new operator,
+///   and a guest chain is addressed to the operator it was minted for.
+///   A record naming any other one describes a chain that can no longer
+///   be proved to, whatever its recorded expiry says.
+/// - Inside the margin, inclusive of the boundary.
+pub(crate) fn guest_needs_renewal(lease: &GuestLease, current_audience: &Did, now: u64) -> bool {
+    let (Some(audience), Some(expires_at)) = (&lease.audience, lease.expires_at) else {
+        return true;
+    };
+    audience != current_audience || now.saturating_add(GUEST_RENEWAL_MARGIN_SECONDS) >= expires_at
+}
+
+/// Make sure every credential this worker is about to sign with is still
+/// good, rotating the operator and replaying every guest invite onto it
+/// when anything is due.
 ///
 /// Rotation replaces the operator key, not just its delegation: the
 /// certificate store is content-addressed with no delete, and its chain
@@ -1131,46 +1192,106 @@ pub async fn drain_sync(state: &AppState) {
 /// the same audience would sit beside the lapsed one and be chosen about
 /// half the time. A new key means a new audience and no ambiguity.
 ///
+/// That is also why one guest coming due rotates for all of them. The
+/// operator is shared by every mounted repository, so a new audience
+/// orphans every guest chain at once, and the only safe rotation is the
+/// one that re-mints the whole set. Durable spaces need no replay: they
+/// reach the operator through `space -> root -> device -> operator`,
+/// whose last hop `session::open` re-mints anyway.
+///
 /// The replacement is built over the state's existing storage pool, so
 /// every repository and branch handle the reactor has cached stays
 /// valid — the operator changes, the spaces underneath do not.
 ///
-/// Best-effort. Minting is local (a key derivation and a self-signed
-/// delegation, no network), but a failure here must not take the drain
-/// down: the current session keeps working until it lapses, and the next
-/// drain tries again.
-async fn renew_session(state: &AppState) {
-    let (profile, storage, expires_at) = {
+/// Order matters at the end: every replacement chain is retained first,
+/// every record is written second, and only then does the state adopt
+/// the new operator. A failure anywhere leaves the current operator and
+/// the current records exactly as they were — the chains retained for an
+/// audience nothing points at are inert, and a record still naming the
+/// previous operator reads as due on the next attempt.
+pub(crate) async fn ensure_session_authority(state: &AppState) -> Result<(), TonkWorkerError> {
+    let now = crate::session::now();
+    let (profile, storage, expires_at, audience, leases) = {
         let tonk = state.read().await;
-        if !crate::session::needs_renewal(tonk.session_expires_at, crate::session::now()) {
-            return;
-        }
         (
             tonk.profile.clone(),
             tonk.storage.clone(),
             tonk.session_expires_at,
+            tonk.operator.did(),
+            crate::router::join::guest_leases(&tonk).await?,
         )
     };
 
+    if !crate::session::needs_renewal(expires_at, now)
+        && !any_guest_renewable(&leases, &audience, now).await?
+    {
+        return Ok(());
+    }
+
     // Mint outside the lock — nothing else may proceed while a write
     // lock is held, and this signs.
-    let session = match crate::session::open(&profile, &storage).await {
-        Ok(session) => session,
-        Err(error) => {
-            log!("signing session rotation failed, keeping the current one: {error}");
-            return;
-        }
-    };
+    let session = crate::session::open(&profile, &storage).await?;
 
     let mut tonk = state.write().await;
     // A concurrent drain may have rotated while this one was minting.
     // Theirs is no worse than ours, and adopting both would retire a
     // session that requests are already presenting.
     if tonk.session_expires_at != expires_at {
-        return;
+        return Ok(());
     }
+
+    // Re-read under the exclusive lock: a visit that committed after the
+    // check above holds a chain for the operator we are about to retire,
+    // and would silently lose its access if the batch were built from
+    // the earlier snapshot.
+    let leases = crate::router::join::guest_leases(&tonk).await?;
+    let candidate = session.operator.did();
+    let mut grants = Vec::with_capacity(leases.len());
+    for lease in &leases {
+        let Some(invite) = crate::router::join::renewable_invite(lease, now).await? else {
+            continue;
+        };
+        grants.push((
+            lease,
+            crate::router::join::mint_guest_grant(invite, &candidate).await?,
+        ));
+    }
+
+    for (_, grant) in &grants {
+        crate::router::join::retain_guest_grant(&tonk, &tonk.operator, grant).await?;
+    }
+    for (lease, grant) in &grants {
+        crate::router::join::save_guest(&tonk, &tonk.operator, &lease.subject, &lease.url, grant)
+            .await?;
+    }
+
     tonk.operator = session.operator;
     tonk.session_expires_at = session.expires_at;
+    Ok(())
+}
+
+/// Whether any guest is both due and still replayable.
+///
+/// Being due is not enough on its own: a guest whose invite has itself
+/// expired can never be renewed, and rotating for it would only produce
+/// another dead chain — on every sync boundary, forever, since the
+/// record would stay inside the margin. So the decision to rotate needs
+/// the invite, not just the record.
+async fn any_guest_renewable(
+    leases: &[GuestLease],
+    audience: &Did,
+    now: u64,
+) -> Result<bool, TonkWorkerError> {
+    for lease in leases {
+        if guest_needs_renewal(lease, audience, now)
+            && crate::router::join::renewable_invite(lease, now)
+                .await?
+                .is_some()
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// `POST /api/sync` — an external sync poke.
@@ -1393,6 +1514,86 @@ mod tests {
         );
     }
 
+    /// A synthetic lease. The subject is irrelevant to the predicate —
+    /// only the recorded audience and expiry decide whether the chain
+    /// standing on it is still usable.
+    async fn lease(audience: Option<&Did>, expires_at: Option<u64>) -> GuestLease {
+        GuestLease {
+            subject: signer(&[3u8; 32]).await,
+            url: "https://hub.tonk.xyz/join?access=x#seed".to_string(),
+            audience: audience.cloned(),
+            expires_at,
+        }
+    }
+
+    async fn signer(seed: &[u8; 32]) -> Did {
+        use dialog_credentials::ed25519::Ed25519Signer;
+        use dialog_varsig::Principal as _;
+        Ed25519Signer::import(seed).await.unwrap().did()
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_a_guest_outside_the_five_minute_margin() {
+        let operator = signer(&[1u8; 32]).await;
+        let expires_at = 1_000_000;
+        let lease = lease(Some(&operator), Some(expires_at)).await;
+
+        assert!(!guest_needs_renewal(
+            &lease,
+            &operator,
+            expires_at - GUEST_RENEWAL_MARGIN_SECONDS - 1
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_renews_a_guest_inside_the_margin() {
+        let operator = signer(&[1u8; 32]).await;
+        let expires_at = 1_000_000;
+        let lease = lease(Some(&operator), Some(expires_at)).await;
+
+        assert!(
+            guest_needs_renewal(&lease, &operator, expires_at - GUEST_RENEWAL_MARGIN_SECONDS),
+            "the boundary is inclusive: a guest exactly one margin out is due",
+        );
+        assert!(
+            guest_needs_renewal(&lease, &operator, expires_at + 1),
+            "a lapsed guest must replay rather than keep presenting a dead chain",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_renews_legacy_guest_metadata() {
+        let operator = signer(&[1u8; 32]).await;
+
+        assert!(
+            guest_needs_renewal(&lease(None, None).await, &operator, 0),
+            "a v1 record says nothing about the live delegation, so it is \
+             due once and rewrites itself in the current shape",
+        );
+        assert!(
+            guest_needs_renewal(&lease(Some(&operator), None).await, &operator, 0),
+            "half the metadata is no better than none",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_renews_an_audience_mismatch_after_worker_restart() {
+        let recorded = signer(&[1u8; 32]).await;
+        let current = signer(&[2u8; 32]).await;
+        let expires_at = 1_000_000;
+        let lease = lease(Some(&recorded), Some(expires_at)).await;
+
+        assert!(
+            guest_needs_renewal(
+                &lease,
+                &current,
+                expires_at - GUEST_RENEWAL_MARGIN_SECONDS * 10
+            ),
+            "a restart derives a new operator, and a chain addressed to the \
+             old one cannot be proved to however long it has left",
+        );
+    }
+
     // `forget` is service-worker scoped (wasm-gated), so this one is too.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     #[dialog_common::test]
@@ -1461,6 +1662,293 @@ mod overlay_tests {
             rows[0].did.0,
             tonk.profile.did().this(),
             "did must match the profile DID for the sigil",
+        );
+    }
+}
+
+/// Renewal tests — wasm-only, because they need real credential storage
+/// and a real certificate store to rotate against.
+///
+/// None of them sleep. A guest hop lasts an hour, so waiting for one to
+/// approach its margin is not a test; instead the stored metadata is
+/// rewritten into the margin, which is exactly the state renewal reads.
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod renewal_tests {
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    use dialog_varsig::Did;
+
+    use super::{GUEST_RENEWAL_MARGIN_SECONDS, ensure_session_authority};
+    use crate::router::AppState;
+    use crate::router::join::{guest_lease, guest_record_bytes, store_guest_record};
+    use crate::router::{
+        api_router_with_state,
+        tests::{join_invite_url, open_invite_url, test_state, visit_invite},
+    };
+
+    /// Visit an open invite and return the subject it mounted.
+    async fn guest(app: &axum::Router, subject_tag: u8, ephemeral_tag: u8) -> Did {
+        let (url, key) = open_invite_url(subject_tag, ephemeral_tag, None).await;
+        assert_eq!(
+            visit_invite(app, &url).await,
+            axum::http::StatusCode::CREATED
+        );
+        key.parse().expect("the routing key is the subject DID")
+    }
+
+    async fn operator_did(state: &AppState) -> Did {
+        state.read().await.operator.did()
+    }
+
+    /// Move a guest's recorded expiry into the renewal margin, leaving
+    /// its retained URL and audience alone.
+    async fn expire_into_margin(state: &AppState, subject: &Did) -> u64 {
+        let tonk = state.write().await;
+        let lease = guest_lease(&tonk, subject)
+            .await
+            .expect("the record reads")
+            .expect("a visit retains one");
+        let due_at = crate::session::now() + GUEST_RENEWAL_MARGIN_SECONDS - 1;
+        store_guest_record(
+            &tonk,
+            subject,
+            &lease.url,
+            &lease.audience.expect("a fresh record names its audience"),
+            due_at,
+        )
+        .await
+        .expect("the record rewrites");
+        due_at
+    }
+
+    /// Whether the worker can currently prove `subject` to its own
+    /// operator — the walk every presign runs — and what bounds it.
+    async fn proof_expiry(state: &AppState, subject: &Did) -> Option<u64> {
+        let tonk = state.read().await;
+        tonk.profile
+            .access()
+            .prove(dialog_capability::Subject::from(subject.clone()))
+            .audience(&tonk.operator)
+            .perform(&tonk.operator)
+            .await
+            .expect("the subject must still be provable")
+            .duration
+            .expiration
+    }
+
+    #[dialog_common::test]
+    async fn it_rotates_and_rebinds_a_guest_before_expiry() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let subject = guest(&app, 130, 131).await;
+        let before = operator_did(&state).await;
+        let due_at = expire_into_margin(&state, &subject).await;
+
+        ensure_session_authority(&state)
+            .await
+            .expect("renewal runs");
+
+        let after = operator_did(&state).await;
+        assert_ne!(
+            before, after,
+            "a replacement guest chain needs its own audience, or the store \
+             keeps the lapsed one beside it and proves either one",
+        );
+
+        let lease = {
+            let tonk = state.read().await;
+            guest_lease(&tonk, &subject)
+                .await
+                .expect("the record reads")
+                .expect("the guest is still a guest")
+        };
+        assert_eq!(
+            lease.audience.as_ref(),
+            Some(&after),
+            "the record must follow the operator it was replayed onto",
+        );
+        assert!(
+            lease.expires_at.expect("v2 metadata") > due_at,
+            "renewal is only renewal if the expiry actually moves out",
+        );
+        assert_eq!(
+            proof_expiry(&state, &subject).await,
+            lease.expires_at,
+            "the chain the presign walk finds is the one the record describes",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rebinds_a_fresh_guest_after_operator_restart() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let subject = guest(&app, 132, 133).await;
+        let recorded = {
+            let tonk = state.read().await;
+            guest_lease(&tonk, &subject)
+                .await
+                .unwrap()
+                .unwrap()
+                .expires_at
+                .unwrap()
+        };
+
+        // What a service-worker restart leaves behind: a new operator
+        // over the same profile and storage, and a guest record still
+        // naming the old one with an hour left on it.
+        let restarted = {
+            let mut tonk = state.write().await;
+            let session = crate::session::open(&tonk.profile, &tonk.storage)
+                .await
+                .expect("a replacement session opens");
+            let did = session.operator.did();
+            tonk.operator = session.operator;
+            tonk.session_expires_at = session.expires_at;
+            did
+        };
+        assert!(
+            recorded > crate::session::now() + GUEST_RENEWAL_MARGIN_SECONDS,
+            "the recorded expiry is deliberately far away, so only the \
+             audience mismatch can be what forces the replay",
+        );
+
+        ensure_session_authority(&state)
+            .await
+            .expect("renewal runs");
+
+        let after = operator_did(&state).await;
+        assert_ne!(restarted, after, "the mismatch forces a rotation");
+        let lease = {
+            let tonk = state.read().await;
+            guest_lease(&tonk, &subject).await.unwrap().unwrap()
+        };
+        assert_eq!(lease.audience.as_ref(), Some(&after));
+        assert_eq!(proof_expiry(&state, &subject).await, lease.expires_at);
+    }
+
+    #[dialog_common::test]
+    async fn it_rebinds_every_guest_when_one_guest_forces_rotation() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let first = guest(&app, 134, 135).await;
+        let second = guest(&app, 136, 137).await;
+        let (durable_url, durable_key) = open_invite_url(138, 139, None).await;
+        assert_eq!(
+            join_invite_url(&app, &durable_url).await,
+            axum::http::StatusCode::CREATED
+        );
+        let durable: Did = durable_key.parse().unwrap();
+
+        // Only the first guest is due. The operator is shared, so the
+        // rotation it forces has to carry the second one with it.
+        expire_into_margin(&state, &first).await;
+        let before = operator_did(&state).await;
+
+        ensure_session_authority(&state)
+            .await
+            .expect("renewal runs");
+
+        let after = operator_did(&state).await;
+        assert_ne!(before, after);
+        for subject in [&first, &second] {
+            let lease = {
+                let tonk = state.read().await;
+                guest_lease(&tonk, subject).await.unwrap().unwrap()
+            };
+            assert_eq!(
+                lease.audience.as_ref(),
+                Some(&after),
+                "a guest that was not itself due still loses its chain to the \
+                 rotation, so it has to be replayed too",
+            );
+            assert_eq!(proof_expiry(&state, subject).await, lease.expires_at);
+        }
+        assert!(
+            proof_expiry(&state, &durable).await.is_some(),
+            "a durable space reaches the new operator through the re-minted \
+             session hop, so it must survive the rotation as well",
+        );
+
+        // One rotation for the whole set, not one per guest.
+        let settled = operator_did(&state).await;
+        ensure_session_authority(&state)
+            .await
+            .expect("a settled set renews nothing");
+        assert_eq!(
+            settled,
+            operator_did(&state).await,
+            "with every guest rebound there is nothing left to be due for",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_rotate_a_healthy_operator_or_guest() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let subject = guest(&app, 140, 141).await;
+        let before = operator_did(&state).await;
+        let bytes = {
+            let tonk = state.read().await;
+            guest_record_bytes(&tonk, &subject).await.unwrap()
+        };
+
+        ensure_session_authority(&state).await.unwrap();
+        ensure_session_authority(&state).await.unwrap();
+
+        assert_eq!(
+            before,
+            operator_did(&state).await,
+            "a session and a guest both well inside their margins must not \
+             churn the operator on every sync boundary",
+        );
+        let tonk = state.read().await;
+        assert_eq!(
+            guest_record_bytes(&tonk, &subject).await.unwrap(),
+            bytes,
+            "and nothing about the retained record is rewritten",
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_the_current_operator_when_guest_replay_fails() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let subject = guest(&app, 142, 143).await;
+
+        // Local corruption: a record that no longer holds an invite. It
+        // is due, so renewal has to try it, and it cannot succeed.
+        {
+            let tonk = state.write().await;
+            let audience = tonk.operator.did();
+            store_guest_record(
+                &tonk,
+                &subject,
+                "not-an-invite",
+                &audience,
+                crate::session::now() + GUEST_RENEWAL_MARGIN_SECONDS - 1,
+            )
+            .await
+            .expect("the record rewrites");
+        }
+        let (before, expires_at, bytes) = {
+            let tonk = state.read().await;
+            (
+                tonk.operator.did(),
+                tonk.session_expires_at,
+                guest_record_bytes(&tonk, &subject).await.unwrap(),
+            )
+        };
+
+        let result = ensure_session_authority(&state).await;
+
+        assert!(
+            result.is_err(),
+            "a guest that cannot be replayed is reported, not skipped past \
+             into a rotation that would strand it",
+        );
+        let tonk = state.read().await;
+        assert_eq!(tonk.operator.did(), before, "the operator is untouched");
+        assert_eq!(tonk.session_expires_at, expires_at);
+        assert_eq!(
+            guest_record_bytes(&tonk, &subject).await.unwrap(),
+            bytes,
+            "the malformed record is preserved for diagnosis, not deleted",
         );
     }
 }


### PR DESCRIPTION
## Problem

An accountless guest holds one hour of bounded authority (`Invite::visit`, capped at `VISIT_TTL_SECONDS`) and no way to get more. Two failures follow from that:

- The delegation lapses and the next remote operation presents a dead credential.
- A service-worker restart derives a new operator, orphaning every guest chain addressed to the previous one — whatever time those chains had left.

Either way the access service is right to refuse, and the guest is stranded until someone hands them a fresh link.

## Approach

Renew rather than extend. The retained open-invite URL is the renewable authority; each guest hop stays capped at one hour, so no individual delegation gets weaker.

Before any remote operation presigns (`pull`, `push`, `sync`, `sync_status`, and the sync drain), `ensure_session_authority` checks the signing session and every retained guest record. When anything is due it rotates the operator **once** and replays every still-valid guest invite onto it:

1. retain every replacement chain,
2. write every record,
3. then swap `tonk.operator`.

A failure at any point leaves the previous operator and every record exactly as they were. Chains retained for an audience nothing points at are inert, and a record still naming the old operator reads as due on the next attempt.

One guest coming due rotates for all of them: the operator is shared by every mounted repository, so a new audience orphans the whole set at once. Durable spaces need no replay — their last hop is the `profile -> operator` session delegation the rotation re-mints anyway.

Guest records gain the two facts that decide whether replaying is due — which operator the live chain is addressed to, and when it lapses. Version 1 records read as metadata-unknown, which forces one refresh that rewrites them in the current shape.

## Two judgement calls worth review

**A dead invite does not trigger rotation.** A guest whose *parent invite* has already expired would otherwise sit permanently inside the renewal margin and ask for a rotation on every sync boundary, forever, each one minting another dead chain. `join::renewable_invite` parses the retained URL and declines when the invite's own effective expiry has passed, so rotation is only triggered by a guest that replaying could actually help.

**A corrupt guest record blocks rotation entirely**, including the session's own. That is what the spec called for and what `it_keeps_the_current_operator_when_guest_replay_fails` asserts, but the blast radius is worth naming: one unparseable record stops every space from rotating until it is cleared. The alternative — skipping it — would silently strand that guest instead. Happy to trade the other way if reviewers prefer.

## Scope

No account-service request, account attachment, new root, permanent guest grant, invite-URL change, wire-format change, or `Cargo.lock` change. Expiry and revocation stay enforced remotely on the next ordinary call; explicit promotion remains the only path to durable membership.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo test -p tonk-invite` | 20/20, incl. the unchanged one-hour bound test |
| `cargo test -p tonk-worker --lib` | 79/79 |
| `cargo test -p tonk-access-service --features helpers expiry` | 5/5 |
| `test:web:debug` | 1268/1268, 1 skipped |
| `nix flake check 'path:.'` | pass |

11 new tests. Five are renewal integration tests in a service worker: rotate-and-rebind before expiry, rebind after an operator restart, rebind every guest when one forces rotation, no rotation when everything is healthy, and preserve state when replay fails. None of them sleep — expiry is driven by writing stored metadata directly, since waiting out a one-hour hop is not a test.

Plan: `plan/guest-session-renewal.md`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing renewable guest sessions for accountless guests, ensuring their remote operations remain authorized without compromising existing delegation limits.

### Detailed summary
- Updated guest record structure to include `audience` and `expires_at`.
- Implemented `ensure_session_authority` to renew guest sessions before remote operations.
- Added functions for minting, retaining, and saving guest grants.
- Enhanced tests for guest session renewal and authority checks.
- Improved documentation on guest authority and session management.

> The following files were skipped due to too many changes: `rust/tonk-worker/src/router/join.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->