### PR TITLE
ci: publish immutable, content-named CLI releases

### DIFF
--- a/.github/workflows/cli-pin.yml
+++ b/.github/workflows/cli-pin.yml
@@ -1,0 +1,168 @@
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit, tag, or branch to build and publish (e.g. v0.6.7).'
+        required: true
+        type: string
+      tag:
+        description: 'Release tag to publish under. Defaults to `tonk-<source-tree-hash>`.'
+        required: false
+        type: string
+
+name: 'Pin CLI release'
+
+# Publish an immutable CLI release for a ref that predates automatic
+# pinning.
+#
+# `cli.yml` pins every build it runs, but only from the moment that
+# landed. Anything older has no pinned release and cannot get one from
+# that workflow: GitHub reads `workflow_dispatch` inputs from the file
+# *at the dispatched ref*, so dispatching an old tag fails with
+# "Unexpected inputs provided" — the input does not exist back there, and
+# history cannot be edited to add it.
+#
+# This workflow inverts that. It lives on the default branch, so its
+# inputs always exist, and it *checks out* the ref being published. That
+# makes any point in history publishable without rewriting it, which is
+# what a format migration needs: the export half of a migration runs
+# under the build that wrote the data.
+#
+# It never touches the rolling tags, so the stable and staging channels
+# are unaffected by anything published here.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: 'Build pinned CLI'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact-name: tonk-linux-x86_64
+          - os: macos-latest
+            artifact-name: tonk-macos-arm64
+    steps:
+      # The ref being published, not the branch this workflow lives on.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: wimpysworld/nothing-but-nix@main
+        if: runner.os == 'Linux'
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: 'Build tonk'
+        run: nix build --accept-flake-config .#tonk-cli
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: result/bin/tonk
+          overwrite: true
+      # The source-tree hash names the release when no tag is given. Only
+      # one leg records it: the source tree is platform-independent.
+      - name: 'Record the source-tree hash'
+        if: matrix.artifact-name == 'tonk-linux-x86_64'
+        run: |
+          mkdir -p tree
+          src="$(nix eval --raw --accept-flake-config .#tonk-cli.src)"
+          basename "$src" | cut -d- -f1 | cut -c1-12 > tree/tree.txt
+          cat tree/tree.txt
+      - uses: actions/upload-artifact@v4
+        if: matrix.artifact-name == 'tonk-linux-x86_64'
+        with:
+          name: tree
+          path: tree/tree.txt
+          overwrite: true
+
+  publish:
+    name: 'Publish pinned release'
+    needs: ['build']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # `install.sh` ships as a release asset, and the one that belongs
+      # with these binaries is the one from the same ref.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: tonk-macos-arm64
+          path: artifacts/macos-arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: tonk-linux-x86_64
+          path: artifacts/linux-x86_64
+      - uses: actions/download-artifact@v4
+        with:
+          name: tree
+          path: artifacts/tree
+      - name: Prepare release assets
+        run: |
+          # Archive each binary as `tonk` so it extracts ready to run,
+          # with the executable bit preserved across the download.
+          install -m 0755 artifacts/macos-arm64/tonk tonk
+          tar -czf tonk-macos-arm64.tar.gz tonk
+          rm tonk
+          install -m 0755 artifacts/linux-x86_64/tonk tonk
+          tar -czf tonk-linux-x86_64.tar.gz tonk
+          rm tonk
+          sha256sum tonk-macos-arm64.tar.gz tonk-linux-x86_64.tar.gz > checksums.txt
+          tree="$(cat artifacts/tree/tree.txt)"
+          version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
+            | grep -m1 '^version' \
+            | sed -E 's/.*"([^"]+)".*/\1/')"
+          cat > manifest.json <<EOF
+          {
+            "version": "$version",
+            "commit": "$(git rev-parse HEAD)",
+            "tree": "$tree",
+            "channel": "pinned",
+            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          python3 -c 'import json,sys; m=json.load(open("manifest.json")); [sys.exit(f"manifest missing {k}") for k in ("version","commit","tree","channel","built_at") if not m.get(k)]'
+          cat manifest.json
+          echo "tag=${{ inputs.tag }}" >> "$GITHUB_ENV"
+          if [ -z "${{ inputs.tag }}" ]; then
+            echo "tag=tonk-$tree" >> "$GITHUB_ENV"
+          fi
+      - name: Create pinned release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.tag }}
+          target_commitish: ${{ inputs.ref }}
+          name: tonk CLI ${{ env.tag }}
+          body: |
+            Immutable release of the tonk CLI built from `${{ inputs.ref }}`,
+            kept downloadable so data written by this build can always be
+            migrated forward.
+
+            ```
+            curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh \
+              | TONK_RELEASE=${{ env.tag }} sh
+            ```
+
+            On macOS the binary is unsigned. The install script clears the
+            Gatekeeper quarantine for you; if you extract by hand and macOS
+            blocks it, run `xattr -d com.apple.quarantine tonk`.
+          # Never the newest thing: this is history, and `make_latest`
+          # would point `releases/latest` at an older build.
+          prerelease: true
+          make_latest: false
+          files: |
+            tonk-macos-arm64.tar.gz
+            tonk-linux-x86_64.tar.gz
+            checksums.txt
+            manifest.json
+            install.sh

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,5 +1,18 @@
 on:
   workflow_dispatch:
+    inputs:
+      # Publish to an immutable tag instead of the rolling one.
+      #
+      # The rolling tags (`tonk-latest`, `tonk-staging`) are what the
+      # installer resolves by channel, so they must keep moving. But a
+      # format change needs its predecessor to stay downloadable forever,
+      # and a tag that gets deleted and recreated cannot be that. Dispatch
+      # this workflow on the older ref with `release_tag: v0.6.7` to leave
+      # a permanent release beside the rolling ones.
+      release_tag:
+        description: 'Immutable tag to publish to (e.g. v0.6.7). Empty publishes to the rolling channel tag.'
+        required: false
+        type: string
   pull_request:
   push:
     branches:
@@ -36,6 +49,23 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: 'Build tonk'
         run: nix build --accept-flake-config .#tonk-cli
+      # Name the build by the hash of its Rust source tree rather than by
+      # commit: a doc-only change leaves it identical, and the same tree
+      # reached from `stable` or `staging` is one build. Computed here
+      # because only this job has nix.
+      - name: 'Record the source-tree hash'
+        if: matrix.artifact-name == 'tonk-linux-x86_64'
+        run: |
+          mkdir -p tree
+          src="$(nix eval --raw --accept-flake-config .#tonk-cli.src)"
+          basename "$src" | cut -d- -f1 | cut -c1-12 > tree/tree.txt
+          cat tree/tree.txt
+      - uses: actions/upload-artifact@v4
+        if: matrix.artifact-name == 'tonk-linux-x86_64'
+        with:
+          name: tree
+          path: tree/tree.txt
+          overwrite: true
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
@@ -58,6 +88,10 @@ jobs:
         with:
           name: tonk-linux-x86_64
           path: artifacts/linux-x86_64
+      - uses: actions/download-artifact@v4
+        with:
+          name: tree
+          path: artifacts/tree
       - name: Prepare release assets
         run: |
           # Archive each binary as `tonk` so it extracts ready to run,
@@ -75,10 +109,14 @@ jobs:
           version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
             | grep -m1 '^version' \
             | sed -E 's/.*"([^"]+)".*/\1/')"
