### PR TITLE
Consumer provisioning via /provider/add

### DIFF
--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -36,7 +36,7 @@ async fn handle_inner(
     body: &[u8],
     req: &Request,
     ctx: &RouteContext<()>,
-) -> Result<tonk_account::customer::Receipt, RegistrationError> {
+) -> Result<crate::registration::Answer, RegistrationError> {
     use worker::Date;
 
     use crate::email::Resend;

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -30,9 +30,11 @@ use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 use dialog_varsig::{Did, Principal};
 use ipld_core::ipld::Ipld;
 use ipld_core::serde::from_ipld;
+use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tonk_account::customer::{
-    Activate, Customer, CustomerStatus, Enroll, Receipt, RegistrationError,
+    Activate, Add, ConsumerReceipt, Customer, CustomerStatus, Enroll, Provider as ProviderRole,
+    Receipt, RegistrationError,
 };
 
 use crate::email::EmailSender;
@@ -44,6 +46,12 @@ pub const ENROLL_COMMAND: [&str; 2] = ["customer", "enroll"];
 
 /// The command path segments of [`Activate`].
 pub const ACTIVATE_COMMAND: [&str; 2] = ["customer", "activate"];
+
+/// The command path segments of [`Add`].
+pub const PROVIDER_ADD_COMMAND: [&str; 2] = ["provider", "add"];
+
+/// The command path a consent delegation must grant, or a prefix of it.
+pub const CONSUMER_PROVISION_COMMAND: [&str; 2] = ["consumer", "provision"];
 
 /// How far in the future an enrollment invocation's mandatory
 /// expiration may sit: the five-minute ceremony window plus a one-minute
@@ -63,6 +71,8 @@ pub enum RegistrationCommand {
     Enroll,
     /// `/customer/activate`
     Activate,
+    /// `/provider/add`
+    ProviderAdd,
 }
 
 /// Peek at a container's invocation command without verifying anything.
@@ -76,8 +86,20 @@ pub fn registration_command(container_bytes: &[u8]) -> Option<RegistrationComman
     match segments.as_slice() {
         segments if segments == ENROLL_COMMAND => Some(RegistrationCommand::Enroll),
         segments if segments == ACTIVATE_COMMAND => Some(RegistrationCommand::Activate),
+        segments if segments == PROVIDER_ADD_COMMAND => Some(RegistrationCommand::ProviderAdd),
         _ => None,
     }
+}
+
+/// The JSON answer to a registration invocation: a customer receipt for
+/// the `/customer` commands, a consumer receipt for `/provider/add`.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum Answer {
+    /// `/customer/enroll` and `/customer/activate` answer the customer.
+    Customer(Receipt),
+    /// `/provider/add` answers the provisioned consumer.
+    Consumer(ConsumerReceipt),
 }
 
 /// The environment a registration invocation executes against: storage,
@@ -103,9 +125,9 @@ pub struct Registration<'a, S, E> {
 impl<S: Store, E: EmailSender> Registration<'_, S, E> {
     /// Verify the container, decode its capability, and perform it
     /// against this environment.
-    pub async fn handle(&self) -> Result<Receipt, RegistrationError>
+    pub async fn handle(&self) -> Result<Answer, RegistrationError>
     where
