### PR TITLE
ci(cli): sign and notarize macOS binaries

### DIFF
--- a/.github/actions/sign-notarize-macos/action.yml
+++ b/.github/actions/sign-notarize-macos/action.yml
@@ -1,0 +1,159 @@
+name: 'Sign and notarize macOS CLI'
+description: 'Developer ID sign a staged CLI binary and require Apple notarization'
+
+inputs:
+  binary-path:
+    description: 'Writable path to the macOS CLI binary'
+    required: true
+  certificate-p12:
+    description: 'Base64-encoded Developer ID Application PKCS#12 archive'
+    required: true
+  certificate-password:
+    description: 'Password for the PKCS#12 archive'
+    required: true
+  app-store-connect-key:
+    description: 'App Store Connect API private key in PEM format'
+    required: true
+  app-store-connect-key-id:
+    description: 'App Store Connect API key ID'
+    required: true
+  app-store-connect-issuer-id:
+    description: 'App Store Connect API issuer ID for the team key'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 'Sign and notarize binary'
+      shell: bash
+      env:
+        BINARY_PATH: ${{ inputs.binary-path }}
+        CERTIFICATE_P12: ${{ inputs.certificate-p12 }}
+        CERTIFICATE_PASSWORD: ${{ inputs.certificate-password }}
+        APP_STORE_CONNECT_KEY: ${{ inputs.app-store-connect-key }}
+        APP_STORE_CONNECT_KEY_ID: ${{ inputs.app-store-connect-key-id }}
+        APP_STORE_CONNECT_ISSUER_ID: ${{ inputs.app-store-connect-issuer-id }}
+      run: |
+        set -euo pipefail
+
+        if [[ "${RUNNER_OS:-}" != "macOS" ]]; then
+          echo "::error::macOS signing must run on a macOS runner"
+          exit 1
+        fi
+
+        for required in \
+          BINARY_PATH \
+          CERTIFICATE_P12 \
+          CERTIFICATE_PASSWORD \
+          APP_STORE_CONNECT_KEY \
+          APP_STORE_CONNECT_KEY_ID \
+          APP_STORE_CONNECT_ISSUER_ID
+        do
+          if [[ -z "${!required:-}" ]]; then
+            echo "::error::$required is required for macOS release signing"
+            exit 1
+          fi
+        done
+
+        if [[ ! -f "$BINARY_PATH" ]]; then
+          echo "::error::macOS binary does not exist at $BINARY_PATH"
+          exit 1
+        fi
+
+        signing_dir="$(mktemp -d "$RUNNER_TEMP/tonk-signing.XXXXXX")"
+        certificate_path="$signing_dir/developer-id.p12"
+        api_key_path="$signing_dir/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+        keychain_path="$signing_dir/tonk-signing.keychain-db"
+        notarization_archive="$signing_dir/tonk.zip"
+        notarization_response="$signing_dir/notarization.json"
+        keychain_password="$(openssl rand -base64 32)"
+
+        cleanup() {
+          security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
+          rm -f \
+            "$certificate_path" \
+            "$api_key_path" \
+            "$notarization_archive" \
+            "$notarization_response" \
+            "$keychain_path"
+          rmdir "$signing_dir" >/dev/null 2>&1 || true
+        }
+        trap cleanup EXIT
+
+        printf '%s' "$CERTIFICATE_P12" \
+          | base64 --decode > "$certificate_path"
+        printf '%s' "$APP_STORE_CONNECT_KEY" > "$api_key_path"
+        chmod 0600 "$certificate_path" "$api_key_path"
+
+        security create-keychain -p "$keychain_password" "$keychain_path"
+        security set-keychain-settings -lut 21600 "$keychain_path"
+        security unlock-keychain -p "$keychain_password" "$keychain_path"
+        security import "$certificate_path" \
+          -k "$keychain_path" \
+          -P "$CERTIFICATE_PASSWORD" \
+          -T /usr/bin/codesign
+        security set-key-partition-list \
+          -S apple-tool:,apple: \
+          -s \
+          -k "$keychain_password" \
+          "$keychain_path"
+
+        signing_identity="$(
+          security find-identity -v -p codesigning "$keychain_path" \
+            | awk '/Developer ID Application/ { print $2; exit }'
+        )"
+        if [[ -z "$signing_identity" ]]; then
+          echo "::error::PKCS#12 archive has no Developer ID Application identity"
+          exit 1
+        fi
+
+        codesign \
+          --force \
+          --keychain "$keychain_path" \
+          --options runtime \
+          --sign "$signing_identity" \
+          --timestamp \
+          "$BINARY_PATH"
+        codesign --verify --strict --verbose=2 "$BINARY_PATH"
+
+        ditto -c -k --keepParent "$BINARY_PATH" "$notarization_archive"
+        if ! xcrun notarytool submit "$notarization_archive" \
+          --key "$api_key_path" \
+          --key-id "$APP_STORE_CONNECT_KEY_ID" \
+          --issuer "$APP_STORE_CONNECT_ISSUER_ID" \
+          --wait \
+          --timeout 60m \
+          --output-format json > "$notarization_response"
+        then
+          echo "::error::could not submit the macOS CLI for notarization"
+          if [[ -s "$notarization_response" ]]; then
+            cat "$notarization_response"
+          fi
+          exit 1
+        fi
+
+        notarization_status="$(
+          python3 -c \
+            'import json, sys; print(json.load(open(sys.argv[1])).get("status", ""))' \
+            "$notarization_response"
+        )"
+        notarization_id="$(
+          python3 -c \
+            'import json, sys; print(json.load(open(sys.argv[1])).get("id", ""))' \
+            "$notarization_response"
+        )"
+        echo "Apple notarization $notarization_id: $notarization_status"
+
+        if [[ "$notarization_status" != "Accepted" ]]; then
+          echo "::error::Apple rejected the macOS CLI notarization"
+          if [[ -n "$notarization_id" ]]; then
+            xcrun notarytool log "$notarization_id" \
+              --key "$api_key_path" \
+              --key-id "$APP_STORE_CONNECT_KEY_ID" \
+              --issuer "$APP_STORE_CONNECT_ISSUER_ID" || true
+          fi
+          exit 1
+        fi
+
+        codesign --verify --strict --verbose=2 "$BINARY_PATH"
+        spctl --assess --type execute --verbose=2 "$BINARY_PATH"

