### PR TITLE
fix(diagnose): make the tree inspector show what the tree actually holds

### DIFF
--- a/rust/dialog-reactor/src/formula.rs
+++ b/rust/dialog-reactor/src/formula.rs
@@ -22,12 +22,13 @@ use std::collections::BTreeMap;
 
 use base58::{FromBase58, ToBase58};
 use dialog_artifacts::inspect::{
-    EntrySummary, KeyComponent, KeySummary, NodeSummary, SpanSummary, inspect_entries,
-    inspect_keys, inspect_node, inspect_spans, key_components, separator_components,
+    EntrySummary, KeyComponent, KeySummary, NodeSummary, SpanSummary, inspect_blob_records,
+    inspect_entries, inspect_keys, inspect_manifest, inspect_node, inspect_spans, key_components,
+    separator_components,
 };
 use dialog_artifacts::{
-    ATTRIBUTE_KEY_TAG, Artifact, Datum, DialogArtifactsError, ENTITY_KEY_TAG, Key, VALUE_KEY_TAG,
-    Value,
+    ATTRIBUTE_KEY_TAG, Artifact, COVERAGE_KEY_TAG, Datum, DialogArtifactsError, ENTITY_KEY_TAG,
+    HISTORY_KEY_TAG, Key, VALUE_KEY_TAG, Value,
 };
 use dialog_query::Term;
 use dialog_repository::{
@@ -224,6 +225,34 @@ fn node_fields(bytes: &[u8]) -> Result<BTreeMap<String, Ipld>, FormulaError> {
     fields.insert("kind".into(), Ipld::String(summary.kind.into()));
     fields.insert("size".into(), Ipld::Integer(summary.size as i128));
     fields.insert("count".into(), Ipld::Integer(summary.count as i128));
+    // The subtree's advisory scale code (a log-scale entry-count estimate)
+    // and the hitchhiker ops buffered on this node — the two numbers that
+    // explain the tree's SHAPE rather than its contents. Novelty is always
+    // 0 for a segment; it is reported anyway so the field never vanishes.
+    fields.insert("scale".into(), Ipld::Integer(summary.scale as i128));
+    fields.insert("novelty".into(), Ipld::Integer(summary.novelty as i128));
+    // Every node embeds the manifest it was written under, so the
+    // configuration that produced this shape is readable off the node
+    // itself rather than assumed from the current defaults.
+    if let Ok(manifest) = inspect_manifest(bytes.to_vec()) {
+        let mut m: BTreeMap<String, Ipld> = BTreeMap::new();
+        m.insert("version".into(), Ipld::Integer(manifest.version as i128));
+        m.insert("fanout".into(), Ipld::Integer(1i128 << manifest.fanout_n));
+        m.insert(
+            "max-separator".into(),
+            Ipld::Integer(manifest.max_separator as i128),
+        );
+        m.insert("inline".into(), Ipld::Integer(manifest.inline_n as i128));
+        m.insert(
+            "spill-prefix".into(),
+            Ipld::Integer(manifest.spill_prefix as i128),
+        );
+        m.insert(
+            "max-segment".into(),
+            Ipld::Integer(manifest.max_segment as i128),
+        );
+        fields.insert("manifest".into(), Ipld::Map(m));
+    }
     if summary.kind == "segment" {
         let keys: Vec<KeySummary> = inspect_keys(bytes.to_vec())?;
         if let Some(last) = keys.last() {
@@ -334,7 +363,7 @@ async fn entry_rows<Env: SelectProvider>(
         return Ok(vec![]); // an index has no entries
     }
     let keys: Vec<KeySummary> = inspect_keys(bytes.clone())?;
-    let entries: Vec<EntrySummary> = inspect_entries(bytes)?;
+    let entries: Vec<EntrySummary> = inspect_entries(bytes.clone())?;
 
     let mut rows = Vec::with_capacity(entries.len());
     for entry in entries {
@@ -348,12 +377,46 @@ async fn entry_rows<Env: SelectProvider>(
             fields.insert("rank".into(), Ipld::Integer(key.rank as i128));
         }
 
+        // The index a key belongs to, read off its leading tag. A segment
+        // holds more than entity-attribute-value facts: history and
+        // coverage records, blob-index records. Naming the ordering lets
+        // the inspector render each for what it is instead of trying to
+        // read them all as facts.
+        let ordering = entry
+            .key
+            .first()
+            .copied()
+            .map(tag_name)
+            .unwrap_or("unknown");
+        fields.insert("ordering".into(), Ipld::String(ordering.into()));
+
+        // Claim metadata: which version wrote the entry, what it descends
+        // from, and how much was folded into it. This is what makes a
+        // history or coverage record legible — a covering record is the
+        // one that supersedes prior versions.
+        if !entry.origin.is_empty() {
+            fields.insert("origin".into(), Ipld::String(bytes_hex(&entry.origin)));
+        }
+        fields.insert("edition".into(), Ipld::Integer(entry.edition as i128));
+        fields.insert("cause".into(), Ipld::Integer(entry.cause as i128));
+        fields.insert("collapsed".into(), Ipld::Integer(entry.collapsed as i128));
+        fields.insert("supersedes".into(), Ipld::Integer(entry.supersedes as i128));
+        fields.insert("retraction".into(), Ipld::Bool(entry.retraction));
+        if let Some(spill) = &entry.spill {
+            fields.insert("spill".into(), Ipld::String(to_base58(spill)));
+        }
+
         // A segment holds asserted facts; a retraction is a tombstone. The
         // entity/attribute/value all live IN the key (the datum carries only
         // causal metadata), so reconstruct the fact from the key — standing
         // in a placeholder for a spilled value, since the inspector has no
-        // store to fetch the block. The synthesized datum carries no cause;
-        // the inspector doesn't render one.
+        // store to fetch the block.
+        //
+        // Only EAV-shaped keys reconstruct. A history, coverage or blob
+        // key decodes to no artifact, and treating that as fatal used to
+        // abort the WHOLE entry list — one history record and the segment
+        // rendered empty. Such an entry keeps its key components and
+        // metadata and simply reports no fact.
         if entry.state == "removed" {
             fields.insert("retracted".into(), Ipld::Bool(true));
         } else {
@@ -366,16 +429,16 @@ async fn entry_rows<Env: SelectProvider>(
                 supersedes: Vec::new(),
                 retraction: false,
             };
-            let artifact = Artifact::from_key_datum_placeholder(&key, &datum)
-                .map_err(|e| FormulaError::Decode(e.to_string()))?;
-            fields.insert("entity".into(), Ipld::String(artifact.of.to_string()));
-            fields.insert("attribute".into(), Ipld::String(artifact.the.to_string()));
-            fields.insert(
-                "type".into(),
-                Ipld::String(artifact.is.data_type().to_string()),
-            );
-            if let Some(ipld) = value_to_ipld(&artifact.is) {
-                fields.insert("value".into(), ipld);
+            if let Ok(artifact) = Artifact::from_key_datum_placeholder(&key, &datum) {
+                fields.insert("entity".into(), Ipld::String(artifact.of.to_string()));
+                fields.insert("attribute".into(), Ipld::String(artifact.the.to_string()));
+                fields.insert(
+                    "type".into(),
+                    Ipld::String(artifact.is.data_type().to_string()),
+                );
+                if let Some(ipld) = value_to_ipld(&artifact.is) {
+                    fields.insert("value".into(), ipld);
+                }
             }
         }
 
@@ -383,6 +446,25 @@ async fn entry_rows<Env: SelectProvider>(
             this: key_hex,
             fields,
         });
+    }
+
+    // Blob-index entries carry no claim metadata, so they come back from
+    // the entry walk with everything empty; their real payload (the
+    // referenced hash, its size and record version) lives in a parallel
+    // index. Merge it in by segment position so a blob row is a blob row
+    // rather than an entry that appears to say nothing.
+    for record in inspect_blob_records(bytes)? {
+        if let Some(row) = rows
+            .iter_mut()
+            .find(|row| row.fields.get("at") == Some(&Ipld::Integer(record.at as i128)))
+        {
+            row.fields
+                .insert("blob".into(), Ipld::String(bytes_hex(&record.blob)));
+            row.fields
+                .insert("blob-size".into(), Ipld::Integer(record.size as i128));
+            row.fields
+                .insert("blob-version".into(), Ipld::Integer(record.version as i128));
+        }
     }
     Ok(rows)
 }
@@ -431,23 +513,151 @@ fn key_parts(bytes: &[u8]) -> Vec<Ipld> {
 /// so the outline's left edge reads in the right hue — `\0concept:J4J64…`
 /// shows as `concept:J4J64…` in entity-blue rather than structural gray.
 fn separator_parts(bytes: &[u8]) -> Vec<Ipld> {
-    let lead_kind = match bytes.first() {
-        Some(&ENTITY_KEY_TAG) => "entity",
-        Some(&ATTRIBUTE_KEY_TAG) => "attribute",
-        Some(&VALUE_KEY_TAG) => "value",
-        _ => "opaque",
-    };
     separator_components(bytes)
         .iter()
-        .map(|component| match component.kind {
-            "prefix" => component_part(&KeyComponent {
-                kind: lead_kind,
-                text: component.text.clone(),
-                bytes: component.bytes.clone(),
-            }),
-            _ => component_part(component),
+        .flat_map(|component| match component.kind {
+            "prefix" => prefix_fields(bytes.first().copied(), component),
+            _ => vec![component_part(component)],
         })
         .collect()
+}
+
+/// Split a separator's front-coded `prefix` into the key FIELDS it spans.
+///
+/// Dialog reports everything after the tag as one opaque `prefix`, but a
+/// separator is a truncated key: its bytes are the leading fields of a
+/// real key, NUL-delimited, cut wherever the prefix ends. Painting the
+/// whole run one colour mislabels it — `db:concept␀db.meta/concept␀d`
+/// showed as a single entity when it is an entity, an attribute, and the
+/// first byte of the next entity. Split on the delimiters and colour each
+/// field by its position in the ordering, so a separator reads with the
+/// same colour code as a full key.
+///
+/// The final field is usually truncated mid-value (that is the point of
+/// front-coding), so it is reported as-is; the key's own components would
+/// be wrong to synthesize here.
+fn prefix_fields(tag: Option<u8>, component: &KeyComponent) -> Vec<Ipld> {
+    // Field order per index, mirroring dialog's `key_components`: the
+    // ordering's leading sort column comes first.
+    let order: &[&str] = match tag {
+        Some(ENTITY_KEY_TAG) => &["entity", "attribute", "vtype", "value"],
+        Some(ATTRIBUTE_KEY_TAG) => &["attribute", "entity", "vtype", "value"],
+        Some(VALUE_KEY_TAG) => &["vtype", "value", "attribute", "entity"],
+        // A history or coverage separator opens with a 32-byte origin
+        // and an 8-byte big-endian edition — raw binary, which renders
+        // as a run of overlapping control glyphs if passed through as
+        // text. Report them as the version they encode.
+        Some(HISTORY_KEY_TAG) | Some(COVERAGE_KEY_TAG) => {
+            return version_fields(&component.bytes);
+        }
+        // An unknown tag has no field layout at all, so leave it opaque
+        // rather than colouring it by a layout it does not have.
+        _ => return vec![component_part(component)],
+    };
+
+    // In value-ordering the key opens with a one-byte VALUE TYPE tag
+    // rather than a NUL-delimited field, so it has to be peeled off
+    // before splitting — otherwise it fuses with the value that follows
+    // and every later field lands one slot early (an attribute showing
+    // up where the value belongs).
+    let mut parts = Vec::new();
+    let mut rest = component.bytes.as_slice();
+    let mut next = 0usize;
+    if tag == Some(VALUE_KEY_TAG)
+        && let Some((vtype, tail)) = rest.split_first()
+    {
+        parts.push(component_part(&KeyComponent {
+            kind: "vtype",
+            text: value_type_name(*vtype),
+            bytes: vec![*vtype],
+        }));
+        rest = tail;
+        next = 1;
+    }
+
+    parts.extend(
+        rest.split(|b| *b == 0)
+            .filter(|field| !field.is_empty())
+            .enumerate()
+            .map(|(index, field)| {
+                component_part(&KeyComponent {
+                    kind: order.get(next + index).copied().unwrap_or("opaque"),
+                    text: String::from_utf8_lossy(field).into_owned(),
+                    bytes: field.to_vec(),
+                })
+            }),
+    );
+    parts
+}
+
+/// Decode a history/coverage separator's leading bytes into readable
+/// version fields: a 32-byte origin and an 8-byte big-endian edition.
+///
+/// Front-coding truncates anywhere, so each field is emitted only if
+/// wholly present; whatever follows the version is the EAV tail, which
+/// is reported as one component rather than guessed at.
+fn version_fields(bytes: &[u8]) -> Vec<Ipld> {
+    const ORIGIN: usize = 32;
+    const EDITION: usize = 8;
+
+    let mut parts = Vec::new();
+    let Some(origin) = bytes.get(..ORIGIN) else {
+        // Too short to carry a whole origin — nothing decodable.
+        return vec![component_part(&KeyComponent {
+            kind: "opaque",
+            text: bytes_hex(bytes),
+            bytes: bytes.to_vec(),
+        })];
+    };
+    parts.push(component_part(&KeyComponent {
+        kind: "origin",
+        text: format!("origin:{}", bytes_hex(origin).trim_start_matches("0x")),
+        bytes: origin.to_vec(),
+    }));
+
+    let rest = &bytes[ORIGIN..];
+    if let Some(edition) = rest.get(..EDITION) {
+        let n = edition.iter().fold(0u64, |acc, b| (acc << 8) | *b as u64);
+        parts.push(component_part(&KeyComponent {
+            kind: "edition",
+            text: format!("@{n}"),
+            bytes: edition.to_vec(),
+        }));
+        let tail = &rest[EDITION..];
+        if !tail.is_empty() {
+            parts.push(component_part(&KeyComponent {
+                kind: "entity",
+                text: String::from_utf8_lossy(tail).into_owned(),
+                bytes: tail.to_vec(),
+            }));
+        }
+    } else if !rest.is_empty() {
+        parts.push(component_part(&KeyComponent {
+            kind: "opaque",
+            text: bytes_hex(rest),
+            bytes: rest.to_vec(),
+        }));
+    }
+    parts
+}
+
+/// The human name of a value-type tag, matching what dialog's own
+/// `key_components` renders for a `vtype` component (which formats the
+/// decoded [`ValueDataType`]). The tags are the enum's discriminants.
+fn value_type_name(tag: u8) -> String {
+    match tag {
+        0 => "Bytes",
+        1 => "Entity",
+        2 => "Boolean",
+        3 => "String",
+        4 => "UnsignedInt",
+        5 => "SignedInt",
+        6 => "Float",
+        7 => "Record",
+        8 => "Symbol",
+        _ => return format!("type {tag}"),
+    }
+    .to_owned()
 }
 
 /// Resolve the required `key` input: a `0x`-prefixed hex string of the raw
@@ -521,4 +731,113 @@ fn bytes_hex(bytes: &[u8]) -> String {
         s.push_str(&format!("{b:02x}"));
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// Read a component list back as `(kind, text)` pairs.
+    fn kinds(parts: &[Ipld]) -> Vec<(String, String)> {
+        parts
+            .iter()
+            .map(|part| {
+                let Ipld::Map(m) = part else {
+                    panic!("component must be a map")
+                };
+                let get = |k: &str| match m.get(k) {
+                    Some(Ipld::String(s)) => s.clone(),
+                    other => panic!("{k} must be a string, got {other:?}"),
+                };
+                (get("kind"), get("text"))
+            })
+            .collect()
+    }
+
+    /// A separator is a front-coded prefix spanning SEVERAL key fields,
+    /// NUL-delimited. Painting the run one colour mislabels it — the
+    /// reported symptom was `db:concept␀db.meta/concept␀d` rendering as
+    /// a single entity when it is an entity, an attribute, and the first
+    /// byte of the next field.
+    #[dialog_common::test]
+    fn it_splits_an_entity_separator_into_its_fields() {
+        let mut bytes = vec![ENTITY_KEY_TAG];
+        bytes.extend_from_slice(b"concept:J4J64\0db.concept.with/n");
+
+        let parts = kinds(&separator_parts(&bytes));
+
+        assert_eq!(
+            parts,
+            vec![
+                ("index".to_owned(), "entity".to_owned()),
+                ("entity".to_owned(), "concept:J4J64".to_owned()),
+                ("attribute".to_owned(), "db.concept.with/n".to_owned()),
+            ]
+        );
+    }
+
+    /// Value ordering opens with a one-byte VALUE TYPE tag rather than a
+    /// NUL-delimited field. Splitting without peeling it off fuses it to
+    /// the value that follows and shifts every later field one slot
+    /// early — the attribute then lands where the value belongs.
+    #[dialog_common::test]
+    fn it_peels_the_value_type_tag_before_splitting() {
+        let mut bytes = vec![VALUE_KEY_TAG];
+        bytes.push(1); // ValueDataType::Entity
+        bytes.extend_from_slice(b"db:concept\0db.meta/concept\0d");
+
+        let parts = kinds(&separator_parts(&bytes));
+
+        assert_eq!(
+            parts,
+            vec![
+                ("index".to_owned(), "value".to_owned()),
+                ("vtype".to_owned(), "Entity".to_owned()),
+                ("value".to_owned(), "db:concept".to_owned()),
+                ("attribute".to_owned(), "db.meta/concept".to_owned()),
+                ("entity".to_owned(), "d".to_owned()),
+            ]
+        );
+    }
+
+    /// A history separator opens with a 32-byte origin and an 8-byte
+    /// big-endian edition. Passed through as text those render as a run
+    /// of overlapping control glyphs, so they decode to the version they
+    /// encode instead.
+    #[dialog_common::test]
+    fn it_decodes_a_history_separator_as_a_version() {
+        let mut bytes = vec![HISTORY_KEY_TAG];
+        bytes.extend_from_slice(&[0xab; 32]);
+        bytes.extend_from_slice(&7u64.to_be_bytes());
+
+        let parts = kinds(&separator_parts(&bytes));
+
+        assert_eq!(parts[0], ("index".to_owned(), "history".to_owned()));
+        assert_eq!(parts[1].0, "origin");
+        assert!(
+            parts[1].1.starts_with("origin:abab"),
+            "origin renders as hex, got {:?}",
+            parts[1].1
+        );
+        assert_eq!(parts[2], ("edition".to_owned(), "@7".to_owned()));
+    }
+
+    /// Front-coding truncates anywhere, so a separator may carry only
+    /// part of the version. A partial origin stays opaque rather than
+    /// being decoded from bytes that are not all there.
+    #[dialog_common::test]
+    fn it_leaves_a_truncated_history_separator_opaque() {
+        let mut bytes = vec![HISTORY_KEY_TAG];
+        bytes.extend_from_slice(&[0xab; 8]); // short of a whole origin
+
+        let parts = kinds(&separator_parts(&bytes));
+
+        assert_eq!(parts[0], ("index".to_owned(), "history".to_owned()));
+        assert_eq!(parts[1].0, "opaque");
+    }
 }

--- a/rust/tonk-analyzer/src/analysis.rs
+++ b/rust/tonk-analyzer/src/analysis.rs
@@ -291,6 +291,9 @@ pub enum AnalyzeLowerError {
     /// `Claim`s on the structured transact wire (yet).
     #[error("rule applications cannot be lowered to a transact claim")]
     Rule,
+    /// A `tree/*` resolver — read-only, so it has no claim form.
+    #[error("resolver applications are read-only and cannot be lowered to a transact claim")]
+    Resolver,
     /// A bare `xyz.tonk/...` domain claim — no concept descriptor
     /// to carry on the predicate.
     #[error("domain applications cannot be lowered to a transact claim")]
@@ -322,6 +325,9 @@ fn lower_statement(
         Application::Rule { .. } | Application::DeductiveRule { .. } => {
             return Err(AnalyzeLowerError::Rule);
         }
+        // Read-only: a resolver heads a query, never a mutation, so it
+        // never reaches the transact wire.
+        Application::Resolver { .. } => return Err(AnalyzeLowerError::Resolver),
     };
     let this = query.terms.get("this").and_then(term_entity);
     let descriptor = query.predicate.clone();

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -67,7 +67,10 @@ pub use error::{
     AnalyzeDiagnostic, AnalyzeDiagnosticKind, AnalyzeError, AnalyzeErrorKind, DiagnosticSeverity,
 };
 pub use formula::{FormulaCompletion, formula_completions};
-pub use resolver_registry::{ResolverCompletion, resolver_completions};
+pub use resolver_registry::{
+    ResolverCompletion, ResolverOperand, resolver_completions, resolver_operands,
+};
+pub use rule::builtin_kind;
 pub use scan::scan_variables;
 
 use tonk_schema::concept::QueryEnv;
@@ -569,6 +572,7 @@ fn predicate_of(application: &Application, transient: bool) -> Predicate {
         Application::Rule { .. } | Application::DeductiveRule { .. } => {
             Predicate::Domain("rule".to_owned())
         }
+        Application::Resolver { query, .. } => Predicate::Domain(query.name().to_owned()),
     }
 }
 
@@ -713,6 +717,11 @@ fn synthesize_implicit_queries(document: &mut DocumentAnalysis) {
             // synthesised one.
             Application::Rule { .. } | Application::DeductiveRule { .. } => unreachable!(
                 "rule applications should have been filtered out by the matches! check"
+            ),
+            // Snapshots read back what a MUTATION touched; a resolver
+            // is read-only, so it never appears among them.
+            Application::Resolver { .. } => unreachable!(
+                "resolver applications are read-only and never produce a mutation to snapshot"
             ),
         };
         // Reuse the assertion's head name so the rendered
@@ -1799,6 +1808,37 @@ concept!: &a
             matches!(err.kind, AnalyzeErrorKind::DuplicateName { .. }),
             "expected DuplicateName, got {err:?}"
         );
+    }
+
+    /// A concept declared under a built-in's name → `ReservedName`.
+    ///
+    /// Premise heads resolve formulas, constraints and resolvers
+    /// before concepts, so such a concept could never be referenced:
+    /// every mention would silently mean the built-in. Reporting it
+    /// at the declaration is the only place the user can still act.
+    #[dialog_common::test]
+    async fn it_rejects_a_concept_named_after_a_builtin() {
+        for reserved in ["tree/node", "math/sum"] {
+            let syntax = must_parse(&format!(
+                r#"
+concept!: &{reserved}
+  with:
+    tag:
+      the: x.y/tag
+      as: Text
+      cardinality: one
+      description: "T"
+"#
+            ));
+            let err = match analyze_empty(&syntax).await {
+                Err(err) => err,
+                Ok(_) => panic!("`{reserved}` must be rejected as a concept name"),
+            };
+            assert!(
+                matches!(err.kind, AnalyzeErrorKind::ReservedName { .. }),
+                "expected ReservedName for {reserved:?}, got {err:?}"
+            );
+        }
     }
 
     /// An anchor and a `this: ?var` that share a name →

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -257,6 +257,19 @@ pub enum AnalyzeErrorKind {
         /// The name that was duplicated.
         name: String,
     },
+    /// A concept was declared under a name a built-in premise
+    /// already claims. Premise heads resolve built-ins before
+    /// concepts, so the declaration would be unreachable.
+    #[error(
+        "{name:?} is a built-in {kind} — a concept declared under that name could never be referenced; pick another name"
+    )]
+    ReservedName {
+        /// The name that collides with a built-in.
+        name: String,
+        /// What kind of built-in claims it: `formula`, `constraint`,
+        /// or `resolver`.
+        kind: &'static str,
+    },
     /// An anchor and a `?variable` are used with the same name —
     /// they share the same namespace.
     #[error("name {name:?} is used as both an anchor declaration and a variable — pick one")]
@@ -515,6 +528,7 @@ impl AnalyzeErrorKind {
             Self::AssertionWithoutFields { .. } => "E_ASSERTION_WITHOUT_FIELDS",
             Self::InvalidAttributeBody { .. } => "E_INVALID_ATTRIBUTE_BODY",
             Self::InvalidConceptBody { .. } => "E_INVALID_CONCEPT_BODY",
+            Self::ReservedName { .. } => "E_RESERVED_NAME",
             Self::UnknownConcept { .. } => "E_UNKNOWN_CONCEPT",
             Self::UnknownField { .. } => "E_UNKNOWN_FIELD",
             Self::DuplicateConceptField { .. } => "E_DUPLICATE_CONCEPT_FIELD",

--- a/rust/tonk-analyzer/src/analyzer/query.rs
+++ b/rust/tonk-analyzer/src/analyzer/query.rs
@@ -10,6 +10,7 @@ use tonk_notation::{Application as SyntaxApplication, Field, HeadName};
 use super::assertion::derive_head_intent;
 use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::field::{field_value_to_term, is_meta_field, validate_claim_attribute};
+use super::resolver_registry::{ResolverInfo, lookup_resolver};
 use super::scope::Scope;
 use crate::analyzer::Working;
 use tonk_schema::transact::{Application, DomainApplication, ThisIntent};
@@ -26,6 +27,12 @@ pub(crate) fn build_query_application(
     let head_range = query.predicate.range;
     match &query.predicate.name {
         HeadName::Concept(concept_name) => {
+            // A `tree/*` resolver reads the store's own structure, so it
+            // heads a query like a concept does — but it resolves from
+            // dialog's resolver registry rather than the branch.
+            if let Some(resolver) = lookup_resolver(concept_name) {
+                return build_resolver_query(query, resolver, scope, analysis);
+            }
             let resolved = scope.concept(concept_name).ok_or_else(|| {
                 AnalyzeError::at(
                     AnalyzeErrorKind::UnknownConcept {
@@ -144,6 +151,66 @@ pub(crate) fn build_query_application(
             head_range,
         )),
     }
+}
+
+/// Build a resolver query head (`tree/node:`, `tree/entry:`, …).
+///
+/// The body's fields are the resolver's operands, exactly as in premise
+/// position: unknown ones are rejected against dialog's own schema, and
+/// the ones a document omits stay unbound — a resolver's outputs are
+/// values it produces, not requirements. Only its required input must
+/// be bound, which dialog's planner enforces.
+fn build_resolver_query(
+    query: &SyntaxApplication,
+    resolver: &ResolverInfo,
+    scope: &Scope,
+    analysis: &Working,
+) -> Result<Application, AnalyzeError> {
+    let mut terms = Parameters::new();
+    for field in &query.fields {
+        if is_meta_field(&field.name) {
+            continue;
+        }
+        if !resolver.operands().any(|operand| operand == field.name) {
+            let mut valid: Vec<&str> = resolver.operands().collect();
+            valid.sort_unstable();
+            return Err(AnalyzeError::at(
+                AnalyzeErrorKind::UnknownFormulaOperand {
+                    formula: resolver.name.to_owned(),
+                    operand: field.name.clone(),
+                    valid: valid.join(", "),
+                },
+                field.name_range,
+            ));
+        }
+        let term = field_value_to_term(
+            &field.name,
+            &field.value,
+            field.value_range,
+            scope,
+            analysis,
+            None,
+        )?;
+        terms.insert(field.name.clone(), term);
+    }
+
+    // Route through serde by name, the same way premises do, so the
+    // analyzer never names resolver types by hand.
+    let value = serde_json::json!({ "assert": resolver.name, "where": terms });
+    let resolver_query: dialog_query::ResolverQuery =
+        serde_json::from_value(value).map_err(|e| {
+            AnalyzeError::at(
+                AnalyzeErrorKind::UnknownConcept {
+                    name: format!("{} ({e})", resolver.name),
+                },
+                query.predicate.range,
+            )
+        })?;
+
+    Ok(Application::Resolver {
+        query: Box::new(resolver_query),
+        terms,
+    })
 }
 
 fn this_term_for_query(this: &ThisIntent) -> Term<dialog_query::Any> {

--- a/rust/tonk-analyzer/src/analyzer/resolver_registry.rs
+++ b/rust/tonk-analyzer/src/analyzer/resolver_registry.rs
@@ -29,20 +29,49 @@ use std::sync::OnceLock;
 
 use dialog_query::ResolverQuery;
 
-/// One built-in resolver: its formal name plus its operand names.
+/// One operand of a resolver, as dialog's own schema describes it.
+#[derive(Clone)]
+pub struct ResolverOperand {
+    /// The operand name, written as a key under the premise's `where:`.
+    pub name: String,
+    /// Dialog's one-line description of what this operand carries.
+    pub description: String,
+    /// Whether the operand is a *required input* — a term that must
+    /// already be bound when the premise runs, rather than one the
+    /// resolver produces. `of` is required on every `tree/*` resolver:
+    /// they select by content address, so there is nothing to scan.
+    pub required: bool,
+}
+
+/// One built-in resolver: its formal name plus its operands.
 pub(crate) struct ResolverInfo {
     /// The formal name — the string [`ResolverQuery`] serializes under
     /// and the name a premise's `assert:` must carry (e.g. `tree/node`).
     pub name: &'static str,
-    /// The resolver's operand names, read off the dialog type's schema.
-    pub operands: Vec<String>,
+    /// The resolver's operands, read off the dialog type's schema.
+    pub operands: Vec<ResolverOperand>,
 }
 
 impl ResolverInfo {
     /// Operand names in this resolver's schema, unordered.
     pub fn operands(&self) -> impl Iterator<Item = &str> {
-        self.operands.iter().map(String::as_str)
+        self.operands.iter().map(|o| o.name.as_str())
     }
+}
+
+/// The operands of a built-in resolver, for completing keys under a
+/// resolver premise's `where:`. `None` for names that aren't resolvers.
+///
+/// Sorted with required inputs first, then alphabetically — the
+/// required term is the one a document cannot omit, so it leads.
+pub fn resolver_operands(name: &str) -> Option<Vec<ResolverOperand>> {
+    let mut operands = lookup_resolver(name)?.operands.clone();
+    operands.sort_by(|a, b| {
+        b.required
+            .cmp(&a.required)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Some(operands)
 }
 
 /// Look up a built-in resolver by its formal name. Returns `None` for
@@ -106,8 +135,16 @@ fn build_registry() -> Vec<ResolverInfo> {
         let query: ResolverQuery =
             serde_json::from_value(serde_json::json!({ "assert": name, "where": {} }))
                 .unwrap_or_else(|e| panic!("dialog resolver {name:?} must deserialize: {e}"));
-        let mut operands: Vec<String> = query.schema().iter().map(|(k, _)| k.clone()).collect();
-        operands.sort_unstable();
+        let mut operands: Vec<ResolverOperand> = query
+            .schema()
+            .iter()
+            .map(|(name, field)| ResolverOperand {
+                name: name.clone(),
+                description: field.description().to_owned(),
+                required: field.requirement().is_required(),
+            })
+            .collect();
+        operands.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         ResolverInfo {
             name: query.name(),
             operands,
@@ -159,6 +196,39 @@ mod tests {
                 "`{name}` keys on `of`; saw {operands:?}"
             );
         }
+    }
+
+    /// Operands carry dialog's own descriptions and requiredness, so
+    /// the editor can tell an input that must be bound apart from a
+    /// binding the resolver produces. `of` is the required one on
+    /// every `tree/*` resolver, and it must sort first.
+    #[dialog_common::test]
+    fn it_describes_resolver_operands() {
+        let operands = resolver_operands("tree/node").expect("`tree/node` is a resolver");
+
+        let of = &operands[0];
+        assert_eq!(of.name, "of", "the required input must lead");
+        assert!(
+            of.required,
+            "`of` selects by content address, so it is an input"
+        );
+        assert!(
+            !of.description.is_empty(),
+            "operand descriptions come off dialog's schema"
+        );
+
+        let kind = operands
+            .iter()
+            .find(|o| o.name == "kind")
+            .expect("`tree/node` reports a node kind");
+        assert!(!kind.required, "`kind` is produced, not supplied");
+        assert!(!kind.description.is_empty());
+    }
+
+    /// Names that are not resolvers have no operands to offer.
+    #[dialog_common::test]
+    fn it_offers_no_operands_for_non_resolvers() {
+        assert!(resolver_operands("person").is_none());
     }
 
     /// A name that is not a resolver falls through, so the caller can

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -623,6 +623,24 @@ fn parse_rule_body(application: &SyntaxApplication) -> Result<RuleBody<'_>, Anal
 /// Formulas and constraints are recognised first — they're fixed
 /// sets that never live on the branch, so the registry lookups are
 /// authoritative. Anything else resolves as a concept.
+/// What kind of built-in claims `name`, if any.
+///
+/// Premise heads resolve built-ins before concepts (see
+/// [`lift_premise`]), so this is also the authority on which names a
+/// concept may not take: anything this reports is unreachable as a
+/// concept name.
+pub fn builtin_kind(name: &str) -> Option<&'static str> {
+    if lookup_formula(name).is_some() {
+        Some("formula")
+    } else if lookup_constraint(name).is_some() {
+        Some("constraint")
+    } else if lookup_resolver(name).is_some() {
+        Some("resolver")
+    } else {
+        None
+    }
+}
+
 fn lift_premise(
     premise: &NotationPremise,
     scope: &Scope,

--- a/rust/tonk-analyzer/src/analyzer/scope.rs
+++ b/rust/tonk-analyzer/src/analyzer/scope.rs
@@ -12,6 +12,7 @@ use dialog_artifacts::Entity;
 use parking_lot::Mutex;
 
 use super::error::{AnalyzeError, AnalyzeErrorKind};
+use super::rule::builtin_kind;
 use tonk_schema::resolution::{AttributeDefinition, ConceptDefinition};
 use tonk_schema::rule::Rule;
 
@@ -100,6 +101,20 @@ impl Scope {
         entity: Entity,
         range: lsp_types::Range,
     ) -> Result<(), AnalyzeError> {
+        // Premise heads resolve built-in formulas, constraints and
+        // resolvers before concepts, so a declaration under one of
+        // their names could never be referenced — every mention would
+        // silently mean the built-in. Reject it here, at the one
+        // chokepoint every declaration passes through.
+        if let Some(kind) = builtin_kind(name) {
+            return Err(AnalyzeError::at(
+                AnalyzeErrorKind::ReservedName {
+                    name: name.to_owned(),
+                    kind,
+                },
+                range,
+            ));
+        }
         if self.variables.lock().contains_key(name) {
             return Err(AnalyzeError::at(
                 AnalyzeErrorKind::NameShadowing {

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -34,6 +34,23 @@ impl TestSite {
         })
     }
 
+    /// The base58 reference of this branch's current tree root.
+    ///
+    /// A resolver selects by content address, so `tree/*` needs this
+    /// bound before it can run. Real documents reach it by joining
+    /// through the branch revision; tests that are pinning resolver
+    /// behavior rather than the join read it directly.
+    pub async fn tree_root(&self) -> Result<String> {
+        let session = self.site.branch().await?;
+        let revision = session
+            .handle()
+            .revision()
+            .ok_or_else(|| anyhow::anyhow!("branch has no revision yet"))?;
+        // `TreeReference` displays as `#<base58>`; the resolver takes
+        // the bare reference.
+        Ok(revision.tree.to_string().trim_start_matches('#').to_owned())
+    }
+
     pub async fn eval_inline(&self, doc: &str) -> Result<eval::Outcome, eval::EvalError> {
         eval::run_against_site(
             &self.site,

--- a/rust/tonk-cli/tests/live_migration.rs
+++ b/rust/tonk-cli/tests/live_migration.rs
@@ -163,3 +163,54 @@ concept!: &alert
 
     Ok(())
 }
+
+/// A `tree/*` resolver is usable as a top-level query head, not just
+/// inside a rule premise.
+///
+/// The inspector reads the store's structure through these; going
+/// through the evaluate endpoint (rather than the worker's bespoke
+/// `tree/*` formula interception) is what makes tree state ordinary
+/// queryable data — joinable, subscribable, composable.
+#[dialog_common::test]
+async fn it_answers_a_top_level_resolver_query() -> Result<()> {
+    let test = common::TestSite::new().await?;
+
+    // Something durable, so the tree has a root worth describing.
+    test.eval_inline(
+        r#"concept!: &marker
+  with:
+    tag:
+      the: live.check/marker-tag
+      as: text
+      cardinality: one
+      description: "tag"
+"#,
+    )
+    .await?;
+    test.eval_inline("marker!: &one\n  tag: \"hi\"\n").await?;
+
+    // The resolver selects by content address, so its `of` must be
+    // bound. A document reaches the root by joining through the
+    // branch's revision; here the reference is read back directly so
+    // the test pins the resolver, not the join.
+    let root = test.tree_root().await?;
+    let rows = test
+        .eval_inline(&format!("tree/node:\n  of: \"{root}\"\n  kind: ?kind\n"))
+        .await?
+        .stdout;
+
+    // The root of a tree holding real facts is a branch node, and the
+    // resolver must bind `?kind` to say so. Asserting the resolved
+    // value (not merely that some row came back) is what makes this
+    // fail if the resolver is reached but answers with nothing.
+    assert!(
+        rows.contains(r#"kind: "index""#),
+        "the resolver must bind ?kind to the root node's kind; saw:\n{rows}"
+    );
+    assert!(
+        rows.contains(&root),
+        "the row must describe the node that was asked for; saw:\n{rows}"
+    );
+
+    Ok(())
+}

--- a/rust/tonk-evaluator/src/evaluate.rs
+++ b/rust/tonk-evaluator/src/evaluate.rs
@@ -902,6 +902,13 @@ fn render_block(
     application: &Application,
     source_frames: &[Parameters],
 ) -> QueryMatchBlock {
+    // A resolver has no concept descriptor — its shape is its own
+    // operand slots — so it renders through its own path rather than
+    // borrowing a descriptor's field list.
+    if let Application::Resolver { query, terms } = application {
+        return render_resolver_block(label, query, terms, source_frames);
+    }
+
     let descriptor = match application {
         Application::Concept { query: q, .. } => q.predicate.clone(),
         Application::Domain { application: d, .. } => ConceptQuery::from(d.clone()).predicate,
@@ -915,6 +922,7 @@ fn render_block(
                 results: Vec::new(),
             };
         }
+        Application::Resolver { .. } => unreachable!("handled above"),
     };
 
     // Variable names this expression binds — used to dedupe rows.
@@ -922,7 +930,9 @@ fn render_block(
     let terms = match application {
         Application::Concept { query: q, .. } => &q.terms,
         Application::Domain { application: d, .. } => &d.parameters,
-        Application::Rule { .. } | Application::DeductiveRule { .. } => {
+        Application::Rule { .. }
+        | Application::DeductiveRule { .. }
+        | Application::Resolver { .. } => {
             unreachable!("filtered above")
         }
     };
@@ -965,8 +975,10 @@ fn render_one_result(
     let terms = match application {
         Application::Concept { query: q, .. } => &q.terms,
         Application::Domain { application: d, .. } => &d.parameters,
-        Application::Rule { .. } | Application::DeductiveRule { .. } => {
-            unreachable!("render_one_result is not called for rule applications")
+        Application::Rule { .. }
+        | Application::DeductiveRule { .. }
+        | Application::Resolver { .. } => {
+            unreachable!("render_one_result is not called for rule or resolver applications")
         }
     };
 
@@ -1009,6 +1021,67 @@ fn render_one_result(
     }
 
     QueryResult { this, fields }
+}
+
+/// Render a resolver expression's rows.
+///
+/// A resolver row is slot→value with no entity of its own, so `this`
+/// stays empty and every bound operand becomes a field. Rows dedupe on
+/// the same variables the concept path uses, so a resolver joined into
+/// a document behaves like any other expression.
+fn render_resolver_block(
+    label: String,
+    query: &dialog_query::ResolverQuery,
+    terms: &Parameters,
+    source_frames: &[Parameters],
+) -> QueryMatchBlock {
+    let _ = query;
+    let mut my_vars: Vec<String> = Vec::new();
+    for (_, term) in terms.iter() {
+        if let Term::Variable {
+            name: Some(name), ..
+        } = term
+            && !my_vars.contains(name)
+        {
+            my_vars.push(name.clone());
+        }
+    }
+
+    let mut seen = std::collections::HashSet::<Vec<String>>::new();
+    let mut results = Vec::new();
+    for frame in source_frames {
+        let mut key = Vec::with_capacity(my_vars.len());
+        for var in &my_vars {
+            key.push(match frame.get(var) {
+                Some(Term::Constant(v)) => format!("{v:?}"),
+                _ => String::new(),
+            });
+        }
+        if !seen.insert(key) {
+            continue;
+        }
+
+        let mut fields = BTreeMap::new();
+        for (slot, term) in terms.iter() {
+            let value = match term {
+                Term::Constant(value) => value_to_json(value),
+                Term::Variable {
+                    name: Some(name), ..
+                } => match frame.get(name) {
+                    Some(Term::Constant(value)) => value_to_json(value),
+                    _ => continue,
+                },
+                _ => continue,
+            };
+            fields.insert(slot.to_owned(), value);
+        }
+        results.push(QueryResult {
+            this: String::new(),
+            fields,
+        });
+    }
+
+    QueryMatchBlock { label, results }
 }
 
 fn value_to_json(value: &Value) -> serde_json::Value {

--- a/rust/tonk-language-server/src/server.rs
+++ b/rust/tonk-language-server/src/server.rs
@@ -282,6 +282,10 @@ impl Server {
             out
         } else if is_variable_position(&line_prefix) {
             variable_completions(text, position)
+        } else if is_body_position(&line_prefix)
+            && let Some(resolver) = enclosing_resolver(text, position)
+        {
+            resolver_operand_completions(&resolver)
         } else if let Some(head) = enclosing_head(text, position)
             && is_body_position(&line_prefix)
         {
@@ -829,6 +833,72 @@ fn enclosing_head(text: &str, position: lsp_types::Position) -> Option<String> {
     None
 }
 
+/// The resolver name governing the `where:` block the cursor sits
+/// in, if any.
+///
+/// A resolver premise nests two ways — as a rule premise
+///
+/// ```yaml
+/// when:
+///   - assert: tree/node
+///     where:
+///       <cursor>
+/// ```
+///
+/// where [`enclosing_head`] would report the enclosing `rule`, not
+/// the resolver. So walk up looking for the nearest `assert:` line
+/// whose value names a resolver, stopping at a blank line (which
+/// ends the block) exactly as `enclosing_head` does.
+fn enclosing_resolver(text: &str, position: lsp_types::Position) -> Option<String> {
+    let line_index = position.line as usize;
+    let prior: Vec<&str> = text.split('\n').take(line_index).collect();
+    for line in prior.into_iter().rev() {
+        let trimmed = line.strip_suffix('\r').unwrap_or(line);
+        if trimmed.trim().is_empty() {
+            return None;
+        }
+        let body = trimmed.trim_start();
+        let body = body.strip_prefix('-').map_or(body, str::trim_start);
+        if let Some(value) = body.strip_prefix("assert:") {
+            // A quoted name (`">"`) is a constraint, never a
+            // resolver, and the quotes are not part of the name.
+            let name = value.trim().trim_matches(['"', '\'']);
+            return tonk_analyzer::analyzer::resolver_operands(name).map(|_| name.to_owned());
+        }
+    }
+    None
+}
+
+/// Operand names a resolver's `where:` block accepts, carrying
+/// dialog's own descriptions. Required inputs are labelled as such
+/// and sort first: `of` must be bound for the premise to run at
+/// all, so offering it indistinguishably from a produced binding
+/// would invite a query that cannot be planned.
+fn resolver_operand_completions(name: &str) -> Vec<CompletionItem> {
+    use lsp_types::{CompletionItemKind, Documentation};
+
+    let Some(operands) = tonk_analyzer::analyzer::resolver_operands(name) else {
+        return Vec::new();
+    };
+
+    operands
+        .into_iter()
+        .enumerate()
+        .map(|(index, operand)| CompletionItem {
+            label: operand.name.clone(),
+            kind: Some(CompletionItemKind::FIELD),
+            detail: operand.required.then(|| "required input".to_owned()),
+            documentation: (!operand.description.is_empty())
+                .then_some(Documentation::String(operand.description)),
+            // Preserve the required-first order the registry sorted
+            // into; clients otherwise re-sort by label.
+            sort_text: Some(format!("{index:03}")),
+            insert_text: Some(format!("{}: ", operand.name)),
+            ..CompletionItem::default()
+        })
+        .collect()
+}
+
 /// Field names declared by the head's concept descriptor, plus
 /// the always-available `this:` meta-key. Looks up the concept
 /// in the built-in registry first; falls back to resolving
@@ -889,12 +959,22 @@ async fn head_completions<O: Opened + ?Sized>(opened: Option<&O>) -> Vec<Complet
         out.push(CompletionItem {
             label: (*name).to_owned(),
             kind: Some(CompletionItemKind::CLASS),
+            // Name the namespace. In `assert:` position concepts share
+            // the list with formulas, constraints and resolvers, and
+            // the names can collide (`tree/node` is a resolver, and a
+            // branch could publish a concept spelled the same) — the
+            // label alone does not say which one you are accepting.
+            detail: Some("concept".to_owned()),
             documentation: definition
                 .descriptor
                 .concept()
                 .description()
                 .map(|d| Documentation::String(d.to_owned())),
             insert_text: Some((*name).to_owned()),
+            // Concepts sort ahead of built-ins: they are what a
+            // document mostly names, and the built-in sets are small
+            // and fixed.
+            sort_text: Some(format!("1{name}")),
             ..CompletionItem::default()
         });
     }
@@ -966,9 +1046,10 @@ fn formula_completions_items() -> Vec<CompletionItem> {
         .map(|formula| CompletionItem {
             label: formula.name.to_owned(),
             kind: Some(CompletionItemKind::FUNCTION),
-            detail: Some(formula.detail.clone()),
+            detail: Some("formula".to_owned()),
             documentation: Some(Documentation::String(formula.detail)),
             insert_text: Some(formula.name.to_owned()),
+            sort_text: Some(format!("2{}", formula.name)),
             ..CompletionItem::default()
         })
         .collect()
@@ -987,8 +1068,9 @@ fn constraint_completions_items() -> Vec<CompletionItem> {
         .map(|constraint| CompletionItem {
             label: constraint.name.to_owned(),
             kind: Some(CompletionItemKind::OPERATOR),
-            detail: Some(constraint.detail.clone()),
+            detail: Some("constraint".to_owned()),
             documentation: Some(Documentation::String(constraint.detail)),
+            sort_text: Some(format!("2{}", constraint.name)),
             // Insert the notation form, not the bare name: an
             // unquoted `>` would parse as a folded scalar.
             insert_text: Some(constraint.insert.clone()),
@@ -1013,9 +1095,10 @@ fn resolver_completions_items() -> Vec<CompletionItem> {
             // computing a value, so it presents as a function-like
             // premise head, the same as a formula.
             kind: Some(CompletionItemKind::FUNCTION),
-            detail: Some(resolver.detail.clone()),
+            detail: Some("resolver".to_owned()),
             documentation: Some(Documentation::String(resolver.detail)),
             insert_text: Some(resolver.name.to_owned()),
+            sort_text: Some(format!("2{}", resolver.name)),
             ..CompletionItem::default()
         })
         .collect()
@@ -1664,6 +1747,171 @@ mod tests {
         assert_eq!(insert_for(">"), "\">\"");
         assert_eq!(insert_for(">="), "\">=\"");
         assert_eq!(insert_for("<"), "<");
+    }
+
+    /// Names collide across namespaces — `tree/node` is a resolver,
+    /// and nothing stops a branch publishing a concept spelled the
+    /// same. In `assert:` position all four namespaces share one
+    /// list, so every item must say which namespace it came from or
+    /// the user cannot tell what they are accepting.
+    #[dialog_common::test]
+    async fn it_labels_the_namespace_of_each_premise_completion() {
+        let mut server = Server::new();
+        let _ = run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": { "capabilities": {} }
+            }),
+        )
+        .await;
+        let text = "rule!:\n  assert!: counter\n  when:\n    - assert: ";
+        run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": "tonk-buffer:///test",
+                        "languageId": "carry-asserted",
+                        "version": 1,
+                        "text": text
+                    }
+                }
+            }),
+        )
+        .await;
+        let _ = server.take_outbound();
+        let reply = run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "textDocument/completion",
+                "params": {
+                    "textDocument": { "uri": "tonk-buffer:///test" },
+                    "position": { "line": 3, "character": 14 }
+                }
+            }),
+        )
+        .await
+        .expect("response");
+        let items = reply["result"]["items"].as_array().expect("items array");
+
+        let detail_for = |name: &str| -> String {
+            items
+                .iter()
+                .find(|i| i["label"].as_str() == Some(name))
+                .and_then(|i| i["detail"].as_str())
+                .unwrap_or_default()
+                .to_owned()
+        };
+
+        assert_eq!(detail_for("tree/node"), "resolver");
+        assert_eq!(detail_for("math/sum"), "formula");
+        assert_eq!(detail_for("=="), "constraint");
+        assert_eq!(detail_for("concept"), "concept");
+    }
+
+    /// Inside a resolver premise's `where:`, the offered keys are the
+    /// resolver's own operands — read off dialog's schema, carrying
+    /// its descriptions, with the required input first. Without this
+    /// the block completes to nothing, since a resolver has no
+    /// concept descriptor to read fields from.
+    #[dialog_common::test]
+    async fn it_offers_resolver_operands_inside_a_premise_where_block() {
+        let mut server = Server::new();
+        let _ = run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": { "capabilities": {} }
+            }),
+        )
+        .await;
+        let text =
+            "rule!:\n  assert!: alert\n  when:\n    - assert: tree/node\n      where:\n        ";
+        run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": "tonk-buffer:///test",
+                        "languageId": "carry-asserted",
+                        "version": 1,
+                        "text": text
+                    }
+                }
+            }),
+        )
+        .await;
+        let _ = server.take_outbound();
+        let reply = run(
+            &mut server,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "textDocument/completion",
+                "params": {
+                    "textDocument": { "uri": "tonk-buffer:///test" },
+                    "position": { "line": 5, "character": 8 }
+                }
+            }),
+        )
+        .await
+        .expect("response");
+        let items = reply["result"]["items"].as_array().expect("items array");
+        let labels: Vec<&str> = items
+            .iter()
+            .map(|i| i["label"].as_str().unwrap_or_default())
+            .collect();
+
+        for operand in ["of", "kind", "size", "count"] {
+            assert!(
+                labels.contains(&operand),
+                "expected `{operand}` among tree/node operands, got {labels:?}"
+            );
+        }
+
+        let of = items
+            .iter()
+            .find(|i| i["label"].as_str() == Some("of"))
+            .expect("`of` is offered");
+        assert_eq!(
+            of["detail"].as_str(),
+            Some("required input"),
+            "`of` must be marked as the term that has to be bound"
+        );
+        assert!(
+            of["documentation"].as_str().is_some_and(|d| !d.is_empty()),
+            "operand docs come off dialog's schema"
+        );
+    }
+
+    /// A quoted constraint is not a resolver. `- assert: ">"` names
+    /// the range predicate, so its `where:` must fall through to the
+    /// ordinary path rather than being read as a resolver named `>`.
+    #[dialog_common::test]
+    fn it_does_not_read_a_quoted_constraint_as_a_resolver() {
+        let text = "rule!:\n  when:\n    - assert: \">\"\n      where:\n        ";
+        let position = lsp_types::Position {
+            line: 4,
+            character: 8,
+        };
+        assert_eq!(enclosing_resolver(text, position), None);
+
+        let resolver = "rule!:\n  when:\n    - assert: tree/span\n      where:\n        ";
+        assert_eq!(
+            enclosing_resolver(resolver, position).as_deref(),
+            Some("tree/span")
+        );
     }
 
     /// Accepting a namespaced completion over a typed partial name

--- a/rust/tonk-notation/guide.md
+++ b/rust/tonk-notation/guide.md
@@ -700,3 +700,27 @@ reference feeds the next node lookup:
 
 Operands you leave out are simply not bound, exactly as with a
 formula's outputs; only the required input (`of:`) must be given.
+
+A resolver also heads a query on its own, not just a rule premise:
+
+```yaml
+tree/node:
+  of: "8QsR69j39jU7acb4H9VfsSpR2SrHJ6f2PPKHoosnsAPr"
+  kind: ?kind
+```
+
+### Built-in names are reserved
+
+Premise heads resolve built-ins — formulas, predicates, resolvers —
+before concepts. A concept declared under one of those names could
+never be referenced, since every mention would mean the built-in, so
+declaring one is an error rather than a silent shadowing:
+
+```yaml
+concept!: &tree/node   # error: "tree/node" is a built-in resolver
+```
+
+In the editor each `assert:` completion is labelled with the
+namespace it comes from (`concept`, `formula`, `constraint`,
+`resolver`), and a resolver's `where:` block completes to that
+resolver's own operands, with the required input listed first.

--- a/rust/tonk-schema/src/concept.rs
+++ b/rust/tonk-schema/src/concept.rs
@@ -908,6 +908,19 @@ impl Application for AnonymousConceptQuery {
 /// Stable empty descriptor used as the unused `predicate` slot of
 /// the synthetic [`ConceptQuery`] in
 /// [`AnonymousConceptQuery::realize`].
+/// The entity a resolver row reports as its `this`.
+///
+/// Resolver rows describe blocks, not entities, so there is no real
+/// subject to report — but a `ConceptConclusion` requires one. Naming
+/// the resolver (`db:tree/node`) keeps it honest: the identity says
+/// which resolver produced the row rather than pretending the row is
+/// a fact about some entity.
+fn resolver_row_entity(name: &str) -> Entity {
+    format!("db:{name}")
+        .parse()
+        .expect("a resolver name forms a valid `db:` entity URI")
+}
+
 fn stub_predicate() -> ConceptDescriptor {
     // A descriptor must have at least one required field, so the
     // stub carries a single placeholder. `realize` never reads the
@@ -1026,6 +1039,10 @@ pub enum QueryPlan {
     AnonymousCommand(AnonymousConceptQuery),
     /// Rule-of-rule enumeration via [`AnonymousRuleQuery`].
     AnonymousRule(AnonymousRuleQuery),
+    /// A `tree/*` resolver — dialog answers it by content address
+    /// over immutable blocks, so it describes the store's own
+    /// structure rather than the facts inside it.
+    Resolver(Box<dialog_query::ResolverQuery>),
 }
 
 /// Convert an [`Application`](crate::transact::Application) into
@@ -1040,6 +1057,7 @@ pub fn application_to_plan(application: crate::transact::Application) -> QueryPl
     match application {
         Application::Concept { query, .. } => QueryPlan::from(query),
         Application::Domain { application, .. } => QueryPlan::from(ConceptQuery::from(application)),
+        Application::Resolver { query, .. } => QueryPlan::Resolver(query),
         Application::Rule { .. } | Application::DeductiveRule { .. } => panic!(
             "rule applications have no QueryPlan projection — \
              rules are write-only via Statement::Assert/Retract"
@@ -1103,6 +1121,12 @@ impl Application for QueryPlan {
                         yield each?;
                     }
                 }
+                QueryPlan::Resolver(q) => {
+                    let stream = Application::evaluate(*q, selection, env);
+                    for await each in stream {
+                        yield each?;
+                    }
+                }
             }
         }
     }
@@ -1113,6 +1137,32 @@ impl Application for QueryPlan {
             QueryPlan::AnonymousConcept(q) => Application::realize(q, source),
             QueryPlan::AnonymousCommand(q) => Application::realize(q, source),
             QueryPlan::AnonymousRule(q) => Application::realize(q, source),
+            // A resolver row is slot→value with no entity of its own,
+            // while `ConceptConclusion` requires a bound `this` and
+            // keeps its fields private. The row's values travel in the
+            // `Match` (which is what the renderer reads), so the
+            // conclusion only needs to exist: give it the resolver's
+            // own subject reference as `this`, which is the closest
+            // thing a resolver row has to an identity.
+            QueryPlan::Resolver(q) => {
+                // A resolver row is slot→value describing a BLOCK, not
+                // a fact about an entity — and `ConceptConclusion`
+                // requires an Entity-typed `this`, while a resolver's
+                // subject is a content address (a base58 string). The
+                // row's values ride the `Match`, which is what the
+                // renderer reads, so the conclusion only needs a
+                // well-formed identity: name the resolver itself.
+                let mut terms = q.parameters().clone();
+                terms.insert(
+                    "this".to_string(),
+                    Term::Constant(Value::Entity(resolver_row_entity(q.name()))),
+                );
+                let synthetic = ConceptQuery {
+                    terms,
+                    predicate: stub_predicate(),
+                };
+                Application::realize(&synthetic, source)
+            }
         }
     }
 }

