### PR TITLE
Meter invocations into an ingest database

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,38 +149,51 @@ jobs:
       # The access worker's control database follows the same per-PR shape
       # as the account worker's, and for the same reason: divergent
       # migration histories cannot share a database.
-      - name: Prepare preview access database
+      - name: Prepare preview access databases
         if: github.event_name == 'pull_request'
         id: access-database
         run: |
           set -euo pipefail
-          database="tonk-access-control-pr-${{ github.event.pull_request.number }}"
-          config="$PWD/wrangler.preview.toml"
-          database_id="$({
-            nix --accept-flake-config develop .#ci --command wrangler d1 list --json
-          } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
-          if [ -z "$database_id" ]; then
-            nix --accept-flake-config develop .#ci --command \
-              wrangler d1 create "$database" --location weur
-            database_id="$({
+          resolve() {
+            local database="$1"
+            local id
+            id="$({
               nix --accept-flake-config develop .#ci --command wrangler d1 list --json
             } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
-          fi
-          if [ -z "$database_id" ]; then
-            echo "::error::Could not resolve the D1 database id for $database"
-            exit 1
-          fi
+            if [ -z "$id" ]; then
+              nix --accept-flake-config develop .#ci --command \
+                wrangler d1 create "$database" --location weur >&2
+              id="$({
+                nix --accept-flake-config develop .#ci --command wrangler d1 list --json
+              } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"
+            fi
+            if [ -z "$id" ]; then
+              echo "::error::Could not resolve the D1 database id for $database" >&2
+              exit 1
+            fi
+            echo "$id"
+          }
+          control="tonk-access-control-pr-${{ github.event.pull_request.number }}"
+          ingest="tonk-access-ingest-pr-${{ github.event.pull_request.number }}"
+          config="$PWD/wrangler.preview.toml"
+          control_id="$(resolve "$control")"
+          ingest_id="$(resolve "$ingest")"
           cp wrangler.toml "$config"
           sed -i \
-            -e "s/database_name = \"tonk-access-control-preview\"/database_name = \"$database\"/" \
-            -e "s/database_id = \"REPLACED-PER-PULL-REQUEST\"/database_id = \"$database_id\"/" \
+            -e "s/database_name = \"tonk-access-control-preview\"/database_name = \"$control\"/" \
+            -e "s/database_id = \"REPLACED-PER-PULL-REQUEST\"/database_id = \"$control_id\"/" \
+            -e "s/database_name = \"tonk-access-ingest-preview\"/database_name = \"$ingest\"/" \
+            -e "s/database_id = \"INGEST-REPLACED-PER-PULL-REQUEST\"/database_id = \"$ingest_id\"/" \
             "$config"
-          if ! grep -Fq "database_name = \"$database\"" "$config" \
-            || ! grep -Fq "database_id = \"$database_id\"" "$config"; then
-            echo "::error::Could not bind the access preview config to $database"
+          if ! grep -Fq "database_name = \"$control\"" "$config" \
+            || ! grep -Fq "database_id = \"$control_id\"" "$config" \
+            || ! grep -Fq "database_name = \"$ingest\"" "$config" \
+            || ! grep -Fq "database_id = \"$ingest_id\"" "$config"; then
+            echo "::error::Could not bind the access preview config to $control/$ingest"
             exit 1
           fi
-          echo "database=$database" >> "$GITHUB_OUTPUT"
+          echo "database=$control" >> "$GITHUB_OUTPUT"
+          echo "ingest=$ingest" >> "$GITHUB_OUTPUT"
           echo "config=$config" >> "$GITHUB_OUTPUT"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -192,6 +205,10 @@ jobs:
           nix --accept-flake-config develop .#ci --command \
             wrangler d1 migrations apply \
               "${{ steps.access-database.outputs.database }}" --remote \
+              --env preview -c "${{ steps.access-database.outputs.config }}"
+          nix --accept-flake-config develop .#ci --command \
+            wrangler d1 migrations apply \
+              "${{ steps.access-database.outputs.ingest }}" --remote \
               --env preview -c "${{ steps.access-database.outputs.config }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -264,6 +281,9 @@ jobs:
           nix --accept-flake-config develop --command \
             wrangler d1 migrations apply tonk-access-control-staging --remote \
               --env staging -c wrangler.toml
+          nix --accept-flake-config develop --command \
+            wrangler d1 migrations apply tonk-access-ingest-staging --remote \
+              --env staging -c wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -297,6 +317,9 @@ jobs:
         run: |
           nix --accept-flake-config develop --command \
             wrangler d1 migrations apply tonk-access-control --remote \
+              -c wrangler.toml
+          nix --accept-flake-config develop --command \
+            wrangler d1 migrations apply tonk-access-ingest --remote \
               -c wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -349,7 +372,8 @@ jobs:
           set -euo pipefail
           for database in \
             "tonk-accounts-pr-${{ github.event.pull_request.number }}" \
-            "tonk-access-control-pr-${{ github.event.pull_request.number }}"; do
+            "tonk-access-control-pr-${{ github.event.pull_request.number }}" \
+            "tonk-access-ingest-pr-${{ github.event.pull_request.number }}"; do
             database_id="$({
               nix --accept-flake-config develop .#ci --command wrangler d1 list --json
             } | jq -r --arg name "$database" '.[] | select(.name == $name) | .uuid' | head -n 1)"

--- a/rust/tonk-access-service/migrations-ingest/0001_ingest.sql
+++ b/rust/tonk-access-service/migrations-ingest/0001_ingest.sql
@@ -1,0 +1,34 @@
+-- Ingest: one row per invocation, with the invocation bytes inline.
+-- Bulky, write-heavy, disposable once charged and archived; split from
+-- the control database so it has its own 10 GB ceiling and its schema
+-- churn stays clear of billing state. See plan/Access metering.md.
+
+-- No secondary indexes: each one adds a written row per insert.
+CREATE TABLE invocation (
+  id       INTEGER PRIMARY KEY,   -- cursor within this database
+  ts       INTEGER NOT NULL,
+  cid      TEXT    NOT NULL,      -- evidence key
+  consumer TEXT    NOT NULL,
+  issuer   TEXT    NOT NULL,
+  cmd      TEXT    NOT NULL,
+  outcome  TEXT    NOT NULL,      -- ok | denied
+  reason   TEXT,
+  bytes    INTEGER NOT NULL DEFAULT 0,
+  compute  INTEGER NOT NULL DEFAULT 0,
+  chain    TEXT    NOT NULL,      -- id of the flattened proof set
+  body     BLOB    NOT NULL       -- invocation bytes, proofs by reference
+);
+
+-- The transitive proof set, flattened at write time so evidence
+-- retrieval is two queries rather than a recursive walk. Written once
+-- per unique operator session, referenced by every invocation in it.
+CREATE TABLE chain (
+  chain TEXT NOT NULL,
+  proof TEXT NOT NULL,
+  PRIMARY KEY (chain, proof)
+);
+
+CREATE TABLE block (
+  cid  TEXT PRIMARY KEY,
+  body BLOB NOT NULL
+);

