### PR TITLE
fix(ci): verify notarized macOS CLI as code

### DIFF
--- a/.github/actions/sign-notarize-macos/action.yml
+++ b/.github/actions/sign-notarize-macos/action.yml
@@ -172,4 +172,8 @@ runs:
         fi
 
         codesign --verify --strict --verbose=2 "$BINARY_PATH"
-        spctl --assess --type execute --verbose=2 "$BINARY_PATH"
+        codesign \
+          -vvvv \
+          -R="notarized" \
+          --check-notarization \
+          "$BINARY_PATH"

--- a/.github/actions/sign-notarize-macos/test.sh
+++ b/.github/actions/sign-notarize-macos/test.sh
@@ -60,10 +60,26 @@ cat > "$mock_dir/codesign" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+check_notarization=false
+notarized_requirement=false
 for argument in "$@"; do
-  if [[ "$argument" == "--verify" ]]; then
-    exit 0
+  case "$argument" in
+    --check-notarization) check_notarization=true ;;
+    -R=notarized) notarized_requirement=true ;;
+  esac
+done
+
+if [[ "$check_notarization" == true ]]; then
+  if [[ "$notarized_requirement" != true ]]; then
+    printf 'notarization check did not require a notarized ticket\n' >&2
+    exit 1
   fi
+  touch "$TEST_STATE_DIR/notarization-checked"
+  exit 0
+fi
+
+for argument in "$@"; do
+  [[ "$argument" == "--verify" ]] && exit 0
 done
 
 keychain_path="$(cat "$TEST_STATE_DIR/current-keychain")"
@@ -91,7 +107,9 @@ EOF
 
 cat > "$mock_dir/spctl" <<'EOF'
 #!/usr/bin/env bash
-exit 0
+printf '%s\n' \
+  'artifacts/tonk: rejected (the code is valid but does not seem to be an app)' >&2
+exit 3
 EOF
 
 chmod +x "$mock_dir/security" "$mock_dir/codesign" "$mock_dir/ditto" \
@@ -114,6 +132,11 @@ export APP_STORE_CONNECT_KEY_ID=TESTKEY123
 export APP_STORE_CONNECT_ISSUER_ID=00000000-0000-0000-0000-000000000000
 
 bash "$test_dir/action.sh"
+
+if [[ ! -f "$state_dir/notarization-checked" ]]; then
+  printf 'notarization ticket was not verified for the CLI binary\n' >&2
+  exit 1
+fi
 
 expected_keychain="/Users/runner/Library/Keychains/login.keychain-db"
 actual_keychains="$(cat "$state_dir/search-list")"

--- a/docs/macos-cli-signing.md
+++ b/docs/macos-cli-signing.md
@@ -9,8 +9,9 @@ The release boundary is `.github/actions/sign-notarize-macos/action.yml`. It
 copies no credentials into the repository: it imports the certificate into an
 ephemeral keychain, signs the already-staged binary with hardened runtime and a
 secure timestamp, waits for Apple to accept a ZIP containing that binary, and
-then requires both `codesign` and `spctl` verification to pass. Any missing
-credential, rejected submission, or failed verification stops artifact upload.
+then requires `codesign` to validate both its signature and Apple's online
+notarization ticket. Any missing credential, rejected submission, or failed
+verification stops artifact upload.
 
 ## Required credentials
 
@@ -58,8 +59,10 @@ artifact.
 
 The submitted ZIP is only the notarization transport. Release archives and npm
 packages contain the exact signed executable that Apple accepted. Apple's
-ticket is published online for Gatekeeper; `spctl` verifies that ticket on the
-runner before CI uploads the binary.
+ticket is published online for Gatekeeper; `codesign --check-notarization` with
+a `notarized` requirement verifies that ticket on the runner before CI uploads
+the binary. The action does not use `spctl --type execute`: that assessment is
+for apps and rejects a valid raw CLI executable as “not an app.”
 
 The first push to `staging` after provisioning the secrets is the end-to-end
 credential check. After it publishes, download and inspect the artifact on a