--- a/rust/tonk-schema/src/transact.rs
+++ b/rust/tonk-schema/src/transact.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 
 use crate::prelude::EntityExt;
 use crate::rule::{DeductiveRule, InductiveRule};
+use dialog_query::ResolverQuery;
 use indexmap::IndexMap;
 use serde::Serialize;
 use tonk_core::claim::{ConceptDescriptor, PredicateApplication, ValueMap};
@@ -192,6 +193,28 @@ pub enum Application {
         /// the content-addressed install.
         this: ThisIntent,
     },
+    /// A resolver head (`tree/node:`, `tree/entry:`, …) — a premise
+    /// dialog answers by content address over immutable blocks rather
+    /// than by scanning the mutable head.
+    ///
+    /// Read-only by construction: a resolver describes what storage
+    /// already holds, so there is nothing to assert. It reaches the
+    /// query path so the tree inspector can read the store's own
+    /// structure as ordinary query rows.
+    Resolver {
+        /// The resolver, already validated against dialog's schema.
+        query: Box<ResolverQuery>,
+        /// The resolver's operand terms.
+        ///
+        /// Carried alongside the query because `ResolverQuery`
+        /// rebuilds its parameter map on every call (its terms are
+        /// per-variant struct fields, not a stored map), so there is
+        /// nothing to borrow — and [`Application::parameters`] must
+        /// return a reference. Callers read this to learn which
+        /// variables the expression binds; an empty map here silently
+        /// yields no rows.
+        terms: Parameters,
+    },
 }
 
 impl Application {
@@ -205,6 +228,10 @@ impl Application {
             Self::Concept { query, .. } => &query.terms,
             Self::Domain { application, .. } => &application.parameters,
             Self::Rule { .. } | Self::DeductiveRule { .. } => empty_parameters(),
+            // A resolver's operands ARE its parameters: callers read
+            // them to learn which variables the expression binds, so
+            // returning an empty set here silently yields no rows.
+            Self::Resolver { terms, .. } => terms,
         }
     }
 
