### PR TITLE
fix(worker): accept 64 MiB blob uploads

### DIFF
--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -206,8 +206,9 @@ pub fn api_router(state: TonkState) -> (Router, Arc<LspHub>) {
 
 /// Largest accepted `POST …/blob` body. The handler buffers the whole
 /// upload in service-worker memory before writing it to the blob store,
-/// so this caps that buffer, not just the wire size.
-pub const BLOB_UPLOAD_LIMIT: usize = 32 * 1024 * 1024;
+/// so this caps that buffer, not just the wire size. Keep this conservative
+/// until the browser upload and remote sync paths stream end to end.
+pub const BLOB_UPLOAD_LIMIT: usize = 64 * 1024 * 1024;
 
 /// Variant of [`api_router`] that also surfaces the wrapped
 /// [`AppState`] handle. The worker uses this so it can consult

--- a/rust/tonk-worker/src/router/blob.rs
+++ b/rust/tonk-worker/src/router/blob.rs
@@ -487,24 +487,23 @@ mod tests {
         assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
     }
 
-    /// The blob route accepts bodies past axum's 2 MiB extractor default —
-    /// real image files routinely exceed it — up to the route's own
-    /// [`crate::router::BLOB_UPLOAD_LIMIT`] ceiling.
+    /// The blob route accepts a body at its configured buffered-upload ceiling.
     #[dialog_common::test]
-    async fn it_accepts_an_upload_larger_than_the_axum_default_limit() {
+    async fn it_accepts_an_upload_at_the_buffered_limit() {
         let tonk = test_state().await;
         let app_state = Arc::new(RwLock::new(tonk));
         let (app, _lsp) = api_router_from_state(app_state.clone());
         let repo = put_repo(&app, "blob-large").await;
 
-        let payload = vec![0xabu8; 3 * 1024 * 1024];
+        let expected_size = 64 * 1024 * 1024;
+        let payload = vec![0xabu8; expected_size];
         let up = app
             .oneshot(
                 Request::builder()
                     .uri(format!("/api/repository/{repo}/branch/main/blob"))
                     .method("POST")
                     .header("content-type", "application/octet-stream")
-                    .body(Body::from(payload.clone()))
+                    .body(Body::from(payload))
                     .unwrap(),
             )
             .await
@@ -512,13 +511,13 @@ mod tests {
         assert_eq!(
             up.status(),
             StatusCode::OK,
-            "a 3 MiB upload lands (the 2 MiB axum default would 413 it)",
+            "a 64 MiB upload lands at the configured buffered limit",
         );
         let body = axum::body::to_bytes(up.into_body(), usize::MAX)
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["size"], payload.len());
+        assert_eq!(json["size"], expected_size);
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## Summary

- raise the buffered service-worker blob upload ceiling from 32 MiB to 64 MiB
- exercise the configured ceiling with a real 64 MiB route upload
- keep the limit explicitly conservative until browser upload and remote sync stream end to end

## Testing

- nix develop path:. -c cargo test -p tonk-worker --target wasm32-unknown-unknown router::blob::tests:: -- --nocapture (6 passed)
- cargo fmt --check
- git diff --check

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on increasing the `BLOB_UPLOAD_LIMIT` constant and updating related tests to reflect this change. It aims to improve the handling of larger uploads in the application.

### Detailed summary
- Increased `BLOB_UPLOAD_LIMIT` from `32 MiB` to `64 MiB`.
- Updated the test function name to reflect the new upload limit.
- Adjusted the test payload size to match the new `BLOB_UPLOAD_LIMIT`.
- Modified assertions in the test to check against the updated expected size.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->