### PR TITLE
Passkey fan-out: multiple credentials per account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ dependencies = [
  "wasm-bindgen-test",
  "worker",
  "worker-macros",
+ "zeroize",
 ]
 
 [[package]]

--- a/plan/passkey-fanout.md
+++ b/plan/passkey-fanout.md
@@ -108,6 +108,43 @@ Smallest stable slice first; each step is independently shippable and useful.
 4. **Anchor normalization and email-gated recovery** in the account service.
 5. **v1 opt-in fan-out** (`subject → recovery` minting at sign-in) and the revocation walk UX.
 
+## Status
+
+Landed on `feat/passkey-fanout`:
+
+- **Step 1.** `RevocationAuthority::Peer` in `tonk-identity/src/revocation.rs`, plus
+  `mint_peer_revocation`. Gated on the witnessed path being subject-open, so
+  space invites keep the narrower classes.
+- **Step 2, enabling half.** `tonk-identity/src/credential.rs` mints the
+  `credential → peer` enrollment link and composes chains under it;
+  `delegation::validate_account_grant` replaces the five separate
+  "exactly one proof" checks in the account service, worker and CLI, so a
+  device may present `root → credential → device` at any depth. The
+  registry now records the device's own hop rather than the chain root —
+  identical for a one-hop grant, so no migration.
+
+Not started: the browser enrollment ceremony and wherever the enrollment link
+is served from (a device holding only the second passkey has no way to obtain
+`root → C2` today), and steps 3–5.
+
+Two decisions the implementation surfaced, both left open deliberately:
+
+- **Peer at the account service's device-revocation gate.** `revoke_device`
+  admits only `Delegated` (a device revoking itself) and `PathIssuer` (the
+  account root). Admitting `Peer` would also let any *device* revoke any other
+  device, because the service cannot tell a credential from a device — both
+  hold subject-open chains from the root. That drops the current requirement
+  that cross-device revocation re-derive the root from the passkey. Wants a
+  decision before it is written.
+- **Revocation artifacts are screened globally by target CID.** An artifact is
+  authorized relative to its witnessed path, but `tonk-access-service` and the
+  R2 key record only the target CID. Anyone who holds a delegation's bytes can
+  mint `attacker → issuer`, prepend it to make the target sit at index 1, and
+  qualify as `PathIssuer` — which globally revokes it. Reachable today by any
+  invitee against their inviter's link. Predates this work and is untouched by
+  it; subject-scoping the screen does not fix it, because subject-open grants
+  are meant to apply across subjects.
+
 ## Open questions
 
 - Whether dialog-ucan policy predicates could scope `root → recovery` tighter than "full, by convention" without breaking the attenuation argument — revisit when policies land; do not block on it.

--- a/plan/passkey-fanout.md
+++ b/plan/passkey-fanout.md
@@ -1,6 +1,6 @@
 # Passkey fan-out design spec
 
-**Goal:** Let one account hold multiple passkeys as equal peers — enrolled from a signed-in device or recovered through email + one-time code — without coupling the account subject to any single passkey, without hiding authority state from the user, and without binding the account to Tonk's account service any harder than it is today.
+**Goal:** Let one account hold multiple passkeys as equal peers — enrolled through email + one-time code, or opportunistically from a credential that happens to be reachable — without coupling the account subject to any single passkey, without hiding authority state from the user, and without binding the account to Tonk's account service any harder than it is today.
 
 **Approach:** Break the identity `account subject = HKDF(passkey PRF)`. Each passkey's PRF derives a *credential key*, one of many. The account subject becomes a fresh ephemeral root keypair that exists only during account genesis: it signs the repository descriptor, fans out subject-open delegations to the first credential key and to a recovery anchor (the account service's DID), and is then discarded. Later passkeys enroll by collecting delegations from every reachable anchor — a sibling credential, the recovery anchor, or both — so every credential ends up with at least one chain of uniform depth under a durable anchor. Peer equality for account-level acts (enrollment, revocation) is expressed in verification rules, not chain shape: any credential holding a currently-valid chain to the account subject may act for the account.
 
@@ -23,6 +23,8 @@
 - **Recovery anchor** — the account service's own DID, holding a direct subject-open delegation from the root. A competing provider added later is just another anchor, reached through an existing chain rather than the root.
 - **Sibling chain** — `root → credential_A → credential_B`: credential A enrolled credential B directly.
 - **Anchor chain** — `root → recovery → credential_B`: the recovery anchor enrolled (or normalized) credential B.
+- **Chain store** — a dumb map from audience DID to the delegations addressed to it. Holds only self-authenticating artifacts, so it can withhold but never forge. The account repository is the durable copy; the service's is a replica.
+- **Claim** — "give me every delegation whose audience is this key". The one call a device with nothing but a freshly derived credential key can usefully make.
 
 ## Genesis ceremony
 
@@ -35,7 +37,9 @@ Replaces the current flow where `create_account` treats the passkey-derived sign
    - `root → C1`, subject-open, no expiry;
    - `root → recovery`, subject-open, no expiry, audience = the account service DID published at the descriptor remote.
 4. Zeroize and drop the root.
-5. Persist both delegations and the descriptor to the account repository genesis; the service stores its own copy of `root → recovery` and indexes email → subject.
+5. Persist both delegations and the descriptor to the account repository genesis; publish both to the chain store keyed by audience; the service indexes email → subject.
+
+**Anchor invariant.** Because the root is destroyed, every direct `root → x` anchor that will ever exist must be minted in step 3. After genesis, new anchors are only reachable by an existing credential delegating one (`Ca → competitor-recovery`), never by the root. An account that skips the recovery anchor at genesis can never be given one except through a live credential — and if all credentials are lost first, it is gone. This is the sharp edge storacha hit from the other direction (their space key survives but is often effectively lost, and "if a user doesn't have the private key for space, they cannot delegate access to a new email DID"). Genesis is therefore not the place to make the recovery anchor optional.
 
 The `root → recovery` delegation is deliberately full (subject-open, empty command), not enroll-scoped: UCAN attenuation means an audience can only re-delegate what it holds, and recovery must be able to confer full account authority on a replacement credential. The containment is procedural and structural instead: the delegation is visible in the user's own repo, revocable by any peer credential, and the service's stated policy is to exercise it only for credential enrollment after email + OTP verification. A user who distrusts the service revokes that one link and (via any credential) delegates an equivalent anchor elsewhere.
 
