### PR TITLE
fix(cli): delete a spot's data when removing it, and say what that costs

### DIFF
--- a/rust/tonk-cli/src/account_spots.rs
+++ b/rust/tonk-cli/src/account_spots.rs
@@ -378,9 +378,18 @@ pub async fn pull(
     }
     let target = store.canonical_site(&name);
     if target.exists() {
+        // Reached most often after `tonk spot rm --keep-data`: the
+        // registry forgot the name but the data still holds it, so
+        // point at both ways to clear the collision rather than
+        // reporting it as a bare fact.
         return Err(name_error(
             Some(&name),
-            format!("the canonical site {} already exists", target.display()),
+            format!(
+                "the canonical site {target} already exists and belongs to no \
+                 registered spot; adopt it with `tonk spot new {name} --site {target}` \
+                 or delete the directory",
+                target = target.display()
+            ),
         ));
     }
 
@@ -465,6 +474,19 @@ async fn marker(site: &TonkSite, subject: &Did) -> Result<Option<Vec<u8>>> {
         Err(error) if crate::account_state::credential_is_missing(&error) => Ok(None),
         Err(error) => Err(error).context("failed to load the account backup marker"),
     }
+}
+
+/// Whether this device has already uploaded an account backup for
+/// `site`'s repository.
+///
+/// Answered from the local marker credential alone, so it costs no
+/// network round trip and works while logged out. The marker is
+/// written only after the account service accepts the payload
+/// ([`back_up_site_with_connection`]), which makes its presence a
+/// claim that a backup exists — the claim `tonk spot rm` leans on
+/// when it tells someone their data is recoverable.
+pub async fn has_account_backup(site: &TonkSite) -> Result<bool> {
+    Ok(marker(site, &site.repository.did()).await?.is_some())
 }
 
 async fn back_up_site_with_connection(

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -643,18 +643,44 @@ enum SpotCommand {
     #[command(after_help = "Examples:\n  tonk spot list")]
     List,
 
-    /// Remove a spot from the registry (data stays unless --delete)
-    #[command(after_help = "Examples:\n  tonk spot rm garden\n  tonk spot rm garden --delete")]
+    /// Delete a spot and its data from disk
+    ///
+    /// This destroys the spot's facts, not just its registration.
+    /// It asks for confirmation first, and says whether the data is
+    /// backed up to your account (so you can pull it again) or
+    /// local-only (so it is gone for good).
+    ///
+    /// To stop a directory from resolving to a spot without touching
+    /// any data, use `tonk spot unbind`. To drop the registration but
+    /// keep the data, use --keep-data.
+    #[command(
+        after_help = "Examples:\n  tonk spot rm garden\n  tonk spot rm garden --yes\n  tonk spot rm garden --keep-data"
+    )]
     Rm {
-        /// Spot name to unregister.
+        /// Spot name to delete.
         #[arg(value_name = "NAME")]
         name: String,
-        /// Also delete the site directory from disk.
-        #[arg(long)]
+        /// Unregister the spot but leave its data on disk.
+        ///
+        /// The data then belongs to no spot: `tonk spot list` reports
+        /// it, `tonk spot new <name> --site <path>` adopts it back,
+        /// and it keeps its canonical name reserved against `tonk
+        /// join` and `tonk account spots pull`.
+        #[arg(long, conflicts_with = "delete")]
+        keep_data: bool,
+        /// Delete without asking for confirmation.
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Accepted for compatibility — deleting the data is now the
+        /// default, so this flag does nothing.
+        #[arg(long, hide = true)]
         delete: bool,
     },
 
     /// Unbind a directory from its spot (see `tonk use`)
+    ///
+    /// Only unlinks the directory: the spot stays registered and no
+    /// data is touched. `tonk spot rm` is the one that deletes.
     ///
     /// Matches exactly: run from the directory that was bound,
     /// not a subdirectory of it.
@@ -1462,7 +1488,14 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
             .await
             {
                 Ok(outcome) => {
-                    println!("Registered spot '{}'", outcome.name);
+                    if outcome.adopted {
+                        println!(
+                            "Registered spot '{}' on the site data already at that path",
+                            outcome.name
+                        );
+                    } else {
+                        println!("Registered spot '{}'", outcome.name);
+                    }
                     println!("site: {}", outcome.site.display());
                     println!("DID: {}", outcome.did);
                     println!("binding: {}", cwd.display());
@@ -1487,6 +1520,7 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                 Ok(listing) => {
                     if listing.rows.is_empty() {
                         println!("(no spots registered; create one with `tonk spot new <name>`)");
+                        print_orphaned_sites(&listing.orphans);
                         return ExitCode::Success;
                     }
                     let active = listing.active.as_ref().map(|c| c.name.as_str());
@@ -1512,26 +1546,18 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                             println!("  {directory}\t{name}", directory = directory.display());
                         }
                     }
+                    print_orphaned_sites(&listing.orphans);
                     ExitCode::Success
                 }
                 Err(err) => print_failure(err),
             }
         }
