### PR TITLE
fix(cli): include current hash in synced status

### DIFF
--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -121,11 +121,11 @@ enum Command {
         concept: Option<String>,
     },
 
-    /// Report how local main relates to its upstream
+    /// Report how local main relates to its upstream and its current hash
     ///
     /// Prints `synced`, `ahead`, `behind`, `diverged`, or
-    /// `no-upstream`. Read-only — fetches the upstream head without
-    /// merging.
+    /// `no-upstream`, followed by the current local tree hash. Read-only —
+    /// fetches the upstream head without merging.
     #[command(after_help = "Examples:\n  tonk status")]
     Status,
 
@@ -2092,9 +2092,12 @@ async fn status_op(spot: Option<&str>) -> ExitCode {
         source = resolved.source,
     );
 
-    match sync::status(&site).await {
-        Ok(state) => {
-            println!("{}", render_sync_state(state));
+    match sync::status_with_hash(&site).await {
+        Ok(status) => {
+            println!("{}", render_sync_state(status.state));
+            if let Some(hash) = status.hash {
+                println!("hash: {hash}");
+            }
             ExitCode::Success
         }
         Err(err) => {

--- a/rust/tonk-cli/src/sync.rs
+++ b/rust/tonk-cli/src/sync.rs
@@ -8,7 +8,7 @@
 //! no SSE clients), so this skips the reactor wrapper the
 //! worker uses.
 
-use dialog_repository::{FetchError, PullError, PushError, Revision};
+use dialog_repository::{FetchError, PullError, PushError, Revision, TreeReference};
 use thiserror::Error;
 use tonk_schema::{SyncState, classify};
 
@@ -29,6 +29,15 @@ pub struct SyncOutcome {
     /// pull. Lets the caller print "pushed" / "nothing to push"
     /// without comparing revisions itself.
     pub advanced: bool,
+}
+
+/// The local branch's relationship to its upstream and current tree hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncStatus {
+    /// How the local and upstream heads compare.
+    pub state: SyncState,
+    /// The local branch's current tree root, when it has a revision.
+    pub hash: Option<TreeReference>,
 }
 
 /// Failure modes for [`push`] / [`pull`].
@@ -125,21 +134,33 @@ pub async fn pull(site: &TonkSite) -> Result<SyncOutcome, SyncError> {
 /// [`SyncState::NoUpstream`] — not an error — so `tonk status`
 /// always has something to print.
 pub async fn status(site: &TonkSite) -> Result<SyncState, SyncError> {
+    Ok(status_with_hash(site).await?.state)
+}
+
+/// Classify the site's sync state and retain its current local tree hash.
+pub async fn status_with_hash(site: &TonkSite) -> Result<SyncStatus, SyncError> {
     let session = site
         .branch()
         .await
         .map_err(|e| SyncError::Io(format!("acquire branch: {e}")))?;
     let branch = session.handle();
     let local = branch.revision();
+    let hash = local.as_ref().map(|revision| revision.tree.clone());
     if branch.upstream().is_none() {
-        return Ok(SyncState::NoUpstream);
+        return Ok(SyncStatus {
+            state: SyncState::NoUpstream,
+            hash,
+        });
     }
     let remote = branch
         .fetch()
         .perform(&site.operator)
         .await
         .map_err(map_fetch_error)?;
-    Ok(classify(local.as_ref(), remote.as_ref()).into())
+    Ok(SyncStatus {
+        state: classify(local.as_ref(), remote.as_ref()).into(),
+        hash,
+    })
 }
 
 fn map_fetch_error(error: FetchError) -> SyncError {

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -704,6 +704,47 @@ mod when_minting_against_a_live_remote {
     }
 }
 
+#[cfg(feature = "integration-tests")]
+mod when_status_is_synced {
+    use anyhow::Result;
+    use tonk_access_service::helpers::AccessServiceAddress;
+
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_includes_the_current_hash(env: AccessServiceAddress) -> Result<()> {
+        let state = tempfile::tempdir()?;
+        let state_dir = state.path().to_path_buf();
+        let endpoint = env.access_service_url.trim_end_matches('/').to_owned();
+
+        let (expected_hash, status) = tokio::task::spawn_blocking(move || {
+            spot_with_remotes(&state_dir, &[("origin", &endpoint)]);
+
+            let pushed = run(&state_dir, &["push"], &[]);
+            assert!(pushed.status.success(), "{}", stderr_of(&pushed));
+            let pushed = stdout_of(&pushed);
+            let expected_hash = pushed
+                .lines()
+                .find_map(|line| line.strip_prefix("after:  "))
+                .expect("push reports the current hash")
+                .to_owned();
+
+            let status = run(&state_dir, &["status"], &[]);
+            assert!(status.status.success(), "{}", stderr_of(&status));
+            (expected_hash, stdout_of(&status))
+        })
+        .await
+        .expect("blocking tonk invocations join");
+
+        assert!(status.contains("\nsynced\n"), "{status}");
+        assert!(
+            status.contains(&format!("hash: {expected_hash}")),
+            "current hash {expected_hash} missing from status output:\n{status}"
+        );
+        Ok(())
+    }
+}
+
 mod when_a_directory_is_bound {
     use super::*;
 


### PR DESCRIPTION
## Summary
- retain the local tree hash alongside the sync classification
- print the current hash from tonk status, including when the branch is synced
- cover the CLI output against a real synced local remote

## Verification
- cargo fmt --all -- --check
- cargo test -p tonk-cli --test sync --bin tonk
- cargo test -p tonk-cli --test cli_spot --features integration-tests

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` CLI tool by modifying the status reporting feature to include the current local tree hash alongside the sync state. It also introduces a new test to verify this functionality.

### Detailed summary
- Updated `tonk.rs` to report the current local tree hash in the `status` command output.
- Modified the `sync::status` function to call `sync::status_with_hash`.
- Added the `SyncStatus` struct to include both sync state and current tree hash.
- Introduced a new integration test for verifying the inclusion of the current hash in the status output.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->