### PR TITLE
ci: drop target_commitish from the pinned release

### DIFF
--- a/.github/workflows/cli-pin.yml
+++ b/.github/workflows/cli-pin.yml
@@ -141,7 +141,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.tag }}
-          target_commitish: ${{ inputs.ref }}
+          # No `target_commitish`: GitHub accepts only a branch name or a
+          # SHA there, so passing a tag ref fails validation outright. When
+          # the tag already exists — the usual case for publishing history —
+          # the tag decides the commit anyway.
           name: tonk CLI ${{ env.tag }}
           body: |
             Immutable release of the tonk CLI built from `${{ inputs.ref }}`,


### PR DESCRIPTION
The first `v0.6.7` publish failed after both builds succeeded:

```
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
```

GitHub accepts only a branch name or a SHA in `target_commitish`, so passing a
tag ref is rejected. It was never needed either — when the tag already exists,
which is the case whenever publishing a point in history, the tag decides the
commit.

Build jobs were unaffected; this only touches the publish step.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow for `tonk CLI` by removing the `target_commitish` parameter. It clarifies that only branch names or SHA can be used, as passing a tag ref fails validation. 

### Detailed summary
- Removed the `target_commitish` parameter from the workflow.
- Added comments explaining the reasoning behind the change.
- Updated the `name` and `body` fields to reflect the new tag structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->