-        SpotCommand::Rm { name, delete } => match tonk_cli::spot::remove(&store, &name, delete) {
-            Ok(outcome) => {
-                println!("Removed spot '{}' from the registry", outcome.name);
-                if outcome.deleted {
-                    println!("site deleted: {}", outcome.site.display());
-                } else {
-                    println!("site kept at {}", outcome.site.display());
-                }
-                for directory in &outcome.unbound {
-                    println!("unbound {}", directory.display());
-                }
-                ExitCode::Success
-            }
-            Err(err) => print_failure(err),
-        },
+        SpotCommand::Rm {
+            name,
+            keep_data,
+            yes,
+            delete: _,
+        } => spot_rm(&store, &name, keep_data, yes).await,
         SpotCommand::Unbind { path } => {
             let directory = match path.or_else(working_directory) {
                 Some(directory) => directory,
@@ -1550,6 +1576,150 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
             }
         }
     }
+}
+
+/// Report canonical site data that no registered spot names.
+///
+/// Silent when there is none, so the common listing stays clean. When
+/// there is some it belongs on screen: it is otherwise entirely
+/// invisible, and it is the thing that will refuse a later `tonk
+/// join` or `tonk account spots pull` on the same name.
+fn print_orphaned_sites(orphans: &[PathBuf]) {
+    if orphans.is_empty() {
+        return;
+    }
+    println!();
+    println!("unregistered site data (belongs to no spot):");
+    for path in orphans {
+        println!("  {}", path.display());
+    }
+    println!("  adopt it with `tonk spot new <name> --site <path>`, or delete the directory");
+}
+
+/// `tonk spot rm` — delete a spot's data, or (with --keep-data) just
+/// its registration.
+///
+/// Deleting is the default because the alternative is worse: an
+/// unregistered site directory is invisible to every command that
+/// reads the registry, yet still holds the canonical name against
+/// `tonk join --name` and `tonk account spots pull --name`. Making
+/// that the accident-shaped path instead of the deliberate one is
+/// what this command is for.
+async fn spot_rm(
+    store: &tonk_cli::spot::SpotStore,
+    name: &str,
+    keep_data: bool,
+    yes: bool,
+) -> ExitCode {
+    use tonk_cli::spot::{Data, Deletion};
+
+    let registry = match store.load() {
+        Ok(registry) => registry,
+        Err(err) => return print_failure(err),
+    };
+    // Resolved up front so the confirmation can name the exact
+    // directory it is about to destroy, and so an unknown name fails
+    // before anything is inspected or printed.
+    let Some(entry) = registry.spots.get(name) else {
+        return print_failure(tonk_cli::spot::SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+            binding: None,
+        });
+    };
+    let site = entry.site.clone();
+
+    if keep_data {
+        return match tonk_cli::spot::remove(store, name, Data::Keep) {
+            Ok(outcome) => {
+                println!("Unregistered spot '{}'", outcome.name);
+                println!("data kept at {}", outcome.site.display());
+                println!(
+                    "  it belongs to no spot now: re-adopt it with \
+                     `tonk spot new <name> --site {}`,",
+                    outcome.site.display()
+                );
+                println!("  or delete it with `tonk spot rm <name>` after re-adopting");
+                for directory in &outcome.unbound {
+                    println!("unbound {}", directory.display());
+                }
+                ExitCode::Success
+            }
+            Err(err) => print_failure(err),
+        };
+    }
+
+    if !yes {
+        // Checked before anything is inspected or printed: there is
+        // no one to read a warning addressed to a pipe, and
+        // inspecting the site to write it means opening a repository
+        // this command was never going to be allowed to delete.
+        if !std::io::stdin().is_terminal() {
+            return print_error(format!(
+                "refusing to delete '{name}': stdin is not a terminal, so the \
+                 confirmation cannot be answered. Pass --yes to delete without \
+                 confirming, or --keep-data to unregister without deleting."
+            ));
+        }
+        let recovery = tonk_cli::recovery::inspect(&site, site::default_config()).await;
+        println!();
+        println!("This permanently deletes the spot's data from disk:");
+        println!("  {}", site.display());
+        println!();
+        println!("{}", recovery.consequence(name));
+        if let Some(hint) = recovery.restore_hint() {
+            println!("  {hint}");
+        }
+        println!();
+        if !confirm_by_name(name) {
+            // Non-zero: a caller chaining off `tonk spot rm` must not
+            // read "you declined" as "it is gone".
+            println!("Aborted; nothing was deleted.");
+            return ExitCode::IoError;
+        }
+    }
+
+    match tonk_cli::spot::remove(store, name, Data::Delete) {
+        Ok(outcome) => {
+            match outcome.data {
+                Deletion::Deleted => {
+                    println!("Deleted spot '{}' and its data", outcome.name);
+                    println!("removed {}", outcome.site.display());
+                }
+                // Nothing was destroyed, so don't say it was.
+                Deletion::AlreadyGone => {
+                    println!("Unregistered spot '{}'", outcome.name);
+                    println!("its data was already gone from {}", outcome.site.display());
+                }
+                Deletion::Kept => unreachable!("Data::Delete never keeps the site"),
+            }
+            for directory in &outcome.unbound {
+                println!("unbound {}", directory.display());
+            }
+            ExitCode::Success
+        }
+        Err(err) => print_failure(err),
+    }
+}
+
+/// Require the operator to type `name` back, returning whether they
+/// did. Callers check for a terminal first.
+///
+/// Typing the name rather than `y` is deliberate: this is the one
+/// tonk command that destroys facts, and the cost of a mistaken
+/// keystroke is unbounded. Anything else — a wrong answer, a closed
+/// stdin, a write that fails — reads as "no", the only safe way to
+/// resolve a confirmation nobody gave.
+fn confirm_by_name(name: &str) -> bool {
+    print!("Type '{name}' to confirm: ");
+    if std::io::stdout().flush().is_err() {
+        return false;
+    }
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    answer.trim() == name
 }
 
 async fn eval(args: EvalArgs, spot: Option<&str>) -> ExitCode {

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -107,7 +107,17 @@ pub enum InviteError {
     /// already exists. The join must never clobber existing site
     /// storage; the user removes it (or picks another spot name)
     /// first.
-    #[error("a site already exists at {0}; remove it or pick another spot name")]
+    ///
+    /// The likeliest way to reach this without having noticed is
+    /// `tonk spot rm --keep-data` under the same name, which leaves
+    /// data here that no registry entry mentions — so the message
+    /// names both ways out rather than just "remove it".
+    #[error(
+        "a site already exists at {0}\n\
+         it belongs to no registered spot; adopt it with \
+         `tonk spot new <name> --site {0}`,\n\
+         delete the directory, or join under another spot name"
+    )]
     SiteAlreadyExists(PathBuf),
     /// Anything else — key generation, delegation building,
     /// storage I/O. Surfaced verbatim.

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -10,6 +10,8 @@
 //! - [`site`] — repo+branch open/init; resolved via the spot registry.
 //! - [`spot`] — spot registry: named spots, canonical storage, selection.
 //! - [`account_spots`] — account inventory, pull, and backup reconciliation.
