### PR TITLE
chore: release 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account-service"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "dialog-common",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "bs58",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "blake3",
  "bs58",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5047,7 +5047,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "dialog-capability",
  "dialog-common",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
Bump the workspace version 0.6.6 -> 0.6.7, which is what cuts the CLI release: on merge, `release-tag.yml` sees `[workspace.package] version` change, tags `v0.6.7` at the merged commit, and that tag starts `cli-npm.yml` to publish `@tonk/cli@0.6.7` to `@latest`.

Patch level: everything on staging since `v0.6.6` is a fix, apart from one worker-side feature with no CLI surface.

- 3793d7952 fix(cli): restart a handoff the service will not reissue (#695)
- 5afaba53b feat(worker): renew guest session authority from the retained invite (#693)
- 17c15b31e ci: deploy the account worker with every release (#690)
- 771277509 fix(cli): recover and adopt a spot's account authority (#689)
- 95fc18396 fix(cli): stop an undeliverable detach from bricking account link (#688)
- d1f185d5c fix(cli): reject expired authorization sessions (#687)

Cargo.toml plus Cargo.lock only, no other files touched.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version number for multiple packages in the `Cargo.toml` and `Cargo.lock` files from `0.6.6` to `0.6.7`, indicating a new release for various components of the project.

### Detailed summary
- Updated version from `0.6.6` to `0.6.7` for:
  - `dialog-reactor`
  - `tonk-access-service`
  - `tonk-account`
  - `tonk-account-service`
  - `tonk-analytics`
  - `tonk-analyzer`
  - `tonk-board`
  - `tonk-cli`
  - `tonk-code`
  - `tonk-common`
  - `tonk-core`
  - `tonk-display`
  - `tonk-evaluator`
  - `tonk-fab`
  - `tonk-guest`
  - `tonk-host`
  - `tonk-identity`
  - `tonk-inspector`
  - `tonk-invite`
  - `tonk-language-server`
  - `tonk-macros`
  - `tonk-notation`
  - `tonk-portal`
  - `tonk-prose`
  - `tonk-render`
  - `tonk-router`
  - `tonk-schema`
  - `tonk-sigil`
  - `tonk-table`
  - `tonk-template`
  - `tonk-tree`
  - `tonk-ui`
  - `tonk-worker`
  - `tonk-worker-api`
  - `tonk-workspace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->