@@ -215,6 +242,9 @@ impl Application {
             | Self::Domain { this, .. }
             | Self::Rule { this, .. }
             | Self::DeductiveRule { this, .. } => this,
+            // A resolver keys on its own `of:` reference, never on a
+            // `this:` entity.
+            Self::Resolver { .. } => &ThisIntent::Derived,
         }
     }
 
@@ -225,7 +255,7 @@ impl Application {
             Self::Concept { name, .. } | Self::Domain { name, .. } => {
                 name.as_ref().map(AnchorName::as_str)
             }
-            Self::Rule { .. } | Self::DeductiveRule { .. } => None,
+            Self::Rule { .. } | Self::DeductiveRule { .. } | Self::Resolver { .. } => None,
         }
     }
 
@@ -401,6 +431,15 @@ impl Planner for Application {
             }))),
             Self::Rule { rule, .. } => Ok(ApplicationPlan::Rule(rule)),
             Self::DeductiveRule { rule, .. } => Ok(ApplicationPlan::DeductiveRule(rule)),
+            // Read-only by construction: a resolver describes what
+            // storage already holds, so it never reaches the mutation
+            // planner. The analyzer only ever builds one for a query
+            // head — an assertion with a resolver name resolves as a
+            // concept and fails there first.
+            Self::Resolver { .. } => unreachable!(
+                "a resolver is read-only — it has no mutation plan and \
+                 the analyzer never lifts one into an assertion"
+            ),
         }
     }
 }

