### PR TITLE
feat(account): record passkey creation facts in the account space

### DIFF
--- a/plan/passkey-facts-in-account-space.md
+++ b/plan/passkey-facts-in-account-space.md
@@ -1,0 +1,301 @@
+# Portable passkey facts in the account space implementation plan
+
+**Goal:** Make the hidden root-owned account repository the source of truth for passkey creation time and creation device, so those facts travel with the account instead of living only in the account service's D1 row.
+
+**Approach:** Add one account-subject-keyed concept, `AccountPasskeyCreated`, alongside the existing `AccountDisplayName`. Seed it from this device's `tonk-local-root-v1` record whenever the account repository is ready and the fact is absent, which also repairs accounts whose creation invocation carried no metadata. The local worker's `/api/account/summary` prefers the space fact and falls back to the provider row, and renders passkey facts even when the provider is unreachable.
+
+**Constraints:**
+- The D1 `accounts.passkey_created_at` / `passkey_created_on` columns and the provider's `POST /account/summary` response stay exactly as they are. This change is additive; nothing is dropped and no row is backfilled by inference.
+- **Fresh account creation keeps writing D1.** No task touches `rust/tonk-identity/src/ceremony.rs:247-256` (which binds `passkeyCreatedAt`/`passkeyCreatedOn` into the root-signed creation invocation) or `rust/tonk-account-service/src/core/accounts.rs:94` (which stores them). New accounts therefore land in both places, and the two values are expected to agree. They serve different purposes: the D1 row is the immutable claim fixed at creation inside a root-signed invocation and never updated, while the space fact is the portable one that any linked device can read without the provider. Keeping both means a later divergence is detectable rather than invisible.
+- Passkey metadata remains informational. Nothing in root derivation, delegation bytes/CIDs, authorization, revocation, or account-repository authority may read or depend on it.
+- `created_on` describes the browser/OS where Tonk ran `navigator.credentials.create()`, never the current password manager or storage provider.
+- Account and device `created_at` values must never be substituted for passkey creation time. Absent metadata renders as an explicit unavailable state.
+- The account space is only written when `AccountStateStatus::Ready`. An unconfigured or unhydrated account must never block the dashboard or the sweep.
+- No new dependencies. No changes to `tonk-cli` (it has no account-summary path and never writes `AccountDisplayName`).
+
+## File map
+
+- `rust/tonk-schema/src/domain.rs`: `account::PasskeyCreatedAt` and `account::PasskeyCreatedOn` attributes.
+- `rust/tonk-schema/src/account.rs`: the `AccountPasskeyCreated` concept and its constructor/accessor.
+- `rust/tonk-schema/src/lib.rs`: re-export next to `AccountDisplayName`.
+- `rust/tonk-worker/src/router/account_state.rs`: read and seed the space fact, wired into the ready sweep and the post-hydration path.
+- `rust/tonk-worker/src/router/account_devices.rs`: provider-response type, source-preference merge, and provider-unavailable fallback in `summary`.
+- `rust/tonk-worker-api/src/account.rs`: `AccountSummary::email` becomes optional.
+- `rust/tonk-ui/src/account.rs`: render an absent email as unavailable without hiding passkey facts.
+- `rust/tonk-ui/src/account_flow.rs`: real-browser coverage that the facts still render end to end.
+
+## Task 1: Add the account-space passkey concept
+
+**Files:**
+- Modify: `rust/tonk-schema/src/domain.rs:536-545` (`pub mod account`)
+- Modify: `rust/tonk-schema/src/account.rs` (new concept after `AccountDisplayName`)
+- Modify: `rust/tonk-schema/src/lib.rs:69`
+- Test: `rust/tonk-schema/src/account.rs:31` (`mod tests`)
+
+**Interfaces:**
+
+Produces, in `domain.rs` `pub mod account`:
+
+```rust
+    /// Browser-reported Unix time in seconds, captured immediately after
+    /// `navigator.credentials.create()` returned. `f64` because the value
+    /// system stores numbers as `Float`; second-resolution Unix times convert
+    /// losslessly at this magnitude. Cardinality-one: an account has one
+    /// passkey creation moment, so concurrent linked-device writes converge on
+    /// a deterministic winner rather than accumulating.
+    #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct PasskeyCreatedAt(pub f64);
+
+    /// The browser and operating system where passkey creation ran, e.g.
+    /// `Chrome on macOS`. Never the password manager or storage provider —
+    /// WebAuthn does not expose those reliably.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct PasskeyCreatedOn(pub String);
+```
+
+Produces, in `account.rs`:
+
+```rust
+/// Facts Tonk recorded when it created this account's passkey, keyed by the
+/// immutable account subject.
+///
+/// Informational only: no derivation, delegation, authorization, or revocation
+/// path reads these. Both attributes are asserted in one transaction, so a
+/// query requiring both never observes a half-written pair.
+///
+/// Derives `PartialOrd` but not `Ord`, because [`PasskeyCreatedAt`] wraps an
+/// `f64` — the same shape `command::Invite` uses for its `TimeStamp`.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct AccountPasskeyCreated {
+    /// The immutable account subject.
+    pub this: Entity,
+    /// Unix seconds at credential creation.
+    pub created_at: PasskeyCreatedAt,
+    /// Browser and operating-system label where creation ran.
+    pub created_on: PasskeyCreatedOn,
+}
+
+impl AccountPasskeyCreated {
+    /// Record creation facts on the account subject.
+    pub fn new(account: Entity, created_at: u64, created_on: String) -> Self {
+        Self {
+            this: account,
+            created_at: PasskeyCreatedAt(created_at as f64),
+            created_on: PasskeyCreatedOn(created_on),
+        }
+    }
+
+    /// Unix seconds, back in the integer form the wire DTO carries.
+    pub fn seconds(&self) -> u64 {
+        self.created_at.0 as u64
+    }
+}
+```
+
+The `use` line at `account.rs:6` becomes
+`use crate::domain::account::{DisplayName, PasskeyCreatedAt, PasskeyCreatedOn};`.
+`lib.rs:69` becomes `pub use account::{AccountDisplayName, AccountPasskeyCreated};`.
+
+- [x] Add `wasm_bindgen_test_configure!(run_in_browser);` to `account.rs`'s `mod tests`, mirroring `rust/tonk-schema/src/membership.rs:174-176`. The mod currently has no configure line, so any test added to it would try to run under Node and fail `test:web:debug` with `failed to find or execute Node.js`.
+- [x] Add `it_round_trips_passkey_creation_facts_on_the_account_subject`: on a `helpers::test_repo` branch, assert `AccountPasskeyCreated::new(account.this(), 1_754_380_800, "Chrome on macOS".into())`, then `select` with `this: Term::from(account.this())`, `created_at: Term::var("created_at")`, `created_on: Term::var("created_on")`; expect exactly one row, `seconds() == 1_754_380_800`, and `created_on.0 == "Chrome on macOS"`.
+- [x] Add `it_keeps_one_passkey_creation_fact_per_account`: reuse the `converge(a_first)` helper at `account.rs:41` to write two different pairs on divergent branches, merge both orders, and expect one surviving row whose `seconds()` and `created_on` come from the *same* write in both orders. This is what proves the two attributes cannot be torn apart by cardinality-one merge.
+- [x] Run `nix develop -c cargo test -p tonk-schema account::tests`; expect both to fail to compile with `cannot find type AccountPasskeyCreated`.
+- [x] Add the two attributes, the concept, the constructor/accessor, and the re-export.
+- [x] Run `nix develop -c cargo test -p tonk-schema account::tests`; expect success.
+- [x] Run `nix develop -c cargo test -p tonk-schema`; expect success.
+
+## Task 2: Seed the fact from this device's local root
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account_state.rs` (new `passkey_facts` and `seed_passkey_facts`, plus call sites at `sync_ready:497` and `ensure_account_state_swept:555`)
+- Test: `rust/tonk-worker/src/router/account_state.rs:1100` (`mod tests`, native)
+
+**Interfaces:**
+
+- Consumes: `crate::router::identity::local_root(tonk) -> Result<LocalRoot, _>` whose `passkey: Option<tonk_worker_api::PasskeyMetadata>` field (`identity.rs:41`) holds `{ created_at: u64, created_on: String }`; and `require_ready_account_state(tonk) -> Result<ReadyAccountBranch, _>`.
+- Produces:
+
+```rust
+/// This account's passkey facts as recorded in the account space, absent when
+/// the account is not ready or carries none.
+///
+/// Best-effort by design — the dashboard has an explicit unavailable state and
+/// must not fail because a hidden system repository is mid-hydration. Every
+/// `None` that is not simply "no fact" is logged, so an unreadable branch is
+/// visible rather than silent.
+pub(crate) async fn passkey_facts(tonk: &TonkState) -> Option<tonk_worker_api::PasskeyMetadata>;
+
+/// Write this device's recorded passkey facts into the account space when it
+/// has them and the space does not. Returns whether it wrote.
+///
+/// Idempotent: a device that only ever *evaluated* an existing root has
+/// nothing to contribute and returns `false` without touching the branch.
+pub(crate) async fn seed_passkey_facts(tonk: &TonkState) -> bool;
+```
+
+Both are plain `async fn` on all targets, not `#[cfg(wasm32)]`-gated like `converge_account_state`, so the native test below can drive them. Only the `sync_queue.mark_dirty` call inside `seed_passkey_facts` is cfg-gated, matching `adopt_account_display_name:813-814`.
+
+`seed_passkey_facts` order of operations, which matters:
+1. `require_ready_account_state`; on `Err`, return `false` without logging (unconfigured and unhydrated are ordinary states, hit on every sweep of a signed-out profile).
+2. Query `AccountPasskeyCreated` for `ready.subject.this()`. On a query error, `log!` and return `false`. On a non-empty result, return `false` — an existing fact is never overwritten, so a device that later derives a different label cannot rewrite history.
+3. `local_root(tonk).await` — on `Err`, return `false`. `.passkey` `None` → return `false`.
+4. Assert `AccountPasskeyCreated::new(ready.subject.this(), metadata.created_at, metadata.created_on)` and commit on `MAIN_BRANCH`. On commit error, `log!` and return `false`.
+5. `mark_dirty` (wasm only), return `true`.
+
+Call sites:
+
+- In `sync_ready`, between the `pull` at `:491-496` and `converge_account_state` at `:497`, so the seed sees remote facts before deciding and is included in the `push` at `:500`:
+  ```rust
+      if seed_passkey_facts(tonk).await {
+          log!("recorded this device's passkey creation facts in the account space");
+      }
+  ```
+- In `ensure_account_state_swept`, immediately before `converge_account_state` at `:555` (the post-hydration branch), with the same two lines. This is the path a freshly created account takes, where `sync_ready` has not run yet.
+
+- [x] Add `it_seeds_passkey_creation_facts_from_the_local_root` to the native tests mod, cloning the setup of `it_mounts_hydrates_and_keeps_readiness_offline` at `account_state.rs:1101-1182` (access service, profile, `bootstrap_profile`, generated root, signed descriptor, minted device delegation, `persist_root`, `persist_link`, trusted marker). Change one thing: pass `passkey: Some(tonk_worker_api::PasskeyMetadata { created_at: 1_754_380_800, created_on: "Chrome on macOS".to_string() })` to `persist_root` instead of `None`. Then `ensure_account_state(&state).await == AccountStateStatus::Ready`, and query `AccountPasskeyCreated` on the ready branch expecting exactly one row with `seconds() == 1_754_380_800` and `created_on.0 == "Chrome on macOS"`.
+- [x] Extend the same test to call `ensure_account_state` a second time and re-query, expecting still exactly one row with identical values — the seed must be idempotent across every sweep.
+- [x] Add `it_seeds_nothing_when_the_local_root_has_no_passkey_metadata` with the identical setup but `passkey: None`, expecting `ensure_account_state` to reach `Ready` and the `AccountPasskeyCreated` query to return zero rows. This is the evaluated-root case, and it must degrade to the provider fallback rather than to a fabricated value.
+- [x] Run `nix develop -c cargo test -p tonk-worker account_state`; expect both new tests to fail — the first with zero rows returned, the second failing to compile until `seed_passkey_facts` exists.
+- [x] Implement `passkey_facts` and `seed_passkey_facts` with the five-step ordering above, and add the two call sites.
+- [x] Run `nix develop -c cargo test -p tonk-worker account_state`; expect success.
+- [x] Run `nix develop -c test:native:debug`; expect success.
+
+## Task 3: Prefer the space fact in the account summary
+
+**Files:**
+- Modify: `rust/tonk-worker/src/router/account_devices.rs:93-119` (`summary`), plus a new provider-response type and merge function
+- Test: `rust/tonk-worker/src/router/account_devices.rs:210` (`mod tests`)
+
+**Interfaces:**
+
+- Consumes: `account_state::passkey_facts` from Task 2.
+- Produces:
+
+```rust
+/// The account service's `POST /account/summary` response.
+///
+/// Deliberately its own type rather than [`AccountSummary`]: the provider hop
+/// and the local hop no longer carry the same shape, and decoding the provider
+/// straight into the local DTO is what would silently re-couple them.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderSummary {
+    email: String,
+    passkey: Option<PasskeyMetadata>,
+}
+
+/// Prefer the portable account-space fact; fall back to what the provider
+/// recorded at account creation.
+///
+/// The provider row is not a legacy-only path. Every account still writes it at
+/// creation, and it answers three live cases: an account created before the
+/// space fact existed, a device that never held the passkey and so cannot seed
+/// it, and a fresh account read in the window between account creation and the
+/// first sweep that seeds the space.
+fn merge_summary(
+    email: String,
+    space: Option<PasskeyMetadata>,
+    provider: Option<PasskeyMetadata>,
+) -> AccountSummary {
+    AccountSummary {
+        email,
+        passkey: space.or(provider),
+    }
+}
+```
+
+`summary` reads `account_state::passkey_facts(&state)` before building the invocation, decodes the provider body into `ProviderSummary` instead of `AccountSummary`, and returns `merge_summary(provider.email, space, provider.passkey)`. `AccountSummary::email` stays `String` in this task; Task 4 changes it.
+
+- [x] Add `it_prefers_the_account_space_passkey_fact_over_the_provider_row` covering all three combinations against `merge_summary` directly: space `Some(a)` + provider `Some(b)` → `a`; space `None` + provider `Some(b)` → `b`; both `None` → `None`. A pure function keeps this out of the service-worker harness, which has no provider to stub.
+- [x] Run `nix develop -c test:web:debug -E 'test(account_devices)'`; expect a compile failure on the missing `merge_summary`. (`test:web:debug` builds the wasm test archive and runs `cargo nextest run --archive-file …`, appending whatever arguments follow — so nextest filter expressions work, but a bare `--` separator does not.)
+- [x] Add `ProviderSummary`, `merge_summary`, and rewire `summary` to read the space first and decode the provider into `ProviderSummary`.
+- [x] Run `nix develop -c test:web:debug -E 'test(account_devices)'`; expect success.
+- [x] Run `nix develop -c cargo test -p tonk-worker`; expect success.
+
+## Task 4: Render passkey facts when the provider is unreachable
+
+This is the task that cashes in the portability. Until it lands, the space is the preferred source but the dashboard still fails whole when the provider is down, because `email` has no other home and `load_summary` treats any error as total.
+
+**Files:**
+- Modify: `rust/tonk-worker-api/src/account.rs:10-15` (`AccountSummary`)
+- Modify: `rust/tonk-worker/src/router/account_devices.rs` (`summary`, `merge_summary`)
+- Modify: `rust/tonk-ui/src/account.rs:197-216` (`render_summary`)
+- Test: `rust/tonk-ui/src/account.rs:1248` (`mod tests`)
+
+**Interfaces:**
+
+- Produces: `AccountSummary { email: Option<String>, passkey: Option<PasskeyMetadata> }`. `email` is `None` only when the provider could not be reached and the space had facts to show; the email itself stays service-owned and is never mirrored into the space (it is the uniqueness key and the enumeration boundary).
+- `merge_summary`'s first parameter becomes `Option<String>`.
+
+`summary` control flow after the change:
+
+```rust
+    let space = super::account_state::passkey_facts(&state).await;
+    match super::http::post_cbor(&endpoint, &body).await {
+        Ok(response) => {
+            let provider: ProviderSummary = serde_json::from_slice(&response.body)
+                .map_err(|error| {
+                    TonkWorkerError::Internal(format!("parse account summary: {error}"))
+                })?;
+            Ok(Json(merge_summary(Some(provider.email), space, provider.passkey)))
+        }
+        // The account repository already answered the passkey question, so an
+        // unreachable provider costs the email and nothing else. With no space
+        // fact there is nothing to serve, and the caller keeps the real error.
+        Err(error) if space.is_some() => {
+            log!("account summary falling back to account-space facts: {error}");
+            Ok(Json(merge_summary(None, space, None)))
+        }
+        Err(error) => Err(error),
+    }
+```
+
+`render_summary` replaces `set_text(host, "#account-email-value", &summary.email)` at `:198` with a match that writes the address when present and `"Unavailable"` when absent, leaving the existing passkey arms at `:199-215` untouched. No markup or stylesheet change: `#account-email-value` already exists and already renders `Unavailable` on the total-failure path at `:228`.
+
+- [x] Add `it_renders_passkey_facts_without_a_verified_email` to `tonk-ui`'s browser tests: build a host from the existing `host()` helper at `account.rs:1254`, call `render_summary` with `AccountSummary { email: None, passkey: Some(PasskeyMetadata { created_at: 1_754_380_800, created_on: "Chrome on macOS".into() }) }`, and expect `#account-email-value` to read `Unavailable`, `#account-passkey-device-value` to read `Chrome on macOS`, and `#account-passkey-created-value` to be non-empty and not equal to `Unavailable`.
+- [x] Run `nix develop -c test:web:debug -E 'package(tonk-ui)'`; expect a type error on `email: None`.
+- [x] Change the DTO, `merge_summary`'s signature, `summary`'s fallback arm, and `render_summary`'s email arm.
+- [x] Run `nix develop -c test:web:debug -E 'package(tonk-ui)'`; expect success.
+- [x] Run `nix develop -c cargo test -p tonk-worker-api -p tonk-worker`; expect success.
+
+## Task 5: Verify the complete slice
+
+- [x] Run `nix develop -c cargo fmt --all -- --check` and `git diff --check`.
+- [x] Run `nix flake check` — the lint gate is workspace `clippy --all-targets --all-features` plus fmt, and `--all-features` compiles integration tests that per-crate runs skip.
+- [x] Run `nix develop -c test:native:debug` and `nix develop -c test:web:debug`; expect success.
+- [x] Run `nix develop -c build:web`; expect success. Confirm every new file is tracked first — an untracked file breaks the flake source snapshot.
+- [x] Run `nix develop -c test:e2e`. `it_signs_up_through_the_account_panels` in `rust/tonk-ui/src/account_flow.rs` already asserts the verified email, a non-empty localized creation date, and a `Chrome on …` label; it must stay green, now served from the account space rather than D1.
+- [x] Extend `account_flow.rs` with a second assertion after signup: read `/api/account/summary` twice and confirm the passkey values are byte-identical, proving the seed does not rewrite itself on the next sweep.
+- [x] Re-read the diff and confirm no account `created_at` or device `created_at` is presented as passkey creation time, and that no code path outside the summary and the dashboard reads either new attribute.
+
+## Explicitly deferred
+
+- Dropping the D1 columns, the creation-time write, or the provider's `passkey` response field. Existing accounts have no other source, devices that never held the passkey cannot seed the space, and the creation-time row is the only copy fixed by a root-signed invocation. Removing any of it is a separate decision, not a follow-up implied by this plan.
+- Per-credential modelling. `accounts.credential_id` is a single column and this concept is keyed on the account subject, so both still assume one passkey per account. Multiple passkeys need a credential-keyed entity and a rule for which one the dashboard shows; that belongs with the fan-out work in `plan/passkey-fanout.md`, not here.
+- Mirroring the verified email into the account space. It is the uniqueness key and the enumeration boundary, and moving it would change the service's security model rather than just where a fact is stored.
+- Backfilling `passkey_created_on` for accounts whose creating device is gone. Any value Tonk could synthesize would be a guess presented as a record.
+- Recording authenticator attachment, backup eligibility, or AAGUID. Still deferred for the reasons in `plan/passkey-account-summary.md:143-147`.
+
+## Findings during implementation
+
+- **Cardinality-one merge is per attribute, not per concept.** Task 1's
+  `it_keeps_one_passkey_creation_fact_per_account` was specified to prove that
+  asserting both attributes in one transaction keeps them from being torn
+  apart. It disproves it: two replicas that record *different* pairs converge
+  to one value per attribute independently, and the surviving row paired one
+  replica's `created_at` with the other's `created_on`. Convergence is
+  order-independent, but the pair is not atomic.
+
+  The write rules make this unreachable rather than merely unlikely:
+  `evaluate_root` (`rust/tonk-identity/src/ceremony.rs:151`) records no
+  metadata, so only the browser that ran `navigator.credentials.create()` ever
+  holds a pair, and one account has one such pair to seed from any device. The
+  test now pins what holds — identical concurrent seeds survive intact, and
+  divergent ones still converge in either order — and the concept doc says
+  plainly that per-attribute merge is what a second recorded pair would run
+  into. Making the pair atomic means keying it on the credential rather than
+  the account, which is the deferred per-credential modelling.