--- a/rust/tonk-access-service/src/error.rs
+++ b/rust/tonk-access-service/src/error.rs
@@ -37,6 +37,18 @@ impl From<Rejection> for Refusal {
 impl Refusal {
     /// A refusal for a failure of our own machinery that is not worth
     /// retrying as-is.
+    /// The refusal's stable kind tag, as it appears on the wire.
+    pub fn kind(&self) -> String {
+        let value = match self {
+            Refusal::Authorization(reason) => serde_json::to_value(reason),
+            Refusal::Rejection(rejection) => serde_json::to_value(rejection),
+        };
+        value
+            .ok()
+            .and_then(|value| value["kind"].as_str().map(str::to_owned))
+            .unwrap_or_else(|| "Unclassified".to_string())
+    }
+
     pub fn unclassified(detail: impl Into<String>) -> Self {
         Self::Rejection(Rejection::Unclassified {
             detail: detail.into(),

--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -6,7 +6,7 @@
 
 use dialog_credentials::Ed25519Signer;
 use tonk_account::customer::RegistrationError;
-use worker::{Request, Response, RouteContext, console_error};
+use worker::{Env, Request, Response, RouteContext, console_error};
 
 use crate::service::{did_document, signer_from_hex};
 
@@ -17,12 +17,8 @@ const DEFAULT_EMAIL_TOKEN_TTL: u64 = 24 * 60 * 60;
 
 /// Answer a registration invocation.
 #[cfg(target_arch = "wasm32")]
-pub async fn handle(
-    body: &[u8],
-    req: &Request,
-    ctx: &RouteContext<()>,
-) -> worker::Result<Response> {
-    match handle_inner(body, req, ctx).await {
+pub async fn handle(body: &[u8], req: &Request, env: &Env) -> worker::Result<Response> {
+    match handle_inner(body, req, env).await {
         Ok(receipt) => Response::from_json(&receipt),
         Err(err) => {
             let response = Response::from_json(&serde_json::json!({ "error": err }))?;
@@ -35,7 +31,7 @@ pub async fn handle(
 async fn handle_inner(
     body: &[u8],
     req: &Request,
-    ctx: &RouteContext<()>,
+    env: &Env,
 ) -> Result<crate::registration::Answer, RegistrationError> {
     use worker::Date;
 
@@ -44,16 +40,15 @@ async fn handle_inner(
     use crate::store::d1::D1Store;
 
     let store = D1Store::new(
-        ctx.env
-            .d1("CONTROL")
+        env.d1("CONTROL")
             .map_err(|err| internal(format!("control database: {err}")))?,
     );
-    let service = service_signer(ctx)?;
-    let api_key = ctx
+    let service = service_signer(env)?;
+    let api_key = env
         .secret("RESEND_API_KEY")
         .map_err(|err| internal(format!("RESEND_API_KEY: {err}")))?
         .to_string();
-    let from = ctx
+    let from = env
         .var("EMAIL_FROM")
         .map_err(|err| internal(format!("EMAIL_FROM: {err}")))?
         .to_string();
@@ -63,7 +58,7 @@ async fn handle_inner(
         .url()
         .map_err(|err| internal(format!("request url: {err}")))?;
     let origin = url.origin().ascii_serialization();
-    let activation_ttl = ctx
+    let activation_ttl = env
         .var("EMAIL_TOKEN_TTL")
         .ok()
         .and_then(|value| value.to_string().parse().ok())
@@ -87,8 +82,8 @@ fn internal(message: String) -> RegistrationError {
 }
 
 /// The service's signing identity, from the `SERVICE_SECRET_KEY` secret.
-fn service_signer(ctx: &RouteContext<()>) -> Result<Ed25519Signer, RegistrationError> {
-    let seed = ctx
+fn service_signer(env: &Env) -> Result<Ed25519Signer, RegistrationError> {
+    let seed = env
         .secret("SERVICE_SECRET_KEY")
         .map_err(|err| internal(format!("SERVICE_SECRET_KEY: {err}")))?
         .to_string();
@@ -151,7 +146,7 @@ pub async fn handle_customer(_req: Request, ctx: RouteContext<()>) -> worker::Re
 
 /// GET `/.well-known/did.json` → the service's DID document.
 pub async fn handle_did_document(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
-    let signer = match service_signer(&ctx) {
+    let signer = match service_signer(&ctx.env) {
         Ok(signer) => signer,
         Err(err) => {
             console_error!("did document unavailable: {err}");

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -4,6 +4,10 @@
 //! 1. Reading the CBOR-encoded UCAN container from the request body
 //! 2. Passing it to UcanAuthorizer for verification and authorization
 //! 3. Returning the serialized AuthorizedRequest as CBOR
+//!
+//! Served outside the Router, straight from the fetch event: recording
+//! an invocation must outlive the response, and only the event's
+//! [`Context`] can extend the isolate's life for it.
 
 use crate::error::Refusal;
 #[cfg(target_arch = "wasm32")]
@@ -35,68 +39,120 @@ pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Res
     Ok(response.with_headers(headers))
 }
 
-/// POST /ucan/ → Authorize UCAN invocation and return presigned S3 request
-pub async fn handle(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
-    let response = match handle_inner(&mut req, &ctx).await {
-        Ok(response) => response,
-        Err(err) => err.to_response()?,
+/// POST /ucan/ → Authorize UCAN invocation and return presigned S3
+/// request, recording the invocation in ingest under `ctx.wait_until`.
+pub async fn serve(mut req: Request, env: Env, ctx: Context) -> Result<Response> {
+    let body_bytes = match req.bytes().await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            let refusal: Refusal = AuthorizeError::Malformed {
+                detail: format!("failed to read request body: {e}"),
+            }
+            .into();
+            return Ok(with_cors_headers(refusal.to_response()?));
+        }
     };
+
+    // Registration commands ride the same endpoint; anything else falls
+    // through to the presign path untouched. Registration is not
+    // metered: those invocations are once-per-account ceremonies, not
+    // billable operations.
+    #[cfg(target_arch = "wasm32")]
+    if registration_command(&body_bytes).is_some() {
+        return handle_registration(&body_bytes, &req, &env)
+            .await
+            .map(with_cors_headers);
+    }
+
+    let (response, metered) = match presign(&body_bytes, &env).await {
+        Ok((response, bytes)) => (response, Some(("ok", None, bytes))),
+        Err(refusal) => {
+            // Denials are recorded — a client retrying against a blocked
+            // consumer still costs invocations — but only attributable
+            // ones: infra failures and malformed containers are the
+            // service's cost, not the consumer's.
+            let metered =
+                matches!(refusal.status(), 401 | 403).then(|| ("denied", Some(refusal.kind()), 0));
+            (refusal.to_response()?, metered)
+        }
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    if let Some((outcome, reason, bytes)) = metered {
+        record_invocation(&body_bytes, outcome, reason, bytes, &env, &ctx);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = (metered, ctx);
+
     Ok(with_cors_headers(response))
 }
 
-async fn handle_inner(
-    req: &mut Request,
-    ctx: &RouteContext<()>,
-) -> std::result::Result<Response, Refusal> {
-    // 1. Read the request body as bytes
-    let body_bytes = req.bytes().await.map_err(|e| AuthorizeError::Malformed {
-        detail: format!("failed to read request body: {e}"),
-    })?;
+/// Queue the invocation record behind the response. Failures are logged,
+/// never surfaced: metering loss errs in the customer's favour and must
+/// not cost them the permit they already hold.
+#[cfg(target_arch = "wasm32")]
+fn record_invocation(
+    body_bytes: &[u8],
+    outcome: &'static str,
+    reason: Option<String>,
+    bytes: u64,
+    env: &Env,
+    ctx: &Context,
+) {
+    use crate::store::ingest::{D1Ingest, IngestStore};
 
-    // 1b. Registration commands ride the same endpoint; anything else
-    // falls through to the presign path untouched.
-    #[cfg(target_arch = "wasm32")]
-    if registration_command(&body_bytes).is_some() {
-        return handle_registration(&body_bytes, req, ctx)
-            .await
-            .map_err(|err| Refusal::unclassified(format!("registration failed: {err}")));
+    let now = Date::now().as_millis() / 1_000;
+    let Some(record) = crate::metering::collect(body_bytes, outcome, reason, bytes, now) else {
+        return;
+    };
+    match env.d1("INGEST") {
+        Ok(database) => ctx.wait_until(async move {
+            if let Err(err) = D1Ingest::new(database).record(&record).await {
+                console_error!("metering write failed: {err}");
+            }
+        }),
+        Err(err) => console_error!("metering skipped, no INGEST binding: {err}"),
     }
+}
 
-    // 2. Create the UcanAuthorizer from environment config
-    let authorizer = create_authorizer(ctx)?;
-
-    // 3. Authorize the UCAN container
+/// Authorize the container and answer the presigned request, together
+/// with the declared write bytes when the permit carries them.
+async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response, u64), Refusal> {
+    let authorizer = create_authorizer(env)?;
     let authorized_request = authorizer
-        .authorize(&body_bytes)
+        .authorize(body_bytes)
         .await
         .map_err(map_access_error)?;
 
-    // 3b. Screen the presented credentials: the window they claim, and
+    // Screen the presented credentials: the window they claim, and
     // whether any of them belongs to a revoked device. Runs only after
     // cryptographic authorization succeeded, and fails closed: a
     // presign the screen cannot clear is refused.
     #[cfg(target_arch = "wasm32")]
-    screen_credentials(&body_bytes, ctx).await?;
+    screen_credentials(body_bytes, env).await?;
 
-    // 4. Serialize the response as CBOR
+    // Write permits carry the declared size as a signed Content-Length,
+    // which is the exact byte figure metering records.
+    let bytes = authorized_request
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.parse().ok())
+        .unwrap_or(0);
+
     let cbor_bytes = serde_ipld_dagcbor::to_vec(&authorized_request)
         .map_err(|e| Refusal::unclassified(format!("failed to serialize response: {e}")))?;
-
-    // 5. Return CBOR response
     Response::from_bytes(cbor_bytes)
         .map(|r| {
             let headers = Headers::new();
             let _ = headers.set("Content-Type", "application/cbor");
-            r.with_headers(headers)
+            (r.with_headers(headers), bytes)
         })
         .map_err(|e| Refusal::unclassified(format!("response error: {e}")))
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn screen_credentials(
-    body_bytes: &[u8],
-    ctx: &RouteContext<()>,
-) -> std::result::Result<(), Refusal> {
+async fn screen_credentials(body_bytes: &[u8], env: &Env) -> std::result::Result<(), Refusal> {
     use crate::expiry::{WindowVerdict, check_window};
     use crate::revocation::{self, SetVerdict, r2::R2RevocationSource};
 
@@ -135,7 +191,7 @@ async fn screen_credentials(
         }
     }
 
-    let registry = match ctx.bucket("REVOCATIONS") {
+    let registry = match env.bucket("REVOCATIONS") {
         Ok(bucket) => R2RevocationSource::new(bucket),
         Err(err) => {
             console_error!("revocation screen unavailable, no REVOCATIONS binding: {err}");
@@ -185,36 +241,36 @@ thread_local! {
 /// an isolate cannot see change — so reading the bindings once and
 /// reusing the result costs nothing in freshness. A failed build is
 /// not cached: the next request tries again.
-fn create_authorizer(ctx: &RouteContext<()>) -> std::result::Result<UcanAuthorizer, Refusal> {
+fn create_authorizer(env: &Env) -> std::result::Result<UcanAuthorizer, Refusal> {
     AUTHORIZER.with(|cached| {
         if let Some(authorizer) = cached.get() {
             return Ok(authorizer.clone());
         }
-        let authorizer = build_authorizer(ctx)?;
+        let authorizer = build_authorizer(env)?;
         let _ = cached.set(authorizer.clone());
         Ok(authorizer)
     })
 }
 
 /// Create UcanAuthorizer from environment configuration.
-fn build_authorizer(ctx: &RouteContext<()>) -> std::result::Result<UcanAuthorizer, Refusal> {
+fn build_authorizer(env: &Env) -> std::result::Result<UcanAuthorizer, Refusal> {
     // Get R2 configuration from environment
-    let account_id = ctx
+    let account_id = env
         .var("R2_ACCOUNT_ID")
         .map_err(|e| Refusal::unclassified(format!("Missing R2_ACCOUNT_ID: {e}")))?
         .to_string();
 
-    let access_key_id = ctx
+    let access_key_id = env
         .secret("R2_ACCESS_KEY_ID")
         .map_err(|e| Refusal::unclassified(format!("Missing R2_ACCESS_KEY_ID: {e}")))?
         .to_string();
 
-    let secret_access_key = ctx
+    let secret_access_key = env
         .secret("R2_SECRET_ACCESS_KEY")
         .map_err(|e| Refusal::unclassified(format!("Missing R2_SECRET_ACCESS_KEY: {e}")))?
         .to_string();
 
-    let bucket = ctx
+    let bucket = env
         .var("R2_BUCKET_NAME")
         .map_err(|e| Refusal::unclassified(format!("Missing R2_BUCKET_NAME: {e}")))?
         .to_string();

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -9,6 +9,7 @@ use crate::email::{CapturedEmail, EmailError, EmailSender};
 use crate::registration::{Registration, registration_command};
 use crate::service::did_document;
 use crate::shortcut::{Shortcut, object_key_for, requested_ttl, unavailable_invite_html};
+use crate::store::ingest::{IngestStore, SqliteIngest};
 use crate::store::sqlite::SqliteStore;
 use async_trait::async_trait;
 use dialog_common::helpers::{Provider, Service};
@@ -53,6 +54,7 @@ pub struct AccessServer {
 /// service signer.
 struct RegistrationState {
     store: SqliteStore,
+    ingest: SqliteIngest,
     emails: Arc<CapturedEmail>,
     sender: AnnouncedEmail,
     service: Ed25519Signer,
@@ -114,6 +116,7 @@ impl AccessServer {
         let service_did = service.did().to_string();
         let registration = Arc::new(RegistrationState {
             store: SqliteStore::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
+            ingest: SqliteIngest::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
             emails: emails.clone(),
             sender: AnnouncedEmail(emails.clone()),
             service,
@@ -261,6 +264,18 @@ async fn handle_request(
                 .unwrap(),
         ));
     }
+    if req.method() == Method::GET && req.uri().path() == "/_test/ingest" {
+        let count = registration.ingest.invocations().unwrap_or_default();
+        return Ok(cors_response(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(
+                    serde_json::json!({ "invocations": count }).to_string(),
+                )))
+                .unwrap(),
+        ));
+    }
     if req.method() == Method::GET && req.uri().path() == "/_test/service" {
         let body = serde_json::json!({ "did": registration.service.did().to_string() });
         return Ok(cors_response(
@@ -391,7 +406,32 @@ async fn handle_request(
 
     // Authorize the UCAN container using UcanAuthorizer
     let authorizer = authorizer.read().await;
-    match authorizer.authorize(&body_bytes).await {
+    let outcome = authorizer.authorize(&body_bytes).await;
+    // Metering mirrors the worker: permits and attributable denials are
+    // recorded, infra failures and unparseable containers are not.
+    let metered = match &outcome {
+        Ok(descriptor) => {
+            let bytes = descriptor
+                .headers
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                .and_then(|(_, value)| value.parse().ok())
+                .unwrap_or(0);
+            Some(("ok", None, bytes))
+        }
+        Err(dialog_remote_s3::S3Error::Authorization(reason)) => {
+            Some(("denied", Some(format!("{reason:?}")), 0))
+        }
+        Err(_) => None,
+    };
+    if let Some((label, reason, bytes)) = metered
+        && let Some(record) =
+            crate::metering::collect(&body_bytes, label, reason, bytes, unix_now())
+        && let Err(error) = registration.ingest.record(&record).await
+    {
+        eprintln!("metering write failed: {error}");
+    }
+    match outcome {
         Ok(descriptor) => {
             // Serialize the AuthorizedRequest as CBOR
             match serde_ipld_dagcbor::to_vec(&descriptor) {

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -47,6 +47,7 @@ mod error;
 #[cfg(any(target_arch = "wasm32", test))]
 mod expiry;
 mod handlers;
+pub mod metering;
 pub mod registration;
 #[cfg(any(target_arch = "wasm32", test))]
 mod revocation;
@@ -60,7 +61,13 @@ pub mod helpers;
 
 /// Worker entrypoint
 #[event(fetch)]
-async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
+    // POST /ucan/ is served outside the Router: recording an invocation
+    // must outlive the response, and only the fetch event's `Context`
+    // can extend the isolate's life for that write.
+    if matches!(req.method(), Method::Post) && req.path() == "/ucan/" {
+        return handlers::ucan::serve(req, env, ctx).await;
+    }
     let router = Router::new();
 
     router
@@ -78,9 +85,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .get_async("/", handlers::info::handle)
         // Health check
         .get_async("/health", handlers::health::handle)
-        // UCAN authorization endpoint (with CORS preflight support)
+        // UCAN authorization CORS preflight; POST is served above.
         .options_async("/ucan/", handlers::ucan::handle_options)
-        .post_async("/ucan/", handlers::ucan::handle)
         // Shortcut service: permissionless same-origin link shortening
         .options_async("/@", handlers::shortcut::handle_options)
         .put_async("/@", handlers::shortcut::handle_put)

--- a/rust/tonk-access-service/src/metering.rs
+++ b/rust/tonk-access-service/src/metering.rs
@@ -1,0 +1,112 @@
+//! Metering collection: turn a presented container into an invocation
+//! record for the ingest database.
+//!
+//! Pure parsing, shared by the worker's hot path and the native helpers
+//! server. Metering is authorization-based: an issued permit is billed
+//! whether or not the client uses it, and denied invocations are
+//! recorded too, since a client retrying against a blocked consumer
+//! still costs invocations.
+
+use dialog_ucan_core::{Container, Delegation, Invocation};
+use dialog_varsig::algorithm::eddsa::Ed25519Signature;
+
+use crate::store::ingest::InvocationRecord;
+
+/// Parse `container_bytes` into a record. `None` when the container does
+/// not parse: there is no consumer to attribute, and the authorizer
+/// refused it without spending anything attributable.
+pub fn collect(
+    container_bytes: &[u8],
+    outcome: &'static str,
+    reason: Option<String>,
+    bytes: u64,
+    now: u64,
+) -> Option<InvocationRecord> {
+    let tokens = Container::from_bytes(container_bytes).ok()?.into_tokens();
+    let mut tokens = tokens.into_iter();
+    let body = tokens.next()?;
+    let invocation: Invocation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(&body).ok()?;
+
+    let mut proofs = Vec::new();
+    for token in tokens {
+        let delegation: Delegation<Ed25519Signature> =
+            serde_ipld_dagcbor::from_slice(&token).ok()?;
+        proofs.push((delegation.to_cid().to_string(), token));
+    }
+    // The flattened set's identity: a hash over its sorted members, so
+    // the same presented chain lands on the same rows regardless of
+    // token order.
+    let mut cids: Vec<&str> = proofs.iter().map(|(cid, _)| cid.as_str()).collect();
+    cids.sort_unstable();
+    let mut hasher = blake3::Hasher::new();
+    for cid in cids {
+        hasher.update(cid.as_bytes());
+        hasher.update(b"\n");
+    }
+    let chain = hasher.finalize().to_hex().to_string();
+
+    Some(InvocationRecord {
+        ts: now,
+        cid: invocation.to_cid().to_string(),
+        consumer: invocation.subject().to_string(),
+        issuer: invocation.issuer().to_string(),
+        cmd: format!("/{}", invocation.command().0.join("/")),
+        outcome,
+        reason,
+        bytes,
+        chain,
+        body,
+        proofs,
+    })
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    async fn it_collects_a_record_with_a_stable_chain_identity() {
+        use dialog_credentials::Ed25519Signer;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+        use dialog_ucan_core::{DelegationBuilder, InvocationBuilder, InvocationChain};
+        use dialog_varsig::Principal;
+        use std::collections::HashMap;
+
+        let root = Ed25519Signer::import(&[7u8; 32]).await.unwrap();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let delegation = DelegationBuilder::new()
+            .issuer(root.clone())
+            .audience(&device.did())
+            .subject(dialog_ucan_core::subject::Subject::Specific(root.did()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(device)
+            .audience(&root.did())
+            .subject(&root.did())
+            .command(vec!["memory".into(), "resolve".into()])
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let container = InvocationChain::new(
+            invocation,
+            HashMap::from([(cid, std::sync::Arc::new(delegation))]),
+        )
+        .to_bytes()
+        .unwrap();
+
+        let record = collect(&container, "ok", None, 0, 1_755_000_000).unwrap();
+        assert_eq!(record.cmd, "/memory/resolve");
+        assert_eq!(record.consumer, root.did().to_string());
+        assert_eq!(record.proofs.len(), 1);
+        let again = collect(&container, "ok", None, 0, 1_755_000_000).unwrap();
+        assert_eq!(record.chain, again.chain);
+
+        assert!(collect(b"not a container", "ok", None, 0, 0).is_none());
+    }
+}

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -28,13 +28,14 @@ use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
 use dialog_ucan_core::{Container, Delegation, Invocation, InvocationBuilder, InvocationChain};
 use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 use dialog_varsig::{Did, Principal};
+use ipld_core::cid::Cid;
 use ipld_core::ipld::Ipld;
 use ipld_core::serde::from_ipld;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tonk_account::customer::{
     Activate, Add, ConsumerReceipt, Customer, CustomerStatus, Enroll, Provider as ProviderRole,
-    Receipt, RegistrationError,
+    Receipt, RegistrationError, deposit_scopes,
 };
 
 use crate::email::EmailSender;
@@ -206,8 +207,21 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             });
         }
 
-        let deposit = self.deposited_delegation(&effect.access.to_string())?;
-        self.verify_deposit(&deposit.delegation, &customer).await?;
+        self.verify_deposits(&effect.access, &customer).await?;
+        // What gets stored is everything the deposit needs to be
+        // exercised later: the scoped heads together with the chain
+        // links that walk them back to the customer, re-encoded as a
+        // container of their exact bytes.
+        let access = Container::new(
+            self.delegation_tokens()?
+                .into_iter()
+                .map(|token| token.bytes)
+                .collect(),
+        )
+        .to_bytes()
+        .map_err(|err| RegistrationError::Internal {
+            message: format!("encoding the access deposit failed: {err}"),
+        })?;
 
         match self
             .store
@@ -217,13 +231,7 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
         {
             None => {
                 self.store
-                    .enroll_customer(
-                        customer.as_str(),
-                        &address,
-                        &deposit.bytes,
-                        SIGNUP_PLAN,
-                        self.now,
-                    )
+                    .enroll_customer(customer.as_str(), &address, &access, SIGNUP_PLAN, self.now)
                     .await
                     .map_err(internal)?;
             }
@@ -516,7 +524,47 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             })
     }
 
-    /// Validate the deposited access delegation: issued under the
+    /// Validate the deposited access delegations against the expected
+    /// [`deposit_scopes`]: each named deposit must match one scope
+    /// exactly — its command and its policy — and together they must
+    /// cover every scope, so the service ends up holding precisely its
+    /// own branch of the account space and the index catalog backing it.
+    /// A broader grant, `/` included, is refused rather than stored.
+    async fn verify_deposits(
+        &self,
+        access: &[Cid],
+        customer: &Did,
+    ) -> Result<(), RegistrationError> {
+        let expected = deposit_scopes(customer, &self.service.did());
+        let mut covered = [false; 2];
+        for cid in access {
+            let deposit = self.deposited_delegation(&cid.to_string())?;
+            let matched = expected.iter().position(|scope| {
+                deposit.delegation.command().segments() == scope.command.segments()
+                    && deposit.delegation.policy() == &scope.policy()
+            });
+            let Some(index) = matched else {
+                return Err(RegistrationError::Forbidden {
+                    message: format!(
+                        "deposit /{} is broader than the scopes enrollment accepts",
+                        deposit.delegation.command().segments().join("/")
+                    ),
+                });
+            };
+            covered[index] = true;
+            self.verify_deposit(&deposit.delegation, customer).await?;
+        }
+        if covered != [true; 2] {
+            return Err(RegistrationError::Forbidden {
+                message: "the deposit must cover the service's branch in memory and the index \
+                          catalog"
+                    .to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate one deposited access delegation: issued under the
     /// customer's authority to this service, signature-valid, and inside
     /// its own time window. It is an argument being deposited, not a
     /// proof, so it never extends the invocation's chain.
@@ -703,8 +751,6 @@ fn timestamp(seconds: u64) -> Result<Timestamp, RegistrationError> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use ipld_core::cid::Cid;
-
     use super::*;
 
     #[dialog_common::test]
@@ -716,7 +762,7 @@ mod tests {
         );
         let enroll = subject.clone().attenuate(Customer).invoke(Enroll {
             email: "alice@example.com".into(),
-            access: Cid::default(),
+            access: vec![Cid::default()],
         });
         assert_eq!(enroll.ability(), format!("/{}", ENROLL_COMMAND.join("/")));
         let activate = subject.attenuate(Customer).invoke(Activate {

--- a/rust/tonk-access-service/src/store.rs
+++ b/rust/tonk-access-service/src/store.rs
@@ -166,6 +166,8 @@ UPDATE customer
  WHERE did = ?1 AND status = 'Registered'
 "#;
 
+pub mod ingest;
+
 #[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
 pub mod sqlite;
 

--- a/rust/tonk-access-service/src/store/ingest.rs
+++ b/rust/tonk-access-service/src/store/ingest.rs
@@ -1,0 +1,214 @@
+//! Ingest storage: one recorded row per invocation.
+//!
+//! The ordered SQL files under `migrations-ingest/` are the schema's
+//! source of truth, applied by Wrangler to the ingest D1 database and by
+//! [`SqliteIngest`] natively. Deliberately a separate database from
+//! control: bulky, write-heavy, disposable once charged and archived,
+//! with its own 10 GB ceiling.
+
+use async_trait::async_trait;
+
+use super::StoreError;
+
+/// One invocation, as recorded on the hot path.
+#[derive(Debug, Clone)]
+pub struct InvocationRecord {
+    /// When it was authorized, as a unix timestamp in seconds.
+    pub ts: u64,
+    /// The invocation's CID, the evidence key.
+    pub cid: String,
+    /// The consumer space the invocation addressed.
+    pub consumer: String,
+    /// Who signed the invocation.
+    pub issuer: String,
+    /// The command path, `/`-joined.
+    pub cmd: String,
+    /// `ok` or `denied`.
+    pub outcome: &'static str,
+    /// Why a denied invocation was denied.
+    pub reason: Option<String>,
+    /// Declared write bytes, zero elsewhere.
+    pub bytes: u64,
+    /// Identifier of the flattened proof set.
+    pub chain: String,
+    /// The invocation's exact bytes.
+    pub body: Vec<u8>,
+    /// The proof set: each delegation's CID and exact bytes. Written
+    /// with `INSERT OR IGNORE`, so a chain already seen costs writes
+    /// only the first time.
+    pub proofs: Vec<(String, Vec<u8>)>,
+}
+
+/// Where invocation records land. Declared through the dual
+/// `async_trait` forms, like [`Store`](super::Store).
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait IngestStore {
+    /// Durably record one invocation with its chain and blocks, in one
+    /// batch.
+    async fn record(&self, record: &InvocationRecord) -> Result<(), StoreError>;
+}
+
+// Shared query text, as in the control store.
+
+pub const INSERT_INVOCATION: &str = r#"
+INSERT INTO invocation (ts, cid, consumer, issuer, cmd, outcome, reason,
+                        bytes, compute, chain, body)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0, ?9, ?10)
+"#;
+
+pub const INSERT_CHAIN: &str = r#"
+INSERT OR IGNORE INTO chain (chain, proof) VALUES (?1, ?2)
+"#;
+
+pub const INSERT_BLOCK: &str = r#"
+INSERT OR IGNORE INTO block (cid, body) VALUES (?1, ?2)
+"#;
+
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+mod sqlite {
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use rusqlite::{Connection, params};
+
+    use super::super::StoreError;
+    use super::{INSERT_BLOCK, INSERT_CHAIN, INSERT_INVOCATION, IngestStore, InvocationRecord};
+
+    /// Native `rusqlite`-backed [`IngestStore`], for tests and local
+    /// development.
+    pub struct SqliteIngest(Mutex<Connection>);
+
+    impl SqliteIngest {
+        /// Open a fresh in-memory database and apply every migration
+        /// under `migrations-ingest/`.
+        pub fn in_memory() -> Result<Self, StoreError> {
+            let conn = Connection::open_in_memory()
+                .map_err(|err| StoreError::Internal(err.to_string()))?;
+            conn.execute_batch(include_str!("../../migrations-ingest/0001_ingest.sql"))
+                .map_err(|err| StoreError::Internal(err.to_string()))?;
+            Ok(Self(Mutex::new(conn)))
+        }
+
+        /// How many invocations are recorded, for test inspection.
+        pub fn invocations(&self) -> Result<u64, StoreError> {
+            let conn = self.0.lock().expect("ingest mutex poisoned");
+            conn.query_row("SELECT COUNT(*) FROM invocation", [], |row| row.get(0))
+                .map_err(|err| StoreError::Internal(err.to_string()))
+        }
+    }
+
+    #[async_trait]
+    impl IngestStore for SqliteIngest {
+        async fn record(&self, record: &InvocationRecord) -> Result<(), StoreError> {
+            let mut conn = self.0.lock().expect("ingest mutex poisoned");
+            let tx = conn
+                .transaction()
+                .map_err(|err| StoreError::Internal(err.to_string()))?;
+            tx.execute(
+                INSERT_INVOCATION,
+                params![
+                    record.ts as i64,
+                    record.cid,
+                    record.consumer,
+                    record.issuer,
+                    record.cmd,
+                    record.outcome,
+                    record.reason,
+                    record.bytes as i64,
+                    record.chain,
+                    record.body,
+                ],
+            )
+            .map_err(|err| StoreError::Internal(err.to_string()))?;
+            for (cid, body) in &record.proofs {
+                tx.execute(INSERT_CHAIN, params![record.chain, cid])
+                    .map_err(|err| StoreError::Internal(err.to_string()))?;
+                tx.execute(INSERT_BLOCK, params![cid, body])
+                    .map_err(|err| StoreError::Internal(err.to_string()))?;
+            }
+            tx.commit()
+                .map_err(|err| StoreError::Internal(err.to_string()))
+        }
+    }
+}
+
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+pub use sqlite::SqliteIngest;
+
+#[cfg(target_arch = "wasm32")]
+mod d1 {
+    use async_trait::async_trait;
+    use worker::d1::D1Database;
+    use worker::wasm_bindgen::JsValue;
+
+    use super::super::StoreError;
+    use super::{INSERT_BLOCK, INSERT_CHAIN, INSERT_INVOCATION, IngestStore, InvocationRecord};
+
+    /// Cloudflare D1-backed [`IngestStore`], for production use.
+    pub struct D1Ingest(D1Database);
+
+    impl D1Ingest {
+        /// Wrap a D1 database binding.
+        pub fn new(db: D1Database) -> Self {
+            Self(db)
+        }
+    }
+
+    fn map_err(err: worker::Error) -> StoreError {
+        StoreError::Internal(err.to_string())
+    }
+
+    #[async_trait(?Send)]
+    impl IngestStore for D1Ingest {
+        async fn record(&self, record: &InvocationRecord) -> Result<(), StoreError> {
+            let mut statements = Vec::with_capacity(1 + record.proofs.len() * 2);
+            statements.push(
+                self.0
+                    .prepare(INSERT_INVOCATION)
+                    .bind(&[
+                        JsValue::from_f64(record.ts as f64),
+                        JsValue::from(record.cid.as_str()),
+                        JsValue::from(record.consumer.as_str()),
+                        JsValue::from(record.issuer.as_str()),
+                        JsValue::from(record.cmd.as_str()),
+                        JsValue::from(record.outcome),
+                        record
+                            .reason
+                            .as_deref()
+                            .map(JsValue::from)
+                            .unwrap_or(JsValue::NULL),
+                        JsValue::from_f64(record.bytes as f64),
+                        JsValue::from(record.chain.as_str()),
+                        js_sys::Uint8Array::from(record.body.as_slice()).into(),
+                    ])
+                    .map_err(map_err)?,
+            );
+            for (cid, body) in &record.proofs {
+                statements.push(
+                    self.0
+                        .prepare(INSERT_CHAIN)
+                        .bind(&[
+                            JsValue::from(record.chain.as_str()),
+                            JsValue::from(cid.as_str()),
+                        ])
+                        .map_err(map_err)?,
+                );
+                statements.push(
+                    self.0
+                        .prepare(INSERT_BLOCK)
+                        .bind(&[
+                            JsValue::from(cid.as_str()),
+                            js_sys::Uint8Array::from(body.as_slice()).into(),
+                        ])
+                        .map_err(map_err)?,
+                );
+            }
+            self.0.batch(statements).await.map_err(map_err)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use d1::D1Ingest;

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -27,7 +27,7 @@ use tonk_access_service::helpers::AccessServiceAddress;
 use tonk_access_service::registration::{Answer, Registration, SIGNUP_TERMS};
 use tonk_access_service::store::Store;
 use tonk_access_service::store::sqlite::SqliteStore;
-use tonk_account::customer::{Receipt, RegistrationError};
+use tonk_account::customer::{Receipt, RegistrationError, deposit_scopes};
 
 /// Current time as unix seconds.
 fn unix_now() -> u64 {
@@ -96,27 +96,44 @@ fn as_customer(answer: Answer) -> Receipt {
     }
 }
 
-/// Build an enroll container: a self-signed `/customer/enroll` invocation
-/// carrying the deposited access delegation as an extra container token.
-async fn enroll_container(customer: &Ed25519Signer, service: &Did, email: &str) -> Vec<u8> {
-    let deposit = DelegationBuilder::new()
-        .issuer(customer.clone())
-        .audience(service)
-        .subject(DelegatedSubject::Specific(customer.did()))
-        .command(vec![])
-        .try_build()
-        .await
-        .expect("deposit delegation");
-    enroll_container_with_deposit(customer, email, &deposit, true).await
+/// Mint the scoped deposits enrollment requires, issued directly by the
+/// customer to `audience` (the service, except in refusal tests).
+async fn scoped_deposits(
+    customer: &Ed25519Signer,
+    service: &Did,
+    audience: &Did,
+) -> Vec<Delegation<Ed25519Signature>> {
+    let mut deposits = Vec::new();
+    for scope in deposit_scopes(&customer.did(), service) {
+        deposits.push(
+            DelegationBuilder::new()
+                .issuer(customer.clone())
+                .audience(audience)
+                .subject(scope.subject.clone())
+                .command(scope.command.segments().clone())
+                .policy(scope.policy())
+                .try_build()
+                .await
+                .expect("deposit delegation"),
+        );
+    }
+    deposits
 }
 
-/// Build an enroll container with an explicit deposit, optionally leaving
-/// its bytes out of the container.
-async fn enroll_container_with_deposit(
+/// Build an enroll container: a self-signed `/customer/enroll` invocation
+/// carrying the deposited access delegations as extra container tokens.
+async fn enroll_container(customer: &Ed25519Signer, service: &Did, email: &str) -> Vec<u8> {
+    let deposits = scoped_deposits(customer, service, service).await;
+    enroll_container_with_deposits(customer, email, &deposits, true).await
+}
+
+/// Build an enroll container with explicit deposits, optionally leaving
+/// their bytes out of the container.
+async fn enroll_container_with_deposits(
     customer: &Ed25519Signer,
     email: &str,
-    deposit: &Delegation<Ed25519Signature>,
-    carry_deposit: bool,
+    deposits: &[Delegation<Ed25519Signature>],
+    carry_deposits: bool,
 ) -> Vec<u8> {
     let invocation = InvocationBuilder::new()
         .issuer(customer.clone())
@@ -125,7 +142,15 @@ async fn enroll_container_with_deposit(
         .command(vec!["customer".to_string(), "enroll".to_string()])
         .arguments(BTreeMap::from([
             ("email".to_string(), Promised::String(email.to_string())),
-            ("access".to_string(), Promised::Link(deposit.to_cid())),
+            (
+                "access".to_string(),
+                Promised::List(
+                    deposits
+                        .iter()
+                        .map(|deposit| Promised::Link(deposit.to_cid()))
+                        .collect(),
+                ),
+            ),
         ]))
         .proofs(vec![])
         .expiration(Timestamp::five_minutes_from_now())
@@ -133,8 +158,10 @@ async fn enroll_container_with_deposit(
         .await
         .expect("enroll invocation");
     let mut tokens = vec![serde_ipld_dagcbor::to_vec(&invocation).expect("invocation encodes")];
-    if carry_deposit {
-        tokens.push(deposit.encoded().to_vec());
+    if carry_deposits {
+        for deposit in deposits {
+            tokens.push(deposit.encoded().to_vec());
+        }
     }
     Container::new(tokens)
         .to_bytes()
@@ -319,18 +346,13 @@ async fn it_refuses_an_expired_activation_link_without_a_storage_lookup() -> any
 }
 
 #[dialog_common::test]
-async fn it_requires_the_deposited_delegation_to_travel_in_the_container() -> anyhow::Result<()> {
+async fn it_requires_the_deposited_delegations_to_travel_in_the_container() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;
-    let deposit = DelegationBuilder::new()
-        .issuer(customer.clone())
-        .audience(&fixture.service.did())
-        .subject(DelegatedSubject::Specific(customer.did()))
-        .command(vec![])
-        .try_build()
-        .await?;
+    let service = fixture.service.did();
+    let deposits = scoped_deposits(&customer, &service, &service).await;
     let container =
-        enroll_container_with_deposit(&customer, "alice@example.com", &deposit, false).await;
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, false).await;
     let refusal = fixture.registration(&container).handle().await.unwrap_err();
     assert!(matches!(refusal, RegistrationError::Invalid { .. }));
     Ok(())
@@ -341,16 +363,49 @@ async fn it_refuses_a_deposit_issued_to_someone_else() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;
     let stranger = Ed25519Signer::generate().await?;
-    // The deposit must be issued to this service, not a third party.
-    let deposit = DelegationBuilder::new()
+    // The deposits must be issued to this service, not a third party.
+    let service = fixture.service.did();
+    let deposits = scoped_deposits(&customer, &service, &stranger.did()).await;
+    let container =
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, true).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_refuses_a_deposit_broader_than_the_scopes() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    // The old shape of the deposit: an unscoped grant of `/` over the
+    // whole account space. Enrollment must refuse it rather than hold it.
+    let unscoped = DelegationBuilder::new()
         .issuer(customer.clone())
-        .audience(&stranger.did())
+        .audience(&service)
         .subject(DelegatedSubject::Specific(customer.did()))
         .command(vec![])
         .try_build()
         .await?;
     let container =
-        enroll_container_with_deposit(&customer, "alice@example.com", &deposit, true).await;
+        enroll_container_with_deposits(&customer, "alice@example.com", &[unscoped], true).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_requires_the_deposits_to_cover_both_scopes() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    // Only the memory grant, no index catalog: the service could publish
+    // a branch pointer but never ship its nodes, so enrollment refuses
+    // the incomplete set.
+    let mut deposits = scoped_deposits(&customer, &service, &service).await;
+    deposits.truncate(1);
+    let container =
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, true).await;
     let refusal = fixture.registration(&container).handle().await.unwrap_err();
     assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
     Ok(())

--- a/rust/tonk-access-service/tests/ucan_integration.rs
+++ b/rust/tonk-access-service/tests/ucan_integration.rs
@@ -87,6 +87,20 @@ async fn it_pushes_and_pulls_via_ucan(env: AccessServiceAddress) -> anyhow::Resu
 
     assert_eq!(results.len(), 1);
 
+    // Metering rides the same path: every permit the push and pull drew
+    // landed one invocation row in ingest.
+    let ingest: serde_json::Value = reqwest::get(format!(
+        "{}/_test/ingest",
+        env.access_service_url.trim_end_matches('/')
+    ))
+    .await?
+    .json()
+    .await?;
+    assert!(
+        ingest["invocations"].as_u64().unwrap_or(0) > 0,
+        "presigned operations must be recorded: {ingest}"
+    );
+
     Ok(())
 }
 

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -9,6 +9,9 @@
 //! definition.
 
 use dialog_capability::{Attenuate, Attenuation, Effect, Subject};
+use dialog_effects::archive::{Archive, Catalog};
+use dialog_effects::memory::{Memory, Space};
+use dialog_ucan::Scope;
 use dialog_varsig::Did;
 use ipld_core::cid::Cid;
 use serde::{Deserialize, Serialize};
@@ -29,15 +32,45 @@ impl Attenuation for Customer {
 pub struct Enroll {
     /// Address the activation link is sent to.
     pub email: String,
-    /// The deposited delegation granting the service access to the
-    /// account space, by CID; its bytes travel in the same container. An
-    /// argument, not a proof: it never extends the invocation's chain.
-    pub access: Cid,
+    /// The deposited delegations granting the service access to the
+    /// account space, by CID; their bytes travel in the same container.
+    /// Arguments, not proofs: they never extend the invocation's chain.
+    /// The set must cover exactly the [`deposit_scopes`]: the service's
+    /// own branch in memory and the index catalog backing it.
+    pub access: Vec<Cid>,
 }
 
 impl Effect for Enroll {
     type Of = Customer;
     type Output = Result<Receipt, RegistrationError>;
+}
+
+/// The archive catalog an enrollment deposit covers: the tree-node index
+/// backing branch push and pull. Catalog reads still require knowing a
+/// node's digest, which only the scoped memory cells reveal.
+pub const SERVICE_CATALOG: &str = "index";
+
+/// The memory space of the branch the service writes under the account:
+/// named by the service's own DID, so the grant is per-service and
+/// rotates with the key. A service whose identity changes re-enrolls
+/// into a fresh branch rather than inheriting the old one.
+pub fn service_space(service: &Did) -> String {
+    format!("branch/{service}")
+}
+
+/// The scopes an enrollment deposit must grant the service, derived from
+/// capability chains so client and verifier share one definition: the
+/// account's service-named branch in memory, and the index catalog its
+/// pushes and pulls go through. Nothing broader — in particular not `/` —
+/// is accepted as a deposit.
+pub fn deposit_scopes(customer: &Did, service: &Did) -> [Scope; 2] {
+    let memory = Subject::from(customer.clone())
+        .attenuate(Memory)
+        .attenuate(Space::new(service_space(service)));
+    let archive = Subject::from(customer.clone())
+        .attenuate(Archive)
+        .attenuate(Catalog::new(SERVICE_CATALOG));
+    [Scope::from(&memory), Scope::from(&archive)]
 }
 
 /// `/customer/activate` — finalize enrollment. The invocation's subject
@@ -230,7 +263,7 @@ mod tests {
     fn it_derives_the_role_first_command_paths() {
         let enroll: Capability<Enroll> = subject().attenuate(Customer).invoke(Enroll {
             email: "alice@example.com".into(),
-            access: Cid::default(),
+            access: vec![Cid::default()],
         });
         assert_eq!(enroll.ability(), "/customer/enroll");
 
@@ -248,6 +281,27 @@ mod tests {
 
         let provision: Capability<Provision> = subject().attenuate(Consumer).invoke(Provision);
         assert_eq!(provision.ability(), "/consumer/provision");
+    }
+
+    #[test]
+    fn it_scopes_the_deposit_to_the_service_branch_and_index() {
+        let customer = did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        let service = did!("key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z");
+        let [memory, archive] = deposit_scopes(&customer, &service);
+
+        assert_eq!(memory.command.segments(), &["memory".to_string()]);
+        assert_eq!(
+            memory.parameters.as_map().get("space"),
+            Some(&ipld_core::ipld::Ipld::String(format!("branch/{service}")))
+        );
+        assert_eq!(archive.command.segments(), &["archive".to_string()]);
+        assert_eq!(
+            archive.parameters.as_map().get("catalog"),
+            Some(&ipld_core::ipld::Ipld::String("index".to_string()))
+        );
+        for scope in [&memory, &archive] {
+            assert_eq!(scope.policy().len(), 1, "one equality predicate per scope");
+        }
     }
 
     #[test]

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -13,12 +13,12 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
-use dialog_ucan_core::subject::Subject;
 use dialog_ucan_core::time::timestamp::Timestamp;
 use dialog_ucan_core::{
     Container, DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain,
 };
 use dialog_varsig::Did;
+use tonk_account::customer::deposit_scopes;
 
 /// Build a device-signed account-service invocation container.
 ///
@@ -65,11 +65,12 @@ pub async fn build_device_invocation(
 /// Build a `/customer/enroll` container for the access service.
 ///
 /// The invocation is device-signed on the account's subject, exactly as
-/// [`build_device_invocation`] does, and additionally deposits a
-/// delegation granting `service` access to the account space. The
-/// deposit is device-issued; the service walks it back to the account
-/// through the same `root → device` grant the invocation proves with,
-/// which rides in the same container.
+/// [`build_device_invocation`] does, and additionally deposits the
+/// scoped delegations granting `service` access to its own branch of the
+/// account space — the [`deposit_scopes`], nothing broader. The deposits
+/// are device-issued; the service walks them back to the account through
+/// the same `root → device` grant the invocation proves with, which
+/// rides in the same container.
 pub async fn build_enroll_invocation(
     device: Ed25519Signer,
     link: &DelegationChain,
@@ -77,17 +78,30 @@ pub async fn build_enroll_invocation(
     email: &str,
 ) -> Result<Vec<u8>> {
     let root_did = link.issuer().clone();
-    let deposit = DelegationBuilder::new()
-        .issuer(device.clone())
-        .audience(service)
-        .subject(Subject::Specific(root_did))
-        .command(vec![])
-        .try_build()
-        .await
-        .context("failed to mint the access deposit")?;
+    let mut deposits = Vec::new();
+    for scope in deposit_scopes(&root_did, service) {
+        let deposit = DelegationBuilder::new()
+            .issuer(device.clone())
+            .audience(service)
+            .subject(scope.subject.clone())
+            .command(scope.command.segments().clone())
+            .policy(scope.policy())
+            .try_build()
+            .await
+            .context("failed to mint the access deposit")?;
+        deposits.push(deposit);
+    }
     let arguments = BTreeMap::from([
         ("email".to_string(), Promised::String(email.to_string())),
-        ("access".to_string(), Promised::Link(deposit.to_cid())),
+        (
+            "access".to_string(),
+            Promised::List(
+                deposits
+                    .iter()
+                    .map(|deposit| Promised::Link(deposit.to_cid()))
+                    .collect(),
+            ),
+        ),
     ]);
     let invocation = build_device_invocation(
         device,
@@ -99,7 +113,9 @@ pub async fn build_enroll_invocation(
     let mut tokens = Container::from_bytes(&invocation)
         .context("failed to reopen the enroll container")?
         .into_tokens();
-    tokens.push(deposit.encoded().to_vec());
+    for deposit in &deposits {
+        tokens.push(deposit.encoded().to_vec());
+    }
     Container::new(tokens)
         .to_bytes()
         .context("failed to encode the enroll container")

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -8,24 +8,19 @@
 //! deployment serving this page — so endpoints derive from the request
 //! origin and the service DID comes from `/.well-known/tonk`.
 
-use std::collections::BTreeMap;
-
 use axum::{
     Json,
     extract::{Extension, State},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_ucan_core::promise::Promised;
-use dialog_ucan_core::subject::Subject as DelegatedSubject;
 use dialog_ucan_core::time::timestamp::Timestamp;
-use dialog_ucan_core::{Container, DelegationBuilder};
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_account::CUSTOMER_CREDENTIAL_SITE;
 use tonk_account::customer::{CustomerStatus, Receipt};
 use tonk_common::log;
-use tonk_identity::request::build_device_invocation;
+use tonk_identity::request::build_enroll_invocation;
 use url::Url;
 
 use super::AppState;
@@ -96,45 +91,15 @@ pub async fn enroll(
     let service_did = service_did(origin.url()).await?;
     let device = state.profile.signer().signer().clone();
 
-    // The deposit: this device grants the service access to the account
-    // space under the customer's authority. Its chain link (the
-    // `root → device` grant) rides in the same container as the
-    // invocation's proof, so the service can walk the deposit back to
-    // the customer.
-    let deposit = DelegationBuilder::new()
-        .issuer(device.clone())
-        .audience(&service_did)
-        .subject(DelegatedSubject::Specific(root_did.clone()))
-        .command(vec![])
-        .try_build()
+    // The deposits — the service's scoped grants into the account
+    // space — and their chain link (the `root → device` grant) all ride
+    // in the container `build_enroll_invocation` assembles, so the
+    // service can walk them back to the customer.
+    let body = build_enroll_invocation(device, &link, &service_did, &email)
         .await
         .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to mint the access deposit: {error}"))
+            TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
         })?;
-
-    let arguments = BTreeMap::from([
-        ("email".to_string(), Promised::String(email.clone())),
-        ("access".to_string(), Promised::Link(deposit.to_cid())),
-    ]);
-    let invocation = build_device_invocation(
-        device,
-        &link,
-        vec!["customer".to_string(), "enroll".to_string()],
-        arguments,
-    )
-    .await
-    .map_err(|error| {
-        TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
-    })?;
-    let mut tokens = Container::from_bytes(&invocation)
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to reopen the enroll container: {error}"))
-        })?
-        .into_tokens();
-    tokens.push(deposit.encoded().to_vec());
-    let body = Container::new(tokens).to_bytes().map_err(|error| {
-        TonkWorkerError::Internal(format!("failed to encode the enroll container: {error}"))
-    })?;
 
     let endpoint = ucan_endpoint(origin.url())?;
     let receipt = match post_cbor(&endpoint, &body).await {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -48,6 +48,16 @@ database_name = "tonk-access-control"
 database_id = ""
 migrations_dir = "rust/tonk-access-service/migrations"
 
+# Ingest: one row per invocation, metering's write path. Separate from
+# control so bulky invocation rows get their own 10 GB ceiling and can
+# later rotate. The hot path logs and continues when the binding is
+# absent; the presign path never depends on it.
+[[d1_databases]]
+binding = "INGEST"
+database_name = "tonk-access-ingest"
+database_id = ""
+migrations_dir = "rust/tonk-access-service/migrations-ingest"
+
 [vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
 R2_BUCKET_NAME = "tonk-spaces"
@@ -73,6 +83,12 @@ binding = "CONTROL"
 database_name = "tonk-access-control-staging"
 database_id = ""
 migrations_dir = "rust/tonk-access-service/migrations"
+
+[[env.staging.d1_databases]]
+binding = "INGEST"
+database_name = "tonk-access-ingest-staging"
+database_id = ""
+migrations_dir = "rust/tonk-access-service/migrations-ingest"
 
 [env.staging.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
@@ -114,6 +130,12 @@ binding = "CONTROL"
 database_name = "tonk-access-control-preview"
 database_id = "REPLACED-PER-PULL-REQUEST"
 migrations_dir = "rust/tonk-access-service/migrations"
+
+[[env.preview.d1_databases]]
+binding = "INGEST"
+database_name = "tonk-access-ingest-preview"
+database_id = "INGEST-REPLACED-PER-PULL-REQUEST"
+migrations_dir = "rust/tonk-access-service/migrations-ingest"
 
 [env.preview.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"


### PR DESCRIPTION
Stacked on #714. Phase 0 (meter, no enforcement, no billing) of the [access metering plan](https://github.com/tonk-labs/tonk/pull/702): the full write path for activity, so calibration data accumulates while everything else stays as it was.

`POST /ucan/` now records one row per attributable invocation into a second D1 database (`INGEST`), deliberately separate from control: bulky, write-heavy, disposable once charged, with its own 10 GB ceiling. Permits record with the declared write bytes read off the signed `Content-Length`; 401/403 refusals record as `outcome = denied` with the refusal's kind, since a client retrying against a blocked consumer still costs invocations; infra failures and unparseable containers are the service's cost and are not attributed. The invocation bytes ride inline, and the presented proof set is flattened once per operator session (`INSERT OR IGNORE` on `chain`/`block`), keyed by a hash over the sorted proof CIDs so token order does not split sessions.

The endpoint moves out of the Router onto the fetch event: recording must outlive the response, and only the event's `Context` provides `wait_until`. The authorizer and registration handlers take `Env` directly as a result. A metering failure logs and never costs the caller the permit they already hold, and a missing `INGEST` binding (pre-bootstrap deploys) skips metering rather than refusing service.

The native helpers server mirrors the same collection into sqlite with a `/_test/ingest` probe, and the push/pull integration test asserts its permits landed as rows. CI provisions `tonk-access-ingest-pr-<N>` per preview alongside the control database; staging/production need a one-time `wrangler d1 create tonk-access-ingest{-staging,}` with ids filled into `wrangler.toml`, added to the bootstrap list from #713.

Next in the stack: the charge cron (usage aggregation → ledger) per plan §10.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `ingest` module to handle invocation records in a separate database, enhancing the metering functionality. It includes new database schemas, updates to various handlers, and adjustments to ensure proper recording of invocation metrics.

### Detailed summary
- Added `ingest` module for handling invocation records.
- Introduced new SQL tables for `invocation`, `chain`, and `block`.
- Updated `main` function to handle POST requests for `/ucan/` and record invocations.
- Enhanced error handling in the `handle` function.
- Modified `record_invocation` to log invocation metrics.
- Updated `registration` logic to support multiple access deposits.
- Implemented scoped deposits for customer enrollments.
- Adjusted tests to verify new functionality and ensure correctness.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->