-        Self: Provider<Enroll> + Provider<Activate>,
+        Self: Provider<Enroll> + Provider<Activate> + Provider<Add>,
     {
         match registration_command(self.container) {
             Some(RegistrationCommand::Enroll) => {
@@ -113,11 +135,26 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
                     .verified_chain(&ENROLL_COMMAND, Some(CEREMONY_WINDOW_SECONDS))
                     .await?;
                 let effect: Enroll = deserialize_arguments(chain.arguments())?;
-                Subject::from(chain.subject().clone())
-                    .attenuate(Customer)
-                    .invoke(effect)
-                    .perform(self)
-                    .await
+                Ok(Answer::Customer(
+                    Subject::from(chain.subject().clone())
+                        .attenuate(Customer)
+                        .invoke(effect)
+                        .perform(self)
+                        .await?,
+                ))
+            }
+            Some(RegistrationCommand::ProviderAdd) => {
+                let chain = self
+                    .verified_chain(&PROVIDER_ADD_COMMAND, Some(CEREMONY_WINDOW_SECONDS))
+                    .await?;
+                let effect: Add = deserialize_arguments(chain.arguments())?;
+                Ok(Answer::Consumer(
+                    Subject::from(chain.subject().clone())
+                        .attenuate(ProviderRole)
+                        .invoke(effect)
+                        .perform(self)
+                        .await?,
+                ))
             }
             Some(RegistrationCommand::Activate) => {
                 // The presented invocation is the one enrollment emailed:
@@ -138,11 +175,13 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
                     });
                 }
                 let effect: Activate = deserialize_arguments(chain.arguments())?;
-                Subject::from(service)
-                    .attenuate(Customer)
-                    .invoke(effect)
-                    .perform(self)
-                    .await
+                Ok(Answer::Customer(
+                    Subject::from(service)
+                        .attenuate(Customer)
+                        .invoke(effect)
+                        .perform(self)
+                        .await?,
+                ))
             }
             None => Err(RegistrationError::Invalid {
                 message: "not a registration invocation".to_string(),
@@ -252,6 +291,104 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             Some(_) => Err(RegistrationError::CustomerSuspended),
             None => Err(RegistrationError::UnknownCustomer),
         }
+    }
+
+    /// Execute a verified `/provider/add`: validate the deposited consent
+    /// and provision the consumer under the invoking customer.
+    /// Re-provisioning under the same customer is a no-op success; a
+    /// consumer another customer provides is refused. Activation is not
+    /// required to add, only to serve: consumers added while the provider
+    /// is `Registered` go live with its activation.
+    pub async fn add(
+        &self,
+        capability: Capability<Add>,
+    ) -> Result<ConsumerReceipt, RegistrationError> {
+        let provider = capability.subject().clone();
+        let effect = capability.into_effect();
+        match self
+            .store
+            .customer(provider.as_str())
+            .await
+            .map_err(internal)?
+        {
+            None => return Err(RegistrationError::UnknownCustomer),
+            Some(customer) if customer.status == CustomerStatus::Suspended => {
+                return Err(RegistrationError::CustomerSuspended);
+            }
+            Some(_) => {}
+        }
+        let consent = self.deposited_delegation(&effect.consent.to_string())?;
+        self.verify_consent(&consent.delegation, &effect.consumer, &provider)
+            .await?;
+        if !self
+            .store
+            .add_consumer(effect.consumer.as_str(), provider.as_str(), self.now)
+            .await
+            .map_err(internal)?
+        {
+            return Err(RegistrationError::ConsumerProvided);
+        }
+        Ok(ConsumerReceipt {
+            consumer: effect.consumer,
+            provider,
+        })
+    }
+
+    /// Validate the deposited consent: the consumer's own delegation to
+    /// the invoking customer, granting `/consumer/provision` or broader,
+    /// signature-valid and inside its window. The audience is what binds
+    /// it, so a consent given to one customer cannot enrol a different
+    /// one; a powerline delegation from the space satisfies it as-is.
+    async fn verify_consent(
+        &self,
+        consent: &Delegation<Ed25519Signature>,
+        consumer: &Did,
+        provider: &Did,
+    ) -> Result<(), RegistrationError> {
+        if consent.issuer() != consumer {
+            return Err(RegistrationError::Forbidden {
+                message: format!(
+                    "consent must be issued by {consumer}, got {}",
+                    consent.issuer()
+                ),
+            });
+        }
+        if consent.audience() != provider {
+            return Err(RegistrationError::Forbidden {
+                message: format!(
+                    "consent was issued to {}, not the invoking customer",
+                    consent.audience()
+                ),
+            });
+        }
+        if let DelegatedSubject::Specific(subject) = consent.subject()
+            && subject != consumer
+        {
+            return Err(RegistrationError::Forbidden {
+                message: format!("consent must cover the consumer space, got {subject}"),
+            });
+        }
+        let granted = &consent.command().0;
+        if !granted
+            .iter()
+            .zip(CONSUMER_PROVISION_COMMAND.iter())
+            .all(|(granted, required)| granted == required)
+            || granted.len() > CONSUMER_PROVISION_COMMAND.len()
+        {
+            return Err(RegistrationError::Forbidden {
+                message: format!(
+                    "consent grants /{}, which does not cover /consumer/provision",
+                    granted.join("/")
+                ),
+            });
+        }
+        self.check_window(consent)?;
+        consent
+            .verify_signature(&Ed25519KeyResolver)
+            .await
+            .map_err(|err| RegistrationError::Unauthorized {
+                message: format!("consent failed to verify: {err}"),
+            })
     }
 
     /// Mint the activation invocation and wrap it into a link. The
