### PR TITLE
feat(ui): browser multi-account: one profile per account, switched in place

### DIFF
--- a/plan/multi-account-browser.md
+++ b/plan/multi-account-browser.md
@@ -1,0 +1,126 @@
+# Browser multi-account support implementation plan
+
+**Goal:** Let several accounts be signed in on one browser concurrently, with an account switcher, where each account sees only its own spaces and the hidden profile/account repositories (display name, future preferences) follow the active account. Remove the confusion where account A's spaces remain visible and syncable after signing into account B.
+
+**Approach:** Profile-per-account. Everything that should swap per account is already scoped to the worker profile: the replica index that is the space list, the `tonk-local-root-v1` record, the `tonk-account-provider-v1` attachment, the trusted-base marker, the hidden account-repository mount and its `AccountKeys` hiding, the `tonk-space-root-v1/*` escrow prefixes, the profile display name, and the UCAN certificate store. So instead of adding an account dimension to any of those, give each account its own profile and make switching repoint the existing active-profile pointer (`tonk-active-profile-v1` on the fixed registry profile, `rust/tonk-worker/src/device.rs`). The dormant `device::rotate` machinery becomes the seed of "add account". Isolation then falls out of existing structure rather than being patched leak by leak: the certificate store, restore inventory, and space list can never cross accounts because they never leave their profile.
+
+A switcher menu needs to know about profiles it has not opened, so a small roster record lives beside the pointer on the registry profile and is maintained by the worker at the moments it already has the facts in hand (boot, link, unlink, rename, switch).
+
+**Scope:** Browser only — `rust/tonk-worker`, `rust/tonk-worker-api`, `rust/tonk-ui`. No CLI changes and no account-service changes in this pass (follow-ups listed at the end).
+
+**Verified constraints that shape the design:**
+
+- A page reload does not restart the service worker. `rust/tonk-ui/assets/service_worker.js` memoizes the wasm worker (`tonkServiceWorkerResolves`), and `TonkServiceWorker::new` (`rust/tonk-worker/src/worker.rs:1676`) runs once per SW process. Switching must therefore rebuild `TonkState` in place — swap the value inside the `Arc<RwLock<TonkState>>` returned by `api_router_with_state` — and also write the pointer so a genuine SW restart boots the same profile.
+- `validate_grant` (`rust/tonk-worker/src/router/identity.rs:44-59`) requires the root delegation's audience to equal the current profile DID. A ceremony run against profile A can never be persisted into profile B, so "add account" must rotate to the fresh profile first and then run the unchanged sign-in ceremony there.
+- Device DID equals profile DID, and the account service enforces one active attachment per device DID globally (`devices_one_active_did`). Distinct profiles are distinct devices, so concurrent attachments from one browser do not collide, and switching needs no server interaction at all.
+- `main@profile:tonk` (`rust/tonk-host/src/location.rs`) routes to whatever profile the worker opened; the name is a compatibility literal. The Hub directory view, the FAB space switcher, and every sealed profile view follow the active profile with zero changes.
+- `Profile::open` is open-or-create, so an activation endpoint must validate the requested name against the roster before opening — an unvalidated name would silently mint a garbage key.
+- Existing installs must grandfather in without migration: the current (possibly mixed) profile becomes one roster entry, bound to whatever account it is attached to, or listed as a local workspace if signed out. Local (never-signed-in) workspaces remain first-class switcher entries.
+
+## Profile roster
+
+New credential site on the registry profile, sibling of `ACTIVE_PROFILE_SITE` in `rust/tonk-worker/src/device.rs`:
+
+```rust
+const PROFILE_ROSTER_SITE: &str = "tonk-profile-roster-v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RosterEntry {
+    pub profile_name: String,
+    pub root_did: Option<String>,   // None => local workspace
+    pub provider: Option<String>,
+    pub email: Option<String>,      // best-effort, may lag
+    pub display_name: Option<String>,
+    pub last_active_at: u64,        // unix seconds
+}
+```
+
+Stored as JSON-serialized `Vec<RosterEntry>`. Chosen over deriving the menu by opening every profile at render time, which would cost key-material load, IDB open, and credential reads per profile per render; the roster is one credential load, and every event that changes an entry already runs in the worker. Registry-profile credential writes are performed directly against storage exactly as `Registry::rotate` already does, so they work regardless of which profile is active — that is what makes the endpoint ordering below safe.
+
+Staleness policy: the active profile's entry is refreshed inline by `GET /api/profiles` from live state (`resolve_display_name`, `local_root`, `provider` are cheap per-profile reads). Inactive entries are as-of their profile's last activation; a display name renamed on another device converges the next time that account's profile is activated. Documented and accepted.
+
+`Registry` (currently a private struct) becomes pub(crate) with a handle stored on `TonkState` (`registry: device::Registry`) — the worker constructs `Registry::device()`, router tests construct the existing `scratch()` pattern so they neither collide with each other nor touch the real profile store. New methods: `set_active`, `read_roster`, `upsert_roster`, `remove_from_roster`.
+
+Grandfathering is the boot-time upsert: on every worker boot the active profile's entry is written best-effort (inside the existing detached catch-up task in `TonkServiceWorker::new`), so existing installs self-populate. `rotate` has zero callers today, so no dormant pre-existing profiles need back-filling.
+
+## Worker endpoints
+
+New module `rust/tonk-worker/src/router/profiles.rs`, wired in `router.rs` next to the `/api/profile` block. DTOs in `rust/tonk-worker-api/src/profiles.rs` (`ProfileRosterEntry` camelCase mirror plus `active: bool`; `ProfilesResponse { active, profiles }`; `ActivateProfileRequest { profile }`), exported from lib.rs with the crate's serde round-trip tests. Pattern to copy: `rust/tonk-worker-api/src/account.rs`.
+
+- `GET /api/profiles` — roster plus which entry is active, active entry refreshed from live state before returning.
+- `POST /api/profiles/activate` — validate the name is `REGISTRY_PROFILE` or a roster member, then:
+  1. build the replacement `TonkState` for the target profile without holding the state write lock, via a factored-out `boot_state` (see below);
+  2. `registry.set_active` — only after the target opened successfully, so a failed open never repoints;
+  3. `*state.write().await = new_state`;
+  4. upsert the entry's `last_active_at` and respond with `ProfilesResponse`.
+  After the swap, spawn the same detached `ensure_account_state` + `restore_spaces` catch-up the boot path runs. `restore_spaces`'s process-global in-flight guard needs no change. The calling tab reloads itself after the response.
+- `POST /api/profiles/add` — rotate to a fresh profile via `registry.rotate` and swap with the same machinery. Abandoned-add reuse guard: if the current profile has no persisted local root (`identity::load_record` returns `None`) and no user-space replicas (`profile_name::real_space_keys` empty), it is already a fresh landing pad — return it unchanged instead of minting another orphan key.
+- `DELETE /api/profiles/{name}` (polish) — roster-only removal: refuses the active profile with `Conflict`, removes the entry, leaves the `{name}.profile` database and any space databases untouched. No server-side detach.
+
+Boot refactor in `rust/tonk-worker/src/worker.rs`: extract `boot_state(...) -> Result<TonkState, _>` from `TonkServiceWorker::new` steps 2–4 (open active profile, `session::open`, `Reactor::new` + `TonkState` construction, `bootstrap_profile`) so boot and activation share one path.
+
+Roster maintenance hooks: small best-effort `upsert_roster` calls in `link`, `unlink`, and `establish_repository` (`rust/tonk-worker/src/router/account.rs`) and in the `rename_display_name` path (`rust/tonk-worker/src/router/account_state.rs`). Email is captured best-effort during `link` via the existing devices/summary fetch.
+
+## Login, add-account, and sign-out rules
+
+Worker-enforced rule for persisting a ceremony's root (`persist_root`, `rust/tonk-worker/src/router/identity.rs`):
+
+- No persisted local root — link in place. Covers the grandfathered first sign-in of an existing local profile and every fresh profile minted by add-account.
+- Same root as the persisted record — idempotent re-sign-in in place. `root_needs_persist` (`rust/tonk-ui/src/account.rs:664`) already skips the save; `persist_root`'s equal-record early return keeps it idempotent.
+- Different root — `Conflict`, with error text directing to add-account. This restores the guard that commit 697c86cb5 relaxed, narrowing the relaxation to same-root record updates. It lands in the same change as the UI add-account flow, which replaces the relaxation's only purpose (switching accounts by re-login), so there is no intermediate regression.
+
+Sign-out stays per-profile and non-destructive: `unlink` continues to zero the provider record and keep root, data, and certificates. Its roster upsert clears the entry's account fields so the row renders as a local workspace; the persisted local-root record stays on the profile, so "sign back in" still short-circuits in place. The existing confirm copy ("your spots stay here") remains accurate. With a switcher, switching becomes the common path and sign-out the rare one.
+
+If a "sign back in" ceremony nevertheless returns a different root — the passkey assertion is a discoverable-credential picker with no `allowCredentials`, so the browser chooses — the worker's `Conflict` surfaces and the UI error offers the add-account action.
+
+## Switcher UI
+
+Account panel only in this pass (no FAB changes), in the existing `<tonk-account>` custom-element style (`rust/tonk-ui/src/account.rs`, `account.html`, `account.css`). Account routes already bypass the sealed portal because WebAuthn must run top-level.
+
+- `account.html`: a profiles section inside `#account-success` above sign-out, with `#account-profile-list` and an `#account-add-profile` "Add account" button. A compact list on `#account-choice` shows the other roster entries plus a "Use a different account" affordance.
+- `account.rs`: `render_profiles(host, &ProfilesResponse)` in the DOM-building style of `render_devices`; rows carry `data-activate="{profile_name}"`, the active row is marked and inert. Click delegation like the existing `data-revoke` listener: `api::activate_profile(name)` then `location.reload()`. "Add account" / "Use a different account": `api::add_account_profile()` then reload — the fresh profile lands on the normal Choice flow and the entire existing create/link ceremony code runs there unchanged.
+- Which-account-am-I: the active roster entry's email/display name renders in the success masthead (the panel already shows `#account-email-value`); the active marker in the list covers the rest.
+- `rust/tonk-ui/src/api.rs` wrappers in the shape of `unlink_account`: `list_profiles`, `activate_profile`, `add_account_profile`, and later `remove_profile`.
+
+## Cross-profile residue
+
+- **Shared space storage.** A space's IndexedDB/OPFS name is exactly its routing key, with no profile prefix, so two profiles replicating one space share its storage. The space-removal flow's best-effort `delete_space_storage` (`rust/tonk-worker/src/router/repository.rs`) run in one profile would break another profile's replica. Proportional guard now: before deleting storage, skip the deletion (still removing the replica rows) whenever the roster has more than one entry, with a log line. The failure mode is leaked storage, never data loss — blocks are re-fetchable for sync-enabled spaces. A precise guard that consults the other profiles' indexes is deferred.
+- **`tonk:auto-sync:{repo}` localStorage** is keyed by routing key only and therefore shared across profiles. Accepted: per-account space sets are disjoint except deliberately shared spaces, where a shared pause preference is defensible; namespacing would orphan existing preferences.
+- **sessionStorage pending intent** is per-tab and strays are already discarded by `load_status`; the add-account reload arrives with no `next`. No change.
+- **Multi-tab.** Other open tabs keep talking to the swapped worker and render the new profile's data until reloaded. The switching tab reloads itself; broadcasting a reload to sibling clients is a listed follow-up.
+
+## Delivery order
+
+Three stacked changes, smallest first:
+
+1. **Worker roster and switch plumbing.** `device.rs` roster (`RosterEntry`, registry methods, pub(crate) `Registry` with the handle on `TonkState`); `boot_state` extraction and boot-time roster upsert; `rust/tonk-worker-api/src/profiles.rs` DTOs; `GET /api/profiles` and `POST /api/profiles/activate`; roster maintenance hooks in link/unlink/establish/rename; the coarse `delete_space_storage` guard.
+2. **Add-account flow and switcher UI.** `POST /api/profiles/add` with the reuse guard; `persist_root` tightening (replacing `it_replaces_the_local_root_after_signing_out`); `api.rs` wrappers; `account.html`/`account.rs`/`account.css` switcher rendering, activate/add handlers, and the Choice-panel routing.
+3. **Polish (optional).** `DELETE /api/profiles/{name}` plus a "Remove from this browser" row action; roster email backfill on boot; sibling-tab reload broadcast if cheap.
+
+## Tests
+
+Named `it_does_x`; worker and UI suites are wasm-gated (darwin needs Chrome plus a major-matched chromedriver).
+
+Worker:
+- device.rs — `it_reads_an_empty_roster_before_any_entry_is_written`, `it_upserts_a_roster_entry_by_profile_name`.
+- profiles.rs — `it_lists_the_active_profile_with_its_account_state` (via the existing `attach_test_account` helper), `it_refuses_to_activate_a_profile_the_roster_does_not_name`, `it_serves_the_other_profiles_spaces_after_activation` (create a space, add a profile, the swapped state lists none, switching back restores it), `it_repoints_the_active_pointer_only_after_the_target_profile_opens`, `it_rotates_to_a_fresh_profile_for_add_account`, `it_reuses_an_unattached_empty_profile_instead_of_rotating_again`, and later `it_refuses_to_remove_the_active_profile_from_the_roster`.
+- account.rs — `it_marks_the_profile_local_in_the_roster_after_unlink`.
+- identity.rs — `it_rejects_a_different_root_on_a_previously_linked_profile`.
+
+UI:
+- account.rs — extend `it_authors_a_single_signed_in_dashboard` selectors with `#account-profile-list` and `#account-add-profile`; `it_renders_local_and_account_roster_rows`; `it_marks_the_active_profile_row_inert`; `it_offers_a_different_account_from_the_choice_panel_when_a_root_is_persisted`.
+- account_flow.rs integration, with a second virtual authenticator — `it_adds_a_second_account_and_switches_between_disjoint_space_lists`: sign up A, create a space, add account, sign up B, assert B's hub lacks A's space, switch back to A, assert it returns.
+
+## Verification
+
+- `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --all --check` (the repo lint gate; `profiles.rs` must compile natively via the wasm_compat pattern).
+- The wasm worker and UI test suites per the repo testing setup.
+- Manual: serve the UI; sign in as A and create a space; add account and sign up B; the switcher shows both entries and each hub shows only its own spaces; the hidden display name follows each account; sign out B and its row turns local; switch to A and its spaces and name return; hard-restart the service worker (close all tabs or update) and it boots into the profile the pointer names.
+
+## Deferred follow-ups
+
+- Server-side detach on sign-out or remove-from-browser. The browser has no detach path at all today (the CLI queues a `SignedDetachIntent`); the stale active attachment row on the account service is pre-existing behavior, made harmless for switching by per-profile device DIDs.
+- The precise shared-space storage guard (per-profile index consultation before `delete_space_storage`), and profile-data deletion on remove-from-browser (the `{name}.profile` database and orphaned space databases stay).
+- Sibling-tab refresh broadcast after a switch.
+- FAB switcher entry point; per-profile namespacing of `tonk:auto-sync:*`; any preferences UI.
+- CLI multi-account: grow `AccountSessionState` to multiple accounts with an active pointer, associate spot entries with an account, and filter listing/reconciliation by the active account — leaning on the already-account-keyed `tonk-space-root-v2/{subject}/{root}` prefixes.