@@ -69,7 +72,7 @@ Mac:
 tar -xzf tonk-macos-arm64.tar.gz
 codesign --verify --strict --verbose=2 tonk
 codesign --display --verbose=4 tonk
-spctl --assess --type execute --verbose=2 tonk
+codesign -vvvv -R="notarized" --check-notarization tonk
 ```
 
 ## Rotation
@@ -77,4 +80,4 @@ spctl --assess --type execute --verbose=2 tonk
 Replace all five repository secrets before the certificate or API key expires
 or is revoked, then validate with a staging release. Revoke the old App Store
 Connect key and remove the old certificate from the team's secrets manager only
-after the new staging artifact passes `codesign` and `spctl` assessment.
+after the new staging artifact passes signature and notarization checks.

--- a/docs/plans/2026-08-18-macos-cli-signing.md
+++ b/docs/plans/2026-08-18-macos-cli-signing.md
@@ -14,6 +14,7 @@
 ## File map
 
 - `.github/actions/sign-notarize-macos/action.yml`: Import credentials, sign one staged CLI binary, notarize it, verify it, and clean up credentials.
+- `.github/actions/sign-notarize-macos/test.sh`: Exercise the macOS command boundary with mocked signing and notarization tools.
 - `.github/workflows/cli.yml`: Stage build outputs and sign/notarize release-capable macOS builds.
 - `.github/workflows/cli-pin.yml`: Sign/notarize historical macOS builds with the current local action.
 - `.github/workflows/cli-npm.yml`: Sign/notarize the macOS binary before npm packaging.
@@ -35,7 +36,7 @@
 - [x] Import the base64 PKCS#12 certificate into a randomly passworded temporary keychain and select a `Developer ID Application` identity.
 - [x] Sign with `codesign --force --options runtime --timestamp`, then require `codesign --verify --strict` to succeed.
 - [x] Submit a ZIP containing the signed binary with `xcrun notarytool submit --wait --output-format json`; require status `Accepted` and print Apple's log on rejection.
-- [x] Require `spctl --assess --type execute` to accept the signed binary.
+- [x] Require `codesign -R="notarized" --check-notarization` to validate Apple's online ticket for the raw CLI binary; do not use the app-only `spctl --type execute` assessment.
 - [x] Delete the temporary keychain, certificate, API key, archive, and notarization response on every exit.
 - [x] Parse the action as YAML and syntax-check its shell body.
 


### PR DESCRIPTION
## Summary

- replace the app-only `spctl --type execute` assessment with `codesign -R="notarized" --check-notarization` for the raw CLI executable
- retain strict signature verification after Apple accepts the submission
- update the regression harness and signing runbook for the correct product type

## Root cause

Staging successfully imported the Developer ID identity, signed the binary, verified the signature, and received Apple notarization status `Accepted`. The final `spctl` command then exited 3 with `the code is valid but does not seem to be an app` because `tonk` is a standalone Mach-O executable, not an app bundle.

Failed staging run: https://github.com/tonk-labs/tonk/actions/runs/32235226209

## Verification

- regression observed failing before the fix with the exact `spctl` message and exit code 3 after simulated Apple acceptance
- regression passes after requiring `codesign --check-notarization` with a `notarized` requirement
- ShellCheck passes for the composite action body and regression harness
- composite-action YAML parsing, Bash syntax, and `git diff --check` pass

## Live validation

PR builds intentionally do not receive Apple release secrets. The real online notarization requirement check will run on the staging push after merge.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the notarization process for macOS CLI binaries by replacing `spctl` checks with `codesign` notarization validation, enhancing the verification mechanism and ensuring compliance with Apple's requirements.

### Detailed summary
- Replaced `spctl` assessment with `codesign --check-notarization` in `.github/actions/sign-notarize-macos/action.yml`.
- Added checks for notarization in `.github/actions/sign-notarize-macos/test.sh`.
- Updated documentation to reflect changes in notarization verification.
- Removed references to `spctl` in favor of `codesign` checks throughout documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->