+//! - [`recovery`] — whether a spot's data exists anywhere but this
+//!   disk, so deleting it can say what it costs.
 //! - [`identity`] — local profile management.
 //! - [`agents`] — claim-backed spot context and `AGENTS.md` projection data.
 //! - [`authoring`] — pure notation builders (concept, view, and the
@@ -48,6 +50,7 @@ pub mod identity;
 pub mod invite;
 pub mod migrate;
 pub mod output;
+pub mod recovery;
 pub mod remote;
 pub mod render;
 pub mod schema;

--- a/rust/tonk-cli/src/recovery.rs
+++ b/rust/tonk-cli/src/recovery.rs
@@ -1,0 +1,158 @@
+//! Whether a spot's data survives being deleted.
+//!
+//! `tonk spot rm` destroys a site directory, and how bad that is
+//! depends entirely on where else the facts exist. A spot backed up
+//! to an account can be pulled down again; a spot that only ever
+//! pushed to a remote can be recovered from that remote if the
+//! operator still holds authority over it; a spot with no upstream at
+//! all exists nowhere else, and deleting it is final.
+//!
+//! The registry cannot answer this — [`crate::spot::SpotEntry`] is a
+//! path and nothing more — so the answer is read out of the site
+//! itself: the `main` branch's upstream, plus the local account
+//! backup marker. Both are local reads. Deliberately no network call:
+//! a confirmation prompt that hangs on a dead account service is a
+//! worse failure than one that reports what this device knows.
+
+use std::path::Path;
+
+use crate::site::{SiteConfig, TonkSite};
+
+/// Where a spot's data exists besides this directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Recovery {
+    /// Backed up to the linked account, and pullable again by
+    /// subject.
+    Account {
+        /// Repository subject DID, the argument `tonk account spots
+        /// pull` takes.
+        subject: String,
+    },
+    /// Pushed to a remote, but with no account backup recorded on
+    /// this device. Recoverable only by someone who can still reach
+    /// that remote with authority over the repository — an invite,
+    /// or another device that holds the delegation.
+    Remote {
+        /// Local name of the tracked remote.
+        name: String,
+        /// Its endpoint URL.
+        endpoint: String,
+    },
+    /// No upstream: this directory is the only copy.
+    LocalOnly,
+    /// The site would not open, so nothing can be claimed either
+    /// way. Reported rather than assumed, because guessing
+    /// "recoverable" invites data loss and guessing "local-only"
+    /// cries wolf.
+    Unknown {
+        /// Why the inspection failed, for the operator to judge.
+        detail: String,
+    },
+}
+
+impl Recovery {
+    /// True only when this device can point at a copy it knows how
+    /// to fetch back.
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self, Recovery::Account { .. })
+    }
+
+    /// What deleting `name` costs, phrased for a confirmation
+    /// prompt.
+    pub fn consequence(&self, name: &str) -> String {
+        match self {
+            Recovery::Account { subject } => format!(
+                "'{name}' is backed up to your account ({subject}).\n\
+                 You can pull it down again after deleting it."
+            ),
+            Recovery::Remote {
+                name: remote,
+                endpoint,
+            } => format!(
+                "'{name}' pushes to '{remote}' ({endpoint}) but has no account\n\
+                 backup on this device. Deleting it here keeps whatever the remote\n\
+                 already holds, but this device loses its access to it."
+            ),
+            Recovery::LocalOnly => format!(
+                "'{name}' is local-only: it has no upstream and no account backup,\n\
+                 so this is the only copy and deleting it cannot be undone."
+            ),
+            Recovery::Unknown { detail } => format!(
+                "'{name}' could not be inspected, so whether it exists anywhere else\n\
+                 is unknown ({detail}). Treat this as unrecoverable."
+            ),
+        }
+    }
+
+    /// How to get the data back, when this device knows a way.
+    pub fn restore_hint(&self) -> Option<String> {
+        match self {
+            Recovery::Account { subject } => Some(format!(
+                "restore it later with `tonk account spots pull {subject}`"
+            )),
+            Recovery::Remote { .. } | Recovery::LocalOnly | Recovery::Unknown { .. } => None,
+        }
+    }
+}
+
+/// Inspect the site at `path` and report where else its data lives.
+///
+/// Never fails: every error becomes [`Recovery::Unknown`], because
+/// the caller's next move is to show a human a warning either way,
+/// and a probe that can abort the command it is trying to make safe
+/// has the priorities backwards.
+pub async fn inspect(path: &Path, config: SiteConfig) -> Recovery {
+    let site = match TonkSite::open_with(path, config).await {
+        Ok(site) => site,
+        Err(error) => {
+            return Recovery::Unknown {
+                detail: format!("{error}"),
+            };
+        }
+    };
+
+    let upstream = match crate::remote::upstream_remote(&site).await {
+        Ok(Some(upstream)) => upstream,
+        // No upstream is a definite answer, not a failed one: a
+        // branch that tracks nothing has pushed nowhere.
+        Ok(None) => return Recovery::LocalOnly,
+        Err(error) => {
+            return Recovery::Unknown {
+                detail: format!("{error}"),
+            };
+        }
+    };
+
+    // An account backup is only ever written for a site that has an
+    // upstream, so this is checked second and only here.
+    match crate::account_spots::has_account_backup(&site).await {
+        Ok(true) => {
+            return Recovery::Account {
+                subject: site.repository.did().to_string(),
+            };
+        }
+        Ok(false) => {}
+        Err(error) => {
+            return Recovery::Unknown {
+                detail: format!("{error:#}"),
+            };
+        }
+    }
+
+    let endpoint = match crate::remote::find(&site, &upstream).await {
+        Ok(Some(record)) => record.endpoint,
+        // The upstream names a remote the meta branch no longer
+        // describes. The push target is real enough to mention;
+        // only its address is missing.
+        Ok(None) => "address unknown".to_owned(),
+        Err(error) => {
+            return Recovery::Unknown {
+                detail: format!("{error}"),
+            };
+        }
+    };
+    Recovery::Remote {
+        name: upstream,
+        endpoint,
+    }
+}

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -75,6 +75,21 @@ const OPERATOR_CONTEXT: &[u8] = b"slide";
 /// Name of the `.tonk/` sub-directory holding repository data.
 pub const SITE_DIRNAME: &str = ".tonk";
 