@@ -506,6 +643,18 @@ where
 {
     async fn execute(&self, input: Capability<Activate>) -> Result<Receipt, RegistrationError> {
         self.activate(input).await
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S, E> Provider<Add> for Registration<'_, S, E>
+where
+    S: Store + ConditionalSync,
+    E: EmailSender + ConditionalSync,
+{
+    async fn execute(&self, input: Capability<Add>) -> Result<ConsumerReceipt, RegistrationError> {
+        self.add(input).await
     }
 }
 

--- a/rust/tonk-access-service/src/store.rs
+++ b/rust/tonk-access-service/src/store.rs
@@ -99,6 +99,11 @@ pub trait Store {
     /// a row changed; an `Active` customer's email is never touched here.
     async fn update_registered_email(&self, did: &str, email: &str) -> Result<bool, StoreError>;
 
+    /// Provision `did` as a consumer under `provider`. Idempotent for the
+    /// same provider; answers false when a different customer already
+    /// provides it, which the caller reports as a conflict.
+    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError>;
+
     /// Promote a `Registered` customer to `Active`, recording the
     /// activation time, terms acceptance, and cycle anchor. Returns false
     /// when no `Registered` row matched, which the caller disambiguates
@@ -135,6 +140,16 @@ pub const INSERT_SELF_CONSUMER: &str = r#"
 INSERT INTO consumer (did, provider, registered)
 VALUES (?1, ?1, ?2)
 ON CONFLICT (did) DO NOTHING
+"#;
+
+/// Provisioning is idempotent per provider: re-adding under the same
+/// customer re-runs the update, while a consumer someone else provides
+/// matches no row and changes nothing.
+pub const ADD_CONSUMER: &str = r#"
+INSERT INTO consumer (did, provider, registered)
+VALUES (?1, ?2, ?3)
+ON CONFLICT (did) DO UPDATE SET provider = excluded.provider
+WHERE consumer.provider IS NULL OR consumer.provider = excluded.provider
 "#;
 
 pub const UPDATE_REGISTERED_EMAIL: &str = r#"

--- a/rust/tonk-access-service/src/store/d1.rs
+++ b/rust/tonk-access-service/src/store/d1.rs
@@ -13,8 +13,8 @@ use worker::d1::D1Database;
 use worker::wasm_bindgen::JsValue;
 
 use crate::store::{
-    ACTIVATE_CUSTOMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER, SELECT_CONSUMER,
-    SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
+    ACTIVATE_CUSTOMER, ADD_CONSUMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER,
+    SELECT_CONSUMER, SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Cloudflare D1-backed [`Store`], for production use.
@@ -149,6 +149,22 @@ impl Store for D1Store {
             .0
             .prepare(UPDATE_REGISTERED_EMAIL)
             .bind(&[JsValue::from(did), JsValue::from(email)])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        Ok(changed_rows(&result) > 0)
+    }
+
+    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(ADD_CONSUMER)
+            .bind(&[
+                JsValue::from(did),
+                JsValue::from(provider),
+                JsValue::from_f64(now as f64),
+            ])
             .map_err(map_err)?
             .run()
             .await

--- a/rust/tonk-access-service/src/store/sqlite.rs
+++ b/rust/tonk-access-service/src/store/sqlite.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use super::{
-    ACTIVATE_CUSTOMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER, SELECT_CONSUMER,
-    SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
+    ACTIVATE_CUSTOMER, ADD_CONSUMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER,
+    SELECT_CONSUMER, SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -112,6 +112,14 @@ impl Store for SqliteStore {
         let conn = self.0.lock().expect("store mutex poisoned");
         let changed = conn
             .execute(UPDATE_REGISTERED_EMAIL, params![did, email])
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+
+    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(ADD_CONSUMER, params![did, provider, now as i64])
             .map_err(map_err)?;
         Ok(changed > 0)
     }

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -24,10 +24,10 @@ use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 use dialog_varsig::{Did, Principal};
 use tonk_access_service::email::CapturedEmail;
 use tonk_access_service::helpers::AccessServiceAddress;
-use tonk_access_service::registration::{Registration, SIGNUP_TERMS};
+use tonk_access_service::registration::{Answer, Registration, SIGNUP_TERMS};
 use tonk_access_service::store::Store;
 use tonk_access_service::store::sqlite::SqliteStore;
-use tonk_account::customer::RegistrationError;
+use tonk_account::customer::{Receipt, RegistrationError};
 
 /// Current time as unix seconds.
 fn unix_now() -> u64 {
@@ -85,6 +85,14 @@ impl Fixture {
             .last()
             .cloned()
             .expect("an activation email was captured")
+    }
+}
+
+/// Unwrap a customer receipt, refusing the consumer-shaped answer.
+fn as_customer(answer: Answer) -> Receipt {
+    match answer {
+        Answer::Customer(receipt) => receipt,
+        Answer::Consumer(receipt) => panic!("expected a customer receipt, got {receipt:?}"),
     }
 }
 
@@ -183,7 +191,7 @@ async fn it_enrolls_a_customer_and_emails_an_activation_link() -> anyhow::Result
     let customer = Ed25519Signer::generate().await?;
     let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
 
-    let receipt = fixture.registration(&container).handle().await.unwrap();
+    let receipt = as_customer(fixture.registration(&container).handle().await.unwrap());
     assert_eq!(receipt.customer, customer.did());
     assert_eq!(serde_json::to_value(receipt.status)?, "Registered");
 
@@ -204,7 +212,7 @@ async fn it_activates_by_presenting_the_emailed_invocation_from_any_device() -> 
     // it is activating, no customer key involved, so a click on any
     // device finalizes.
     let container = link_container(&fixture.last_email().1);
-    let receipt = fixture.registration(&container).handle().await.unwrap();
+    let receipt = as_customer(fixture.registration(&container).handle().await.unwrap());
     assert_eq!(receipt.customer, customer.did());
     assert_eq!(serde_json::to_value(receipt.status)?, "Active");
 
@@ -219,7 +227,7 @@ async fn it_activates_by_presenting_the_emailed_invocation_from_any_device() -> 
 
     // Clicking twice leaves the customer active and writes no duplicate
     // state.
-    let receipt = fixture.registration(&container).handle().await.unwrap();
+    let receipt = as_customer(fixture.registration(&container).handle().await.unwrap());
     assert_eq!(serde_json::to_value(receipt.status)?, "Active");
     Ok(())
 }
@@ -362,6 +370,120 @@ async fn it_registers_the_account_consumer_atomically_with_the_customer() -> any
         .unwrap()
         .expect("the account space is a consumer");
     assert_eq!(consumer.provider.as_deref(), Some(customer.did().as_str()));
+    Ok(())
+}
+
+/// Build a `/provider/add` container: a customer-signed invocation
+/// depositing the space's consent delegation.
+async fn add_container(
+    customer: &Ed25519Signer,
+    space: &Ed25519Signer,
+    consent_to: &Did,
+) -> Vec<u8> {
+    let consent = DelegationBuilder::new()
+        .issuer(space.clone())
+        .audience(consent_to)
+        .subject(DelegatedSubject::Specific(space.did()))
+        .command(vec![])
+        .try_build()
+        .await
+        .expect("consent delegation");
+    let invocation = InvocationBuilder::new()
+        .issuer(customer.clone())
+        .audience(&customer.did())
+        .subject(&customer.did())
+        .command(vec!["provider".to_string(), "add".to_string()])
+        .arguments(BTreeMap::from([
+            (
+                "consumer".to_string(),
+                Promised::String(space.did().to_string()),
+            ),
+            ("consent".to_string(), Promised::Link(consent.to_cid())),
+        ]))
+        .proofs(vec![])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .expect("add invocation");
+    let tokens = vec![
+        serde_ipld_dagcbor::to_vec(&invocation).expect("invocation encodes"),
+        consent.encoded().to_vec(),
+    ];
+    Container::new(tokens)
+        .to_bytes()
+        .expect("container encodes")
+}
+
+#[dialog_common::test]
+async fn it_provisions_a_consumer_with_the_spaces_consent() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let space = Ed25519Signer::generate().await?;
+    let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    // Activation is not required to add, only to serve: the customer is
+    // still Registered here.
+    let container = add_container(&customer, &space, &customer.did()).await;
+    let Answer::Consumer(receipt) = fixture.registration(&container).handle().await.unwrap() else {
+        panic!("expected a consumer receipt");
+    };
+    assert_eq!(receipt.consumer, space.did());
+    assert_eq!(receipt.provider, customer.did());
+
+    let consumer = fixture
+        .store
+        .consumer(space.did().as_str())
+        .await
+        .unwrap()
+        .expect("the consumer row exists");
+    assert_eq!(consumer.provider.as_deref(), Some(customer.did().as_str()));
+
+    // Re-provisioning under the same customer is a no-op success.
+    let container = add_container(&customer, &space, &customer.did()).await;
+    assert!(fixture.registration(&container).handle().await.is_ok());
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_refuses_provisioning_someone_elses_consumer() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let alice = Ed25519Signer::generate().await?;
+    let mallory = Ed25519Signer::generate().await?;
+    let space = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    for (customer, email) in [
+        (&alice, "alice@example.com"),
+        (&mallory, "mallory@example.com"),
+    ] {
+        let container = enroll_container(customer, &service, email).await;
+        fixture.registration(&container).handle().await.unwrap();
+    }
+
+    let container = add_container(&alice, &space, &alice.did()).await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    let container = add_container(&mallory, &space, &mallory.did()).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::ConsumerProvided));
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_refuses_a_consent_issued_to_another_customer() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let alice = Ed25519Signer::generate().await?;
+    let mallory = Ed25519Signer::generate().await?;
+    let space = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    let container = enroll_container(&mallory, &service, "mallory@example.com").await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    // The space consented to Alice; Mallory presenting that consent must
+    // not become its provider.
+    let container = add_container(&mallory, &space, &alice.did()).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
     Ok(())
 }
 

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -58,6 +58,63 @@ impl Effect for Activate {
     type Output = Result<Receipt, RegistrationError>;
 }
 
