### PR TITLE
fix(sync): recover lazy-tree pushes and legacy Vault migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "dialog-repository",
  "dialog-search-tree",
  "dialog-storage",
+ "futures-util",
  "ipld-core",
  "parking_lot",
  "serde_json",

--- a/rust/dialog-reactor/Cargo.toml
+++ b/rust/dialog-reactor/Cargo.toml
@@ -20,6 +20,7 @@ dialog-query = { workspace = true }
 dialog-repository = { workspace = true }
 dialog-search-tree = { workspace = true }
 dialog-storage = { workspace = true }
+futures-util = { workspace = true }
 ipld-core = { workspace = true }
 parking_lot = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/dialog-reactor/src/push.rs
+++ b/rust/dialog-reactor/src/push.rs
@@ -7,6 +7,43 @@
 use super::BranchReference;
 use super::env::{BranchOpenProvider, LoadProvider, PushProvider};
 use super::error::ReactorError;
+use dialog_artifacts::tree::TreeStorageBridge;
+use dialog_artifacts::{Index, Key};
+use dialog_common::Blake3Hash as NodeHash;
+use dialog_repository::{
+    NetworkedIndex, PushError, RepositoryArchiveExt as _, RepositoryMemoryExt as _, Upstream,
+};
+use dialog_search_tree::{ContentAddressedStorage as TreeStorage, DialogSearchTreeError};
+use dialog_storage::{Blake3Hash, DialogStorageError, StorageBackend};
+use futures_util::TryStreamExt as _;
+
+const MISSING_LOCAL_TREE_NODE: &str = "Blob not found in storage:";
+
+fn is_missing_local_tree_node(error: &PushError) -> bool {
+    matches!(
+        error,
+        PushError::Tree(DialogSearchTreeError::Node(message))
+            if message.starts_with(MISSING_LOCAL_TREE_NODE)
+    )
+}
+
+/// Materialize every search-tree node reachable from `roots` through a
+/// storage backend that may fetch and cache remote misses.
+async fn hydrate_tree_roots<S>(roots: &[NodeHash], store: S) -> Result<(), DialogSearchTreeError>
+where
+    S: StorageBackend<Key = Blake3Hash, Value = Vec<u8>, Error = DialogStorageError>
+        + Clone
+        + dialog_common::ConditionalSync,
+{
+    let storage = TreeStorage::new(TreeStorageBridge(store));
+    for root in roots {
+        let tree = Index::from_hash(root.clone());
+        let entries = tree.stream_range(Key::min()..=Key::max(), &storage);
+        tokio::pin!(entries);
+        while entries.try_next().await?.is_some() {}
+    }
+    Ok(())
+}
 
 /// Push-to-upstream effect.
 pub struct Push<'a> {