+/// Whether `root` already holds site data.
+///
+/// The dialog repository always lands in `<root>/<REPO_NAME>/`, so
+/// that directory is the marker regardless of how the site was
+/// created. Callers use it to tell "creating a site here" from
+/// "adopting the site already here" — a distinction
+/// [`TonkSite::init_at_with`] deliberately erases by being
+/// idempotent.
+///
+/// A bare `root` that exists but holds no repository reads as no
+/// data: an empty directory is not a site.
+pub fn has_site_data(root: &Path) -> bool {
+    root.join(REPO_NAME).is_dir()
+}
+
 /// An opened tonk site: profile, operator, repository, and a
 /// reactor, all wired up against the on-disk `.tonk/` directory.
 ///

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -165,7 +165,11 @@ pub enum SpotError {
     },
     /// `spot new` against a name that already exists. Re-pointing
     /// is an explicit `rm` + `new`, never an overwrite.
-    #[error("spot '{0}' already exists; run `tonk spot rm {0}` first to re-point it")]
+    #[error(
+        "spot '{0}' already exists; to re-point the name run \
+         `tonk spot rm {0} --keep-data` first, or `tonk spot rm {0}` \
+         to delete its data as well"
+    )]
     Exists(String),
     /// The registry file exists but doesn't parse. Deliberately
     /// not self-healing: silently recreating it would orphan every
@@ -270,6 +274,46 @@ impl SpotStore {
     /// Purely a path computation — nothing is created.
     pub fn canonical_site(&self, name: &str) -> PathBuf {
         self.dir.join(SPOTS_DIRNAME).join(name)
+    }
+
+    /// The root holding canonical site directories.
+    pub fn spots_root(&self) -> PathBuf {
+        self.dir.join(SPOTS_DIRNAME)
+    }
+
+    /// Canonical site directories that no registry entry names.
+    ///
+    /// These are left by `tonk spot rm --keep-data` (and by a
+    /// hand-edited `spots.json`). They are invisible to every other
+    /// command yet still occupy their names: `tonk join --name x` and
+    /// `tonk account spots pull --name x` both refuse to write over
+    /// one. Listing them is what makes that state recoverable instead
+    /// of merely confusing.
+    ///
+    /// A store whose `spots/` directory cannot be read has no
+    /// orphans to report — this is a diagnostic, never a reason to
+    /// fail a command that was otherwise fine.
+    pub fn orphaned_sites(&self, registry: &Registry) -> Vec<PathBuf> {
+        let registered: Vec<PathBuf> = registry
+            .spots
+            .values()
+            .map(|entry| canonical(&entry.site))
+            .collect();
+        let Ok(entries) = std::fs::read_dir(self.spots_root()) else {
+            return Vec::new();
+        };
+        // Canonicalized on the way out, not just for the comparison:
+        // these paths get printed as `--site` arguments, and a path
+        // that doesn't compare equal to the one `spot new` would
+        // register is a path that re-creates this same confusion.
+        let mut orphans: Vec<PathBuf> = entries
+            .flatten()
+            .filter(|entry| entry.path().is_dir())
+            .map(|entry| canonical(&entry.path()))
+            .filter(|path| !registered.contains(path))
+            .collect();
+        orphans.sort();
+        orphans
     }
 
     /// Load the registry. A missing file is an empty registry (the
@@ -424,6 +468,43 @@ pub struct CreateOutcome {
     pub site: PathBuf,
     /// The site repository's DID.
     pub did: String,
+    /// Whether site data was already at the target and got adopted
+    /// rather than created.
+    ///
+    /// Adoption is the point of `--site`, but it also happens
+    /// silently at the canonical path after `tonk spot rm
+    /// --keep-data` — the same name picks its old data back up. That
+    /// is usually what someone wants and never what they expect, so
+    /// the caller says which one happened.
+    pub adopted: bool,
+}
+
+/// What [`remove`] should do with the spot's site data.
+///
+/// Explicit rather than a `bool` because the two arms are not
+/// variations on one operation: deleting is irreversible and
+/// keeping leaves data behind that no registry entry names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Data {
+    /// Delete the site directory from disk.
+    Delete,
+    /// Leave the site directory where it is. The data then belongs
+    /// to no registered spot — see [`SpotStore::orphaned_sites`].
+    Keep,
+}
+
+/// What happened to the site directory during [`remove`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Deletion {
+    /// The directory was deleted.
+    Deleted,
+    /// [`Data::Delete`] was asked for but nothing was there — the
+    /// registry named a directory that had already been removed by
+    /// hand. Distinguished from `Deleted` so output can say the
+    /// data was already gone rather than claim to have destroyed it.
+    AlreadyGone,
+    /// [`Data::Keep`]: the directory is still on disk.
+    Kept,
 }
 
 /// Outcome of [`remove`].