+/// Ability segment `/provider`: acts a customer takes as the party
+/// paying for consumer spaces. Distinct from `/customer` so delegating
+/// one role can never leak the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provider;
+
+impl Attenuation for Provider {
+    type Of = Subject;
+}
+
+/// `/provider/add` — provision a consumer space under the invoking
+/// customer. The invocation's subject is the customer DID; the consumer's
+/// consent travels as a deposited delegation named by CID.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Attenuate)]
+pub struct Add {
+    /// The space being provisioned.
+    pub consumer: Did,
+    /// The consent delegation, by CID; its bytes travel in the same
+    /// container. It must root at the consumer and be issued to the
+    /// invoking customer, granting `/consumer/provision` or broader.
+    pub consent: Cid,
+}
+
+impl Effect for Add {
+    type Of = Provider;
+    type Output = Result<ConsumerReceipt, RegistrationError>;
+}
+
+/// Ability segment `/consumer`: acts a space takes on its own behalf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Consumer;
+
+impl Attenuation for Consumer {
+    type Of = Subject;
+}
+
+/// `/consumer/provision` — the consent a space delegates to the customer
+/// it accepts as its provider; the delegation's audience is what names
+/// that customer. Never invoked: it exists to be deposited with
+/// [`Add`], and a powerline delegation satisfies it as-is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Attenuate)]
+pub struct Provision;
+
+impl Effect for Provision {
+    type Of = Consumer;
+    type Output = ();
+}
+
+/// The successful answer to a `/provider/add` invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConsumerReceipt {
+    /// The provisioned space.
+    pub consumer: Did,
+    /// The customer now providing it.
+    pub provider: Did,
+}
+
 /// Customer lifecycle state, as stored and as answered on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CustomerStatus {
