### PR TITLE
feat(worker): create spaces before an account exists

### DIFF
--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -897,37 +897,99 @@ pub mod tests {
     /// of "not signed in": no root at all, and a root with no account behind
     /// it. Neither may create a spot — one that exists without an account is
     /// local-only and never backed up, and nothing later would say so.
-    async fn create_space_refusal(state: TonkState) -> serde_json::Value {
-        let (app, _lsp) = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/spaces")
-                    .method("POST")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"name":"Notes","remote":null,"template":null}"#,
-                    ))
-                    .unwrap(),
-            )
+    /// A space creates before any account exists, delegated to the most
+    /// durable key the profile holds (plan/Account model.md §2): the
+    /// device key when there is no root, the root when there is one.
+    #[dialog_common::test]
+    async fn it_creates_a_space_before_any_account_exists() {
+        let (app, state, _lsp) = super::api_router_with_state(test_state_without_root().await);
+        let key = put_repo(&app, "pre-account").await;
+        {
+            let tonk = state.read().await;
+            let repository = tonk
+                .profile
+                .repository(&key)
+                .load()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+            let prefix = super::repository::space_root_prefix(&tonk, &repository.did())
+                .await
+                .unwrap();
+            assert_eq!(
+                prefix.audience(),
+                &tonk.profile.did(),
+                "with no root, the space delegates to the profile's device key"
+            );
+        }
+
+        let (app, state, _lsp) = super::api_router_with_state(test_state_without_account().await);
+        let key = put_repo(&app, "signed-out").await;
+        let tonk = state.read().await;
+        let repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::CONFLICT);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        let prefix = super::repository::space_root_prefix(&tonk, &repository.did())
             .await
             .unwrap();
-        serde_json::from_slice(&body).unwrap()
+        let root = super::identity::local_root(&tonk).await.unwrap();
+        assert_eq!(
+            prefix.audience(),
+            &root.root_did,
+            "with a bare root, the space delegates to it"
+        );
     }
 
+    /// A space created before any root existed is adopted once one does:
+    /// its own signer re-delegates to the root and the stored prefix is
+    /// replaced, so the account holds the authority going forward.
     #[dialog_common::test]