@@ -431,10 +512,11 @@ pub struct CreateOutcome {
 pub struct RemoveOutcome {
     /// The removed registry name.
     pub name: String,
-    /// Where the site lived (still lives, unless `deleted`).
+    /// Where the site lived (still lives, when `data` is
+    /// [`Deletion::Kept`]).
     pub site: PathBuf,
-    /// Whether the site directory was deleted from disk.
-    pub deleted: bool,
+    /// What became of the site directory.
+    pub data: Deletion,
     /// Directories that were bound to this spot and are no longer
     /// bound to anything.
     pub unbound: Vec<PathBuf>,
@@ -450,6 +532,9 @@ pub struct Listing {
     pub bindings: Vec<(PathBuf, String)>,
     /// The spot a bare command would hit right now, with source.
     pub active: Option<Resolved>,
+    /// Site data under `spots/` that no entry names. See
+    /// [`SpotStore::orphaned_sites`].
+    pub orphans: Vec<PathBuf>,
 }
 
 /// Register an already-mounted canonical site without binding any directory.
@@ -510,6 +595,9 @@ pub async fn create(
     let target = site_override
         .map(Path::to_path_buf)
         .unwrap_or_else(|| store.canonical_site(name));
+    // Asked before init, which is idempotent and so cannot tell us
+    // afterwards whether it created or adopted.
+    let adopted = crate::site::has_site_data(&target);
     let site = crate::site::TonkSite::init_at_with(&target, config)
         .await
         .map_err(|e| SpotError::Init(format!("{e:#}")))?;
@@ -518,6 +606,7 @@ pub async fn create(
         name: name.to_owned(),
         site: site.root.clone(),
         did: site.repository.did().to_string(),
+        adopted,
     };
     registry.spots.insert(
         name.to_owned(),
@@ -622,13 +711,25 @@ pub fn listing(
         rows,
         bindings,
         active: store.resolve(flag, env, cwd).ok(),
+        orphans: store.orphaned_sites(&registry),
     })
 }
 
-/// Remove `name` from the registry. Site data stays on disk unless
-/// `delete` — the registry is the authority on names, not a lifecycle
-/// manager for storage it didn't necessarily create.
-pub fn remove(store: &SpotStore, name: &str, delete: bool) -> Result<RemoveOutcome, SpotError> {
+/// Remove `name` from the registry, deleting its site data or
+/// leaving it behind per `data`.
+///
+/// The data is deleted *before* the registry is saved. The reverse
+/// order looks more cautious and is worse: a delete that fails after
+/// the entry is already gone leaves data on disk that nothing names,
+/// which is precisely the state that later blocks `tonk join` and
+/// `tonk account spots pull` on the same name. Deleting first means a
+/// failure leaves the spot fully registered and the command safe to
+/// retry.
+///
+/// The residual risk runs the other way — data deleted, registry save
+/// fails — and is benign: the entry points at an empty path, `tonk
+/// spot list` shows it, and re-running `rm` clears it.
+pub fn remove(store: &SpotStore, name: &str, data: Data) -> Result<RemoveOutcome, SpotError> {
     let mut registry = store.load()?;
     let Some(entry) = registry.spots.remove(name) else {
         return Err(SpotError::Unknown {
@@ -649,22 +750,29 @@ pub fn remove(store: &SpotStore, name: &str, delete: bool) -> Result<RemoveOutco
     for directory in &unbound {
         registry.bindings.remove(directory);
     }
-    store.save(&registry)?;
-    let deleted = if delete {
-        std::fs::remove_dir_all(&entry.site).map_err(|e| {
-            SpotError::Io(format!(
-                "entry removed, but deleting {} failed: {e}",
-                entry.site.display()
-            ))
-        })?;
-        true
-    } else {
-        false
+
+    let deletion = match data {
+        Data::Keep => Deletion::Kept,
+        Data::Delete => match std::fs::remove_dir_all(&entry.site) {
+            Ok(()) => Deletion::Deleted,
+            // The registry outlived the directory. Nothing to
+            // destroy and nothing to warn about beyond saying so:
+            // dropping the entry is still the right outcome.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Deletion::AlreadyGone,
+            Err(e) => {
+                return Err(SpotError::Io(format!(
+                    "could not delete {}: {e}; spot '{name}' is still registered",
+                    entry.site.display()
+                )));
+            }
+        },
     };
+    store.save(&registry)?;
+
     Ok(RemoveOutcome {
         name: name.to_owned(),
         site: entry.site,
-        deleted,
+        data: deletion,
         unbound,
     })
 }
@@ -1065,12 +1173,62 @@ mod tests {
             bind(&store, "a", Path::new("/proj")).expect("bind a");
             bind(&store, "b", Path::new("/other")).expect("bind b");
 
-            let outcome = remove(&store, "a", false).expect("remove");
+            let outcome = remove(&store, "a", Data::Keep).expect("remove");
             assert_eq!(outcome.unbound, vec![PathBuf::from("/proj")]);
 
             let bindings = store.load().expect("load").bindings;
             assert_eq!(bindings.get(Path::new("/other")), Some(&"b".to_owned()));
             assert!(!bindings.contains_key(Path::new("/proj")));
+        }
+    }
+
+    mod removal {
+        use super::*;
+
+        /// A failed delete must leave the spot registered. The
+        /// alternative — name unregistered, data still on disk — is
+        /// the exact state this command exists to prevent, and
+        /// reaching it by accident is worse than failing loudly.
+        #[dialog_common::test]
+        fn it_keeps_the_entry_registered_when_the_delete_fails() {
+            let (tmp, store) = store();
+            // A regular file where a site directory should be:
+            // `remove_dir_all` refuses it, and not with NotFound.
+            let site = tmp.path().join("not-a-directory");
+            std::fs::write(&site, b"").expect("write");
+            store
+                .save(&registry_with(
+                    &[("a", site.to_str().expect("utf-8 path"))],
+                    None,
+                ))
+                .expect("save");
+
+            let err = remove(&store, "a", Data::Delete).expect_err("delete fails");
+            assert!(err.to_string().contains("still registered"), "{err}");
+            assert!(
+                store.load().expect("load").spots.contains_key("a"),
+                "the entry survives a failed delete"
+            );
+        }
+
+        #[dialog_common::test]
+        fn it_counts_only_unregistered_site_directories_as_orphans() {
+            let (tmp, store) = store();
+            let live = store.canonical_site("live");
+            let kept = store.canonical_site("kept");
+            std::fs::create_dir_all(&live).expect("live");
+            std::fs::create_dir_all(&kept).expect("kept");
+            let registry = registry_with(&[("live", live.to_str().expect("utf-8 path"))], None);
+            store.save(&registry).expect("save");
+
+            assert_eq!(
+                store.orphaned_sites(&registry),
+                vec![kept.canonicalize().expect("canonicalize kept")]
+            );
+            // A store whose `spots/` root does not exist yet has
+            // nothing to report rather than something to fail on.
+            let empty = SpotStore::at(tmp.path().join("nowhere"));
+            assert!(empty.orphaned_sites(&registry).is_empty());
         }
     }
 

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -939,3 +939,122 @@ mod when_a_binding_is_orphaned {
         assert!(stderr.contains("spot unbind"), "{stderr}");
     }
 }
+
+/// `tonk spot rm` is the only command that destroys facts, so its
+/// guard rails are worth exercising through the real binary: the
+/// prompt, the non-interactive refusal, and what each mode leaves on
+/// disk. `run` pipes stdin, so every invocation here is exactly the
+/// non-terminal case a script would hit.
+mod when_deleting_a_spot {
+    use super::*;
+
+    /// Create a spot at its canonical path, bound to `cwd`, and
+    /// return where its data landed.
+    fn canonical_spot(state_dir: &Path, cwd: &Path, name: &str) -> std::path::PathBuf {
+        let output = run_in(state_dir, cwd, &["spot", "new", name], &[]);
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        let site = state_dir.join("spots").join(name);
+        assert!(site.is_dir(), "site data at {}", site.display());
+        site
+    }
+
+    fn work_dir(state: &tempfile::TempDir) -> std::path::PathBuf {
+        let work = state.path().join("work");
+        std::fs::create_dir_all(&work).expect("mkdir work");
+        work.canonicalize().expect("canonicalize work")
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_to_delete_when_the_prompt_cannot_be_answered() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let work = work_dir(&state);
+        let site = canonical_spot(state.path(), &work, "garden");
+
+        let output = run_in(state.path(), &work, &["spot", "rm", "garden"], &[]);
+        assert!(!output.status.success(), "{}", stdout_of(&output));
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("stdin is not a terminal"), "{stderr}");
+        assert!(stderr.contains("--yes"), "{stderr}");
+        assert!(stderr.contains("--keep-data"), "{stderr}");
+
+        // Nothing moved: the spot is still registered and its data
+        // is untouched.
+        assert!(site.is_dir(), "data survives the refusal");
+        let listed = stdout_of(&run(state.path(), &["spot", "list"], &[]));
+        assert!(listed.contains("garden"), "{listed}");
+    }
+
+    #[dialog_common::test]
+    fn it_deletes_the_data_with_yes() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let work = work_dir(&state);
+        let site = canonical_spot(state.path(), &work, "garden");
+
+        let output = run_in(state.path(), &work, &["spot", "rm", "garden", "--yes"], &[]);
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        let stdout = stdout_of(&output);
+        assert!(
+            stdout.contains("Deleted spot 'garden' and its data"),
+            "{stdout}"
+        );
+        assert!(!site.exists(), "data deleted");
+
+        let listed = stdout_of(&run(state.path(), &["spot", "list"], &[]));
+        assert!(listed.contains("no spots registered"), "{listed}");
+        assert!(!listed.contains("unregistered site data"), "{listed}");
+    }
+
+    /// The old default, now explicit. What matters is that the data
+    /// it leaves behind stops being invisible.
+    #[dialog_common::test]
+    fn it_reports_kept_data_as_unregistered_and_re_adoptable() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let work = work_dir(&state);
+        let site = canonical_spot(state.path(), &work, "garden");
+
+        let output = run_in(
+            state.path(),
+            &work,
+            &["spot", "rm", "garden", "--keep-data"],
+            &[],
+        );
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        let stdout = stdout_of(&output);
+        assert!(stdout.contains("Unregistered spot 'garden'"), "{stdout}");
+        assert!(stdout.contains("data kept at"), "{stdout}");
+        assert!(site.is_dir(), "data kept");
+
+        let listed = stdout_of(&run(state.path(), &["spot", "list"], &[]));
+        assert!(listed.contains("unregistered site data"), "{listed}");
+        let canonical = site.canonicalize().expect("canonicalize site");
+        assert!(
+            listed.contains(&canonical.display().to_string()),
+            "{listed}"
+        );
+    }
+
+    /// Re-using the name after `--keep-data` silently picks the old
+    /// facts back up. Useful, but it must say so — otherwise a spot
+    /// that was just "removed" comes back full of data.
+    #[dialog_common::test]
+    fn it_says_when_a_new_spot_adopted_leftover_data() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let work = work_dir(&state);
+        canonical_spot(state.path(), &work, "garden");
+        let removed = run_in(
+            state.path(),
+            &work,
+            &["spot", "rm", "garden", "--keep-data"],
+            &[],
+        );
+        assert!(removed.status.success(), "{}", stderr_of(&removed));
+
+        let output = run_in(state.path(), &work, &["spot", "new", "garden"], &[]);
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        let stdout = stdout_of(&output);
+        assert!(
+            stdout.contains("on the site data already at that path"),
+            "{stdout}"
+        );
+    }
+}

--- a/rust/tonk-cli/tests/spot.rs
+++ b/rust/tonk-cli/tests/spot.rs
@@ -74,17 +74,18 @@ mod when_creating_a_spot {
 
 mod when_removing_a_spot {
     use super::*;
+    use tonk_cli::spot::{Data, Deletion};
 
     #[dialog_common::test]
-    async fn it_unregisters_but_keeps_data_by_default() -> Result<()> {
+    async fn it_deletes_the_site_dir_and_the_entry() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         let store = SpotStore::at(tmp.path().join("state"));
         let config = common::isolated_config(&tmp.path().canonicalize()?)?;
         let created = spot::create(&store, "garden", None, Some(tmp.path()), config).await?;
 
-        let outcome = spot::remove(&store, "garden", false)?;
-        assert!(!outcome.deleted);
-        assert!(created.site.exists(), "data kept");
+        let outcome = spot::remove(&store, "garden", Data::Delete)?;
+        assert_eq!(outcome.data, Deletion::Deleted);
+        assert!(!created.site.exists(), "data removed");
         // Entry and its binding are gone.
         assert!(store.load()?.spots.is_empty());
         assert!(store.load()?.bindings.is_empty());
@@ -92,15 +93,78 @@ mod when_removing_a_spot {
     }
 
     #[dialog_common::test]
-    async fn it_deletes_the_site_dir_with_delete() -> Result<()> {
+    async fn it_keeps_the_site_dir_with_keep() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         let store = SpotStore::at(tmp.path().join("state"));
         let config = common::isolated_config(&tmp.path().canonicalize()?)?;
         let created = spot::create(&store, "garden", None, Some(tmp.path()), config).await?;
 
-        let outcome = spot::remove(&store, "garden", true)?;
-        assert!(outcome.deleted);
-        assert!(!created.site.exists(), "data removed");
+        let outcome = spot::remove(&store, "garden", Data::Keep)?;
+        assert_eq!(outcome.data, Deletion::Kept);
+        assert!(created.site.exists(), "data kept");
+        assert!(store.load()?.spots.is_empty());
+        Ok(())
+    }
+
+    /// The registry can outlive the directory it names — someone
+    /// deletes it by hand, or a sync tool does. Dropping the entry is
+    /// still right; the outcome just must not claim a deletion that
+    /// never happened.
+    #[dialog_common::test]
+    async fn it_reports_an_already_missing_site_rather_than_failing() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, Some(tmp.path()), config).await?;
+        std::fs::remove_dir_all(&created.site)?;
+
+        let outcome = spot::remove(&store, "garden", Data::Delete)?;
+        assert_eq!(outcome.data, Deletion::AlreadyGone);
+        assert!(store.load()?.spots.is_empty());
+        Ok(())
+    }
+
+    /// Data kept behind is data no entry names. `spot list` has to
+    /// report it, because nothing else will and it still holds the
+    /// canonical name against a later join or account pull.
+    #[dialog_common::test]
+    async fn it_leaves_kept_data_visible_as_an_orphan() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+        let created = spot::create(&store, "garden", None, Some(tmp.path()), config).await?;
+        assert!(
+            spot::listing(&store, None, None, None)?.orphans.is_empty(),
+            "a registered spot is not an orphan"
+        );
+
+        spot::remove(&store, "garden", Data::Keep)?;
+        let listing = spot::listing(&store, None, None, None)?;
+        assert_eq!(listing.orphans, vec![created.site.clone()]);
+
+        // Deleting the data clears the orphan too.
+        std::fs::remove_dir_all(&created.site)?;
+        assert!(spot::listing(&store, None, None, None)?.orphans.is_empty());
+        Ok(())
+    }
+
+    /// Re-creating the name after `Data::Keep` picks the old facts
+    /// back up. That is the useful behaviour, but it is silent, so
+    /// `create` reports which of the two happened.
+    #[dialog_common::test]
+    async fn it_reports_adoption_when_a_name_reclaims_kept_data() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        let created =
+            spot::create(&store, "garden", None, Some(tmp.path()), config.clone()).await?;
+        assert!(!created.adopted, "a fresh site is not adopted");
+        spot::remove(&store, "garden", Data::Keep)?;
+
+        let again = spot::create(&store, "garden", None, Some(tmp.path()), config).await?;
+        assert!(again.adopted, "the kept data was adopted");
+        assert_eq!(again.did, created.did, "same repository, not a new one");
         Ok(())
     }
 }