@@ -126,6 +183,9 @@ pub enum RegistrationError {
     /// No customer to act on.
     #[error("no such customer")]
     UnknownCustomer,
+    /// The consumer already has a different provider.
+    #[error("this consumer already has a provider")]
+    ConsumerProvided,
     /// The customer is already active, so enrollment is refused.
     #[error("this customer is already active")]
     CustomerActive,
@@ -148,7 +208,9 @@ impl RegistrationError {
             RegistrationError::Unauthorized { .. } => 401,
             RegistrationError::Forbidden { .. } => 403,
             RegistrationError::UnknownCustomer => 404,
-            RegistrationError::CustomerActive | RegistrationError::CustomerSuspended => 409,
+            RegistrationError::CustomerActive
+            | RegistrationError::CustomerSuspended
+            | RegistrationError::ConsumerProvided => 409,
             RegistrationError::Internal { .. } => 500,
         }
     }
@@ -177,6 +239,15 @@ mod tests {
             terms: "2026-08".into(),
         });
         assert_eq!(activate.ability(), "/customer/activate");
+
+        let add: Capability<Add> = subject().attenuate(Provider).invoke(Add {
+            consumer: did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"),
+            consent: Cid::default(),
+        });
+        assert_eq!(add.ability(), "/provider/add");
+
+        let provision: Capability<Provision> = subject().attenuate(Consumer).invoke(Provision);
+        assert_eq!(provision.ability(), "/consumer/provision");
     }
 
     #[test]