+          # Content hash of the filtered Rust source tree, computed by the
+          # build job (which has nix) and carried here as an artifact.
+          tree="$(cat artifacts/tree/tree.txt)"
           cat > manifest.json <<EOF
           {
             "version": "$version",
             "commit": "${{ github.sha }}",
+            "tree": "$tree",
             "channel": "staging",
             "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -87,6 +125,35 @@ jobs:
           # cannot parse.
           python3 -c 'import json,sys; m=json.load(open("manifest.json")); [sys.exit(f"manifest missing {k}") for k in ("version","commit","channel","built_at") if not m.get(k)]'
           cat manifest.json
+          echo "tree=$tree" >> "$GITHUB_ENV"
+      # Same pinned release the stable job publishes. Which channel a build
+      # came from does not matter to the person migrating data it wrote —
+      # only that the exact build stays downloadable. Content addressing is
+      # what makes the channel irrelevant, and a tree already released from
+      # the other channel simply resolves to the same tag.
+      - name: Create pinned release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: tonk-${{ env.tree }}
+          name: tonk CLI ${{ env.tree }}
+          body: |
+            Immutable release of the tonk CLI, named for the hash of its
+            Rust source tree. Kept downloadable so data written by this
+            build can always be migrated forward.
+
+            ```
+            curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh \
+              | TONK_RELEASE=tonk-${{ env.tree }} sh
+            ```
+          prerelease: true
+          make_latest: false
+          files: |
+            tonk-macos-arm64.tar.gz
+            tonk-linux-x86_64.tar.gz
+            checksums.txt
+            manifest.json
+            install.sh
+
       - name: Delete existing staging release
         run: gh release delete tonk-staging --yes --cleanup-tag || true
         env:
@@ -140,6 +207,10 @@ jobs:
         with:
           name: tonk-linux-x86_64
           path: artifacts/linux-x86_64
+      - uses: actions/download-artifact@v4
+        with:
+          name: tree
+          path: artifacts/tree
       - name: Prepare release assets
         run: |
           # Archive each binary as `tonk` so it extracts ready to run,
@@ -157,10 +228,14 @@ jobs:
           version="$(grep -A30 '^\[workspace.package\]' Cargo.toml \
             | grep -m1 '^version' \
             | sed -E 's/.*"([^"]+)".*/\1/')"
+          # Content hash of the filtered Rust source tree, computed by the
+          # build job (which has nix) and carried here as an artifact.
+          tree="$(cat artifacts/tree/tree.txt)"
           cat > manifest.json <<EOF
           {
             "version": "$version",
             "commit": "${{ github.sha }}",
+            "tree": "$tree",
             "channel": "stable",
             "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -169,18 +244,52 @@ jobs:
           # cannot parse.
           python3 -c 'import json,sys; m=json.load(open("manifest.json")); [sys.exit(f"manifest missing {k}") for k in ("version","commit","channel","built_at") if not m.get(k)]'
           cat manifest.json
+          echo "tree=$tree" >> "$GITHUB_ENV"
+      # Only when publishing the rolling tag. A pinned release must not
+      # delete `tonk-latest` — that is the tag the stable channel resolves,
+      # and removing it would break every plain `install.sh` run.
       - name: Delete existing rolling release
+        if: ${{ !inputs.release_tag }}
         run: gh release delete tonk-latest --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-      - name: Create rolling release
+      # Every stable build also leaves a permanent, content-named release.
+      # The rolling tag answers "what is current"; this answers "give me
+      # exactly the build that wrote my data", which is what a format
+      # migration needs and what a moving tag can never provide.
+      - name: Create pinned release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: tonk-latest
-          name: tonk CLI (latest)
+          tag_name: tonk-${{ env.tree }}
+          name: tonk CLI ${{ env.tree }}
           body: |
-            Rolling release of the tonk CLI, built from the latest `stable` branch.
+            Immutable release of the tonk CLI, named for the hash of its
+            Rust source tree. Kept downloadable so data written by this
+            build can always be migrated forward.
+
+            ```
+            curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh \
+              | TONK_RELEASE=tonk-${{ env.tree }} sh
+            ```
+          # Never the newest thing: `make_latest` here would point
+          # `releases/latest` at whichever pinned build ran last.
+          prerelease: true
+          make_latest: false
+          files: |
+            tonk-macos-arm64.tar.gz
+            tonk-linux-x86_64.tar.gz
+            checksums.txt
+            manifest.json
+            install.sh
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_tag || 'tonk-latest' }}
+          name: ${{ inputs.release_tag && format('tonk CLI {0}', inputs.release_tag) || 'tonk CLI (latest)' }}
+          body: |
+            ${{ inputs.release_tag && format('Pinned release of the tonk CLI at `{0}`, kept downloadable so data written by this build can be migrated forward.', inputs.release_tag) || 'Rolling release of the tonk CLI, built from the latest `stable` branch.' }}
 
             **Install (macOS / Linux):**
             ```
@@ -200,8 +309,11 @@ jobs:
             On macOS the binary is unsigned. The install script clears the
             Gatekeeper quarantine for you; if you extract by hand and macOS
             blocks it, run `xattr -d com.apple.quarantine tonk`.
-          prerelease: false
-          make_latest: true
+          # A pinned release is a historical artifact, never the newest
+          # thing: `make_latest` would point `releases/latest` at an older
+          # build and downgrade everyone installing from the stable channel.
+          prerelease: ${{ inputs.release_tag != '' }}
+          make_latest: ${{ inputs.release_tag == '' }}
           files: |
             tonk-macos-arm64.tar.gz
             tonk-linux-x86_64.tar.gz


### PR DESCRIPTION
Migrating data across a format change means running the *old* build to export
it. Today there is no way to get one: the release tags roll, so
`tonk-latest` and `tonk-staging` are deleted and recreated on every build,
and nothing names a specific one.

## What this does

**Every build now also publishes `tonk-<tree>`**, named for the hash of the
filtered Rust source tree it was built from. Not the commit: a doc-only
change leaves the hash identical, and the same tree reached from `stable` or
`staging` is one build — so which channel it came from stops mattering, which
is the point. The hash also goes into `manifest.json`, so a build is
identifiable by content rather than by a version string that repeats across
many commits.

**`cli-pin.yml` covers everything older.** Dispatching `cli.yml` on an old tag
cannot work, and this is worth spelling out because it is unintuitive: GitHub
reads `workflow_dispatch` inputs from the workflow file *at the dispatched
ref*. A new input does not exist in old history, the dispatch fails with
`Unexpected inputs provided`, and history cannot be edited to add it. So this
workflow lives on the default branch — where its inputs always exist — and
*checks out* the ref being published instead.

## Safety

Pinned releases are `prerelease: true` with `make_latest: false`, so they sit
beside the rolling tags without outranking them. Three things are conditional
specifically so a pinned publish cannot disturb a channel: the rolling release
is not deleted, `make_latest` stays off (it would point `releases/latest` at
an *older* build and silently downgrade everyone installing from stable), and
the release is marked prerelease.

`install.sh` already resolves `TONK_RELEASE=<tag>`, so nothing changes
client-side.

## Verified

Both files parse. The source-tree hash was checked to behave as claimed: it
differs between the current tree (`4m5frrhgwdgz`) and the pre-dialog-upgrade
tree (`yrv5fymlyxdz`), and is unchanged by a documentation-only edit. The old
build itself compiles reproducibly through nix from that ref and reports
`tonk 0.6.7`.

Not verifiable before merge: `workflow_dispatch` only registers from the
default branch, so `cli-pin.yml` cannot be dispatched until this lands.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new GitHub Actions workflow for publishing immutable CLI releases, allowing users to specify a commit, tag, or branch. It ensures older commits can be published without modifying history, enhancing the release process for the `tonk` CLI.

### Detailed summary
- Added a new workflow in `.github/workflows/cli-pin.yml` for publishing pinned CLI releases.
- Introduced `workflow_dispatch` inputs for specifying `ref` and optional `tag`.
- Implemented steps for building, recording source-tree hash, and preparing release assets.
- Updated existing workflow in `.github/workflows/cli.yml` to support pinned releases.
- Enhanced release creation with proper tagging and metadata for both pinned and rolling releases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->