### PR TITLE
feat(access): scope the enrollment deposit to the service branch

### DIFF
--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -28,13 +28,14 @@ use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
 use dialog_ucan_core::{Container, Delegation, Invocation, InvocationBuilder, InvocationChain};
 use dialog_varsig::algorithm::eddsa::Ed25519Signature;
 use dialog_varsig::{Did, Principal};
+use ipld_core::cid::Cid;
 use ipld_core::ipld::Ipld;
 use ipld_core::serde::from_ipld;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tonk_account::customer::{
     Activate, Add, ConsumerReceipt, Customer, CustomerStatus, Enroll, Provider as ProviderRole,
-    Receipt, RegistrationError,
+    Receipt, RegistrationError, deposit_scopes,
 };
 
 use crate::email::EmailSender;
@@ -206,8 +207,21 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             });
         }
 
-        let deposit = self.deposited_delegation(&effect.access.to_string())?;
-        self.verify_deposit(&deposit.delegation, &customer).await?;
+        self.verify_deposits(&effect.access, &customer).await?;
+        // What gets stored is everything the deposit needs to be
+        // exercised later: the scoped heads together with the chain
+        // links that walk them back to the customer, re-encoded as a
+        // container of their exact bytes.
+        let access = Container::new(
+            self.delegation_tokens()?
+                .into_iter()
+                .map(|token| token.bytes)
+                .collect(),
+        )
+        .to_bytes()
+        .map_err(|err| RegistrationError::Internal {
+            message: format!("encoding the access deposit failed: {err}"),
+        })?;
 
         match self
             .store
@@ -217,13 +231,7 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
         {
             None => {
                 self.store
-                    .enroll_customer(
-                        customer.as_str(),
-                        &address,
-                        &deposit.bytes,
-                        SIGNUP_PLAN,
-                        self.now,
-                    )
+                    .enroll_customer(customer.as_str(), &address, &access, SIGNUP_PLAN, self.now)
                     .await
                     .map_err(internal)?;
             }
@@ -516,7 +524,47 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             })
     }
 
