### PR TITLE
fix(cli): complete legacy spot migration

### DIFF
--- a/rust/tonk-cli/src/account_state.rs
+++ b/rust/tonk-cli/src/account_state.rs
@@ -273,6 +273,20 @@ pub struct MigrationOutcome {
     pub spots: usize,
     /// Spots already retained, so nothing was written for them.
     pub already: usize,
+    /// The account repository was legacy and could not receive retained spots.
+    pub account_legacy: bool,
+}
+
+fn account_repository_readability(
+    store: &crate::spot::SpotStore,
+    subject: &dialog_varsig::Did,
+) -> tonk_account::Readability {
+    let revision = store.account_dir().join(tonk_account::revision_path(
+        subject.repo_key(),
+        tonk_account::MAIN_BRANCH,
+    ));
+    let bytes = std::fs::read(revision).ok();
+    tonk_account::readability(bytes.as_deref())
 }
 
 /// Move this profile's delegations into their durable homes.
@@ -354,6 +368,12 @@ pub async fn migrate_delegations(
             .context("stored root DID is invalid")?,
         None => return Ok(outcome),
     };
+    if account_repository_readability(store, descriptor.account_subject())
+        == tonk_account::Readability::Legacy
+    {
+        outcome.account_legacy = true;
+        return Ok(outcome);
+    }
     let repository = mount(profile, operator, &descriptor).await?;
     let branch = repository
         .branch(tonk_account::MAIN_BRANCH)