--- a/rust/tonk-ui/src/account.css
+++ b/rust/tonk-ui/src/account.css
@@ -372,7 +372,8 @@ tonk-account {
     margin-bottom: 18px;
 }
 
-.account__devices {
+.account__devices,
+.account__profiles {
     display: grid;
     margin: 0;
     padding: 0;
@@ -380,7 +381,8 @@ tonk-account {
     list-style: none;
 }
 
-.account__device-row {
+.account__device-row,
+.account__profile-row {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
@@ -389,21 +391,24 @@ tonk-account {
     border-bottom: 1px solid var(--account-divider);
 }
 
-.account__device-identity {
+.account__device-identity,
+.account__profile-identity {
     display: flex;
     min-width: 0;
     align-items: center;
     gap: 10px;
 }
 
-.account__device-name {
+.account__device-name,
+.account__profile-name {
     overflow: hidden;
     font-weight: 600;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.account__device-current {
+.account__device-current,
+.account__profile-current {
     flex: none;
     padding: 3px 8px;
     background: var(--account-field);
@@ -413,7 +418,8 @@ tonk-account {
     letter-spacing: 0.02em;
 }
 
-.account__device-meta {
+.account__device-meta,
+.account__profile-meta {
     grid-column: 1;
     min-width: 0;
     margin-top: 4px;
@@ -423,9 +429,22 @@ tonk-account {
     text-wrap: pretty;
 }
 
-.account__device-row .account__button--remove {
+.account__device-row .account__button--remove,
+.account__profile-row .account__button--switch {
     grid-column: 2;
     grid-row: 1 / span 2;
+}
+
+.account__profiles-section .account__button--compact {
+    margin-top: 16px;
+}
+
+.account__choice-profiles {
+    margin-top: 20px;
+}
+
+#account-use-different-account {
+    margin-top: 12px;
 }
 
 .account__signout {
@@ -490,12 +509,14 @@ tonk-account {
     }
 
     .account__device-row,
+    .account__profile-row,
     .account__signout {
         grid-template-columns: minmax(0, 1fr);
         gap: 8px;
     }
 
-    .account__device-row .account__button--remove {
+    .account__device-row .account__button--remove,
+    .account__profile-row .account__button--switch {
         grid-column: 1;
         grid-row: auto;
     }

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -15,6 +15,11 @@
       <button id="account-choose-create" class="account__button" type="button">Create account</button>
       <button id="account-choose-link" class="account__button account__button--secondary" type="button">Log in</button>
     </div>
+    <button id="account-use-different-account" class="account__button account__button--quiet" type="button" hidden>Use a different account</button>
+    <div id="account-choice-profiles" class="account__choice-profiles" hidden>
+      <p class="account__hint">Also on this browser:</p>
+      <ul id="account-choice-profile-list" class="account__profiles"></ul>
+    </div>
   </section>
 
   <section id="account-create" class="account__panel" hidden>
@@ -104,6 +109,15 @@
         <p>These devices can open and sync your Tonk spots. Remove any device you no longer use or recognise.</p>
       </div>
       <ul id="account-device-list" class="account__devices"></ul>
+    </section>
+
+    <section class="account__section account__profiles-section" aria-labelledby="account-profiles-title">
+      <div class="account__section-heading">
+        <h2 id="account-profiles-title">Accounts on this browser</h2>
+        <p>Each account keeps its own spots. Switching swaps which one this browser shows.</p>
+      </div>
+      <ul id="account-profile-list" class="account__profiles"></ul>
+      <button id="account-add-profile" class="account__button account__button--secondary account__button--compact" type="button">Add account</button>
     </section>
 
     <section class="account__signout" aria-labelledby="account-signout-title">

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -146,6 +146,8 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-handoff-submit",
         "#account-setup-submit",
         "#account-unlink",
+        "#account-add-profile",
+        "#account-use-different-account",
     ] {
         if let Ok(Some(button)) = host.query_selector(selector)
             && let Ok(button) = button.dyn_into::<HtmlButtonElement>()
@@ -186,6 +188,7 @@ fn show_success(host: &HtmlElement) {
     set_mode(host, "success");
     load_summary(host.clone());
     load_devices(host.clone());
+    load_profiles(host.clone());
 }
 
 fn set_text(host: &HtmlElement, selector: &str, value: &str) {
@@ -364,6 +367,160 @@ fn render_devices(host: &HtmlElement, devices: &[tonk_worker_api::AccountDevice]
     }
 }
 
+/// What a switcher row is titled: the roster's display name, else the
+/// profile's storage name — never blank.
+fn profile_row_label(entry: &tonk_worker_api::ProfileRosterEntry) -> String {
+    entry
+        .display_name
+        .clone()
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| entry.profile_name.clone())
+}
+
+/// Render roster rows into `list_selector`. The active row is marked and
+/// inert; every other row carries a Switch button with
+/// `data-activate="{profile_name}"` for the shared click delegation.
+/// `others_only` drops the active row entirely — the Choice panel's
+/// compact list describes the profiles the user could go to, not the
+/// fresh one they are on.
+fn render_profile_rows(
+    host: &HtmlElement,
+    list_selector: &str,
+    profiles: &tonk_worker_api::ProfilesResponse,
+    others_only: bool,
+) {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    let Ok(Some(list)) = host.query_selector(list_selector) else {
+        return;
+    };
+    list.set_inner_html("");
+    for entry in &profiles.profiles {
+        if others_only && entry.active {
+            continue;
+        }
+        let Ok(item) = document.create_element("li") else {
+            continue;
+        };
+        let _ = item.set_attribute("class", "account__profile-row");
+        if entry.active {
+            let _ = item.set_attribute("data-active", "true");
+        }
+
+        let Ok(identity) = document.create_element("div") else {
+            continue;
+        };
+        let _ = identity.set_attribute("class", "account__profile-identity");
+        let Ok(name) = document.create_element("span") else {
+            continue;
+        };
+        let _ = name.set_attribute("class", "account__profile-name");
+        let label = profile_row_label(entry);
+        name.set_text_content(Some(&label));
+        let _ = identity.append_child(&name);
+        if entry.active {
+            let Ok(marker) = document.create_element("span") else {
+                continue;
+            };
+            let _ = marker.set_attribute("class", "account__profile-current");
+            marker.set_text_content(Some("Current"));
+            let _ = identity.append_child(&marker);
+        }
+
+        let Ok(meta) = document.create_element("span") else {
+            continue;
+        };
+        let _ = meta.set_attribute("class", "account__profile-meta");
+        meta.set_text_content(Some(match &entry.email {
+            Some(email) => email,
+            None if entry.provider.is_some() => "Signed in",
+            None => "Local workspace",
+        }));
+
+        let _ = item.append_child(&identity);
+        let _ = item.append_child(&meta);
+
+        if !entry.active {
+            let Ok(button) = document.create_element("button") else {
+                continue;
+            };
+            let _ = button.set_attribute("type", "button");
+            let _ = button.set_attribute("class", "account__button account__button--switch");
+            let _ = button.set_attribute("data-activate", &entry.profile_name);
+            let _ = button.set_attribute("aria-label", &format!("Switch to {label}"));
+            button.set_text_content(Some("Switch"));
+            let _ = item.append_child(&button);
+        }
+        let _ = list.append_child(&item);
+    }
+}
+
+/// Fill the signed-in dashboard's switcher section.
+fn render_profiles(host: &HtmlElement, profiles: &tonk_worker_api::ProfilesResponse) {
+    render_profile_rows(host, "#account-profile-list", profiles, false);
+}
+
+/// Fill the Choice panel's compact switcher: the other roster entries,
+/// plus the "Use a different account" affordance when this profile has a
+/// persisted root — logging in here with another passkey would be
+/// refused, so the way to another account is a fresh profile.
+fn render_choice_profiles(
+    host: &HtmlElement,
+    profiles: &tonk_worker_api::ProfilesResponse,
+    root_persisted: bool,
+) {
+    render_profile_rows(host, "#account-choice-profile-list", profiles, true);
+    let has_others = profiles.profiles.iter().any(|entry| !entry.active);
+    if let Ok(Some(section)) = host.query_selector("#account-choice-profiles") {
+        if has_others {
+            let _ = section.remove_attribute("hidden");
+        } else {
+            let _ = section.set_attribute("hidden", "");
+        }
+    }
+    if let Ok(Some(button)) = host.query_selector("#account-use-different-account") {
+        if root_persisted {
+            let _ = button.remove_attribute("hidden");
+        } else {
+            let _ = button.set_attribute("hidden", "");
+        }
+    }
+}
+
+fn load_profiles(host: HtmlElement) {
+    spawn_local(async move {
+        match crate::api::list_profiles().await {
+            Ok(profiles) => render_profiles(&host, &profiles),
+            Err(error) => {
+                web_sys::console::warn_1(&format!("profile roster unavailable: {error}").into());
+            }
+        }
+    });
+}
+
+fn load_choice_profiles(host: HtmlElement, root_persisted: bool) {
+    spawn_local(async move {
+        match crate::api::list_profiles().await {
+            Ok(profiles) => render_choice_profiles(&host, &profiles, root_persisted),
+            Err(error) => {
+                web_sys::console::warn_1(&format!("profile roster unavailable: {error}").into());
+            }
+        }
+    });
+}
+
+/// Reload so every surface re-renders the profile the worker now serves.
+fn reload_into_switched_profile(host: &HtmlElement) {
+    match window().map(|window| window.location().reload()) {
+        Some(Ok(())) => {}
+        _ => {
+            set_busy(host, false, "");
+            load_status(host.clone());
+        }
+    }
+}
+
 fn revocation_status(
     acknowledgement: &RevokeDeviceAcknowledgement,
     self_revoke: bool,
@@ -533,6 +690,10 @@ fn load_status(host: HtmlElement) {
         }
         match crate::api::account_status().await {
             Ok(status) => {
+                // A persisted root with no provider is a signed-out
+                // profile: logging in here with a DIFFERENT passkey is
+                // refused, so the Choice panel offers a fresh profile.
+                let root_persisted = matches!(status, AccountStatus::Unregistered { .. });
                 let account_state = match status {
                     AccountStatus::Registered { account_state, .. } => Some(account_state),
                     AccountStatus::RootMissing { .. } | AccountStatus::Unregistered { .. } => None,
@@ -555,6 +716,7 @@ fn load_status(host: HtmlElement) {
                     Landing::Choice { revoke_hint } => {
                         set_busy(&host, false, "");
                         set_mode(&host, "choice");
+                        load_choice_profiles(host.clone(), root_persisted);
                         if revoke_hint {
                             show_error(
                                 &host,
@@ -1116,6 +1278,60 @@ fn bind(host: &HtmlElement) {
         });
     });
 
+    // "Add account" (dashboard) and "Use a different account" (Choice)
+    // are the same move: rotate onto a fresh profile and land on the
+    // normal sign-in flow there, leaving this profile intact.
+    for selector in ["#account-add-profile", "#account-use-different-account"] {
+        on_click(host, selector, |host| {
+            clear_error(&host);
+            set_busy(&host, true, "Preparing another sign-in…");
+            spawn_local(async move {
+                match crate::api::add_account_profile().await {
+                    Ok(_) => reload_into_switched_profile(&host),
+                    Err(error) => {
+                        set_busy(&host, false, "");
+                        show_error(&host, error.to_string());
+                    }
+                }
+            });
+        });
+    }
+
+    // Switch rows are re-rendered wholesale, so both lists get one
+    // delegated listener keyed off `data-activate` — the same pattern
+    // the device list uses for `data-revoke`.
+    for selector in ["#account-profile-list", "#account-choice-profile-list"] {
+        let Ok(Some(list)) = host.query_selector(selector) else {
+            continue;
+        };
+        let host_for_switch = host.clone();
+        let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let Some(target) = event
+                .target()
+                .and_then(|target| target.dyn_into::<web_sys::Element>().ok())
+            else {
+                return;
+            };
+            let Some(profile) = target.get_attribute("data-activate") else {
+                return;
+            };
+            let host = host_for_switch.clone();
+            clear_error(&host);
+            set_busy(&host, true, "Switching account…");
+            spawn_local(async move {
+                match crate::api::activate_profile(profile).await {
+                    Ok(_) => reload_into_switched_profile(&host),
+                    Err(error) => {
+                        set_busy(&host, false, "");
+                        show_error(&host, error.to_string());
+                    }
+                }
+            });
+        });
+        let _ = list.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref());
+        closure.forget();
+    }
+
     if let Ok(Some(list)) = host.query_selector("#account-device-list") {
         let host_for_revoke = host.clone();
         let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
@@ -1517,6 +1733,8 @@ mod tests {
             "#account-email-value",
             "#account-passkey-created-value",
             "#account-passkey-device-value",
+            "#account-profile-list",
+            "#account-add-profile",
             ".account__passkey",
             ".account__signout",
         ] {
@@ -1551,6 +1769,125 @@ mod tests {
         assert!(
             host.query_selector("#account-devices").unwrap().is_none(),
             "the signed-in dashboard should be the only device-management surface"
+        );
+    }
+
+    fn roster_fixture() -> tonk_worker_api::ProfilesResponse {
+        tonk_worker_api::ProfilesResponse {
+            active: "tonk".into(),
+            profiles: vec![
+                tonk_worker_api::ProfileRosterEntry {
+                    profile_name: "tonk".into(),
+                    root_did: Some("did:key:zRootA".into()),
+                    provider: Some("https://accounts.example".into()),
+                    email: Some("person@example.com".into()),
+                    display_name: Some("Alice".into()),
+                    last_active_at: 1_754_380_800,
+                    active: true,
+                },
+                tonk_worker_api::ProfileRosterEntry {
+                    profile_name: "tonk-0a12".into(),
+                    root_did: None,
+                    provider: None,
+                    email: None,
+                    display_name: Some("brave-otter".into()),
+                    last_active_at: 1_754_000_000,
+                    active: false,
+                },
+            ],
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_renders_local_and_account_roster_rows() {
+        let host = host();
+        render_profiles(&host, &roster_fixture());
+
+        let list = host
+            .query_selector("#account-profile-list")
+            .unwrap()
+            .unwrap();
+        assert_eq!(list.query_selector_all("li").unwrap().length(), 2);
+        let text = list.text_content().unwrap();
+        assert!(
+            text.contains("person@example.com"),
+            "an account row shows its email"
+        );
+        assert!(
+            text.contains("Local workspace"),
+            "a never-signed-in row says what it is"
+        );
+        assert!(text.contains("Alice") && text.contains("brave-otter"));
+
+        let button = list
+            .query_selector("button[data-activate=\"tonk-0a12\"]")
+            .unwrap()
+            .expect("the other profile's row offers a switch");
+        assert_eq!(button.text_content().as_deref(), Some("Switch"));
+    }
+
+    #[dialog_common::test]
+    fn it_marks_the_active_profile_row_inert() {
+        let host = host();
+        render_profiles(&host, &roster_fixture());
+
+        let list = host
+            .query_selector("#account-profile-list")
+            .unwrap()
+            .unwrap();
+        let active = list
+            .query_selector("li[data-active]")
+            .unwrap()
+            .expect("the active profile renders a marked row");
+        assert!(active.text_content().unwrap().contains("Current"));
+        assert!(
+            active.query_selector("button").unwrap().is_none(),
+            "the active row must not offer an action"
+        );
+        assert_eq!(
+            list.query_selector_all("button[data-activate]")
+                .unwrap()
+                .length(),
+            1,
+            "only the other rows are switch targets"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_offers_a_different_account_from_the_choice_panel_when_a_root_is_persisted() {
+        let host = host();
+
+        render_choice_profiles(&host, &roster_fixture(), true);
+        let button = host
+            .query_selector("#account-use-different-account")
+            .unwrap()
+            .unwrap();
+        assert!(
+            !button.has_attribute("hidden"),
+            "a persisted root must surface the way to another account"
+        );
+        let section = host
+            .query_selector("#account-choice-profiles")
+            .unwrap()
+            .unwrap();
+        assert!(
+            !section.has_attribute("hidden"),
+            "other roster entries render on the choice panel"
+        );
+        let list = host
+            .query_selector("#account-choice-profile-list")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            list.query_selector_all("li").unwrap().length(),
+            1,
+            "the compact list shows only the OTHER profiles"
+        );
+
+        render_choice_profiles(&host, &roster_fixture(), false);
+        assert!(
+            button.has_attribute("hidden"),
+            "without a persisted root, plain log-in suffices"
         );
     }
 

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -637,20 +637,17 @@ async fn persist(
     descriptor_hex: String,
     initialize_name: bool,
 ) -> Result<AccountStatus, String> {
-    match crate::api::root_status()
+    let root_status = crate::api::root_status()
         .await
-        .map_err(|error| error.to_string())?
-    {
-        tonk_worker_api::RootStatus::Missing { .. } => {
-            crate::api::save_root(
-                ceremony.credential_id.clone(),
-                ceremony.delegation_hex.clone(),
-                None,
-            )
-            .await
-            .map_err(|error| error.to_string())?;
-        }
-        tonk_worker_api::RootStatus::Ready { .. } => {}
+        .map_err(|error| error.to_string())?;
+    if root_needs_persist(&root_status, &ceremony.root_did) {
+        crate::api::save_root(
+            ceremony.credential_id.clone(),
+            ceremony.delegation_hex.clone(),
+            None,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
     }
     crate::api::save_account_link(
         provider.to_string(),
@@ -662,6 +659,15 @@ async fn persist(
     )
     .await
     .map_err(|error| error.to_string())
+}
+
+fn root_needs_persist(status: &tonk_worker_api::RootStatus, root_did: &str) -> bool {
+    match status {
+        tonk_worker_api::RootStatus::Missing { .. } => true,
+        tonk_worker_api::RootStatus::Ready {
+            root_did: current, ..
+        } => current != root_did,
+    }
 }
 
 /// What to tell someone whose account predates the repository descriptor.
@@ -1417,6 +1423,21 @@ mod tests {
         assert!(input(&host, "#account-code").is_err());
         code.set_value("123456");
         assert_eq!(input(&host, "#account-code").as_deref(), Ok("123456"));
+    }
+
+    #[dialog_common::test]
+    fn it_persists_a_different_passkey_root_after_signing_out() {
+        let status = tonk_worker_api::RootStatus::Ready {
+            root_did: "did:key:zOldRoot".into(),
+            device_did: "did:key:zDevice".into(),
+            credential_id: "old-credential".into(),
+            delegation_cid: "bafyold".into(),
+            delegation_hex: "00".into(),
+            passkey: None,
+        };
+
+        assert!(root_needs_persist(&status, "did:key:zNewRoot"));
+        assert!(!root_needs_persist(&status, "did:key:zOldRoot"));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -673,6 +673,82 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_adds_a_second_account_and_switches_between_disjoint_space_lists(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, "first@example.com").await?;
+
+        // First account creates a spot; its Hub lists it.
+        let created = post_json(
+            &driver,
+            "/api/spaces",
+            serde_json::json!({
+                "name": "First Garden",
+                "remote": env.tonk_web.join("ucan/")?,
+                "revocation_url": env.account_service.join("revocations")?,
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let key = successful_body("create first account's spot", &created)["key"]
+            .as_str()
+            .context("create response omitted the spot key")?
+            .to_string();
+        let listed = get_json(&driver, "/api/profile").await?;
+        let space_keys = |body: &serde_json::Value| -> Vec<String> {
+            body["space"]
+                .as_array()
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .filter_map(|entry| entry["key"].as_str().map(str::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        assert!(space_keys(successful_body("list first account's spaces", &listed)).contains(&key));
+        let profiles = get_json(&driver, "/api/profiles").await?;
+        let first_profile = successful_body("list profiles", &profiles)["active"]
+            .as_str()
+            .context("profiles response omitted the active name")?
+            .to_string();
+
+        // Add account: a fresh profile lands on the normal Choice flow,
+        // where the second sign-up runs unchanged.
+        driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        element(&driver, "#account-add-profile")
+            .await?
+            .click()
+            .await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        sign_up(&driver, &env, "second@example.com").await?;
+
+        // The second account sees none of the first account's spots.
+        let listed = get_json(&driver, "/api/profile").await?;
+        assert!(
+            space_keys(successful_body("list second account's spaces", &listed)).is_empty(),
+            "a fresh account must not see the other account's spots"
+        );
+        wait_for_text_containing(&driver, "#account-profile-list", "first@example.com").await?;
+
+        // Switch back through the switcher; the first Hub returns.
+        let selector = format!("#account-profile-list button[data-activate=\"{first_profile}\"]");
+        element(&driver, &selector).await?.click().await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        wait_for_text_containing(&driver, "#account-email-value", "first@example.com").await?;
+        let listed = get_json(&driver, "/api/profile").await?;
+        assert!(
+            space_keys(successful_body("relist first account's spaces", &listed)).contains(&key),
+            "switching back must restore the first account's spot list"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_links_the_cli_through_the_browser_handoff(env: TestEnvironment) -> Result<()> {
         let driver = driver_with_prf(&env).await?;
         sign_up(&driver, &env, EMAIL).await?;

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -3,9 +3,10 @@ use serde::Deserialize;
 use tonk_account::handoff::{LinkSecretRequest, ResolvedLink};
 use tonk_worker_api::{
     AccountDevice, AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus,
-    AccountSummary, EvaluateResponse, IdentifyResponse, JoinRequest, JoinResponse,
-    MembershipResponse, QueryResponse, RepositoryInfo, RevokeDeviceAcknowledgement,
-    RevokeDeviceRequest, RootStatus, SaveRootRequest, SyncResponse, SyncStatusResponse,
+    AccountSummary, ActivateProfileRequest, EvaluateResponse, IdentifyResponse, JoinRequest,
+    JoinResponse, MembershipResponse, ProfilesResponse, QueryResponse, RepositoryInfo,
+    RevokeDeviceAcknowledgement, RevokeDeviceRequest, RootStatus, SaveRootRequest, SyncResponse,
+    SyncStatusResponse,
 };
 
 use crate::error::TonkUiError;
@@ -654,6 +655,66 @@ pub async fn revoke_account_device(
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "POST /api/account/devices/revoke returned {status}: {text}"
+        )))
+    }
+}
+
+/// List every profile signed in (or local) on this browser.
+pub async fn list_profiles() -> Result<ProfilesResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/profiles", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "GET /api/profiles returned {status}: {text}"
+        )))
+    }
+}
+
+/// Swap the worker onto another roster profile. The caller reloads the
+/// page afterwards so every surface re-renders the new profile.
+pub async fn activate_profile(profile: String) -> Result<ProfilesResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/profiles/activate", origin()))
+        .json(&ActivateProfileRequest { profile })
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/profiles/activate returned {status}: {text}"
+        )))
+    }
+}
+
+/// Rotate onto a fresh profile — the landing pad the normal sign-in
+/// ceremony then runs on. The caller reloads the page afterwards.
+pub async fn add_account_profile() -> Result<ProfilesResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/profiles/add", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/profiles/add returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -658,8 +658,7 @@ pub async fn revoke_account_device(
     }
 }
 
-/// Sign out on this device: revoke it in the registry (best-effort,
-/// reported in the response) and rotate onto a fresh key.
+/// Sign out on this device while preserving its local profile and spots.
 pub async fn unlink_account() -> Result<AccountStatus, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -22,6 +22,7 @@ mod identity;
 mod invite;
 mod join;
 mod profile;
+mod profiles;
 mod query;
 mod repository;
 pub mod share;
@@ -49,6 +50,7 @@ pub use join::{
     JoinFailureKind, JoinRequest, JoinResponse, MembershipResponse, VisitRequest, VisitResponse,
 };
 pub use profile::{ProfileInfo, SpaceEntry};
+pub use profiles::{ActivateProfileRequest, ProfileRosterEntry, ProfilesResponse};
 pub use query::Query;
 pub use repository::{
     BranchConfiguration, MemberInfo, RemoteConfiguration, RepositoryConfiguration, RepositoryInfo,

--- a/rust/tonk-worker-api/src/profiles.rs
+++ b/rust/tonk-worker-api/src/profiles.rs
@@ -1,0 +1,96 @@
+//! Profile roster and switching wire DTOs.
+
+use serde::{Deserialize, Serialize};
+
+/// One profile signed in (or local) on this browser, as the switcher
+/// renders it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileRosterEntry {
+    /// Storage name the profile opens under — the activation handle.
+    pub profile_name: String,
+    /// Account root the profile is attached to. Absent for a local
+    /// workspace (never signed in, or signed out).
+    pub root_did: Option<String>,
+    /// Attached provider base URL.
+    pub provider: Option<String>,
+    /// Account email, captured best-effort at link time. May lag.
+    pub email: Option<String>,
+    /// Display name at last refresh.
+    pub display_name: Option<String>,
+    /// When the profile was last activated, seconds since the epoch.
+    pub last_active_at: u64,
+    /// Whether this entry is the profile currently being served.
+    pub active: bool,
+}
+
+/// Response body for `GET /api/profiles` and the switching routes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfilesResponse {
+    /// Name of the profile currently being served.
+    pub active: String,
+    /// Every profile this browser knows, active entry included.
+    pub profiles: Vec<ProfileRosterEntry>,
+}
+
+/// Request body for `POST /api/profiles/activate`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivateProfileRequest {
+    /// Name of the roster profile to swap in.
+    pub profile: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_serializes_roster_entries_in_camel_case() {
+        let json = serde_json::to_value(ProfileRosterEntry {
+            profile_name: "tonk".into(),
+            root_did: Some("did:key:root".into()),
+            provider: Some("https://accounts.example".into()),
+            email: Some("person@example.com".into()),
+            display_name: Some("Alice".into()),
+            last_active_at: 1_754_380_800,
+            active: true,
+        })
+        .unwrap();
+        assert_eq!(json["profileName"], "tonk");
+        assert_eq!(json["rootDid"], "did:key:root");
+        assert_eq!(json["displayName"], "Alice");
+        assert_eq!(json["lastActiveAt"], 1_754_380_800u64);
+        assert_eq!(json["active"], true);
+        assert!(json.get("profile_name").is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_a_profiles_response() {
+        let response = ProfilesResponse {
+            active: "tonk".into(),
+            profiles: vec![ProfileRosterEntry {
+                profile_name: "tonk-0a".into(),
+                root_did: None,
+                provider: None,
+                email: None,
+                display_name: None,
+                last_active_at: 0,
+                active: false,
+            }],
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ProfilesResponse>(&json).unwrap(),
+            response
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_deserializes_an_activation_request() {
+        let request: ActivateProfileRequest =
+            serde_json::from_str(r#"{"profile":"tonk-0a"}"#).unwrap();
+        assert_eq!(request.profile, "tonk-0a");
+    }
+}

--- a/rust/tonk-worker/src/device.rs
+++ b/rust/tonk-worker/src/device.rs
@@ -21,6 +21,7 @@
 use dialog_effects::storage::Directory;
 use dialog_operator::Profile;
 use dialog_storage::provider::storage::Storage;
+use serde::{Deserialize, Serialize};
 use tonk_common::log;
 
 use crate::TonkWorkerError;
@@ -38,22 +39,68 @@ pub const REGISTRY_PROFILE: &str = "tonk";
 /// name as UTF-8.
 const ACTIVE_PROFILE_SITE: &str = "tonk-active-profile-v1";
 
+/// Credential site on the registry profile holding the roster of every
+/// profile this browser knows, as a JSON-serialized `Vec<RosterEntry>`.
+///
+/// A switcher menu has to describe profiles it has not opened, and
+/// opening each one just to render a row would cost key-material load
+/// and credential reads per profile per render. The roster is one
+/// credential load, maintained by the worker at the moments it already
+/// has the facts in hand (boot, link, unlink, rename, switch).
+const PROFILE_ROSTER_SITE: &str = "tonk-profile-roster-v1";
+
+/// One profile this browser knows about, as the switcher renders it.
+///
+/// Inactive entries are as-of their profile's last activation; only the
+/// active profile's entry is refreshed from live state. A display name
+/// renamed on another device converges the next time that account's
+/// profile is activated here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RosterEntry {
+    /// Storage name the profile opens under.
+    pub profile_name: String,
+    /// Account root the profile is attached to. `None` marks a local
+    /// workspace — never signed in, or signed out.
+    pub root_did: Option<String>,
+    /// Attached provider base URL.
+    pub provider: Option<String>,
+    /// Account email, captured best-effort at link time. May lag.
+    pub email: Option<String>,
+    /// Display name at last refresh.
+    pub display_name: Option<String>,
+    /// When the profile was last activated, unix seconds.
+    pub last_active_at: u64,
+}
+
 /// Where the pointer lives: a profile name and the directory it is
 /// opened in. The worker uses [`Registry::device`]; tests point at a
 /// scratch directory under their own name so they neither collide with
 /// each other nor touch the real profile store.
-struct Registry {
-    profile: String,
-    directory: Directory,
+///
+/// Reads and writes go directly against storage — never through the
+/// active profile — so they work regardless of which profile is
+/// active. That is what lets an activation write the pointer for a
+/// profile it has not swapped in yet.
+#[derive(Clone)]
+pub(crate) struct Registry {
+    pub(crate) profile: String,
+    pub(crate) directory: Directory,
 }
 
 impl Registry {
     /// The one this device actually uses.
-    fn device() -> Self {
+    pub(crate) fn device() -> Self {
         Self {
             profile: REGISTRY_PROFILE.to_string(),
             directory: Directory::Profile,
         }
+    }
+
+    /// The name of the profile a device starts with — the registry's
+    /// own. Valid as an activation target even when no roster entry
+    /// names it.
+    pub(crate) fn initial_profile(&self) -> &str {
+        &self.profile
     }
 
     async fn open_self(&self, storage: &Storage<DefaultSpace>) -> Result<Profile, TonkWorkerError> {
@@ -98,7 +145,7 @@ impl Registry {
     }
 
     /// Open the profile this device currently signs as.
-    async fn open_active(
+    pub(crate) async fn open_active(
         &self,
         storage: &Storage<DefaultSpace>,
     ) -> Result<(String, Profile), TonkWorkerError> {
@@ -117,18 +164,119 @@ impl Registry {
             return Ok((name, registry));
         }
 
-        let profile = Profile::open(&name)
+        let profile = self.open_profile(storage, &name).await?;
+        Ok((name, profile))
+    }
+
+    /// Open a profile by name in the registry's directory.
+    ///
+    /// `Profile::open` is open-or-create, so callers activating a
+    /// user-supplied name must validate it against the roster first —
+    /// an unvalidated name would silently mint a garbage key.
+    pub(crate) async fn open_profile(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        name: &str,
+    ) -> Result<Profile, TonkWorkerError> {
+        Profile::open(name)
             .at(self.directory.clone())
             .perform(storage)
             .await
             .map_err(|error| {
                 TonkWorkerError::Internal(format!("failed to open profile '{name}': {error}"))
-            })?;
-        Ok((name, profile))
+            })
+    }
+
+    /// Point the active-profile pointer at `name`.
+    ///
+    /// Callers repoint only after the target profile opened (and its
+    /// state built) successfully, so a failed activation never strands
+    /// the next boot on a profile that does not work.
+    pub(crate) async fn set_active(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        name: &str,
+    ) -> Result<(), TonkWorkerError> {
+        let registry = self.open_self(storage).await?;
+        registry
+            .credential()
+            .site(ACTIVE_PROFILE_SITE)
+            .save(name.as_bytes().to_vec())
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to record the active profile: {error}"))
+            })
+    }
+
+    /// The stored roster, or empty when none was ever written.
+    pub(crate) async fn read_roster(
+        &self,
+        storage: &Storage<DefaultSpace>,
+    ) -> Result<Vec<RosterEntry>, TonkWorkerError> {
+        let registry = self.open_self(storage).await?;
+        let bytes = match registry
+            .credential()
+            .site(PROFILE_ROSTER_SITE)
+            .load::<Vec<u8>>()
+            .perform(storage)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(error) if crate::credential::is_missing(&error) => return Ok(Vec::new()),
+            Err(error) => {
+                return Err(TonkWorkerError::Internal(format!(
+                    "failed to read the profile roster: {error}"
+                )));
+            }
+        };
+        if bytes.is_empty() {
+            return Ok(Vec::new());
+        }
+        serde_json::from_slice(&bytes).map_err(|error| {
+            TonkWorkerError::Internal(format!("stored profile roster is malformed: {error}"))
+        })
+    }
+
+    /// Insert or replace the roster entry named by `entry.profile_name`.
+    pub(crate) async fn upsert_roster(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        entry: RosterEntry,
+    ) -> Result<(), TonkWorkerError> {
+        let mut roster = self.read_roster(storage).await?;
+        match roster
+            .iter_mut()
+            .find(|existing| existing.profile_name == entry.profile_name)
+        {
+            Some(existing) => *existing = entry,
+            None => roster.push(entry),
+        }
+        self.write_roster(storage, &roster).await
+    }
+
+    async fn write_roster(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        roster: &[RosterEntry],
+    ) -> Result<(), TonkWorkerError> {
+        let bytes = serde_json::to_vec(roster).map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to serialize the profile roster: {error}"))
+        })?;
+        let registry = self.open_self(storage).await?;
+        registry
+            .credential()
+            .site(PROFILE_ROSTER_SITE)
+            .save(bytes)
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to save the profile roster: {error}"))
+            })
     }
 
     /// Generate a fresh profile and make it the active one.
-    async fn rotate(
+    pub(crate) async fn rotate(
         &self,
         storage: &Storage<DefaultSpace>,
     ) -> Result<(String, Profile), TonkWorkerError> {
@@ -255,6 +403,53 @@ mod tests {
             "the pointer has to survive a restart, or a rotated device reverts \
              to the key it revoked"
         );
+    }
+
+    fn entry(name: &str, display_name: &str) -> RosterEntry {
+        RosterEntry {
+            profile_name: name.to_string(),
+            root_did: None,
+            provider: None,
+            email: None,
+            display_name: Some(display_name.to_string()),
+            last_active_at: 0,
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_an_empty_roster_before_any_entry_is_written() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        assert_eq!(registry.read_roster(&storage).await.unwrap(), Vec::new());
+    }
+
+    #[dialog_common::test]
+    async fn it_upserts_a_roster_entry_by_profile_name() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        registry
+            .upsert_roster(&storage, entry("one", "first"))
+            .await
+            .unwrap();
+        registry
+            .upsert_roster(&storage, entry("two", "second"))
+            .await
+            .unwrap();
+        registry
+            .upsert_roster(&storage, entry("one", "renamed"))
+            .await
+            .unwrap();
+
+        let roster = registry.read_roster(&storage).await.unwrap();
+        assert_eq!(roster.len(), 2, "an upsert replaces, never duplicates");
+        assert_eq!(
+            roster[0].display_name.as_deref(),
+            Some("renamed"),
+            "the entry keeps its position and takes the new value"
+        );
+        assert_eq!(roster[1].profile_name, "two");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -74,6 +74,8 @@ mod lsp_env;
 mod profile;
 pub use profile::{ProfileInfo, SpaceEntry};
 
+pub(crate) mod profiles;
+
 mod profile_name;
 
 mod evaluate;
@@ -241,6 +243,12 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route("/api/account/summary", get(account_devices::summary))
         .route("/api/account/devices/revoke", post(account_devices::revoke))
         .route("/api/profile", get(profile::get_profile))
+        // Profile roster and switching — every account signed in on this
+        // browser has its own profile; these list them, swap the active
+        // one, and mint a fresh landing pad for "add account".
+        .route("/api/profiles", get(profiles::list))
+        .route("/api/profiles/activate", post(profiles::activate))
+        .route("/api/profiles/add", post(profiles::add))
         // Profile-as-repository routes. The profile is its own
         // repository but lives outside the named-repo namespace
         // (no `repo` segment), so it gets a parallel route
@@ -592,6 +600,16 @@ pub mod tests {
             .expect("Failed to open a test signing session");
 
         let reactor = crate::Reactor::new(profile.clone());
+        // The registry mirrors production shape — the state's own profile
+        // is the registry profile, exactly as `Registry::device()` signs
+        // as `tonk` until the first rotation. Uniquely named per state,
+        // so tests neither collide with each other nor touch the real
+        // registry, while rotated/activated profiles still resolve in the
+        // same directory the test profile itself lives in.
+        let registry = crate::device::Registry {
+            profile: profile_name.clone(),
+            directory: dialog_effects::storage::Directory::Profile,
+        };
         TonkState {
             profile,
             operator: session.operator,
@@ -605,6 +623,7 @@ pub mod tests {
             commands: super::command_registry(),
             clients: Default::default(),
             account_keys: Default::default(),
+            registry,
         }
     }
 

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -281,6 +281,16 @@ pub async fn establish_repository(
     } else {
         super::account_state::ensure_account_state(&tonk).await;
     }
+
+    // Roster upkeep: this profile just became an account row. The email
+    // comes best-effort from the provider; a failed fetch leaves it
+    // blank until a later refresh.
+    let email = super::account_devices::account_summary(&tonk)
+        .await
+        .ok()
+        .map(|summary| summary.email);
+    super::profiles::upsert_active_entry(&tonk, email).await;
+
     Ok(Json(status(&tonk).await?))
 }
 
@@ -356,6 +366,15 @@ pub async fn link(
     crate::router::account_backup::back_up_existing_spaces(&state).await;
     crate::router::restore::restore_spaces(&state).await;
 
+    // Roster upkeep: this profile just became an account row. The email
+    // comes best-effort from the provider; a failed fetch leaves it
+    // blank until a later refresh.
+    let email = super::account_devices::account_summary(&state)
+        .await
+        .ok()
+        .map(|summary| summary.email);
+    super::profiles::upsert_active_entry(&state, email).await;
+
     Ok(Json(status(&state).await?))
 }
 
@@ -375,6 +394,11 @@ pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>
         })?;
     // The account repository is no longer this profile's to hide.
     state.account_keys.invalidate();
+    // Roster upkeep: with no provider attached the entry's account
+    // fields clear, so the switcher renders this row as a local
+    // workspace. The persisted root stays, so signing back in with the
+    // same passkey still short-circuits in place.
+    super::profiles::upsert_active_entry(&state, None).await;
     Ok(Json(status(&state).await?))
 }
 
@@ -500,6 +524,39 @@ mod tests {
         };
         let error = link(State(state.clone()), Json(request)).await.unwrap_err();
         assert!(matches!(error, TonkWorkerError::Forbidden(_)));
+    }
+
+    #[dialog_common::test]
+    async fn it_marks_the_profile_local_in_the_roster_after_unlink() {
+        let state = Arc::new(RwLock::new(test_state_without_account().await));
+        let request = {
+            let state = state.read().await;
+            matching_request(&state).await
+        };
+        let _ = link(State(state.clone()), Json(request)).await.unwrap();
+        {
+            let tonk = state.read().await;
+            let roster = tonk.registry.read_roster(&tonk.storage).await.unwrap();
+            let entry = roster
+                .iter()
+                .find(|entry| entry.profile_name == tonk.profile_name)
+                .expect("link writes the profile's roster entry");
+            assert!(entry.root_did.is_some());
+            assert_eq!(entry.provider.as_deref(), Some(TEST_ACCOUNT_PROVIDER));
+        }
+
+        let _ = unlink(State(state.clone())).await.unwrap();
+
+        let tonk = state.read().await;
+        let roster = tonk.registry.read_roster(&tonk.storage).await.unwrap();
+        let entry = roster
+            .iter()
+            .find(|entry| entry.profile_name == tonk.profile_name)
+            .expect("unlink keeps the roster entry");
+        assert!(
+            entry.root_did.is_none() && entry.provider.is_none() && entry.email.is_none(),
+            "a signed-out profile renders as a local workspace"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -90,13 +90,12 @@ pub async fn list(
     Ok(Json(fetch_devices(&state, &link, &service).await?))
 }
 
-/// Return verified account facts authorized by this profile's active grant.
-#[wasm_compat]
-pub async fn summary(
-    State(state): State<AppState>,
-) -> Result<Json<AccountSummary>, TonkWorkerError> {
-    let state = state.read().await;
-    let (link, service) = linked_service(&state).await?;
+/// Fetch the provider's verified account facts for the linked profile.
+///
+/// Shared by the HTTP route and the roster hooks that capture the
+/// account email best-effort at link time.
+pub(crate) async fn account_summary(state: &TonkState) -> Result<AccountSummary, TonkWorkerError> {
+    let (link, service) = linked_service(state).await?;
     let body = tonk_identity::request::build_device_invocation(
         state.profile.signer().signer().clone(),
         &link,
@@ -113,9 +112,17 @@ pub async fn summary(
     ))
     .map_err(|error| TonkWorkerError::Internal(format!("invalid account provider URL: {error}")))?;
     let response = super::http::post_cbor(&endpoint, &body).await?;
-    let summary = serde_json::from_slice(&response.body)
-        .map_err(|error| TonkWorkerError::Internal(format!("parse account summary: {error}")))?;
-    Ok(Json(summary))
+    serde_json::from_slice(&response.body)
+        .map_err(|error| TonkWorkerError::Internal(format!("parse account summary: {error}")))
+}
+
+/// Return verified account facts authorized by this profile's active grant.
+#[wasm_compat]
+pub async fn summary(
+    State(state): State<AppState>,
+) -> Result<Json<AccountSummary>, TonkWorkerError> {
+    let state = state.read().await;
+    Ok(Json(account_summary(&state).await?))
 }
 
 async fn self_revocation(

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -882,7 +882,10 @@ pub(crate) async fn rename_display_name(
         if configured_descriptor(tonk).await.is_none() {
             return Err(account_state_unavailable());
         }
-        return adopt_account_display_name(tonk, name).await.map(Some);
+        let response = adopt_account_display_name(tonk, name).await?;
+        // Roster upkeep: the switcher row shows the new name.
+        super::profiles::upsert_active_entry(tonk, None).await;
+        return Ok(Some(response));
     }
 
     let profile_entity = tonk.profile.did().this();
@@ -918,6 +921,9 @@ pub(crate) async fn rename_display_name(
         }
         crate::router::sync::publish_self_identity(tonk, &key, tonk_account::MAIN_BRANCH).await;
     }
+
+    // Roster upkeep: the switcher row shows the new name.
+    super::profiles::upsert_active_entry(tonk, None).await;
 
     Ok(Some(AccountDisplayNameResponse {
         name: name.to_string(),
@@ -1118,7 +1124,7 @@ mod tests {
             operator: session.operator,
             storage,
             session_expires_at: session.expires_at,
-            profile_name: name,
+            profile_name: name.clone(),
             reactor,
             view_bindings: Default::default(),
             bridges: Default::default(),
@@ -1126,6 +1132,10 @@ mod tests {
             commands: crate::router::command_registry(),
             clients: Default::default(),
             account_keys: Default::default(),
+            registry: crate::device::Registry {
+                profile: name.clone(),
+                directory: dialog_effects::storage::Directory::Profile,
+            },
         };
         crate::router::repository::bootstrap_profile(&state)
             .await

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -16,7 +16,7 @@ use crate::worker::TonkState;
 const LOCAL_ROOT_SITE: &str = "tonk-local-root-v1";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct LocalRootRecord {
+pub(crate) struct LocalRootRecord {
     version: u8,
     credential_id: String,
     delegation: Vec<u8>,
@@ -77,7 +77,9 @@ pub(crate) async fn validate_grant(
     Ok(chain)
 }
 
-async fn load_record(state: &TonkState) -> Result<Option<LocalRootRecord>, TonkWorkerError> {
+pub(crate) async fn load_record(
+    state: &TonkState,
+) -> Result<Option<LocalRootRecord>, TonkWorkerError> {
     let bytes = match state
         .profile
         .credential()
@@ -194,18 +196,27 @@ pub(crate) async fn persist_root(
         if existing == record {
             return Ok(status(local_root(state).await?));
         }
-        if super::account::provider(state).await.is_some() {
+        // Same root, different record — a re-minted grant or refreshed
+        // metadata — updates in place; that covers signing back in after
+        // sign-out. A DIFFERENT root is another account's passkey: each
+        // account keeps its own profile, so it lands through add-account
+        // and never overwrites the root this profile's spaces hang off.
+        // An unreadable stored delegation refuses too — the roots can't
+        // be proven equal.
+        let stored_root = DelegationChain::try_from(existing.delegation.as_slice())
+            .ok()
+            .map(|stored| stored.issuer().clone());
+        if stored_root.as_ref() != Some(chain.issuer()) {
             return Err(TonkWorkerError::Conflict(
-                "a different local root is already persisted".to_string(),
+                "a different account is already signed in on this profile; \
+                 use \"Add account\" to sign in with another account"
+                    .to_string(),
             ));
         }
     }
 
-    // The local-root site is the latest account projection, not the only
-    // authority this profile has ever held. After sign-out there is no active
-    // provider attachment, so a successful ceremony for another passkey may
-    // replace it. Saving the new grant below leaves earlier access
-    // certificates in the profile store intact.
+    // Saving the new grant below leaves earlier access certificates in
+    // the profile store intact.
     state
         .profile
         .access()
@@ -342,32 +353,72 @@ mod tests {
         ));
     }
 
+    /// Sign-out keeps the profile's root, data, and certificates; a
+    /// later ceremony that resolves a DIFFERENT passkey is another
+    /// account arriving, and each account gets its own profile via
+    /// add-account. Persisting it here would silently rebind this
+    /// profile's spaces to a root that never owned them.
     #[dialog_common::test]
-    async fn it_replaces_the_local_root_after_signing_out() {
+    async fn it_rejects_a_different_root_on_a_previously_linked_profile() {
         let state = Arc::new(RwLock::new(test_state().await));
         let previous_root = {
             let state = state.read().await;
             local_root(&state).await.unwrap().root_did
         };
         let device = state.read().await.profile.did();
-        let (replacement, replacement_grant) = request_for(2, &device).await;
+        let (replacement, _) = request_for(2, &device).await;
 
         let _ = super::super::account::unlink(State(state.clone()))
             .await
             .unwrap();
-        let Json(status) = save(State(state.clone()), Json(replacement)).await.unwrap();
+        let error = save(State(state.clone()), Json(replacement))
+            .await
+            .unwrap_err();
 
-        assert!(matches!(
-            status,
-            RootStatus::Ready { root_did, delegation_cid, .. }
-                if root_did == replacement_grant.issuer().to_string()
-                    && delegation_cid == replacement_grant.proof_cids()[0].to_string()
-        ));
+        assert!(matches!(error, TonkWorkerError::Conflict(_)));
         let current_root = {
             let state = state.read().await;
             local_root(&state).await.unwrap().root_did
         };
-        assert_ne!(current_root, previous_root);
+        assert_eq!(
+            current_root, previous_root,
+            "the refused ceremony must leave the persisted root untouched"
+        );
+    }
+
+    /// The same root signing back in after sign-out updates in place —
+    /// tightening the different-root path must not break re-sign-in.
+    #[dialog_common::test]
+    async fn it_accepts_the_same_root_again_after_signing_out() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let (device, profile_name) = {
+            let state = state.read().await;
+            (state.profile.did(), state.profile_name.clone())
+        };
+        // Re-derive the fixture's own root and mint a FRESH grant for it:
+        // same root, different record bytes — what a real re-sign-in
+        // ceremony produces.
+        let root = Ed25519Signer::import(&crate::router::tests::test_root_seed(&profile_name))
+            .await
+            .unwrap();
+        let grant = tonk_identity::delegation::mint_device_delegation(root, &device)
+            .await
+            .unwrap();
+        let request = SaveRootRequest {
+            credential_id: "renewed-credential".to_string(),
+            delegation_hex: hex::encode(grant.to_bytes().unwrap()),
+            passkey: None,
+        };
+
+        let _ = super::super::account::unlink(State(state.clone()))
+            .await
+            .unwrap();
+        let Json(status) = save(State(state.clone()), Json(request)).await.unwrap();
+
+        assert!(matches!(
+            status,
+            RootStatus::Ready { root_did, .. } if root_did == grant.issuer().to_string()
+        ));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -191,14 +191,21 @@ pub(crate) async fn persist_root(
         passkey,
     };
     if let Some(existing) = load_record(state).await? {
-        if existing != record {
+        if existing == record {
+            return Ok(status(local_root(state).await?));
+        }
+        if super::account::provider(state).await.is_some() {
             return Err(TonkWorkerError::Conflict(
                 "a different local root is already persisted".to_string(),
             ));
         }
-        return Ok(status(local_root(state).await?));
     }
 
+    // The local-root site is the latest account projection, not the only
+    // authority this profile has ever held. After sign-out there is no active
+    // provider attachment, so a successful ceremony for another passkey may
+    // replace it. Saving the new grant below leaves earlier access
+    // certificates in the profile store intact.
     state
         .profile
         .access()
@@ -251,7 +258,7 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
-    use crate::router::tests::test_state_without_root;
+    use crate::router::tests::{test_state, test_state_without_root};
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     wasm_bindgen_test_configure!(run_in_service_worker);
 
@@ -325,16 +332,42 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_replacing_a_ready_root_with_another_root() {
-        let state = Arc::new(RwLock::new(test_state_without_root().await));
+        let state = Arc::new(RwLock::new(test_state().await));
         let device = state.read().await.profile.did();
-        let (first, _) = request_for(1, &device).await;
         let (second, _) = request_for(2, &device).await;
-        let _ = save(State(state.clone()), Json(first)).await.unwrap();
 
         assert!(matches!(
             save(State(state), Json(second)).await,
             Err(TonkWorkerError::Conflict(_))
         ));
+    }
+
+    #[dialog_common::test]
+    async fn it_replaces_the_local_root_after_signing_out() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let previous_root = {
+            let state = state.read().await;
+            local_root(&state).await.unwrap().root_did
+        };
+        let device = state.read().await.profile.did();
+        let (replacement, replacement_grant) = request_for(2, &device).await;
+
+        let _ = super::super::account::unlink(State(state.clone()))
+            .await
+            .unwrap();
+        let Json(status) = save(State(state.clone()), Json(replacement)).await.unwrap();
+
+        assert!(matches!(
+            status,
+            RootStatus::Ready { root_did, delegation_cid, .. }
+                if root_did == replacement_grant.issuer().to_string()
+                    && delegation_cid == replacement_grant.proof_cids()[0].to_string()
+        ));
+        let current_root = {
+            let state = state.read().await;
+            local_root(&state).await.unwrap().root_did
+        };
+        assert_ne!(current_root, previous_root);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -282,6 +282,10 @@ mod tests {
             commands: crate::router::command_registry(),
             clients: Default::default(),
             account_keys: Default::default(),
+            registry: crate::device::Registry {
+                profile: name.to_string(),
+                directory: dialog_effects::storage::Directory::Profile,
+            },
         }
     }
 

--- a/rust/tonk-worker/src/router/profiles.rs
+++ b/rust/tonk-worker/src/router/profiles.rs
@@ -1,0 +1,441 @@
+//! Profile roster and switching — one profile per account, swapped in
+//! place.
+//!
+//! Everything that should follow the active account is already scoped to
+//! the worker profile (the replica index, the local root, the provider
+//! attachment, the hidden account repository, the display name, the
+//! certificate store), so switching accounts is switching profiles: build
+//! a replacement [`TonkState`] for the target profile, repoint the
+//! registry's active-profile pointer, and swap the value inside the
+//! shared state handle. A page reload does not restart the service
+//! worker, so the in-place swap is what a switch IS; the pointer write
+//! only covers a genuine SW restart.
+
+use axum::{Json, extract::State};
+use axum_wasm_macros::wasm_compat;
+use dialog_storage::provider::storage::Storage;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_common::log;
+use tonk_worker_api::{ActivateProfileRequest, ProfileRosterEntry, ProfilesResponse};
+
+use super::AppState;
+use crate::TonkWorkerError;
+use crate::device::RosterEntry;
+use crate::worker::{DefaultSpace, TonkState};
+
+fn now_unix() -> u64 {
+    web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// The active profile's roster entry, rebuilt from live state.
+///
+/// The account fields all derive from the provider attachment: an
+/// unattached profile is a local workspace whatever root record it still
+/// holds, which is exactly how sign-out demotes a row without deleting
+/// anything. `email` overrides when `Some`; otherwise the stored entry's
+/// email carries forward while an account is attached — the roster is
+/// the only place it lives between provider fetches.
+async fn refreshed_entry(
+    tonk: &TonkState,
+    existing: Option<&RosterEntry>,
+    email: Option<String>,
+) -> RosterEntry {
+    let provider = super::account::provider(tonk).await;
+    let root_did = if provider.is_some() {
+        super::identity::local_root(tonk)
+            .await
+            .ok()
+            .map(|root| root.root_did.to_string())
+    } else {
+        None
+    };
+    let email = if provider.is_some() {
+        email.or_else(|| existing.and_then(|entry| entry.email.clone()))
+    } else {
+        None
+    };
+    RosterEntry {
+        profile_name: tonk.profile_name.clone(),
+        root_did,
+        provider,
+        email,
+        display_name: Some(super::profile_name::resolve_display_name(tonk).await),
+        last_active_at: existing
+            .map(|entry| entry.last_active_at)
+            .filter(|&at| at > 0)
+            .unwrap_or_else(now_unix),
+    }
+}
+
+/// Refresh the active profile's roster entry from live state.
+///
+/// Best-effort: every caller is a moment that already succeeded (boot,
+/// link, unlink, establish, rename), and a roster miss must not turn it
+/// into a failure. A stale entry costs a stale switcher row, healed by
+/// the next refresh.
+pub(crate) async fn upsert_active_entry(tonk: &TonkState, email: Option<String>) {
+    if let Err(error) = try_upsert_active_entry(tonk, email).await {
+        log!("profile roster upsert skipped: {error}");
+    }
+}
+
+async fn try_upsert_active_entry(
+    tonk: &TonkState,
+    email: Option<String>,
+) -> Result<(), TonkWorkerError> {
+    let roster = tonk.registry.read_roster(&tonk.storage).await?;
+    let existing = roster
+        .iter()
+        .find(|entry| entry.profile_name == tonk.profile_name);
+    let entry = refreshed_entry(tonk, existing, email).await;
+    tonk.registry.upsert_roster(&tonk.storage, entry).await
+}
+
+fn response_from(active: &str, roster: Vec<RosterEntry>) -> ProfilesResponse {
+    ProfilesResponse {
+        active: active.to_string(),
+        profiles: roster
+            .into_iter()
+            .map(|entry| ProfileRosterEntry {
+                active: entry.profile_name == active,
+                profile_name: entry.profile_name,
+                root_did: entry.root_did,
+                provider: entry.provider,
+                email: entry.email,
+                display_name: entry.display_name,
+                last_active_at: entry.last_active_at,
+            })
+            .collect(),
+    }
+}
+
+/// The roster with the active profile's entry refreshed from live state,
+/// written back so the stored roster converges as a side effect.
+/// Inactive entries are served as-of their profile's last activation.
+async fn refreshed_response(tonk: &TonkState) -> Result<ProfilesResponse, TonkWorkerError> {
+    let mut roster = tonk.registry.read_roster(&tonk.storage).await?;
+    let existing = roster
+        .iter()
+        .find(|entry| entry.profile_name == tonk.profile_name)
+        .cloned();
+    let entry = refreshed_entry(tonk, existing.as_ref(), None).await;
+    if existing.as_ref() != Some(&entry) {
+        tonk.registry
+            .upsert_roster(&tonk.storage, entry.clone())
+            .await?;
+    }
+    match roster
+        .iter_mut()
+        .find(|slot| slot.profile_name == entry.profile_name)
+    {
+        Some(slot) => *slot = entry,
+        None => roster.push(entry),
+    }
+    Ok(response_from(&tonk.profile_name, roster))
+}
+
+/// `GET /api/profiles`.
+#[wasm_compat]
+pub async fn list(
+    State(state): State<AppState>,
+) -> Result<Json<ProfilesResponse>, TonkWorkerError> {
+    let tonk = state.read().await;
+    Ok(Json(refreshed_response(&tonk).await?))
+}
+
+/// `POST /api/profiles/activate`.
+#[wasm_compat]
+pub async fn activate(
+    State(state): State<AppState>,
+    Json(request): Json<ActivateProfileRequest>,
+) -> Result<Json<ProfilesResponse>, TonkWorkerError> {
+    let name = request.profile;
+    let (registry, active) = {
+        let tonk = state.read().await;
+        // Validate before opening anything: `Profile::open` is
+        // open-or-create, so an unvalidated name would silently mint a
+        // garbage key. The initial profile is always a valid target even
+        // when nothing ever wrote its roster entry.
+        if name != tonk.registry.initial_profile()
+            && !tonk
+                .registry
+                .read_roster(&tonk.storage)
+                .await?
+                .iter()
+                .any(|entry| entry.profile_name == name)
+        {
+            return Err(TonkWorkerError::NotFound(format!(
+                "no profile '{name}' on this browser"
+            )));
+        }
+        // Keep the outgoing profile reachable: its entry may never have
+        // been written if every earlier best-effort upsert failed.
+        upsert_active_entry(&tonk, None).await;
+        (tonk.registry.clone(), tonk.profile_name.clone())
+    };
+    if name == active {
+        let tonk = state.read().await;
+        return Ok(Json(refreshed_response(&tonk).await?));
+    }
+
+    // Build the replacement state WITHOUT holding the state write lock —
+    // opening a profile and bootstrapping its meta branch await storage
+    // IO, and in-flight requests must keep being served meanwhile.
+    let storage = Storage::<DefaultSpace>::default();
+    let profile = registry.open_profile(&storage, &name).await?;
+    let new_state =
+        crate::worker::boot_state(storage, name.clone(), profile, registry.clone()).await?;
+    // Only a target that opened and booted repoints the pointer, so a
+    // failed activation never strands the next SW restart.
+    registry.set_active(&new_state.storage, &name).await?;
+    finish_swap(&state, new_state).await
+}
+
+/// `POST /api/profiles/add`.
+///
+/// Rotate to a fresh profile and swap onto it — the landing pad the
+/// unchanged sign-in ceremony then runs on. `validate_grant` binds a
+/// ceremony to the profile that ran it, so "add account" moves first;
+/// the ceremony that follows can only ever persist here.
+#[wasm_compat]
+pub async fn add(State(state): State<AppState>) -> Result<Json<ProfilesResponse>, TonkWorkerError> {
+    let registry = {
+        let tonk = state.read().await;
+        // Abandoned-add reuse: a profile with no persisted root and no
+        // user spaces is already a fresh landing pad — hand it back
+        // rather than minting another orphan key.
+        if super::identity::load_record(&tonk).await?.is_none() {
+            let fresh = true;
+            #[cfg(target_arch = "wasm32")]
+            let fresh = fresh && super::profile_name::real_space_keys(&tonk).await.is_empty();
+            if fresh {
+                return Ok(Json(refreshed_response(&tonk).await?));
+            }
+        }
+        upsert_active_entry(&tonk, None).await;
+        tonk.registry.clone()
+    };
+
+    let storage = Storage::<DefaultSpace>::default();
+    let (name, profile) = registry.rotate(&storage).await?;
+    let new_state = crate::worker::boot_state(storage, name, profile, registry).await?;
+    finish_swap(&state, new_state).await
+}
+
+/// Stamp the incoming profile's roster entry, swap the state in, and
+/// kick off the same detached catch-up the boot path runs.
+async fn finish_swap(
+    state: &AppState,
+    new_state: TonkState,
+) -> Result<Json<ProfilesResponse>, TonkWorkerError> {
+    let name = new_state.profile_name.clone();
+    let registry = new_state.registry.clone();
+    let mut roster = registry.read_roster(&new_state.storage).await?;
+    let existing = roster
+        .iter()
+        .find(|entry| entry.profile_name == name)
+        .cloned();
+    let mut entry = refreshed_entry(&new_state, existing.as_ref(), None).await;
+    entry.last_active_at = now_unix();
+    registry
+        .upsert_roster(&new_state.storage, entry.clone())
+        .await?;
+    match roster
+        .iter_mut()
+        .find(|slot| slot.profile_name == entry.profile_name)
+    {
+        Some(slot) => *slot = entry,
+        None => roster.push(entry),
+    }
+    let response = response_from(&name, roster);
+
+    *state.write().await = new_state;
+
+    // Catch up on whatever account the swapped-in profile is attached
+    // to, exactly as a boot would. Fire-and-forget: account-service
+    // latency must not delay the switch, and `restore_spaces` no-ops
+    // when the profile is unlinked.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let state = state.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let tonk = state.read().await;
+            super::account_state::ensure_account_state(&tonk).await;
+            super::restore::restore_spaces(&tonk).await;
+        });
+    }
+
+    Ok(Json(response))
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    use crate::router::account::TEST_ACCOUNT_PROVIDER;
+    use crate::router::tests::{put_repo, test_state, test_state_without_root};
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    async fn space_keys(state: &AppState) -> Vec<String> {
+        let axum::Json(info) = crate::router::profile::get_profile(State(state.clone()))
+            .await
+            .unwrap();
+        info.space.into_iter().map(|entry| entry.key).collect()
+    }
+
+    #[dialog_common::test]
+    async fn it_lists_the_active_profile_with_its_account_state() {
+        let state = Arc::new(RwLock::new(test_state().await));
+
+        let Json(response) = list(State(state.clone())).await.unwrap();
+
+        let active = response
+            .profiles
+            .iter()
+            .find(|entry| entry.active)
+            .expect("the active profile lists itself");
+        assert_eq!(active.profile_name, response.active);
+        assert_eq!(active.provider.as_deref(), Some(TEST_ACCOUNT_PROVIDER));
+        assert!(
+            active.root_did.is_some(),
+            "an attached profile names its account root"
+        );
+        assert!(active.display_name.is_some());
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_to_activate_a_profile_the_roster_does_not_name() {
+        let state = Arc::new(RwLock::new(test_state().await));
+
+        let error = activate(
+            State(state),
+            Json(ActivateProfileRequest {
+                profile: "no-such-profile".to_string(),
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, TonkWorkerError::NotFound(_)),
+            "an unvalidated name must never be opened (open-or-create \
+             would mint a garbage key), got {error:?}"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rotates_to_a_fresh_profile_for_add_account() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let (original_name, original_did) = {
+            let tonk = state.read().await;
+            (tonk.profile_name.clone(), tonk.profile.did())
+        };
+
+        let Json(response) = add(State(state.clone())).await.unwrap();
+
+        let tonk = state.read().await;
+        assert_ne!(tonk.profile_name, original_name);
+        assert_ne!(
+            tonk.profile.did(),
+            original_did,
+            "add-account must land on a fresh key"
+        );
+        assert_eq!(response.active, tonk.profile_name);
+        let fresh = response
+            .profiles
+            .iter()
+            .find(|entry| entry.active)
+            .expect("the fresh profile lists itself");
+        assert!(
+            fresh.provider.is_none() && fresh.root_did.is_none(),
+            "the landing pad starts as a local workspace"
+        );
+        assert!(
+            response
+                .profiles
+                .iter()
+                .any(|entry| entry.profile_name == original_name),
+            "the outgoing profile stays reachable from the roster"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reuses_an_unattached_empty_profile_instead_of_rotating_again() {
+        let state = Arc::new(RwLock::new(test_state_without_root().await));
+        let before = state.read().await.profile_name.clone();
+
+        let Json(response) = add(State(state.clone())).await.unwrap();
+
+        assert_eq!(
+            response.active, before,
+            "a rootless, space-less profile is already a fresh landing pad"
+        );
+        assert_eq!(state.read().await.profile_name, before);
+    }
+
+    #[dialog_common::test]
+    async fn it_serves_the_other_profiles_spaces_after_activation() {
+        let (app, state, _lsp) = crate::api_router_with_state(test_state().await);
+        let original = state.read().await.profile_name.clone();
+        let key = put_repo(&app, "switching-space").await;
+        assert!(space_keys(&state).await.contains(&key));
+
+        let _ = add(State(state.clone())).await.unwrap();
+        assert!(
+            space_keys(&state).await.is_empty(),
+            "a fresh profile must not see the other account's spaces"
+        );
+
+        let _ = activate(
+            State(state.clone()),
+            Json(ActivateProfileRequest {
+                profile: original.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(state.read().await.profile_name, original);
+        assert!(
+            space_keys(&state).await.contains(&key),
+            "switching back must restore the original space list"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_repoints_the_active_pointer_only_after_the_target_profile_opens() {
+        let state = Arc::new(RwLock::new(test_state().await));
+        let registry = state.read().await.registry.clone();
+        let initial = registry.initial_profile().to_string();
+
+        // A refused activation leaves the pointer untouched.
+        let _ = activate(
+            State(state.clone()),
+            Json(ActivateProfileRequest {
+                profile: "no-such-profile".to_string(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        let (name, _) = registry
+            .open_active(&Storage::<DefaultSpace>::default())
+            .await
+            .unwrap();
+        assert_eq!(name, initial);
+
+        // A successful swap repoints it at the profile that booted.
+        let Json(response) = add(State(state.clone())).await.unwrap();
+        let (name, _) = registry
+            .open_active(&Storage::<DefaultSpace>::default())
+            .await
+            .unwrap();
+        assert_eq!(name, response.active);
+    }
+}

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -3258,7 +3258,15 @@ pub async fn bootstrap_profile(tonk: &TonkState) -> Result<(), RepositoryError> 
     // de-duplicates rather than minting fresh claims, so it's safe on
     // every boot. Fetch is only available in the SW scope; native
     // builds skip it (the Hub is a browser-only surface).
-    seed_profile_library(tonk).await?;
+    //
+    // Best-effort: this runs again on every boot and profile
+    // activation, so a failed fetch (an offline worker restart, a
+    // harness that serves no library) costs a degraded Hub until the
+    // next attempt — not a worker that refuses to boot or a profile
+    // switch that dies half-way.
+    if let Err(error) = seed_profile_library(tonk).await {
+        log!("profile library seed skipped: {error}");
+    }
 
     // Drain the poll the bootstrap commit scheduled.
     tonk.reactor.run_scheduled_polls(&tonk.operator).await;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1814,7 +1814,34 @@ async fn remove_space_inner(state: &AppState, subject: &Did) -> Result<(), Repos
     }
     // Storage cleanup after the lock is released — the delete awaits
     // browser IO and must not stall other requests.
-    let _ = wasm_bindgen_futures::JsFuture::from(delete_space_storage(subject.repo_key())).await;
+    //
+    // A space's storage is keyed by routing key alone, with no profile
+    // prefix, so two profiles replicating one space SHARE its storage.
+    // With more than one profile on this browser the delete is skipped
+    // (the replica rows above are still removed): the failure mode is
+    // leaked storage, never data loss — blocks are re-fetchable for
+    // sync-enabled spaces. A precise guard that consults the other
+    // profiles' replica indexes is deferred. An unreadable roster skips
+    // too, since sharing can't be ruled out.
+    let other_profiles = {
+        let tonk = state.read().await;
+        match tonk.registry.read_roster(&tonk.storage).await {
+            Ok(roster) => roster.len() > 1,
+            Err(error) => {
+                log!("profile roster unreadable before storage delete: {error}");
+                true
+            }
+        }
+    };
+    if other_profiles {
+        log!(
+            "keeping storage for '{}': another profile on this browser may replicate it",
+            subject.repo_key()
+        );
+    } else {
+        let _ =
+            wasm_bindgen_futures::JsFuture::from(delete_space_storage(subject.repo_key())).await;
+    }
 
     // The delete ran unlocked, so a concurrent `drain_sync` could have
     // reached in and re-acquired the repo (e.g. to pull) while it was in

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -374,6 +374,12 @@ pub struct TonkState {
     /// HTTP surface, so it sits on the hot path for every repository request.
     /// See [`crate::router::AccountKeys`].
     pub account_keys: crate::router::AccountKeys,
+    /// Handle to the fixed registry profile recording which profile is
+    /// active and the roster of every profile this browser knows. Held so
+    /// the profile-switching routes can validate, repoint, and annotate
+    /// without re-deriving where the registry lives — and so tests can
+    /// point it at a scratch registry instead of the real one.
+    pub(crate) registry: crate::device::Registry,
 }
 
 // SAFETY: Web browsers run Wasm in a single thread only. The interior types
@@ -1626,6 +1632,48 @@ const SYNC_HIDDEN_INTERVAL_MS: i32 = 60_000;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const SYNC_HIDDEN_MAX_MS: i32 = 3_600_000;
 
+/// Build a [`TonkState`] for an already-opened profile — the shared core
+/// of worker boot and profile activation.
+///
+/// Opens a signing session over `storage`, constructs the reactive state,
+/// and bootstraps the profile repo's meta branch (idempotent). The
+/// registry's active-profile pointer is deliberately not touched here:
+/// activation repoints it only after this succeeds, so a failed build
+/// never strands the next boot on a broken profile.
+pub(crate) async fn boot_state(
+    storage: Storage<DefaultSpace>,
+    profile_name: String,
+    profile: Profile,
+    registry: crate::device::Registry,
+) -> Result<TonkState, crate::TonkWorkerError> {
+    let session = crate::session::open(&profile, &storage)
+        .await
+        .map_err(|e| {
+            crate::TonkWorkerError::Internal(format!("failed to open a signing session: {e}"))
+        })?;
+
+    let reactor = crate::Reactor::new(profile.clone());
+    let state = TonkState {
+        profile,
+        operator: session.operator,
+        storage,
+        session_expires_at: session.expires_at,
+        profile_name,
+        reactor,
+        view_bindings: Default::default(),
+        bridges: Default::default(),
+        commands: crate::router::command_registry(),
+        sync_queue: Default::default(),
+        clients: Default::default(),
+        account_keys: Default::default(),
+        registry,
+    };
+    bootstrap_profile(&state).await.map_err(|e| {
+        crate::TonkWorkerError::Internal(format!("failed to bootstrap profile meta: {e}"))
+    })?;
+    Ok(state)
+}
+
 /// The main Tonk service worker that handles browser fetch events.
 ///
 /// This struct bridges the browser's service worker API with an Axum router,
@@ -1684,41 +1732,22 @@ impl TonkServiceWorker {
         let storage = Storage::<DefaultSpace>::default();
 
         // 2. Open the profile this device signs as. Usually the one it
-        // started with; a device that has signed out since then signs
-        // as the profile that replaced the key it revoked.
-        let (profile_name, profile) = crate::device::open_active(&storage)
+        // started with; a device that has signed out (or added an
+        // account) since then signs as whatever profile the registry's
+        // pointer names.
+        let registry = crate::device::Registry::device();
+        let (profile_name, profile) = registry
+            .open_active(&storage)
             .await
             .map_err(|e| JsError::new(&format!("Failed to open profile: {}", e)))?;
         log!("Profile DID: {}", profile.did());
 
-        // 3. Open a signing session — an operator keyed for this
-        // session alone, authorized by a delegation that expires. The
-        // storage is shared, not handed over, so a later rotation can
-        // build its replacement over the same pool.
-        let session = crate::session::open(&profile, &storage)
+        // 3–4. Open a signing session, build state, and bootstrap the
+        // profile repo's meta branch — shared with profile activation,
+        // which rebuilds the same state for a different profile.
+        let state = boot_state(storage, profile_name, profile, registry)
             .await
-            .map_err(|e| JsError::new(&format!("Failed to open a signing session: {}", e)))?;
-
-        // 4. Build state and bootstrap the profile repo's meta
-        // branch. Idempotent — safe to run on every worker boot.
-        let reactor = crate::Reactor::new(profile.clone());
-        let state = TonkState {
-            profile,
-            operator: session.operator,
-            storage,
-            session_expires_at: session.expires_at,
-            profile_name,
-            reactor,
-            view_bindings: Default::default(),
-            bridges: Default::default(),
-            commands: crate::router::command_registry(),
-            sync_queue: Default::default(),
-            clients: Default::default(),
-            account_keys: Default::default(),
-        };
-        bootstrap_profile(&state)
-            .await
-            .map_err(|e| JsError::new(&format!("Failed to bootstrap profile meta: {}", e)))?;
+            .map_err(|e| JsError::new(&format!("Failed to initialize the worker: {e}")))?;
 
         // 5. Wrap state in the router. `api_router_with_state`
         // returns the LSP hub *and* a cloneable `AppState` handle:
@@ -1742,6 +1771,10 @@ impl TonkServiceWorker {
             let state = state.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let tonk = state.read().await;
+                // Best-effort roster upsert so existing installs
+                // self-populate a switcher entry for the profile they
+                // already have — the grandfathering path.
+                crate::router::profiles::upsert_active_entry(&tonk, None).await;
                 crate::router::account_state::ensure_account_state(&tonk).await;
                 crate::router::restore::restore_spaces(&tonk).await;
             });


### PR DESCRIPTION
Lets several accounts be signed in on one browser concurrently, with an account switcher, where each account sees only its own spots and the hidden profile/account state follows the active account. Plan: `plan/multi-account-browser.md` (committed here).

## Approach

Profile-per-account. Everything that should swap per account is already scoped to the worker profile (replica index, local root, provider attachment, hidden account repository, display name, certificate store), so switching accounts is switching profiles: build a replacement `TonkState` for the target profile, repoint the existing `tonk-active-profile-v1` pointer, and swap the value inside the shared state handle — a page reload does not restart the service worker, so the in-place swap is what a switch is. Isolation falls out of existing structure rather than being patched leak by leak.

## What's here

- **Worker roster + switching** (`e07c178`): a `tonk-profile-roster-v1` roster beside the pointer on the registry profile, maintained best-effort at boot/link/unlink/establish/rename/switch (existing installs grandfather in via the boot upsert); `boot_state` extracted from `TonkServiceWorker::new` and shared with activation; `GET /api/profiles`, `POST /api/profiles/activate` (roster-validated — `Profile::open` is open-or-create, so an unvalidated name would mint a garbage key; the pointer only repoints after the target boots), `POST /api/profiles/add` (rotates to a fresh landing pad, reusing an abandoned rootless/space-less one). Space removal skips the best-effort storage delete when the roster names more than one profile, since space storage is keyed by routing key alone and may be shared.
- **Switcher UI + sign-in rule** (`4285029`): the account dashboard lists every profile on this browser (active row marked and inert) with an Add account action; the Choice panel shows the other profiles and offers "Use a different account" when a root is persisted. With add-account in place, `persist_root` re-tightens the rule 697c86c relaxed: a ceremony resolving a *different* root than the persisted one is a Conflict directing to add-account; same-root re-sign-in after sign-out still updates in place.
- **Best-effort profile-library seed** (`d07f80a`): `bootstrap_profile` no longer dies on a failed `/library/profile.yaml` fetch — it runs on every boot and now every activation, the seed is idempotent, and a degraded Hub beats a dead worker or a half-finished switch.

Distinct profiles are distinct device DIDs, so concurrent attachments don't collide on the account service's `devices_one_active_did` and switching needs no server interaction. Sign-out stays per-profile and non-destructive; the row just renders as a local workspace.

## Verification

- `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --all --check`, native suites: green.
- wasm browser suites (tonk-worker / tonk-ui / tonk-worker-api): 327 tests green, including new roster, activate/add, unlink-roster, and different-root-conflict tests.
- New real-browser e2e `it_adds_a_second_account_and_switches_between_disjoint_space_lists`: sign up A, create a spot, add account, sign up B, B's Hub is empty, switch back through the switcher, A's spot returns — passing.

## Deferred (listed in the plan)

Stage-3 polish (`DELETE /api/profiles/{name}` / remove-from-browser, sibling-tab reload broadcast, precise shared-storage guard), server-side detach on sign-out, per-profile `tonk:auto-sync:*` namespacing, FAB switcher entry point, CLI multi-account.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the profile management functionality within the application, allowing users to manage multiple profiles more effectively. It introduces new API endpoints for profiles and updates the UI to support profile switching.

### Detailed summary
- Added `profiles` module with API endpoints for listing, activating, and adding profiles.
- Introduced `ProfileRosterEntry` and `ProfilesResponse` data structures.
- Updated UI to include profile management features, such as displaying and switching profiles.
- Enhanced backend logic to handle profile state and roster updates.
- Added tests for profile management functionality.

> The following files were skipped due to too many changes: `rust/tonk-worker/src/router/profiles.rs`, `plan/multi-account-browser.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->