-    /// Validate the deposited access delegation: issued under the
+    /// Validate the deposited access delegations against the expected
+    /// [`deposit_scopes`]: each named deposit must match one scope
+    /// exactly — its command and its policy — and together they must
+    /// cover every scope, so the service ends up holding precisely its
+    /// own branch of the account space and the index catalog backing it.
+    /// A broader grant, `/` included, is refused rather than stored.
+    async fn verify_deposits(
+        &self,
+        access: &[Cid],
+        customer: &Did,
+    ) -> Result<(), RegistrationError> {
+        let expected = deposit_scopes(customer, &self.service.did());
+        let mut covered = [false; 2];
+        for cid in access {
+            let deposit = self.deposited_delegation(&cid.to_string())?;
+            let matched = expected.iter().position(|scope| {
+                deposit.delegation.command().segments() == scope.command.segments()
+                    && deposit.delegation.policy() == &scope.policy()
+            });
+            let Some(index) = matched else {
+                return Err(RegistrationError::Forbidden {
+                    message: format!(
+                        "deposit /{} is broader than the scopes enrollment accepts",
+                        deposit.delegation.command().segments().join("/")
+                    ),
+                });
+            };
+            covered[index] = true;
+            self.verify_deposit(&deposit.delegation, customer).await?;
+        }
+        if covered != [true; 2] {
+            return Err(RegistrationError::Forbidden {
+                message: "the deposit must cover the service's branch in memory and the index \
+                          catalog"
+                    .to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate one deposited access delegation: issued under the
     /// customer's authority to this service, signature-valid, and inside
     /// its own time window. It is an argument being deposited, not a
     /// proof, so it never extends the invocation's chain.
@@ -703,8 +751,6 @@ fn timestamp(seconds: u64) -> Result<Timestamp, RegistrationError> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use ipld_core::cid::Cid;
-
     use super::*;
 
     #[dialog_common::test]
@@ -716,7 +762,7 @@ mod tests {
         );
         let enroll = subject.clone().attenuate(Customer).invoke(Enroll {
             email: "alice@example.com".into(),
-            access: Cid::default(),
+            access: vec![Cid::default()],
         });
         assert_eq!(enroll.ability(), format!("/{}", ENROLL_COMMAND.join("/")));
         let activate = subject.attenuate(Customer).invoke(Activate {

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -27,7 +27,7 @@ use tonk_access_service::helpers::AccessServiceAddress;
 use tonk_access_service::registration::{Answer, Registration, SIGNUP_TERMS};
 use tonk_access_service::store::Store;
 use tonk_access_service::store::sqlite::SqliteStore;
-use tonk_account::customer::{Receipt, RegistrationError};
+use tonk_account::customer::{Receipt, RegistrationError, deposit_scopes};
 
 /// Current time as unix seconds.
 fn unix_now() -> u64 {
@@ -96,27 +96,44 @@ fn as_customer(answer: Answer) -> Receipt {
     }
 }
 
-/// Build an enroll container: a self-signed `/customer/enroll` invocation
-/// carrying the deposited access delegation as an extra container token.
-async fn enroll_container(customer: &Ed25519Signer, service: &Did, email: &str) -> Vec<u8> {
-    let deposit = DelegationBuilder::new()
-        .issuer(customer.clone())
-        .audience(service)
-        .subject(DelegatedSubject::Specific(customer.did()))
-        .command(vec![])
-        .try_build()
-        .await
-        .expect("deposit delegation");
-    enroll_container_with_deposit(customer, email, &deposit, true).await
+/// Mint the scoped deposits enrollment requires, issued directly by the
+/// customer to `audience` (the service, except in refusal tests).
+async fn scoped_deposits(
+    customer: &Ed25519Signer,
+    service: &Did,
+    audience: &Did,
+) -> Vec<Delegation<Ed25519Signature>> {
+    let mut deposits = Vec::new();
+    for scope in deposit_scopes(&customer.did(), service) {
+        deposits.push(
+            DelegationBuilder::new()
+                .issuer(customer.clone())
+                .audience(audience)
+                .subject(scope.subject.clone())
+                .command(scope.command.segments().clone())
+                .policy(scope.policy())
+                .try_build()
+                .await
+                .expect("deposit delegation"),
+        );
+    }
+    deposits
 }
 
-/// Build an enroll container with an explicit deposit, optionally leaving
-/// its bytes out of the container.
-async fn enroll_container_with_deposit(
+/// Build an enroll container: a self-signed `/customer/enroll` invocation
+/// carrying the deposited access delegations as extra container tokens.
+async fn enroll_container(customer: &Ed25519Signer, service: &Did, email: &str) -> Vec<u8> {
+    let deposits = scoped_deposits(customer, service, service).await;
+    enroll_container_with_deposits(customer, email, &deposits, true).await
+}
+
+/// Build an enroll container with explicit deposits, optionally leaving
+/// their bytes out of the container.
+async fn enroll_container_with_deposits(
     customer: &Ed25519Signer,
     email: &str,
-    deposit: &Delegation<Ed25519Signature>,
-    carry_deposit: bool,
+    deposits: &[Delegation<Ed25519Signature>],
+    carry_deposits: bool,
 ) -> Vec<u8> {
     let invocation = InvocationBuilder::new()
         .issuer(customer.clone())
@@ -125,7 +142,15 @@ async fn enroll_container_with_deposit(
         .command(vec!["customer".to_string(), "enroll".to_string()])
         .arguments(BTreeMap::from([
             ("email".to_string(), Promised::String(email.to_string())),
-            ("access".to_string(), Promised::Link(deposit.to_cid())),
+            (
+                "access".to_string(),
+                Promised::List(
+                    deposits
+                        .iter()
+                        .map(|deposit| Promised::Link(deposit.to_cid()))
+                        .collect(),
+                ),
+            ),
         ]))
         .proofs(vec![])
         .expiration(Timestamp::five_minutes_from_now())
@@ -133,8 +158,10 @@ async fn enroll_container_with_deposit(
         .await
         .expect("enroll invocation");
     let mut tokens = vec![serde_ipld_dagcbor::to_vec(&invocation).expect("invocation encodes")];
-    if carry_deposit {
-        tokens.push(deposit.encoded().to_vec());
+    if carry_deposits {
+        for deposit in deposits {
+            tokens.push(deposit.encoded().to_vec());
+        }
     }
     Container::new(tokens)
         .to_bytes()
@@ -319,18 +346,13 @@ async fn it_refuses_an_expired_activation_link_without_a_storage_lookup() -> any
 }
 
 #[dialog_common::test]
-async fn it_requires_the_deposited_delegation_to_travel_in_the_container() -> anyhow::Result<()> {
+async fn it_requires_the_deposited_delegations_to_travel_in_the_container() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;
-    let deposit = DelegationBuilder::new()
-        .issuer(customer.clone())
-        .audience(&fixture.service.did())
-        .subject(DelegatedSubject::Specific(customer.did()))
-        .command(vec![])
-        .try_build()
-        .await?;
+    let service = fixture.service.did();
+    let deposits = scoped_deposits(&customer, &service, &service).await;
     let container =
-        enroll_container_with_deposit(&customer, "alice@example.com", &deposit, false).await;
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, false).await;
     let refusal = fixture.registration(&container).handle().await.unwrap_err();
     assert!(matches!(refusal, RegistrationError::Invalid { .. }));
     Ok(())
@@ -341,16 +363,49 @@ async fn it_refuses_a_deposit_issued_to_someone_else() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;
     let stranger = Ed25519Signer::generate().await?;
-    // The deposit must be issued to this service, not a third party.
-    let deposit = DelegationBuilder::new()
+    // The deposits must be issued to this service, not a third party.
+    let service = fixture.service.did();
+    let deposits = scoped_deposits(&customer, &service, &stranger.did()).await;
+    let container =
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, true).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_refuses_a_deposit_broader_than_the_scopes() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    // The old shape of the deposit: an unscoped grant of `/` over the
+    // whole account space. Enrollment must refuse it rather than hold it.
+    let unscoped = DelegationBuilder::new()
         .issuer(customer.clone())
-        .audience(&stranger.did())
+        .audience(&service)
         .subject(DelegatedSubject::Specific(customer.did()))
         .command(vec![])
         .try_build()
         .await?;
     let container =
-        enroll_container_with_deposit(&customer, "alice@example.com", &deposit, true).await;
+        enroll_container_with_deposits(&customer, "alice@example.com", &[unscoped], true).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_requires_the_deposits_to_cover_both_scopes() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let service = fixture.service.did();
+    // Only the memory grant, no index catalog: the service could publish
+    // a branch pointer but never ship its nodes, so enrollment refuses
+    // the incomplete set.
+    let mut deposits = scoped_deposits(&customer, &service, &service).await;
+    deposits.truncate(1);
+    let container =
+        enroll_container_with_deposits(&customer, "alice@example.com", &deposits, true).await;
     let refusal = fixture.registration(&container).handle().await.unwrap_err();
     assert!(matches!(refusal, RegistrationError::Forbidden { .. }));
     Ok(())

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -9,6 +9,9 @@
 //! definition.
 
 use dialog_capability::{Attenuate, Attenuation, Effect, Subject};
+use dialog_effects::archive::{Archive, Catalog};
+use dialog_effects::memory::{Memory, Space};
+use dialog_ucan::Scope;
 use dialog_varsig::Did;
 use ipld_core::cid::Cid;
 use serde::{Deserialize, Serialize};
@@ -29,15 +32,45 @@ impl Attenuation for Customer {
 pub struct Enroll {
     /// Address the activation link is sent to.
     pub email: String,
-    /// The deposited delegation granting the service access to the
-    /// account space, by CID; its bytes travel in the same container. An
-    /// argument, not a proof: it never extends the invocation's chain.
-    pub access: Cid,
+    /// The deposited delegations granting the service access to the
+    /// account space, by CID; their bytes travel in the same container.
+    /// Arguments, not proofs: they never extend the invocation's chain.
+    /// The set must cover exactly the [`deposit_scopes`]: the service's
+    /// own branch in memory and the index catalog backing it.
+    pub access: Vec<Cid>,
 }
 
 impl Effect for Enroll {
     type Of = Customer;
     type Output = Result<Receipt, RegistrationError>;
+}
+
+/// The archive catalog an enrollment deposit covers: the tree-node index
+/// backing branch push and pull. Catalog reads still require knowing a
+/// node's digest, which only the scoped memory cells reveal.
+pub const SERVICE_CATALOG: &str = "index";
+
+/// The memory space of the branch the service writes under the account:
+/// named by the service's own DID, so the grant is per-service and
+/// rotates with the key. A service whose identity changes re-enrolls
+/// into a fresh branch rather than inheriting the old one.
+pub fn service_space(service: &Did) -> String {
+    format!("branch/{service}")
+}
+
+/// The scopes an enrollment deposit must grant the service, derived from
+/// capability chains so client and verifier share one definition: the
+/// account's service-named branch in memory, and the index catalog its
+/// pushes and pulls go through. Nothing broader — in particular not `/` —
+/// is accepted as a deposit.
+pub fn deposit_scopes(customer: &Did, service: &Did) -> [Scope; 2] {
+    let memory = Subject::from(customer.clone())
+        .attenuate(Memory)
+        .attenuate(Space::new(service_space(service)));
+    let archive = Subject::from(customer.clone())
+        .attenuate(Archive)
+        .attenuate(Catalog::new(SERVICE_CATALOG));
+    [Scope::from(&memory), Scope::from(&archive)]
 }
 
 /// `/customer/activate` — finalize enrollment. The invocation's subject
@@ -230,7 +263,7 @@ mod tests {
     fn it_derives_the_role_first_command_paths() {
         let enroll: Capability<Enroll> = subject().attenuate(Customer).invoke(Enroll {
             email: "alice@example.com".into(),
-            access: Cid::default(),
+            access: vec![Cid::default()],
         });
         assert_eq!(enroll.ability(), "/customer/enroll");
 
@@ -248,6 +281,27 @@ mod tests {
 
         let provision: Capability<Provision> = subject().attenuate(Consumer).invoke(Provision);
         assert_eq!(provision.ability(), "/consumer/provision");
+    }
+
+    #[test]
+    fn it_scopes_the_deposit_to_the_service_branch_and_index() {
+        let customer = did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        let service = did!("key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z");
+        let [memory, archive] = deposit_scopes(&customer, &service);
+
+        assert_eq!(memory.command.segments(), &["memory".to_string()]);
+        assert_eq!(
+            memory.parameters.as_map().get("space"),
+            Some(&ipld_core::ipld::Ipld::String(format!("branch/{service}")))
+        );
+        assert_eq!(archive.command.segments(), &["archive".to_string()]);
+        assert_eq!(
+            archive.parameters.as_map().get("catalog"),
+            Some(&ipld_core::ipld::Ipld::String("index".to_string()))
+        );
+        for scope in [&memory, &archive] {
+            assert_eq!(scope.policy().len(), 1, "one equality predicate per scope");
+        }
     }
 
     #[test]

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -13,12 +13,12 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
-use dialog_ucan_core::subject::Subject;
 use dialog_ucan_core::time::timestamp::Timestamp;
 use dialog_ucan_core::{
     Container, DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain,
 };
 use dialog_varsig::Did;
+use tonk_account::customer::deposit_scopes;
 
 /// Build a device-signed account-service invocation container.
 ///
@@ -65,11 +65,12 @@ pub async fn build_device_invocation(
 /// Build a `/customer/enroll` container for the access service.
 ///
 /// The invocation is device-signed on the account's subject, exactly as
-/// [`build_device_invocation`] does, and additionally deposits a
-/// delegation granting `service` access to the account space. The
-/// deposit is device-issued; the service walks it back to the account
-/// through the same `root → device` grant the invocation proves with,
-/// which rides in the same container.
+/// [`build_device_invocation`] does, and additionally deposits the
+/// scoped delegations granting `service` access to its own branch of the
+/// account space — the [`deposit_scopes`], nothing broader. The deposits
+/// are device-issued; the service walks them back to the account through
+/// the same `root → device` grant the invocation proves with, which
+/// rides in the same container.
 pub async fn build_enroll_invocation(
     device: Ed25519Signer,
     link: &DelegationChain,
@@ -77,17 +78,30 @@ pub async fn build_enroll_invocation(
     email: &str,
 ) -> Result<Vec<u8>> {
     let root_did = link.issuer().clone();
-    let deposit = DelegationBuilder::new()
-        .issuer(device.clone())
-        .audience(service)
-        .subject(Subject::Specific(root_did))
-        .command(vec![])
-        .try_build()
-        .await
-        .context("failed to mint the access deposit")?;
+    let mut deposits = Vec::new();
+    for scope in deposit_scopes(&root_did, service) {
+        let deposit = DelegationBuilder::new()
+            .issuer(device.clone())
+            .audience(service)
+            .subject(scope.subject.clone())
+            .command(scope.command.segments().clone())
+            .policy(scope.policy())
+            .try_build()
+            .await
+            .context("failed to mint the access deposit")?;
+        deposits.push(deposit);
+    }
     let arguments = BTreeMap::from([
         ("email".to_string(), Promised::String(email.to_string())),
-        ("access".to_string(), Promised::Link(deposit.to_cid())),
+        (
+            "access".to_string(),
+            Promised::List(
+                deposits
+                    .iter()
+                    .map(|deposit| Promised::Link(deposit.to_cid()))
+                    .collect(),
+            ),
+        ),
     ]);
     let invocation = build_device_invocation(
         device,
@@ -99,7 +113,9 @@ pub async fn build_enroll_invocation(
     let mut tokens = Container::from_bytes(&invocation)
         .context("failed to reopen the enroll container")?
         .into_tokens();
-    tokens.push(deposit.encoded().to_vec());
+    for deposit in &deposits {
+        tokens.push(deposit.encoded().to_vec());
+    }
     Container::new(tokens)
         .to_bytes()
         .context("failed to encode the enroll container")

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -8,24 +8,19 @@
 //! deployment serving this page — so endpoints derive from the request
 //! origin and the service DID comes from `/.well-known/tonk`.
 
-use std::collections::BTreeMap;
-
 use axum::{
     Json,
     extract::{Extension, State},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_ucan_core::promise::Promised;
-use dialog_ucan_core::subject::Subject as DelegatedSubject;
 use dialog_ucan_core::time::timestamp::Timestamp;
-use dialog_ucan_core::{Container, DelegationBuilder};
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_account::CUSTOMER_CREDENTIAL_SITE;
 use tonk_account::customer::{CustomerStatus, Receipt};
 use tonk_common::log;
-use tonk_identity::request::build_device_invocation;
+use tonk_identity::request::build_enroll_invocation;
 use url::Url;
 
 use super::AppState;
@@ -96,45 +91,15 @@ pub async fn enroll(
     let service_did = service_did(origin.url()).await?;
     let device = state.profile.signer().signer().clone();
 
-    // The deposit: this device grants the service access to the account
-    // space under the customer's authority. Its chain link (the
-    // `root → device` grant) rides in the same container as the
-    // invocation's proof, so the service can walk the deposit back to
-    // the customer.
-    let deposit = DelegationBuilder::new()
-        .issuer(device.clone())
-        .audience(&service_did)
-        .subject(DelegatedSubject::Specific(root_did.clone()))
-        .command(vec![])
-        .try_build()
+    // The deposits — the service's scoped grants into the account
+    // space — and their chain link (the `root → device` grant) all ride
+    // in the container `build_enroll_invocation` assembles, so the
+    // service can walk them back to the customer.
+    let body = build_enroll_invocation(device, &link, &service_did, &email)
         .await
         .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to mint the access deposit: {error}"))
+            TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
         })?;
-
-    let arguments = BTreeMap::from([
-        ("email".to_string(), Promised::String(email.clone())),
-        ("access".to_string(), Promised::Link(deposit.to_cid())),
-    ]);
-    let invocation = build_device_invocation(
-        device,
-        &link,
-        vec!["customer".to_string(), "enroll".to_string()],
-        arguments,
-    )
-    .await
-    .map_err(|error| {
-        TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
-    })?;
-    let mut tokens = Container::from_bytes(&invocation)
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to reopen the enroll container: {error}"))
-        })?
-        .into_tokens();
-    tokens.push(deposit.encoded().to_vec());
-    let body = Container::new(tokens).to_bytes().map_err(|error| {
-        TonkWorkerError::Internal(format!("failed to encode the enroll container: {error}"))
-    })?;
 
     let endpoint = ucan_endpoint(origin.url())?;
     let receipt = match post_cbor(&endpoint, &body).await {


### PR DESCRIPTION
Stacked on #715.

Enrollment deposited an unscoped grant of `/` over the whole account space, which made the access service's control database a honeypot of full-account credentials: anyone holding a stored deposit could rewrite any branch of the account. The service only ever needs to write its own data (usage, billing) into the account repo, so the deposit now grants exactly that.

The deposit is two delegations derived from capability chains, so the client that mints them and the server that checks them share one definition (`tonk_account::customer::deposit_scopes`):

- `/memory` with policy `space == "branch/{service-did}"` — the service's own branch of the account repo. Naming the branch by the service DID makes the grant per-service and rotates it with the key: a service whose identity changes re-enrolls into a fresh branch.
- `/archive` with policy `catalog == "index"` — the tree-node catalog branch push/pull goes through. Reads still require knowing a node's digest, which only the scoped memory cells reveal.

The scopes are built as `Subject → Memory → Space` / `Subject → Archive → Catalog` chains and lowered through `dialog_ucan::Scope` into delegation command + policy predicates. The server matches each deposited head against the expected scopes exactly (command and policy), refuses anything broader (`/` included), and requires the set to cover both. What gets stored is now the full deposit chain — scoped heads plus the `root → device` link that walks them back to the customer — re-encoded as a container, where before only the unusable head was kept.

The worker's inline deposit construction is replaced by the shared `tonk_identity::request::build_enroll_invocation`, so web, CLI, and tests all mint the same shape.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the enrollment process by implementing scoped access deposits, ensuring that services only receive access to their designated branches within the account space.

### Detailed summary
- Added `deposit_scopes` function to define scoped access for services.
- Updated `build_enroll_invocation` to handle multiple scoped deposits.
- Modified `enroll` function to utilize `build_enroll_invocation`.
- Changed `access` field in `Enroll` struct to accept a vector of CIDs.
- Implemented `verify_deposits` to validate that deposits match expected scopes.
- Updated tests to reflect changes in deposit handling and validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->