--- a/rust/tonk-cli/src/customer.rs
+++ b/rust/tonk-cli/src/customer.rs
@@ -136,6 +136,48 @@ pub async fn enroll(profile: &Profile, email: Option<String>) -> Result<Receipt>
     }
 }
 
+/// Provision `consumer` with the access service under this profile's
+/// account, depositing `consent` — the space's powerline to the account.
+/// A consumer another customer already provides is left alone: the space
+/// exists and works locally either way.
+pub async fn provision(
+    profile: &Profile,
+    consumer: &Did,
+    consent: &dialog_ucan_core::DelegationChain,
+) -> Result<()> {
+    let connection = crate::account::optional_connection(profile)
+        .await?
+        .context("no active account; run `tonk account link`")?;
+    let origin = access_origin(profile)
+        .await?
+        .context("the account has no repository descriptor to locate its service by")?;
+    let body = tonk_identity::request::build_provider_add_invocation(
+        profile.signer().signer().clone(),
+        &connection.link,
+        consumer,
+        consent,
+    )
+    .await?;
+    let response = reqwest::Client::new()
+        .post(origin.join("ucan/")?)
+        .header("content-type", "application/cbor")
+        .body(body)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .context("failed to reach the access service")?;
+    if response.status().is_success() {
+        return Ok(());
+    }
+    let status = response.status();
+    let refusal: serde_json::Value = response.json().await.unwrap_or_default();
+    match serde_json::from_value::<RegistrationError>(refusal["error"].clone()) {
+        Ok(RegistrationError::ConsumerProvided) => Ok(()),
+        Ok(refusal) => bail!("the access service refused provisioning: {refusal}"),
+        Err(_) => bail!("access service rejected provisioning ({status})"),
+    }
+}
+
 /// The service's view of this profile's account: `Ok(None)` when the
 /// profile is not linked or its account has no located service, and an
 /// inner `None` when the service does not know the customer.

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -409,6 +409,13 @@ async fn bootstrap_repository(
         eprintln!("warning: space not retained into the account space: {error:#}");
     }
 