--- a/rust/tonk-tree/src/inspector.rs
+++ b/rust/tonk-tree/src/inspector.rs
@@ -1,5 +1,5 @@
 //! The node inspector pane: the selected node's detail (full hash, size,
-//! count, storage, upper key) and, for a segment, its entries table.
+//! count, storage, separator) and, for a segment, its entries table.
 //! Values are formatted so their type is legible; clicking a fact row
 //! unfolds a detail view.
 
@@ -62,6 +62,15 @@ pub fn render(state: &Shared) {
     if let Some(rank) = node.rank {
         let _ = body.append_child(&kv("rank", &rank.to_string()));
     }
+    // Scale and novelty describe the node's SHAPE — how much the subtree
+    // is estimated to hold, and how much is buffered on it rather than
+    // written down. Both are what the root has to say about the tree.
+    if let Some(scale) = node.scale {
+        let _ = body.append_child(&kv("scale", &scale.to_string()));
+    }
+    if let Some(novelty) = node.novelty {
+        let _ = body.append_child(&kv("novelty", &novelty.to_string()));
+    }
     let _ = body.append_child(&kv(
         "storage",
         if node.cached {
@@ -71,8 +80,17 @@ pub fn render(state: &Shared) {
         },
     ));
 
+    // The configuration the node was written under, read off the node
+    // itself rather than assumed from today's defaults.
+    if !node.manifest.is_empty() {
+        let _ = body.append_child(&el("h3").text("manifest"));
+        for (label, value) in &node.manifest {
+            let _ = body.append_child(&kv(label, &value.to_string()));
+        }
+    }
+
     if !node.bound_parts.is_empty() {
-        let _ = body.append_child(&kv("upper key", ""));
+        let _ = body.append_child(&kv("separator", ""));
         let keyrow = el("div").class("keybytes");
         append_key_full(&keyrow, &node.bound_parts);
         let _ = body.append_child(&keyrow);
@@ -155,12 +173,20 @@ fn entry_table(entries: &[TreeEntry]) -> Element {
         let ent = el("td").class("col-ent");
         if let Some(e) = &entry.entity {
             ent.set_text_content(Some(&short(e, 14)));
+        } else if let Some(blob) = &entry.blob {
+            // A blob-index row has no entity — it references content.
+            ent.set_text_content(Some(&format!("blob:{}", short(blob, 10))));
         }
         let _ = tr.append_child(&ent);
 
-        let attr = el("td")
-            .class("col-attr")
-            .text(entry.attribute.as_deref().unwrap_or(""));
+        // A history, coverage or blob record has no attribute; naming
+        // its index there says what the row IS, instead of leaving the
+        // cell blank as though the record were malformed.
+        let attr = match (&entry.attribute, &entry.ordering) {
+            (Some(a), _) => el("td").class("col-attr").text(a),
+            (None, Some(ordering)) => el("td").class("col-attr col-ordering").text(ordering),
+            (None, None) => el("td").class("col-attr"),
+        };
         let _ = tr.append_child(&attr);
 
         let val_td = el("td").class("col-val");
@@ -174,6 +200,12 @@ fn entry_table(entries: &[TreeEntry]) -> Element {
                 .class(&format!("val val-{}", t.to_lowercase()))
                 .text(&trunc(&formatted, 40));
             let _ = val_td.append_child(&span);
+        } else if let Some(size) = entry.blob_size {
+            val_td.set_text_content(Some(&human_size(size)));
+        } else if entry.supersedes.is_some_and(|n| n > 0) {
+            // A covering record's payload IS how much it supersedes.
+            let n = entry.supersedes.unwrap_or(0);
+            val_td.set_text_content(Some(&format!("covers {n}")));
         }
         let _ = tr.append_child(&val_td);
 
@@ -213,6 +245,36 @@ fn entry_detail(entry: &TreeEntry) -> Element {
     if let Some(v) = &entry.value {
         let t = entry.type_name.as_deref().unwrap_or("");
         let _ = box_.append_child(&kv("value", &key::format_value(v, t)));
+    }
+    if let Some(ordering) = &entry.ordering {
+        let _ = box_.append_child(&kv("index", ordering));
+    }
+    // The claim version and its lineage. Zeroes are omitted: an ordinary
+    // fact carries none of this, and printing `cause 0` on every row
+    // would bury the records where it is the whole story.
+    if let (Some(origin), Some(edition)) = (&entry.origin, entry.edition) {
+        let _ = box_.append_child(&kv("version", &format!("{}@{edition}", short(origin, 12))));
+    }
+    for (label, value) in [
+        ("cause", entry.cause),
+        ("collapsed", entry.collapsed),
+        ("supersedes", entry.supersedes),
+    ] {
+        if let Some(n) = value.filter(|n| *n > 0) {
+            let _ = box_.append_child(&kv(label, &n.to_string()));
+        }
+    }
+    if entry.retraction {
+        let _ = box_.append_child(&kv("retraction", "yes"));
+    }
+    if let Some(spill) = &entry.spill {
+        let _ = box_.append_child(&kv("spilled to", spill));
+    }
+    if let Some(blob) = &entry.blob {
+        let _ = box_.append_child(&kv("blob", blob));
+        if let Some(size) = entry.blob_size {
+            let _ = box_.append_child(&kv("blob size", &human_size(size)));
+        }
     }
     let keyrow = el("div").class("keybytes");
     append_key_full(&keyrow, &entry.key_parts);

--- a/rust/tonk-tree/src/key.rs
+++ b/rust/tonk-tree/src/key.rs
@@ -105,7 +105,15 @@ pub fn components(parts: &[KeyPart]) -> Vec<Component> {
             "vtype" => (1usize, format!("Value type: {}", p.hex)),
             _ => (hex_len(&p.hex).max(1), label.to_owned()),
         };
-        let text = glyphs(&p.text);
+        // The index chip spells out its ordering (`entity`, `attribute`,
+        // `value`), but the segments that follow are already colour-coded
+        // by exactly that, and hovering gives the full name. The word is
+        // redundant noise in a dense key, so the chip keeps one letter.
+        let text = if p.kind == "index" {
+            initial(&p.text)
+        } else {
+            glyphs(&p.text)
+        };
         out.push(Component {
             label,
             part,
@@ -116,6 +124,15 @@ pub fn components(parts: &[KeyPart]) -> Vec<Component> {
         offset += len;
     }
     out
+}
+
+/// The single-character stand-in for an ordering name: its first letter,
+/// upper-cased (`entity` → `E`). The tooltip still carries the full name.
+fn initial(name: &str) -> String {
+    name.chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_default()
 }
 
 /// Title-case an ordering name for the index tooltip (`entity` → `Entity

--- a/rust/tonk-tree/src/model.rs
+++ b/rust/tonk-tree/src/model.rs
@@ -47,6 +47,14 @@ pub struct TreeNode {
     pub bound_parts: Vec<KeyPart>,
     pub rank: Option<u64>,
     pub cached: bool,
+    /// The subtree's advisory scale code — a log-scale estimate of how
+    /// many entries sit beneath this node.
+    pub scale: Option<u64>,
+    /// Hitchhiker ops buffered on this node (always 0 for a segment).
+    pub novelty: Option<u64>,
+    /// The format manifest the node embeds: the configuration that
+    /// produced this shape, as `(label, value)` rows in display order.
+    pub manifest: Vec<(String, u64)>,
 }
 
 /// One entry in a segment — the `tree/entry` shape.
@@ -59,6 +67,24 @@ pub struct TreeEntry {
     pub attribute: Option<String>,
     pub type_name: Option<String>,
     pub value: Option<serde_json::Value>,
+    /// Which index this key belongs to — `entity`, `attribute`,
+    /// `value`, `history`, `coverage`, or `blob`. A segment holds more
+    /// than facts, and only this says which kind a row is.
+    pub ordering: Option<String>,
+    /// Claim version: the origin half (hex) and the edition counter.
+    pub origin: Option<String>,
+    pub edition: Option<u64>,
+    /// Prior versions in this entry's cause, and how many were folded
+    /// into it. A covering record is the one that `supersedes` others.
+    pub cause: Option<u64>,
+    pub collapsed: Option<u64>,
+    pub supersedes: Option<u64>,
+    pub retraction: bool,
+    /// A spilled value's block reference, when the value did not inline.
+    pub spill: Option<String>,
+    /// For a blob-index row: the referenced hash and its size.
+    pub blob: Option<String>,
+    pub blob_size: Option<u64>,
 }
 
 /// Raw Conclusion row off the wire.
@@ -81,6 +107,31 @@ fn parts(map: &serde_json::Map<String, serde_json::Value>, k: &str) -> Vec<KeyPa
     map.get(k)
         .and_then(|v| serde_json::from_value::<Vec<KeyPart>>(v.clone()).ok())
         .unwrap_or_default()
+}
+
+/// The node's embedded manifest as ordered `(label, value)` rows. The
+/// order is the manifest's own reading order — format version first,
+/// then the parameters that decide the tree's shape — rather than the
+/// map's alphabetical one.
+fn manifest_rows(map: &serde_json::Map<String, serde_json::Value>) -> Vec<(String, u64)> {
+    let Some(m) = map.get("manifest").and_then(|v| v.as_object()) else {
+        return Vec::new();
+    };
+    [
+        "version",
+        "fanout",
+        "max-separator",
+        "inline",
+        "spill-prefix",
+        "max-segment",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        m.get(key)
+            .and_then(|v| v.as_u64())
+            .map(|value| (key.to_owned(), value))
+    })
+    .collect()
 }
 
 /// The worker-backed tree loader for a `{repo, branch}`. Cheap to clone
@@ -167,6 +218,9 @@ impl Loader {
             bound_parts: parts(f, "bound-parts"),
             rank: u(f, "rank"),
             cached: f.get("cached").and_then(|v| v.as_bool()) != Some(false),
+            scale: u(f, "scale"),
+            novelty: u(f, "novelty"),
+            manifest: manifest_rows(f),
         }
     }
 
@@ -200,6 +254,16 @@ impl Loader {
                     attribute: s(f, "attribute"),
                     type_name: s(f, "type"),
                     value: f.get("value").cloned(),
+                    ordering: s(f, "ordering"),
+                    origin: s(f, "origin"),
+                    edition: u(f, "edition"),
+                    cause: u(f, "cause"),
+                    collapsed: u(f, "collapsed"),
+                    supersedes: u(f, "supersedes"),
+                    retraction: f.get("retraction").and_then(|v| v.as_bool()) == Some(true),
+                    spill: s(f, "spill"),
+                    blob: s(f, "blob"),
+                    blob_size: u(f, "blob-size"),
                 }
             })
             .collect())