@@ -693,8 +713,34 @@ pub async fn ensure_with_operator_and_store(
 #[cfg(test)]
 mod tests {
     use dialog_credentials::Ed25519Signer;
+    use tonk_schema::prelude::DidExt as _;
 
     use super::*;
+
+    #[test]
+    fn it_detects_a_legacy_account_repository_before_opening_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = crate::spot::SpotStore::at(temp.path().join("state"));
+        let subject: dialog_varsig::Did =
+            "did:key:z6MkhFDyBYNT1Y1jNj8RJKVc7CWurCVPmrnGEGmbYxvwHJkX"
+                .parse()
+                .unwrap();
+        let revision = store.account_dir().join(tonk_account::revision_path(
+            subject.repo_key(),
+            tonk_account::MAIN_BRANCH,
+        ));
+        std::fs::create_dir_all(revision.parent().unwrap()).unwrap();
+        std::fs::write(
+            &revision,
+            include_bytes!("../../tonk-account/tests/fixtures/revision-legacy.cbor"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            account_repository_readability(&store, &subject),
+            tonk_account::Readability::Legacy
+        );
+    }
 
     #[dialog_common::test]
     async fn it_requires_the_exact_descriptor_hash() {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1327,6 +1327,12 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                         if outcome.spots == 1 { "" } else { "s" },
                         outcome.already
                     );
+                    if outcome.account_legacy {
+                        eprintln!(
+                            "warning: the account repository is still in the legacy format; \
+                             certificate migration completed, but spot retention was skipped"
+                        );
+                    }
                     ExitCode::Success
                 }
                 Err(error) => print_failure(error),
@@ -1946,11 +1952,19 @@ async fn legacy_migrate(
     // migrated repositories usable — doing it the other way round leaves
     // data that imports cleanly and cannot be pushed anywhere.
     match tonk_cli::account_state::migrate_delegations_here().await {
-        Ok(outcome) => println!(
-            "account: {} certificate(s) moved into access facts, \
-             {} spot(s) retained ({} already there)",
-            outcome.certificates, outcome.spots, outcome.already
-        ),
+        Ok(outcome) => {
+            println!(
+                "account: {} certificate(s) moved into access facts, \
+                 {} spot(s) retained ({} already there)",
+                outcome.certificates, outcome.spots, outcome.already
+            );
+            if outcome.account_legacy {
+                eprintln!(
+                    "warning: the account repository is still in the legacy format; \
+                     certificate migration completed, but spot retention was skipped"
+                );
+            }
+        }
         // An unlinked profile has no account to migrate, which is ordinary
         // rather than a failure — but anything else is worth stopping for,
         // since the repositories below would inherit the problem.
@@ -1973,12 +1987,30 @@ async fn legacy_migrate(
             Ok(upgraded) => upgraded,
             Err(error) => return print_failure(error),
         };
+        let blobs = match tonk_cli::legacy::migrate_blobs(
+            &cli,
+            &site,
+            branch,
+            &upgraded.blobs,
+            &destination,
+            workspace.path(),
+        )
+        .await
+        {
+            Ok(blobs) => blobs,
+            Err(error) => return print_failure(error),
+        };
         if let Err(error) = transfer::import_branch(&destination, branch, &upgraded.csv).await {
             return print_failure(error);
         }
         println!(
-            "{branch}: {} rows ({} renamed, {} dropped as dialog's own)",
-            upgraded.migration.kept, upgraded.migration.remapped, upgraded.migration.dropped
+            "{branch}: {} rows ({} remapped, {} dropped as dialog's own), \
+             {} blobs ({} bytes)",
+            upgraded.migration.kept,
+            upgraded.migration.remapped,
+            upgraded.migration.dropped,
+            blobs.copied,
+            blobs.bytes
         );
     }
     println!("upgraded {} branch(es)", branches.len());

--- a/rust/tonk-cli/src/blob.rs
+++ b/rust/tonk-cli/src/blob.rs
@@ -63,6 +63,43 @@ pub struct AddOutcome {
     pub content_type: String,
 }
 
+/// A blob attached to a branch without asserting or changing fact metadata.
+#[derive(Debug)]
+pub struct AttachOutcome {
+    /// The content-addressed entity derived from the imported bytes.
+    pub entity: Entity,
+    /// Number of imported bytes.
+    pub size: u64,
+}
+
+/// Attach a file's bytes to a named branch without asserting metadata.
+pub async fn attach(
+    site: &TonkSite,
+    branch: &str,
+    path: &Path,
+) -> Result<AttachOutcome, BlobError> {
+    let file = tokio::fs::File::open(path).await?;
+    let size = file.metadata().await?.len();
+
+    use futures_util::StreamExt as _;
+    let source = tokio_util::io::ReaderStream::new(file).map(|chunk| {
+        chunk
+            .map(|bytes| bytes.to_vec())
+            .map_err(|error| dialog_effects::blob::BlobError::Storage(error.to_string()))
+    });
+    let session = site
+        .named_branch(branch)
+        .await
+        .map_err(|error| BlobError::Site(format!("acquire branch {branch:?}: {error}")))?;
+    let entity = Blob::import(Box::pin(source))
+        .write(session.handle().blobs())
+        .perform(&site.operator)
+        .await
+        .map_err(|error| BlobError::Site(format!("write blob: {error}")))?;
+
+    Ok(AttachOutcome { entity, size })
+}
+
 /// Map a file extension to a MIME type. Keep in sync with
 /// tonk-worker's `mime_for_extension` until the two are
 /// consolidated (planned for the display milestone).

--- a/rust/tonk-cli/src/legacy.rs
+++ b/rust/tonk-cli/src/legacy.rs
@@ -5,23 +5,27 @@
 //! the new build reserves `dialog.*` against application writes and refuses
 //! the whole transaction on the first such row.
 //!
-//! The rename is mechanical — `dialog.attribute/id` became `db.attribute/id`,
-//! and so on for 49 of the 58 names a real legacy export carries. What did
-//! *not* survive is dialog's own bookkeeping: the old rules system
-//! (`dialog.effect/*`), and the handful of markers the new build regenerates
-//! for itself. Those are dropped rather than translated, because the new
-//! build writes its own.
+//! Most renames are mechanical — `dialog.attribute/id` became
+//! `db.attribute/id`, and so on for 49 of the 58 names a real legacy export
+//! carries. Runtime-injected replica attributes also changed from
+//! `dialog.origin/*` to `dialog.replica/*`; those names live inside schema
+//! rows and are rewritten explicitly. What did *not* survive is dialog's own
+//! bookkeeping: the old rules system (`dialog.effect/*`), and the handful of
+//! markers the new build regenerates for itself. Those are dropped rather
+//! than translated, because the new build writes its own.
 //!
 //! Remapping is preferred over re-deriving the schema from
 //! `tonk schema` output. Both work, but this carries the data the spot
 //! actually had — a schema that drifted from the standard library keeps its
 //! drift — and a table cannot fail halfway through a re-evaluation.
 
+use std::collections::BTreeSet;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
+use dialog_artifacts::Entity;
 
 /// The last release that can read pre-upgrade data.
 ///
@@ -106,6 +110,45 @@ pub struct Upgraded {
     pub migration: Migration,
     /// The migrated CSV, ready to import.
     pub csv: PathBuf,
+    /// Content-addressed blobs referenced by the migrated facts.
+    pub blobs: Vec<Entity>,
+}
+
+/// Find every valid `blob:<hash>` entity referenced by an export.
+///
+/// Blob references may be subjects, entity-valued facts, or embedded in
+/// rendered text such as HTML, so discovery scans the complete CSV payload
+/// rather than only one column.
+pub fn blob_references<R: BufRead>(mut source: R) -> Result<Vec<Entity>> {
+    let mut export = String::new();
+    source
+        .read_to_string(&mut export)
+        .context("failed to read the export while finding blobs")?;
+
+    let mut references = BTreeSet::new();
+    for (start, _) in export.match_indices("blob:") {
+        let candidate: String = export[start + "blob:".len()..]
+            .chars()
+            .take_while(|character| {
+                matches!(
+                    character,
+                    '1'..='9'
+                        | 'A'..='H'
+                        | 'J'..='N'
+                        | 'P'..='Z'
+                        | 'a'..='k'
+                        | 'm'..='z'
+                )
+            })
+            .collect();
+        let Ok(entity) = format!("blob:{candidate}").parse::<Entity>() else {
+            continue;
+        };
+        if entity.blob_hash().is_some() {
+            references.insert(entity);
+        }
+    }
+    Ok(references.into_iter().collect())
 }
 
 /// Export a legacy branch and rewrite it into something this build imports.
@@ -123,12 +166,78 @@ pub fn upgrade_branch(cli: &Path, spot: &str, branch: &str, workspace: &Path) ->
     let sink = std::fs::File::create(&migrated)
         .with_context(|| format!("failed to write {}", migrated.display()))?;
     let migration = migrate_export(std::io::BufReader::new(source), sink)?;
+    let migrated_source = std::fs::File::open(&migrated)
+        .with_context(|| format!("failed to read {}", migrated.display()))?;
+    let blobs = blob_references(std::io::BufReader::new(migrated_source))?;
 
     Ok(Upgraded {
         branch: branch.to_owned(),
         migration,
         csv: migrated,
+        blobs,
     })
+}
+
+/// What copying the referenced blob payloads into a current branch did.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BlobMigration {
+    /// Payloads copied and verified by their content address.
+    pub copied: usize,
+    /// Total payload bytes copied.
+    pub bytes: u64,
+}
+
+/// Copy legacy blob payloads into a current branch without inventing facts.
+///
+/// The legacy CLI is the reader because the current build cannot open the
+/// source branch. Each payload is streamed to a temporary file, attached to
+/// the destination, and accepted only when the resulting content address is
+/// exactly the entity referenced by the migrated facts.
+pub async fn migrate_blobs(
+    cli: &Path,
+    spot: &str,
+    branch: &str,
+    blobs: &[Entity],
+    destination: &crate::site::TonkSite,
+    workspace: &Path,
+) -> Result<BlobMigration> {
+    let mut migration = BlobMigration::default();
+    for (index, expected) in blobs.iter().enumerate() {
+        let payload = workspace.join(format!("legacy-blob-{index}"));
+        let output = std::fs::File::create(&payload)
+            .with_context(|| format!("failed to create {}", payload.display()))?;
+        let status = Command::new(cli)
+            .arg("blob")
+            .arg("cat")
+            .arg(expected.as_str())
+            .arg("--spot")
+            .arg(spot)
+            .env("DO_NOT_TRACK", "1")
+            .stdout(Stdio::from(output))
+            .status()
+            .with_context(|| format!("could not read legacy blob {expected}"))?;
+        if !status.success() {
+            bail!("legacy blob {expected} could not be read: {status}");
+        }
+
+        let attached = crate::blob::attach(destination, branch, &payload)
+            .await
+            .with_context(|| format!("failed to attach legacy blob {expected}"))?;
+        if attached.entity != *expected {
+            bail!(
+                "legacy blob content address mismatch: expected {expected}, got {}",
+                attached.entity
+            );
+        }
+        migration.copied += 1;
+        migration.bytes += attached.size;
+
+        let completed = index + 1;
+        if completed == 1 || completed % 25 == 0 || completed == blobs.len() {
+            eprintln!("blobs: {completed}/{} verified", blobs.len());
+        }
+    }
+    Ok(migration)
 }
 
 fn run(command: &mut Command) -> Result<()> {
@@ -146,6 +255,26 @@ fn run(command: &mut Command) -> Result<()> {
 fn split_attribute(line: &str) -> Option<(&str, &str)> {
     let end = line.find(',')?;
     Some((&line[..end], &line[end..]))
+}
+
+/// Runtime-owned attribute IDs that changed meaning without moving into the
+/// `db.*` schema namespace. They appear as values of `db.attribute/id` rows,
+/// so renaming only the CSV's first column leaves concepts bound to an
+/// attribute the current runtime never injects.
+const RUNTIME_ATTRIBUTE_RENAMES: &[(&str, &str)] = &[
+    ("dialog.origin/subject", "dialog.replica/subject"),
+    ("dialog.origin/profile", "dialog.replica/profile"),
+];
+
+fn rename_runtime_attribute_id(the: &str, rest: &str) -> Option<String> {
+    if !matches!(the, "dialog.attribute/id" | "db.attribute/id") {
+        return None;
+    }
+    RUNTIME_ATTRIBUTE_RENAMES.iter().find_map(|(old, new)| {
+        let old = format!(",text,{old},");
+        rest.contains(&old)
+            .then(|| rest.replacen(&old, &format!(",text,{new},"), 1))
+    })
 }
 
 /// Attribute families the new build owns and regenerates. Importing them is
@@ -170,7 +299,7 @@ const DROP_EXACT: &[&str] = &[
 pub struct Migration {
     /// Rows carried into the new export.
     pub kept: usize,
-    /// Rows whose attribute moved from `dialog.` to `db.`.
+    /// Rows whose schema or runtime attribute name was remapped.
     pub remapped: usize,
     /// Rows dropped because the new build owns that attribute.
     pub dropped: usize,
@@ -223,13 +352,14 @@ pub fn migrate_export<R: BufRead, W: Write>(source: R, mut out: W) -> Result<Mig
             continue;
         }
         dropping = false;
-        match rename(the) {
-            Some(renamed) => {
-                migration.remapped += 1;
-                writeln!(out, "{renamed}{rest}").context("failed to write a migrated row")?;
-            }
-            None => writeln!(out, "{line}").context("failed to write a migrated row")?,
+        let renamed = rename(the);
+        let remapped_id = rename_runtime_attribute_id(the, rest);
+        if renamed.is_some() || remapped_id.is_some() {
+            migration.remapped += 1;
         }
+        let output_the = renamed.as_deref().unwrap_or(the);
+        let output_rest = remapped_id.as_deref().unwrap_or(rest);
+        writeln!(out, "{output_the}{output_rest}").context("failed to write a migrated row")?;
         migration.kept += 1;
     }
     out.flush().context("failed to flush the migrated export")?;
@@ -248,6 +378,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn it_finds_blob_references_anywhere_in_an_export_once() {
+        let first = Entity::from_blob(&[1; 32]).unwrap();
+        let second = Entity::from_blob(&[2; 32]).unwrap();
+        let third = Entity::from_blob(&[3; 32]).unwrap();
+        let csv = format!(
+            "the,of,as,is,cause\n\
+             app/file,{first},entity,{second},\n\
+             app/view,id:page,text,\"<img src='{third}'> {first}\",\n\
+             app/note,id:note,text,blob:not-a-content-hash,\n"
+        );
+
+        assert_eq!(
+            blob_references(csv.as_bytes()).unwrap(),
+            vec![first, second, third]
+        );
+    }
+
+    #[test]
     fn it_renames_the_schema_namespace() {
         assert_eq!(
             rename("dialog.attribute/id").as_deref(),
@@ -259,6 +407,21 @@ mod tests {
         );
         // An application attribute is not dialog's to rename.
         assert_eq!(rename("xyz.tonk.view/model"), None);
+    }
+
+    #[test]
+    fn it_updates_runtime_attribute_ids_inside_schema_rows() {
+        let legacy = "the,of,as,is,cause\n\
+            dialog.attribute/id,the:subject,text,dialog.origin/subject,\n\
+            dialog.attribute/id,the:profile,text,dialog.origin/profile,\n";
+        let mut out = Vec::new();
+
+        migrate_export(legacy.as_bytes(), &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+
+        assert!(text.contains(",text,dialog.replica/subject,"), "{text}");
+        assert!(text.contains(",text,dialog.replica/profile,"), "{text}");
+        assert!(!text.contains("dialog.origin/"), "{text}");
     }
 
     /// A quoted value may span lines, so a row is not a line. Treating each

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -30,6 +30,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tonk_schema::{RepositoryName, prelude::DidExt as _};
 
 /// Environment variable naming the spot to use, beaten only by the
 /// `--spot` flag. Automation (agents, bench, CI) should always set
@@ -601,6 +602,27 @@ pub async fn create(
     let site = crate::site::TonkSite::init_at_with(&target, config)
         .await
         .map_err(|e| SpotError::Init(format!("{e:#}")))?;
+
+    // A fresh CLI spot must carry the same self-identifying row the worker's
+    // create path writes. Invite validation uses this fact to distinguish a
+    // usable repository from an arbitrary branch that happens to have data.
+    // Adoption preserves the existing repository's name instead of treating
+    // the local registry alias as a rename request.
+    if !adopted {
+        site.branch()
+            .await
+            .map_err(|e| SpotError::Init(format!("failed to open main branch: {e}")))?
+            .handle()
+            .transaction()
+            .assert(RepositoryName {
+                this: site.repository.did().this(),
+                name: tonk_schema::domain::repo::Name(name.to_owned()),
+            })
+            .commit()
+            .perform(&site.operator)
+            .await
+            .map_err(|e| SpotError::Init(format!("failed to stamp repository identity: {e}")))?;
+    }
 
     let outcome = CreateOutcome {
         name: name.to_owned(),

--- a/rust/tonk-cli/tests/blob.rs
+++ b/rust/tonk-cli/tests/blob.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use anyhow::Result;
+use dialog_artifacts::Entity;
 use tonk_cli::blob;
 
 use crate::common::TestSite;
@@ -38,6 +39,96 @@ async fn it_honors_an_explicit_content_type_override() -> Result<()> {
     )
     .await?;
     assert_eq!(outcome.content_type, "application/octet-stream");
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_attaches_blob_bytes_without_asserting_metadata() -> Result<()> {
+    let test = TestSite::new().await?;
+    let file = test.parent.join("legacy.bin");
+    tokio::fs::write(&file, b"legacy blob bytes").await?;
+
+    let attached = blob::attach(&test.site, "main", &file).await;
+    assert!(attached.is_ok(), "raw attachment failed: {attached:?}");
+    let attached = attached.unwrap();
+
+    let mut out = Vec::new();
+    blob::cat(&test.site, attached.entity.as_str(), &mut out).await?;
+    assert_eq!(out, b"legacy blob bytes");
+
+    let export = test.parent.join("after-attach.csv");
+    tonk_cli::transfer::export(
+        &test.site,
+        tonk_cli::transfer::Destination::File(export.clone()),
+    )
+    .await?;
+    let csv = tokio::fs::read_to_string(export).await?;
+    assert!(
+        !csv.contains(attached.entity.as_str()),
+        "raw attachment must not invent metadata facts: {csv}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[dialog_common::test]
+async fn it_copies_and_verifies_a_blob_from_the_legacy_cli() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test = TestSite::new().await?;
+    let bytes = b"legacy blob bytes";
+    let expected = Entity::from_blob(blake3::hash(bytes).as_bytes())?;
+    let cli = test.parent.join("legacy-tonk");
+    tokio::fs::write(&cli, b"#!/bin/sh\nprintf 'legacy blob bytes'\n").await?;
+    let mut permissions = tokio::fs::metadata(&cli).await?.permissions();
+    permissions.set_mode(0o755);
+    tokio::fs::set_permissions(&cli, permissions).await?;
+
+    let migration = tonk_cli::legacy::migrate_blobs(
+        &cli,
+        "legacy",
+        "main",
+        std::slice::from_ref(&expected),
+        &test.site,
+        &test.parent,
+    )
+    .await?;
+    assert_eq!(migration.copied, 1);
+    assert_eq!(migration.bytes, bytes.len() as u64);
+
+    let mut out = Vec::new();
+    blob::cat(&test.site, expected.as_str(), &mut out).await?;
+    assert_eq!(out, bytes);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[dialog_common::test]
+async fn it_refuses_legacy_blob_bytes_with_the_wrong_content_address() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let test = TestSite::new().await?;
+    let expected = Entity::from_blob(&[9; 32])?;
+    let cli = test.parent.join("legacy-tonk");
+    tokio::fs::write(&cli, b"#!/bin/sh\nprintf 'different bytes'\n").await?;
+    let mut permissions = tokio::fs::metadata(&cli).await?.permissions();
+    permissions.set_mode(0o755);
+    tokio::fs::set_permissions(&cli, permissions).await?;
+
+    let error = tonk_cli::legacy::migrate_blobs(
+        &cli,
+        "legacy",
+        "main",
+        &[expected],
+        &test.site,
+        &test.parent,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("content address mismatch"),
+        "unexpected error: {error:#}"
+    );
     Ok(())
 }
 

--- a/rust/tonk-cli/tests/spot.rs
+++ b/rust/tonk-cli/tests/spot.rs
@@ -6,8 +6,11 @@
 mod common;
 
 use anyhow::Result;
+use dialog_query::{Output as _, Query, Term};
 use tonk_cli::site::TonkSite;
 use tonk_cli::spot::{self, SpotStore};
+use tonk_schema::RepositoryName;
+use tonk_schema::prelude::DidExt as _;
 
 mod when_creating_a_spot {
     use super::*;
@@ -30,6 +33,31 @@ mod when_creating_a_spot {
         // And the site actually opens.
         let opened = TonkSite::open_with(&resolved.site, config).await?;
         assert_eq!(opened.repository.did().to_string(), outcome.did);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_stamps_the_repository_identity_used_by_join() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let store = SpotStore::at(tmp.path().join("state"));
+        let config = common::isolated_config(&tmp.path().canonicalize()?)?;
+
+        let created = spot::create(&store, "garden", None, None, config.clone()).await?;
+        let site = TonkSite::open_with(&created.site, config).await?;
+        let branch = site.branch().await?;
+        let rows: Vec<RepositoryName> = branch
+            .handle()
+            .query()
+            .select(Query::<RepositoryName> {
+                this: Term::from(site.repository.did().this()),
+                name: Term::var("name"),
+            })
+            .perform(&site.operator)
+            .try_vec()
+            .await?;
+
+        assert_eq!(rows.len(), 1, "a joinable spot has one self identity row");
+        assert_eq!(rows[0].name.0, "garden");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- let certificate migration finish when the linked account repository is still in the legacy wire format, while warning that account spot retention was skipped
- discover every referenced legacy blob, stream it through the pinned v0.6.7 CLI, attach it to the destination branch, and verify the resulting content address
- remap dialog.origin runtime attribute IDs to dialog.replica and stamp fresh CLI spots with the repository identity required by join validation

## Verification

- cargo fmt --all -- --check
- cargo test -p tonk-cli
- cargo test -p tonk-cli --features integration-tests,legacy-migration --test legacy_migration -- --nocapture (2 passed)
- live staging recovery migrated 5,780 rows and 404 blobs / 664,741,754 bytes; the recovered workspace rendered after joining, and a sampled 3,067,894-byte blob returned HTTP 200 with the expected content type

## Scope

The existing legacy exporter still supports main only. Migration imports into a fresh destination repository, so the repository DID changes; this PR does not attempt history- or DID-preserving wire conversion.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk-cli` by implementing repository identity stamping, legacy account handling, and blob migration features. It introduces new tests and modifies existing functionalities to support these features.

### Detailed summary
- Added repository identity stamping during spot creation.
- Introduced `AttachOutcome` for blob attachment without metadata assertion.
- Implemented legacy account repository detection and handling.
- Enhanced blob migration functionality to verify content addresses.
- Added tests for repository identity stamping and blob attachment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->