+    // The billing half of the same act: provision the new space as a
+    // consumer of the access service, depositing the powerline as its
+    // consent. Non-fatal for the same reason retain is.
+    if let Err(error) = crate::customer::provision(profile, &signer_repo.did(), &prefix).await {
+        eprintln!("warning: space not provisioned with the sync service: {error:#}");
+    }
+
     profile
         .repository(REPO_NAME)
         .load()

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -105,6 +105,47 @@ pub async fn build_enroll_invocation(
         .context("failed to encode the enroll container")
 }
 
+/// Build a `/provider/add` container for the access service.
+///
+/// The invocation is device-signed on the account's subject, and the
+/// space's consent chain — its powerline to the account — is deposited
+/// alongside, named by the CID of its head. The server walks the consent
+/// from the consumer to the invoking customer.
+pub async fn build_provider_add_invocation(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    consumer: &Did,
+    consent: &DelegationChain,
+) -> Result<Vec<u8>> {
+    let head = consent
+        .proofs()
+        .next()
+        .context("the consent chain carries no delegation")?;
+    let arguments = BTreeMap::from([
+        (
+            "consumer".to_string(),
+            Promised::String(consumer.to_string()),
+        ),
+        ("consent".to_string(), Promised::Link(head.to_cid())),
+    ]);
+    let invocation = build_device_invocation(
+        device,
+        link,
+        vec!["provider".to_string(), "add".to_string()],
+        arguments,
+    )
+    .await?;
+    let mut tokens = Container::from_bytes(&invocation)
+        .context("failed to reopen the add container")?
+        .into_tokens();
+    for delegation in consent.proofs() {
+        tokens.push(delegation.encoded().to_vec());
+    }
+    Container::new(tokens)
+        .to_bytes()
+        .context("failed to encode the add container")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -210,6 +210,59 @@ pub async fn get_state(
     }))
 }
 