@@ -43,15 +47,29 @@ The `root → recovery` delegation is deliberately full (subject-open, empty com
 
 Every enrollment produces a new credential key `Cn` from a new passkey's PRF and collects delegations from **every reachable anchor path**. A device stores all chains it holds; verifiers accept any one valid, unrevoked chain.
 
-**Sibling path (signed-in device present).** Credential `Ca` mints `Ca → Cn`, subject-open. Chain: `root → Ca → Cn` (or longer, through however `Ca` itself is anchored). Works offline, involves no service. This alone is sufficient authority.
+**Anchor path — the primary flow.** The user creates a passkey on the new platform, derives `Cn`, and asks the account service to enroll it. The service emails a one-time code; on verification it mints `recovery → Cn` under its `root → recovery` proof and publishes it to the chain store keyed by `Cn`. Chain: `root → recovery → Cn`, depth two regardless of enrollment order — this is what makes credentials effective peers for survivability.
 
-**Anchor path (service reachable).** The service mints `recovery → Cn` under its `root → recovery` proof. Chain: `root → recovery → Cn`, depth two regardless of enrollment order — this is what makes credentials effective peers for survivability.
+Nothing else has to be present. A factory-fresh iPhone holding only the new passkey does: derive `Cn` from PRF → claim by `Cn`'s DID → receive `root → recovery → Cn`. No second device, no QR code, no out-of-band pairing.
 
-Anchor-chain issuance is **always email + OTP gated**, even when the requester presents a currently-valid sibling chain. Rationale: an anchor chain outlives revocation of the enrolling credential. If issuance were gated only on "holds a valid chain", an attacker who briefly compromises one passkey could enroll a shadow credential, normalize it to an anchor chain, and survive the victim revoking the compromised passkey. Email gating puts a second factor and a notification in front of exactly that escalation.
+Anchor-chain issuance is **always email + OTP gated**, even when the requester presents a currently-valid sibling chain. Rationale: an anchor chain outlives revocation of the enrolling credential. If issuance were gated only on "holds a valid chain", an attacker who briefly compromises one passkey could enroll a shadow credential, normalize it to an anchor chain, and survive the victim revoking the compromised passkey. Email gating puts a second factor and a notification in front of exactly that escalation. Every anchor issuance also notifies the account email, so the escalation is loud even when it succeeds.
 
-The standard ceremony when both paths are available: sibling delegation minted locally and stored immediately; anchor chain requested in the same flow, gated by OTP, stored when it arrives. A credential holding only a sibling chain can request anchor normalization at any later time through the same gate.
+The cost of making email primary, stated plainly: mailbox control becomes equivalent to account control. The containments are that the anchor link is visible and revocable by any peer, and that issuance is always announced.
 
-Every enrollment appends a fact to the account repository's enrollment log: enrolled credential DID, enrolling authority (sibling DID or recovery), timestamp, and user-facing label. The log is auditable data, not an authority source — verification never consults it — but revocation tooling walks it (below).
+**Sibling path — opportunistic, not a UX.** When a credential is reachable anyway during enrollment, `Ca` also mints `Ca → Cn`, subject-open, giving `root → Ca → Cn`. This is free, works offline, involves no service, and is sufficient authority on its own. It is not a flow the user is ever asked to perform: it is an extra chain the device keeps, and it is what gives `Cn` Peer/Delegated revocation authority over links an anchor chain alone would not cover. A credential holding only a sibling chain can request anchor normalization later through the same OTP gate.
+
+Every enrollment appends a fact to the account repository's enrollment log: enrolled credential DID, enrolling authority (sibling DID or recovery), timestamp, and user-facing label. Sync-path verification never consults it — a presented chain stands on its own. Account-level acts do: revocation tooling walks it, and the seniority tie-break below reads its ordering. Whether that makes it an authority source for those acts is the one structural question still open (below).
+
+## Chain store
+
+The bootstrap problem is narrow and has one answer: a device that has just derived `Cn` and holds nothing else needs to *find* `root → recovery → Cn`. It cannot read the account repository, because the authority to sync that repository is the very thing it is looking for.
+
+So the service exposes a store keyed by audience DID, with two operations — publish a delegation, and claim everything addressed to a key. This is deliberately not a credential registry and holds no policy:
+
+- Entries are self-authenticating UCAN delegations. The store can withhold an entry; it cannot forge one, cannot alter one, and grants nothing by holding one.
+- Claiming is unauthenticated by design. Knowing a credential's DID is not authority — the delegation is only usable by whoever holds that key.
+- Every entry also lives in the account repository. A user, or a competing provider, can serve the same bytes; nothing here is reconstructible only from tonk-run state.
+
+This is the piece taken directly from storacha's `access/delegate` / `access/claim`, and it is the whole of what the account service needs to do for enrollment beyond signing `recovery → Cn`.
 
 ## Verification
 
@@ -65,7 +83,9 @@ Add a third class:
 
 - **Peer** — the signer presents any currently-valid delegation chain from the *same account subject* to itself. Any enrolled credential may revoke any delegation whose subject is the account.
 
-This is the flat, equal-peers semantics, expressed where it belongs — in the verifier — rather than by contorting chain shape. The Delegated class's sharp edge (a downstream key revoking its own ancestor to lock others out) is inherited by Peer and accepted: a revocation war between two credentials both claiming to be the user is resolved by the recovery flow (email + OTP re-enrollment), which is exactly the arbiter it should be.
+This is the flat, equal-peers semantics, expressed where it belongs — in the verifier — rather than by contorting chain shape. The Delegated class's sharp edge (a downstream key revoking its own ancestor to lock others out) is inherited by Peer and accepted.
+
+**Mutual revocation.** Two credentials revoking each other resolves by **seniority**: removals always win over concurrent non-removals, and between two removals the credential enrolled earlier survives. This is `@localfirst/auth`'s rule and it is better than the conservative "both revoked" reading — it avoids handing a briefly-compromised credential a mutual-destruction move, and it never orphans an account. The enrollment log already records the ordering the rule needs, which makes it the first thing in this design that reads the log (see the open question below). Recovery through email + OTP remains the arbiter of last resort when seniority is not enough.
 
 Revoking a credential (the "lost Chrome passkey" flow, driven from any signed-in peer):
 
@@ -79,7 +99,7 @@ Revoking the recovery anchor (`root → recovery`) is allowed under Peer authori
 ## Recovery (all credentials lost)
 
 1. User proves email control via OTP at the account service.
-2. Service creates a passkey ceremony for a new credential key `Cr`, mints `recovery → Cr`, records an enrollment-log fact marked `recovered`, and notifies the account email.
+2. Service creates a passkey ceremony for a new credential key `Cr`, mints `recovery → Cr`, publishes it to the chain store keyed by `Cr`, records an enrollment-log fact marked `recovered`, and notifies the account email.
 3. `Cr` now holds full authority; the user is prompted to review the credential list and revoke lost credentials (Peer authority).
 
 There is no service-side custodial key beyond the `root → recovery` audience keypair the user already sees in their own chain. Losing email *and* all passkeys loses the account; that is the honest boundary of this design and must be stated at account creation.
@@ -87,7 +107,7 @@ There is no service-side custodial key beyond the `root → recovery` audience k
 ## Storage and portability
 
 - The account repository (root-owned, established at genesis) is the durable home of: the descriptor, all delegation chains, all revocation artifacts, and the enrollment log. Every linked device replicates it. Exporting the account is cloning the repo.
-- The service's R2 chain store and D1 email index are reconstructible caches. Anything present there but absent from the account repo is a bug.
+- The service's chain store and D1 email index are reconstructible caches. Anything present there but absent from the account repo is a bug — including the audience-keyed enrollment entries, which must be written to the repo by whichever credential first successfully claims them.
 - Migrating to a competing provider: any credential delegates a new anchor (`Ca → competitor-recovery`, subject-open), the user enrolls a passkey under the competitor's RP through it, and optionally revokes `root → recovery`. The new anchor's chain is depth three rather than two; Peer verification makes depth irrelevant.
 
 ## Existing v1 accounts
@@ -98,15 +118,36 @@ A v1 account's subject *is* its passkey-derived key — which means, unlike the 
 - What v1 accounts never gain: compromise of the *first* passkey is compromise of the subject itself, unrevocable by construction. A full re-key (new account, data migration) is the only cure and is out of scope here.
 - Verifiers and ceremonies must therefore not assume the subject key is unreachable; they must accept both "subject signs directly" (v1) and "chain from subject" (fan-out) forever.
 
+## Prior art
+
+The closest system is storacha's w3up. It is worth being precise about what to take and what not to.
+
+Their shape: a **space** `did:key` generated locally is the subject; an **account** `did:mailto` holds no key material at all and exists as a stable audience; an **agent** `did:key` per device. At space creation the space delegates full authority to the account. A new agent invokes `access/request`, the service emails a confirmation, and on approval issues both the account→agent delegation and a `ucan/attest` session; the agent then polls `access/claim` for everything addressed to it.
+
+Take:
+
+- **The email-gated issuance flow.** Confirmed as the ergonomic path, and it does not require a second device.
+- **`access/delegate` / `access/claim`** — the audience-keyed chain store above.
+- **Their failure mode as our invariant.** A space whose key is gone and which never got a recovery account is unrecoverable, with no way to add one after the fact.
+
+Do not take:
+
+- **Attestation rooted at the service.** `ucan/attest` carries `with: did:web:web3.storage` — the service's *own* DID. Verifiers must hardcode trust in it, and no link in the chain expresses that power, so no user can cut it. They need this only because `did:mailto` cannot sign: the account→agent delegation carries a placeholder signature and is worthless without the service vouching for it.
+
+Our recovery anchor is a real keypair that got its authority from the account subject at genesis, so it simply *signs* `recovery → Cn`. Same UX, derived rather than inherent authority, visible as one revocable link, and no attestation concept or placeholder-signature machinery. That difference is the entire reason to keep the anchor as a delegation rather than adopting their session model wholesale.
+
+Other systems informing this design: Fission/webnative and Keybase device provisioning (out-of-band pairing — rejected here on UX grounds, see deferred); KERI (self-certifying identifiers, append-only key event log, witnesses that hold receipts and no authority); `@localfirst/auth` (signature-chain membership, seniority tie-break); SPKI/SDSI certificate chain discovery (the store of self-authenticating certificates is a cache anyone can run — the argument that licenses the chain store above).
+
 ## Suggested landing order
 
-Smallest stable slice first; each step is independently shippable and useful.
+Smallest stable slice first; each step is independently shippable and useful. Steps 1 and 2 are done; see Status.
 
 1. **Peer revocation authority** in `revocation.rs` — self-contained, testable, needed by everything else, and immediately useful to v1 accounts.
-2. **Sibling enrollment** — multi-passkey for v1 accounts (subject key mints sibling delegations directly). Fixes the Chrome-on-Mac / Safari-on-iOS split with no service or genesis change.
-3. **Ephemeral-root genesis + recovery anchor** for new accounts, plus the enrollment log.
-4. **Anchor normalization and email-gated recovery** in the account service.
-5. **v1 opt-in fan-out** (`subject → recovery` minting at sign-in) and the revocation walk UX.
+2. **Multi-hop account grants** — a device may present `root → credential → device`. Prerequisite for any credential that is not the subject itself.
+3. **Chain store** — publish and claim, keyed by audience DID. No policy, no new authority, and it is what removes the need for any pairing ceremony. Transport before policy.
+4. **Email-gated anchor issuance** — `recovery → Cn` behind OTP, published to the store, notified to the account email. With 3, this is the whole enrollment flow for v1 accounts: the v1 subject key mints `subject → recovery` at sign-in, and every later passkey enrolls through the anchor.
+5. **Ephemeral-root genesis** for new accounts, plus the enrollment log.
+6. **Revocation walk UX** and the seniority tie-break, which is the first consumer of the enrollment log.
 
 ## Status
 
@@ -115,7 +156,7 @@ Landed on `feat/passkey-fanout`:
 - **Step 1.** `RevocationAuthority::Peer` in `tonk-identity/src/revocation.rs`, plus
   `mint_peer_revocation`. Gated on the witnessed path being subject-open, so
   space invites keep the narrower classes.
-- **Step 2, enabling half.** `tonk-identity/src/credential.rs` mints the
+- **Step 2.** `tonk-identity/src/credential.rs` mints the
   `credential → peer` enrollment link and composes chains under it;
   `delegation::validate_account_grant` replaces the five separate
   "exactly one proof" checks in the account service, worker and CLI, so a
@@ -123,9 +164,9 @@ Landed on `feat/passkey-fanout`:
   registry now records the device's own hop rather than the chain root —
   identical for a one-hop grant, so no migration.
 
-Not started: the browser enrollment ceremony and wherever the enrollment link
-is served from (a device holding only the second passkey has no way to obtain
-`root → C2` today), and steps 3–5.
+Next is the chain store (step 3), which is what closes the bootstrap gap: a
+device holding only the second passkey currently has no way to obtain
+`root → C2`.
 
 Two decisions the implementation surfaced, both left open deliberately:
 
@@ -147,13 +188,16 @@ Two decisions the implementation surfaced, both left open deliberately:
 
 ## Open questions
 
+- **Is the enrollment log an authority source?** This spec says no — verification consults only chains, so the hot path needs no registry. The price is that a credential and a device are structurally identical (both hold subject-open chains from the root), so no policy can express "credentials may revoke peers, devices may not"; that is exactly why the account service's device-revocation gate is stuck (above). KERI, Keybase and `@localfirst/auth` all go the other way and make the log authoritative for membership, accepting the lookup. The seniority tie-break already needs to read it. Decide this before step 5 — it is the one structural question left, and answering it "yes, for account-level acts only" would keep the sync hot path chain-only while unblocking the gate.
 - Whether dialog-ucan policy predicates could scope `root → recovery` tighter than "full, by convention" without breaking the attenuation argument — revisit when policies land; do not block on it.
-- Concurrent revocation races (two credentials revoking each other) resolve through recovery, but the verifier-visible interim state needs defining: likely "both revoked until re-enrollment", the conservative reading.
 - Whether the enrollment log lives on the account repo's `main` alongside chains or in a reserved namespace — decide with the first implementation PR; the meta branch is local-only and cannot hold it.
+- Whether the chain store should be readable without knowing a credential DID (e.g. "everything under this account subject"). Claiming by audience leaks nothing; enumerating by subject would expose the credential roster to anyone who knows the account DID.
 - How many chains a device should retain. Minimum: its best anchor chain plus any sibling chain it depends on for Peer/Delegated revocation authority over links it may need to cut. Default to retaining everything; chains are small.
 
 ## Explicitly deferred
 
+- **Out-of-band pairing** (QR / short code through a relay, as in Fission device linking and Keybase device provisioning). It is the dominant answer in the prior art and needs no service state at all, but it requires two devices in hand and is markedly worse UX than an emailed code. The opportunistic sibling path covers the case where a second credential is present anyway; a deliberate pairing ceremony is not built.
+- **WebAuthn `largeBlob`.** Storing a credential's own chain inside the credential would make an enrolled passkey fully self-sufficient — one assertion returns both the PRF output and the chain, with no store and no network. Measured against this design's chains it fits comfortably: 280 bytes for one hop, 551 for two, 822 for three, against a 2 KB per-credential budget. Not built: blobs are only writable on an assertion *after* creation, so enrollment gains a ceremony step, and support is uneven (Safari/iOS 17+, Windows 11 only, varies by authenticator and unconfirmed for Google Password Manager). Revisit as an offline optimization once the chain store exists.
 - Paper keys, secondary recovery providers, and social recovery — the anchor mechanism accommodates all three; none are built until there is an immediate use.
 - Deliberate subject rotation (re-key ceremony) for v1 accounts.
 - Attestation or provenance claims about where a passkey is stored (password manager vs platform); WebAuthn does not expose this reliably.

--- a/plan/passkey-fanout.md
+++ b/plan/passkey-fanout.md
@@ -1,0 +1,123 @@
+# Passkey fan-out design spec
+
+**Goal:** Let one account hold multiple passkeys as equal peers — enrolled from a signed-in device or recovered through email + one-time code — without coupling the account subject to any single passkey, without hiding authority state from the user, and without binding the account to Tonk's account service any harder than it is today.
+
+**Approach:** Break the identity `account subject = HKDF(passkey PRF)`. Each passkey's PRF derives a *credential key*, one of many. The account subject becomes a fresh ephemeral root keypair that exists only during account genesis: it signs the repository descriptor, fans out subject-open delegations to the first credential key and to a recovery anchor (the account service's DID), and is then discarded. Later passkeys enroll by collecting delegations from every reachable anchor — a sibling credential, the recovery anchor, or both — so every credential ends up with at least one chain of uniform depth under a durable anchor. Peer equality for account-level acts (enrollment, revocation) is expressed in verification rules, not chain shape: any credential holding a currently-valid chain to the account subject may act for the account.
+
+**Constraints:**
+
+- The recovery anchor's authority must be visible in the delegation chain, revocable, and reproducible by a competing provider. Email + OTP is the service's *policy* for exercising a capability it visibly holds, never an out-of-band authority living only in its database.
+- No state required to reconstruct or exercise account authority may exist only in tonk-run services. Chains, revocation artifacts, and the enrollment log live in the root-owned account repository; D1 and R2 are cache and index (survivability rule).
+- The credential derivation itself (`derive.rs`, `tonk/root-key/v1`) is unchanged — only its *meaning* changes, from "the account subject" to "a credential key". Existing passkeys keep deriving the same key.
+- Account delegations remain subject-open and audience-specific (`delegation.rs` shape). Space invites remain subject-specific; the two shapes must not blur (invite subject invariant).
+- Existing v1 accounts (subject = first passkey's derived key) must keep working unmodified, and must be able to opt into fan-out without re-keying.
+- The descriptor (`AccountRepositoryDescriptorV1`) is unchanged: it names a `did:key` subject and is signed once by that subject's key. Under fan-out the signature happens during genesis while the ephemeral root is alive.
+- WebAuthn credentials are bound to `rp.id`. Portability lives entirely at the delegation layer: the account (subject DID, chains, repo) ports; individual passkeys never do.
+- No speculative surface: this spec covers multiple passkeys and email-gated recovery. Paper keys, secondary providers, and social recovery must *fit* the model but are not built now.
+
+## Terms
+
+- **Credential key** — the Ed25519 key derived from one passkey's PRF output. Today this is called the root; after this change it is one credential among peers.
+- **Account root** — a fresh Ed25519 keypair generated at account genesis and discarded before genesis completes. Its DID is the account subject forever.
+- **Anchor** — an audience of a direct `root → x` delegation minted during genesis. Initially: the first credential key and the recovery anchor.
+- **Recovery anchor** — the account service's own DID, holding a direct subject-open delegation from the root. A competing provider added later is just another anchor, reached through an existing chain rather than the root.
+- **Sibling chain** — `root → credential_A → credential_B`: credential A enrolled credential B directly.
+- **Anchor chain** — `root → recovery → credential_B`: the recovery anchor enrolled (or normalized) credential B.
+
+## Genesis ceremony
+
+Replaces the current flow where `create_account` treats the passkey-derived signer as the subject.
+
+1. Create the passkey; derive credential key `C1` from its PRF output.
+2. Generate the ephemeral account root in the browser. It never leaves the ceremony scope.
+3. Root signs, in order:
+   - the account repository descriptor (unchanged v1 format; subject = root DID);
+   - `root → C1`, subject-open, no expiry;
+   - `root → recovery`, subject-open, no expiry, audience = the account service DID published at the descriptor remote.
+4. Zeroize and drop the root.
+5. Persist both delegations and the descriptor to the account repository genesis; the service stores its own copy of `root → recovery` and indexes email → subject.
+
+The `root → recovery` delegation is deliberately full (subject-open, empty command), not enroll-scoped: UCAN attenuation means an audience can only re-delegate what it holds, and recovery must be able to confer full account authority on a replacement credential. The containment is procedural and structural instead: the delegation is visible in the user's own repo, revocable by any peer credential, and the service's stated policy is to exercise it only for credential enrollment after email + OTP verification. A user who distrusts the service revokes that one link and (via any credential) delegates an equivalent anchor elsewhere.
+
+## Enrollment ceremonies
+
+Every enrollment produces a new credential key `Cn` from a new passkey's PRF and collects delegations from **every reachable anchor path**. A device stores all chains it holds; verifiers accept any one valid, unrevoked chain.
+
+**Sibling path (signed-in device present).** Credential `Ca` mints `Ca → Cn`, subject-open. Chain: `root → Ca → Cn` (or longer, through however `Ca` itself is anchored). Works offline, involves no service. This alone is sufficient authority.
+
+**Anchor path (service reachable).** The service mints `recovery → Cn` under its `root → recovery` proof. Chain: `root → recovery → Cn`, depth two regardless of enrollment order — this is what makes credentials effective peers for survivability.
+
+Anchor-chain issuance is **always email + OTP gated**, even when the requester presents a currently-valid sibling chain. Rationale: an anchor chain outlives revocation of the enrolling credential. If issuance were gated only on "holds a valid chain", an attacker who briefly compromises one passkey could enroll a shadow credential, normalize it to an anchor chain, and survive the victim revoking the compromised passkey. Email gating puts a second factor and a notification in front of exactly that escalation.
+
+The standard ceremony when both paths are available: sibling delegation minted locally and stored immediately; anchor chain requested in the same flow, gated by OTP, stored when it arrives. A credential holding only a sibling chain can request anchor normalization at any later time through the same gate.
+
+Every enrollment appends a fact to the account repository's enrollment log: enrolled credential DID, enrolling authority (sibling DID or recovery), timestamp, and user-facing label. The log is auditable data, not an authority source — verification never consults it — but revocation tooling walks it (below).
+
+## Verification
+
+Unchanged in mechanism: a verifier accepts an invocation when it carries a valid delegation chain from the account subject to the invoker, with no chain link revoked. What changes is only that several chains may exist per credential and verifiers must accept any one of them. No keyring lookup, no repo-state dependency on the hot path.
+
+## Revocation
+
+`revocation.rs` artifacts already carry their own witness path and verify without a registry. Two authority classes exist today: **PathIssuer** (signer issued a delegation in the witnessed prefix) and **Delegated** (signer's authority flows through the target). Both break down under fan-out for the case that matters most — a peer revoking a link it does not depend on: Safari holding only `root → recovery → safari` has neither class of authority over `root → chrome`.
+
+Add a third class:
+
+- **Peer** — the signer presents any currently-valid delegation chain from the *same account subject* to itself. Any enrolled credential may revoke any delegation whose subject is the account.
+
+This is the flat, equal-peers semantics, expressed where it belongs — in the verifier — rather than by contorting chain shape. The Delegated class's sharp edge (a downstream key revoking its own ancestor to lock others out) is inherited by Peer and accepted: a revocation war between two credentials both claiming to be the user is resolved by the recovery flow (email + OTP re-enrollment), which is exactly the arbiter it should be.
+
+Revoking a credential (the "lost Chrome passkey" flow, driven from any signed-in peer):
+
+1. Walk the enrollment log for every delegation *issued by* the revoked credential and every credential enrolled through it that was later anchor-normalized.
+2. Mint revocation artifacts for: the revoked credential's inbound links (`root → chrome`, any `x → chrome`), and — surfaced to the user for confirmation, not automatic — anything it enrolled.
+3. Persist artifacts to the account repository and push to the service, which serves them to verifiers.
+4. For each surviving credential holding only chains through the revoked link, prompt anchor normalization (email + OTP) so it regains a live chain.
+
+Revoking the recovery anchor (`root → recovery`) is allowed under Peer authority and orphans nothing that holds a sibling chain — but it removes email recovery entirely until an equivalent anchor is delegated elsewhere. The UX must say so plainly.
+
+## Recovery (all credentials lost)
+
+1. User proves email control via OTP at the account service.
+2. Service creates a passkey ceremony for a new credential key `Cr`, mints `recovery → Cr`, records an enrollment-log fact marked `recovered`, and notifies the account email.
+3. `Cr` now holds full authority; the user is prompted to review the credential list and revoke lost credentials (Peer authority).
+
+There is no service-side custodial key beyond the `root → recovery` audience keypair the user already sees in their own chain. Losing email *and* all passkeys loses the account; that is the honest boundary of this design and must be stated at account creation.
+
+## Storage and portability
+
+- The account repository (root-owned, established at genesis) is the durable home of: the descriptor, all delegation chains, all revocation artifacts, and the enrollment log. Every linked device replicates it. Exporting the account is cloning the repo.
+- The service's R2 chain store and D1 email index are reconstructible caches. Anything present there but absent from the account repo is a bug.
+- Migrating to a competing provider: any credential delegates a new anchor (`Ca → competitor-recovery`, subject-open), the user enrolls a passkey under the competitor's RP through it, and optionally revokes `root → recovery`. The new anchor's chain is depth three rather than two; Peer verification makes depth irrelevant.
+
+## Existing v1 accounts
+
+A v1 account's subject *is* its passkey-derived key — which means, unlike the fan-out design, its root is still alive and re-derivable. That is a migration advantage:
+
+- At any sign-in, the v1 credential can mint `subject → recovery` and enroll further passkeys as siblings, gaining everything in this spec except subject-rotation protection. No re-keying, no descriptor change; the subject key simply also remains a usable credential.
+- What v1 accounts never gain: compromise of the *first* passkey is compromise of the subject itself, unrevocable by construction. A full re-key (new account, data migration) is the only cure and is out of scope here.
+- Verifiers and ceremonies must therefore not assume the subject key is unreachable; they must accept both "subject signs directly" (v1) and "chain from subject" (fan-out) forever.
+
+## Suggested landing order
+
+Smallest stable slice first; each step is independently shippable and useful.
+
+1. **Peer revocation authority** in `revocation.rs` — self-contained, testable, needed by everything else, and immediately useful to v1 accounts.
+2. **Sibling enrollment** — multi-passkey for v1 accounts (subject key mints sibling delegations directly). Fixes the Chrome-on-Mac / Safari-on-iOS split with no service or genesis change.
+3. **Ephemeral-root genesis + recovery anchor** for new accounts, plus the enrollment log.
+4. **Anchor normalization and email-gated recovery** in the account service.
+5. **v1 opt-in fan-out** (`subject → recovery` minting at sign-in) and the revocation walk UX.
+
+## Open questions
+
+- Whether dialog-ucan policy predicates could scope `root → recovery` tighter than "full, by convention" without breaking the attenuation argument — revisit when policies land; do not block on it.
+- Concurrent revocation races (two credentials revoking each other) resolve through recovery, but the verifier-visible interim state needs defining: likely "both revoked until re-enrollment", the conservative reading.
+- Whether the enrollment log lives on the account repo's `main` alongside chains or in a reserved namespace — decide with the first implementation PR; the meta branch is local-only and cannot hold it.
+- How many chains a device should retain. Minimum: its best anchor chain plus any sibling chain it depends on for Peer/Delegated revocation authority over links it may need to cut. Default to retaining everything; chains are small.
+
+## Explicitly deferred
+
+- Paper keys, secondary recovery providers, and social recovery — the anchor mechanism accommodates all three; none are built until there is an immediate use.
+- Deliberate subject rotation (re-key ceremony) for v1 accounts.
+- Attestation or provenance claims about where a passkey is stored (password manager vs platform); WebAuthn does not expose this reliably.
+- Quorum rules for destructive account acts (N-of-M credentials to revoke the recovery anchor); single-credential Peer authority is accepted for now.

--- a/plan/passkey-fanout.md
+++ b/plan/passkey-fanout.md
@@ -149,6 +149,21 @@ Smallest stable slice first; each step is independently shippable and useful. St
 5. **Ephemeral-root genesis** for new accounts, plus the enrollment log.
 6. **Revocation walk UX** and the seniority tie-break, which is the first consumer of the enrollment log.
 
+## Deployment
+
+`RECOVERY_ANCHOR_SEED` is a per-environment worker secret: 32 bytes, hex. It
+is not in `wrangler.account.toml` and must be set with `wrangler secret put`
+for production, staging and preview separately — three different anchors, so
+a staging account can never be enrolled against by production or the reverse.
+
+Rotating it is not a routine operation. An account that delegated to the old
+key keeps working for everything except this service's anchor path, which
+starts refusing with a conflict rather than silently doing something else.
+Recovering such an account needs a live credential to delegate to the new
+anchor. Nothing else in the service depends on the secret, so an environment
+without one serves every other route normally and simply omits
+`recoveryAnchor` from `GET /`.
+
 ## Status
 
 Landed on `feat/passkey-fanout`:
@@ -173,8 +188,30 @@ Landed on `feat/passkey-fanout`:
   chain's shape and signatures and that this service hosts the account it
   runs from — the latter is anti-abuse, not authority.
 
-Next is step 4: email-gated `recovery → Cn` issuance. The transport it needs
-now exists.
+- **Step 4.** `anchor.rs` builds the service's anchor signer from a
+  `RECOVERY_ANCHOR_SEED` secret and `GET /` publishes its DID, which is what
+  a genesis reads to address `root → recovery`. `core/enrollment.rs` verifies
+  a one-time code, loads that account's anchor proof, mints
+  `recovery → Cn`, publishes it to the audience-keyed store and mails the
+  account holder — best-effort, since the chain is already minted by then.
+  `POST /enrollments/confirm` drives it. Anchor proofs are filed under an
+  `anchors/{account_root}` prefix when published, because the anchor is the
+  audience for every account at once and claiming by audience would return
+  all of them.
+- **Step 5, genesis.** `ceremony::create_account_with_ephemeral_root`
+  generates the subject, signs the descriptor, fans out to the first
+  credential and to the anchor, grants the device through the credential
+  (`root → C1 → device`), and drops the key. Two accounts created from the
+  same passkey get different subjects, which is the property the old design
+  could not have.
+
+Remaining: the enrollment log, and step 6's revocation walk and seniority
+tie-break, which reads it. The log lives in the account repository, so it
+needs the repo write path rather than anything in the account service — and
+it wants the authority question below answered first. Also unbuilt: the
+browser wiring that calls these ceremonies, and `v1` accounts publishing
+`subject → recovery` at sign-in, which is a few lines against
+`mint_enrollment` once there is a UI to hang it on.
 
 Two decisions the implementation surfaced, both left open deliberately:
 

--- a/plan/passkey-fanout.md
+++ b/plan/passkey-fanout.md
@@ -164,9 +164,17 @@ Landed on `feat/passkey-fanout`:
   registry now records the device's own hop rather than the chain root —
   identical for a one-hop grant, so no migration.
 
-Next is the chain store (step 3), which is what closes the bootstrap gap: a
-device holding only the second passkey currently has no way to obtain
-`root → C2`.
+- **Step 3.** `tonk-account-service/src/enrollments.rs` plus its R2 adapter
+  and handlers: `POST /enrollments` publishes a chain, `GET
+  /enrollments/{credential_did}` claims everything addressed to a key. Both
+  unauthenticated, for the reason `/revocations` is. Objects live under an
+  `enrollments/` prefix in the existing `CHAINS` bucket, so there is no new
+  binding and no wrangler change in any environment. Publication checks the
+  chain's shape and signatures and that this service hosts the account it
+  runs from — the latter is anti-abuse, not authority.
+
+Next is step 4: email-gated `recovery → Cn` issuance. The transport it needs
+now exists.
 
 Two decisions the implementation surfaced, both left open deliberately:
 

--- a/rust/tonk-account-service/Cargo.toml
+++ b/rust/tonk-account-service/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 getrandom = { workspace = true }
 getrandom_0_2 = { workspace = true }
 thiserror = { workspace = true }
+zeroize = { workspace = true }
 
 # Native helpers server (optional, "helpers" feature)
 anyhow = { workspace = true, optional = true }

--- a/rust/tonk-account-service/src/anchor.rs
+++ b/rust/tonk-account-service/src/anchor.rs
@@ -1,0 +1,67 @@
+//! The service's recovery-anchor identity.
+//!
+//! The anchor is an ordinary Ed25519 keypair. It has no inherent standing:
+//! it can act for an account only where that account's root delegated to it
+//! at genesis, and that delegation is one visible, revocable link in the
+//! user's own chain. Nothing here is a trusted authority — swap the seed and
+//! every account that never delegated to the new key is simply unreachable
+//! by this service, which is the property we want.
+
+use dialog_credentials::Ed25519Signer;
+use zeroize::Zeroizing;
+
+/// Worker secret holding the anchor seed, hex-encoded.
+pub const ANCHOR_SEED_SECRET: &str = "RECOVERY_ANCHOR_SEED";
+
+/// Why the configured anchor seed could not be used.
+#[derive(Debug, thiserror::Error)]
+pub enum AnchorError {
+    /// The seed is absent, not hex, or the wrong length.
+    #[error("recovery anchor seed is unusable: {0}")]
+    Seed(String),
+    /// The key could not be imported.
+    #[error("recovery anchor key could not be imported: {0}")]
+    Import(String),
+}
+
+/// Build the anchor signer from a hex-encoded 32-byte seed.
+pub async fn from_seed_hex(seed_hex: &str) -> Result<Ed25519Signer, AnchorError> {
+    let decoded = hex::decode(seed_hex.trim())
+        .map_err(|error| AnchorError::Seed(format!("not hex: {error}")))?;
+    let seed: Zeroizing<[u8; 32]> = Zeroizing::new(
+        decoded
+            .as_slice()
+            .try_into()
+            .map_err(|_| AnchorError::Seed(format!("expected 32 bytes, got {}", decoded.len())))?,
+    );
+    Ed25519Signer::import(&*seed)
+        .await
+        .map_err(|error| AnchorError::Import(error.to_string()))
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use dialog_varsig::Principal;
+
+    #[dialog_common::test]
+    async fn it_derives_a_stable_did_from_one_seed() {
+        let seed = hex::encode([3u8; 32]);
+        let first = from_seed_hex(&seed).await.unwrap();
+        let second = from_seed_hex(&format!(" {seed}\n")).await.unwrap();
+
+        assert_eq!(first.did(), second.did());
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_seed_of_the_wrong_length() {
+        assert!(matches!(
+            from_seed_hex(&hex::encode([3u8; 16])).await,
+            Err(AnchorError::Seed(_))
+        ));
+        assert!(matches!(
+            from_seed_hex("nonsense").await,
+            Err(AnchorError::Seed(_))
+        ));
+    }
+}

--- a/rust/tonk-account-service/src/bin/local.rs
+++ b/rust/tonk-account-service/src/bin/local.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         loop {
             let captured: Vec<(String, String)> = {
-                let mut inbox = emails.0.lock().expect("captured email mutex poisoned");
+                let mut inbox = emails.codes.lock().expect("captured email mutex poisoned");
                 std::mem::take(&mut *inbox)
             };
             for (address, code) in captured {

--- a/rust/tonk-account-service/src/core.rs
+++ b/rust/tonk-account-service/src/core.rs
@@ -15,6 +15,7 @@ pub mod codes;
 pub mod delegation;
 pub mod descriptor;
 pub mod devices;
+pub mod enrollment;
 pub mod links;
 
 /// Errors shared by every ceremony in this crate.

--- a/rust/tonk-account-service/src/core/codes.rs
+++ b/rust/tonk-account-service/src/core/codes.rs
@@ -116,7 +116,7 @@ mod tests {
         request_code(&store, &sender, "A@X.com", "123456", 100)
             .await
             .unwrap();
-        let sent = sender.0.lock().unwrap().clone();
+        let sent = sender.codes.lock().unwrap().clone();
         assert_eq!(sent, vec![("a@x.com".to_string(), "123456".to_string())]);
         verify_code(&store, "a@x.com", "123456", 200).await.unwrap();
         // consumed: the same code no longer verifies

--- a/rust/tonk-account-service/src/core/delegation.rs
+++ b/rust/tonk-account-service/src/core/delegation.rs
@@ -1,16 +1,19 @@
-//! Checking a `root → device` delegation chain presented at account
+//! Checking the account-authority chain a device presents at account
 //! creation or device linking.
 
-use dialog_credentials::Ed25519KeyResolver;
 use dialog_ucan_core::DelegationChain;
+use dialog_varsig::Did;
+use tonk_identity::delegation::{GrantError, validate_account_grant};
 
 use crate::core::CeremonyError;
 
-/// Parse and check a hex-encoded `root → device` delegation chain.
+/// Parse and check a hex-encoded chain from `root_did` to `device_did`.
 ///
-/// Requires exactly one proof, issued by `root_did` to `device_did`,
-/// subject-open, with a valid signature. Returns the delegation's CID,
-/// stringified — the key `devices.delegation_cid` is stored under.
+/// One hop is the common case; a device whose passkey was enrolled as a
+/// peer of another presents `root → credential → device`. Every hop must be
+/// subject-open, command-open and signed. Returns the CID of the device's
+/// own inbound hop — the key `devices.delegation_cid` is stored under, and
+/// the one a revocation of this device names.
 pub async fn check_device_delegation(
     delegation_hex: &str,
     root_did: &str,
@@ -20,36 +23,122 @@ pub async fn check_device_delegation(
         .map_err(|err| CeremonyError::Invalid(format!("bad delegation hex: {err}")))?;
     let chain = DelegationChain::try_from(&bytes[..])
         .map_err(|err| CeremonyError::Invalid(format!("bad delegation chain: {err}")))?;
+    let device: Did = device_did
+        .parse()
+        .map_err(|err| CeremonyError::Invalid(format!("bad device DID: {err}")))?;
 
-    if chain.proof_cids().len() != 1 {
-        return Err(CeremonyError::Invalid(
-            "delegation chain must have exactly one proof".to_string(),
-        ));
-    }
     if chain.issuer().to_string() != root_did {
         return Err(CeremonyError::Invalid(
             "delegation issuer does not match the claimed root".to_string(),
         ));
     }
-    if chain.audience().to_string() != device_did {
-        return Err(CeremonyError::Invalid(
-            "delegation audience does not match the device".to_string(),
-        ));
-    }
-    if chain.subject().is_some() {
-        return Err(CeremonyError::Invalid(
-            "root to device delegation must be subject-open".to_string(),
-        ));
-    }
 
-    let proof = chain
-        .proofs()
-        .next()
-        .expect("a chain with one proof cid has one proof");
-    proof
-        .verify_signature(&Ed25519KeyResolver)
+    let grant = validate_account_grant(&chain, &device)
         .await
-        .map_err(|err| CeremonyError::Unauthorized(format!("bad delegation signature: {err}")))?;
+        .map_err(|err| match err {
+            GrantError::Signature(message) => {
+                CeremonyError::Unauthorized(format!("bad delegation signature: {message}"))
+            }
+            other => CeremonyError::Invalid(other.to_string()),
+        })?;
 
-    Ok(chain.proof_cids()[0].to_string())
+    Ok(grant.delegation_cid.to_string())
+}
+
+// Native only: a Worker exports `fetch`, which the wasm-bindgen harness
+// shadows when it loads the module, so no test in this crate runs under wasm.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_varsig::Principal;
+    use tonk_identity::credential::{extend_with_enrollment, mint_enrollment};
+    use tonk_identity::delegation::mint_device_delegation;
+
+    use super::*;
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_one_hop_root_grant() {
+        let root = signer(1).await;
+        let device = signer(2).await;
+        let chain = mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+
+        let cid = check_device_delegation(
+            &hex::encode(chain.to_bytes().unwrap()),
+            root.did().as_ref(),
+            device.did().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(cid, chain.proof_cids()[0].to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_device_granted_by_an_enrolled_peer_credential() {
+        let root = signer(1).await;
+        let peer = signer(3).await;
+        let device = signer(2).await;
+        let enrollment = mint_enrollment(root.clone(), &peer.did()).await.unwrap();
+        let chain = extend_with_enrollment(&enrollment, peer, &device.did())
+            .await
+            .unwrap();
+
+        let cid = check_device_delegation(
+            &hex::encode(chain.to_bytes().unwrap()),
+            root.did().as_ref(),
+            device.did().as_ref(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            cid,
+            chain.proof_cids()[1].to_string(),
+            "the registry records the device's own hop, not the enrollment"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_rooted_at_another_account() {
+        let root = signer(1).await;
+        let other_root = signer(9).await;
+        let device = signer(2).await;
+        let chain = mint_device_delegation(other_root, &device.did())
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            check_device_delegation(
+                &hex::encode(chain.to_bytes().unwrap()),
+                root.did().as_ref(),
+                device.did().as_ref(),
+            )
+            .await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_that_stops_short_of_the_device() {
+        let root = signer(1).await;
+        let peer = signer(3).await;
+        let device = signer(2).await;
+        let enrollment = mint_enrollment(root.clone(), &peer.did()).await.unwrap();
+
+        assert!(matches!(
+            check_device_delegation(
+                &hex::encode(enrollment.to_bytes().unwrap()),
+                root.did().as_ref(),
+                device.did().as_ref(),
+            )
+            .await,
+            Err(CeremonyError::Invalid(_))
+        ));
+    }
 }

--- a/rust/tonk-account-service/src/core/enrollment.rs
+++ b/rust/tonk-account-service/src/core/enrollment.rs
@@ -1,0 +1,344 @@
+//! Email-gated issuance of an anchor chain to a new credential.
+//!
+//! The service holds `root → recovery` for an account because that account's
+//! root delegated to it at genesis. Exercising it is policy, not authority:
+//! the policy is a one-time code to the account address, and a notice to the
+//! same address whether or not the person asked for it.
+//!
+//! The gate stands even when the caller already holds a valid chain. An
+//! anchor chain outlives revocation of whatever enrolled it, so "holds a
+//! valid chain" would let a briefly compromised passkey mint itself a
+//! successor that survives being revoked.
+
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::DelegationChain;
+use dialog_varsig::{Did, Principal};
+use tonk_identity::credential::extend_with_enrollment;
+
+use crate::core::CeremonyError;
+use crate::core::codes::verify_code;
+use crate::email::EmailSender;
+use crate::enrollments::{EnrollmentStore, verify};
+use crate::revocations::PutOutcome;
+use crate::store::Store;
+
+/// An anchor chain minted for one credential.
+pub struct IssuedAnchor {
+    /// Account subject the chain runs from.
+    pub account_root: Did,
+    /// Credential the chain was issued to.
+    pub credential: Did,
+    /// The full `root → recovery → credential` chain.
+    pub chain: DelegationChain,
+    /// Whether publication created a new entry.
+    pub stored: bool,
+}
+
+/// Load the account's anchor proof and check it is one this key can extend.
+async fn anchor_proof<E: EnrollmentStore>(
+    enrollments: &E,
+    anchor_did: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain, CeremonyError> {
+    let bytes = enrollments
+        .anchor(account_root)
+        .await
+        .map_err(|error| CeremonyError::Internal(error.to_string()))?
+        .ok_or_else(|| {
+            CeremonyError::Conflict(
+                "this account has no recovery anchor; enrol from a device that holds a credential"
+                    .to_string(),
+            )
+        })?;
+    let chain = DelegationChain::try_from(bytes.as_slice()).map_err(|error| {
+        CeremonyError::Internal(format!("stored anchor proof is unreadable: {error}"))
+    })?;
+    if chain.issuer() != account_root {
+        return Err(CeremonyError::Internal(
+            "stored anchor proof does not run from this account".to_string(),
+        ));
+    }
+    if chain.audience() != anchor_did {
+        return Err(CeremonyError::Conflict(
+            "this account's recovery anchor is a different key; it may have been rotated or revoked"
+                .to_string(),
+        ));
+    }
+    Ok(chain)
+}
+
+/// Verify `code` for `email`, then mint and publish `recovery → credential`.
+#[allow(clippy::too_many_arguments)]
+pub async fn issue_anchor_chain<S: Store, E: EnrollmentStore, M: EmailSender>(
+    store: &S,
+    enrollments: &E,
+    emails: &M,
+    anchor: Ed25519Signer,
+    email: &str,
+    code: &str,
+    credential: &Did,
+    now: u64,
+) -> Result<IssuedAnchor, CeremonyError> {
+    verify_code(store, email, code, now).await?;
+
+    let account = store
+        .account_by_email(&email.to_lowercase())
+        .await?
+        .ok_or_else(|| CeremonyError::NotFound("no account for this address".to_string()))?;
+    let account_root: Did = account.root_did.parse().map_err(|error| {
+        CeremonyError::Internal(format!("stored account root DID is invalid: {error:?}"))
+    })?;
+    if credential == &account_root {
+        return Err(CeremonyError::Invalid(
+            "the account subject cannot be enrolled as its own credential".to_string(),
+        ));
+    }
+
+    let anchor_did = anchor.did();
+    let proof = anchor_proof(enrollments, &anchor_did, &account_root).await?;
+    let chain = extend_with_enrollment(&proof, anchor, credential)
+        .await
+        .map_err(|error| CeremonyError::Internal(format!("failed to mint the chain: {error}")))?;
+
+    let bytes = chain
+        .to_bytes()
+        .map_err(|error| CeremonyError::Internal(format!("failed to serialize: {error}")))?;
+    let verified = verify(&bytes)
+        .await
+        .map_err(|error| CeremonyError::Internal(format!("minted an invalid chain: {error}")))?;
+    let stored = enrollments
+        .put(&verified, &bytes)
+        .await
+        .map_err(|error| CeremonyError::Internal(error.to_string()))?
+        == PutOutcome::Stored;
+
+    // Delivery is best-effort on purpose: the chain is already minted and
+    // published, and failing the request now would leave the caller unable to
+    // tell whether it happened. A missed notice is logged, not fatal.
+    if let Err(error) = emails
+        .send_enrollment_notice(&account.email, credential.as_ref())
+        .await
+    {
+        crate::core::log_detail(&format!("enrollment notice failed to send: {error:?}"));
+    }
+
+    Ok(IssuedAnchor {
+        account_root,
+        credential: credential.clone(),
+        chain,
+        stored,
+    })
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::core::codes::request_code;
+    use crate::email::CapturedEmail;
+    use crate::enrollments::MemoryEnrollmentStore;
+    use crate::store::sqlite::SqliteStore;
+    use tonk_identity::credential::mint_enrollment;
+
+    const EMAIL: &str = "peer@example.com";
+    const CODE: &str = "123456";
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    /// An account whose root delegated to the anchor at genesis, with the
+    /// resulting proof filed the way the publish route files it.
+    async fn account_with_anchor(
+        store: &SqliteStore,
+        enrollments: &MemoryEnrollmentStore,
+        anchor: &Ed25519Signer,
+    ) -> Ed25519Signer {
+        let root = register(store).await;
+        let proof = mint_enrollment(root.clone(), &anchor.did()).await.unwrap();
+        enrollments
+            .put_anchor(&root.did(), &proof.to_bytes().unwrap())
+            .await
+            .unwrap();
+        root
+    }
+
+    async fn register(store: &SqliteStore) -> Ed25519Signer {
+        let root = signer(1).await;
+        store
+            .create_account(EMAIL, root.did().as_ref(), "credential", 100)
+            .await
+            .unwrap();
+        root
+    }
+
+    async fn pending_code(store: &SqliteStore, emails: &CapturedEmail) {
+        request_code(store, emails, EMAIL, CODE, 100).await.unwrap();
+    }
+
+    #[dialog_common::test]
+    async fn it_issues_a_depth_two_chain_and_announces_it() {
+        let store = SqliteStore::in_memory().unwrap();
+        let enrollments = MemoryEnrollmentStore::default();
+        let emails = CapturedEmail::default();
+        let anchor = signer(2).await;
+        let root = account_with_anchor(&store, &enrollments, &anchor).await;
+        let credential = signer(3).await;
+        pending_code(&store, &emails).await;
+
+        let issued = issue_anchor_chain(
+            &store,
+            &enrollments,
+            &emails,
+            anchor.clone(),
+            EMAIL,
+            CODE,
+            &credential.did(),
+            200,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(issued.account_root, root.did());
+        assert_eq!(
+            issued.chain.proof_cids().len(),
+            2,
+            "root → anchor → credential"
+        );
+        assert_eq!(*issued.chain.audience(), credential.did());
+        assert!(issued.stored);
+        assert_eq!(
+            emails.notices.lock().unwrap().as_slice(),
+            [(EMAIL.to_string(), credential.did().to_string())],
+        );
+
+        // The credential can now find its chain with nothing but its own DID.
+        let claimed = enrollments.claim(&credential.did()).await.unwrap();
+        assert_eq!(claimed, vec![issued.chain.to_bytes().unwrap()]);
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_without_a_verified_code() {
+        let store = SqliteStore::in_memory().unwrap();
+        let enrollments = MemoryEnrollmentStore::default();
+        let emails = CapturedEmail::default();
+        let anchor = signer(2).await;
+        account_with_anchor(&store, &enrollments, &anchor).await;
+        let credential = signer(3).await;
+        pending_code(&store, &emails).await;
+
+        assert!(matches!(
+            issue_anchor_chain(
+                &store,
+                &enrollments,
+                &emails,
+                anchor,
+                EMAIL,
+                "000000",
+                &credential.did(),
+                200,
+            )
+            .await,
+            Err(CeremonyError::CodeInvalid)
+        ));
+        assert!(
+            enrollments
+                .claim(&credential.did())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(emails.notices.lock().unwrap().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_consumes_the_code_so_one_gate_yields_one_credential() {
+        let store = SqliteStore::in_memory().unwrap();
+        let enrollments = MemoryEnrollmentStore::default();
+        let emails = CapturedEmail::default();
+        let anchor = signer(2).await;
+        account_with_anchor(&store, &enrollments, &anchor).await;
+        pending_code(&store, &emails).await;
+
+        issue_anchor_chain(
+            &store,
+            &enrollments,
+            &emails,
+            anchor.clone(),
+            EMAIL,
+            CODE,
+            &signer(3).await.did(),
+            200,
+        )
+        .await
+        .unwrap();
+
+        let shadow = signer(4).await;
+        assert!(matches!(
+            issue_anchor_chain(
+                &store,
+                &enrollments,
+                &emails,
+                anchor,
+                EMAIL,
+                CODE,
+                &shadow.did(),
+                201,
+            )
+            .await,
+            Err(CeremonyError::CodeInvalid)
+        ));
+        assert!(enrollments.claim(&shadow.did()).await.unwrap().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_when_the_account_never_delegated_to_this_anchor() {
+        let store = SqliteStore::in_memory().unwrap();
+        let enrollments = MemoryEnrollmentStore::default();
+        let emails = CapturedEmail::default();
+        let anchor = signer(2).await;
+        register(&store).await;
+        pending_code(&store, &emails).await;
+
+        assert!(matches!(
+            issue_anchor_chain(
+                &store,
+                &enrollments,
+                &emails,
+                anchor,
+                EMAIL,
+                CODE,
+                &signer(3).await.did(),
+                200,
+            )
+            .await,
+            Err(CeremonyError::Conflict(_))
+        ));
+    }
+
+    /// A seed rotation must not let the service act for accounts that
+    /// delegated to the key it used to hold.
+    #[dialog_common::test]
+    async fn it_refuses_when_the_anchor_key_is_not_the_one_delegated_to() {
+        let store = SqliteStore::in_memory().unwrap();
+        let enrollments = MemoryEnrollmentStore::default();
+        let emails = CapturedEmail::default();
+        let delegated = signer(2).await;
+        account_with_anchor(&store, &enrollments, &delegated).await;
+        pending_code(&store, &emails).await;
+
+        assert!(matches!(
+            issue_anchor_chain(
+                &store,
+                &enrollments,
+                &emails,
+                signer(9).await,
+                EMAIL,
+                CODE,
+                &signer(3).await.did(),
+                200,
+            )
+            .await,
+            Err(CeremonyError::Conflict(_))
+        ));
+    }
+}

--- a/rust/tonk-account-service/src/email.rs
+++ b/rust/tonk-account-service/src/email.rs
@@ -11,26 +11,52 @@ pub enum EmailError {
     Send(String),
 }
 
-/// Delivery backend for one-time verification codes.
+/// Delivery backend for account mail.
 #[allow(async_fn_in_trait)]
 pub trait EmailSender {
     /// Send `code` to `email`.
     async fn send_code(&self, email: &str, code: &str) -> Result<(), EmailError>;
+
+    /// Tell an account holder that `credential` was enrolled.
+    ///
+    /// An anchor chain outlives revocation of whatever enrolled it, so the
+    /// person has to hear about one being issued even when the ceremony
+    /// succeeded exactly as intended. This is the loud half of the gate; the
+    /// code is the second factor.
+    async fn send_enrollment_notice(&self, email: &str, credential: &str)
+    -> Result<(), EmailError>;
 }
 
 /// An [`EmailSender`] that records every send instead of delivering it,
 /// for tests and local development.
 #[cfg(any(test, feature = "helpers"))]
 #[derive(Default)]
-pub struct CapturedEmail(pub std::sync::Mutex<Vec<(String, String)>>);
+pub struct CapturedEmail {
+    /// `(email, code)` for every verification code not sent.
+    pub codes: std::sync::Mutex<Vec<(String, String)>>,
+    /// `(email, credential DID)` for every enrollment notice not sent.
+    pub notices: std::sync::Mutex<Vec<(String, String)>>,
+}
 
 #[cfg(any(test, feature = "helpers"))]
 impl EmailSender for CapturedEmail {
     async fn send_code(&self, email: &str, code: &str) -> Result<(), EmailError> {
-        self.0
+        self.codes
             .lock()
             .expect("captured email mutex poisoned")
             .push((email.to_string(), code.to_string()));
+        Ok(())
+    }
+
+    async fn send_enrollment_notice(
+        &self,
+        email: &str,
+        credential: &str,
+    ) -> Result<(), EmailError> {
+        self.notices
+            .lock()
+            .expect("captured email mutex poisoned")
+            .push((email.to_string(), credential.to_string()));
         Ok(())
     }
 }

--- a/rust/tonk-account-service/src/email/resend.rs
+++ b/rust/tonk-account-service/src/email/resend.rs
@@ -32,13 +32,13 @@ struct SendRequest<'a> {
     text: String,
 }
 
-impl EmailSender for Resend {
-    async fn send_code(&self, email: &str, code: &str) -> Result<(), EmailError> {
+impl Resend {
+    async fn send(&self, email: &str, subject: &str, text: String) -> Result<(), EmailError> {
         let body = SendRequest {
             from: &self.from,
             to: [email],
-            subject: "Your tonk verification code",
-            text: format!("Your code is {code}. It expires in 10 minutes."),
+            subject,
+            text,
         };
         let body_json =
             serde_json::to_string(&body).map_err(|err| EmailError::Send(err.to_string()))?;
@@ -72,5 +72,34 @@ impl EmailSender for Resend {
             )));
         }
         Ok(())
+    }
+}
+
+impl EmailSender for Resend {
+    async fn send_code(&self, email: &str, code: &str) -> Result<(), EmailError> {
+        self.send(
+            email,
+            "Your tonk verification code",
+            format!("Your code is {code}. It expires in 10 minutes."),
+        )
+        .await
+    }
+
+    async fn send_enrollment_notice(
+        &self,
+        email: &str,
+        credential: &str,
+    ) -> Result<(), EmailError> {
+        self.send(
+            email,
+            "A new passkey was added to your tonk account",
+            format!(
+                "A passkey was enrolled on your tonk account.\n\n\
+                 Credential: {credential}\n\n\
+                 If this was not you, sign in from a device you still trust \
+                 and revoke it. Anyone holding this passkey can act as you."
+            ),
+        )
+        .await
     }
 }

--- a/rust/tonk-account-service/src/enrollments.rs
+++ b/rust/tonk-account-service/src/enrollments.rs
@@ -71,7 +71,26 @@ pub trait EnrollmentStore {
 
     /// Every chain addressed to `credential`, at most [`MAX_CLAIMED`].
     async fn claim(&self, credential: &Did) -> Result<Vec<Vec<u8>>, EnrollmentStoreError>;
+
+    /// File `bytes` as the proof this service holds for `account_root`.
+    ///
+    /// A chain addressed to the service's own anchor is also indexed by the
+    /// account it comes from, because the anchor is the audience for every
+    /// account at once: claiming by audience would return the world. Last
+    /// write wins, which is harmless — after genesis the root is gone, so
+    /// there is only ever one such chain to write.
+    async fn put_anchor(
+        &self,
+        account_root: &Did,
+        bytes: &[u8],
+    ) -> Result<(), EnrollmentStoreError>;
+
+    /// The anchor proof filed for `account_root`, if any.
+    async fn anchor(&self, account_root: &Did) -> Result<Option<Vec<u8>>, EnrollmentStoreError>;
 }
+
+/// Prefix holding one anchor proof per account.
+pub const ANCHOR_PREFIX: &str = "anchors/";
 
 /// Derive the only permitted object key for a verified chain.
 pub fn object_key(verified: &VerifiedEnrollment) -> String {
@@ -126,15 +145,24 @@ mod memory {
     #[derive(Default)]
     pub struct MemoryEnrollmentStore(Mutex<BTreeMap<String, Vec<u8>>>);
 
+    impl MemoryEnrollmentStore {
+        fn entries(
+            &self,
+        ) -> Result<std::sync::MutexGuard<'_, BTreeMap<String, Vec<u8>>>, EnrollmentStoreError>
+        {
+            self.0.lock().map_err(|_| {
+                EnrollmentStoreError::Internal("enrollment store lock poisoned".to_string())
+            })
+        }
+    }
+
     impl EnrollmentStore for MemoryEnrollmentStore {
         async fn put(
             &self,
             verified: &VerifiedEnrollment,
             bytes: &[u8],
         ) -> Result<PutOutcome, EnrollmentStoreError> {
-            let mut entries = self.0.lock().map_err(|_| {
-                EnrollmentStoreError::Internal("enrollment store lock poisoned".to_string())
-            })?;
+            let mut entries = self.entries()?;
             let key = object_key(verified);
             if entries.contains_key(&key) {
                 return Ok(PutOutcome::Existing);
@@ -144,9 +172,7 @@ mod memory {
         }
 
         async fn claim(&self, credential: &Did) -> Result<Vec<Vec<u8>>, EnrollmentStoreError> {
-            let entries = self.0.lock().map_err(|_| {
-                EnrollmentStoreError::Internal("enrollment store lock poisoned".to_string())
-            })?;
+            let entries = self.entries()?;
             let prefix = format!("{ENROLLMENT_PREFIX}{credential}/");
             Ok(entries
                 .range(prefix.clone()..)
@@ -154,6 +180,26 @@ mod memory {
                 .take(MAX_CLAIMED)
                 .map(|(_, bytes)| bytes.clone())
                 .collect())
+        }
+
+        async fn put_anchor(
+            &self,
+            account_root: &Did,
+            bytes: &[u8],
+        ) -> Result<(), EnrollmentStoreError> {
+            self.entries()?
+                .insert(format!("{ANCHOR_PREFIX}{account_root}"), bytes.to_vec());
+            Ok(())
+        }
+
+        async fn anchor(
+            &self,
+            account_root: &Did,
+        ) -> Result<Option<Vec<u8>>, EnrollmentStoreError> {
+            Ok(self
+                .entries()?
+                .get(&format!("{ANCHOR_PREFIX}{account_root}"))
+                .cloned())
         }
     }
 }

--- a/rust/tonk-account-service/src/enrollments.rs
+++ b/rust/tonk-account-service/src/enrollments.rs
@@ -1,0 +1,311 @@
+//! Audience-keyed publication of enrollment chains.
+//!
+//! A device that has just derived a credential key from a new passkey holds
+//! nothing else — not the account subject, not a delegation, and not the
+//! account repository it would eventually read them from, because the
+//! authority to sync that repository is the thing it is looking for. The one
+//! question it can ask is "what has been addressed to this key?".
+//!
+//! So entries are keyed by audience DID. Each is an ordinary signed
+//! delegation chain: self-authenticating, and useless to anyone without the
+//! audience's private key. That is why claiming needs no authorization and
+//! why this store confers nothing by holding an entry. It can withhold one;
+//! it cannot forge or alter one.
+
+use dialog_ucan_core::DelegationChain;
+use dialog_varsig::Did;
+use tonk_identity::delegation::{GrantError, validate_account_grant};
+
+use crate::core::backup::chain_key;
+use crate::revocations::PutOutcome;
+
+/// Prefix containing every published enrollment chain.
+pub const ENROLLMENT_PREFIX: &str = "enrollments/";
+
+/// Most entries returned for one credential.
+///
+/// A credential collects one chain per anchor path it was enrolled through,
+/// so the real number is a handful. The bound is here so that a hostile
+/// account cannot turn one claim into an unbounded read.
+pub const MAX_CLAIMED: usize = 64;
+
+/// Facts derived from a verified enrollment chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedEnrollment {
+    /// Account subject the chain runs from.
+    pub account_root: Did,
+    /// Credential the chain is addressed to, and the key it is stored under.
+    pub credential: Did,
+    /// Content-addressed key for these exact bytes.
+    pub key: String,
+}
+
+/// Errors surfaced by an enrollment store.
+#[derive(Debug, thiserror::Error)]
+pub enum EnrollmentStoreError {
+    /// The durable backend failed.
+    #[error("enrollment store failed: {0}")]
+    Internal(String),
+}
+
+/// Why an enrollment chain could not be accepted.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    /// The bytes are malformed or not shaped like account authority.
+    #[error("invalid enrollment chain: {0}")]
+    Invalid(String),
+    /// The chain is well-formed but a hop's signature does not verify.
+    #[error("unauthorized enrollment chain: {0}")]
+    Unauthorized(String),
+}
+
+/// Immutable writer and audience-keyed reader for enrollment chains.
+#[allow(async_fn_in_trait)]
+pub trait EnrollmentStore {
+    /// Store `bytes` at the key derived from `verified`.
+    async fn put(
+        &self,
+        verified: &VerifiedEnrollment,
+        bytes: &[u8],
+    ) -> Result<PutOutcome, EnrollmentStoreError>;
+
+    /// Every chain addressed to `credential`, at most [`MAX_CLAIMED`].
+    async fn claim(&self, credential: &Did) -> Result<Vec<Vec<u8>>, EnrollmentStoreError>;
+}
+
+/// Derive the only permitted object key for a verified chain.
+pub fn object_key(verified: &VerifiedEnrollment) -> String {
+    format!(
+        "{ENROLLMENT_PREFIX}{}/{}",
+        verified.credential, verified.key
+    )
+}
+
+/// Parse and check an enrollment chain.
+///
+/// The chain must run from an account subject to the credential it is
+/// addressed to, with every hop subject-open, command-open and signed. That
+/// is the same walk a device's grant gets, so it is the same function; the
+/// audience checked against is the chain's own, which is what makes this a
+/// statement about where the chain ends rather than about who is asking.
+pub async fn verify(bytes: &[u8]) -> Result<VerifiedEnrollment, VerifyError> {
+    let chain = DelegationChain::try_from(bytes)
+        .map_err(|error| VerifyError::Invalid(format!("bad delegation container: {error}")))?;
+    let canonical = chain
+        .to_bytes()
+        .map_err(|error| VerifyError::Invalid(format!("chain does not re-encode: {error}")))?;
+    if canonical != bytes {
+        return Err(VerifyError::Invalid(
+            "delegation container is not canonical".to_string(),
+        ));
+    }
+
+    let credential = chain.audience().clone();
+    let grant = validate_account_grant(&chain, &credential)
+        .await
+        .map_err(|error| match error {
+            GrantError::Signature(message) => VerifyError::Unauthorized(message),
+            other => VerifyError::Invalid(other.to_string()),
+        })?;
+
+    Ok(VerifiedEnrollment {
+        account_root: grant.root_did,
+        credential,
+        key: chain_key(bytes),
+    })
+}
+
+#[cfg(any(test, feature = "helpers"))]
+mod memory {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// In-memory enrollment store for tests and local development.
+    #[derive(Default)]
+    pub struct MemoryEnrollmentStore(Mutex<BTreeMap<String, Vec<u8>>>);
+
+    impl EnrollmentStore for MemoryEnrollmentStore {
+        async fn put(
+            &self,
+            verified: &VerifiedEnrollment,
+            bytes: &[u8],
+        ) -> Result<PutOutcome, EnrollmentStoreError> {
+            let mut entries = self.0.lock().map_err(|_| {
+                EnrollmentStoreError::Internal("enrollment store lock poisoned".to_string())
+            })?;
+            let key = object_key(verified);
+            if entries.contains_key(&key) {
+                return Ok(PutOutcome::Existing);
+            }
+            entries.insert(key, bytes.to_vec());
+            Ok(PutOutcome::Stored)
+        }
+
+        async fn claim(&self, credential: &Did) -> Result<Vec<Vec<u8>>, EnrollmentStoreError> {
+            let entries = self.0.lock().map_err(|_| {
+                EnrollmentStoreError::Internal("enrollment store lock poisoned".to_string())
+            })?;
+            let prefix = format!("{ENROLLMENT_PREFIX}{credential}/");
+            Ok(entries
+                .range(prefix.clone()..)
+                .take_while(|(key, _)| key.starts_with(&prefix))
+                .take(MAX_CLAIMED)
+                .map(|(_, bytes)| bytes.clone())
+                .collect())
+        }
+    }
+}
+
+#[cfg(any(test, feature = "helpers"))]
+pub use memory::MemoryEnrollmentStore;
+
+#[cfg(target_arch = "wasm32")]
+pub mod r2;
+
+// Native only, for the reason given in `revocations.rs`: a Worker exports
+// `fetch`, which the wasm-bindgen harness shadows when it loads the module.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use dialog_credentials::Ed25519Signer;
+    use dialog_varsig::Principal;
+    use tonk_identity::credential::{extend_with_enrollment, mint_enrollment};
+    use tonk_identity::delegation::mint_device_delegation;
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    /// `root → recovery → credential`, the shape the anchor path produces.
+    async fn anchor_chain() -> (Did, Did, Vec<u8>) {
+        let root = signer(1).await;
+        let recovery = signer(2).await;
+        let credential = signer(3).await;
+        let anchor = mint_enrollment(root.clone(), &recovery.did())
+            .await
+            .unwrap();
+        let chain = extend_with_enrollment(&anchor, recovery, &credential.did())
+            .await
+            .unwrap();
+        (root.did(), credential.did(), chain.to_bytes().unwrap())
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_the_account_and_credential_a_chain_connects() {
+        let (root, credential, bytes) = anchor_chain().await;
+
+        let verified = verify(&bytes).await.unwrap();
+
+        assert_eq!(verified.account_root, root);
+        assert_eq!(verified.credential, credential);
+        assert_eq!(
+            object_key(&verified),
+            format!("enrollments/{credential}/{}", verified.key)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_every_chain_addressed_to_one_credential() {
+        let store = MemoryEnrollmentStore::default();
+        let root = signer(1).await;
+        let recovery = signer(2).await;
+        let credential = signer(3).await;
+
+        // The same credential enrolled twice: once straight from the account
+        // subject, once through the recovery anchor.
+        let sibling = mint_device_delegation(root.clone(), &credential.did())
+            .await
+            .unwrap()
+            .to_bytes()
+            .unwrap();
+        let anchor = mint_enrollment(root.clone(), &recovery.did())
+            .await
+            .unwrap();
+        let anchored = extend_with_enrollment(&anchor, recovery, &credential.did())
+            .await
+            .unwrap()
+            .to_bytes()
+            .unwrap();
+        for bytes in [&sibling, &anchored] {
+            let verified = verify(bytes).await.unwrap();
+            store.put(&verified, bytes).await.unwrap();
+        }
+
+        let mut claimed = store.claim(&credential.did()).await.unwrap();
+        claimed.sort();
+        let mut expected = vec![sibling, anchored];
+        expected.sort();
+        assert_eq!(claimed, expected);
+    }
+
+    #[dialog_common::test]
+    async fn it_claims_nothing_for_an_unrelated_credential() {
+        let store = MemoryEnrollmentStore::default();
+        let (_, _, bytes) = anchor_chain().await;
+        let verified = verify(&bytes).await.unwrap();
+        store.put(&verified, &bytes).await.unwrap();
+        let stranger = signer(9).await;
+
+        assert!(store.claim(&stranger.did()).await.unwrap().is_empty());
+    }
+
+    #[dialog_common::test]
+    async fn it_stores_identical_bytes_once() {
+        let store = MemoryEnrollmentStore::default();
+        let (_, credential, bytes) = anchor_chain().await;
+        let verified = verify(&bytes).await.unwrap();
+
+        assert_eq!(
+            store.put(&verified, &bytes).await.unwrap(),
+            PutOutcome::Stored
+        );
+        assert_eq!(
+            store.put(&verified, &bytes).await.unwrap(),
+            PutOutcome::Existing
+        );
+        assert_eq!(store.claim(&credential).await.unwrap().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_with_a_broken_signature() {
+        let (_, _, bytes) = anchor_chain().await;
+        let mut tampered = bytes.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0xff;
+
+        assert!(verify(&tampered).await.is_err());
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_bytes_that_are_not_a_delegation_container() {
+        assert!(matches!(
+            verify(b"not a container").await,
+            Err(VerifyError::Invalid(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_subject_specific_chain() {
+        use dialog_ucan_core::DelegationBuilder;
+        use dialog_ucan_core::subject::Subject;
+
+        let space = signer(4).await;
+        let member = signer(5).await;
+        let invite = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&member.did())
+            .subject(Subject::Specific(space.did()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let bytes = DelegationChain::new(invite).to_bytes().unwrap();
+
+        assert!(
+            matches!(verify(&bytes).await, Err(VerifyError::Invalid(_))),
+            "a space invite is not account authority and must not be claimable"
+        );
+    }
+}

--- a/rust/tonk-account-service/src/enrollments/r2.rs
+++ b/rust/tonk-account-service/src/enrollments/r2.rs
@@ -1,0 +1,83 @@
+//! Cloudflare R2 enrollment store.
+//!
+//! Shares the chain bucket rather than taking a binding of its own: the
+//! objects live under `enrollments/{credential_did}/{key}`, disjoint from
+//! `chains/` and `spot-heads/`. One fewer binding is one fewer thing that
+//! can be missing from a deploy.
+
+use dialog_varsig::Did;
+use worker::Bucket;
+
+use super::{
+    ENROLLMENT_PREFIX, EnrollmentStore, EnrollmentStoreError, MAX_CLAIMED, VerifiedEnrollment,
+    object_key,
+};
+use crate::revocations::PutOutcome;
+
+/// R2-backed enrollment store.
+pub struct R2EnrollmentStore(Bucket);
+
+impl R2EnrollmentStore {
+    /// Wrap the chain bucket binding.
+    pub fn new(bucket: Bucket) -> Self {
+        Self(bucket)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, EnrollmentStoreError> {
+        let Some(object) = self
+            .0
+            .get(key)
+            .execute()
+            .await
+            .map_err(|error| EnrollmentStoreError::Internal(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        let Some(body) = object.body() else {
+            return Ok(None);
+        };
+        body.bytes()
+            .await
+            .map(Some)
+            .map_err(|error| EnrollmentStoreError::Internal(error.to_string()))
+    }
+}
+
+impl EnrollmentStore for R2EnrollmentStore {
+    async fn put(
+        &self,
+        verified: &VerifiedEnrollment,
+        bytes: &[u8],
+    ) -> Result<PutOutcome, EnrollmentStoreError> {
+        let key = object_key(verified);
+        if self.get(&key).await?.is_some() {
+            return Ok(PutOutcome::Existing);
+        }
+        self.0
+            .put(key, bytes.to_vec())
+            .execute()
+            .await
+            .map_err(|error| EnrollmentStoreError::Internal(error.to_string()))?;
+        Ok(PutOutcome::Stored)
+    }
+
+    async fn claim(&self, credential: &Did) -> Result<Vec<Vec<u8>>, EnrollmentStoreError> {
+        let prefix = format!("{ENROLLMENT_PREFIX}{credential}/");
+        let listing = self
+            .0
+            .list()
+            .prefix(prefix)
+            .limit(MAX_CLAIMED as u32)
+            .execute()
+            .await
+            .map_err(|error| EnrollmentStoreError::Internal(error.to_string()))?;
+
+        let mut chains = Vec::new();
+        for object in listing.objects() {
+            if let Some(bytes) = self.get(&object.key()).await? {
+                chains.push(bytes);
+            }
+        }
+        Ok(chains)
+    }
+}

--- a/rust/tonk-account-service/src/enrollments/r2.rs
+++ b/rust/tonk-account-service/src/enrollments/r2.rs
@@ -9,8 +9,8 @@ use dialog_varsig::Did;
 use worker::Bucket;
 
 use super::{
-    ENROLLMENT_PREFIX, EnrollmentStore, EnrollmentStoreError, MAX_CLAIMED, VerifiedEnrollment,
-    object_key,
+    ANCHOR_PREFIX, ENROLLMENT_PREFIX, EnrollmentStore, EnrollmentStoreError, MAX_CLAIMED,
+    VerifiedEnrollment, object_key,
 };
 use crate::revocations::PutOutcome;
 
@@ -79,5 +79,22 @@ impl EnrollmentStore for R2EnrollmentStore {
             }
         }
         Ok(chains)
+    }
+
+    async fn put_anchor(
+        &self,
+        account_root: &Did,
+        bytes: &[u8],
+    ) -> Result<(), EnrollmentStoreError> {
+        self.0
+            .put(format!("{ANCHOR_PREFIX}{account_root}"), bytes.to_vec())
+            .execute()
+            .await
+            .map_err(|error| EnrollmentStoreError::Internal(error.to_string()))?;
+        Ok(())
+    }
+
+    async fn anchor(&self, account_root: &Did) -> Result<Option<Vec<u8>>, EnrollmentStoreError> {
+        self.get(&format!("{ANCHOR_PREFIX}{account_root}")).await
     }
 }

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -13,6 +13,8 @@ pub mod codes;
 #[cfg(target_arch = "wasm32")]
 pub mod devices;
 #[cfg(target_arch = "wasm32")]
+pub mod enrollments;
+#[cfg(target_arch = "wasm32")]
 pub mod links;
 #[cfg(target_arch = "wasm32")]
 pub mod repository;
@@ -24,7 +26,7 @@ pub mod revocations;
 pub fn with_cors_headers(response: worker::Response) -> worker::Response {
     let headers = response.headers().clone();
     let _ = headers.set("Access-Control-Allow-Origin", "*");
-    let _ = headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+    let _ = headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     let _ = headers.set("Access-Control-Allow-Headers", "Content-Type");
     let _ = headers.set(
         "Access-Control-Expose-Headers",
@@ -109,6 +111,21 @@ pub fn build_chains(
         crate::error::ServiceError::new(crate::error::ErrorCode::InternalError, "internal error")
     })?;
     Ok(crate::chains::r2::R2ChainStore::new(bucket))
+}
+
+/// Build the enrollment store from the `CHAINS` binding.
+///
+/// Deliberately the same bucket the chain backup uses: enrollment objects
+/// live under their own prefix, so this needs no new deployment binding.
+#[cfg(target_arch = "wasm32")]
+pub fn build_enrollments(
+    ctx: &worker::RouteContext<()>,
+) -> std::result::Result<crate::enrollments::r2::R2EnrollmentStore, crate::error::ServiceError> {
+    let bucket = ctx.bucket("CHAINS").map_err(|err| {
+        worker::console_error!("missing R2 binding: {err}");
+        crate::error::ServiceError::new(crate::error::ErrorCode::InternalError, "internal error")
+    })?;
+    Ok(crate::enrollments::r2::R2EnrollmentStore::new(bucket))
 }
 
 /// Build the immutable revocation writer from the `REVOCATIONS` binding.

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -128,6 +128,35 @@ pub fn build_enrollments(
     Ok(crate::enrollments::r2::R2EnrollmentStore::new(bucket))
 }
 
+/// Build the recovery-anchor signer from the `RECOVERY_ANCHOR_SEED` secret.
+///
+/// Absent or malformed, the anchor routes are unavailable and every other
+/// route is unaffected: an account that never delegated to this key loses
+/// nothing by the service not holding it.
+#[cfg(target_arch = "wasm32")]
+pub async fn build_anchor(
+    ctx: &worker::RouteContext<()>,
+) -> std::result::Result<dialog_credentials::Ed25519Signer, crate::error::ServiceError> {
+    let seed = ctx
+        .secret(crate::anchor::ANCHOR_SEED_SECRET)
+        .map_err(|err| {
+            worker::console_error!("missing recovery anchor secret: {err}");
+            crate::error::ServiceError::new(
+                crate::error::ErrorCode::InternalError,
+                "this service has no recovery anchor configured",
+            )
+        })?;
+    crate::anchor::from_seed_hex(&seed.to_string())
+        .await
+        .map_err(|err| {
+            worker::console_error!("unusable recovery anchor seed: {err}");
+            crate::error::ServiceError::new(
+                crate::error::ErrorCode::InternalError,
+                "this service has no recovery anchor configured",
+            )
+        })
+}
+
 /// Build the immutable revocation writer from the `REVOCATIONS` binding.
 #[cfg(target_arch = "wasm32")]
 pub fn build_revocations(

--- a/rust/tonk-account-service/src/handlers/codes.rs
+++ b/rust/tonk-account-service/src/handlers/codes.rs
@@ -56,7 +56,7 @@ async fn handle_inner(
 
 /// Build a [`Resend`] sender from the worker environment's
 /// `RESEND_API_KEY` secret and `EMAIL_FROM` variable.
-fn build_resend(ctx: &RouteContext<()>) -> std::result::Result<Resend, ServiceError> {
+pub(crate) fn build_resend(ctx: &RouteContext<()>) -> std::result::Result<Resend, ServiceError> {
     let api_key = ctx
         .secret("RESEND_API_KEY")
         .map_err(|err| {

--- a/rust/tonk-account-service/src/handlers/enrollments.rs
+++ b/rust/tonk-account-service/src/handlers/enrollments.rs
@@ -1,0 +1,146 @@
+//! Publication and claiming of audience-keyed enrollment chains.
+//!
+//! Both routes are unauthenticated, for the same reason `/revocations` is:
+//! the bytes are self-authenticating and neither holding nor handing back a
+//! delegation grants anything to anyone who lacks the audience's key.
+
+use worker::*;
+
+use dialog_varsig::Did;
+
+use crate::enrollments::{EnrollmentStore, VerifyError, verify};
+use crate::error::{ErrorCode, ServiceError};
+use crate::handlers::{build_enrollments, build_store, with_cors_headers};
+use crate::revocations::PutOutcome;
+use crate::store::Store;
+
+/// A chain deep enough to need more than this is not an enrollment.
+pub(crate) const MAX_CHAIN_BYTES: usize = 8 * 1024;
+
+pub(crate) fn verify_error(error: VerifyError) -> ServiceError {
+    match error {
+        VerifyError::Invalid(message) => ServiceError::new(ErrorCode::InvalidArgument, message),
+        VerifyError::Unauthorized(message) => ServiceError::new(ErrorCode::Forbidden, message),
+    }
+}
+
+/// `OPTIONS /enrollments*` → CORS preflight.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /enrollments` → publish a chain addressed to a credential.
+pub async fn handle_publish(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_publish_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(error) => error.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_publish_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let content_type = req
+        .headers()
+        .get("Content-Type")
+        .map_err(|error| {
+            ServiceError::new(
+                ErrorCode::InvalidArgument,
+                format!("failed to read Content-Type: {error}"),
+            )
+        })?
+        .unwrap_or_default();
+    if content_type.split(';').next() != Some("application/cbor") {
+        return Err(ServiceError::new(
+            ErrorCode::InvalidArgument,
+            "Content-Type must be application/cbor",
+        ));
+    }
+
+    let bytes = req.bytes().await.map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("failed to read request body: {error}"),
+        )
+    })?;
+    if bytes.len() > MAX_CHAIN_BYTES {
+        return Err(ServiceError::new(
+            ErrorCode::InvalidArgument,
+            "enrollment chain exceeds 8 KiB",
+        ));
+    }
+
+    let verified = verify(&bytes).await.map_err(verify_error)?;
+
+    // Not a judgement about who may enroll — the chain already settles that.
+    // It keeps the bucket from being free storage for accounts that are not
+    // ours, which is the only thing an open write endpoint invites.
+    let store = build_store(ctx)?;
+    if store
+        .account_by_root(verified.account_root.as_ref())
+        .await
+        .map_err(|error| {
+            console_error!("enrollment account lookup failed: {error:?}");
+            ServiceError::new(ErrorCode::InternalError, "internal error")
+        })?
+        .is_none()
+    {
+        return Err(ServiceError::new(
+            ErrorCode::NotFound,
+            "this service does not host the account the chain runs from",
+        ));
+    }
+
+    let enrollments = build_enrollments(ctx)?;
+    let stored = enrollments.put(&verified, &bytes).await.map_err(|error| {
+        console_error!("enrollment publication failed: {error}");
+        ServiceError::new(ErrorCode::InternalError, "internal error")
+    })? == PutOutcome::Stored;
+
+    Response::from_json(&serde_json::json!({
+        "credential": verified.credential.to_string(),
+        "accountRoot": verified.account_root.to_string(),
+        "key": verified.key,
+        "stored": stored,
+    }))
+    .map(|response| response.with_status(202))
+    .map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
+}
+
+/// `GET /enrollments/:credential` → every chain addressed to that key.
+pub async fn handle_claim(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_claim_inner(&ctx).await {
+        Ok(response) => response,
+        Err(error) => error.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_claim_inner(ctx: &RouteContext<()>) -> std::result::Result<Response, ServiceError> {
+    let credential = ctx
+        .param("credential")
+        .ok_or_else(|| ServiceError::new(ErrorCode::InvalidArgument, "missing credential DID"))?;
+    let credential: Did = credential.parse().map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("invalid credential DID: {error}"),
+        )
+    })?;
+
+    let enrollments = build_enrollments(ctx)?;
+    let chains = enrollments.claim(&credential).await.map_err(|error| {
+        console_error!("enrollment claim failed: {error}");
+        ServiceError::new(ErrorCode::InternalError, "internal error")
+    })?;
+
+    Response::from_json(&serde_json::json!({
+        "chains": chains.iter().map(hex::encode).collect::<Vec<_>>(),
+    }))
+    .map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
+}

--- a/rust/tonk-account-service/src/handlers/enrollments.rs
+++ b/rust/tonk-account-service/src/handlers/enrollments.rs
@@ -8,9 +8,14 @@ use worker::*;
 
 use dialog_varsig::Did;
 
+use dialog_varsig::Principal;
+
+use crate::core::enrollment::issue_anchor_chain;
 use crate::enrollments::{EnrollmentStore, VerifyError, verify};
 use crate::error::{ErrorCode, ServiceError};
-use crate::handlers::{build_enrollments, build_store, with_cors_headers};
+use crate::handlers::{
+    build_anchor, build_enrollments, build_store, ceremony_error, read_body, with_cors_headers,
+};
 use crate::revocations::PutOutcome;
 use crate::store::Store;
 
@@ -99,6 +104,21 @@ async fn handle_publish_inner(
         ServiceError::new(ErrorCode::InternalError, "internal error")
     })? == PutOutcome::Stored;
 
+    // A chain addressed to this service's own anchor is the proof it will
+    // later extend, so it is additionally filed by the account it comes
+    // from. Claiming by audience would return every account's at once.
+    if let Ok(anchor) = build_anchor(ctx).await
+        && verified.credential == anchor.did()
+    {
+        enrollments
+            .put_anchor(&verified.account_root, &bytes)
+            .await
+            .map_err(|error| {
+                console_error!("anchor proof filing failed: {error}");
+                ServiceError::new(ErrorCode::InternalError, "internal error")
+            })?;
+    }
+
     Response::from_json(&serde_json::json!({
         "credential": verified.credential.to_string(),
         "accountRoot": verified.account_root.to_string(),
@@ -106,6 +126,72 @@ async fn handle_publish_inner(
         "stored": stored,
     }))
     .map(|response| response.with_status(202))
+    .map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
+}
+
+/// `POST /enrollments/confirm` → mint an anchor chain behind a one-time code.
+pub async fn handle_confirm(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_confirm_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(error) => error.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfirmRequest {
+    email: String,
+    code: String,
+    credential: String,
+}
+
+async fn handle_confirm_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body = read_body(req).await?;
+    let request: ConfirmRequest = serde_json::from_slice(&body).map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("failed to parse request body: {error}"),
+        )
+    })?;
+    let credential: Did = request.credential.parse().map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("invalid credential DID: {error}"),
+        )
+    })?;
+
+    let issued = issue_anchor_chain(
+        &build_store(ctx)?,
+        &build_enrollments(ctx)?,
+        &crate::handlers::codes::build_resend(ctx)?,
+        build_anchor(ctx).await?,
+        &request.email,
+        &request.code,
+        &credential,
+        Date::now().as_millis() / 1000,
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    let chain_hex = issued.chain.to_bytes().map(hex::encode).map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InternalError,
+            format!("failed to serialize the chain: {error}"),
+        )
+    })?;
+    Response::from_json(&serde_json::json!({
+        "accountRoot": issued.account_root.to_string(),
+        "credential": issued.credential.to_string(),
+        "chain": chain_hex,
+        "stored": issued.stored,
+    }))
+    .map(|response| response.with_status(201))
     .map_err(|error| {
         ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
     })

--- a/rust/tonk-account-service/src/handlers/info.rs
+++ b/rust/tonk-account-service/src/handlers/info.rs
@@ -2,12 +2,23 @@
 
 use worker::*;
 
+/// `GET /` → what this service is, and the anchor DID an account genesis
+/// delegates to if it wants email-gated enrollment here.
 pub async fn handle(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
-    // Return service info as JSON
-    let info = serde_json::json!({
+    #[allow(unused_mut)]
+    let mut info = serde_json::json!({
         "service": "tonk-account-service",
         "version": env!("CARGO_PKG_VERSION"),
     });
+
+    // Absent when no anchor is configured. Genesis reads this to address
+    // `root → recovery`, so publishing a DID the service cannot sign for
+    // would strand every account created against it.
+    #[cfg(target_arch = "wasm32")]
+    if let Ok(anchor) = crate::handlers::build_anchor(&_ctx).await {
+        use dialog_varsig::Principal;
+        info["recoveryAnchor"] = serde_json::Value::String(anchor.did().to_string());
+    }
 
     Response::from_json(&info)
 }

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -36,6 +36,7 @@ use crate::core::descriptor::establish_descriptor;
 use crate::core::devices::{
     DeviceView, detach_device, list_devices, register_device, revoke_device,
 };
+use crate::core::enrollment::issue_anchor_chain;
 use crate::core::links::{activate_link, complete_link, consume_link, create_link, resolve_link};
 use crate::email::CapturedEmail;
 use crate::enrollments::{
@@ -55,7 +56,15 @@ struct Backends {
     chains: MemoryChainStore,
     revocations: MemoryRevocationStore,
     enrollments: MemoryEnrollmentStore,
+    anchor: dialog_credentials::Ed25519Signer,
     emails: Arc<CapturedEmail>,
+}
+
+impl Backends {
+    fn anchor_did(&self) -> String {
+        use dialog_varsig::Principal;
+        self.anchor.did().to_string()
+    }
 }
 
 /// A running native account service, for integration tests and
@@ -67,6 +76,9 @@ pub struct AccountServer {
     /// Verification-code emails captured instead of sent, so a caller
     /// can read a code back out directly.
     pub emails: Arc<CapturedEmail>,
+    /// DID of this server's recovery anchor, as `GET /` reports it. An
+    /// account genesis delegates `root → recovery` to this key.
+    pub anchor_did: String,
     shutdown_tx: tokio::sync::oneshot::Sender<()>,
     server_handle: tokio::task::JoinHandle<()>,
 }
@@ -77,11 +89,19 @@ impl AccountServer {
     /// a shared `CapturedEmail`.
     pub async fn start() -> AccountServer {
         let emails = Arc::new(CapturedEmail::default());
+        let anchor = crate::anchor::from_seed_hex(&hex::encode([0xa1u8; 32]))
+            .await
+            .expect("a fixed test anchor seed is valid");
+        let anchor_did = {
+            use dialog_varsig::Principal;
+            anchor.did().to_string()
+        };
         let backends = Arc::new(Backends {
             store: SqliteStore::in_memory().expect("in-memory sqlite store"),
             chains: MemoryChainStore::default(),
             revocations: MemoryRevocationStore::default(),
             enrollments: MemoryEnrollmentStore::default(),
+            anchor,
             emails: emails.clone(),
         });
 
@@ -118,6 +138,7 @@ impl AccountServer {
         AccountServer {
             endpoint,
             emails,
+            anchor_did,
             shutdown_tx,
             server_handle,
         }
@@ -145,7 +166,7 @@ async fn handle_request(
     // Owned so an arm that binds the path can still take `req` by value.
     let path = req.uri().path().to_string();
     let response = match (req.method().clone(), path.as_str()) {
-        (Method::GET, "/") => return Ok(info_response()),
+        (Method::GET, "/") => return Ok(info_response(&backends)),
         (Method::GET, "/health") => return Ok(health_response()),
         (Method::GET, "/_test/emails") => emails_route(&backends),
         (Method::GET, "/_test/spots") => spots_route(req, &backends).await,
@@ -168,6 +189,7 @@ async fn handle_request(
         (Method::POST, "/links/activate") => links_activate_route(req, &backends).await,
         (Method::POST, "/links/consume") => links_consume_route(req, &backends).await,
         (Method::POST, "/enrollments") => enrollments_publish_route(req, &backends).await,
+        (Method::POST, "/enrollments/confirm") => enrollments_confirm_route(req, &backends).await,
         (Method::GET, claim) if claim.starts_with("/enrollments/") => {
             enrollments_claim_route(&claim["/enrollments/".len()..], &backends).await
         }
@@ -210,12 +232,13 @@ async fn account_summary_route(
 }
 
 /// `GET /` → service info. Not CORS-wrapped, matching the worker.
-fn info_response() -> Response<Full<Bytes>> {
+fn info_response(backends: &Backends) -> Response<Full<Bytes>> {
     json_response(
         StatusCode::OK,
         &serde_json::json!({
             "service": "tonk-account-service",
             "version": env!("CARGO_PKG_VERSION"),
+            "recoveryAnchor": backends.anchor_did(),
         }),
     )
 }
@@ -260,7 +283,7 @@ impl From<DeviceView> for DeviceJson {
 /// `GET /_test/emails` → a non-draining snapshot of captured codes.
 fn emails_route(backends: &Backends) -> Result<Response<Full<Bytes>>, ServiceError> {
     let emails =
-        backends.emails.0.lock().map_err(|_| {
+        backends.emails.codes.lock().map_err(|_| {
             ServiceError::new(ErrorCode::InternalError, "captured email lock poisoned")
         })?;
     let snapshot: Vec<_> = emails
@@ -643,6 +666,16 @@ async fn enrollments_publish_route(
             ServiceError::new(ErrorCode::InternalError, "internal error")
         })?
         == PutOutcome::Stored;
+    if verified.credential.to_string() == backends.anchor_did() {
+        backends
+            .enrollments
+            .put_anchor(&verified.account_root, &bytes)
+            .await
+            .map_err(|error| {
+                eprintln!("anchor proof filing failed: {error}");
+                ServiceError::new(ErrorCode::InternalError, "internal error")
+            })?;
+    }
 
     Ok(json_response(
         StatusCode::ACCEPTED,
@@ -678,6 +711,50 @@ async fn enrollments_claim_route(
         StatusCode::OK,
         &serde_json::json!({
             "chains": chains.iter().map(hex::encode).collect::<Vec<_>>(),
+        }),
+    ))
+}
+
+/// `POST /enrollments/confirm` → mint an anchor chain behind a one-time code.
+async fn enrollments_confirm_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ConfirmRequest {
+        email: String,
+        code: String,
+        credential: String,
+    }
+
+    let request: ConfirmRequest = parse_json(req).await?;
+    let credential: dialog_varsig::Did = request.credential.parse().map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("invalid credential DID: {error}"),
+        )
+    })?;
+    let issued = issue_anchor_chain(
+        &backends.store,
+        &backends.enrollments,
+        backends.emails.as_ref(),
+        backends.anchor.clone(),
+        &request.email,
+        &request.code,
+        &credential,
+        unix_now(),
+    )
+    .await
+    .map_err(ceremony_error)?;
+
+    Ok(json_response(
+        StatusCode::CREATED,
+        &serde_json::json!({
+            "accountRoot": issued.account_root.to_string(),
+            "credential": issued.credential.to_string(),
+            "chain": hex::encode(issued.chain.to_bytes().expect("a minted chain serializes")),
+            "stored": issued.stored,
         }),
     ))
 }

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -38,9 +38,13 @@ use crate::core::devices::{
 };
 use crate::core::links::{activate_link, complete_link, consume_link, create_link, resolve_link};
 use crate::email::CapturedEmail;
+use crate::enrollments::{
+    EnrollmentStore, MemoryEnrollmentStore, VerifyError as EnrollmentVerifyError,
+    verify as verify_enrollment,
+};
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::ceremony_error;
-use crate::revocations::{MemoryRevocationStore, PublishError, publish};
+use crate::revocations::{MemoryRevocationStore, PublishError, PutOutcome, publish};
 use crate::store::Store;
 use crate::store::sqlite::SqliteStore;
 use tonk_identity::revocation::VerifyError;
@@ -50,6 +54,7 @@ struct Backends {
     store: SqliteStore,
     chains: MemoryChainStore,
     revocations: MemoryRevocationStore,
+    enrollments: MemoryEnrollmentStore,
     emails: Arc<CapturedEmail>,
 }
 
@@ -76,6 +81,7 @@ impl AccountServer {
             store: SqliteStore::in_memory().expect("in-memory sqlite store"),
             chains: MemoryChainStore::default(),
             revocations: MemoryRevocationStore::default(),
+            enrollments: MemoryEnrollmentStore::default(),
             emails: emails.clone(),
         });
 
@@ -136,7 +142,9 @@ async fn handle_request(
         return Ok(cors_response(no_content()));
     }
 
-    let response = match (req.method().clone(), req.uri().path()) {
+    // Owned so an arm that binds the path can still take `req` by value.
+    let path = req.uri().path().to_string();
+    let response = match (req.method().clone(), path.as_str()) {
         (Method::GET, "/") => return Ok(info_response()),
         (Method::GET, "/health") => return Ok(health_response()),
         (Method::GET, "/_test/emails") => emails_route(&backends),
@@ -159,6 +167,10 @@ async fn handle_request(
         (Method::POST, "/links/complete") => links_complete_route(req, &backends).await,
         (Method::POST, "/links/activate") => links_activate_route(req, &backends).await,
         (Method::POST, "/links/consume") => links_consume_route(req, &backends).await,
+        (Method::POST, "/enrollments") => enrollments_publish_route(req, &backends).await,
+        (Method::GET, claim) if claim.starts_with("/enrollments/") => {
+            enrollments_claim_route(&claim["/enrollments/".len()..], &backends).await
+        }
         (Method::POST, "/chains/put") => chains_put_route(req, &backends).await,
         (Method::POST, "/chains/list") => chains_list_route(req, &backends).await,
         (Method::POST, "/chains/spots") => chains_spots_route(req, &backends).await,
@@ -568,6 +580,104 @@ async fn revocations_route(
             "targetCid": outcome.verified.target_cid,
             "artifactCid": outcome.verified.artifact_cid,
             "stored": outcome.stored,
+        }),
+    ))
+}
+
+/// `POST /enrollments` → publish a chain addressed to a credential.
+async fn enrollments_publish_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    const MAX_BYTES: usize = 8 * 1024;
+    let content_type = req
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if content_type.split(';').next() != Some("application/cbor") {
+        return Err(ServiceError::new(
+            ErrorCode::InvalidArgument,
+            "Content-Type must be application/cbor",
+        ));
+    }
+    let bytes = body_bytes(req).await?;
+    if bytes.len() > MAX_BYTES {
+        return Err(ServiceError::new(
+            ErrorCode::InvalidArgument,
+            "enrollment chain exceeds 8 KiB",
+        ));
+    }
+
+    let verified = verify_enrollment(&bytes)
+        .await
+        .map_err(|error| match error {
+            EnrollmentVerifyError::Invalid(message) => {
+                ServiceError::new(ErrorCode::InvalidArgument, message)
+            }
+            EnrollmentVerifyError::Unauthorized(message) => {
+                ServiceError::new(ErrorCode::Forbidden, message)
+            }
+        })?;
+    if backends
+        .store
+        .account_by_root(verified.account_root.as_ref())
+        .await
+        .map_err(|error| {
+            eprintln!("enrollment account lookup failed: {error:?}");
+            ServiceError::new(ErrorCode::InternalError, "internal error")
+        })?
+        .is_none()
+    {
+        return Err(ServiceError::new(
+            ErrorCode::NotFound,
+            "this service does not host the account the chain runs from",
+        ));
+    }
+    let stored = backends
+        .enrollments
+        .put(&verified, &bytes)
+        .await
+        .map_err(|error| {
+            eprintln!("enrollment publication failed: {error}");
+            ServiceError::new(ErrorCode::InternalError, "internal error")
+        })?
+        == PutOutcome::Stored;
+
+    Ok(json_response(
+        StatusCode::ACCEPTED,
+        &serde_json::json!({
+            "credential": verified.credential.to_string(),
+            "accountRoot": verified.account_root.to_string(),
+            "key": verified.key,
+            "stored": stored,
+        }),
+    ))
+}
+
+/// `GET /enrollments/{credential}` → every chain addressed to that key.
+async fn enrollments_claim_route(
+    credential: &str,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let credential: dialog_varsig::Did = credential.parse().map_err(|error| {
+        ServiceError::new(
+            ErrorCode::InvalidArgument,
+            format!("invalid credential DID: {error}"),
+        )
+    })?;
+    let chains = backends
+        .enrollments
+        .claim(&credential)
+        .await
+        .map_err(|error| {
+            eprintln!("enrollment claim failed: {error}");
+            ServiceError::new(ErrorCode::InternalError, "internal error")
+        })?;
+    Ok(json_response(
+        StatusCode::OK,
+        &serde_json::json!({
+            "chains": chains.iter().map(hex::encode).collect::<Vec<_>>(),
         }),
     ))
 }

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -10,6 +10,7 @@
 
 use worker::*;
 
+pub mod anchor;
 pub mod auth;
 pub mod chains;
 pub mod core;
@@ -70,6 +71,14 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/links/consume", handlers::links::handle_options)
         .post_async("/enrollments", handlers::enrollments::handle_publish)
         .options_async("/enrollments", handlers::enrollments::handle_options)
+        .post_async(
+            "/enrollments/confirm",
+            handlers::enrollments::handle_confirm,
+        )
+        .options_async(
+            "/enrollments/confirm",
+            handlers::enrollments::handle_options,
+        )
         .get_async(
             "/enrollments/:credential",
             handlers::enrollments::handle_claim,

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -14,6 +14,7 @@ pub mod auth;
 pub mod chains;
 pub mod core;
 pub mod email;
+pub mod enrollments;
 pub mod error;
 mod handlers;
 #[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
@@ -67,6 +68,16 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/links/activate", handlers::links::handle_options)
         .post_async("/links/consume", handlers::links::handle_consume)
         .options_async("/links/consume", handlers::links::handle_options)
+        .post_async("/enrollments", handlers::enrollments::handle_publish)
+        .options_async("/enrollments", handlers::enrollments::handle_options)
+        .get_async(
+            "/enrollments/:credential",
+            handlers::enrollments::handle_claim,
+        )
+        .options_async(
+            "/enrollments/:credential",
+            handlers::enrollments::handle_options,
+        )
         .post_async("/chains/put", handlers::chains::handle_put)
         .options_async("/chains/put", handlers::chains::handle_options)
         .post_async("/chains/list", handlers::chains::handle_list)

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -1213,3 +1213,127 @@ async fn it_drives_the_full_ceremony_over_http() {
         .unwrap();
     assert_eq!(rejected.status(), 403);
 }
+
+/// The bootstrap a second passkey depends on: a device that has only just
+/// derived its credential key, holding no delegation and no account
+/// identity, asks for whatever has been addressed to that key and gets a
+/// usable chain back.
+#[dialog_common::test]
+async fn it_publishes_and_claims_an_enrollment_chain_over_http() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+
+    client
+        .post(format!("{base}/codes"))
+        .json(&serde_json::json!({ "email": "peer@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    let code = {
+        let sent = server.emails.0.lock().unwrap();
+        sent.iter()
+            .find(|(email, _)| email == "peer@example.com")
+            .map(|(_, code): &(String, String)| code.clone())
+            .expect("a code was sent")
+    };
+    let created = client
+        .post(format!("{base}/accounts"))
+        .header("Content-Type", "application/cbor")
+        .body(account_creation("peer@example.com", &code).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 201);
+
+    // The account root enrols a second passkey's credential key. Under
+    // fan-out this hop would be signed by the recovery anchor; for a v1
+    // account the subject signs it directly, and the store cannot tell.
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let credential = tonk_identity::derive::derive_root_signer(&[21u8; 32])
+        .await
+        .unwrap();
+    let enrollment = tonk_identity::credential::mint_enrollment(root, &credential.did())
+        .await
+        .unwrap();
+    let bytes = enrollment.to_bytes().unwrap();
+
+    let published = client
+        .post(format!("{base}/enrollments"))
+        .header("Content-Type", "application/cbor")
+        .body(bytes.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(published.status(), 202);
+    let published: serde_json::Value = published.json().await.unwrap();
+    assert_eq!(published["credential"], credential.did().to_string());
+    assert_eq!(published["stored"], true);
+
+    // Republishing the same bytes is idempotent rather than a second entry.
+    let again = client
+        .post(format!("{base}/enrollments"))
+        .header("Content-Type", "application/cbor")
+        .body(bytes.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        again.json::<serde_json::Value>().await.unwrap()["stored"],
+        false
+    );
+
+    // The claim: everything this device brings is its own DID.
+    let claimed = client
+        .get(format!("{base}/enrollments/{}", credential.did()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(claimed.status(), 200);
+    let claimed: serde_json::Value = claimed.json().await.unwrap();
+    let chains = claimed["chains"].as_array().unwrap();
+    assert_eq!(chains.len(), 1);
+    assert_eq!(chains[0].as_str().unwrap(), hex::encode(&bytes));
+
+    // A key nobody enrolled gets nothing, not an error.
+    let stranger = Ed25519Signer::import(&[22u8; 32]).await.unwrap();
+    let empty = client
+        .get(format!("{base}/enrollments/{}", stranger.did()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), 200);
+    assert!(
+        empty.json::<serde_json::Value>().await.unwrap()["chains"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+
+    server.stop().await;
+}
+
+/// The bucket is not free storage: a chain that is perfectly valid but runs
+/// from an account this service has never heard of is refused.
+#[dialog_common::test]
+async fn it_refuses_an_enrollment_for_an_account_it_does_not_host() {
+    let server = AccountServer::start().await;
+    let stranger_root = Ed25519Signer::import(&[23u8; 32]).await.unwrap();
+    let credential = Ed25519Signer::import(&[24u8; 32]).await.unwrap();
+    let enrollment = tonk_identity::credential::mint_enrollment(stranger_root, &credential.did())
+        .await
+        .unwrap();
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/enrollments", server.endpoint))
+        .header("Content-Type", "application/cbor")
+        .body(enrollment.to_bytes().unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 404);
+    server.stop().await;
+}

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -212,7 +212,7 @@ async fn it_exhausts_verification_attempts_over_http() {
         .unwrap()
         .error_for_status()
         .unwrap();
-    let correct = server.emails.0.lock().unwrap()[0].1.clone();
+    let correct = server.emails.codes.lock().unwrap()[0].1.clone();
     let wrong = if correct == "000000" {
         "111111"
     } else {
@@ -262,7 +262,15 @@ async fn it_checks_email_availability_only_after_a_valid_code() {
         .unwrap()
         .error_for_status()
         .unwrap();
-    let first_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    let first_code = server
+        .emails
+        .codes
+        .lock()
+        .unwrap()
+        .last()
+        .unwrap()
+        .1
+        .clone();
     let created = client
         .post(format!("{}/accounts", server.endpoint))
         .header("Content-Type", "application/cbor")
@@ -280,7 +288,15 @@ async fn it_checks_email_availability_only_after_a_valid_code() {
         .unwrap()
         .error_for_status()
         .unwrap();
-    let existing_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    let existing_code = server
+        .emails
+        .codes
+        .lock()
+        .unwrap()
+        .last()
+        .unwrap()
+        .1
+        .clone();
     let conflict = client
         .post(format!("{}/accounts/preflight", server.endpoint))
         .json(&serde_json::json!({
@@ -307,7 +323,15 @@ async fn it_checks_email_availability_only_after_a_valid_code() {
         .unwrap()
         .error_for_status()
         .unwrap();
-    let available_code = server.emails.0.lock().unwrap().last().unwrap().1.clone();
+    let available_code = server
+        .emails
+        .codes
+        .lock()
+        .unwrap()
+        .last()
+        .unwrap()
+        .1
+        .clone();
     for _ in 0..2 {
         let response = client
             .post(format!("{}/accounts/preflight", server.endpoint))
@@ -451,7 +475,7 @@ async fn it_explains_an_already_registered_email_over_http() {
     let email = "person@example.com";
 
     let latest_code = || {
-        let sent = server.emails.0.lock().unwrap();
+        let sent = server.emails.codes.lock().unwrap();
         sent.iter()
             .rfind(|(to, _)| to == email)
             .map(|(_, code): &(String, String)| code.clone())
@@ -535,7 +559,7 @@ async fn it_drives_the_full_ceremony_over_http() {
     assert_eq!(response.status(), 200);
 
     let code = {
-        let sent = server.emails.0.lock().unwrap();
+        let sent = server.emails.codes.lock().unwrap();
         sent.iter()
             .find(|(email, _)| email == "person@example.com")
             .map(|(_, code): &(String, String)| code.clone())
@@ -1120,7 +1144,7 @@ async fn it_drives_the_full_ceremony_over_http() {
         .error_for_status()
         .unwrap();
     let other_code = {
-        let sent = server.emails.0.lock().unwrap();
+        let sent = server.emails.codes.lock().unwrap();
         sent.iter()
             .rfind(|(email, _)| email == other_email)
             .map(|(_, code)| code.clone())
@@ -1231,7 +1255,7 @@ async fn it_publishes_and_claims_an_enrollment_chain_over_http() {
         .await
         .unwrap();
     let code = {
-        let sent = server.emails.0.lock().unwrap();
+        let sent = server.emails.codes.lock().unwrap();
         sent.iter()
             .find(|(email, _)| email == "peer@example.com")
             .map(|(_, code): &(String, String)| code.clone())
@@ -1335,5 +1359,136 @@ async fn it_refuses_an_enrollment_for_an_account_it_does_not_host() {
         .unwrap();
 
     assert_eq!(response.status(), 404);
+    server.stop().await;
+}
+
+/// The flow a second passkey actually walks: the account delegates to the
+/// service's anchor once, then every later credential is enrolled behind a
+/// code sent to the account address and claims its chain with nothing but
+/// its own DID.
+#[dialog_common::test]
+async fn it_enrols_a_second_credential_behind_an_emailed_code() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let base = server.endpoint.clone();
+    let email = "anchored@example.com";
+
+    let request_code = async |client: &reqwest::Client| {
+        client
+            .post(format!("{base}/codes"))
+            .json(&serde_json::json!({ "email": email }))
+            .send()
+            .await
+            .unwrap();
+        server
+            .emails
+            .codes
+            .lock()
+            .unwrap()
+            .last()
+            .unwrap()
+            .1
+            .clone()
+    };
+
+    // The anchor DID is published, so genesis knows who to delegate to.
+    let info: serde_json::Value = client
+        .get(format!("{base}/"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let anchor: Did = info["recoveryAnchor"].as_str().unwrap().parse().unwrap();
+    assert_eq!(anchor.to_string(), server.anchor_did);
+
+    let code = request_code(&client).await;
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    client
+        .post(format!("{base}/accounts"))
+        .header("Content-Type", "application/cbor")
+        .body(account_creation(email, &code).await)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Enrolling before the anchor exists has nothing to extend.
+    let credential = Ed25519Signer::import(&[31u8; 32]).await.unwrap();
+    let too_early = client
+        .post(format!("{base}/enrollments/confirm"))
+        .json(&serde_json::json!({
+            "email": email,
+            "code": request_code(&client).await,
+            "credential": credential.did().to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(too_early.status(), 409);
+
+    // A signed-in credential publishes `root → anchor` once. The service
+    // files it as the proof it may later extend.
+    let anchor_proof = tonk_identity::credential::mint_enrollment(root.clone(), &anchor)
+        .await
+        .unwrap();
+    client
+        .post(format!("{base}/enrollments"))
+        .header("Content-Type", "application/cbor")
+        .body(anchor_proof.to_bytes().unwrap())
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    let issued = client
+        .post(format!("{base}/enrollments/confirm"))
+        .json(&serde_json::json!({
+            "email": email,
+            "code": request_code(&client).await,
+            "credential": credential.did().to_string(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(issued.status(), 201);
+    let issued: serde_json::Value = issued.json().await.unwrap();
+    assert_eq!(issued["accountRoot"], root.did().to_string());
+
+    // The account holder is told, whether or not they asked.
+    assert_eq!(
+        server.emails.notices.lock().unwrap().as_slice(),
+        [(email.to_string(), credential.did().to_string())],
+    );
+
+    // And the new credential's device now presents a chain the registry
+    // accepts: root → anchor → credential → device.
+    let claimed: serde_json::Value = client
+        .get(format!("{base}/enrollments/{}", credential.did()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let chain_hex = claimed["chains"].as_array().unwrap()[0].as_str().unwrap();
+    assert_eq!(chain_hex, issued["chain"].as_str().unwrap());
+    let chain = DelegationChain::try_from(hex::decode(chain_hex).unwrap().as_slice()).unwrap();
+    let phone = Ed25519Signer::import(&[32u8; 32]).await.unwrap();
+    let device_chain =
+        tonk_identity::credential::extend_with_enrollment(&chain, credential, &phone.did())
+            .await
+            .unwrap();
+    let grant = tonk_identity::delegation::validate_account_grant(&device_chain, &phone.did())
+        .await
+        .unwrap();
+    assert_eq!(grant.root_did, root.did());
+    assert_eq!(device_chain.proof_cids().len(), 3);
+
     server.stop().await;
 }

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -273,21 +273,10 @@ async fn active_from_consumed(
         hex::decode(&consumed.delegation_hex).context("invalid local-root delegation hex")?;
     let chain = DelegationChain::try_from(bytes.as_slice())
         .context("invalid local-root delegation container")?;
-    if chain.proof_cids().len() != 1
-        || chain.subject().is_some()
-        || chain.audience() != &profile.did()
-    {
-        bail!("local-root delegation has an invalid shape");
-    }
-    let proof = chain
-        .proofs()
-        .next()
-        .context("local-root delegation is missing its proof")?;
-    proof
-        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+    let root_did = tonk_identity::delegation::validate_account_grant(&chain, &profile.did())
         .await
-        .context("local-root delegation signature is invalid")?;
-    let root_did = chain.issuer().clone();
+        .context("local-root delegation is not usable account authority")?
+        .root_did;
     let descriptor = hex::decode(&consumed.descriptor_hex)
         .context("invalid descriptor hex from account service")?;
     let now = std::time::SystemTime::now()
@@ -955,7 +944,10 @@ impl AccountConnection {
             hex::decode(&active.delegation_hex).context("active account grant hex is invalid")?;
         let link = DelegationChain::try_from(bytes.as_slice())
             .context("active account grant is invalid")?;
-        if link.proof_cids().len() != 1 || link.proof_cids()[0].to_string() != active.delegation_cid
+        if link
+            .proof_cids()
+            .last()
+            .is_none_or(|cid| cid.to_string() != active.delegation_cid)
         {
             bail!("active account grant does not match canonical session state");
         }

--- a/rust/tonk-cli/src/identity.rs
+++ b/rust/tonk-cli/src/identity.rs
@@ -7,7 +7,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use dialog_effects::credential::CredentialError;
 use dialog_operator::{Operator, Profile};
 use dialog_storage::provider::storage::{NativeSpace, Storage};
@@ -88,24 +88,13 @@ pub async fn save_local_root(
     let bytes = hex::decode(&delegation_hex).context("invalid local-root delegation hex")?;
     let chain = DelegationChain::try_from(bytes.as_slice())
         .context("invalid local-root delegation container")?;
-    if chain.proof_cids().len() != 1 || chain.subject().is_some() {
-        bail!("local-root delegation has an invalid shape");
-    }
-    if chain.audience() != &profile.did() {
-        bail!("local-root delegation targets another device");
-    }
-    let proof = chain
-        .proofs()
-        .next()
-        .context("local-root delegation is missing its proof")?;
-    proof
-        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+    let grant = tonk_identity::delegation::validate_account_grant(&chain, &profile.did())
         .await
-        .context("local-root delegation signature is invalid")?;
+        .context("local-root delegation is not usable account authority")?;
     let record = LocalRoot {
         credential_id,
-        root_did: chain.issuer().to_string(),
-        delegation_cid: chain.proof_cids()[0].to_string(),
+        root_did: grant.root_did.to_string(),
+        delegation_cid: grant.delegation_cid.to_string(),
         delegation_hex,
     };
     // The latest handoff replaces this compatibility projection. Historical

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -99,7 +99,7 @@ impl AccountFixture {
             .await?
             .error_for_status()?;
         let code = {
-            let emails = server.emails.0.lock().unwrap();
+            let emails = server.emails.codes.lock().unwrap();
             emails
                 .iter()
                 .find(|(recipient, _)| recipient == &email)

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -14,6 +14,7 @@ dialog-varsig = { workspace = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
 ipld-core = { workspace = true }
+rand = { workspace = true }
 sha2_0_10 = { workspace = true }
 thiserror = { workspace = true }
 tonk-account = { workspace = true }
@@ -22,7 +23,6 @@ zeroize = { workspace = true }
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom_0_3 = { workspace = true }
 js-sys = { workspace = true }
-rand = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -265,6 +265,95 @@ pub async fn create_account(
     .await
 }
 
+/// Output of the ephemeral-root genesis ceremony.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenesisCeremony {
+    /// The account subject: a key that no longer exists anywhere.
+    pub account_subject: String,
+    /// Hex-encoded `root → credential`, the first passkey's enrollment.
+    pub credential_delegation_hex: String,
+    /// Hex-encoded `root → anchor`, the only recovery path this account
+    /// will ever have that did not come through a live credential.
+    pub anchor_delegation_hex: String,
+    /// Root-signed account creation request.
+    pub account: AccountCeremony,
+}
+
+/// Create an account whose subject is a key destroyed during the ceremony.
+///
+/// The passkey-derived key stops being the account and becomes one credential
+/// among peers: the subject is a fresh keypair that signs the descriptor and
+/// fans out to the credential and to `anchor`, then goes away. Nothing can
+/// ever mint a direct `root → x` delegation again, which is what makes both
+/// of those delegations load-bearing — see the anchor invariant in the spec.
+///
+/// The device's grant runs `root → credential → device`, so the credential
+/// remains the thing that authorizes devices day to day.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_account_with_ephemeral_root(
+    credential: Ed25519Signer,
+    anchor: &dialog_varsig::Did,
+    email: String,
+    code: String,
+    credential_id: String,
+    device_did: dialog_varsig::Did,
+    device_name: String,
+    remote: String,
+    passkey: Option<PasskeyCreationMetadata>,
+) -> Result<GenesisCeremony> {
+    // Generated here and dropped at the end of this function. The seed
+    // zeroizes with its guard; the signer holds the only other copy, and on
+    // the web target that copy is a non-extractable WebCrypto key.
+    let seed = zeroize::Zeroizing::new(rand::random::<[u8; 32]>());
+    let root = Ed25519Signer::import(&*seed)
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to generate the account root: {err}"))?;
+    let account_subject = root.did().to_string();
+
+    let credential_link = crate::credential::mint_enrollment(root.clone(), &credential.did())
+        .await
+        .context("failed to enrol the first credential")?;
+    let anchor_link = crate::credential::mint_enrollment(root.clone(), anchor)
+        .await
+        .context("failed to delegate to the recovery anchor")?;
+    let device_chain =
+        crate::credential::extend_with_enrollment(&credential_link, credential, &device_did)
+            .await
+            .context("failed to grant the device through the credential")?;
+
+    let account = create_account(
+        root,
+        email,
+        code,
+        credential_id,
+        device_did,
+        device_name,
+        hex::encode(
+            device_chain
+                .to_bytes()
+                .context("failed to serialize the device grant")?,
+        ),
+        remote,
+        passkey,
+    )
+    .await?;
+
+    Ok(GenesisCeremony {
+        account_subject,
+        credential_delegation_hex: hex::encode(
+            credential_link
+                .to_bytes()
+                .context("failed to serialize the credential enrollment")?,
+        ),
+        anchor_delegation_hex: hex::encode(
+            anchor_link
+                .to_bytes()
+                .context("failed to serialize the anchor delegation")?,
+        ),
+        account,
+    })
+}
+
 /// Create a passkey root and sign its account request without immediately
 /// asking the new passkey for a second assertion.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -496,6 +585,101 @@ mod tests {
         let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
         assert!(!chain.arguments().contains_key("passkeyCreatedAt"));
         assert!(!chain.arguments().contains_key("passkeyCreatedOn"));
+    }
+
+    #[dialog_common::test]
+    async fn it_makes_the_account_subject_a_key_no_one_holds() {
+        let credential = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let anchor = Ed25519Signer::import(&[9u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+
+        let genesis = create_account_with_ephemeral_root(
+            credential.clone(),
+            &anchor.did(),
+            "a@x.com".into(),
+            "123456".into(),
+            "credential".into(),
+            device.did(),
+            "laptop".into(),
+            "https://accounts.example/ucan/".into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let subject: dialog_varsig::Did = genesis.account_subject.parse().unwrap();
+        assert_ne!(subject, credential.did(), "the passkey is not the account");
+        assert_ne!(subject, device.did());
+        assert_ne!(subject, anchor.did());
+
+        // Both genesis delegations run from the subject, and neither could be
+        // minted again once this ceremony returns.
+        let credential_link = DelegationChain::try_from(
+            hex::decode(&genesis.credential_delegation_hex)
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let anchor_link = DelegationChain::try_from(
+            hex::decode(&genesis.anchor_delegation_hex)
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        assert_eq!(*credential_link.issuer(), subject);
+        assert_eq!(*credential_link.audience(), credential.did());
+        assert_eq!(*anchor_link.issuer(), subject);
+        assert_eq!(*anchor_link.audience(), anchor.did());
+
+        // The descriptor is signed by the subject while it still exists.
+        let descriptor = tonk_account::AccountRepositoryDescriptorV1::validate(
+            &hex::decode(genesis.account.descriptor_hex.as_ref().unwrap()).unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(*descriptor.account_subject(), subject);
+
+        // And the device's grant reaches it through the credential.
+        let grant = DelegationChain::try_from(
+            hex::decode(&genesis.account.delegation_hex)
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        assert_eq!(grant.proof_cids().len(), 2, "root → credential → device");
+        let validated = crate::delegation::validate_account_grant(&grant, &device.did())
+            .await
+            .unwrap();
+        assert_eq!(validated.root_did, subject);
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_a_distinct_subject_for_every_account() {
+        let credential = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let anchor = Ed25519Signer::import(&[9u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let genesis = async || {
+            create_account_with_ephemeral_root(
+                credential.clone(),
+                &anchor.did(),
+                "a@x.com".into(),
+                "123456".into(),
+                "credential".into(),
+                device.did(),
+                "laptop".into(),
+                "https://accounts.example/ucan/".into(),
+                None,
+            )
+            .await
+            .unwrap()
+            .account_subject
+        };
+
+        assert_ne!(
+            genesis().await,
+            genesis().await,
+            "the same passkey must not re-derive an account subject"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-identity/src/credential.rs
+++ b/rust/tonk-identity/src/credential.rs
@@ -1,0 +1,143 @@
+//! Enrolling a second passkey as a peer of the first.
+//!
+//! A passkey is bound to one authenticator. An account that lives in a
+//! single passkey therefore lives on whatever platforms that authenticator
+//! reaches — Chrome on a Mac and Safari on an iPhone are routinely not the
+//! same set. Enrollment breaks that: the credential derived from a second
+//! passkey receives its own subject-open delegation, and every device it
+//! grants presents `account → credential → device`.
+//!
+//! The enrollment link is the same shape as a device grant, deliberately.
+//! A peer credential must be able to do everything the credential that
+//! enrolled it can do, including enrolling further peers and revoking the
+//! link it came through.
+
+use anyhow::Result;
+use dialog_credentials::Ed25519Signer;
+use dialog_ucan_core::DelegationChain;
+use dialog_varsig::Did;
+
+use crate::delegation::mint_device_delegation;
+
+/// Mint the `credential → peer` enrollment link.
+///
+/// `credential` is whichever key is reachable at enrollment time: the
+/// account root itself for an account whose subject is its first passkey,
+/// or any already-enrolled peer.
+pub async fn mint_enrollment(credential: Ed25519Signer, peer: &Did) -> Result<DelegationChain> {
+    mint_device_delegation(credential, peer).await
+}
+
+/// Extend the enrolling credential's own chain with a new enrollment hop.
+///
+/// Passing the enroller's chain rather than assuming it is the account root
+/// is what lets a peer enrol a further peer: the composed chain still runs
+/// from the account subject, so verifiers need no notion of enrolment depth.
+pub async fn extend_with_enrollment(
+    enroller_chain: &DelegationChain,
+    enroller: Ed25519Signer,
+    peer: &Did,
+) -> Result<DelegationChain> {
+    let enrollment = mint_enrollment(enroller, peer).await?;
+    let link = enrollment
+        .proofs()
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("enrollment chain has no proof"))?
+        .clone();
+    enroller_chain
+        .push(link)
+        .map_err(|err| anyhow::anyhow!("failed to extend the enroller's chain: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::delegation::{GrantError, validate_account_grant};
+    use dialog_varsig::Principal;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const ROOT_PRF: [u8; 32] = [1u8; 32];
+    const PEER_PRF: [u8; 32] = [2u8; 32];
+    const THIRD_PRF: [u8; 32] = [3u8; 32];
+    const DEVICE_SEED: [u8; 32] = [4u8; 32];
+
+    async fn signer(seed: &[u8; 32]) -> Ed25519Signer {
+        Ed25519Signer::import(seed).await.unwrap()
+    }
+
+    #[dialog_common::test]
+    async fn it_grants_a_peer_credential_the_same_shape_as_a_device() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let peer = crate::derive::derive_root_signer(&PEER_PRF).await.unwrap();
+
+        let enrollment = mint_enrollment(root, &peer.did()).await.unwrap();
+
+        assert_eq!(*enrollment.audience(), peer.did());
+        assert!(
+            enrollment.subject().is_none(),
+            "a peer credential must be able to act for the account anywhere"
+        );
+        assert!(enrollment.expiration().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_validates_a_device_granted_by_an_enrolled_peer() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let root_did = root.did();
+        let peer = crate::derive::derive_root_signer(&PEER_PRF).await.unwrap();
+        let device = signer(&DEVICE_SEED).await;
+
+        let enrollment = mint_enrollment(root, &peer.did()).await.unwrap();
+        let chain = extend_with_enrollment(&enrollment, peer, &device.did())
+            .await
+            .unwrap();
+
+        let grant = validate_account_grant(&chain, &device.did()).await.unwrap();
+        assert_eq!(grant.root_did, root_did, "the account subject is unchanged");
+        assert_eq!(grant.device_did, device.did());
+        assert_eq!(
+            grant.delegation_cid,
+            chain.proof_cids()[1],
+            "a revocation of this device names the device's own hop"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_lets_a_peer_enrol_a_further_peer() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let root_did = root.did();
+        let peer = crate::derive::derive_root_signer(&PEER_PRF).await.unwrap();
+        let third = crate::derive::derive_root_signer(&THIRD_PRF).await.unwrap();
+        let device = signer(&DEVICE_SEED).await;
+
+        let first = mint_enrollment(root, &peer.did()).await.unwrap();
+        let second = extend_with_enrollment(&first, peer, &third.did())
+            .await
+            .unwrap();
+        let chain = extend_with_enrollment(&second, third, &device.did())
+            .await
+            .unwrap();
+
+        let grant = validate_account_grant(&chain, &device.did()).await.unwrap();
+        assert_eq!(grant.root_did, root_did);
+        assert_eq!(chain.proof_cids().len(), 3);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_a_chain_that_ends_at_another_device() {
+        let root = crate::derive::derive_root_signer(&ROOT_PRF).await.unwrap();
+        let peer = crate::derive::derive_root_signer(&PEER_PRF).await.unwrap();
+        let other = signer(&DEVICE_SEED).await;
+
+        let enrollment = mint_enrollment(root, &peer.did()).await.unwrap();
+
+        assert!(matches!(
+            validate_account_grant(&enrollment, &other.did()).await,
+            Err(GrantError::Audience(_))
+        ));
+    }
+}

--- a/rust/tonk-identity/src/delegation.rs
+++ b/rust/tonk-identity/src/delegation.rs
@@ -1,10 +1,11 @@
-//! The `root → device` delegation.
+//! The delegation from an account root down to one device.
 
 use anyhow::Result;
-use dialog_credentials::Ed25519Signer;
+use dialog_credentials::{Ed25519KeyResolver, Ed25519Signer};
 use dialog_ucan_core::subject::Subject as UcanSubject;
 use dialog_ucan_core::{DelegationBuilder, DelegationChain};
 use dialog_varsig::Did;
+use ipld_core::cid::Cid;
 
 /// Mint the `root → device` delegation: subject-open, audience-specific —
 /// "this device may act as me, for anything". Deliberately the opposite
@@ -19,6 +20,72 @@ pub async fn mint_device_delegation(root: Ed25519Signer, device: &Did) -> Result
         .await
         .map_err(|e| anyhow::anyhow!("failed to mint the device delegation: {e}"))?;
     Ok(DelegationChain::new(delegation))
+}
+
+/// A validated chain of account authority ending at one device.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountGrant {
+    /// Account root the chain starts from — the account subject.
+    pub root_did: Did,
+    /// Device the chain ends at.
+    pub device_did: Did,
+    /// CID of the device's own inbound link, the hop a revocation of this
+    /// device names. For a one-hop grant this is the whole chain.
+    pub delegation_cid: Cid,
+}
+
+/// Why a presented chain is not an account grant.
+#[derive(Debug, thiserror::Error)]
+pub enum GrantError {
+    /// The chain is not shaped like account authority.
+    #[error("{0}")]
+    Shape(String),
+    /// The chain does not end at the expected device.
+    #[error("{0}")]
+    Audience(String),
+    /// A hop's signature failed to verify.
+    #[error("{0}")]
+    Signature(String),
+}
+
+/// Validate a chain running from an account root to `device`.
+///
+/// One hop is the common case — the root delegating straight to a device —
+/// but a device whose credential was enrolled as a peer presents
+/// `root → credential → device`, and a peer of a peer presents more. Every
+/// hop must keep the account shape: subject-open, command-open, and signed.
+pub async fn validate_account_grant(
+    chain: &DelegationChain,
+    device: &Did,
+) -> std::result::Result<AccountGrant, GrantError> {
+    if chain.audience() != device {
+        return Err(GrantError::Audience(
+            "account grant audience is not this device".to_string(),
+        ));
+    }
+    for delegation in chain.proofs() {
+        if !delegation.command().0.is_empty() {
+            return Err(GrantError::Shape(
+                "account grant must be command-open".to_string(),
+            ));
+        }
+        if !matches!(delegation.subject(), UcanSubject::Any) {
+            return Err(GrantError::Shape(
+                "every hop of an account grant must be subject-open".to_string(),
+            ));
+        }
+        delegation
+            .verify_signature(&Ed25519KeyResolver)
+            .await
+            .map_err(|error| {
+                GrantError::Signature(format!("invalid account grant signature: {error}"))
+            })?;
+    }
+    Ok(AccountGrant {
+        root_did: chain.issuer().clone(),
+        device_did: device.clone(),
+        delegation_cid: chain.proof_cids()[chain.proof_cids().len() - 1],
+    })
 }
 
 #[cfg(test)]

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -7,6 +7,7 @@
 //! delegation; day-to-day operation never touches the root key.
 
 pub mod ceremony;
+pub mod credential;
 pub mod delegation;
 pub mod derive;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-identity/src/revocation.rs
+++ b/rust/tonk-identity/src/revocation.rs
@@ -30,6 +30,9 @@ pub enum RevocationAuthority {
     PathIssuer,
     /// The signer exercised authority delegated through the target.
     Delegated,
+    /// The signer holds its own currently-valid chain from the same
+    /// subject-open authority the target answers to.
+    Peer,
 }
 
 /// Facts derived from a verified revocation artifact.
@@ -108,6 +111,16 @@ fn subject(path: &DelegationChain) -> Did {
         .unwrap_or_else(|| path.issuer().clone())
 }
 
+/// Whether `signer_subject` is the subject-open authority `path` answers to.
+///
+/// Account delegations are subject-open, so every credential enrolled under
+/// an account holds a chain from the same root and each is the others' peer.
+/// Space invites are subject-specific and stay on the narrower path-issuer
+/// and delegated classes: the two shapes must not blur.
+fn is_account_peer(path: &DelegationChain, signer_subject: &Did) -> bool {
+    path.subject().is_none() && signer_subject == path.issuer()
+}
+
 async fn mint(
     issuer: Ed25519Signer,
     path: &DelegationChain,
@@ -158,6 +171,30 @@ pub async fn mint_self_revocation(
     target: &Cid,
 ) -> Result<Vec<u8>> {
     mint(device, grant, target, Some(grant)).await
+}
+
+/// Mint a revocation signed by a peer credential of the same account.
+///
+/// `proofs` is the signer's own chain from the account subject; unlike a
+/// delegated revocation it need not run through the target. This is how a
+/// credential anchored one way (`root → recovery → safari`) withdraws a link
+/// it does not itself depend on (`root → chrome`).
+pub async fn mint_peer_revocation(
+    credential: Ed25519Signer,
+    path: &DelegationChain,
+    target: &Cid,
+    proofs: &DelegationChain,
+) -> Result<Vec<u8>> {
+    if path.subject().is_some() {
+        anyhow::bail!("peer revocation requires a subject-open account path");
+    }
+    if subject(proofs) != subject(path) {
+        anyhow::bail!("peer proofs do not chain from the account subject");
+    }
+    if proofs.audience() != &credential.did() {
+        anyhow::bail!("peer proofs do not reach the signing credential");
+    }
+    mint(credential, path, target, Some(proofs)).await
 }
 
 /// Mint a revocation signed under an attached delegation proof chain.
@@ -248,12 +285,16 @@ pub async fn verify(bytes: &[u8]) -> std::result::Result<VerifiedRevocation, Ver
         chain.verify(&Ed25519KeyResolver).await.map_err(|err| {
             VerifyError::Unauthorized(format!("delegated authority failed to verify: {err}"))
         })?;
-        if !chain.proofs().contains(&target) {
+        if chain.proofs().contains(&target) {
+            RevocationAuthority::Delegated
+        } else if is_account_peer(&path, chain.subject()) {
+            RevocationAuthority::Peer
+        } else {
             return Err(VerifyError::Unauthorized(
-                "delegated revocation does not attach the target as a proof".to_string(),
+                "revocation neither attaches the target as a proof nor proves peer authority"
+                    .to_string(),
             ));
         }
-        RevocationAuthority::Delegated
     };
 
     let canonical_bytes = chain.to_bytes().map_err(|err| {
@@ -329,6 +370,41 @@ mod tests {
             .unwrap();
         let path = DelegationChain::new(first).push(second).unwrap();
         (space, member, invite, path)
+    }
+
+    /// One account whose credentials are anchored differently:
+    /// `root → recovery → safari` and `root → chrome`. Neither credential's
+    /// chain contains the other's link.
+    struct FannedOutAccount {
+        safari: Ed25519Signer,
+        safari_chain: DelegationChain,
+        chrome: Ed25519Signer,
+        chrome_chain: DelegationChain,
+    }
+
+    async fn fanned_out_account() -> FannedOutAccount {
+        let root = signer(1).await;
+        let recovery = signer(10).await;
+        let safari = signer(11).await;
+        let chrome = signer(12).await;
+        let anchor = crate::delegation::mint_device_delegation(root.clone(), &recovery.did())
+            .await
+            .unwrap();
+        let enrollment = crate::delegation::mint_device_delegation(recovery, &safari.did())
+            .await
+            .unwrap();
+        let safari_chain = anchor
+            .push(enrollment.proofs().next().unwrap().clone())
+            .unwrap();
+        let chrome_chain = crate::delegation::mint_device_delegation(root, &chrome.did())
+            .await
+            .unwrap();
+        FannedOutAccount {
+            safari,
+            safari_chain,
+            chrome,
+            chrome_chain,
+        }
     }
 
     async fn raw_revocation(
@@ -415,6 +491,128 @@ mod tests {
 
         assert_eq!(verified.issuer, member.did());
         assert_eq!(verified.authority, RevocationAuthority::PathIssuer);
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_a_peer_revocation_of_a_link_the_signer_does_not_hold() {
+        let account = fanned_out_account().await;
+        let target = account.chrome_chain.proof_cids()[0];
+        let verified = verify(
+            &mint_peer_revocation(
+                account.safari.clone(),
+                &account.chrome_chain,
+                &target,
+                &account.safari_chain,
+            )
+            .await
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(verified.target_cid, target.to_string());
+        assert_eq!(verified.issuer, account.safari.did());
+        assert_eq!(verified.authority, RevocationAuthority::Peer);
+    }
+
+    #[dialog_common::test]
+    async fn it_verifies_a_peer_revocation_of_the_recovery_anchor() {
+        let account = fanned_out_account().await;
+        let target = account.safari_chain.proof_cids()[0];
+        let verified = verify(
+            &mint_peer_revocation(
+                account.chrome.clone(),
+                &account.safari_chain,
+                &target,
+                &account.chrome_chain,
+            )
+            .await
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(verified.issuer, account.chrome.did());
+        assert_eq!(verified.authority, RevocationAuthority::Peer);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_peer_authority_from_another_account() {
+        let account = fanned_out_account().await;
+        let outsider = signer(20).await;
+        let other_root = signer(21).await;
+        let other_chain = crate::delegation::mint_device_delegation(other_root, &outsider.did())
+            .await
+            .unwrap();
+        let target = account.chrome_chain.proof_cids()[0];
+        let bytes =
+            mint_delegated_revocation(outsider, &account.chrome_chain, &target, &other_chain)
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            verify(&bytes).await,
+            Err(VerifyError::Unauthorized(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_peer_authority_over_a_subject_specific_invite() {
+        let (space, _, _, path) = invite_path().await;
+        let bystander = signer(7).await;
+        let membership = DelegationBuilder::new()
+            .issuer(space.clone())
+            .audience(&bystander.did())
+            .subject(Subject::Specific(space.did()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let membership = DelegationChain::new(membership);
+        let target = path.proof_cids()[0];
+
+        assert!(
+            mint_peer_revocation(bystander.clone(), &path, &target, &membership)
+                .await
+                .is_err(),
+            "an invite path is subject-specific and has no peers"
+        );
+
+        let bytes = mint_delegated_revocation(bystander, &path, &target, &membership)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&bytes).await,
+            Err(VerifyError::Unauthorized(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_to_mint_a_peer_revocation_without_account_proofs() {
+        let account = fanned_out_account().await;
+        let outsider = signer(20).await;
+        let other_root = signer(21).await;
+        let other_chain = crate::delegation::mint_device_delegation(other_root, &outsider.did())
+            .await
+            .unwrap();
+        let target = account.chrome_chain.proof_cids()[0];
+
+        assert!(
+            mint_peer_revocation(outsider, &account.chrome_chain, &target, &other_chain)
+                .await
+                .is_err()
+        );
+        assert!(
+            mint_peer_revocation(
+                account.chrome.clone(),
+                &account.chrome_chain,
+                &target,
+                &account.safari_chain,
+            )
+            .await
+            .is_err(),
+            "proofs must reach the signing credential"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -7,6 +7,7 @@ use dialog_ucan_core::DelegationChain;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
+use tonk_identity::delegation::GrantError;
 use tonk_worker_api::{PasskeyMetadata, RootStatus, SaveRootRequest};
 
 use super::AppState;
@@ -47,32 +48,14 @@ pub(crate) async fn validate_grant(
 ) -> Result<DelegationChain, TonkWorkerError> {
     let chain = DelegationChain::try_from(bytes.as_slice())
         .map_err(|error| TonkWorkerError::Router(format!("invalid root delegation: {error}")))?;
-    if chain.proof_cids().len() != 1 {
-        return Err(TonkWorkerError::Router(
-            "root delegation must contain exactly one proof".to_string(),
-        ));
-    }
-    if chain.audience() != device_did {
-        return Err(TonkWorkerError::Forbidden(
-            "root delegation audience is not the current profile".to_string(),
-        ));
-    }
-    if chain.subject().is_some() {
-        return Err(TonkWorkerError::Router(
-            "root delegation must be subject-open".to_string(),
-        ));
-    }
-    let proof = chain.proofs().next().expect("one-proof chain");
-    if !proof.command().0.is_empty() {
-        return Err(TonkWorkerError::Router(
-            "root delegation must be command-open".to_string(),
-        ));
-    }
-    proof
-        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+    tonk_identity::delegation::validate_account_grant(&chain, device_did)
         .await
-        .map_err(|error| {
-            TonkWorkerError::Forbidden(format!("invalid root delegation signature: {error}"))
+        .map_err(|error| match error {
+            GrantError::Shape(message) => TonkWorkerError::Router(message),
+            GrantError::Audience(_) => TonkWorkerError::Forbidden(
+                "root delegation audience is not the current profile".to_string(),
+            ),
+            GrantError::Signature(message) => TonkWorkerError::Forbidden(message),
         })?;
     Ok(chain)
 }


### PR DESCRIPTION
One account, several passkeys, none of them the account. The full design is
in `plan/passkey-fanout.md`; this is the specification of what the branch
makes true.

## Identity

An account's subject is an Ed25519 keypair generated during genesis and
destroyed before genesis returns. Nothing holds it afterwards.

A passkey's PRF output derives a **credential key** — the same derivation as
today, `tonk/root-key/v1`, unchanged. What changes is its meaning: it is one
credential among peers rather than the account itself.

Every credential reaches the subject through a chain of subject-open,
command-open delegations. A device reaches it through a credential. Depth is
not fixed and carries no meaning: `root → C1 → device`,
`root → recovery → C2 → device` and longer are equally valid.

## Genesis

The subject signs, in this order, and is then dropped:

1. the account repository descriptor (unchanged v1 format),
2. `root → C1`, to the first passkey's credential key,
3. `root → recovery`, to the account service's anchor DID.

**Anchor invariant.** Because the subject is destroyed, every direct
`root → x` delegation that will ever exist is minted here. Afterwards a new
anchor is reachable only by an existing credential delegating one. An account
that leaves genesis without a recovery anchor can never be given one except
through a live credential.

## Enrollment

A credential is enrolled by receiving a subject-open delegation. Two paths
produce one, and a credential may hold chains from both:

- **Anchor path**, the flow a person walks. The service verifies a one-time
  code sent to the account address, mints `recovery → Cn` under its genesis
  proof, publishes it, and mails the account address that it did. Requires
  nothing but the new passkey — no second device.
- **Sibling path**, taken opportunistically when a credential is reachable
  anyway. `Ca → Cn`, minted locally, no service involved. Never a step the
  person is asked to perform.

Anchor issuance is gated on the code **even when the caller already holds a
valid chain**. An anchor chain outlives revocation of whatever enrolled it,
so gating on "holds a chain" would let a briefly compromised passkey mint
itself a successor that survives being revoked.

## Chain store

A device that has just derived `Cn` holds nothing else — not the subject, not
a delegation, and not the account repository, whose sync authority is the
thing it is looking for. It asks what has been addressed to the one key it
has.

- `POST /enrollments` publishes a chain. Unauthenticated: the bytes are
  signed and self-authenticating, so publishing confers nothing.
- `GET /enrollments/{credential_did}` returns every chain addressed to that
  key. Unauthenticated: knowing a DID is not authority, and a delegation is
  useless without the matching private key.

The store can withhold an entry. It cannot forge, alter, or grant by holding
one. Every entry also belongs in the account repository, so the user or a
competing provider can serve the same bytes.

Publication additionally requires that this service hosts the account the
chain runs from. That is anti-abuse — the chain itself already settles who
may enrol — and keeps the bucket from being open storage.

## Revocation

Verification is unchanged in mechanism: a valid, unrevoked chain from the
subject to the invoker, any one of several. What is added is an authority
class, because neither existing class covers a peer withdrawing a link it
does not depend on — Safari holding only `root → recovery → safari` has no
standing over `root → chrome` under either.

- **Peer** — the signer presents its own currently-valid chain from the same
  subject-open authority the target answers to.

Gated on the witnessed path being subject-open, so space invites, which are
subject-specific, keep the narrower classes and the two delegation shapes
stay distinct.

## Positions this takes

**The recovery anchor is a delegation, not an authority.** It is a real
keypair whose standing comes from one visible link the user can cut. This is
deliberately not storacha's `ucan/attest`, which roots the equivalent power
in the service's own DID, where no verifier can decline it and no user can
revoke it. They need that indirection because `did:mailto` cannot sign; an
anchor holding a key does not.

**Email control becomes account control.** That is the cost of the anchor
path being the flow, and it is stated rather than mitigated away. The
containments are that the link is revocable by any peer and that every
issuance is announced to the account address.

**Losing the email and every passkey loses the account.** There is no
service-side key beyond the anchor the user already sees in their own chain.

## Not in this branch

The enrollment log and the revocation walk that reads it; the seniority rule
for mutual revocation; browser wiring for any of these ceremonies; v1
accounts publishing `subject → recovery` at sign-in.

Two decisions are deliberately unmade and recorded in the plan: whether
`Peer` is admissible at the account service's device-revocation gate, and
whether the enrollment log is an authority source for account-level acts.
The second blocks the first.

Separately, and predating this work: revocation artifacts are screened
globally by target CID, so anyone holding a delegation's bytes can prepend a
link they mint and qualify as `PathIssuer` over it. Untouched here and
described in the plan's status section.

## Deployment

`RECOVERY_ANCHOR_SEED` is a per-environment worker secret, 32 bytes hex, set
with `wrangler secret put` — deliberately absent from `wrangler.account.toml`
so production, staging and preview hold different anchors. Without it every
other route behaves normally and `GET /` omits `recoveryAnchor`. No new
bindings, buckets or migrations: enrollment objects share the existing
`CHAINS` bucket under their own prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAfmVJYm3tHXZmYToJQqnE


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `tonk-account-service`, focusing on enrollment functionalities, error handling, and the integration of a new `zeroize` dependency for secure key management. It also refines email handling and adds new enrollment routes.

### Detailed summary
- Added `pub mod enrollment` to `src/core.rs`.
- Introduced `zeroize` dependency in `Cargo.toml`.
- Enhanced email handling with `send_enrollment_notice`.
- Added new routes for enrollment: `handle_publish`, `handle_confirm`, `handle_claim`.
- Implemented `R2EnrollmentStore` for managing enrollments.
- Refined error handling and response structures.
- Updated `build_anchor` and `build_enrollments` functions.
- Improved tests for enrollment and delegation functionalities.

> The following files were skipped due to too many changes: `rust/tonk-account-service/src/core/enrollment.rs`, `rust/tonk-account-service/tests/service.rs`, `rust/tonk-account-service/src/enrollments.rs`, `plan/passkey-fanout.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->