### PR TITLE
feat(worker): read linked state from the account replica signal

### DIFF
--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -124,6 +124,29 @@ pub(crate) async fn member_did(
     super::identity::root_did(state).await
 }
 
+/// Whether this profile is linked, read from the account replica the
+/// profile repository indexes rather than a stored flag (plan/Account
+/// model.md §5). Two deliberate deviations from the pure signal:
+///
+/// - A legacy account attached before repository descriptors existed has
+///   nothing mounted to read; its descriptor-less record stands in until
+///   `establish_repository` upgrades it.
+/// - A transient index read failure falls back to the stored attachment
+///   instead of signing the profile out on a flaky read.
+async fn linked(state: &crate::worker::TonkState) -> bool {
+    match super::account_state::linked_account(state).await {
+        Ok(Some(_)) => true,
+        Ok(None) => matches!(
+            attachment(state).await,
+            Some(record) if record.descriptor().is_none()
+        ),
+        Err(error) => {
+            log!("linked-state read failed, falling back to the stored attachment: {error}");
+            attachment(state).await.is_some()
+        }
+    }
+}
+
 /// Refuse unless this device holds an account.
 ///
 /// The precondition every durable operation shares. Durable authority is only
@@ -133,16 +156,17 @@ pub(crate) async fn member_did(
 /// synchronization states of an account that exists, and refusing on them
 /// would invent a way to be stuck with no way out.
 ///
-/// [`attachment`] resolves the record against the local root and is fail-safe,
-/// so a missing root, an unreadable record and another account's descriptor
-/// all land here as "no account" rather than as an error the caller has to
-/// distinguish.
+/// [`linked`] reads the replica signal and is fail-safe through the stored
+/// attachment, so a missing root, an unreadable record and another account's
+/// descriptor all land here as "no account" rather than as an error the
+/// caller has to distinguish.
 pub(crate) async fn require_account(
     state: &crate::worker::TonkState,
 ) -> Result<(), TonkWorkerError> {
-    match attachment(state).await {
-        Some(_) => Ok(()),
-        None => Err(TonkWorkerError::AccountRequired),
+    if linked(state).await {
+        Ok(())
+    } else {
+        Err(TonkWorkerError::AccountRequired)
     }
 }
 
@@ -208,6 +232,15 @@ async fn status(state: &crate::worker::TonkState) -> Result<AccountStatus, TonkW
             root_did: root.root_did.to_string(),
             device_did,
         }),