--- a/.github/workflows/cli-npm.yml
+++ b/.github/workflows/cli-npm.yml
@@ -107,10 +107,27 @@ jobs:
       - name: 'Build tonk'
         run: nix build --accept-flake-config .#tonk-cli
 
+      - name: 'Stage tonk artifact'
+        run: |
+          mkdir -p artifacts
+          cp result/bin/tonk artifacts/tonk
+          chmod 0755 artifacts/tonk
+
+      - name: 'Sign and notarize macOS artifact'
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/sign-notarize-macos
+        with:
+          binary-path: artifacts/tonk
+          certificate-p12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          app-store-connect-key: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          app-store-connect-issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: result/bin/tonk
+          path: artifacts/tonk
 
   publish:
     name: 'Publish to npm'

--- a/.github/workflows/cli-pin.yml
+++ b/.github/workflows/cli-pin.yml
@@ -51,6 +51,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+      # The ref being built may predate this action. Keep the workflow
+      # commit's signing code in a separate checkout so historical source
+      # can still pass through the current release-security boundary.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: .ci
       - uses: wimpysworld/nothing-but-nix@main
         if: runner.os == 'Linux'
       - uses: cachix/install-nix-action@v31
@@ -62,10 +69,25 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: 'Build tonk'
         run: nix build --accept-flake-config .#tonk-cli
+      - name: 'Stage tonk artifact'
+        run: |
+          mkdir -p artifacts
+          cp result/bin/tonk artifacts/tonk
+          chmod 0755 artifacts/tonk
+      - name: 'Sign and notarize macOS artifact'
+        if: runner.os == 'macOS'
+        uses: ./.ci/.github/actions/sign-notarize-macos
+        with:
+          binary-path: artifacts/tonk
+          certificate-p12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          app-store-connect-key: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          app-store-connect-issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: result/bin/tonk
+          path: artifacts/tonk
           overwrite: true
       # The source-tree hash names the release when no tag is given. Only
       # one leg records it: the source tree is platform-independent.