### PR DESCRIPTION
## The bug

`tonk spot rm garden` dropped the registry entry but left the site directory on disk. Nothing named that data afterwards, yet it still held the canonical path — so re-adding the same name diverged three ways:

| command | before |
| --- | --- |
| `tonk join --name garden` | refused: `SiteAlreadyExists` |
| `tonk account spots pull --name garden` | refused: "the canonical site already exists" |
| `tonk spot new garden` | **silently adopted the stale facts** |

`--delete` already existed, but it was opt-in, which made the limbo state the one you reach by accident.

## What changed

**`tonk spot rm <name>` deletes the data by default**, behind a confirmation that names the directory and reports whether the facts exist anywhere else:

```
This permanently deletes the spot's data from disk:
  ~/Library/Application Support/tonk/spots/garden

'garden' is local-only: it has no upstream and no account backup,
so this is the only copy and deleting it cannot be undone.

Type 'garden' to confirm:
```

- `--keep-data` is the old behaviour, now explicit, and explains what it left behind and how to adopt it back.
- `--yes` skips the prompt. `--delete` is kept as a hidden no-op so existing invocations keep working.
- A non-terminal stdin is refused *before* the site is opened, rather than defaulted either way. Declining exits non-zero, so a caller chaining off the command cannot read "you declined" as "it is gone".

