### PR TITLE
feat(identity): mint the enrollment deposit account-signed at ceremony

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ temp/**
 # Repositories minted by test runs against ephemeral local services.
 # They carry throwaway credentials and must never be committed.
 rust/**/did:key:*
+# Local dev service state (dev:web ACCESS_STATE_DIR)
+.tonk-dev/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,6 +4533,7 @@ dependencies = [
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tonk-account",
@@ -4541,6 +4542,7 @@ dependencies = [
  "tonk-invite",
  "tonk-worker-api",
  "url",
+ "urlencoding",
  "worker",
  "worker-macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,6 +4905,7 @@ dependencies = [
  "js-sys",
  "rand 0.9.5",
  "serde-wasm-bindgen",
+ "serde_ipld_dagcbor",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",

--- a/flake.nix
+++ b/flake.nix
@@ -219,11 +219,17 @@
                 # not on the access service's own port, or the /activate
                 # route 404s.
                 export ACCESS_PUBLIC_ORIGIN="http://localhost:8080"
-                # Persist the dev service's state (customers, service key,
-                # blob snapshot) across restarts: a wiped in-memory service
-                # orphans every client that holds credentials against it.
-                export ACCESS_STATE_DIR="$PWD/.tonk-dev/access"
-                mkdir -p "$ACCESS_STATE_DIR"
+                # Regular runs are ephemeral: the access service keeps its
+                # state in memory and a restart starts clean. Export
+                # ACCESS_STATE_DIR (e.g. "$PWD/.tonk-dev/access") before
+                # dev:web to persist customers, the service key, and a
+                # blob snapshot between runs — without it, restarting the
+                # service orphans every client holding credentials
+                # against it, so clear site data after a restart.
+                if [ -n "''${ACCESS_STATE_DIR:-}" ]; then
+                  mkdir -p "$ACCESS_STATE_DIR"
+                  echo "dev:web: persisting access-service state in $ACCESS_STATE_DIR"
+                fi
                 # stdout carries the `ACCESS_SERVICE_URL=` line; stderr (build
                 # progress) stays on the terminal.
                 cargo run --bin tonk-access-local --features helpers >"$ACCESS_LOG" &

--- a/flake.nix
+++ b/flake.nix
@@ -219,6 +219,11 @@
                 # not on the access service's own port, or the /activate
                 # route 404s.
                 export ACCESS_PUBLIC_ORIGIN="http://localhost:8080"
+                # Persist the dev service's state (customers, service key,
+                # blob snapshot) across restarts: a wiped in-memory service
+                # orphans every client that holds credentials against it.
+                export ACCESS_STATE_DIR="$PWD/.tonk-dev/access"
+                mkdir -p "$ACCESS_STATE_DIR"
                 # stdout carries the `ACCESS_SERVICE_URL=` line; stderr (build
                 # progress) stays on the terminal.
                 cargo run --bin tonk-access-local --features helpers >"$ACCESS_LOG" &

--- a/rust/tonk-access-service/Cargo.toml
+++ b/rust/tonk-access-service/Cargo.toml
@@ -49,6 +49,7 @@ serde_ipld_dagcbor = { workspace = true }
 serde_json = { workspace = true }
 
 getrandom = { workspace = true }
+urlencoding = { workspace = true }
 getrandom_0_2 = { workspace = true }
 # Utilities
 thiserror = { workspace = true }
@@ -59,6 +60,7 @@ async-trait = { workspace = true }
 # Test helpers (optional, for integration testing)
 anyhow = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 dialog-common = { workspace = true }
 dialog-storage = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
@@ -83,6 +85,7 @@ dialog-storage = { workspace = true, features = ["helpers"] }
 dialog-ucan-core = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
+tempfile = { workspace = true }
 # The client-side glue the mint handler shortens with. Exercised against
 # the real service so the two halves are tested against each other, not
 # against a restatement of the wire format.
@@ -105,6 +108,7 @@ helpers = [
   "dep:http-body-util",
   "dep:hyper",
   "dep:hyper-util",
+  "dep:reqwest",
   "dep:rusqlite",
   "dep:tokio",
   "dialog-common/helpers",

--- a/rust/tonk-access-service/src/bin/local.rs
+++ b/rust/tonk-access-service/src/bin/local.rs
@@ -29,6 +29,12 @@ async fn main() -> anyhow::Result<()> {
         // Behind a dev proxy the activation links must open on the page
         // origin, not this server's own port.
         public_origin: std::env::var("ACCESS_PUBLIC_ORIGIN").ok(),
+        // Persist customers, the service key, and a blob snapshot, so a
+        // restarted dev service stops wiping the state clients hold
+        // credentials against.
+        state_dir: std::env::var("ACCESS_STATE_DIR")
+            .ok()
+            .map(std::path::PathBuf::from),
         ..Default::default()
     })
     .await?;

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -90,6 +90,7 @@ impl AccessServer {
         secret_key: &str,
         deployment: Option<tonk_worker_api::DeploymentConfig>,
         public_origin: Option<String>,
+        state_dir: Option<&std::path::Path>,
     ) -> anyhow::Result<Self> {
         // Create S3 credentials for the authorizer
         let address = Address::builder(&s3_server.endpoint)
@@ -110,13 +111,31 @@ impl AccessServer {
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let emails = Arc::new(CapturedEmail::default());
-        let service = Ed25519Signer::generate()
-            .await
-            .map_err(|err| anyhow::anyhow!("service signer: {err:?}"))?;
+        // A persistent state dir keeps the service's identity stable
+        // across restarts; rotating it would orphan the deposits and the
+        // enrollment records the published service DID anchors.
+        let service = match state_dir {
+            Some(dir) => persistent_signer(dir).await?,
+            None => Ed25519Signer::generate()
+                .await
+                .map_err(|err| anyhow::anyhow!("service signer: {err:?}"))?,
+        };
         let service_did = service.did().to_string();
+        let (store, ingest) = match state_dir {
+            Some(dir) => (
+                SqliteStore::open(&dir.join("control.sqlite"))
+                    .map_err(|err| anyhow::anyhow!("{err}"))?,
+                SqliteIngest::open(&dir.join("ingest.sqlite"))
+                    .map_err(|err| anyhow::anyhow!("{err}"))?,
+            ),
+            None => (
+                SqliteStore::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
+                SqliteIngest::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
+            ),
+        };
         let registration = Arc::new(RegistrationState {
-            store: SqliteStore::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
-            ingest: SqliteIngest::in_memory().map_err(|err| anyhow::anyhow!("{err}"))?,
+            store,
+            ingest,
             emails: emails.clone(),
             sender: AnnouncedEmail(emails.clone()),
             service,
@@ -611,6 +630,13 @@ pub struct AccessServiceSettings {
     /// Origin activation links open on, when it differs from the
     /// server's own address (a dev proxy in front of it).
     pub public_origin: Option<String>,
+    /// Directory the service persists its state under: control and
+    /// ingest databases, the service signing key, and a snapshot of the
+    /// blob store. Absent means fully in-memory, the shape tests want; a
+    /// dev stack sets it so a restart stops wiping registrations and
+    /// every synced block — and the delegations retained in account
+    /// repositories with them.
+    pub state_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for AccessServiceSettings {
@@ -621,6 +647,200 @@ impl Default for AccessServiceSettings {
             secret_access_key: "test-secret-key".to_string(),
             deployment: None,
             public_origin: None,
+            state_dir: None,
+        }
+    }
+}
+
+/// The service's signing identity from `{dir}/service.key`, minting and
+/// persisting a fresh seed on first start.
+async fn persistent_signer(dir: &std::path::Path) -> anyhow::Result<Ed25519Signer> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join("service.key");
+    if let Ok(seed) = std::fs::read_to_string(&path) {
+        return crate::service::signer_from_hex(seed.trim())
+            .map_err(|message| anyhow::anyhow!("stored service key is unusable: {message}"));
+    }
+    let mut seed = [0u8; 32];
+    getrandom::fill(&mut seed).map_err(|err| anyhow::anyhow!("no entropy source: {err}"))?;
+    let encoded = hex::encode(seed);
+    std::fs::write(&path, &encoded)?;
+    crate::service::signer_from_hex(&encoded)
+        .map_err(|message| anyhow::anyhow!("fresh service key is unusable: {message}"))
+}
+
+/// Dev durability for the in-memory blob store: hydrate it from a
+/// directory at start and mirror it back on a short cadence. The store
+/// is only reachable over its S3 API — presigned uploads go straight to
+/// it, never through this server — so the mirror polls a listing rather
+/// than hooking writes. Cheap at development sizes, and the price of not
+/// losing every synced block (and the delegations retained in account
+/// repositories) to a restart.
+mod blob_snapshot {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    use dialog_remote_s3::request::S3Request;
+    use dialog_remote_s3::s3::S3Credential;
+    use dialog_remote_s3::{Address, Permit};
+
+    async fn permit(
+        credential: &S3Credential,
+        address: &Address,
+        method: &str,
+        path: &str,
+        params: Option<Vec<(String, String)>>,
+    ) -> anyhow::Result<Permit> {
+        S3Request {
+            method: method.to_string(),
+            path: path.to_string(),
+            params,
+            ..Default::default()
+        }
+        .attest(credential.clone())
+        .redeem(address)
+        .await
+        .map_err(|err| anyhow::anyhow!("presign {method} {path}: {err:?}"))
+    }
+
+    async fn perform(permit: Permit, body: Option<Vec<u8>>) -> anyhow::Result<reqwest::Response> {
+        let client = reqwest::Client::new();
+        let mut request = match permit.method.as_str() {
+            "PUT" => client.put(permit.url),
+            "DELETE" => client.delete(permit.url),
+            _ => client.get(permit.url),
+        };
+        for (name, value) in &permit.headers {
+            request = request.header(name, value);
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+        Ok(request.send().await?.error_for_status()?)
+    }
+
+    /// One flat file per object: the key percent-encoded, so keys with
+    /// `/` never collide with directory structure.
+    fn file_for(dir: &Path, key: &str) -> PathBuf {
+        dir.join(urlencoding::encode(key).into_owned())
+    }
+
+    fn key_for(file: &Path) -> Option<String> {
+        let name = file.file_name()?.to_str()?;
+        urlencoding::decode(name).ok().map(|key| key.into_owned())
+    }
+
+    /// Extract `(key, etag)` pairs and the continuation token from a
+    /// ListObjectsV2 answer. A hand parse, deliberately: this is a dev
+    /// helper talking to one known server, not a general S3 client.
+    fn parse_listing(xml: &str) -> (Vec<(String, String)>, Option<String>) {
+        fn tags<'a>(xml: &'a str, tag: &str) -> Vec<&'a str> {
+            let open = format!("<{tag}>");
+            let close = format!("</{tag}>");
+            xml.split(open.as_str())
+                .skip(1)
+                .filter_map(|rest| rest.split(close.as_str()).next())
+                .collect()
+        }
+        let mut objects = Vec::new();
+        for contents in xml.split("<Contents>").skip(1) {
+            let keys = tags(contents, "Key");
+            let etags = tags(contents, "ETag");
+            if let (Some(key), Some(etag)) = (keys.first(), etags.first()) {
+                objects.push((key.to_string(), etag.to_string()));
+            }
+        }
+        let token = tags(xml, "NextContinuationToken")
+            .first()
+            .map(|token| token.to_string());
+        (objects, token)
+    }
+
+    async fn list(
+        credential: &S3Credential,
+        address: &Address,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let mut objects = Vec::new();
+        let mut token: Option<String> = None;
+        loop {
+            let mut params = vec![("list-type".to_string(), "2".to_string())];
+            if let Some(token) = &token {
+                params.push(("continuation-token".to_string(), token.clone()));
+            }
+            let permit = permit(credential, address, "GET", "/", Some(params)).await?;
+            let body = perform(permit, None).await?.text().await?;
+            let (page, next) = parse_listing(&body);
+            objects.extend(page);
+            match next {
+                Some(next) => token = Some(next),
+                None => return Ok(objects),
+            }
+        }
+    }
+
+    /// Upload every snapshotted object into the fresh store.
+    pub async fn hydrate(
+        credential: &S3Credential,
+        address: &Address,
+        dir: &Path,
+    ) -> anyhow::Result<usize> {
+        std::fs::create_dir_all(dir)?;
+        let mut restored = 0;
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            let Some(key) = key_for(&path) else { continue };
+            let body = std::fs::read(&path)?;
+            let permit = permit(credential, address, "PUT", &format!("/{key}"), None).await?;
+            perform(permit, Some(body)).await?;
+            restored += 1;
+        }
+        Ok(restored)
+    }
+
+    /// Mirror the store into `dir` forever, on a short cadence. Every
+    /// pass fetches objects whose ETag changed since the last one and
+    /// removes files whose key is gone.
+    pub async fn mirror(credential: S3Credential, address: Address, dir: PathBuf) {
+        let mut seen: HashMap<String, String> = HashMap::new();
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let listing = match list(&credential, &address).await {
+                Ok(listing) => listing,
+                Err(error) => {
+                    eprintln!("blob snapshot listing failed: {error}");
+                    continue;
+                }
+            };
+            let live: HashMap<String, String> = listing.into_iter().collect();
+            for (key, etag) in &live {
+                if seen.get(key) == Some(etag) {
+                    continue;
+                }
+                let fetched = async {
+                    let permit =
+                        permit(&credential, &address, "GET", &format!("/{key}"), None).await?;
+                    let body = perform(permit, None).await?.bytes().await?;
+                    let target = file_for(&dir, key);
+                    let staged = target.with_extension("tmp");
+                    std::fs::write(&staged, &body)?;
+                    std::fs::rename(&staged, &target)?;
+                    Ok::<(), anyhow::Error>(())
+                }
+                .await;
+                match fetched {
+                    Ok(()) => {
+                        seen.insert(key.clone(), etag.clone());
+                    }
+                    Err(error) => eprintln!("blob snapshot of {key} failed: {error}"),
+                }
+            }
+            seen.retain(|key, _| {
+                if live.contains_key(key) {
+                    return true;
+                }
+                let _ = std::fs::remove_file(file_for(&dir, key));
+                false
+            });
         }
     }
 }
@@ -648,6 +868,27 @@ pub async fn access_service(
 
     let s3_endpoint = s3_server.endpoint.clone();
 
+    // With a state dir, refill the fresh in-memory store from the last
+    // snapshot before anything can talk to it, then keep mirroring it
+    // back for the next restart.
+    if let Some(state_dir) = &settings.state_dir {
+        let address = Address::builder(&s3_endpoint)
+            .region("us-east-1")
+            .bucket(bucket)
+            .path_style(true)
+            .build()?;
+        let credential = S3Credential::new(&settings.access_key_id, &settings.secret_access_key);
+        let blobs = state_dir.join("blobs");
+        let restored = blob_snapshot::hydrate(&credential, &address, &blobs).await?;
+        if restored > 0 {
+            println!(
+                "ACCESS_STATE restored {restored} blobs from {}",
+                blobs.display()
+            );
+        }
+        tokio::spawn(blob_snapshot::mirror(credential, address, blobs));
+    }
+
     // Start the UCAN access service
     let access_server = AccessServer::start(
         s3_server,
@@ -656,6 +897,7 @@ pub async fn access_service(
         &settings.secret_access_key,
         settings.deployment,
         settings.public_origin,
+        settings.state_dir.as_deref(),
     )
     .await?;
 

--- a/rust/tonk-access-service/src/store/ingest.rs
+++ b/rust/tonk-access-service/src/store/ingest.rs
@@ -85,8 +85,27 @@ mod sqlite {
         pub fn in_memory() -> Result<Self, StoreError> {
             let conn = Connection::open_in_memory()
                 .map_err(|err| StoreError::Internal(err.to_string()))?;
-            conn.execute_batch(include_str!("../../migrations-ingest/0001_ingest.sql"))
+            Self::prepare(conn)
+        }
+
+        /// Open (or create) a file-backed database, applying the
+        /// migrations only on first open.
+        pub fn open(path: &std::path::Path) -> Result<Self, StoreError> {
+            let conn =
+                Connection::open(path).map_err(|err| StoreError::Internal(err.to_string()))?;
+            Self::prepare(conn)
+        }
+
+        fn prepare(conn: Connection) -> Result<Self, StoreError> {
+            let version: i64 = conn
+                .query_row("PRAGMA user_version", [], |row| row.get(0))
                 .map_err(|err| StoreError::Internal(err.to_string()))?;
+            if version == 0 {
+                conn.execute_batch(include_str!("../../migrations-ingest/0001_ingest.sql"))
+                    .map_err(|err| StoreError::Internal(err.to_string()))?;
+                conn.pragma_update(None, "user_version", 1)
+                    .map_err(|err| StoreError::Internal(err.to_string()))?;
+            }
             Ok(Self(Mutex::new(conn)))
         }
 

--- a/rust/tonk-access-service/src/store/sqlite.rs
+++ b/rust/tonk-access-service/src/store/sqlite.rs
@@ -21,10 +21,29 @@ impl SqliteStore {
     /// in production.
     pub fn in_memory() -> Result<Self, StoreError> {
         let conn = Connection::open_in_memory().map_err(map_err)?;
+        Self::prepare(conn)
+    }
+
+    /// Open (or create) a file-backed database, applying the migrations
+    /// only on first open. Development durability: a restarted local
+    /// service keeps its customers instead of wiping them.
+    pub fn open(path: &std::path::Path) -> Result<Self, StoreError> {
+        let conn = Connection::open(path).map_err(map_err)?;
+        Self::prepare(conn)
+    }
+
+    fn prepare(conn: Connection) -> Result<Self, StoreError> {
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(map_err)?;
-        conn.execute_batch(include_str!("../../migrations/0001_control.sql"))
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
             .map_err(map_err)?;
+        if version == 0 {
+            conn.execute_batch(include_str!("../../migrations/0001_control.sql"))
+                .map_err(map_err)?;
+            conn.pragma_update(None, "user_version", 1)
+                .map_err(map_err)?;
+        }
         Ok(Self(Mutex::new(conn)))
     }
 }

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -395,6 +395,28 @@ async fn it_refuses_a_deposit_broader_than_the_scopes() -> anyhow::Result<()> {
 }
 
 #[dialog_common::test]
+async fn it_walks_a_device_issued_deposit_back_to_the_customer() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    // The fallback shape a device without ceremony-minted deposits
+    // presents: deposits issued by the device, chained to the customer
+    // through the `root → device` grant riding in the same container.
+    let root = Ed25519Signer::generate().await?;
+    let device = Ed25519Signer::generate().await?;
+    let link = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+        .await?;
+    let container = tonk_identity::request::build_enroll_invocation(
+        device,
+        &link,
+        &fixture.service.did(),
+        "alice@example.com",
+    )
+    .await?;
+    let receipt = as_customer(fixture.registration(&container).handle().await.unwrap());
+    assert_eq!(receipt.customer, root.did());
+    Ok(())
+}
+
+#[dialog_common::test]
 async fn it_requires_the_deposits_to_cover_both_scopes() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -402,8 +402,8 @@ async fn it_walks_a_device_issued_deposit_back_to_the_customer() -> anyhow::Resu
     // through the `root → device` grant riding in the same container.
     let root = Ed25519Signer::generate().await?;
     let device = Ed25519Signer::generate().await?;
-    let link = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
-        .await?;
+    let link =
+        tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did()).await?;
     let container = tonk_identity::request::build_enroll_invocation(
         device,
         &link,

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -564,6 +564,58 @@ async fn it_refuses_a_consent_issued_to_another_customer() -> anyhow::Result<()>
     Ok(())
 }
 
+/// A state-dir service survives its own restart: same signing identity,
+/// same customers, and the blob snapshot refills the fresh store. This
+/// is the dev-durability contract — a restarted local service must not
+/// orphan the clients holding credentials against it.
+#[dialog_common::test]
+async fn it_keeps_state_across_restarts_with_a_state_dir() -> anyhow::Result<()> {
+    use tonk_access_service::helpers::{AccessServiceSettings, access_service};
+
+    let state = tempfile::tempdir()?;
+    let settings = AccessServiceSettings {
+        state_dir: Some(state.path().to_path_buf()),
+        ..Default::default()
+    };
+
+    let service = access_service(settings.clone()).await?;
+    let first_did = service.address.service_did.clone();
+    let base = service
+        .address
+        .access_service_url
+        .trim_end_matches('/')
+        .to_string();
+    let customer = Ed25519Signer::generate().await?;
+    let container = enroll_container(&customer, &first_did.parse()?, "alice@example.com").await;
+    let response = reqwest::Client::new()
+        .post(format!("{base}/ucan/"))
+        .header("Content-Type", "application/cbor")
+        .body(container)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200);
+    service.stop().await?;
+
+    let service = access_service(settings).await?;
+    assert_eq!(
+        service.address.service_did, first_did,
+        "the signing identity survives a restart"
+    );
+    let base = service
+        .address
+        .access_service_url
+        .trim_end_matches('/')
+        .to_string();
+    let probe = reqwest::get(format!("{base}/customer/{}", customer.did())).await?;
+    assert_eq!(
+        probe.status(),
+        200,
+        "an enrolled customer survives a restart"
+    );
+    service.stop().await?;
+    Ok(())
+}
+
 #[dialog_common::test]
 async fn it_drives_registration_over_http(env: AccessServiceAddress) -> anyhow::Result<()> {
     let client = reqwest::Client::new();

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -433,9 +433,15 @@ async fn link_via_callback(
 
     // The descriptor tells this device WHERE the account repository lives; a
     // delegation only says who may act. Persisting it is what lets the
-    // account mount and sync at all.
+    // account mount and sync at all. The provider URL prefers what the
+    // page delivered — the page knows its deployment — over the flag,
+    // whose default names production regardless of where the ceremony ran.
+    let provider_url = Some(authorization.service_url.trim())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&options.service_url)
+        .to_owned();
     let provider = AccountProviderRecord::attach(
-        &options.service_url,
+        &provider_url,
         &hex::decode(&authorization.descriptor_hex)
             .context("authorization descriptor is not hex")?,
         &account_did,
@@ -529,6 +535,11 @@ struct CallbackAuthorization {
     /// registration-at-approval; the delegation CID stands in then.
     #[serde(default)]
     attachment_id: String,
+    /// The account service the approving page's deployment uses. Absent
+    /// from pages that predate it; the `--service-url` flag (or its
+    /// production default) stands in then.
+    #[serde(default)]
+    service_url: String,
 }
 
 /// Start or resume a browser handoff and activate its fresh generation.

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -22,6 +22,9 @@ pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.spot/account";
 pub const DEFAULT_LINK_PAGE: &str = "https://tonk.spot/account/link";
 /// Credential-store key for optional provider attachment metadata.
 pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE;
+/// Credential-store key for the account-signed access-service deposits
+/// the linking ceremony delivered, stored as a JSON array of hex.
+pub const SERVICE_DEPOSIT_SITE: &str = "tonk-service-deposit-v1";
 
 // Linking is complete once credentials are durable; repository hydration is
 // best-effort and must not leave the link command waiting indefinitely.
@@ -212,6 +215,33 @@ pub(crate) async fn require_account_with_operator(
 pub(crate) async fn stored_provider(profile: &Profile) -> Result<Option<AccountProviderRecord>> {
     let operator = crate::account_state::credential_operator(profile).await?;
     stored_provider_with_operator(profile, &operator).await
+}
+
+/// The account-signed access-service deposits the linking ceremony
+/// delivered, as raw delegation bytes. Empty for a link that predates
+/// them; enrollment then falls back to a device-issued deposit.
+pub(crate) async fn stored_service_deposits(profile: &Profile) -> Result<Vec<Vec<u8>>> {
+    let operator = crate::account_state::credential_operator(profile).await?;
+    let bytes = match profile
+        .credential()
+        .site(SERVICE_DEPOSIT_SITE)
+        .load::<Vec<u8>>()
+        .perform(&operator)
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(error) if crate::account_state::credential_is_missing(&error) => return Ok(Vec::new()),
+        Err(error) => return Err(error).context("failed to load the service deposits"),
+    };
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let deposits: Vec<String> =
+        serde_json::from_slice(&bytes).context("stored service deposits are unreadable")?;
+    deposits
+        .iter()
+        .map(|deposit| hex::decode(deposit).context("a stored service deposit is not hex"))
+        .collect()
 }
 
 async fn retry_pending_detaches(profile: &Profile) -> Result<crate::account_session::FlushOutcome> {
@@ -454,6 +484,22 @@ async fn link_via_callback(
         .await
         .context("failed to persist the account link")?;
 
+    // The deposits are what a later `tonk account register` presents:
+    // account-signed, so worth keeping even though enrollment may also
+    // run right after this link.
+    if !authorization.deposits_hex.is_empty() {
+        profile
+            .credential()
+            .site(SERVICE_DEPOSIT_SITE)
+            .save(
+                serde_json::to_vec(&authorization.deposits_hex)
+                    .context("failed to serialize the service deposits")?,
+            )
+            .perform(operator)
+            .await
+            .context("failed to persist the service deposits")?;
+    }
+
     let store = match options.store.clone() {
         Some(store) => store,
         None => crate::spot::SpotStore::open().context("failed to locate account state")?,
@@ -529,6 +575,11 @@ struct CallbackAuthorization {
     /// registration-at-approval; the delegation CID stands in then.
     #[serde(default)]
     attachment_id: String,
+    /// Hex-encoded account-signed access-service deposits the ceremony
+    /// minted. Absent from pages that predate them; enrollment then
+    /// falls back to a device-issued deposit.
+    #[serde(default)]
+    deposits_hex: Vec<String>,
 }
 
 /// Start or resume a browser handoff and activate its fresh generation.

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -22,9 +22,6 @@ pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.spot/account";
 pub const DEFAULT_LINK_PAGE: &str = "https://tonk.spot/account/link";
 /// Credential-store key for optional provider attachment metadata.
 pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE;
-/// Credential-store key for the account-signed access-service deposits
-/// the linking ceremony delivered, stored as a JSON array of hex.
-pub const SERVICE_DEPOSIT_SITE: &str = "tonk-service-deposit-v1";
 
 // Linking is complete once credentials are durable; repository hydration is
 // best-effort and must not leave the link command waiting indefinitely.
@@ -215,33 +212,6 @@ pub(crate) async fn require_account_with_operator(
 pub(crate) async fn stored_provider(profile: &Profile) -> Result<Option<AccountProviderRecord>> {
     let operator = crate::account_state::credential_operator(profile).await?;
     stored_provider_with_operator(profile, &operator).await
-}
-
-/// The account-signed access-service deposits the linking ceremony
-/// delivered, as raw delegation bytes. Empty for a link that predates
-/// them; enrollment then falls back to a device-issued deposit.
-pub(crate) async fn stored_service_deposits(profile: &Profile) -> Result<Vec<Vec<u8>>> {
-    let operator = crate::account_state::credential_operator(profile).await?;
-    let bytes = match profile
-        .credential()
-        .site(SERVICE_DEPOSIT_SITE)
-        .load::<Vec<u8>>()
-        .perform(&operator)
-        .await
-    {
-        Ok(bytes) => bytes,
-        Err(error) if crate::account_state::credential_is_missing(&error) => return Ok(Vec::new()),
-        Err(error) => return Err(error).context("failed to load the service deposits"),
-    };
-    if bytes.is_empty() {
-        return Ok(Vec::new());
-    }
-    let deposits: Vec<String> =
-        serde_json::from_slice(&bytes).context("stored service deposits are unreadable")?;
-    deposits
-        .iter()
-        .map(|deposit| hex::decode(deposit).context("a stored service deposit is not hex"))
-        .collect()
 }
 
 async fn retry_pending_detaches(profile: &Profile) -> Result<crate::account_session::FlushOutcome> {
@@ -484,22 +454,6 @@ async fn link_via_callback(
         .await
         .context("failed to persist the account link")?;
 
-    // The deposits are what a later `tonk account register` presents:
-    // account-signed, so worth keeping even though enrollment may also
-    // run right after this link.
-    if !authorization.deposits_hex.is_empty() {
-        profile
-            .credential()
-            .site(SERVICE_DEPOSIT_SITE)
-            .save(
-                serde_json::to_vec(&authorization.deposits_hex)
-                    .context("failed to serialize the service deposits")?,
-            )
-            .perform(operator)
-            .await
-            .context("failed to persist the service deposits")?;
-    }
-
     let store = match options.store.clone() {
         Some(store) => store,
         None => crate::spot::SpotStore::open().context("failed to locate account state")?,
@@ -575,11 +529,6 @@ struct CallbackAuthorization {
     /// registration-at-approval; the delegation CID stands in then.
     #[serde(default)]
     attachment_id: String,
-    /// Hex-encoded account-signed access-service deposits the ceremony
-    /// minted. Absent from pages that predate them; enrollment then
-    /// falls back to a device-issued deposit.
-    #[serde(default)]
-    deposits_hex: Vec<String>,
 }
 
 /// Start or resume a browser handoff and activate its fresh generation.

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -26,6 +26,10 @@ pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SI
 // Linking is complete once credentials are durable; repository hydration is
 // best-effort and must not leave the link command waiting indefinitely.
 
+/// How long the post-link hydration phase may run before the command
+/// reports "waiting for first sync" and returns.
+const HYDRATION_DEADLINE: Duration = Duration::from_secs(10);
+
 /// Descriptive registration name for a native CLI device.
 pub fn default_device_name() -> String {
     let info = os_info::get();
@@ -477,37 +481,53 @@ async fn link_via_callback(
     // holds rather than only what the account issued.
     // `ensure` mounts the account, adopts it as the access upstream, and
     // syncs — the dance that turns a grant into usable, shared authority.
-    let account_state = match crate::account_state::ensure_with_operator_and_store(
-        profile,
-        operator.clone(),
-        store,
-    )
-    .await
-    {
-        Ok(outcome) => outcome.status,
-        Err(_) => AccountStateStatus::Unhydrated,
-    };
-    let mut warning = None;
-    if let Some(branch) = crate::account_state::open_account_branch(profile, operator).await? {
-        let signer = profile.signer().signer().clone();
-        let union = tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
-        let inbound = DelegationChain::try_from(grant_bytes.as_slice())
-            .context("account grant is not a delegation container")?;
-        for (label, chain) in [("account grant", inbound), ("profile union", union)] {
-            if let Err(error) =
-                tonk_account::delegations::retain_space_delegation(&branch, &chain, operator).await
+    // The whole phase runs under a hard deadline: the link is complete
+    // once credentials are durable, and a slow or unreachable remote must
+    // degrade to "waiting for first sync" rather than hang the command.
+    let hydration = tokio::time::timeout(HYDRATION_DEADLINE, async {
+        let account_state = match crate::account_state::ensure_with_operator_and_store(
+            profile,
+            operator.clone(),
+            store,
+        )
+        .await
+        {
+            Ok(outcome) => outcome.status,
+            Err(_) => AccountStateStatus::Unhydrated,
+        };
+        let mut warning = None;
+        if let Some(branch) = crate::account_state::open_account_branch(profile, operator).await? {
+            let signer = profile.signer().signer().clone();
+            let union =
+                tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
+            let inbound = DelegationChain::try_from(grant_bytes.as_slice())
+                .context("account grant is not a delegation container")?;
+            for (label, chain) in [("account grant", inbound), ("profile union", union)] {
+                if let Err(error) =
+                    tonk_account::delegations::retain_space_delegation(&branch, &chain, operator)
+                        .await
+                {
+                    warning = Some(format!(
+                        "{label} was not retained into the account: {error}"
+                    ));
+                }
+            }
+            if warning.is_none()
+                && let Err(error) = branch.push().perform(operator).await
             {
-                warning = Some(format!(
-                    "{label} was not retained into the account: {error}"
-                ));
+                warning = Some(format!("account was authorized but not pushed: {error}"));
             }
         }
-        if warning.is_none()
-            && let Err(error) = branch.push().perform(operator).await
-        {
-            warning = Some(format!("account was authorized but not pushed: {error}"));
-        }
-    }
+        Ok::<_, anyhow::Error>((account_state, warning))
+    })
+    .await;
+    let (account_state, warning) = match hydration {
+        Ok(result) => result?,
+        Err(_) => (
+            AccountStateStatus::Unhydrated,
+            Some("the account repository did not answer in time; sync will retry".to_string()),
+        ),
+    };
 
     Ok(LinkOutcome {
         url,
@@ -873,13 +893,17 @@ async fn post_invocation_raw(
         .with_context(|| format!("failed to reach the account service at {path}"))
 }
 
-/// List the devices registered under this profile's account.
-pub async fn devices(profile: &Profile, service_url: &str) -> Result<Vec<DeviceRow>> {
+/// List the devices registered under this profile's account. The
+/// recorded provider is authoritative; a `service_url` names one only
+/// to cross-check it against the active account.
+pub async fn devices(profile: &Profile, service_url: Option<&str>) -> Result<Vec<DeviceRow>> {
     let _ = retry_pending_detaches(profile).await;
     let connection = optional_connection(profile)
         .await?
         .context("no active account; run `tonk account link`")?;
-    if connection.service_url.trim_end_matches('/') != service_url.trim_end_matches('/') {
+    if let Some(service_url) = service_url
+        && connection.service_url.trim_end_matches('/') != service_url.trim_end_matches('/')
+    {
         bail!("requested provider does not match the active account");
     }
     let response = connection
@@ -975,7 +999,7 @@ pub async fn revoke(
         )
         .await
         .context("failed to sign self-revocation")?;
-        let rows = devices(profile, &options.service_url).await?;
+        let rows = devices(profile, Some(&options.service_url)).await?;
         let row = rows
             .iter()
             .find(|row| row.did == did && row.delegation_cid == target.to_string())
@@ -1012,7 +1036,7 @@ pub async fn revoke(
         return Ok(RevokeOutcome::Revoked);
     }
 
-    let rows = devices(profile, &options.service_url).await?;
+    let rows = devices(profile, Some(&options.service_url)).await?;
     let target = rows
         .iter()
         .find(|row| row.did == did)
@@ -1058,7 +1082,7 @@ pub async fn revoke(
             }
         }
         tokio::select! {
-            rows = devices(profile, &options.service_url) => match rows {
+            rows = devices(profile, Some(&options.service_url)) => match rows {
                 Ok(rows) => {
                     last_error = None;
                     if rows.iter().any(|row| {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -534,21 +534,6 @@ enum AccountCommand {
         via: Option<String>,
     },
 
-    /// Register this account with its sync service
-    ///
-    /// Probes the service first, so a registered account answers without
-    /// resending anything; an unknown or still-pending one is enrolled and
-    /// an activation email goes out.
-    #[command(
-        after_help = "Examples:\n  tonk account register\n  tonk account register --email you@example.com"
-    )]
-    Register {
-        /// Address the activation link is sent to; defaults to the
-        /// account's recorded email.
-        #[arg(long, value_name = "EMAIL")]
-        email: Option<String>,
-    },
-
     /// Disconnect account services on this device
     ///
     /// Preserves the local identity, root, and spots without revoking this
@@ -934,7 +919,6 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
             Some(match command {
                 AccountCommand::Status => "status",
                 AccountCommand::Link { .. } => "link",
-                AccountCommand::Register { .. } => "register",
                 AccountCommand::Logout => "logout",
                 AccountCommand::Spots { command } => match command {
                     None | Some(AccountSpotsCommand::List) => "spots-list",
@@ -1308,46 +1292,26 @@ fn render_account_status(status: account::AccountStatus) -> String {
     }
 }
 
-/// One line per registration fact, matching the status output style.
-fn registration_lines(report: &tonk_cli::customer::RegistrationReport) -> String {
-    use tonk_account::customer::CustomerStatus;
-    match (&report.status, &report.emailed) {
-        (CustomerStatus::Active, _) => "registration: active".to_string(),
-        (CustomerStatus::Registered, Some(email)) => {
-            format!("registration: activation pending\nactivation email sent to {email}")
-        }
-        (CustomerStatus::Registered, None) => "registration: activation pending".to_string(),
-        (CustomerStatus::Suspended, _) => "registration: suspended".to_string(),
-    }
-}
-
-/// Best-effort registration line for `tonk account`, quiet about being
-/// offline: status must answer without the network.
+/// Best-effort registration line, quiet about being offline: status
+/// must answer without the network. Registration itself is web-only —
+/// the browser enrolls during its passkey ceremonies, which is where
+/// the account-signed deposits come from — so this only reads state
+/// and points at the account page when something is missing.
 async fn print_customer_line(profile: &dialog_operator::Profile) {
     use tonk_account::customer::CustomerStatus;
     match tonk_cli::customer::registration_state(profile).await {
         Ok(Some(Some(receipt))) => match receipt.status {
             CustomerStatus::Active => println!("registration: active"),
             CustomerStatus::Registered => {
-                println!("registration: activation pending (resend with `tonk account register`)")
+                println!("registration: activation pending (open the activation email)")
             }
             CustomerStatus::Suspended => println!("registration: suspended"),
         },
-        Ok(Some(None)) => println!("registration: none (run `tonk account register`)"),
+        Ok(Some(None)) => {
+            println!("registration: none (sign in on the account page in a browser to register)")
+        }
         Ok(None) => {}
         Err(_) => println!("registration: unreachable"),
-    }
-}
-
-/// Best-effort registration after a link: the account exists either way,
-/// so a refusal is a warning, not a failed link.
-async fn report_registration(profile: &dialog_operator::Profile, email: Option<String>) {
-    match tonk_cli::customer::ensure_registered(profile, email).await {
-        Ok(report) => println!("{}", registration_lines(&report)),
-        Err(error) => eprintln!(
-            "warning: could not register with the sync service: {error:#}\n\
-             retry with `tonk account register`"
-        ),
     }
 }
 
@@ -1423,21 +1387,12 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 if let Some(warning) = outcome.warning {
                     eprintln!("warning: account repository is not synchronized: {warning}");
                 }
-                report_registration(&profile, None).await;
+                print_customer_line(&profile).await;
                 back_up_all_best_effort(&profile).await;
                 ExitCode::Success
             }
             Err(error) => print_failure(error),
         },
-        AccountCommand::Register { email } => {
-            match tonk_cli::customer::ensure_registered(&profile, email).await {
-                Ok(report) => {
-                    println!("{}", registration_lines(&report));
-                    ExitCode::Success
-                }
-                Err(error) => print_failure(error),
-            }
-        }
         AccountCommand::Logout => match account::logout(&profile).await {
             Ok(()) => {
                 println!("logged out\ndevice: {}", profile.did());

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -556,14 +556,9 @@ enum AccountCommand {
 
     /// List the devices linked to this profile's account
     Devices {
-        /// Account service base URL (for staging or local development).
-        #[arg(
-            long,
-            value_name = "URL",
-            default_value = account::DEFAULT_SERVICE_URL,
-            hide = true
-        )]
-        service_url: String,
+        /// Account service base URL; defaults to the linked provider.
+        #[arg(long, value_name = "URL", hide = true)]
+        service_url: Option<String>,
     },
 
     /// Revoke one of the account's devices by DID
@@ -1457,7 +1452,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             }
         }
         AccountCommand::Devices { service_url } => {
-            match account::devices(&profile, &service_url).await {
+            match account::devices(&profile, service_url.as_deref()).await {
                 Ok(rows) => {
                     let own = profile.did().to_string();
                     for row in rows {
@@ -3159,7 +3154,7 @@ mod account_spots_parser_tests {
                 provider: "https://accounts.example".to_string(),
                 account_state: tonk_account::AccountStateStatus::Ready,
             }),
-            "signed in: yes\nroot: did:root\nprovider: https://accounts.example\ndevice: did:device\naccount state: ready"
+            "signed in: yes\nroot: did:root\nprovider: https://accounts.example\ndevice: did:device\naccount state: synced"
         );
     }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1265,9 +1265,9 @@ async fn agents_op(json: bool, command: Option<AgentsCommand>, spot: Option<&str
 /// How `tonk account` prints the account repository's lifecycle state.
 fn account_state_label(status: tonk_account::AccountStateStatus) -> &'static str {
     match status {
-        tonk_account::AccountStateStatus::Unconfigured => "unconfigured",
-        tonk_account::AccountStateStatus::Unhydrated => "unhydrated",
-        tonk_account::AccountStateStatus::Ready => "ready",
+        tonk_account::AccountStateStatus::Unconfigured => "not set up yet",
+        tonk_account::AccountStateStatus::Unhydrated => "waiting for first sync",
+        tonk_account::AccountStateStatus::Ready => "synced",
     }
 }
 
@@ -1301,17 +1301,23 @@ async fn print_customer_line(profile: &dialog_operator::Profile) {
     use tonk_account::customer::CustomerStatus;
     match tonk_cli::customer::registration_state(profile).await {
         Ok(Some(Some(receipt))) => match receipt.status {
-            CustomerStatus::Active => println!("registration: active"),
+            CustomerStatus::Active => println!("sync service: registered"),
             CustomerStatus::Registered => {
-                println!("registration: activation pending (open the activation email)")
+                println!("sync service: waiting for email confirmation (check your inbox)")
             }
-            CustomerStatus::Suspended => println!("registration: suspended"),
+            CustomerStatus::Suspended => println!("sync service: suspended"),
         },
         Ok(Some(None)) => {
-            println!("registration: none (sign in on the account page in a browser to register)")
+            let page = tonk_cli::customer::access_origin(profile)
+                .await
+                .ok()
+                .flatten()
+                .map(|origin| format!("{origin}account"))
+                .unwrap_or_else(|| "the account page".to_string());
+            println!("sync service: not registered (open {page} in your browser to finish setup)")
         }
         Ok(None) => {}
-        Err(_) => println!("registration: unreachable"),
+        Err(_) => println!("sync service: unreachable"),
     }
 }
 

--- a/rust/tonk-cli/src/customer.rs
+++ b/rust/tonk-cli/src/customer.rs
@@ -1,27 +1,18 @@
 //! Customer registration against the access service.
 //!
 //! The access service serves the account's sync remote, so its origin
-//! comes from the attached repository descriptor and its identity from
-//! `/.well-known/tonk` there. Registration is per account, not per
-//! device: a linked device usually finds the customer already active,
-//! and enrollment exists for first registration and for a service whose
-//! control state was reset.
+//! comes from the attached repository descriptor. Registration is per
+//! account and web-only — the browser enrolls during its passkey
+//! ceremonies, which is where the account-signed deposits come from —
+//! so this module only probes registration state and provisions spaces,
+//! which needs no passkey.
 
 use anyhow::{Context, Result, bail};
 use dialog_varsig::Did;
-use tonk_account::customer::{CustomerStatus, Receipt, RegistrationError};
+use tonk_account::customer::{Receipt, RegistrationError};
 use url::Url;
 
 use dialog_operator::Profile;
-
-/// What `ensure_registered` found and did.
-#[derive(Debug)]
-pub struct RegistrationReport {
-    /// The customer's registration state after this call.
-    pub status: CustomerStatus,
-    /// The email an activation link was (re)sent to, when one was.
-    pub emailed: Option<String>,
-}
 
 /// The access service origin for this profile's account: the attached
 /// repository descriptor's remote, with its `/ucan/` path stripped.
@@ -62,93 +53,6 @@ pub async fn probe(origin: &Url, customer: &Did) -> Result<Option<Receipt>> {
     Ok(Some(response.json().await.context(
         "access service answered an unreadable customer state",
     )?))
-}
-
-/// The access service's signing DID, from its deployment configuration.
-async fn service_did(origin: &Url) -> Result<Did> {
-    let endpoint = origin.join(".well-known/tonk")?;
-    let config: serde_json::Value = reqwest::Client::new()
-        .get(endpoint)
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-        .context("failed to read the deployment configuration")?
-        .error_for_status()
-        .context("the deployment configuration is unavailable")?
-        .json()
-        .await
-        .context("the deployment configuration is invalid")?;
-    config["serviceDid"]
-        .as_str()
-        .context("this deployment publishes no service identity, so enrollment cannot address it")?
-        .parse()
-        .map_err(|error| anyhow::anyhow!("deployment service DID is invalid: {error:?}"))
-}
-
-/// Enroll this profile's account as a customer, sending the activation
-/// link to `email`, or to the account's recorded address when none is
-/// given. Idempotent: re-enrolling while registered resends the link,
-/// and an already-active customer answers as active.
-pub async fn enroll(profile: &Profile, email: Option<String>) -> Result<Receipt> {
-    let connection = crate::account::optional_connection(profile)
-        .await?
-        .context("no active account; run `tonk account link`")?;
-    let origin = access_origin(profile)
-        .await?
-        .context("the account has no repository descriptor to locate its service by")?;
-    let email = match email {
-        Some(email) => email,
-        None => account_email(profile, &connection).await?,
-    };
-    // Prefer the account-signed deposits the linking ceremony delivered:
-    // they are issued by the customer directly and survive revocation of
-    // this device. Without a stored set — a link that predates them —
-    // fall back to a device-issued deposit chained through the link.
-    let deposits = crate::account::stored_service_deposits(profile).await?;
-    let body = if deposits.is_empty() {
-        let service = service_did(&origin).await?;
-        tonk_identity::request::build_enroll_invocation(
-            profile.signer().signer().clone(),
-            &connection.link,
-            &service,
-            &email,
-        )
-        .await?
-    } else {
-        tonk_identity::request::build_enroll_invocation_with_deposits(
-            profile.signer().signer().clone(),
-            &connection.link,
-            &email,
-            &deposits,
-        )
-        .await?
-    };
-    let response = reqwest::Client::new()
-        .post(origin.join("ucan/")?)
-        .header("content-type", "application/cbor")
-        .body(body)
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-        .context("failed to reach the access service")?;
-    if response.status().is_success() {
-        return response
-            .json()
-            .await
-            .context("enrollment answered an unreadable receipt");
-    }
-    let status = response.status();
-    let refusal: serde_json::Value = response.json().await.unwrap_or_default();
-    match serde_json::from_value::<RegistrationError>(refusal["error"].clone()) {
-        // An already-active customer is the outcome enrollment exists to
-        // reach: answer it as one rather than surfacing a refusal.
-        Ok(RegistrationError::CustomerActive) => Ok(Receipt {
-            customer: connection.root_did.clone(),
-            status: CustomerStatus::Active,
-        }),
-        Ok(refusal) => bail!("the access service refused enrollment: {refusal}"),
-        Err(_) => bail!("access service rejected enrollment ({status})"),
-    }
 }
 
 /// Provision `consumer` with the access service under this profile's
@@ -204,67 +108,4 @@ pub async fn registration_state(profile: &Profile) -> Result<Option<Option<Recei
         return Ok(None);
     };
     Ok(Some(probe(&origin, &connection.root_did).await?))
-}
-
-/// Probe the service and enroll when it does not know the account.
-/// Answers what state the customer is in and whether an activation
-/// email went out.
-pub async fn ensure_registered(
-    profile: &Profile,
-    email: Option<String>,
-) -> Result<RegistrationReport> {
-    let connection = crate::account::optional_connection(profile)
-        .await?
-        .context("no active account; run `tonk account link`")?;
-    let origin = access_origin(profile)
-        .await?
-        .context("the account has no repository descriptor to locate its service by")?;
-    if email.is_none()
-        && let Some(receipt) = probe(&origin, &connection.root_did).await?
-        && receipt.status != CustomerStatus::Registered
-    {
-        return Ok(RegistrationReport {
-            status: receipt.status,
-            emailed: None,
-        });
-    }
-    // Unknown to the service, awaiting activation (re-enrolling resends
-    // the link), or the caller named an address: enroll.
-    let recorded = match email {
-        Some(email) => email,
-        None => account_email(profile, &connection).await?,
-    };
-    let receipt = enroll(profile, Some(recorded.clone())).await?;
-    let emailed = (receipt.status == CustomerStatus::Registered).then_some(recorded);
-    Ok(RegistrationReport {
-        status: receipt.status,
-        emailed,
-    })
-}
-
-/// The account's recorded email, from the account service.
-async fn account_email(
-    profile: &Profile,
-    connection: &crate::account::AccountConnection,
-) -> Result<String> {
-    let response = connection
-        .signed_post(
-            profile,
-            "account/summary",
-            vec!["account".into(), "summary".into()],
-            std::collections::BTreeMap::new(),
-        )
-        .await?;
-    if !response.status().is_success() {
-        let status = response.status();
-        bail!("account service rejected the summary request ({status})");
-    }
-    let summary: serde_json::Value = response
-        .json()
-        .await
-        .context("account service answered an unreadable summary")?;
-    summary["email"]
-        .as_str()
-        .map(str::to_owned)
-        .context("the account records no email address to enroll with")
 }

--- a/rust/tonk-cli/src/customer.rs
+++ b/rust/tonk-cli/src/customer.rs
@@ -100,14 +100,29 @@ pub async fn enroll(profile: &Profile, email: Option<String>) -> Result<Receipt>
         Some(email) => email,
         None => account_email(profile, &connection).await?,
     };
-    let service = service_did(&origin).await?;
-    let body = tonk_identity::request::build_enroll_invocation(
-        profile.signer().signer().clone(),
-        &connection.link,
-        &service,
-        &email,
-    )
-    .await?;
+    // Prefer the account-signed deposits the linking ceremony delivered:
+    // they are issued by the customer directly and survive revocation of
+    // this device. Without a stored set — a link that predates them —
+    // fall back to a device-issued deposit chained through the link.
+    let deposits = crate::account::stored_service_deposits(profile).await?;
+    let body = if deposits.is_empty() {
+        let service = service_did(&origin).await?;
+        tonk_identity::request::build_enroll_invocation(
+            profile.signer().signer().clone(),
+            &connection.link,
+            &service,
+            &email,
+        )
+        .await?
+    } else {
+        tonk_identity::request::build_enroll_invocation_with_deposits(
+            profile.signer().signer().clone(),
+            &connection.link,
+            &email,
+            &deposits,
+        )
+        .await?
+    };
     let response = reqwest::Client::new()
         .post(origin.join("ucan/")?)
         .header("content-type", "application/cbor")

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -14,6 +14,7 @@ dialog-varsig = { workspace = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
 ipld-core = { workspace = true }
+serde_ipld_dagcbor = { workspace = true }
 sha2_0_10 = { workspace = true }
 thiserror = { workspace = true }
 tonk-account = { workspace = true }

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -11,9 +11,10 @@ use anyhow::{Context, Result};
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
 use dialog_ucan_core::time::timestamp::Timestamp;
-use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+use dialog_ucan_core::{DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain};
 use dialog_varsig::Principal;
 use ipld_core::cid::Cid;
+use tonk_account::customer::deposit_scopes;
 
 use crate::delegation::mint_device_delegation;
 
@@ -68,6 +69,9 @@ pub struct FreshAccountCeremony {
     pub root: RootCeremony,
     /// Root-signed request submitted to the account service.
     pub account: AccountCeremony,
+    /// Hex-encoded account-signed access-service deposits, when the
+    /// caller named the service; empty otherwise.
+    pub deposits_hex: Vec<String>,
 }
 
 /// Informational metadata captured by the browser that created a passkey.
@@ -273,8 +277,13 @@ pub async fn create_fresh_account(
     device_name: String,
     remote: String,
     created_on: Option<&str>,
+    service: Option<&dialog_varsig::Did>,
 ) -> Result<FreshAccountCeremony> {
     let (root, credential_id, passkey) = create_root_material(Some(&email), created_on).await?;
+    let deposits_hex = match service {
+        Some(service) => mint_service_deposits(&root, service).await?,
+        None => Vec::new(),
+    };
     let root_ceremony = root_ceremony(
         root.clone(),
         credential_id.clone(),
@@ -296,7 +305,34 @@ pub async fn create_fresh_account(
     Ok(FreshAccountCeremony {
         root: root_ceremony,
         account,
+        deposits_hex,
     })
+}
+
+/// Mint the scoped access-service deposits enrollment presents, issued
+/// directly by the account root while a ceremony holds it. An
+/// account-signed deposit outlives the device that carried it: revoking
+/// that device leaves the service's grant standing, where a
+/// device-issued chain would die with its link. Returned hex-encoded so
+/// they cross the JS bridge and ride callback payloads as-is.
+pub async fn mint_service_deposits(
+    root: &Ed25519Signer,
+    service: &dialog_varsig::Did,
+) -> Result<Vec<String>> {
+    let mut deposits = Vec::new();
+    for scope in deposit_scopes(&root.did(), service) {
+        let deposit = DelegationBuilder::new()
+            .issuer(root.clone())
+            .audience(service)
+            .subject(scope.subject.clone())
+            .command(scope.command.segments().clone())
+            .policy(scope.policy())
+            .try_build()
+            .await
+            .context("failed to mint the access-service deposit")?;
+        deposits.push(hex::encode(deposit.encoded()));
+    }
+    Ok(deposits)
 }
 
 /// Build the root-signed request that links a new device to an existing account.

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -233,6 +233,13 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
             "the evaluated passkey does not match rootDid",
         ));
     }
+    let service = service_did_property(&input)?;
+    let deposits = match service {
+        Some(service) => crate::ceremony::mint_service_deposits(&root, &service)
+            .await
+            .map_err(js_error)?,
+        None => Vec::new(),
+    };
     let result = ceremony_result(
         crate::ceremony::create_account(
             root,
@@ -248,7 +255,29 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
         .map_err(js_error)?,
     )?;
     Reflect::set(&result, &"credentialId".into(), &credential_id.into())?;
+    set_deposits(&result, &deposits)?;
     Ok(result)
+}
+
+/// Parse the optional access-service DID a ceremony mints deposits for.
+fn service_did_property(input: &JsValue) -> Result<Option<dialog_varsig::Did>, JsValue> {
+    optional_string_property(input, "serviceDid")
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|error| JsValue::from_str(&format!("invalid serviceDid: {error}")))
+        })
+        .transpose()
+}
+
+/// Attach hex-encoded deposits to a ceremony result as `depositsHex`.
+fn set_deposits(result: &JsValue, deposits: &[String]) -> Result<(), JsValue> {
+    let array = js_sys::Array::new();
+    for deposit in deposits {
+        array.push(&JsValue::from_str(deposit));
+    }
+    Reflect::set(result, &"depositsHex".into(), &array)?;
+    Ok(())
 }
 
 async fn create_fresh_account(input: JsValue) -> Result<JsValue, JsValue> {
@@ -259,12 +288,14 @@ async fn create_fresh_account(input: JsValue) -> Result<JsValue, JsValue> {
     let device_name = string_property(&input, "deviceName")?;
     let remote = string_property(&input, "remote")?;
     let created_on = optional_string_property(&input, "createdOn");
+    let service = service_did_property(&input)?;
     let ceremony = crate::ceremony::create_fresh_account(
         email,
         device_did,
         device_name,
         remote,
         created_on.as_deref(),
+        service.as_ref(),
     )
     .await
     .map_err(js_error)?;
@@ -277,6 +308,7 @@ async fn create_fresh_account(input: JsValue) -> Result<JsValue, JsValue> {
     if let Some(descriptor_hex) = ceremony.account.descriptor_hex {
         Reflect::set(&result, &"descriptorHex".into(), &descriptor_hex.into())?;
     }
+    set_deposits(&result, &ceremony.deposits_hex)?;
     Ok(result)
 }
 
@@ -285,6 +317,7 @@ async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let device_name = string_property(&input, "deviceName")?;
+    let service = service_did_property(&input)?;
     let evaluated = crate::passkey::evaluate_passkey().await.map_err(js_error)?;
     let credential_id = hex::encode(evaluated.id);
     let prf = evaluated
@@ -293,12 +326,19 @@ async fn link_device(input: JsValue) -> Result<JsValue, JsValue> {
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
+    let deposits = match service {
+        Some(service) => crate::ceremony::mint_service_deposits(&root, &service)
+            .await
+            .map_err(js_error)?,
+        None => Vec::new(),
+    };
     let result = ceremony_result(
         crate::ceremony::link_device(root, device_did, device_name)
             .await
             .map_err(js_error)?,
     )?;
     Reflect::set(&result, &"credentialId".into(), &credential_id.into())?;
+    set_deposits(&result, &deposits)?;
     Ok(result)
 }
 
@@ -358,10 +398,17 @@ async fn authorize_device(input: JsValue) -> Result<JsValue, JsValue> {
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let remote = string_property(&input, "remote")?;
+    let service = service_did_property(&input)?;
     let prf = crate::passkey::prf_output().await.map_err(js_error)?;
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
+    let deposits = match service {
+        Some(service) => crate::ceremony::mint_service_deposits(&root, &service)
+            .await
+            .map_err(js_error)?,
+        None => Vec::new(),
+    };
     let authorized = crate::ceremony::authorize_device(root, device_did, &remote)
         .await
         .map_err(js_error)?;
@@ -375,6 +422,7 @@ async fn authorize_device(input: JsValue) -> Result<JsValue, JsValue> {
     ] {
         Reflect::set(&output, &key.into(), &value.into())?;
     }
+    set_deposits(output.as_ref(), &deposits)?;
     Ok(output.into())
 }
 

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -398,17 +398,10 @@ async fn authorize_device(input: JsValue) -> Result<JsValue, JsValue> {
         .parse()
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let remote = string_property(&input, "remote")?;
-    let service = service_did_property(&input)?;
     let prf = crate::passkey::prf_output().await.map_err(js_error)?;
     let root = crate::derive::derive_root_signer(&prf)
         .await
         .map_err(js_error)?;
-    let deposits = match service {
-        Some(service) => crate::ceremony::mint_service_deposits(&root, &service)
-            .await
-            .map_err(js_error)?,
-        None => Vec::new(),
-    };
     let authorized = crate::ceremony::authorize_device(root, device_did, &remote)
         .await
         .map_err(js_error)?;
@@ -422,7 +415,6 @@ async fn authorize_device(input: JsValue) -> Result<JsValue, JsValue> {
     ] {
         Reflect::set(&output, &key.into(), &value.into())?;
     }
-    set_deposits(output.as_ref(), &deposits)?;
     Ok(output.into())
 }
 

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -15,9 +15,11 @@ use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
 use dialog_ucan_core::time::timestamp::Timestamp;
 use dialog_ucan_core::{
-    Container, DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain,
+    Container, Delegation, DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain,
 };
 use dialog_varsig::Did;
+use dialog_varsig::algorithm::eddsa::Ed25519Signature;
+use ipld_core::cid::Cid;
 use tonk_account::customer::deposit_scopes;
 
 /// Build a device-signed account-service invocation container.
@@ -68,9 +70,12 @@ pub async fn build_device_invocation(
 /// [`build_device_invocation`] does, and additionally deposits the
 /// scoped delegations granting `service` access to its own branch of the
 /// account space — the [`deposit_scopes`], nothing broader. The deposits
-/// are device-issued; the service walks them back to the account through
-/// the same `root → device` grant the invocation proves with, which
-/// rides in the same container.
+/// here are device-issued, the fallback for a device holding no
+/// ceremony-minted set; the service walks them back to the account
+/// through the same `root → device` grant the invocation proves with,
+/// which rides in the same container. Prefer
+/// [`build_enroll_invocation_with_deposits`] with account-signed
+/// deposits when a ceremony produced them.
 pub async fn build_enroll_invocation(
     device: Ed25519Signer,
     link: &DelegationChain,
@@ -91,6 +96,41 @@ pub async fn build_enroll_invocation(
             .context("failed to mint the access deposit")?;
         deposits.push(deposit);
     }
+    let named: Vec<(Cid, Vec<u8>)> = deposits
+        .into_iter()
+        .map(|deposit| (deposit.to_cid(), deposit.encoded().to_vec()))
+        .collect();
+    assemble_enroll_container(device, link, email, named).await
+}
+
+/// Build a `/customer/enroll` container around externally minted
+/// deposits — the account-signed set a passkey ceremony produced. These
+/// are issued by the customer directly, so they survive revocation of
+/// the device presenting them.
+pub async fn build_enroll_invocation_with_deposits(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    email: &str,
+    deposits: &[Vec<u8>],
+) -> Result<Vec<u8>> {
+    let named = deposits
+        .iter()
+        .map(|bytes| {
+            let delegation: Delegation<Ed25519Signature> = serde_ipld_dagcbor::from_slice(bytes)
+                .context("a ceremony deposit does not decode as a delegation")?;
+            Ok((delegation.to_cid(), bytes.clone()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    assemble_enroll_container(device, link, email, named).await
+}
+
+/// Assemble the enroll invocation and append the named deposit tokens.
+async fn assemble_enroll_container(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    email: &str,
+    deposits: Vec<(Cid, Vec<u8>)>,
+) -> Result<Vec<u8>> {
     let arguments = BTreeMap::from([
         ("email".to_string(), Promised::String(email.to_string())),
         (
@@ -98,7 +138,7 @@ pub async fn build_enroll_invocation(
             Promised::List(
                 deposits
                     .iter()
-                    .map(|deposit| Promised::Link(deposit.to_cid()))
+                    .map(|(cid, _)| Promised::Link(*cid))
                     .collect(),
             ),
         ),
@@ -113,8 +153,8 @@ pub async fn build_enroll_invocation(
     let mut tokens = Container::from_bytes(&invocation)
         .context("failed to reopen the enroll container")?
         .into_tokens();
-    for deposit in &deposits {
-        tokens.push(deposit.encoded().to_vec());
+    for (_, bytes) in deposits {
+        tokens.push(bytes);
     }
     Container::new(tokens)
         .to_bytes()
@@ -215,5 +255,43 @@ mod tests {
                 "put".to_string()
             ],
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_carries_ceremony_minted_deposits_issued_by_the_account() {
+        let root = crate::derive::derive_root_signer(&[7u8; 32]).await.unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&[8u8; 32]).await.unwrap();
+        let service = Ed25519Signer::import(&[9u8; 32]).await.unwrap();
+        let link = crate::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+
+        let minted = crate::ceremony::mint_service_deposits(&root, &service.did())
+            .await
+            .unwrap();
+        assert_eq!(minted.len(), 2, "one deposit per scope");
+        let deposits: Vec<Vec<u8>> = minted
+            .iter()
+            .map(|deposit| hex::decode(deposit).unwrap())
+            .collect();
+
+        let bytes =
+            build_enroll_invocation_with_deposits(device, &link, "a@example.com", &deposits)
+                .await
+                .unwrap();
+        let tokens = Container::from_bytes(&bytes).unwrap().into_tokens();
+        // Invocation, the root → device link, and the two deposits.
+        assert_eq!(tokens.len(), 4);
+        for token in &tokens[2..] {
+            let deposit: Delegation<Ed25519Signature> =
+                serde_ipld_dagcbor::from_slice(token).unwrap();
+            assert_eq!(
+                deposit.issuer(),
+                &root_did,
+                "deposits are issued by the account itself"
+            );
+            assert_eq!(deposit.audience(), &service.did());
+        }
     }
 }

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -83,6 +83,10 @@
           <dd id="account-email-value">Loading…</dd>
         </div>
         <div>
+          <dt>Sync service</dt>
+          <dd id="account-registration-value">Checking…</dd>
+        </div>
+        <div>
           <dt>Passkey created</dt>
           <dd id="account-passkey-created-value">Loading…</dd>
         </div>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -1060,6 +1060,13 @@ const UNESTABLISHED_ACCOUNT_GUIDANCE: &str = "This account was created before sh
      browser yet. Open /account on a browser that is already signed in to this account and \
      finish account setup there, then sign in here.";
 
+/// Whether this deployment registers accounts with an access service at
+/// all: deployments that publish no service identity have nothing to
+/// enroll with.
+async fn wants_enrollment() -> bool {
+    deployment_service_did().await.is_some()
+}
+
 /// The access-service DID this deployment publishes, for ceremonies that
 /// mint account-signed deposits. Absent config or identity is ordinary:
 /// the ceremony then mints nothing and enrollment falls back to a
@@ -1144,11 +1151,7 @@ async fn complete_remote(
     // but does not undo the attach. The login path names no email; the
     // worker resolves the account's recorded address. Deployments that
     // publish no service identity have no registration to perform.
-    let wants_enrollment = crate::deployment::get()
-        .await
-        .map(|config| config.service_did.is_some())
-        .unwrap_or(false);
-    if wants_enrollment {
+    if wants_enrollment().await {
         set_busy(host, true, "Registering with the sync service…");
         if let Err(error) = crate::api::enroll_customer(enroll_email, &ceremony.deposits_hex).await
         {
@@ -1423,11 +1426,35 @@ fn bind(host: &HtmlElement) {
             set_busy(&host, true, "Waiting for your passkey…");
             spawn_local(async move {
                 let result = async {
-                    let service_url = service(&host).await?;
+                    // Registration precedes linking: a device linked to an
+                    // unregistered account inherits a dead sync path, so a
+                    // signed-in browser the access service does not know
+                    // enrolls before it delegates. The fresh-browser path
+                    // covers this inside its signup ceremony.
+                    if wants_enrollment().await {
+                        let known = crate::api::customer_state()
+                            .await
+                            .map(|state| !state["status"].is_null())
+                            .unwrap_or(false);
+                        if !known {
+                            set_busy(&host, true, "Registering with the sync service…");
+                            crate::api::enroll_customer(None, &[])
+                                .await
+                                .map_err(|error| {
+                                    format!(
+                                        "register with the sync service before linking: {error}"
+                                    )
+                                })?;
+                        }
+                    }
+                    set_busy(&host, true, "Waiting for your passkey…");
+                    // The descriptor must name the same sync remote signup
+                    // established — the page's own `/ucan/` endpoint — or the
+                    // linked device mounts an account it can never reach.
                     let authorized = crate::identity_bridge::authorize_device(
                         crate::identity_bridge::AuthorizeDeviceInput {
                             device_did: audience.clone(),
-                            remote: service_url,
+                            remote: proposed_remote()?,
                         },
                     )
                     .await
@@ -1452,11 +1479,15 @@ fn bind(host: &HtmlElement) {
                     // The delegation alone would leave the device authorized
                     // but unable to find the account repository, so the
                     // descriptor rides along.
+                    // The page knows which account service this deployment
+                    // uses; the CLI records it rather than guessing from a
+                    // flag default.
                     let payload = serde_json::json!({
                         "delegationHex": authorized.delegation_hex,
                         "descriptorHex": authorized.descriptor_hex,
                         "credentialId": authorized.root_did,
                         "attachmentId": attachment_id,
+                        "serviceUrl": service(&host).await.unwrap_or_default(),
                     })
                     .to_string();
                     let encoded = crate::account::encode_authorization(&payload);

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -992,6 +992,17 @@ const UNESTABLISHED_ACCOUNT_GUIDANCE: &str = "This account was created before sh
      browser yet. Open /account on a browser that is already signed in to this account and \
      finish account setup there, then sign in here.";
 
+/// The access-service DID this deployment publishes, for ceremonies that
+/// mint account-signed deposits. Absent config or identity is ordinary:
+/// the ceremony then mints nothing and enrollment falls back to a
+/// device-issued deposit.
+async fn deployment_service_did() -> Option<String> {
+    crate::deployment::get()
+        .await
+        .ok()
+        .and_then(|config| config.service_did)
+}
+
 /// The account repository remote this browser proposes: its own origin's
 /// `/ucan/` endpoint. Only a ceremony ever signs one; the stored descriptor is
 /// always the service-selected winner.
@@ -1071,7 +1082,8 @@ async fn complete_remote(
         .unwrap_or(false);
     if wants_enrollment {
         set_busy(host, true, "Registering with the sync service…");
-        if let Err(error) = crate::api::enroll_customer(enroll_email).await {
+        if let Err(error) = crate::api::enroll_customer(enroll_email, &ceremony.deposits_hex).await
+        {
             web_sys::console::error_1(&format!("customer enrollment failed: {error}").into());
             show_error(
                 host,
@@ -1222,6 +1234,7 @@ fn bind(host: &HtmlElement) {
                 let status = crate::api::root_status()
                     .await
                     .map_err(|error| error.to_string())?;
+                let service_did = deployment_service_did().await;
                 let ceremony = match status {
                     tonk_worker_api::RootStatus::Ready {
                         root_did,
@@ -1239,6 +1252,7 @@ fn bind(host: &HtmlElement) {
                         delegation_hex,
                         passkey,
                         remote: proposed_remote()?,
+                        service_did,
                     })
                     .await
                     .map_err(|error| error.to_string())?,
@@ -1249,6 +1263,7 @@ fn bind(host: &HtmlElement) {
                             device_name,
                             remote: proposed_remote()?,
                             created_on: crate::device_name::current(),
+                            service_did,
                         })
                         .await
                         .map_err(|error| error.to_string())?;
@@ -1264,6 +1279,7 @@ fn bind(host: &HtmlElement) {
                             credential_id: created.credential_id,
                             delegation_hex: created.delegation_hex,
                             invocation_hex: created.invocation_hex,
+                            deposits_hex: created.deposits_hex,
                         }
                     }
                 };
@@ -1303,6 +1319,7 @@ fn bind(host: &HtmlElement) {
                 let ceremony = link_device(LinkDeviceInput {
                     device_did,
                     device_name,
+                    service_did: deployment_service_did().await,
                 })
                 .await
                 .map_err(|error| error.to_string())?;
@@ -1336,6 +1353,7 @@ fn bind(host: &HtmlElement) {
                         crate::identity_bridge::AuthorizeDeviceInput {
                             device_did: audience.clone(),
                             remote: service_url,
+                            service_did: deployment_service_did().await,
                         },
                     )
                     .await
@@ -1365,6 +1383,7 @@ fn bind(host: &HtmlElement) {
                         "descriptorHex": authorized.descriptor_hex,
                         "credentialId": authorized.root_did,
                         "attachmentId": attachment_id,
+                        "depositsHex": authorized.deposits_hex,
                     })
                     .to_string();
                     let encoded = crate::account::encode_authorization(&payload);

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -197,10 +197,35 @@ fn show_success(host: &HtmlElement) {
 /// its absence.
 fn load_activation_notice(host: HtmlElement) {
     spawn_local(async move {
-        let state = match crate::api::customer_state().await {
+        let mut state = match crate::api::customer_state().await {
             Ok(state) => state,
             Err(_) => return,
         };
+        // A linked account the access service does not know is one that
+        // predates registration (or the service's control state was
+        // reset). This signed-in browser is the only party that can fix
+        // that — registration is web-only — so enroll right here, with
+        // the device-chained deposit since no ceremony is at hand, and
+        // fall through to the ordinary pending notice.
+        if state["status"].is_null()
+            && crate::deployment::get()
+                .await
+                .is_ok_and(|config| config.service_did.is_some())
+        {
+            match crate::api::enroll_customer(None, &[]).await {
+                // The receipt names no email; the recorded enrollment does.
+                Ok(_) => match crate::api::customer_state().await {
+                    Ok(fresh) => state = fresh,
+                    Err(_) => return,
+                },
+                Err(error) => {
+                    web_sys::console::error_1(
+                        &format!("customer re-enrollment failed: {error}").into(),
+                    );
+                    return;
+                }
+            }
+        }
         if state["status"].as_str() != Some("Registered") {
             return;
         }
@@ -706,7 +731,37 @@ fn load_status(host: HtmlElement) {
     if handoff_route {
         match callback_request() {
             Some((audience, callback, name)) => {
-                load_callback_request(host, audience, callback, name)
+                // An unlinked browser registers first: the signup or login
+                // ceremony is what creates the account and enrolls it with
+                // the access service, and only then is there an account to
+                // delegate from. The callback request rides the URL, so
+                // once the ceremony settles this reloads into the approval
+                // panel.
+                set_busy(&host, true, "Checking this browser…");
+                spawn_local(async move {
+                    match crate::api::account_status().await {
+                        Ok(AccountStatus::Registered { .. }) => {
+                            load_callback_request(host, audience, callback, name);
+                        }
+                        Ok(status) => {
+                            let root_persisted =
+                                matches!(status, AccountStatus::Unregistered { .. });
+                            set_busy(&host, false, "");
+                            set_mode(&host, "choice");
+                            show_error(
+                                &host,
+                                "Create your account or log in first; approving the \
+                                 command-line device comes right after.",
+                            );
+                            load_choice_profiles(host.clone(), root_persisted);
+                        }
+                        Err(error) => {
+                            set_busy(&host, false, "");
+                            set_mode(&host, "choice");
+                            show_error(&host, error.to_string());
+                        }
+                    }
+                });
             }
             None => load_handoff(host),
         }
@@ -805,6 +860,19 @@ fn apply_link_outcome(host: &HtmlElement, outcome: Option<&(String, Option<Strin
 /// service handoff: the handoff carries a fragment secret and resolves
 /// against the account service, while this carries the waiting process's
 /// audience and callback in the query and never touches a service.
+/// The callback request parked in this page's URL, when this is the
+/// link route carrying one.
+fn pending_callback_request() -> Option<(String, String, String)> {
+    let on_link_route = window()
+        .and_then(|window| window.location().pathname().ok())
+        .is_some_and(|path| path == "/account/link" || path.starts_with("/account/link/"));
+    if on_link_route {
+        callback_request()
+    } else {
+        None
+    }
+}
+
 fn callback_request() -> Option<(String, String, String)> {
     Some((
         query_value("audience")?,
@@ -1091,6 +1159,13 @@ async fn complete_remote(
             );
         }
     }
+    // A pending callback approval takes precedence over settling: the
+    // ceremony ran on the link page precisely to approve a waiting
+    // device, and the account it just made is what the grant issues from.
+    if let Some((audience, callback, name)) = pending_callback_request() {
+        load_callback_request(host.clone(), audience, callback, name);
+        return Ok(());
+    }
     settle(host);
     if initialize_name && is_unhydrated(&status) {
         show_error(
@@ -1353,7 +1428,6 @@ fn bind(host: &HtmlElement) {
                         crate::identity_bridge::AuthorizeDeviceInput {
                             device_did: audience.clone(),
                             remote: service_url,
-                            service_did: deployment_service_did().await,
                         },
                     )
                     .await
@@ -1383,7 +1457,6 @@ fn bind(host: &HtmlElement) {
                         "descriptorHex": authorized.descriptor_hex,
                         "credentialId": authorized.root_did,
                         "attachmentId": attachment_id,
-                        "depositsHex": authorized.deposits_hex,
                     })
                     .to_string();
                     let encoded = crate::account::encode_authorization(&payload);

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -197,9 +197,16 @@ fn show_success(host: &HtmlElement) {
 /// its absence.
 fn load_activation_notice(host: HtmlElement) {
     spawn_local(async move {
+        if !wants_enrollment().await {
+            set_text(&host, "#account-registration-value", "Not used here");
+            return;
+        }
         let mut state = match crate::api::customer_state().await {
             Ok(state) => state,
-            Err(_) => return,
+            Err(_) => {
+                set_text(&host, "#account-registration-value", "Unreachable");
+                return;
+            }
         };
         // A linked account the access service does not know is one that
         // predates registration (or the service's control state was
@@ -222,10 +229,24 @@ fn load_activation_notice(host: HtmlElement) {
                     web_sys::console::error_1(
                         &format!("customer re-enrollment failed: {error}").into(),
                     );
+                    set_text(
+                        &host,
+                        "#account-registration-value",
+                        "Not registered — reload to retry",
+                    );
                     return;
                 }
             }
         }
+        // The facts row always answers; the banner below only nags while
+        // an activation is actually pending.
+        let label = match state["status"].as_str() {
+            Some("Active") => "Active",
+            Some("Registered") => "Waiting for email confirmation",
+            Some("Suspended") => "Suspended",
+            _ => "Not registered",
+        };
+        set_text(&host, "#account-registration-value", label);
         if state["status"].as_str() != Some("Registered") {
             return;
         }

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -512,8 +512,10 @@ mod tests {
         assert!(link.stdout.contains("linked\nroot: did:key:"));
         assert!(link.stdout.contains("device: did:key:"));
         assert!(
-            link.stdout.contains("account state: ready")
-                || link.stdout.contains("account state: unhydrated")
+            link.stdout.contains("account state: synced")
+                || link
+                    .stdout
+                    .contains("account state: waiting for first sync")
         );
 
         Ok(LinkedCli { profile, link })
@@ -876,7 +878,7 @@ mod tests {
         assert!(status.status.success(), "status failed: {}", status.stderr);
         assert!(status.stdout.contains("signed in: yes"));
         assert!(
-            linked.link.stdout.contains("registration:"),
+            linked.link.stdout.contains("sync service:"),
             "the link reports the registration the signup performed: {}",
             linked.link.stdout
         );

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -395,6 +395,14 @@ mod tests {
     }
 
     async fn link_cli(driver: &WebDriver, env: &TestEnvironment) -> Result<LinkedCli> {
+        link_cli_with(driver, env, false).await
+    }
+
+    async fn link_cli_with(
+        driver: &WebDriver,
+        env: &TestEnvironment,
+        register_first: bool,
+    ) -> Result<LinkedCli> {
         let profile = tempfile::tempdir()?;
         let mut command = tonk_command(&profile);
         command
@@ -443,6 +451,25 @@ mod tests {
         );
 
         driver.goto(approval_url.as_str()).await?;
+        if register_first {
+            // A browser with no account yet registers before approving:
+            // the link page opens on the signup panels, and the ceremony
+            // that creates and enrolls the account flows straight into
+            // the approval it was interrupted by.
+            element(driver, "tonk-account[data-mode=\"choice\"]").await?;
+            element(driver, "#account-choose-create")
+                .await?
+                .click()
+                .await?;
+            element(driver, "#account-email")
+                .await?
+                .send_keys(EMAIL)
+                .await?;
+            element(driver, "#account-create-submit")
+                .await?
+                .click()
+                .await?;
+        }
         element(driver, "tonk-account[data-mode=\"handoff\"]").await?;
         wait_for_text(driver, "#account-handoff-name", "e2e terminal").await?;
         let handoff_did = element(driver, "#account-handoff-did")
@@ -825,6 +852,34 @@ mod tests {
         );
         assert!(devices.stdout.contains("active\te2e terminal\t"));
         assert!(devices.stdout.contains(" (this device)"));
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// A CLI approved from a browser with no account yet: the link page
+    /// runs the signup ceremony first — creating and registering the
+    /// account is what makes there be something to delegate — then flows
+    /// straight into the approval panel.
+    #[dialog_common::test]
+    async fn it_registers_before_linking_a_cli_from_a_fresh_browser(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        let linked = link_cli_with(&driver, &env, true).await?;
+
+        let status = run_cli(
+            &linked.profile,
+            &["account".to_string(), "status".to_string()],
+        )
+        .await?;
+        assert!(status.status.success(), "status failed: {}", status.stderr);
+        assert!(status.stdout.contains("signed in: yes"));
+        assert!(
+            linked.link.stdout.contains("registration:"),
+            "the link reports the registration the signup performed: {}",
+            linked.link.stdout
+        );
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -524,11 +524,14 @@ pub async fn save_root(
 /// sending the activation link to `email`, or to the account's recorded
 /// address when none is given. Idempotent: re-enrolling while registered
 /// resends the link, and an already-active customer answers as active.
-pub async fn enroll_customer(email: Option<&str>) -> Result<serde_json::Value, TonkUiError> {
+pub async fn enroll_customer(
+    email: Option<&str>,
+    deposits: &[String],
+) -> Result<serde_json::Value, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/customer/enroll", origin()))
-        .json(&serde_json::json!({ "email": email }))
+        .json(&serde_json::json!({ "email": email, "deposits": deposits }))
         .send()
         .await
         .map_err(into_api_error)?;

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -274,10 +274,6 @@ pub(crate) struct AuthorizeDeviceInput {
     pub device_did: String,
     /// The account repository's remote, so the descriptor names it.
     pub remote: String,
-    /// Access-service DID the ceremony mints account-signed deposits
-    /// for, when the deployment names one.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_did: Option<String>,
 }
 
 /// What the ceremony hands back for delivery to a waiting device.
@@ -290,10 +286,6 @@ pub(crate) struct AuthorizedDevice {
     pub delegation_hex: String,
     /// Exact signed account repository descriptor.
     pub descriptor_hex: String,
-    /// Hex-encoded account-signed access-service deposits, when the
-    /// input named the service.
-    #[serde(default)]
-    pub deposits_hex: Vec<String>,
 }
 
 pub(crate) async fn authorize_device(

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -413,6 +413,7 @@ mod tests {
             device_name: "Browser".into(),
             remote: "https://tonk.spot/ucan/".into(),
             created_on: "Chrome on macOS".into(),
+            service_did: None,
         })
         .await
         .unwrap();
@@ -445,6 +446,7 @@ mod tests {
                 root_did: "did:key:root".into(),
                 credential_id: "credential".into(),
                 delegation_hex: "delegation".into(),
+                service_did: None,
                 passkey: Some(tonk_worker_api::PasskeyMetadata {
                     created_at: 1_754_380_800,
                     created_on: "Chrome on macOS".into(),
@@ -472,6 +474,7 @@ mod tests {
         link_device(LinkDeviceInput {
             device_did: "did:key:device".into(),
             device_name: "Browser".into(),
+            service_did: None,
         })
         .await
         .unwrap();

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -40,6 +40,10 @@ pub(crate) struct CreateAccountInput {
     pub passkey: Option<tonk_worker_api::PasskeyMetadata>,
     /// Account repository remote this browser proposes for the new account.
     pub remote: String,
+    /// Access-service DID the ceremony mints account-signed deposits
+    /// for, when the deployment names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_did: Option<String>,
 }
 
 /// Input for a fresh account whose passkey root does not exist yet.
@@ -51,6 +55,10 @@ pub(crate) struct CreateFreshAccountInput {
     pub device_name: String,
     pub remote: String,
     pub created_on: String,
+    /// Access-service DID the ceremony mints account-signed deposits
+    /// for, when the deployment names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_did: Option<String>,
 }
 
 /// Input for the one-time account repository establishment ceremony.
@@ -78,6 +86,10 @@ pub(crate) struct EstablishCeremonyOutput {
 pub(crate) struct LinkDeviceInput {
     pub device_did: String,
     pub device_name: String,
+    /// Access-service DID the ceremony mints account-signed deposits
+    /// for, when the deployment names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_did: Option<String>,
 }
 
 /// Input for signing a device-grant revocation.
@@ -109,6 +121,10 @@ pub(crate) struct CeremonyOutput {
     pub credential_id: String,
     pub delegation_hex: String,
     pub invocation_hex: String,
+    /// Hex-encoded account-signed access-service deposits, when the
+    /// input named the service.
+    #[serde(default)]
+    pub deposits_hex: Vec<String>,
 }
 
 /// Fresh-root account output, carrying both local persistence and remote
@@ -122,6 +138,10 @@ pub(crate) struct FreshAccountOutput {
     pub delegation_hex: String,
     pub passkey: tonk_worker_api::PasskeyMetadata,
     pub invocation_hex: String,
+    /// Hex-encoded account-signed access-service deposits, when the
+    /// input named the service.
+    #[serde(default)]
+    pub deposits_hex: Vec<String>,
 }
 
 /// Root-signed revocation returned by the ceremony API.
@@ -254,6 +274,10 @@ pub(crate) struct AuthorizeDeviceInput {
     pub device_did: String,
     /// The account repository's remote, so the descriptor names it.
     pub remote: String,
+    /// Access-service DID the ceremony mints account-signed deposits
+    /// for, when the deployment names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_did: Option<String>,
 }
 
 /// What the ceremony hands back for delivery to a waiting device.
@@ -266,6 +290,10 @@ pub(crate) struct AuthorizedDevice {
     pub delegation_hex: String,
     /// Exact signed account repository descriptor.
     pub descriptor_hex: String,
+    /// Hex-encoded account-signed access-service deposits, when the
+    /// input named the service.
+    #[serde(default)]
+    pub deposits_hex: Vec<String>,
 }
 
 pub(crate) async fn authorize_device(

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tonk_account::CUSTOMER_CREDENTIAL_SITE;
 use tonk_account::customer::{CustomerStatus, Receipt};
 use tonk_common::log;
-use tonk_identity::request::build_enroll_invocation;
+use tonk_identity::request::{build_enroll_invocation, build_enroll_invocation_with_deposits};
 use url::Url;
 
 use super::AppState;
@@ -47,6 +47,12 @@ pub struct EnrollRequest {
     /// Address the activation link is sent to. Absent on the login path,
     /// where the account's recorded email is used instead.
     pub email: Option<String>,
+    /// Hex-encoded account-signed deposits the passkey ceremony minted.
+    /// Preferred over the device-issued fallback: an account-signed
+    /// deposit survives revocation of the device that carried it. Empty
+    /// when enrollment runs without a fresh ceremony (a resend).
+    #[serde(default)]
+    pub deposits: Vec<String>,
 }
 
 /// The answer to a customer state read: the service's view when it has
@@ -88,18 +94,30 @@ pub async fn enroll(
                 )
             })?,
     };
-    let service_did = service_did(origin.url()).await?;
     let device = state.profile.signer().signer().clone();
 
     // The deposits — the service's scoped grants into the account
-    // space — and their chain link (the `root → device` grant) all ride
-    // in the container `build_enroll_invocation` assembles, so the
-    // service can walk them back to the customer.
-    let body = build_enroll_invocation(device, &link, &service_did, &email)
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
-        })?;
+    // space — ride in the container alongside the invocation. The
+    // account-signed set a ceremony minted is preferred; without one, a
+    // device-issued set chained through the `root → device` grant is the
+    // fallback the service walks back to the customer.
+    let body = if request.deposits.is_empty() {
+        let service_did = service_did(origin.url()).await?;
+        build_enroll_invocation(device, &link, &service_did, &email).await
+    } else {
+        let deposits = request
+            .deposits
+            .iter()
+            .map(hex::decode)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                TonkWorkerError::Router(format!("a ceremony deposit is not hex: {error}"))
+            })?;
+        build_enroll_invocation_with_deposits(device, &link, &email, &deposits).await
+    }
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to build the enroll invocation: {error}"))
+    })?;
 
     let endpoint = ucan_endpoint(origin.url())?;
     let receipt = match post_cbor(&endpoint, &body).await {


### PR DESCRIPTION
Stacked on #721. Resolves the account-model review's first flaw (device-issued deposits) and makes registration web-only.

A device-issued deposit dies with its device — revoke the device that enrolled and the service's grant into the account space evaporates. The root key only exists in-memory during a passkey ceremony, so that is where the deposit is now minted: `mint_service_deposits` signs the two scoped delegations (`/memory` on the service branch, `/archive` on the index catalog) with the account root itself, and the ceremonies that own registration — signup (`createFreshAccount`, `createAccount`) and login (`linkDevice`) — thread them into enrollment. The invocation presenting them stays device-signed: that part is authentication, and the device is who is talking. The device-chained deposit remains the fallback for enrollments with no ceremony at hand, with a service-side test pinning that the issuer walk works.

Registration itself moves entirely into the browser, because it is per **account**, not per device, and it needs the passkey:

- `tonk account register` and the CLI's enroll machinery are gone. The CLI keeps a read-only `registration:` probe in `tonk account status` and after linking, pointing at the account page when something is missing. (Provisioning of spaces stays CLI-capable — it needs no passkey.)
- A fresh browser opening a CLI approval link registers first: the link page opens on the signup/login panels, and the ceremony that creates and enrolls the account flows straight into the approval panel — the callback request rides the URL, so nothing is lost.
- A signed-in browser whose linked account the access service does not know (pre-registration account, or a wiped dev database) auto-enrolls from the dashboard with the device-chained deposit. This is the piece that makes lazy migration of old accounts converge without anyone running a command.

Real-browser coverage: signup, CLI link from a signed-in browser, device revocation, and the new `it_registers_before_linking_a_cli_from_a_fresh_browser` driving signup-then-approve end to end.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `tonk` project, focusing on persisting service state during development, modifying customer enrollment processes, and improving overall service durability.

### Detailed summary
- Added `.tonk-dev/` to `.gitignore` for local development state.
- Updated `Cargo.toml` to include `serde_ipld_dagcbor`, `urlencoding`, and `tempfile`.
- Modified `enroll_customer` function to accept `deposits`.
- Implemented state persistence in `tonk-access-service`.
- Enhanced customer enrollment handling in `tonk-ui`.
- Introduced service deposits management in `tonk-identity`.
- Added tests for state persistence and deposit handling.

> The following files were skipped due to too many changes: `rust/tonk-access-service/src/helpers/server.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->