+        // The record is provider metadata, not the linked flag: a record
+        // whose descriptor names a repository that was never mounted is a
+        // link that did not complete, and re-linking heals it.
+        Some(record) if record.descriptor().is_some() && !linked(state).await => {
+            Ok(AccountStatus::Unregistered {
+                root_did: root.root_did.to_string(),
+                device_did,
+            })
+        }
         Some(record) => {
             let account_state = if record.descriptor().is_some() {
                 super::account_state::status(state).await
@@ -382,6 +415,10 @@ pub async fn link(
 #[wasm_compat]
 pub async fn unlink(State(state): State<AppState>) -> Result<Json<AccountStatus>, TonkWorkerError> {
     let state = state.read().await;
+    // The replica retraction is the unlink: it clears the linked-state
+    // signal sync and status read. It goes first so a failure leaves the
+    // device consistently linked rather than half signed out.
+    super::account_state::retract_account_replicas(&state).await?;
     state
         .profile
         .credential()
@@ -557,6 +594,74 @@ mod tests {
             entry.root_did.is_none() && entry.provider.is_none() && entry.email.is_none(),
             "a signed-out profile renders as a local workspace"
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_linked_state_from_the_replica_signal() {
+        let state = Arc::new(RwLock::new(test_state_without_account().await));
+        let request = {
+            let state = state.read().await;
+            matching_request(&state).await
+        };
+        let _ = link(State(state.clone()), Json(request)).await.unwrap();
+
+        let tonk = state.read().await;
+        let root = super::super::identity::local_root(&tonk).await.unwrap();
+        let linked = super::super::account_state::linked_account(&tonk)
+            .await
+            .unwrap()
+            .expect("link records the account replica");
+        assert_eq!(linked, root.root_did);
+    }
+
+    #[dialog_common::test]
+    async fn it_treats_an_unmounted_descriptor_record_as_unlinked() {
+        let state = Arc::new(RwLock::new(test_state_without_account().await));
+        // Persist the attachment record directly, without the mount that
+        // link performs: the state a crash mid-link leaves behind. The
+        // record alone must not read as a linked account.
+        {
+            let tonk = state.read().await;
+            let request = matching_request(&tonk).await;
+            let root = super::super::identity::local_root(&tonk).await.unwrap();
+            let descriptor = hex::decode(&request.descriptor_hex).unwrap();
+            let record =
+                AccountProviderRecord::attach(&request.provider, &descriptor, &root.root_did, 1)
+                    .await
+                    .unwrap();
+            save_provider(&tonk, &record).await.unwrap();
+
+            assert!(matches!(
+                require_account(&tonk).await,
+                Err(TonkWorkerError::AccountRequired)
+            ));
+        }
+        let Json(status) = get(State(state)).await.unwrap();
+        assert!(matches!(status, AccountStatus::Unregistered { .. }));
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_the_replica_signal_on_unlink() {
+        let state = Arc::new(RwLock::new(test_state_without_account().await));
+        let request = {
+            let state = state.read().await;
+            matching_request(&state).await
+        };
+        let _ = link(State(state.clone()), Json(request)).await.unwrap();
+        let _ = unlink(State(state.clone())).await.unwrap();
+
+        let tonk = state.read().await;
+        assert!(
+            super::super::account_state::linked_account(&tonk)
+                .await
+                .unwrap()
+                .is_none(),
+            "unlink retracts the account replica"
+        );
+        assert!(matches!(
+            require_account(&tonk).await,
+            Err(TonkWorkerError::AccountRequired)
+        ));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -162,6 +162,13 @@ async fn resolve_account_keys(tonk: &TonkState) -> (HashSet<String>, bool) {
     if let Some(descriptor) = configured_descriptor(tonk).await {
         keys.insert(descriptor.account_subject().repo_key().to_owned());
     }
+    // The account subject is the local root, so its repository key is
+    // derivable without any attachment record. Hiding it this way keeps
+    // an unlinked device's account replica hidden too: unlink retracts
+    // the replica index row, but the repository itself stays on disk.
+    if let Ok(root) = super::identity::local_root(tonk).await {
+        keys.insert(root.root_did.repo_key().to_owned());
+    }
 
     let Ok(meta) = tonk
         .reactor
@@ -197,6 +204,81 @@ async fn resolve_account_keys(tonk: &TonkState) -> (HashSet<String>, bool) {
             .map(|subject| subject.repo_key().to_owned())
     }));
     (keys, true)
+}
+
+/// The account replica rows the profile repository indexes.
+async fn account_replicas(tonk: &TonkState) -> Result<Vec<Replica>, TonkWorkerError> {
+    let meta = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to open the profile index: {error}"))
+        })?;
+    meta.handle()
+        .query()
+        .select(Query::<Replica> {
+            this: Term::var("this"),
+            subject: Term::var("subject"),
+            profile: Term::var("profile"),
+            kind: Term::from(Replica::account_kind()),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to query account replicas: {error}"))
+        })
+}
+
+/// The linked account's subject, read from the account replica the
+/// profile repository indexes — the same remote registration sync draws
+/// its pull population from (plan/Account model.md §5). Mounting the
+/// account repository records it; unlink retracts it. There is no
+/// separate linked flag: an attachment record without this replica is a
+/// link that never completed, not a linked account.
+///
+/// `Err` is a transient index read failure, distinct from a readable
+/// "no replica"; callers with a stored attachment may fall back to it
+/// rather than signing the profile out on a flaky read.
+pub(crate) async fn linked_account(
+    tonk: &TonkState,
+) -> Result<Option<dialog_varsig::Did>, TonkWorkerError> {
+    Ok(account_replicas(tonk)
+        .await?
+        .into_iter()
+        .find_map(|row| row.subject.0.to_string().parse::<dialog_varsig::Did>().ok()))
+}
+
+/// Retract every account replica row from the profile index: the unlink
+/// half of the linked-state signal. The mounted repository and its
+/// remote configuration stay on disk — dialog remotes are create-only —
+/// but nothing tracks them any more, so neither sync nor the linked
+/// signal sees them, and re-linking re-records the same replica.
+pub(crate) async fn retract_account_replicas(tonk: &TonkState) -> Result<(), TonkWorkerError> {
+    let rows = account_replicas(tonk).await?;
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let mut transaction = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction();
+    for row in rows {
+        transaction = transaction.retract(row);
+    }
+    transaction
+        .commit()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to retract account replicas: {error}"))
+        })?;
+    tonk.account_keys.invalidate();
+    Ok(())
 }
 
 async fn mount_account_repository(


### PR DESCRIPTION
Stacked on #719. Implements §5 of `plan/Account model.md` for the browser worker.

The provider record doubled as the linked flag, so it could disagree with sync state: a crash between persisting the record and mounting the account repository left a device that reported linked while sync had nothing to work with. Linked-ness is now read from the account replica row the profile repository indexes — the same remote registration the background drain draws its pull population from — so the signal and sync read one value. `require_account` and `status()` consult it; a descriptor-bearing record whose repository never mounted reads as unlinked, and re-linking heals it (the mount is all-local, so linking flips the signal without network). Unlink retracts the replica rows before tombstoning the record, in that order so a failure leaves the device consistently linked rather than half signed out.

Two deliberate deviations from the pure remote-as-state reading, both flagged rather than papered over:

- **Legacy accounts.** An account attached before repository descriptors existed has nothing mounted to read. Its descriptor-less record stands in until `establish_repository` upgrades it; that fallback dies with the last legacy account.
- **Nothing deletes.** dialog remotes, repositories, and their cells are create-only on the current pin, so sign-out cannot dismantle the remote itself. The retractable replica *facts* carry the signal instead, and the mounted repository stays on disk. To keep it hidden after unlink, the account routing key is now also derived from the local root (the account subject *is* the root), with no record needed.

The provider record stays as what it actually is: provider-service metadata (base URL, descriptor) for the HTTP operations that need it. `provider()` and `account_link()` keep gating on it, since those operations cannot proceed without that metadata anyway.

CLI follows separately — its linked reads live in `stored_provider` call sites and the same split applies.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the handling of account replicas in the `tonk-worker` by introducing new functions to manage linked accounts and retract account replicas, improving the reliability of account state signals.

### Detailed summary
- Added documentation for account subject and repository key handling.
- Introduced `account_replicas` function to query account replica rows.
- Created `linked_account` function to retrieve linked account information.
- Implemented `retract_account_replicas` function to remove account replicas.
- Updated `linked` function to read linked state from account replicas.
- Modified `require_account` to utilize the new `linked` function.
- Enhanced `status` function to reflect unregistered states correctly.
- Updated `unlink` function to clear linked state by retracting replicas first.
- Added tests for linked state retrieval and unmounted descriptor handling.
- Included tests for ensuring correct behavior on unlinking and account requirement checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->