**Recoverability** (new `recovery.rs`) is read locally from the branch upstream plus the account backup marker — never over the network, because a confirmation prompt that hangs on a dead account service is worse than one that reports what this device knows. Four states, not two: account-backed (names the exact `tonk account spots pull <subject>` to run), pushed-to-a-remote-only, local-only, and could-not-inspect — the last treated as unrecoverable rather than guessed.

**Ordering fix:** the directory is now deleted *before* the registry is saved. Saving first looks more cautious and is worse — a delete that fails after the entry is gone lands in exactly the orphaned state this command exists to prevent. Failing first leaves the spot registered and retryable.

**Leftover data is no longer invisible:** `tonk spot list` reports site directories that no spot names, `spot new` says when it adopted existing data instead of creating it, and the join / account-pull collision errors name the directory and both ways out.

`tonk spot unbind` is untouched — it was already the "unlink a directory, keep everything" operation. Both help texts now say which is which.

## Verification

- Full `tonk-cli` suite green (330 tests, 14 new), `cargo fmt` clean, `cargo clippy -p tonk-cli --all-targets --all-features` clean.
- Every prompt path driven through the real binary under a pty: confirm to deleted (exit 0), wrong answer to aborted (exit 4), piped stdin to refused, plus keep-data to orphan listing to re-adopt showing the same DID.
- `cargo clippy --workspace --all-targets --all-features` could not be run: it dies in `aws-lc-sys`'s C build (missing `CoreServices.h`, NEON assert) on macOS 27. Confirmed identical on a clean tree, so pre-existing — but it means workspace-wide clippy is unverified locally and rests on CI.

## Deliberately not included

`rm` does not delete the per-subject profile credentials (`tonk-space-root-v2/...`, `tonk-account-spot-backup-v1/...`), which live outside the site directory and survive deletion. A real leak, but not part of this collision, and cleaning it touches shared identity state — worth its own change.

## Behaviour change to note

`tonk spot rm <name>` is destructive by default now. Anything scripted that relied on it being registry-only needs `--keep-data`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a comprehensive update to the `tonk-cli`, enhancing the functionality related to spot management, particularly focusing on data recovery, deletion, and orphaned site handling.

### Detailed summary
- Added `pub mod recovery` for managing spot data recovery.
- Improved error messaging for site removal.
- Enhanced `has_site_data` function to check for existing site data.
- Updated tests to reflect new deletion behavior.
- Introduced `Data` and `Deletion` enums for clearer site data management.
- Updated command descriptions for clarity on data deletion and retention.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->