--- a/rust/tonk-schema/src/account.rs
+++ b/rust/tonk-schema/src/account.rs
@@ -3,7 +3,7 @@
 use dialog_artifacts::Entity;
 use dialog_query::Concept;
 
-use crate::domain::account::DisplayName;
+use crate::domain::account::{DisplayName, PasskeyCreatedAt, PasskeyCreatedOn};
 
 /// The account-wide display name, keyed by the immutable account subject.
 ///
@@ -28,15 +28,64 @@ impl AccountDisplayName {
     }
 }
 
+/// Facts Tonk recorded when it created this account's passkey, keyed by the
+/// immutable account subject.
+///
+/// Informational only: no derivation, delegation, authorization, or revocation
+/// path reads these. Both attributes are asserted in one transaction, so a
+/// query requiring both never observes a half-written pair on one replica.
+///
+/// Merge is per attribute, not per concept: two replicas that recorded
+/// *different* pairs converge on one value for each attribute independently,
+/// which can pair one device's clock with another device's label. Only the
+/// browser that ran `navigator.credentials.create()` ever records this
+/// metadata — evaluating an existing passkey carries none — so one account has
+/// at most one pair to converge and that mismatch has no way to arise. A
+/// second recorded pair per account would need this keyed on the credential
+/// instead of the account, which is where per-credential modelling belongs.
+///
+/// Derives `PartialOrd` but not `Ord`, because [`PasskeyCreatedAt`] wraps an
+/// `f64` — the same shape `command::Invite` uses for its `TimeStamp`.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct AccountPasskeyCreated {
+    /// The immutable account subject.
+    pub this: Entity,
+    /// Unix seconds at credential creation.
+    pub created_at: PasskeyCreatedAt,
+    /// Browser and operating-system label where creation ran.
+    pub created_on: PasskeyCreatedOn,
+}
+
+impl AccountPasskeyCreated {
+    /// Record creation facts on the account subject.
+    pub fn new(account: Entity, created_at: u64, created_on: String) -> Self {
+        Self {
+            this: account,
+            created_at: PasskeyCreatedAt(created_at as f64),
+            created_on: PasskeyCreatedOn(created_on),
+        }
+    }
+
+    /// Unix seconds, back in the integer form the wire DTO carries.
+    pub fn seconds(&self) -> u64 {
+        self.created_at.0 as u64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
     use dialog_query::{Output as _, Query, Term};
     use dialog_repository::helpers;
     use dialog_varsig::did;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
 
     use super::*;
     use crate::prelude::DidExt as _;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
 
     async fn converge(a_first: bool) -> Result<String> {
         let (operator, profile) = helpers::test_operator_with_profile().await;
@@ -134,6 +183,139 @@ mod tests {
         // cardinality-one merge to decide, not wall-clock latest-write, so
         // asserting the specific winner would only pin that internal choice.
         assert_eq!(a_then_b, b_then_a);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_round_trips_passkey_creation_facts_on_the_account_subject() -> Result<()> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let branch = repository.branch("main").open().perform(&operator).await?;
+        let account = did!("test:account").this();
+
+        branch
+            .transaction()
+            .assert(AccountPasskeyCreated::new(
+                account.clone(),
+                1_754_380_800,
+                "Chrome on macOS".into(),
+            ))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let rows: Vec<AccountPasskeyCreated> = branch
+            .query()
+            .select(Query::<AccountPasskeyCreated> {
+                this: Term::from(account),
+                created_at: Term::var("created_at"),
+                created_on: Term::var("created_on"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].seconds(), 1_754_380_800);
+        assert_eq!(rows[0].created_on.0, "Chrome on macOS");
+        Ok(())
+    }
+
+    /// Record `first` on one replica and `second` on the other, exchange them
+    /// in the given order, and report the single pair that survived.
+    async fn converge_passkey(
+        a_first: bool,
+        first: (u64, &str),
+        second: (u64, &str),
+    ) -> Result<(u64, String)> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let base = repository.branch("base").open().perform(&operator).await?;
+        let base_revision = base.transaction().commit().perform(&operator).await?;
+        let a = repository
+            .branch("replica-a")
+            .open()
+            .perform(&operator)
+            .await?;
+        let b = repository
+            .branch("replica-b")
+            .open()
+            .perform(&operator)
+            .await?;
+        a.reset(base_revision.clone()).perform(&operator).await?;
+        b.reset(base_revision).perform(&operator).await?;
+        a.set_upstream(&b).perform(&operator).await?;
+        b.set_upstream(&a).perform(&operator).await?;
+
+        let account = did!("test:account").this();
+        a.transaction()
+            .assert(AccountPasskeyCreated::new(
+                account.clone(),
+                first.0,
+                first.1.to_string(),
+            ))
+            .commit()
+            .perform(&operator)
+            .await?;
+        b.transaction()
+            .assert(AccountPasskeyCreated::new(
+                account.clone(),
+                second.0,
+                second.1.to_string(),
+            ))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        if a_first {
+            a.pull().perform(&operator).await?;
+            b.pull().perform(&operator).await?;
+        } else {
+            b.pull().perform(&operator).await?;
+            a.pull().perform(&operator).await?;
+        }
+        a.pull().perform(&operator).await?;
+        b.pull().perform(&operator).await?;
+
+        let rows: Vec<AccountPasskeyCreated> = a
+            .query()
+            .select(Query::<AccountPasskeyCreated> {
+                this: Term::from(account),
+                created_at: Term::var("created_at"),
+                created_on: Term::var("created_on"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        assert_eq!(rows.len(), 1, "an account has one passkey creation moment");
+        let row = rows.into_iter().next().expect("one creation fact");
+        Ok((row.seconds(), row.created_on.0))
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_one_passkey_creation_fact_per_account() -> Result<()> {
+        let recorded = (1_754_380_800, "Chrome on macOS");
+
+        // Two devices seeding the same recorded pair is the only concurrency
+        // this fact can actually see: the seed reads the account space first
+        // and only the browser that created the passkey holds metadata to
+        // contribute, so every writer contributes the same pair.
+        let a_then_b = converge_passkey(true, recorded, recorded).await?;
+        let b_then_a = converge_passkey(false, recorded, recorded).await?;
+        assert_eq!(a_then_b, (recorded.0, recorded.1.to_string()));
+        assert_eq!(b_then_a, (recorded.0, recorded.1.to_string()));
+
+        // Divergent pairs converge on one value per attribute, in an order
+        // the merge decides, but *independently* — so the surviving row can
+        // pair one write's time with the other's label. Nothing asserts a
+        // second pair today; this pins the behaviour that per-credential
+        // modelling would have to answer for before one could.
+        let divergent = (1_600_000_000, "Safari on iOS");
+        assert_eq!(
+            converge_passkey(true, recorded, divergent).await?,
+            converge_passkey(false, recorded, divergent).await?,
+            "concurrent creation facts converge regardless of merge order"
+        );
         Ok(())
     }
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -542,6 +542,25 @@ pub mod account {
     #[domain("xyz.tonk.account")]
     #[cardinality(one)]
     pub struct DisplayName(pub String);
+
+    /// Browser-reported Unix time in seconds, captured immediately after
+    /// `navigator.credentials.create()` returned. `f64` because the value
+    /// system stores numbers as `Float`; second-resolution Unix times convert
+    /// losslessly at this magnitude. Cardinality-one: an account has one
+    /// passkey creation moment, so concurrent linked-device writes converge on
+    /// a deterministic winner rather than accumulating.
+    #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct PasskeyCreatedAt(pub f64);
+
+    /// The browser and operating system where passkey creation ran, e.g.
+    /// `Chrome on macOS`. Never the password manager or storage provider —
+    /// WebAuthn does not expose those reliably.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct PasskeyCreatedOn(pub String);
 }
 
 /// Attributes that describe a repository on its content branch, keyed by the

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -66,7 +66,7 @@ pub mod sync;
 pub use sync::*;
 
 pub mod account;
-pub use account::AccountDisplayName;
+pub use account::{AccountDisplayName, AccountPasskeyCreated};
 
 pub mod replica;
 pub use replica::*;

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -198,7 +198,14 @@ fn set_text(host: &HtmlElement, selector: &str, value: &str) {
 }
 
 fn render_summary(host: &HtmlElement, summary: &tonk_worker_api::AccountSummary) {
-    set_text(host, "#account-email-value", &summary.email);
+    // The passkey facts come from the account repository, which answers even
+    // with the account service unreachable. The verified address has no home
+    // outside that service, so it alone goes unavailable.
+    set_text(
+        host,
+        "#account-email-value",
+        summary.email.as_deref().unwrap_or("Unavailable"),
+    );
     match &summary.passkey {
         Some(passkey) => {
             let date = js_sys::Date::new(&JsValue::from_f64(passkey.created_at as f64 * 1000.0))
@@ -1897,7 +1904,7 @@ mod tests {
         render_summary(
             &host,
             &tonk_worker_api::AccountSummary {
-                email: "person@example.com".into(),
+                email: Some("person@example.com".into()),
                 passkey: Some(tonk_worker_api::PasskeyMetadata {
                     created_at: 1_754_380_800,
                     created_on: "Chrome on macOS".into(),
@@ -1924,7 +1931,7 @@ mod tests {
         render_summary(
             &host,
             &tonk_worker_api::AccountSummary {
-                email: "legacy@example.com".into(),
+                email: Some("legacy@example.com".into()),
                 passkey: None,
             },
         );
@@ -1943,6 +1950,49 @@ mod tests {
                 .text_content()
                 .unwrap()
                 .contains("cannot reliably reconstruct")
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_renders_passkey_facts_without_a_verified_email() {
+        let host = host();
+        render_summary(
+            &host,
+            &tonk_worker_api::AccountSummary {
+                email: None,
+                passkey: Some(tonk_worker_api::PasskeyMetadata {
+                    created_at: 1_754_380_800,
+                    created_on: "Chrome on macOS".into(),
+                }),
+            },
+        );
+
+        assert_eq!(
+            host.query_selector("#account-email-value")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Unavailable"),
+            "the verified address lives only at the account service"
+        );
+        assert_eq!(
+            host.query_selector("#account-passkey-device-value")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .as_deref(),
+            Some("Chrome on macOS")
+        );
+        let created = host
+            .query_selector("#account-passkey-created-value")
+            .unwrap()
+            .unwrap()
+            .text_content()
+            .unwrap();
+        assert!(
+            !created.is_empty() && created != "Unavailable",
+            "the account repository carries the creation date without the provider"
         );
     }
 

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -181,6 +181,22 @@ mod tests {
         wait_for_text_containing(&driver, "#account-passkey-device-value", "Chrome on ").await?;
         wait_for_text_containing(&driver, "#account-device-list", "Chrome on ").await?;
 
+        // These facts are served from the account repository, seeded on every
+        // sweep of a ready account. Reading twice proves the seed recognizes
+        // its own fact rather than restamping it with each pass.
+        let first = get_json(&driver, "/api/account/summary").await?;
+        let again = get_json(&driver, "/api/account/summary").await?;
+        let first = successful_body("account summary", &first);
+        let again = successful_body("account summary", &again);
+        assert!(
+            !first["passkey"].is_null(),
+            "signup records passkey facts: {first}"
+        );
+        assert_eq!(
+            first["passkey"], again["passkey"],
+            "a second sweep must not rewrite the recorded creation facts"
+        );
+
         driver.quit().await?;
         Ok(())
     }

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -8,8 +8,11 @@ use crate::PasskeyMetadata;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountSummary {
-    /// Email address verified when the account was created.
-    pub email: String,
+    /// Email address verified when the account was created. Absent only when
+    /// the account service could not be reached: the address is service-owned
+    /// and is never mirrored into the account repository, because it is the
+    /// uniqueness key and the enumeration boundary.
+    pub email: Option<String>,
     /// Facts Tonk recorded during passkey creation, absent for legacy roots.
     pub passkey: Option<PasskeyMetadata>,
 }
@@ -174,7 +177,7 @@ mod tests {
     #[dialog_common::test]
     fn it_serializes_account_summary_passkey_facts_in_camel_case() {
         let json = serde_json::to_value(AccountSummary {
-            email: "person@example.com".into(),
+            email: Some("person@example.com".into()),
             passkey: Some(PasskeyMetadata {
                 created_at: 1_754_380_800,
                 created_on: "Chrome on macOS".into(),
@@ -183,6 +186,20 @@ mod tests {
         .unwrap();
         assert_eq!(json["email"], "person@example.com");
         assert_eq!(json["passkey"]["createdAt"], 1_754_380_800_u64);
+        assert_eq!(json["passkey"]["createdOn"], "Chrome on macOS");
+    }
+
+    #[dialog_common::test]
+    fn it_serves_passkey_facts_without_a_reachable_account_service() {
+        let json = serde_json::to_value(AccountSummary {
+            email: None,
+            passkey: Some(PasskeyMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".into(),
+            }),
+        })
+        .unwrap();
+        assert!(json["email"].is_null());
         assert_eq!(json["passkey"]["createdOn"], "Chrome on macOS");
     }
 

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -288,7 +288,7 @@ pub async fn establish_repository(
     let email = super::account_devices::account_summary(&tonk)
         .await
         .ok()
-        .map(|summary| summary.email);
+        .and_then(|summary| summary.email);
     super::profiles::upsert_active_entry(&tonk, email).await;
 
     Ok(Json(status(&tonk).await?))
@@ -372,7 +372,7 @@ pub async fn link(
     let email = super::account_devices::account_summary(&state)
         .await
         .ok()
-        .map(|summary| summary.email);
+        .and_then(|summary| summary.email);
     super::profiles::upsert_active_entry(&state, email).await;
 
     Ok(Json(status(&state).await?))

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -8,8 +8,10 @@ use dialog_ucan_core::{DelegationChain, promise::Promised};
 use serde::Deserialize;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
+use tonk_common::log;
 use tonk_worker_api::{
-    AccountDevice, AccountSummary, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+    AccountDevice, AccountSummary, PasskeyMetadata, RevokeDeviceAcknowledgement,
+    RevokeDeviceRequest,
 };
 
 use super::AppState;
@@ -90,12 +92,45 @@ pub async fn list(
     Ok(Json(fetch_devices(&state, &link, &service).await?))
 }
 
-/// Fetch the provider's verified account facts for the linked profile.
+/// The account service's `POST /account/summary` response.
+///
+/// Deliberately its own type rather than [`AccountSummary`]: the provider hop
+/// and the local hop no longer carry the same shape, and decoding the provider
+/// straight into the local DTO is what would silently re-couple them.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderSummary {
+    email: String,
+    passkey: Option<PasskeyMetadata>,
+}
+
+/// Prefer the portable account-space fact; fall back to what the provider
+/// recorded at account creation.
+///
+/// The provider row is not a legacy-only path. Every account still writes it at
+/// creation, and it answers three live cases: an account created before the
+/// space fact existed, a device that never held the passkey and so cannot seed
+/// it, and a fresh account read in the window between account creation and the
+/// first sweep that seeds the space.
+fn merge_summary(
+    email: Option<String>,
+    space: Option<PasskeyMetadata>,
+    provider: Option<PasskeyMetadata>,
+) -> AccountSummary {
+    AccountSummary {
+        email,
+        passkey: space.or(provider),
+    }
+}
+
+/// Verified account facts for the linked profile, preferring what the account
+/// repository carries over what the provider recorded.
 ///
 /// Shared by the HTTP route and the roster hooks that capture the
 /// account email best-effort at link time.
 pub(crate) async fn account_summary(state: &TonkState) -> Result<AccountSummary, TonkWorkerError> {
     let (link, service) = linked_service(state).await?;
+    let space = super::account_state::passkey_facts(state).await;
     let body = tonk_identity::request::build_device_invocation(
         state.profile.signer().signer().clone(),
         &link,
@@ -111,9 +146,23 @@ pub(crate) async fn account_summary(state: &TonkState) -> Result<AccountSummary,
         service.trim_end_matches('/')
     ))
     .map_err(|error| TonkWorkerError::Internal(format!("invalid account provider URL: {error}")))?;
-    let response = super::http::post_cbor(&endpoint, &body).await?;
-    serde_json::from_slice(&response.body)
-        .map_err(|error| TonkWorkerError::Internal(format!("parse account summary: {error}")))
+    match super::http::post_cbor(&endpoint, &body).await {
+        Ok(response) => {
+            let provider: ProviderSummary =
+                serde_json::from_slice(&response.body).map_err(|error| {
+                    TonkWorkerError::Internal(format!("parse account summary: {error}"))
+                })?;
+            Ok(merge_summary(Some(provider.email), space, provider.passkey))
+        }
+        // The account repository already answered the passkey question, so an
+        // unreachable provider costs the email and nothing else. With no space
+        // fact there is nothing to serve, and the caller keeps the real error.
+        Err(error) if space.is_some() => {
+            log!("account summary falling back to account-space facts: {error}");
+            Ok(merge_summary(None, space, None))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Return verified account facts authorized by this profile's active grant.
@@ -235,6 +284,44 @@ mod tests {
             summary(State(state)).await,
             Err(TonkWorkerError::NotFound(_))
         ));
+    }
+
+    #[dialog_common::test]
+    fn it_prefers_the_account_space_passkey_fact_over_the_provider_row() {
+        let space = PasskeyMetadata {
+            created_at: 1_754_380_800,
+            created_on: "Chrome on macOS".to_string(),
+        };
+        let provider = PasskeyMetadata {
+            created_at: 1_600_000_000,
+            created_on: "Safari on iOS".to_string(),
+        };
+
+        let merged = merge_summary(
+            Some("person@example.com".to_string()),
+            Some(space.clone()),
+            Some(provider.clone()),
+        );
+        assert_eq!(merged.passkey, Some(space.clone()));
+
+        let fallback = merge_summary(
+            Some("person@example.com".to_string()),
+            None,
+            Some(provider.clone()),
+        );
+        assert_eq!(
+            fallback.passkey,
+            Some(provider),
+            "an account created before the space fact existed still has the provider row"
+        );
+
+        let neither = merge_summary(Some("person@example.com".to_string()), None, None);
+        assert_eq!(neither.passkey, None);
+
+        // What an unreachable provider leaves: the portable fact, no address.
+        let offline = merge_summary(None, Some(space), None);
+        assert_eq!(offline.email, None);
+        assert_eq!(offline.passkey.unwrap().created_on, "Chrome on macOS");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -19,7 +19,7 @@ use tonk_account::{
     probe_remote_main, publish_genesis_if_absent,
 };
 use tonk_common::log;
-use tonk_schema::{Replica, prelude::DidExt as _};
+use tonk_schema::{AccountPasskeyCreated, Replica, prelude::DidExt as _};
 
 use crate::TonkWorkerError;
 use crate::worker::TonkState;
@@ -494,6 +494,11 @@ async fn sync_ready(tonk: &TonkState, key: &str) -> Result<(), String> {
         .perform(&tonk.operator)
         .await
         .map_err(|error| format!("account pull failed: {error}"))?;
+    // After the pull, so the seed sees what other devices already recorded,
+    // and before the push, so anything it writes leaves with this sweep.
+    if seed_passkey_facts(tonk).await {
+        log!("recorded this device's passkey creation facts in the account space");
+    }
     if let Err(error) = converge_account_state(tonk).await {
         log!("account-state convergence after sync failed: {error}");
     }
@@ -552,6 +557,11 @@ pub(crate) async fn ensure_account_state_swept(
         Ok(_) => match hydrate_untrusted(tonk, &key, &repository).await {
             Ok(()) => match mark_trusted(tonk, &descriptor).await {
                 Ok(()) => {
+                    // The path a freshly created account takes, where the
+                    // ready sweep above has not run yet.
+                    if seed_passkey_facts(tonk).await {
+                        log!("recorded this device's passkey creation facts in the account space");
+                    }
                     if let Err(error) = converge_account_state(tonk).await {
                         log!("account-state convergence after hydration failed: {error}");
                     }
@@ -597,6 +607,109 @@ pub(crate) async fn require_ready_account_state(
         .await
         .map_err(|error| TonkWorkerError::Internal(error.to_string()))?;
     Ok(ReadyAccountBranch { key, subject })
+}
+
+/// Read the creation facts recorded on a ready account branch.
+async fn read_passkey_facts(
+    tonk: &TonkState,
+    ready: &ReadyAccountBranch,
+) -> Result<Option<tonk_worker_api::PasskeyMetadata>, TonkWorkerError> {
+    let branch = tonk
+        .reactor
+        .repository(&ready.key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("open ready account state: {error}")))?;
+    let rows: Vec<AccountPasskeyCreated> = branch
+        .handle()
+        .query()
+        .select(Query::<AccountPasskeyCreated> {
+            this: Term::from(ready.subject.this()),
+            created_at: Term::var("created_at"),
+            created_on: Term::var("created_on"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("read account passkey facts: {error:?}"))
+        })?;
+    Ok(rows
+        .into_iter()
+        .next()
+        .map(|row| tonk_worker_api::PasskeyMetadata {
+            created_at: row.seconds(),
+            created_on: row.created_on.0,
+        }))
+}
+
+/// This account's passkey facts as recorded in the account space, absent when
+/// the account is not ready or carries none.
+///
+/// Best-effort by design — the dashboard has an explicit unavailable state and
+/// must not fail because a hidden system repository is mid-hydration. Every
+/// `None` that is not simply "no fact" is logged, so an unreadable branch is
+/// visible rather than silent.
+pub(crate) async fn passkey_facts(tonk: &TonkState) -> Option<tonk_worker_api::PasskeyMetadata> {
+    let ready = require_ready_account_state(tonk).await.ok()?;
+    match read_passkey_facts(tonk, &ready).await {
+        Ok(facts) => facts,
+        Err(error) => {
+            log!("account passkey facts unreadable: {error}");
+            None
+        }
+    }
+}
+
+/// Write this device's recorded passkey facts into the account space when it
+/// has them and the space does not. Returns whether it wrote.
+///
+/// Idempotent: a device that only ever *evaluated* an existing root has
+/// nothing to contribute and returns `false` without touching the branch. So
+/// does a device whose facts are already there — an existing fact is never
+/// overwritten, so a device that later derives a different label cannot
+/// rewrite history.
+pub(crate) async fn seed_passkey_facts(tonk: &TonkState) -> bool {
+    // Unconfigured and unhydrated are ordinary states, reached on every sweep
+    // of a signed-out profile. They are not worth a line in the log.
+    let Ok(ready) = require_ready_account_state(tonk).await else {
+        return false;
+    };
+    match read_passkey_facts(tonk, &ready).await {
+        Ok(None) => {}
+        Ok(Some(_)) => return false,
+        Err(error) => {
+            log!("account passkey facts unreadable before seeding: {error}");
+            return false;
+        }
+    }
+    let Ok(root) = super::identity::local_root(tonk).await else {
+        return false;
+    };
+    let Some(metadata) = root.passkey else {
+        return false;
+    };
+    if let Err(error) = tonk
+        .reactor
+        .repository(&ready.key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(AccountPasskeyCreated::new(
+            ready.subject.this(),
+            metadata.created_at,
+            metadata.created_on,
+        ))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+    {
+        log!("commit account passkey creation facts: {error}");
+        return false;
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    tonk.sync_queue.mark_dirty(&ready.key, js_sys::Date::now());
+    true
 }
 
 /// Project the authoritative account display name into local caches and every
@@ -939,6 +1052,9 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_service_worker);
 
+    #[cfg(not(target_arch = "wasm32"))]
+    use dialog_common::helpers::Provisionable as _;
+
     use super::*;
 
     #[dialog_common::test]
@@ -1103,12 +1219,26 @@ mod tests {
         }
     }
 
+    /// A native `TonkState` on a randomized profile, plus the local root and
+    /// account link that make [`ensure_account_state`] reach `Ready`.
+    ///
+    /// Yields the state, the running access service, and the signed
+    /// descriptor. Callers stop the service and clean up the on-disk verifier
+    /// repository themselves, the way the offline test does.
     #[cfg(not(target_arch = "wasm32"))]
-    #[dialog_common::test]
-    async fn it_mounts_hydrates_and_keeps_readiness_offline() {
-        use dialog_common::helpers::Provisionable as _;
+    async fn ready_account_state(
+        passkey: Option<tonk_worker_api::PasskeyMetadata>,
+    ) -> (
+        TonkState,
+        dialog_common::helpers::Service<
+            tonk_access_service::helpers::AccessServiceAddress,
+            tonk_access_service::helpers::AccessServer,
+        >,
+        AccountRepositoryDescriptorV1,
+    ) {
         use dialog_operator::Profile;
         use dialog_storage::provider::storage::Storage;
+        use dialog_varsig::Principal as _;
         use tonk_access_service::helpers::AccessServiceAddress;
 
         let service = AccessServiceAddress::start(Default::default())
@@ -1149,39 +1279,38 @@ mod tests {
         let descriptor = AccountRepositoryDescriptorV1::sign(&root, &remote)
             .await
             .unwrap();
-        let root_did = {
-            use dialog_varsig::Principal as _;
-            root.did().to_string()
-        };
+        let root_did = root.did().to_string();
         let credential_id = "account-state-test-credential".to_string();
         let delegation =
             tonk_identity::delegation::mint_device_delegation(root, &state.profile.did())
                 .await
                 .unwrap();
         let delegation_hex = hex::encode(delegation.to_bytes().unwrap());
-        // The link now attaches a provider to an already-persisted local root,
-        // so the root has to exist before persist_link will accept it.
+        // The link attaches a provider to an already-persisted local root, so
+        // the root has to exist before persist_link will accept it.
         crate::router::identity::persist_root(
             &state,
             tonk_worker_api::SaveRootRequest {
                 credential_id: credential_id.clone(),
                 delegation_hex: delegation_hex.clone(),
-                passkey: None,
+                passkey,
             },
         )
         .await
         .unwrap();
-        let request = tonk_worker_api::AccountLinkRequest {
-            provider: "https://accounts.example".to_string(),
-            root_did,
-            credential_id,
-            delegation_hex,
-            descriptor_hex: hex::encode(descriptor.bytes()),
-            initialize_name: false,
-        };
-        crate::router::account::persist_link(&state, &request)
-            .await
-            .unwrap();
+        crate::router::account::persist_link(
+            &state,
+            &tonk_worker_api::AccountLinkRequest {
+                provider: "https://accounts.example".to_string(),
+                root_did,
+                credential_id,
+                delegation_hex,
+                descriptor_hex: hex::encode(descriptor.bytes()),
+                initialize_name: false,
+            },
+        )
+        .await
+        .unwrap();
         state
             .profile
             .credential()
@@ -1190,6 +1319,105 @@ mod tests {
             .perform(&state.operator)
             .await
             .unwrap();
+
+        (state, service, descriptor)
+    }
+
+    /// Every recorded creation fact on the ready account branch.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn recorded_passkey_facts(
+        state: &TonkState,
+        ready: &ReadyAccountBranch,
+    ) -> Vec<tonk_schema::AccountPasskeyCreated> {
+        state
+            .reactor
+            .repository(&ready.key)
+            .branch(tonk_account::MAIN_BRANCH)
+            .acquire(&state.operator)
+            .await
+            .unwrap()
+            .handle()
+            .query()
+            .select(Query::<tonk_schema::AccountPasskeyCreated> {
+                this: Term::from(ready.subject.this()),
+                created_at: Term::var("created_at"),
+                created_on: Term::var("created_on"),
+            })
+            .perform(&state.operator)
+            .try_vec()
+            .await
+            .unwrap()
+    }
+
+    /// Remove the on-disk verifier repository `NativeSpace` rooted in the
+    /// package working directory for one randomized fixture.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn discard(state: TonkState, key: &str) {
+        let local = std::env::current_dir().unwrap().join(key);
+        drop(state);
+        if local.is_dir() {
+            std::fs::remove_dir_all(local).unwrap();
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_seeds_passkey_creation_facts_from_the_local_root() {
+        let (state, service, _descriptor) =
+            ready_account_state(Some(tonk_worker_api::PasskeyMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".to_string(),
+            }))
+            .await;
+
+        assert_eq!(
+            ensure_account_state(&state).await,
+            AccountStateStatus::Ready
+        );
+        let ready = require_ready_account_state(&state).await.unwrap();
+        let seeded = recorded_passkey_facts(&state, &ready).await;
+        assert_eq!(seeded.len(), 1);
+        assert_eq!(seeded[0].seconds(), 1_754_380_800);
+        assert_eq!(seeded[0].created_on.0, "Chrome on macOS");
+
+        // The sweep runs on every boot and every heartbeat. A second pass must
+        // find its own fact and leave it exactly as written.
+        assert_eq!(
+            ensure_account_state(&state).await,
+            AccountStateStatus::Ready
+        );
+        let again = recorded_passkey_facts(&state, &ready).await;
+        assert_eq!(again.len(), 1);
+        assert_eq!(again[0].seconds(), 1_754_380_800);
+        assert_eq!(again[0].created_on.0, "Chrome on macOS");
+
+        service.stop().await.unwrap();
+        discard(state, &ready.key);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_seeds_nothing_when_the_local_root_has_no_passkey_metadata() {
+        let (state, service, _descriptor) = ready_account_state(None).await;
+
+        assert_eq!(
+            ensure_account_state(&state).await,
+            AccountStateStatus::Ready
+        );
+        let ready = require_ready_account_state(&state).await.unwrap();
+        assert!(
+            recorded_passkey_facts(&state, &ready).await.is_empty(),
+            "a device that only evaluated an existing passkey has nothing to record"
+        );
+
+        service.stop().await.unwrap();
+        discard(state, &ready.key);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_mounts_hydrates_and_keeps_readiness_offline() {
+        let (state, service, descriptor) = ready_account_state(None).await;
 
         let before = crate::router::profile_name::resolve_display_name(&state).await;
         assert!(matches!(
@@ -1248,12 +1476,6 @@ mod tests {
             AccountStateStatus::Ready
         );
 
-        // NativeSpace roots verifier repositories in the package working
-        // directory for this fixture. Remove only this randomized test repo.
-        let local = std::env::current_dir().unwrap().join(&ready.key);
-        drop(state);
-        if local.is_dir() {
-            std::fs::remove_dir_all(local).unwrap();
-        }
+        discard(state, &ready.key);
     }
 }


### PR DESCRIPTION
Makes the hidden root-owned account repository the source of truth for passkey creation time and creation device, so those facts travel with the account instead of living only in the account service's D1 row.

## What changed

- **`AccountPasskeyCreated`** — a new concept keyed on the immutable account subject, carrying `xyz.tonk.account/passkey-created-at` and `/passkey-created-on`, both cardinality-one.
- **Seeding** — `seed_passkey_facts` writes this device's local-root metadata into the account space when the space has none, from the ready sweep (after pull, before push) and from the post-hydration path a freshly created account takes. It never overwrites an existing fact, so it is idempotent across every sweep, and a device that only *evaluated* an existing passkey contributes nothing.
- **Summary** — `account_summary` reads the space fact first and falls back to the provider row. The provider hop now decodes into its own `ProviderSummary` type rather than the local DTO.
- **Provider-unreachable rendering** — `AccountSummary::email` is now `Option<String>`. With the provider down and space facts present, the dashboard shows the passkey facts and renders the address as `Unavailable` instead of failing whole. With no space fact, the caller keeps the real error.

## What deliberately did not change

Account creation still writes the D1 columns, and `POST /account/summary` is untouched. The two values are expected to agree: the D1 row is the immutable claim fixed at creation inside a root-signed invocation, the space fact is the portable one any linked device can read without the provider. Keeping both makes a later divergence detectable rather than invisible.

Passkey metadata stays informational — nothing in root derivation, delegation, authorization, revocation, or account-repository authority reads it. No account or device `created_at` is ever substituted for passkey creation time; absent metadata renders as an explicit unavailable state.

## One finding worth review

The test that was meant to prove the two attributes cannot be torn apart disproves it. Cardinality-one merge is **per attribute, not per concept**: two replicas holding different pairs converge one field from each, deterministically but torn.

It is unreachable rather than merely unlikely — `evaluate_root` (`rust/tonk-identity/src/ceremony.rs`) records no metadata, so only the browser that ran `navigator.credentials.create()` ever holds a pair, and an account has exactly one pair to seed from any device. The concept doc now says this plainly, and the test pins what actually holds: identical concurrent seeds survive intact, divergent ones still converge in either order. Making the pair atomic means keying it on the credential, which belongs with the deferred per-credential modelling.

## Verification

- `test:native:debug` — 1395 passed
- `test:web:debug` — 1291 passed
- `test:e2e` — 12 passed, including `it_signs_up_through_the_account_panels`, extended to read `/api/account/summary` twice and assert the passkey values are identical (the seed does not rewrite itself)
- `nix flake check` (clippy / rustfmt / nixfmt / shared-deps) and `build:web` green

New coverage: schema round-trip and merge convergence, native seeding (with and without local metadata, plus idempotence across sweeps), source preference in `merge_summary`, and the dashboard rendering passkey facts with no verified email.

## Deferred

Dropping the D1 columns or the provider's `passkey` field; per-credential modelling; mirroring the verified email into the account space; backfilling `passkey_created_on` for accounts whose creating device is gone.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the handling of passkey creation facts within the account system, allowing these facts to be stored in the account repository, improving reliability and accessibility even when the account service is unreachable.

### Detailed summary
- Added `PasskeyCreatedAt` and `PasskeyCreatedOn` attributes.
- Introduced `AccountPasskeyCreated` concept to record passkey creation facts.
- Updated `AccountSummary` to make `email` optional.
- Enhanced `summary` function to prefer account-space facts over provider data.
- Modified UI to display passkey facts even when email is unavailable.
- Implemented tests for passkey fact recording and retrieval.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->