-    async fn it_refuses_space_creation_without_an_account() {
-        let error = create_space_refusal(test_state_without_root().await).await;
-        assert_eq!(error["error"]["code"], "ACCOUNT_REQUIRED");
+    async fn it_adopts_profile_spaces_once_a_root_exists() {
+        let (app, state, _lsp) = super::api_router_with_state(test_state_without_root().await);
+        let key = put_repo(&app, "adopted").await;
 
-        let error = create_space_refusal(test_state_without_account().await).await;
+        let tonk = state.read().await;
+        let root = Ed25519Signer::import(&test_root_seed(&tonk.profile_name))
+            .await
+            .unwrap();
+        let root_did = {
+            use dialog_varsig::Principal as _;
+            root.did()
+        };
+        let grant = tonk_identity::delegation::mint_device_delegation(root, &tonk.profile.did())
+            .await
+            .unwrap();
+        super::identity::persist_root(
+            &tonk,
+            tonk_worker_api::SaveRootRequest {
+                credential_id: "test-credential".to_string(),
+                delegation_hex: hex::encode(grant.to_bytes().unwrap()),
+                passkey: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        super::repository::adopt_profile_spaces(&tonk).await;
+
+        let repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        let prefix = super::repository::space_root_prefix(&tonk, &repository.did())
+            .await
+            .unwrap();
         assert_eq!(
-            error["error"]["code"], "ACCOUNT_REQUIRED",
-            "a bare passkey root is not an account"
+            prefix.audience(),
+            &root_did,
+            "adoption re-delegates the space to the root"
         );
     }
 
@@ -943,24 +1005,6 @@ pub mod tests {
         let (app, _state, _lsp) = super::api_router_with_state(test_state().await);
         let key = put_repo(&app, "account-attached").await;
         assert!(key.starts_with("did:key:"));
-    }
-
-    /// Every creation route shares the gate, not just the one the page uses.
-    #[dialog_common::test]
-    async fn it_refuses_repository_creation_without_an_account() {
-        let (app, _lsp) = api_router(test_state_without_account().await);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/repository/no-account")
-                    .method("PUT")
-                    .header("content-type", "application/json")
-                    .body(Body::from("{}"))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -117,11 +117,18 @@ pub(crate) async fn account_link(
         .map(|root| root.delegation)
 }
 
-/// The local root DID used for every durable membership operation.
+/// The DID membership rows are keyed on: the account root when one is
+/// persisted, so a founder/member row converges across every device on
+/// the same account, else the profile's device key — the only durable
+/// key a pre-account profile has.
 pub(crate) async fn member_did(
     state: &crate::worker::TonkState,
 ) -> Result<dialog_varsig::Did, TonkWorkerError> {
-    super::identity::root_did(state).await
+    match super::identity::root_did(state).await {
+        Ok(did) => Ok(did),
+        Err(TonkWorkerError::RootRequired) => Ok(state.profile.did()),
+        Err(error) => Err(error),
+    }
 }
 
 /// Whether this profile is linked, read from the account replica the
@@ -395,6 +402,11 @@ pub async fn link(
     // spaces. Each account-service request is bounded by the shared HTTP
     // timeout, and awaiting the sequence keeps it inside the fetch lifetime.
     super::account_state::ensure_account_state(&state).await;
+    // Spaces created before this account existed delegate to the profile
+    // key; adopt them under the account root ahead of the backup sweep,
+    // so what gets backed up is the account-rooted authority.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    super::repository::adopt_profile_spaces(&state).await;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     crate::router::account_backup::back_up_existing_spaces(&state).await;
     crate::router::restore::restore_spaces(&state).await;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2631,17 +2631,15 @@ pub async fn create_repository(
     display_name: &str,
     configuration: &RepositoryConfiguration,
 ) -> Result<Repository<SignerCredential>, RepositoryError> {
-    // Ahead of the root read, and ahead of every write: a spot created without
-    // an account is local-only and un-backed-up, and nothing later in this
-    // function would notice. The gate belongs here rather than only at the
-    // command handler so the HTTP route the gate replays through is held to
-    // the same rule.
-    super::account::require_account(tonk)
-        .await
-        .map_err(|_| RepositoryError::AccountRequired)?;
-    let local_root = match super::identity::local_root(tonk).await {
-        Ok(root) => root,
-        Err(TonkWorkerError::RootRequired) => return Err(RepositoryError::RootRequired),
+    // A space can be created before any account exists: it delegates to
+    // the most durable key the client holds — the passkey-derived root
+    // when one is persisted, else the profile's own device key
+    // (plan/Account model.md §2). Such a space is local-only and
+    // un-backed-up until linking redelegates it to the account and
+    // provisions it; see [`adopt_profile_spaces`].
+    let owner = match super::identity::local_root(tonk).await {
+        Ok(root) => root.root_did,
+        Err(TonkWorkerError::RootRequired) => tonk.profile.did(),
         Err(error) => {
             return Err(RepositoryError::Internal(format!(
                 "failed to load local root: {error}"
@@ -2674,11 +2672,11 @@ pub async fn create_repository(
         })?;
     log!("Repository created. DID: {}", repository.did());
 
-    // 2. Delegate subject-specific authority to the stable local root.
+    // 2. Delegate subject-specific authority to the owner key.
     let delegation = repository
         .access()
         .claim(&repository)
-        .delegate(local_root.root_did.clone())
+        .delegate(owner)
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
@@ -2764,6 +2762,102 @@ pub(crate) async fn space_root_prefix(
     DelegationChain::try_from(bytes.as_slice()).map_err(|error| {
         TonkWorkerError::Internal(format!("stored space root delegation is invalid: {error}"))
     })
+}
+
+/// Bring pre-account spaces under the account after linking.
+///
+/// A space created before any account existed delegates to the profile's
+/// device key, the only durable key the client had. Once a root is
+/// persisted, each such space re-delegates from its own signer to the
+/// account root: the stored prefix is replaced, the new authority lands
+/// in the profile's access branch, is retained into the account space,
+/// and the space is provisioned as a consumer under the account's
+/// customer. Spaces already rooted at the account — created while signed
+/// out, or adopted by an earlier pass — skip the redelegation but still
+/// get the retain and the provisioning, both idempotent. Joined replicas
+/// (whose prefix reaches this profile through someone else's chain) are
+/// left alone. Best effort per space: adoption failing must never fail
+/// the link that triggered it.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn adopt_profile_spaces(tonk: &TonkState) {
+    let Ok(root) = super::identity::local_root(tonk).await else {
+        return;
+    };
+    let profile_did = tonk.profile.did();
+    for key in super::profile_name::real_space_keys(tonk).await {
+        let Ok(repository) = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+        else {
+            continue;
+        };
+        let subject = repository.did();
+        let Ok(prefix) = space_root_prefix(tonk, &subject).await else {
+            continue;
+        };
+        let chain = if prefix.audience() == &profile_did {
+            // Joined replicas carry a verifier-only credential: nothing
+            // to redelegate from, their authority is the inviter's.
+            let Some(access) = repository.try_access() else {
+                continue;
+            };
+            let delegation = match access
+                .claim(&repository)
+                .delegate(root.root_did.clone())
+                .perform(&tonk.operator)
+                .await
+            {
+                Ok(delegation) => delegation,
+                Err(error) => {
+                    log!("space '{subject}' was not adopted by the account: {error}");
+                    continue;
+                }
+            };
+            let chain = delegation.into_chain();
+            if let Err(error) = tonk
+                .profile
+                .access()
+                .save(UcanDelegation(chain.clone()))
+                .perform(&tonk.operator)
+                .await
+            {
+                log!("adopted space '{subject}' delegation did not save: {error}");
+                continue;
+            }
+            match chain.to_bytes() {
+                Ok(bytes) => {
+                    if let Err(error) = tonk
+                        .profile
+                        .credential()
+                        .site(format!("{SPACE_ROOT_SITE_PREFIX}{subject}"))
+                        .save(bytes)
+                        .perform(&tonk.operator)
+                        .await
+                    {
+                        log!("adopted space '{subject}' prefix did not persist: {error}");
+                        continue;
+                    }
+                }
+                Err(error) => {
+                    log!("adopted space '{subject}' prefix did not serialize: {error}");
+                    continue;
+                }
+            }
+            log!("space '{subject}' adopted by the account");
+            chain
+        } else if prefix.audience() == &root.root_did {
+            prefix
+        } else {
+            continue;
+        };
+        super::account_state::retain_space_delegation(tonk, &chain).await;
+        if let Err(error) = super::customer::provision_consumer(tonk, &subject, &chain).await {
+            log!("adopted space '{subject}' provisioning skipped: {error}");
+        }
+    }
 }
 
 /// Lay down the meta-branch facts and profile-side index for an


### PR DESCRIPTION
Stacked on #720. Implements §2 + §7 of `plan/Account model.md` for the browser worker: local space creation without an account, and account adoption at link time.

Onboarding should not dead-end on sign-up. A space now creates before any account exists, delegated to the most durable key the client actually has: the passkey-derived root when one is persisted, else the profile's device key. Membership rows key on the same fallback, matching what `record_membership_on_content`'s doc already promised. Such a space is device-local and un-backed-up by construction — there is no key off the device with authority over it — which is the model doc's stated pre-linking limitation, not a regression.

Linking is what upgrades them. `adopt_profile_spaces` runs in `link()` between the account mount and the backup sweep: each profile-delegated space re-delegates from its own signer to the account root, the stored root prefix is replaced, the new authority lands in the profile's access branch, gets retained into the account space, and the space is provisioned as a consumer under the account's customer. Spaces created while signed out (root but no account) skip the redelegation but pick up the retain and provisioning on the same pass; both are idempotent, so repeated links are no-ops. Joined replicas hold verifier-only credentials and are left alone — their authority is the inviter's.

Deliberately not covered here, flagged for follow-up:

- **Join stays gated.** Joining implies sync and someone else's provisioned space; whether pre-account joins make sense is a separate decision.
- **Pre-account sync will be denied.** A pre-account space with an origin remote configured has no provisioned consumer, so its sync attempts 401 until adoption (and land in the metering ingest as denials). Stamping such replicas sync-paused at creation and resuming at adoption would quiet that; it interacts with the sync-pause design, so it is not done here.
- **Membership rows don't converge on adoption.** A founder row keyed on the device key stays keyed on it; converging it to the account root at adoption is roster surgery this PR doesn't attempt.
- **CLI parity.** The CLI's gate runs through `AccountBoundOperator`'s authority rebinding and its `require_account` is already per-site configuration; lifting it follows separately.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of profile spaces in relation to account roots. It introduces logic for adopting spaces created before an account exists and ensures that spaces delegate authority correctly when a root is persisted.

### Detailed summary
- Updated documentation for `member_did` to clarify DID membership rows.
- Enhanced error handling in `member_did`, allowing fallback to profile DID.
- Added logic to adopt profile spaces once an account root exists.
- Introduced tests for space creation before account existence and successful adoption of spaces.
- Refactored `create_repository` to delegate authority to the correct owner key.
- Implemented `adopt_profile_spaces` to manage pre-account spaces under the account after linking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->