@@ -90,11 +112,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      # `install.sh` ships as a release asset, and the one that belongs
-      # with these binaries is the one from the same ref.
+      # `install.sh` ships as a release asset. The current installer is
+      # deliberately overlaid below so it preserves the signature.
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+      # Historical installers ad-hoc signed the binary after download,
+      # overwriting its Developer ID signature. Ship the workflow
+      # commit's current signature-preserving installer instead.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: .ci
       - uses: actions/download-artifact@v4
         with:
           name: tonk-macos-arm64
@@ -109,6 +138,7 @@ jobs:
           path: artifacts/tree
       - name: Prepare release assets
         run: |
+          cp .ci/install.sh install.sh
           # Archive each binary as `tonk` so it extracts ready to run,
           # with the executable bit preserved across the download.
           install -m 0755 artifacts/macos-arm64/tonk tonk
@@ -156,9 +186,7 @@ jobs:
               | TONK_RELEASE=${{ env.tag }} sh
             ```
 
-            On macOS the binary is unsigned. The install script clears the
-            Gatekeeper quarantine for you; if you extract by hand and macOS
-            blocks it, run `xattr -d com.apple.quarantine tonk`.
+            The macOS binary is Developer ID signed and notarized by Apple.
           # Never the newest thing: this is history, and `make_latest`
           # would point `releases/latest` at an older build.
           prerelease: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -49,6 +49,23 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: 'Build tonk'
         run: nix build --accept-flake-config .#tonk-cli
+      # Nix store outputs are read-only. Sign a writable copy and upload
+      # exactly the bytes that passed notarization.
+      - name: 'Stage tonk artifact'
+        run: |
+          mkdir -p artifacts
+          cp result/bin/tonk artifacts/tonk
+          chmod 0755 artifacts/tonk
+      - name: 'Sign and notarize macOS artifact'
+        if: runner.os == 'macOS' && github.event_name != 'pull_request'
+        uses: ./.github/actions/sign-notarize-macos
+        with:
+          binary-path: artifacts/tonk
+          certificate-p12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          app-store-connect-key: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          app-store-connect-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          app-store-connect-issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
       # Name the build by the hash of its Rust source tree rather than by
       # commit: a doc-only change leaves it identical, and the same tree
       # reached from `stable` or `staging` is one build. Computed here
@@ -69,7 +86,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: result/bin/tonk
+          path: artifacts/tonk
 
   publish-staging:
     name: 'Publish Staging'
@@ -178,9 +195,7 @@ jobs:
             - macOS (Apple Silicon): `tonk-macos-arm64.tar.gz`
             - Linux (x86_64): `tonk-linux-x86_64.tar.gz`
 
-            On macOS the binary is unsigned. The install script clears the
-            Gatekeeper quarantine for you; if you extract by hand and macOS
-            blocks it, run `xattr -d com.apple.quarantine tonk`.
+            The macOS binary is Developer ID signed and notarized by Apple.
           prerelease: true
           make_latest: false
           files: |
@@ -306,9 +321,7 @@ jobs:
             - https://github.com/${{ github.repository }}/releases/latest/download/tonk-macos-arm64.tar.gz
             - https://github.com/${{ github.repository }}/releases/latest/download/tonk-linux-x86_64.tar.gz
 
-            On macOS the binary is unsigned. The install script clears the
-            Gatekeeper quarantine for you; if you extract by hand and macOS
-            blocks it, run `xattr -d com.apple.quarantine tonk`.
+            The macOS binary is Developer ID signed and notarized by Apple.
           # A pinned release is a historical artifact, never the newest
           # thing: `make_latest` would point `releases/latest` at an older
           # build and downgrade everyone installing from the stable channel.

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ report.*.json
 # Act secrets (local GitHub Actions)
 .secrets
 
+# Apple signing credentials
+AuthKey_*.p8
+*.p12
+
 # Personal files
 *.local.*
 .idea

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To install the pre-release channel instead, set `TONK_CHANNEL=staging`:
 curl -fsSL https://github.com/tonk-labs/tonk/releases/latest/download/install.sh | TONK_CHANNEL=staging sh
 ```
 