+/// Provision `consumer` with the same-origin access service under this
+/// profile's account, depositing `consent` — the space's powerline to
+/// the account. A consumer another customer already provides is not an
+/// error here: the space exists and works locally either way, and the
+/// caller treats this whole call as best effort.
+pub(crate) async fn provision_consumer(
+    state: &crate::worker::TonkState,
+    consumer: &dialog_varsig::Did,
+    consent: &dialog_ucan_core::DelegationChain,
+) -> Result<(), TonkWorkerError> {
+    use tonk_identity::request::build_provider_add_invocation;
+
+    let link = super::account::account_link(state).await.ok_or_else(|| {
+        TonkWorkerError::NotFound("this profile is not linked to an account".to_string())
+    })?;
+    let device = state.profile.signer().signer().clone();
+    let body = build_provider_add_invocation(device, &link, consumer, consent)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to build the add invocation: {error}"))
+        })?;
+    let origin = service_origin()?;
+    match post_cbor(&ucan_endpoint(&origin)?, &body).await {
+        Ok(_) => Ok(()),
+        Err(HttpError::Upstream(failure))
+            if failure.code.as_deref() == Some("ConsumerProvided") =>
+        {
+            log!("consumer {consumer} already has a provider; leaving it");
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// The worker's own origin, which the access service serves. Known only
+/// inside a service-worker scope; callers outside one (native tests)
+/// carry an origin of their own through `RequestOrigin` instead.
+fn service_origin() -> Result<Url, TonkWorkerError> {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let origin = super::repository::worker_origin().ok_or_else(|| {
+            TonkWorkerError::Internal("the worker origin is unavailable".to_string())
+        })?;
+        format!("{origin}/").parse().map_err(|error| {
+            TonkWorkerError::Internal(format!("worker origin is not a URL: {error}"))
+        })
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    Err(TonkWorkerError::Internal(
+        "the worker origin is only known in a service-worker scope".to_string(),
+    ))
+}
+
 /// The service DID from the same-origin deployment configuration.
 async fn service_did(origin: &Url) -> Result<dialog_varsig::Did, TonkWorkerError> {
     let endpoint = origin

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1250,7 +1250,7 @@ async fn invite_url(proof: &str, remote: &str, seed: &str) -> String {
 /// test harness runs in a *window*, never a `ServiceWorkerGlobalScope`, so
 /// a test driving `invite_url` could only ever reach the no-origin branch.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn worker_origin() -> Option<String> {
+pub(super) fn worker_origin() -> Option<String> {
     use wasm_bindgen::JsCast;
 
     js_sys::global()
@@ -2697,6 +2697,15 @@ pub async fn create_repository(
     // what makes it recoverable on the next device, since a device regains
     // access by pulling the account rather than by fetching an artifact.
     super::account_state::retain_space_delegation(tonk, &prefix).await;
+
+    // The billing half of the same act: provision the new space as a
+    // consumer of the access service, depositing the powerline as its
+    // consent. Best effort for the same reason retain is — a space is
+    // usable the moment its delegations exist locally.
+    if let Err(error) = super::customer::provision_consumer(tonk, &repository.did(), &prefix).await
+    {
+        log!("consumer provisioning skipped: {error}");
+    }
 
     let prefix_bytes = prefix.to_bytes().map_err(|error| {
         RepositoryError::Internal(format!(


### PR DESCRIPTION
Stacked on #713. Second increment of the [access metering plan](https://github.com/tonk-labs/tonk/pull/702): space provisioning, so the service knows which customer pays for which space before metering attributes anything.

`/provider/add` is a capability in `tonk-account::customer` alongside enroll/activate (`Provider` attenuation, so delegating `/provider` can never leak `/customer` or `/sponsor` powers), invoked on the customer's own subject with the space's consent deposited by CID. The consent is the powerline delegation the space already mints to the account at creation, exactly as the plan predicted: the server validates it as the consumer's own delegation to the invoking customer granting `/consumer/provision` or broader (audience is what binds it), and provisions idempotently, `ON CONFLICT` keeps re-adding under the same provider a no-op while a consumer someone else provides answers `ConsumerProvided`. Activation is not required to add, only to serve: consumers added while the provider is `Registered` go live with its activation.

Client side, provisioning happens where retention already does: the worker at space creation next to `retain_space_delegation`, the CLI at spot bootstrap, both best effort for the same reason retain is, a space is usable the moment its delegations exist locally. Both build the container through the shared `tonk_identity::request::build_provider_add_invocation`.

Service tests cover the happy path (consent = powerline, Registered provider), idempotent re-add, second-provider refusal, and a consent issued to a different customer.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the consumer provisioning process in the `tonk` system, introducing new functionalities for handling consumer spaces under providers, along with related error handling and database operations.

### Detailed summary
- Changed return type of a function in `registration.rs` from `Receipt` to `Answer`.
- Added `add_consumer` function in both `sqlite.rs` and `d1.rs` for provisioning consumers.
- Introduced a new command path segment `/provider/add` and its handling in `registration.rs`.
- Enhanced error handling for consumer provisioning scenarios.
- Added tests for consumer provisioning, including cases for successful and refused provisioning.
- Updated `Answer` enum to differentiate between customer and consumer receipts.
- Implemented verification for consent in the provisioning process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->