--- a/rust/tonk-tree/src/web.rs
+++ b/rust/tonk-tree/src/web.rs
@@ -663,13 +663,31 @@ pub fn register() {
 }
 
 const STYLE: &str = r#"
+/* The element is mounted bare inside a view fragment, so `height: 100%`
+   has nothing to resolve against — the ancestor chain is auto-height and
+   the panes grow to fit their content, scrolling the whole page instead
+   of themselves. Styling the route's `tonk-view > *` to fix that would
+   clobber other views' layout, so the bound lives here.
+
+   The route slot gives this element a definite height (see the
+   `.display-view-slot:has(tonk-tree)` rule in `tonk-ui/styles.css`),
+   so filling the parent is enough. `flex: 1 1 0` claims the space when
+   the parent is a flex column — which the guest body and the route
+   chain both are — and `min-height: 0` overrides a flex item's
+   automatic content-height minimum, the thing that otherwise lets the
+   panes push past the bottom edge. Each pane then has a definite
+   height to scroll within, independently of the other. */
 :host {
-  display: grid; grid-template-columns: 1.4fr 1fr; height: 100%;
-  min-height: 240px; color: var(--wa-color-text-normal);
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  flex: 1 1 0; min-height: 0; height: 100%;
+  box-sizing: border-box;
+  color: var(--wa-color-text-normal);
   font-family: var(--wa-font-family-code, ui-monospace, monospace);
   font-size: var(--wa-font-size-s, 13px);
 }
