### PR TITLE
fix(cli): restart a handoff the service will not reissue

### DIFF
--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -127,6 +127,12 @@ requires a fresh browser/passkey handoff; switching accounts is logout followed
 by link. Historical certificates remain available for local spot writes, but
 only the latest active attachment can authorize a remote request.
 
+Interrupting `tonk account link` leaves the handoff recorded so the next run
+resumes it. A link token is one-time, so a service that refuses to reissue it
+has ended that handoff and not this profile's ability to link: the next run
+takes the completed grant if the browser approved in the meantime, and
+otherwise prints a fresh URL rather than re-offering a spent token.
+
 `tonk account logout` commits locally first, so it works offline. Existing
 spots remain readable and editable, while fetch, pull, push, account sync, and
 other access-service requests are denied before HTTP. Logout queues a

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -547,31 +547,80 @@ pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcom
         }
         None => options.service_url.trim_end_matches('/').to_string(),
     };
+    if target_provider != options.service_url.trim_end_matches('/') {
+        bail!("a pending account handoff belongs to another provider; log out to cancel it");
+    }
     clear_detach_for(profile, &operator, &target_provider, options.abandon_detach).await?;
     let device_did = profile.did().to_string();
     let client = reqwest::Client::new();
-    let (service_url, secret, token_hash, activating) = match state.pending_login {
+    let (service_url, secret, token_hash, activating, recovered) = match state.pending_login {
         Some(crate::account_session::PendingLogin::Waiting {
             provider,
             secret,
             token_hash,
         }) => {
-            create_remote(
+            match create_remote(
                 &client,
                 &provider,
                 &token_hash,
                 &device_did,
                 &options.device_name,
             )
-            .await?;
-            (provider, secret, token_hash, None)
+            .await
+            {
+                Ok(()) => (provider, secret, token_hash, None, None),
+                // A waiting handoff holds no grant material, and its token
+                // is one-time: a service that refuses to recreate it —
+                // because that token was already spent, expired, or the
+                // service never made creation idempotent — has ended that
+                // handoff, not this profile's ability to link. Take the
+                // completed material if the browser got there first;
+                // otherwise start a fresh handoff, so a cancelled attempt
+                // never strands the profile on a secret no later attempt
+                // can revive.
+                Err(error) => match consume_once(&client, &provider, &secret).await {
+                    Ok(Some(consumed)) => (provider, secret, token_hash, None, Some(consumed)),
+                    _ => {
+                        eprintln!(
+                            "warning: could not resume the pending handoff ({error:#}); \
+                             starting a new one"
+                        );
+                        let (secret, token_hash) = new_secret();
+                        crate::account_session::begin_login(
+                            profile,
+                            &operator,
+                            crate::account_session::PendingLogin::Waiting {
+                                provider: provider.clone(),
+                                secret: secret.clone(),
+                                token_hash: token_hash.clone(),
+                            },
+                        )
+                        .await?;
+                        create_remote(
+                            &client,
+                            &provider,
+                            &token_hash,
+                            &device_did,
+                            &options.device_name,
+                        )
+                        .await?;
+                        (provider, secret, token_hash, None, None)
+                    }
+                },
+            }
         }
         Some(crate::account_session::PendingLogin::Activating {
             secret, account, ..
         }) => {
             let secret_bytes = hex::decode(&secret).context("pending link secret is invalid")?;
             let token_hash = blake3::hash(&secret_bytes).to_hex().to_string();
-            (account.provider.clone(), secret, token_hash, Some(account))
+            (
+                account.provider.clone(),
+                secret,
+                token_hash,
+                Some(account),
+                None,
+            )
         }
         None => {
             let (secret, token_hash) = new_secret();
@@ -598,17 +647,16 @@ pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcom
                 secret,
                 token_hash,
                 None,
+                None,
             )
         }
     };
-    if service_url.trim_end_matches('/') != options.service_url.trim_end_matches('/') {
-        bail!("a pending account handoff belongs to another provider; log out to cancel it");
-    }
     let url = handoff_url(&options.account_url, &secret);
-    if activating.is_none() {
+    let awaits_approval = activating.is_none() && recovered.is_none();
+    if awaits_approval {
         println!("Open this URL to approve the device:\n{url}");
     }
-    if activating.is_none() && options.open_browser && webbrowser::open(&url).is_err() {
+    if awaits_approval && options.open_browser && webbrowser::open(&url).is_err() {
         eprintln!("Could not open a browser; use the URL above.");
     }
 
@@ -620,7 +668,9 @@ pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcom
 
     let mut delay = Duration::from_millis(500);
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5 * 60);
-    let consumed = if activating.is_some() {
+    let consumed = if recovered.is_some() {
+        recovered
+    } else if activating.is_some() {
         None
     } else {
         Some(loop {

--- a/rust/tonk-cli/src/account_session.rs
+++ b/rust/tonk-cli/src/account_session.rs
@@ -302,6 +302,16 @@ pub async fn begin_login(
     let allowed = match (&state.pending_login, &pending) {
         (None, PendingLogin::Waiting { .. }) => true,
         (Some(existing), candidate) if existing == candidate => true,
+        // Replacing one waiting handoff with another at the same provider
+        // strands nothing: a waiting handoff holds no grant material, only a
+        // one-time secret the service may already have retired.
+        (
+            Some(PendingLogin::Waiting {
+                provider: old_provider,
+                ..
+            }),
+            PendingLogin::Waiting { provider, .. },
+        ) => old_provider == provider,
         (
             Some(PendingLogin::Waiting {
                 provider: old_provider,

--- a/rust/tonk-cli/tests/account_interrupt.rs
+++ b/rust/tonk-cli/tests/account_interrupt.rs
@@ -2,7 +2,7 @@
 
 #![cfg(unix)]
 
-use std::io::{Read as _, Write as _};
+use std::io::{BufRead as _, Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::mpsc;
@@ -14,7 +14,7 @@ fn binary() -> std::path::PathBuf {
         .unwrap_or_else(|| env!("CARGO_BIN_EXE_tonk").into())
 }
 
-fn read_path(stream: &mut TcpStream) -> String {
+fn read_request(stream: &mut TcpStream) -> (String, String) {
     let mut request = Vec::new();
     let mut buffer = [0u8; 4096];
     loop {
@@ -33,14 +33,20 @@ fn read_path(stream: &mut TcpStream) -> String {
             })
             .unwrap_or(0);
         if request.len() >= headers_end + 4 + content_length {
-            return headers
+            let path = headers
                 .lines()
                 .next()
                 .and_then(|line| line.split_whitespace().nth(1))
                 .expect("request path")
                 .to_string();
+            let body = String::from_utf8_lossy(&request[headers_end + 4..]).into_owned();
+            return (path, body);
         }
     }
+}
+
+fn read_path(stream: &mut TcpStream) -> String {
+    read_request(stream).0
 }
 
 fn pending_link_server() -> (String, mpsc::Receiver<()>) {
@@ -75,6 +81,146 @@ fn pending_link_server() -> (String, mpsc::Receiver<()>) {
     (endpoint, pending_rx)
 }
 
+/// A service that treats a link token the way a real one does: `tokenHash`
+/// is created once and every repeat is a conflict. Reports each accepted
+/// creation and each consume poll so a test can act at a known point.
+fn single_use_link_server() -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind account service");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("account service address")
+    );
+    let (events_tx, events_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut issued: Vec<String> = Vec::new();
+        for incoming in listener.incoming() {
+            let Ok(mut stream) = incoming else { return };
+            let (path, body) = read_request(&mut stream);
+            let field = |name: &str| {
+                serde_json::from_str::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|value| value[name].as_str().map(str::to_string))
+                    .unwrap_or_default()
+            };
+            let (status, payload) = match path.as_str() {
+                "/links" => {
+                    let token = field("tokenHash");
+                    if issued.contains(&token) {
+                        (
+                            "409 Conflict",
+                            r#"{"error":{"code":"CONFLICT","message":"conflicts with existing state"}}"#,
+                        )
+                    } else {
+                        issued.push(token.clone());
+                        let _ = events_tx.send(format!("create {token}"));
+                        ("201 Created", "{}")
+                    }
+                }
+                "/links/consume" => {
+                    let _ = events_tx.send(format!("consume {}", field("secret")));
+                    ("202 Accepted", r#"{"pending":true}"#)
+                }
+                other => panic!("unexpected account-service request {other}"),
+            };
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{payload}",
+                payload.len()
+            )
+            .expect("write response");
+            stream.flush().expect("flush response");
+        }
+    });
+    (endpoint, events_rx)
+}
+
+fn spawn_link(home: &std::path::Path, service_url: &str) -> Child {
+    Command::new(binary())
+        .args([
+            "account",
+            "link",
+            "--no-open",
+            "--service-url",
+            service_url,
+            "--account-url",
+            "http://127.0.0.1/account/link",
+        ])
+        .current_dir(home)
+        .env("HOME", home)
+        .env("XDG_DATA_HOME", home.join("data"))
+        .env("TONK_SPOTS_STATE", home.join("spots"))
+        .env("TONK_TELEMETRY_STATE", home.join("telemetry"))
+        .env("TONK_UPDATE_STATE", home.join("update"))
+        .env("TONK_NO_UPDATE_CHECK", "1")
+        .env("DO_NOT_TRACK", "1")
+        .env("NO_PROXY", "127.0.0.1,localhost")
+        .env_remove("TONK_TELEMETRY")
+        .env_remove("TONK_SPOT")
+        .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start tonk account link")
+}
+
+/// The handoff URL the command prints, without blocking the test forever if
+/// it never gets one.
+fn handoff_url(child: &mut Child) -> String {
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (url_tx, url_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout).lines() {
+            let Ok(line) = line else { return };
+            if line.starts_with("http") {
+                let _ = url_tx.send(line);
+                return;
+            }
+        }
+    });
+    url_rx
+        .recv_timeout(Duration::from_secs(30))
+        .expect("account link prints a handoff URL")
+}
+
+fn wait_for_event(events: &mpsc::Receiver<String>, expected: &str) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or_default();
+        let event = events
+            .recv_timeout(remaining)
+            .unwrap_or_else(|_| panic!("account service never saw {expected}"));
+        if event == expected {
+            return;
+        }
+    }
+}
+
+/// SIGINT a command already inside its poll wait and return its stderr.
+fn interrupt(child: &mut Child) -> String {
+    let signal = Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status()
+        .expect("send SIGINT");
+    assert!(signal.success(), "kill -INT failed with {signal}");
+    let status = wait_for_exit(child, Duration::from_secs(5)).unwrap_or_else(|| {
+        child.kill().expect("kill stuck tonk process");
+        child.wait().expect("reap stuck tonk process");
+        panic!("tonk account link stayed alive after SIGINT");
+    });
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("piped stderr")
+        .read_to_string(&mut stderr)
+        .expect("read stderr");
+    assert_eq!(status.code(), Some(4), "stderr: {stderr}");
+    stderr
+}
+
 fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
     let deadline = Instant::now() + timeout;
     loop {
@@ -92,32 +238,7 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
 fn account_link_can_be_interrupted_during_poll_backoff() {
     let temp = tempfile::tempdir().expect("temporary profile");
     let (service_url, pending) = pending_link_server();
-    let mut child = Command::new(binary())
-        .args([
-            "account",
-            "link",
-            "--no-open",
-            "--service-url",
-            &service_url,
-            "--account-url",
-            "http://127.0.0.1/account/link",
-        ])
-        .current_dir(temp.path())
-        .env("HOME", temp.path())
-        .env("XDG_DATA_HOME", temp.path().join("data"))
-        .env("TONK_SPOTS_STATE", temp.path().join("spots"))
-        .env("TONK_TELEMETRY_STATE", temp.path().join("telemetry"))
-        .env("TONK_UPDATE_STATE", temp.path().join("update"))
-        .env("TONK_NO_UPDATE_CHECK", "1")
-        .env("DO_NOT_TRACK", "1")
-        .env("NO_PROXY", "127.0.0.1,localhost")
-        .env_remove("TONK_TELEMETRY")
-        .env_remove("TONK_SPOT")
-        .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT")
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("start tonk account link");
+    let mut child = spawn_link(temp.path(), &service_url);
 
     pending
         .recv_timeout(Duration::from_secs(10))
@@ -125,27 +246,42 @@ fn account_link_can_be_interrupted_during_poll_backoff() {
     // The command starts a 500 ms backoff after receiving the pending
     // response. Place SIGINT inside that gap rather than racing the response.
     std::thread::sleep(Duration::from_millis(100));
-    let signal = Command::new("kill")
-        .args(["-INT", &child.id().to_string()])
-        .status()
-        .expect("send SIGINT");
-    assert!(signal.success(), "kill -INT failed with {signal}");
+    let stderr = interrupt(&mut child);
 
-    let Some(status) = wait_for_exit(&mut child, Duration::from_secs(2)) else {
-        child.kill().expect("kill stuck tonk process");
-        child.wait().expect("reap stuck tonk process");
-        panic!("tonk account link stayed alive after SIGINT during poll backoff");
-    };
-    let mut stderr = String::new();
-    child
-        .stderr
-        .take()
-        .expect("piped stderr")
-        .read_to_string(&mut stderr)
-        .expect("read stderr");
-    assert_eq!(status.code(), Some(4), "stderr: {stderr}");
     assert!(
         stderr.contains("account link cancelled"),
+        "stderr: {stderr}"
+    );
+}
+
+/// A cancelled handoff leaves its one-time token spent at the service. The
+/// next attempt must start a fresh handoff rather than re-offering a token
+/// the service will never accept again, which otherwise leaves the profile
+/// unable to link at all until it logs out.
+#[test]
+fn account_link_restarts_a_handoff_the_service_will_not_recreate() {
+    let temp = tempfile::tempdir().expect("temporary profile");
+    let (service_url, events) = single_use_link_server();
+
+    let mut first = spawn_link(temp.path(), &service_url);
+    let first_url = handoff_url(&mut first);
+    let first_secret = first_url.rsplit('#').next().expect("handoff secret");
+    // SIGINT only counts once the command is inside its poll wait; before
+    // that Tokio has not installed a handler and the default action applies.
+    wait_for_event(&events, &format!("consume {first_secret}"));
+    std::thread::sleep(Duration::from_millis(100));
+    interrupt(&mut first);
+
+    let mut second = spawn_link(temp.path(), &service_url);
+    let second_url = handoff_url(&mut second);
+    let second_secret = second_url.rsplit('#').next().expect("handoff secret");
+    wait_for_event(&events, &format!("consume {second_secret}"));
+    std::thread::sleep(Duration::from_millis(100));
+    let stderr = interrupt(&mut second);
+
+    assert_ne!(first_url, second_url);
+    assert!(
+        stderr.contains("could not resume the pending handoff"),
         "stderr: {stderr}"
     );
 }

--- a/rust/tonk-ui/src/account.css
+++ b/rust/tonk-ui/src/account.css
@@ -149,6 +149,25 @@ tonk-account {
     gap: 12px;
 }
 
+/* A bare `<button>` shrinks to fit while a block `<a>` fills the line, so the
+   two controls only line up once they share an explicit grid track. */
+.account__actions--inline {
+    grid-auto-flow: column;
+    align-items: center;
+    justify-content: start;
+    column-gap: 20px;
+    margin-top: 20px;
+}
+
+.account__actions--inline .account__button {
+    min-width: 208px;
+}
+
+.account__actions--inline .account__button--quiet {
+    min-width: 0;
+    justify-self: start;
+}
+
 .account__eyebrow {
     margin: 0 0 18px;
     color: var(--account-muted);
@@ -158,31 +177,40 @@ tonk-account {
     text-transform: uppercase;
 }
 
+/* Label and value share one pair of gridlines across every row, flush with the
+   panel edges, so the block reads as a table rather than a stack of cards. */
 .account__device {
     display: grid;
-    gap: 1px;
-    margin: 0 0 16px;
-    background: var(--account-divider);
+    grid-template-columns: minmax(0, 150px) minmax(0, 1fr);
+    margin: 0;
+    border-block: 1px solid var(--account-divider);
 }
 
-.account__device div {
+.account__device > div {
     display: grid;
-    gap: 6px;
-    padding: 13px 14px;
-    background: var(--account-field);
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    align-items: baseline;
+    column-gap: 24px;
+    padding: 14px 0;
+}
+
+.account__device > div + div {
+    border-top: 1px solid var(--account-divider);
 }
 
 .account__device dt {
     color: var(--account-muted);
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
 }
 
 .account__device dd {
+    min-height: 1.45em;
     margin: 0;
     overflow-wrap: anywhere;
     font-family: "IBM Plex Mono", ui-monospace, monospace;
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.45;
 }
 
@@ -487,6 +515,24 @@ tonk-account {
 
     .account__facts > div + div {
         border-top: 1px solid var(--account-divider);
+    }
+
+    .account__device {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .account__device > div {
+        row-gap: 5px;
+        padding: 12px 0;
+    }
+
+    .account__actions--inline {
+        grid-auto-flow: row;
+        row-gap: 4px;
+    }
+
+    .account__actions--inline .account__button {
+        min-width: 0;
     }
 
     .account__device-row,

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -56,13 +56,15 @@
 
   <section id="account-handoff" class="account__panel" hidden>
     <p class="account__eyebrow">Link a command-line profile</p>
-    <dl class="account__device">
+    <dl class="account__device" aria-label="Command-line profile details">
       <div><dt>Device</dt><dd id="account-handoff-name"></dd></div>
       <div><dt>Profile DID</dt><dd id="account-handoff-did"></dd></div>
     </dl>
     <p class="account__hint">Only continue if you started this link from your own terminal.</p>
-    <button id="account-handoff-submit" class="account__button" type="button">Approve with passkey</button>
-    <a class="account__button account__button--quiet" href="/account">Cancel</a>
+    <div class="account__actions account__actions--inline">
+      <button id="account-handoff-submit" class="account__button" type="button">Approve with passkey</button>
+      <a class="account__button account__button--quiet" href="/account">Cancel</a>
+    </div>
   </section>
 
   <section id="account-setup" class="account__panel" hidden>


### PR DESCRIPTION
Cancelling `tonk account link` and running it again failed for good:

```
$ tonk account link --service-url https://accounts-staging.tonk.xyz …
Open this URL to approve the device:
https://staging.tonk.xyz/account/link#f98b24c7…
^Cerror: account link cancelled

$ tonk account link --service-url https://accounts-staging.tonk.xyz …
error: account service rejected the link request (409 Conflict):
{"error":{"code":"CONFLICT","message":"conflicts with existing state"}}
```

Only `tonk account logout` cleared it.

## Why it locks

A cancelled handoff stays recorded so the next run can resume it, and that
resume re-offers the same one-time token. A service is entitled to refuse the
token — it was spent, it expired past `LINK_TTL_SECONDS`, or that deployment
predates the idempotent create in #680 — and `link` treated the refusal as
fatal. Every later attempt sent the same dead token, so the profile could not
link at all.

Reproduced against `accounts-staging.tonk.xyz` before #690 deployed:
`POST /links` with one `tokenHash` answered `201` and then `409`. The
deployed service was months behind, which is what made a latent CLI
assumption into a dead end. That gap is closed separately; this is the CLI
half, and it holds against any service version.

## What changes

- A refused create ends that handoff, not the profile's ability to link.
  Consume the old secret first, in case the browser approved while the CLI
  was away, and otherwise warn, mint a fresh secret, and print its URL.
- Replacing one waiting handoff with another at the same provider is now an
  allowed session transition; a waiting handoff holds no grant material.
- The provider-mismatch refusal moves ahead of the first remote call, so a
  handoff belonging to another provider is rejected before this command
  touches the service.

Also included: `fix(account): align the cli link panel to a grid`, laying the
handoff panel's device facts on shared gridlines via subgrid so the panel has
one left edge and both controls share a baseline.

## Verification

`cargo test -p tonk-cli --lib` — 136 pass. `--test account_interrupt` — 2
pass, including a new process-level regression driving two real `tonk account
link` runs against a stub that rejects a repeated `tokenHash`; it fails
without the fix (`account link prints a handoff URL: Disconnected`). `clippy
--all-targets --all-features` and `fmt --check` clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of account linking and handoff processes in the `tonk` CLI and UI, enhancing user experience during interruptions and ensuring proper management of one-time tokens.

### Detailed summary
- Updated `PendingLogin` handling in `account_session.rs` to manage waiting handoffs better.
- Improved documentation in `README.md` for account linking behavior.
- Enhanced UI elements in `account.html` for clearer actions during linking.
- Refined CSS in `account.css` for better layout and alignment of buttons.
- Modified tests in `account_interrupt.rs` to validate behavior during interruptions and handoff restarts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->