### PR TITLE
fix(ci): expose macOS signing keychain to codesign

### DIFF
--- a/.github/actions/sign-notarize-macos/action.yml
+++ b/.github/actions/sign-notarize-macos/action.yml
@@ -67,8 +67,14 @@ runs:
         notarization_archive="$signing_dir/tonk.zip"
         notarization_response="$signing_dir/notarization.json"
         keychain_password="$(openssl rand -base64 32)"
+        original_keychains=()
 
         cleanup() {
+          if ((${#original_keychains[@]} > 0)); then
+            security list-keychains \
+              -d user \
+              -s "${original_keychains[@]}" >/dev/null 2>&1 || true
+          fi
           security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
           rm -f \
             "$certificate_path" \
@@ -79,6 +85,13 @@ runs:
           rmdir "$signing_dir" >/dev/null 2>&1 || true
         }
         trap cleanup EXIT
+
+        while IFS= read -r keychain; do
+          [[ -n "$keychain" ]] && original_keychains+=("$keychain")
+        done < <(
+          security list-keychains -d user \
+            | sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//'
+        )
 
         printf '%s' "$CERTIFICATE_P12" \
           | base64 --decode > "$certificate_path"
@@ -97,6 +110,9 @@ runs:
           -s \
           -k "$keychain_password" \
           "$keychain_path"
+        security list-keychains \
+          -d user \
+          -s "$keychain_path" "${original_keychains[@]}"
 
         signing_identity="$(
           security find-identity -v -p codesigning "$keychain_path" \

--- a/.github/actions/sign-notarize-macos/test.sh
+++ b/.github/actions/sign-notarize-macos/test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+action_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+test_dir="$(mktemp -d "${TMPDIR:-/tmp}/tonk-signing-test.XXXXXX")"
+mock_dir="$test_dir/bin"
+state_dir="$test_dir/state"
+runner_temp="$test_dir/runner"
+
+cleanup() {
+  rm -rf "$test_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$mock_dir" "$state_dir" "$runner_temp"
+printf '%s\n' "/Users/runner/Library/Keychains/login.keychain-db" \
+  > "$state_dir/search-list"
+printf 'unsigned binary' > "$test_dir/tonk"
+
+cat > "$mock_dir/security" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="$1"
+shift
+
+case "$command_name" in
+  create-keychain)
+    keychain_path="${!#}"
+    printf '%s\n' "$keychain_path" > "$TEST_STATE_DIR/current-keychain"
+    ;;
+  list-keychains)
+    if [[ "${1:-}" == "-d" ]]; then
+      shift 2
+    fi
+    if [[ "${1:-}" == "-s" ]]; then
+      shift
+      printf '%s\n' "$@" > "$TEST_STATE_DIR/search-list"
+    else
+      while IFS= read -r keychain; do
+        printf '    "%s"\n' "$keychain"
+      done < "$TEST_STATE_DIR/search-list"
+    fi
+    ;;
+  find-identity)
+    printf '%s\n' \
+      '  1) 2DA41BBEFF8B18B3CEDACFF92F211581F6ABA52E "Developer ID Application: Tonk Labs"'
+    ;;
+  delete-keychain|import|set-keychain-settings|set-key-partition-list|unlock-keychain)
+    ;;
+  *)
+    printf 'unexpected security command: %s\n' "$command_name" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+cat > "$mock_dir/codesign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+for argument in "$@"; do
+  if [[ "$argument" == "--verify" ]]; then
+    exit 0
+  fi
+done
+
+keychain_path="$(cat "$TEST_STATE_DIR/current-keychain")"
+if ! grep -Fxq "$keychain_path" "$TEST_STATE_DIR/search-list"; then
+  printf '%s: no identity found\n' \
+    '2DA41BBEFF8B18B3CEDACFF92F211581F6ABA52E' >&2
+  exit 1
+fi
+EOF
+
+cat > "$mock_dir/ditto" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${!#}"
+: > "$output_path"
+EOF
+
+cat > "$mock_dir/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '{"status":"Accepted","id":"test-submission"}\n'
+EOF
+
+cat > "$mock_dir/spctl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$mock_dir/security" "$mock_dir/codesign" "$mock_dir/ditto" \
+  "$mock_dir/xcrun" "$mock_dir/spctl"
+
+awk '
+  /^      run: \|$/ { in_run = 1; next }
+  in_run { sub(/^        /, ""); print }
+' "$action_dir/action.yml" > "$test_dir/action.sh"
+
+export TEST_STATE_DIR="$state_dir"
+export PATH="$mock_dir:/usr/bin:/bin:/usr/sbin:/sbin"
+export RUNNER_OS=macOS
+export RUNNER_TEMP="$runner_temp"
+export BINARY_PATH="$test_dir/tonk"
+export CERTIFICATE_P12=ZHVtbXk=
+export CERTIFICATE_PASSWORD=test-password
+export APP_STORE_CONNECT_KEY=test-key
+export APP_STORE_CONNECT_KEY_ID=TESTKEY123
+export APP_STORE_CONNECT_ISSUER_ID=00000000-0000-0000-0000-000000000000
+
+bash "$test_dir/action.sh"
+
+expected_keychain="/Users/runner/Library/Keychains/login.keychain-db"
+actual_keychains="$(cat "$state_dir/search-list")"
+if [[ "$actual_keychains" != "$expected_keychain" ]]; then
+  printf 'keychain search list was not restored after signing\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add the ephemeral Developer ID keychain to the macOS user keychain search list before invoking `codesign`
- restore the runner original search list during cleanup
- add a command-boundary regression harness reproducing the staging `SHA-1: no identity found` failure

## Root cause

The certificate and private key imported successfully, and `security find-identity` found the Developer ID identity when given the keychain explicitly. The keychain was never added to the user search list, so `codesign` could not resolve the selected SHA-1 identity. This matches the failed staging run: https://github.com/tonk-labs/tonk/actions/runs/32233413136

## Verification

- regression observed failing before the fix with `2DA41BBEFF8B18B3CEDACFF92F211581F6ABA52E: no identity found`
- `.github/actions/sign-notarize-macos/test.sh` passes after the fix and verifies search-list restoration
- ShellCheck passes for the action body and regression harness
- composite-action YAML parsing, Bash syntax, and `git diff --check` pass

## Live validation

PR builds intentionally do not receive Apple release secrets. The real certificate and notarization service will be exercised by the staging push after merge.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `sign-notarize-macos` GitHub Action by adding functionality to preserve the original keychain list during execution and includes a new test script to mock security commands for better testing.

### Detailed summary
- Introduced `original_keychains` array to store existing keychains.
- Added logic to restore the original keychains in the `cleanup` function.
- Created a mock environment in `test.sh` to simulate security commands.
- Implemented tests to verify keychain restoration after signing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->