-You can also download a `tonk-<platform>.tar.gz` directly from the [releases page](https://github.com/tonk-labs/tonk/releases) and extract the `tonk` binary onto your `PATH`. The macOS binary is not yet Apple-signed, so a hand-downloaded copy needs `xattr -c tonk && codesign --force --sign - tonk` before it will run (the install script does this for you).
+You can also download a `tonk-<platform>.tar.gz` directly from the [releases page](https://github.com/tonk-labs/tonk/releases) and extract the `tonk` binary onto your `PATH`. Newly published macOS binaries are Developer ID signed and notarized by Apple.
 
 ### Update
 
@@ -79,8 +79,8 @@ This upgrades an install made by the install script: it downloads the
 newest staging release, matching npm's default `latest` deployment,
 verifies it against the release checksums, checks the new binary runs,
 and only then replaces the old one — so a failed update leaves your
-working `tonk` untouched. On macOS it re-runs the de-quarantine and
-ad-hoc re-sign for you.
+working `tonk` untouched. On macOS it preserves the published Developer
+ID signature while replacing the executable.
 
 `tonk` checks for new releases once a day and prints a one-line notice
 on stderr when one exists. Turn that off with `tonk update

--- a/docs/macos-cli-signing.md
+++ b/docs/macos-cli-signing.md
@@ -1,0 +1,80 @@
+# macOS CLI signing
+
+The CLI release workflows Developer ID sign and notarize every macOS binary
+before it can be uploaded to a GitHub release or npm. Linux builds are
+unchanged. Pull-request builds do not receive release credentials and therefore
+upload the Nix build's ad-hoc-signed macOS artifact only for CI inspection.
+
+The release boundary is `.github/actions/sign-notarize-macos/action.yml`. It
+copies no credentials into the repository: it imports the certificate into an
+ephemeral keychain, signs the already-staged binary with hardened runtime and a
+secure timestamp, waits for Apple to accept a ZIP containing that binary, and
+then requires both `codesign` and `spctl` verification to pass. Any missing
+credential, rejected submission, or failed verification stops artifact upload.
+
+## Required credentials
+
+Configure these GitHub Actions repository secrets:
+
+| Secret | Contents |
+| --- | --- |
+| `MACOS_CERTIFICATE_P12` | Base64-encoded PKCS#12 export containing the Developer ID Application certificate and its private key |
+| `MACOS_CERTIFICATE_PASSWORD` | Password used when exporting that PKCS#12 archive |
+| `APP_STORE_CONNECT_KEY_P8` | Unmodified PEM contents of an App Store Connect team API private key |
+| `APP_STORE_CONNECT_KEY_ID` | App Store Connect API key ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | Issuer UUID for the App Store Connect team key |
+
+Use a **Developer ID Application** certificate, not a development, Mac App
+Distribution, or Developer ID Installer certificate. The App Store Connect key
+must be a team key: Apple does not allow individual API keys to authenticate
+`notarytool`. Downloaded `.p8` keys are available only once, so retain the
+source credential in the team's secrets manager as well as GitHub.
+
+Export the certificate and private key from Keychain Access as a
+password-protected `.p12`, then configure the secrets from a trusted machine:
+
+```sh
+base64 -i DeveloperIDApplication.p12 | tr -d '\n' \
+  | gh secret set MACOS_CERTIFICATE_P12
+gh secret set MACOS_CERTIFICATE_PASSWORD
+gh secret set APP_STORE_CONNECT_KEY_P8 < AuthKey_KEY_ID.p8
+gh secret set APP_STORE_CONNECT_KEY_ID
+gh secret set APP_STORE_CONNECT_ISSUER_ID
+```
+
+The commands without redirected input prompt for the value, keeping it out of
+shell history. Never commit either credential file or place it in an Actions
+artifact.
+
+## Release coverage
+
+- `.github/workflows/cli.yml` signs pushes to `stable` and `staging`, plus
+  manually dispatched releases. Pull requests deliberately skip the action.
+- `.github/workflows/cli-npm.yml` signs tag-driven and manual npm releases.
+- `.github/workflows/cli-pin.yml` signs historical builds with the action from
+  the workflow commit. It also ships the current installer so an older
+  installer cannot overwrite the new Developer ID signature with an ad-hoc
+  signature.
+
+The submitted ZIP is only the notarization transport. Release archives and npm
+packages contain the exact signed executable that Apple accepted. Apple's
+ticket is published online for Gatekeeper; `spctl` verifies that ticket on the
+runner before CI uploads the binary.
+
+The first push to `staging` after provisioning the secrets is the end-to-end
+credential check. After it publishes, download and inspect the artifact on a
+Mac:
+
+```sh
+tar -xzf tonk-macos-arm64.tar.gz
+codesign --verify --strict --verbose=2 tonk
+codesign --display --verbose=4 tonk
+spctl --assess --type execute --verbose=2 tonk
+```
+
+## Rotation
+
+Replace all five repository secrets before the certificate or API key expires
+or is revoked, then validate with a staging release. Revoke the old App Store
+Connect key and remove the old certificate from the team's secrets manager only
+after the new staging artifact passes `codesign` and `spctl` assessment.

--- a/docs/plans/2026-08-18-macos-cli-signing.md
+++ b/docs/plans/2026-08-18-macos-cli-signing.md
@@ -1,0 +1,89 @@
+# macOS CLI signing and notarization implementation plan
+
+**Goal:** Ensure every macOS `tonk` binary published through GitHub releases or npm is Developer ID signed and accepted by Apple's notarization service before upload.
+**Approach:** Add one repository-local composite action that imports release credentials into an ephemeral keychain, signs a copied Nix build output, submits it with `notarytool`, and verifies the result. Call that action from each CLI distribution workflow while leaving pull-request builds secret-free and non-publishing.
+**Constraints:**
+- Never modify the read-only Nix store output; stage the binary before signing.
+- Use a Developer ID Application identity, hardened runtime, and a secure timestamp.
+- Fail closed before artifact upload for every push, tag, or manual run that can publish.
+- Do not expose Apple credentials to `pull_request` jobs.
+- Publish the exact bytes that passed signing and notarization.
+- Preserve Linux artifacts and existing release naming, checksums, manifests, and npm package layout.
+- Historical pinned builds must use signing logic from the workflow commit, not from the old source ref being built.
+
+## File map
+
+- `.github/actions/sign-notarize-macos/action.yml`: Import credentials, sign one staged CLI binary, notarize it, verify it, and clean up credentials.
+- `.github/workflows/cli.yml`: Stage build outputs and sign/notarize release-capable macOS builds.
+- `.github/workflows/cli-pin.yml`: Sign/notarize historical macOS builds with the current local action.
+- `.github/workflows/cli-npm.yml`: Sign/notarize the macOS binary before npm packaging.
+- `install.sh`: Preserve the Developer ID signature during installation.
+- `rust/tonk-cli/src/update/swap.rs`: Preserve the Developer ID signature during self-update.
+- `docs/macos-cli-signing.md`: Document credential preparation, repository secrets, and release behavior.
+- `README.md`: Replace the obsolete unsigned-binary warning.
+
+### Task 1: Add the signing and notarization boundary
+
+**Files:**
+- Create: `.github/actions/sign-notarize-macos/action.yml`
+
+**Interfaces:**
+- Consumes: `binary-path`, `certificate-p12`, `certificate-password`, `app-store-connect-key`, `app-store-connect-key-id`, and `app-store-connect-issuer-id` inputs.
+- Produces: the same binary path, replaced in place with the Developer ID-signed bytes whose ZIP submission Apple accepted.
+
+- [x] Reject any missing input before changing the staged binary.
+- [x] Import the base64 PKCS#12 certificate into a randomly passworded temporary keychain and select a `Developer ID Application` identity.
+- [x] Sign with `codesign --force --options runtime --timestamp`, then require `codesign --verify --strict` to succeed.
+- [x] Submit a ZIP containing the signed binary with `xcrun notarytool submit --wait --output-format json`; require status `Accepted` and print Apple's log on rejection.
+- [x] Require `spctl --assess --type execute` to accept the signed binary.
+- [x] Delete the temporary keychain, certificate, API key, archive, and notarization response on every exit.
+- [x] Parse the action as YAML and syntax-check its shell body.
+
+### Task 2: Route every macOS distribution through the action
+
+**Files:**
+- Modify: `.github/workflows/cli.yml:build-cli`
+- Modify: `.github/workflows/cli-pin.yml:build`
+- Modify: `.github/workflows/cli-npm.yml:build`
+
+**Interfaces:**
+- Consumes: the repository secrets `MACOS_CERTIFICATE_P12`, `MACOS_CERTIFICATE_PASSWORD`, `APP_STORE_CONNECT_KEY_P8`, `APP_STORE_CONNECT_KEY_ID`, and `APP_STORE_CONNECT_ISSUER_ID`.
+- Produces: the existing `tonk-macos-arm64` artifact name containing the signed/notarized `tonk` binary.
+
+- [x] Copy `result/bin/tonk` to a writable staging path on every matrix leg and upload only that path.
+- [x] Invoke the action only for macOS non-pull-request jobs; release-capable jobs must fail if credentials are absent or Apple rejects the binary.
+- [x] In the pin workflow, check out the workflow commit under a separate path and invoke its action while continuing to build `inputs.ref` from the workspace root.
+- [x] Confirm the release and npm assembly jobs still consume the unchanged artifact names and paths.
+- [x] Parse all changed workflows as YAML and run the strongest available GitHub Actions linter.
+
+### Task 3: Preserve the signature after download
+
+**Files:**
+- Modify: `install.sh:macOS Gatekeeper handling`
+- Modify: `rust/tonk-cli/src/update/swap.rs:prepare`
+- Test: `rust/tonk-cli/src/update/swap.rs:tests`
+- Modify: `.github/workflows/cli-pin.yml:publish`
+
+**Interfaces:**
+- Consumes: the signed binary bytes from the release archive.
+- Produces: an installed or self-updated executable with those exact bytes and its embedded Developer ID signature unchanged.
+
+- [x] Add a macOS-only `it_preserves_signed_binary_bytes` test that archives `/usr/bin/true`, installs it through `swap::install`, and asserts the installed bytes are identical; run it before the fix and expect the existing ad-hoc `codesign --force` call to change the bytes.
+- [x] Remove installer and self-updater ad-hoc signing and obsolete de-quarantine workarounds while retaining checksum verification, executable permissions, and smoke testing.
+- [x] Make historical pinned releases ship the current signature-preserving `install.sh`, because their source ref may contain the obsolete ad-hoc re-signing behavior.
+- [x] Run `cargo test -p tonk-cli update::swap::tests`; expect success.
+
+### Task 4: Document provisioning and the user-visible result
+
+**Files:**
+- Create: `docs/macos-cli-signing.md`
+- Modify: `README.md:direct-download macOS note`
+
+**Interfaces:**
+- Consumes: a Developer ID Application certificate exported as PKCS#12 and an App Store Connect API key authorized for notarization.
+- Produces: exact administrator instructions for configuring the five GitHub Actions secrets and rotating them.
+
+- [x] Document how to encode the certificate and preserve the PEM API key as GitHub secrets without committing either credential.
+- [x] Document the release-versus-pull-request behavior and the fact that raw command-line executables rely on Apple's online notarization ticket.
+- [x] Replace instructions that tell users to ad-hoc sign downloaded binaries with a statement that published macOS artifacts are signed and notarized.
+- [x] Run `git diff --check`, inspect the complete diff, and re-run YAML/shell validation after the final edit.

--- a/install.sh
+++ b/install.sh
@@ -14,9 +14,8 @@
 #   TONK_INSTALL_DIR       where to install (default: /usr/local/bin if
 #                          writable, else $HOME/.local/bin)
 #
-# The macOS binary is not Apple-signed (see BUG-22: Apple code signing). This
-# script clears the Gatekeeper quarantine and ad-hoc signs the binary so it
-# runs; a hand-downloaded binary needs the same `xattr -c` + `codesign`.
+# macOS binaries from the current release workflows are Developer ID signed and
+# notarized. Installation must preserve those exact bytes for Gatekeeper.
 set -eu
 
 REPO="tonk-labs/tonk"
@@ -104,7 +103,7 @@ say "downloading $asset"
 fetch "$url" "$tmp/$asset" || die "download failed: $url"
 
 # Verify the archive against the release's checksums.txt. Refuse to install
-# on mismatch; the binary is unsigned, so this is our integrity gate.
+# on mismatch; this protects the archive independently of platform signing.
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -136,26 +135,6 @@ chmod +x "$tmp/tonk"
 mkdir -p "$INSTALL_DIR"
 mv "$tmp/tonk" "$INSTALL_DIR/tonk"
 dest="$INSTALL_DIR/tonk"
-
-# macOS-only Gatekeeper handling. The tonk binary is not Apple-signed, so
-# Gatekeeper would otherwise quarantine it (and, on recent macOS, can kill
-# it on first launch). Two steps make an unsigned binary runnable:
-#   1. clear every extended attribute, including com.apple.quarantine;
-#   2. apply an ad-hoc signature, which arm64 binaries require to execute
-#      and which is re-established after the move/clear.
-# Both are no-ops off macOS (the tools are absent), so the guard is `Darwin`.
-#
-# Ad-hoc signing is unconditional ONLY because the release binary is
-# currently unsigned, so re-signing can't clobber anything of value. Once
-# BUG-22 ships a real Developer ID signature, make this opt-in (e.g. a
-# TONK_RESIGN_MACOS flag) so a normal install preserves the notarized
-# signature instead of replacing it with a local ad-hoc one.
-if [ "$os" = "Darwin" ]; then
-  xattr -c "$dest" 2>/dev/null || true
-  if command -v codesign >/dev/null 2>&1; then
-    codesign --force --sign - "$dest" 2>/dev/null || true
-  fi
-fi
 
 say "installed tonk to $dest"
 
@@ -221,13 +200,11 @@ case ":$PATH:" in
   *) say "note: $INSTALL_DIR is not on your PATH; add it, e.g. export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
 esac
 
-# Confirm the binary actually runs; if macOS still blocks it, surface the
-# exact recovery command instead of leaving a silent broken install.
+# Confirm the binary actually runs instead of leaving a silent broken install.
 if ! "$dest" --version >/dev/null 2>&1; then
   say "warning: '$dest --version' did not run cleanly."
   if [ "$os" = "Darwin" ]; then
-    say "if macOS blocked it, run: xattr -c \"$dest\" && codesign --force --sign - \"$dest\""
-    say "or allow it once under System Settings > Privacy & Security."
+    say "check your network, then allow it under System Settings > Privacy & Security if macOS blocked it."
   fi
 else
   "$dest" --version 2>/dev/null || true

--- a/rust/tonk-cli/src/update/swap.rs
+++ b/rust/tonk-cli/src/update/swap.rs
@@ -1,8 +1,8 @@
 //! Replacing the running binary.
 //!
 //! Everything is prepared on a temp file in the target's own
-//! directory — extracted, permissioned, de-quarantined, and
-//! smoke-tested — and the `rename()` happens last. A failure at any
+//! directory — extracted, permissioned, and smoke-tested — and the
+//! `rename()` happens last. A failure at any
 //! step therefore leaves the working binary untouched: there is no
 //! rollback path to get wrong, because nothing is ever half-applied.
 
@@ -78,8 +78,8 @@ pub fn foreign_install(path: &Path) -> Option<ForeignInstall> {
 
 /// Verify bytes against an expected hex SHA256.
 ///
-/// The integrity gate: the binary is unsigned, so this is the only
-/// thing between a download and your PATH. Mismatch is fatal.
+/// The archive integrity gate, independent of the platform signature.
+/// Mismatch is fatal.
 pub fn verify_sha256(bytes: &[u8], expected: &str) -> anyhow::Result<()> {
     let actual = hex(&Sha256::digest(bytes));
     if actual != expected.trim().to_ascii_lowercase() {
@@ -168,21 +168,6 @@ fn prepare(archive: &[u8], temp: &Path, target: &Path) -> anyhow::Result<()> {
             .context("could not make the new binary executable")?;
     }
 
-    // macOS: the release binary is unsigned, so Gatekeeper would
-    // quarantine it and arm64 requires *some* signature to execute.
-    // Mirrors what install.sh does after a download.
-    #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("xattr")
-            .arg("-c")
-            .arg(temp)
-            .status();
-        let _ = std::process::Command::new("codesign")
-            .args(["--force", "--sign", "-"])
-            .arg(temp)
-            .status();
-    }
-
     // Smoke-test BEFORE the rename. install.sh tests --version after
     // overwriting, so a bad binary is already your `tonk` by the time
     // you find out; testing first means a bad download never lands.
@@ -205,7 +190,7 @@ mod tests {
     use super::*;
 
     /// A `.tar.gz` holding one entry named `tonk` with `body`.
-    fn archive_with(body: &str) -> Vec<u8> {
+    fn archive_with_bytes(body: &[u8]) -> Vec<u8> {
         let mut header = tar::Header::new_gnu();
         header.set_path("tonk").expect("path");
         header.set_size(body.len() as u64);
@@ -213,12 +198,16 @@ mod tests {
         header.set_cksum();
 
         let mut tar = tar::Builder::new(Vec::new());
-        tar.append(&header, body.as_bytes()).expect("append");
+        tar.append(&header, body).expect("append");
         let tar = tar.into_inner().expect("finish");
 
         let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
         std::io::Write::write_all(&mut encoder, &tar).expect("gz");
         encoder.finish().expect("gz finish")
+    }
+
+    fn archive_with(body: &str) -> Vec<u8> {
+        archive_with_bytes(body.as_bytes())
     }
 
     fn sha_of(bytes: &[u8]) -> String {
@@ -296,6 +285,23 @@ mod tests {
             std::fs::read_to_string(&target)
                 .expect("read")
                 .contains("0.5.0")
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[dialog_common::test]
+    fn it_preserves_signed_binary_bytes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("tonk");
+        let signed = std::fs::read("/usr/bin/true").expect("read signed system binary");
+        let archive = archive_with_bytes(&signed);
+
+        install(&archive, &sha_of(&archive), &target).expect("install");
+
+        assert_eq!(
+            Sha256::digest(std::fs::read(&target).expect("read installed binary")),
+            Sha256::digest(&signed),
+            "install must not replace the embedded Apple signature"
         );
     }
 


### PR DESCRIPTION
## Summary

- Developer ID sign and notarize every macOS CLI artifact before release or npm publication
- fail closed on missing credentials, rejected notarization, or failed Gatekeeper assessment
- preserve the published signature through installation and self-update
- document credential provisioning, rotation, and release coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tonk-cli` (351 passed, 1 ignored)
- `actionlint` on all changed workflow files
- YAML parsing, shell syntax checks, and `git diff --check`

## Live validation

All five repository secret names are configured. Pull-request builds deliberately do not receive release credentials, so the Apple signing and notarization credentials will be exercised by the first staging release after merge.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing Developer ID signing and notarization for macOS binaries of the `tonk` CLI, ensuring that all published binaries are securely signed before release. It updates workflows and documentation to support this process.

### Detailed summary
- Updated `.gitignore` to include Apple signing credentials.
- Added steps to stage and sign the macOS artifact in `.github/workflows/cli.yml`.
- Implemented signing and notarization process with new action in `.github/actions/sign-notarize-macos/action.yml`.
- Updated `README.md` to reflect that macOS binaries are now Developer ID signed and notarized.
- Modified `install.sh` to preserve the Developer ID signature during installation.
- Added documentation on macOS CLI signing in `docs/macos-cli-signing.md`.
- Enhanced tests to ensure the signed binary bytes are preserved during installation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->