-.pane { overflow: auto; padding: var(--wa-space-m, 12px); }
+/* `min-height: 0` overrides the grid item's `auto` minimum, which would
+   otherwise floor each pane at its content height and defeat the scroll. */
+.pane { overflow: auto; min-height: 0; padding: var(--wa-space-m, 12px); }
 .pane.left { border-right: 1px solid var(--wa-color-border-quiet); }
 /* The outline runs at a smaller, denser size — closer to a D3 indented
    tree. The connectors are sized in `em`, so they tighten with it. The
@@ -784,9 +802,12 @@ wa-tree-item > .dot-leaf { position: absolute; z-index: 5;
 .key-seg.seg-entity { color: var(--tonk-circle, #3d6da8); }
 .key-seg.seg-attribute { color: var(--tonk-triangle, #c89a2b); }
 .key-seg.seg-value { color: var(--tonk-square, #b94a3d); }
-/* The value-TYPE tag reads as a distinct marker (a muted violet), so it never
-   blurs into the red value it precedes. */
-.key-seg.seg-vtype { color: #8a6ab0; font-weight: var(--wa-font-weight-normal, 400); }
+/* The value-TYPE tag belongs to the value it precedes, so it carries the
+   value color rather than a hue of its own — violet sat outside the
+   Bauhaus palette. Reduced opacity and the lighter weight keep it
+   subordinate to the value itself. */
+.key-seg.seg-vtype { color: var(--tonk-square, #b94a3d); opacity: 0.7;
+  font-weight: var(--wa-font-weight-normal, 400); }
 .key-seg.seg-unknown { color: var(--tonk-closure, #7a7268); }
 /* The index-type segment is neutral (the page's normal text color). */
 .key-seg.seg-index-type { color: var(--wa-color-text-normal); }
@@ -836,7 +857,8 @@ wa-tree-item > .dot-leaf { position: absolute; z-index: 5;
 .keybytes .key-seg.seg-entity { background: var(--tonk-circle, #3d6da8); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-attribute { background: var(--tonk-triangle, #c89a2b); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-value { background: var(--tonk-square, #b94a3d); color: light-dark(#000, #fff); }
-.keybytes .key-seg.seg-vtype { background: #8a6ab0; color: light-dark(#000, #fff); }
+.keybytes .key-seg.seg-vtype { background: var(--tonk-square, #b94a3d);
+  color: light-dark(#000, #fff); opacity: 0.7; }
 .keybytes .key-seg.seg-unknown { background: var(--tonk-closure, #7a7268); color: light-dark(#000, #fff); }
 .keybytes .key-seg.seg-index-type { background: light-dark(#000, #fff);
   color: light-dark(#fff, #000); }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -380,6 +380,22 @@ tonk-display > .site-pending:not([hidden]) {
     min-height: 0;
 }
 
+/* The tree inspector is a two-pane explorer whose panes scroll
+   INDEPENDENTLY, so it needs a definite height to scroll within — with
+   the slot's default `min-height: 100dvh` the panes grow to fit their
+   content and the whole page scrolls instead, pushing the right pane
+   past the bottom edge. Same shape as the workspace rule above: swap
+   the slot to a hard `height` when it contains the element, so the
+   height is fixed at the viewport rather than floored by it. Keyed on
+   the element (not on `tonk-view > *`, which would clobber sibling
+   views' layout). */
+.display-view-slot:has(tonk-tree) {
+    height: 100dvh;
+}
+.display-view-slot:has(tonk-tree) tonk-tree {
+    min-height: 0;
+}
+
 /* Tonk Hub page (`/`). A centered column: a header row with the
    "New repo" button and the "Repositories" title, then the space
    cards (the `space` directory view). The hub here owns its own


### PR DESCRIPTION
The `/diagnose` route was showing a fraction of what the search tree
holds, and mislabelling some of what it did show. Both causes were in
how entry keys get decoded, so this fixes the decode rather than the
presentation.

## Why

The history index rendered empty. Reconstructing a fact from an entry
key was fatal on failure (`from_key_datum_placeholder(...)?`), so the
first history, coverage or blob record aborted the whole entry list for
that segment. A segment holds more than entity-attribute-value facts,
and dialog's own entry walk never skips them — only ours did.

Separators were painted a single colour, which put fields in the wrong
slots: `db:concept␀db.meta/concept␀d` read as one entity when it is an
entity, an attribute, and the first byte of the next field. A separator
is a front-coded prefix spanning several NUL-delimited fields, and
value-ordering opens with a one-byte type tag that has to be peeled off
before splitting — without that every later field lands one slot early.
History separators lead with a binary origin and edition, which rendered
as a run of overlapping control glyphs.

## Approach

Decode each key by the layout its leading tag actually implies, and let
an entry that is not a fact still be an entry: it keeps its key
components and claim metadata and simply reports no fact. Nodes now also
report the numbers that explain the tree's shape rather than its
contents — scale, novelty, and the manifest each node embeds — and
entries report claim version and lineage, which is what makes a history
or coverage record legible.

Two presentation changes ride along: the key chips drop the spelled-out
ordering (the colour already encodes it, and the tooltip still spells it
out), and the value-type tag takes the value's own colour instead of a
violet that sat outside the palette.

The pane-scrolling fix follows the existing
`.display-view-slot:has(.workspace)` precedent — keyed on the element,
so it does not touch `tonk-view > *` and cannot disturb sibling views.

## Notes

The `tree/*` formulas are fixed here rather than replaced by the
resolvers now reachable through `/evaluate`. The resolvers do the same
decode work, so repointing the loader at them is a transport change
worth doing on its own — it is what would let tree state be subscribed
to and joined against — not something to bundle into a bug fix.

Verified in a browser against a live space: 588 history entries where
there were none, and the reported separator now splits correctly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the handling of resolvers in the codebase, introducing new functionality for resolver queries and improving the management of built-in names to prevent conflicts with concepts.

### Detailed summary
- Added `builtin_kind` function to identify built-in claims.
- Introduced `tree_root` function for resolver queries.
- Implemented error handling for reserved names in concepts.
- Enhanced resolver operand management with descriptions and required flags.
- Updated resolver query handling in the analyzer and evaluator.

> The following files were skipped due to too many changes: `rust/dialog-reactor/src/formula.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->