@@ -26,7 +63,161 @@ impl<'a> Push<'a> {
         Env: LoadProvider + BranchOpenProvider + PushProvider,
     {
         let cached = self.branch.acquire(env).await?;
+
+        // Dialog's push novelty diff currently reads through a local-only
+        // index. A branch adopted from a remote may therefore have a valid
+        // head while some untouched search-tree nodes are still remote-only.
+        // Keep the normal path cheap and repair that one typed failure on
+        // demand. Uploads before the failure are content-addressed, so retrying
+        // after hydration is idempotent.
+        let error = match cached.handle().push().perform(env).await {
+            Ok(_) => return Ok(()),
+            Err(error) if is_missing_local_tree_node(&error) => error,
+            Err(error) => return Err(error.into()),
+        };
+
+        let (remote_name, base) = match cached.handle().upstream() {
+            Some(Upstream::Remote { remote, tree, .. }) => (remote, tree),
+            _ => return Err(error.into()),
+        };
+        let Some(revision) = cached.handle().revision() else {
+            return Err(error.into());
+        };
+        let remote = cached
+            .handle()
+            .subject()
+            .remote(remote_name)
+            .load()
+            .perform(env)
+            .await
+            .map_err(PushError::from)?;
+        let store = NetworkedIndex::new(env, cached.handle().archive().index(), Some(remote));
+        let roots = [
+            NodeHash::from(*base.hash()),
+            NodeHash::from(*revision.tree.hash()),
+        ];
+        // The diff can traverse either side. Walking both roots through the
+        // networked index caches only tree nodes; referenced blob payloads are
+        // still transferred by push's normal shipment phase.
+        hydrate_tree_roots(&roots, store)
+            .await
+            .map_err(PushError::from)?;
+
         cached.handle().push().perform(env).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use dialog_artifacts::tree::ArtifactTreeExt as _;
+    use dialog_artifacts::{Artifact, Instruction, Value};
+    use dialog_search_tree::{Delta, TreeDifference};
+    use dialog_storage::MemoryStorageBackend;
+    use futures_util::stream;
+
+    type Memory = MemoryStorageBackend<Blake3Hash, Vec<u8>>;
+
+    /// A small stand-in for `NetworkedIndex`: local reads first, then remote,
+    /// caching a remote hit locally on the way back.
+    #[derive(Clone)]
+    struct CachingStore {
+        local: Memory,
+        remote: Memory,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl StorageBackend for CachingStore {
+        type Key = Blake3Hash;
+        type Value = Vec<u8>;
+        type Error = DialogStorageError;
+
+        async fn set(&mut self, key: Self::Key, value: Self::Value) -> Result<(), Self::Error> {
+            self.local.set(key, value).await
+        }
+
+        async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+            if let Some(bytes) = self.local.get(key).await? {
+                return Ok(Some(bytes));
+            }
+            let Some(bytes) = self.remote.get(key).await? else {
+                return Ok(None);
+            };
+            let mut local = self.local.clone();
+            local.set(*key, bytes.clone()).await?;
+            Ok(Some(bytes))
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_hydrates_a_lazy_tree_into_local_storage_before_push() -> anyhow::Result<()> {
+        let mut remote = Memory::default();
+        let mut delta = Delta::zero();
+        let mut tree = Index::empty();
+        let instructions = (0..300).map(|index| {
+            Instruction::Assert(Artifact {
+                the: "item/title".parse().unwrap(),
+                of: format!("item:{index}").parse().unwrap(),
+                is: Value::String(format!("Item {index}")),
+                cause: None,
+            })
+        });
+        tree.apply(&mut remote, &mut delta, stream::iter(instructions))
+            .await?;
+        for (_, buffer) in delta.flush() {
+            remote
+                .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                .await?;
+        }
+
+        let base_root = tree.root().clone();
+        let mut delta = Delta::zero();
+        let instructions = (300..600).map(|index| {
+            Instruction::Assert(Artifact {
+                the: "item/title".parse().unwrap(),
+                of: format!("item:{index}").parse().unwrap(),
+                is: Value::String(format!("Item {index}")),
+                cause: None,
+            })
+        });
+        tree.apply(&mut remote, &mut delta, stream::iter(instructions))
+            .await?;
+        for (_, buffer) in delta.flush() {
+            remote
+                .set(*buffer.blake3_hash().as_bytes(), buffer.as_ref().to_vec())
+                .await?;
+        }
+
+        let current_root = tree.root().clone();
+        let local = Memory::default();
+        hydrate_tree_roots(
+            &[base_root.clone(), current_root.clone()],
+            CachingStore {
+                local: local.clone(),
+                remote,
+            },
+        )
+        .await?;
+
+        let storage = TreeStorage::new(TreeStorageBridge(local));
+        let base = Index::from_hash(base_root);
+        let current = Index::from_hash(current_root);
+        if let Err(error) = TreeDifference::compute(&base, &current, &storage, &storage).await {
+            panic!("push's local-only tree differential must succeed after hydration: {error:?}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn it_only_retries_missing_local_tree_nodes() {
+        assert!(is_missing_local_tree_node(&PushError::Tree(
+            DialogSearchTreeError::Node("Blob not found in storage: blake3#missing".to_owned())
+        )));
+        assert!(!is_missing_local_tree_node(&PushError::Tree(
+            DialogSearchTreeError::Operation("tree is invalid".to_owned())
+        )));
     }
 }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -2000,7 +2000,9 @@ async fn legacy_migrate(
             Ok(blobs) => blobs,
             Err(error) => return print_failure(error),
         };
-        if let Err(error) = transfer::import_branch(&destination, branch, &upgraded.csv).await {
+        if let Err(error) =
+            tonk_cli::legacy::import_migrated_branch(&destination, branch, &upgraded.csv).await
+        {
             return print_failure(error);
         }
         println!(

--- a/rust/tonk-cli/src/legacy.rs
+++ b/rust/tonk-cli/src/legacy.rs
@@ -26,6 +26,8 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 use dialog_artifacts::Entity;
+use dialog_query::{Output as _, Query, Term};
+use tonk_schema::meta::{AnonymousAttribute, attribute};
 
 /// The last release that can read pre-upgrade data.
 ///
@@ -238,6 +240,74 @@ pub async fn migrate_blobs(
         }
     }
     Ok(migration)
+}
+
+/// Import a rewritten branch and repair runtime attribute IDs left by an
+/// earlier, pre-fix migration attempt.
+///
+/// CSV import is additive. If a destination already contains
+/// `dialog.origin/*` values, importing their corrected `dialog.replica/*`
+/// counterparts does not retract the stale cardinality-one claims. Explicitly
+/// retracting those claims makes a corrected migration safe to rerun and lets
+/// identity-bound concepts such as `vault/tree` resolve again.
+pub async fn import_migrated_branch(
+    destination: &crate::site::TonkSite,
+    branch: &str,
+    csv: &PathBuf,
+) -> Result<usize> {
+    crate::transfer::import_branch(destination, branch, csv)
+        .await
+        .with_context(|| format!("failed to import migrated branch {branch:?}"))?;
+    repair_runtime_attribute_ids(destination, branch).await
+}
+
+async fn repair_runtime_attribute_ids(
+    destination: &crate::site::TonkSite,
+    branch: &str,
+) -> Result<usize> {
+    let session = destination
+        .named_branch(branch)
+        .await
+        .with_context(|| format!("failed to open migrated branch {branch:?}"))?;
+    let mut stale = Vec::new();
+    for &(old, new) in RUNTIME_ATTRIBUTE_RENAMES {
+        let attributes: Vec<AnonymousAttribute> = session
+            .handle()
+            .query()
+            .select(Query::<AnonymousAttribute> {
+                this: Term::var("attribute"),
+                id: Term::from(attribute::Id(old.to_owned())),
+                r#type: Term::var("type"),
+                cardinality: Term::var("cardinality"),
+                description: Term::var("description"),
+            })
+            .perform(&destination.operator)
+            .try_vec()
+            .await
+            .with_context(|| format!("failed to find stale runtime attribute {old:?}"))?;
+        stale.extend(
+            attributes
+                .into_iter()
+                .map(|attribute| (attribute.this, old, new)),
+        );
+    }
+    if stale.is_empty() {
+        return Ok(0);
+    }
+
+    let repaired = stale.len();
+    let mut transaction = session.handle().transaction();
+    for (entity, old, new) in stale {
+        transaction = transaction
+            .retract(attribute::Id::of(entity.clone()).is(old.to_owned()))
+            .assert(attribute::Id::of(entity).is(new.to_owned()));
+    }
+    transaction
+        .commit()
+        .perform(&destination.operator)
+        .await
+        .with_context(|| format!("failed to repair runtime attributes on branch {branch:?}"))?;
+    Ok(repaired)
 }
 
 fn run(command: &mut Command) -> Result<()> {

--- a/rust/tonk-cli/tests/legacy_migration.rs
+++ b/rust/tonk-cli/tests/legacy_migration.rs
@@ -22,6 +22,61 @@ use anyhow::{Context, Result, bail};
 /// dialog upgrade — it pins dialog `rev = e8bbe462`.
 const LEGACY_RELEASE: &str = "v0.6.7";
 
+/// Runtime-owned fields are the migration boundary that the Vault depends on:
+/// rewriting the CSV text is insufficient unless a current replica can use
+/// the imported concept and see its locally injected identity facts.
+#[tokio::test]
+async fn migrated_runtime_fields_bind_the_current_replica() -> Result<()> {
+    let legacy = "the,of,as,is,cause\n\
+        dialog.attribute/cardinality,the:legacy-profile,text,one,\n\
+        dialog.attribute/id,the:legacy-profile,text,dialog.origin/profile,\n\
+        dialog.attribute/type,the:legacy-profile,text,Entity,\n\
+        dialog.meta/description,the:legacy-profile,text,Legacy profile.,\n\
+        dialog.attribute/cardinality,the:legacy-subject,text,one,\n\
+        dialog.attribute/id,the:legacy-subject,text,dialog.origin/subject,\n\
+        dialog.attribute/type,the:legacy-subject,text,Entity,\n\
+        dialog.meta/description,the:legacy-subject,text,Legacy subject.,\n\
+        dialog.concept.with/profile,tonk:migrated-runtime,entity,the:legacy-profile,\n\
+        dialog.concept.with/subject,tonk:migrated-runtime,entity,the:legacy-subject,\n\
+        dialog.meta/concept,tonk:migrated-runtime,entity,db:concept,\n\
+        db.name/referent,id:migrated/runtime,entity,tonk:migrated-runtime,\n";
+    let mut migrated = Vec::new();
+    tonk_cli::legacy::migrate_export(legacy.as_bytes(), &mut migrated)?;
+
+    let site = common::TestSite::new().await?;
+    // Model a destination imported by the pre-fix migration: schema columns
+    // moved into `db.*`, but the runtime selector values stayed at
+    // `dialog.origin/*`. A corrected rerun must repair this state rather than
+    // requiring the user to discover that the first attempt poisoned it.
+    let pre_fix = legacy.replace("\ndialog.", "\ndb.");
+    let path = site.tmp.path().join("pre-fix-runtime-fields.csv");
+    std::fs::write(&path, pre_fix)?;
+    tonk_cli::transfer::import(&site.site, &path).await?;
+    let before = site
+        .eval_inline("migrated/runtime:\n  subject: ?subject\n  profile: ?profile\n")
+        .await?;
+    assert!(
+        before.response.matches_after[0].results.is_empty(),
+        "the pre-fix fixture must reproduce the unbound runtime concept"
+    );
+
+    let path = site.tmp.path().join("runtime-fields.csv");
+    std::fs::write(&path, migrated)?;
+    tonk_cli::legacy::import_migrated_branch(&site.site, "main", &path).await?;
+
+    let outcome = site
+        .eval_inline("migrated/runtime:\n  subject: ?subject\n  profile: ?profile\n")
+        .await?;
+    let results = &outcome.response.matches_after[0].results;
+    assert_eq!(
+        results.len(),
+        1,
+        "a migrated runtime-bound concept must match this replica; saw:\n{}",
+        outcome.stdout
+    );
+    Ok(())
+}
+
 /// Download and unpack the published legacy CLI, returning its path.
 ///
 /// The real published artifact rather than a local build of the old ref:


### PR DESCRIPTION
## Summary

- hydrate remote-only search-tree nodes when push fails its local novelty diff, then retry only the typed missing-node failure
- repair stale dialog.origin runtime attribute claims left by an earlier legacy migration attempt so Vault identity-bound concepts resolve
- cover both the lazy-tree differential and an already-contaminated migration destination with executable regressions

## Root causes

Pull can leave untouched search-tree nodes remote-only. A later local commit changes the head, and push compares the upstream base to the new tree through a local-only index; the comparison fails before normal blob shipment.

The recovered tonk-team destination also retained dialog.origin/profile and dialog.origin/subject claims from a migration attempt made before PR 712 added its rewrite. CSV import is additive, so rerunning the corrected import did not retract those stale cardinality-one values. vault/tree and vault/here therefore returned zero rows even though the Vault nodes and blob metadata were present.

## Verification

- cargo fmt --all -- --check
- cargo test -p dialog-reactor: 34 passed
- cargo test -p tonk-cli: full suite passed
- cargo test -p tonk-cli --features integration-tests,legacy-migration --test legacy_migration -- --nocapture: 3 passed, including published v0.6.7 migration and push
- cargo clippy -p dialog-reactor -p tonk-cli --lib --bins -- -D warnings

The runtime-binding regression first reproduces the zero-row state and the failed additive rerun, then proves the explicit repair produces a current-replica match.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk` CLI's migration capabilities by introducing a new function to import migrated branches, along with improvements to the handling of runtime attributes and the integration of `futures-util`.

### Detailed summary
- Added `futures-util` as a dependency in `Cargo.toml`.
- Updated `transfer::import_branch` to `tonk_cli::legacy::import_migrated_branch`.
- Introduced `import_migrated_branch` function to handle importing and repairing runtime attributes.
- Implemented `repair_runtime_attribute_ids` for fixing stale attribute IDs.
- Added a test for migrated runtime fields in `legacy_migration.rs`.
- Enhanced error handling in `Push` struct for missing local tree nodes in `push.rs`.
- Introduced `CachingStore` for local and remote storage management in `push.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->