### PR TITLE
feat(cli): isolate multiple account profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,6 +4838,7 @@ dependencies = [
  "tonk-notation",
  "tonk-render",
  "tonk-schema",
+ "tonk-worker-api",
  "url",
  "urlencoding",
  "wasm-bindgen-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4669,6 +4669,7 @@ name = "tonk-account"
 version = "0.6.7"
 dependencies = [
  "anyhow",
+ "base58",
  "blake3",
  "dialog-capability",
  "dialog-common",

--- a/flake.nix
+++ b/flake.nix
@@ -534,6 +534,7 @@
               #!${bash}/bin/bash
               PORT=''${1:-8080}
               ACCESS_SERVICE_PORT=''${2:-8090}
+              NATIVE_PORT=''${3:-8081}
 
               echo "Test server live at https://tonk.network:$PORT"
               # `nix run` execs this script, and this exec in turn makes Caddy
@@ -562,6 +563,11 @@
                       root * ${self.packages.${system}.tonk-ui}
                       try_files {path} /index.html
                       file_server
+                  }
+              }
+              http://127.0.0.1:$NATIVE_PORT {
+                  handle /ucan/* {
+                      reverse_proxy localhost:$ACCESS_SERVICE_PORT
                   }
               }
               EOF

--- a/plan/cli-multi-account-profiles.md
+++ b/plan/cli-multi-account-profiles.md
@@ -1,0 +1,453 @@
+# CLI multi-account profiles and space authority implementation plan
+
+**Goal:** Let one native Tonk installation use several accounts without ever allowing the currently selected account to adopt, authorize, reconcile, or publish another account profile's spaces, while preserving offline local edits and later synchronization through the space's own profile.
+**Approach:** Mirror the browser's profile-per-account boundary. Each native profile owns its Dialog profile, account session, account repository, named-space registry, and canonical space directories; a small install-level registry selects the default profile and maps directory bindings to an exact `(profile, space)` pair. Space-scoped commands resolve that pair first and therefore never borrow authority from the currently selected account. Local writes remain available while the owning profile is logged out; remote forks require that same profile's active account grant and an already-persisted space-to-account prefix.
+**Implementation status (2026-08-19):** Built and verified. Tasks 1–8 are represented by the production paths and focused regressions described below. The complete ordinary and feature-gated suites pass with `RUST_TEST_THREADS=1`; parallel full-suite execution can race the pre-existing carry-migration signing-session fixture, while its exact isolated test passes.
+**Constraints:**
+- The local filesystem is a trusted cache for one OS user, not an account security boundary. This work prevents accidental cross-account operations and unauthorized remote publication through supported CLI paths; it does not claim to protect unencrypted files or credentials from a malicious process running as the same OS user.
+- Offline commits made through profile A while A is logged out are valid local work. They remain pending and may synchronize after A signs in again.
+- A command resolved to profile A must never use profile B's account grant, provider attachment, account repository, deployment defaults, or certificate store, even when B is the install's selected profile.
+- Login, account switching, ordinary sync, status, backup reconciliation, and account migration must never mint a new `space -> current account root` prefix. Prefix minting is allowed only during explicit create, join, pull/recovery, or legacy adoption into the chosen profile.
+- Signing into another account must not replace a rooted profile in place. A known profile can sign back into the same immutable account root; a different account requires a new profile.
+- One profile has at most one immutable account root. The same account root may appear in more than one local profile because each profile is a distinct device identity; `account add` warns instead of attempting to merge incompatible device grants.
+- Logging out detaches provider access only for that profile. It preserves the profile DID, account root, account repository, local spaces, remote configuration, historical authority, and pending local revisions.
+- Directory bindings retain their current precedence role. A directory binding resolves both the space and its profile; the selected account is only the default for explicit `--spot`/`TONK_SPOT`, `spot new`, `join`, and account-scoped commands.
+- Existing installs keep the `tonk` Dialog profile and current install-level `spots.json`, `spots/`, and `account/` directories in place as the grandfathered `legacy` profile. Migration creates metadata only and never moves or deletes user data.
+- New profiles use isolated state directories so older CLI releases can see only the grandfathered profile, not spaces created under another account profile.
+- Space names are profile-scoped. Two profiles may both have a `garden`; a persisted directory binding remains unambiguous because it stores the profile ID as well as the name.
+- Existing custom content remotes and upstreams are never overwritten. Automatic account convergence provisions the deployment default only when a space has no upstream.
+- Account-service backup rows remain projections. Canonical account authority stays in the signed, root-owned account repository; provider APIs never become authorization authority.
+- Do not add encryption, OS-user isolation, signed per-revision authorship, UI removal tombstones, or remote deletion semantics in this change. Those are separate designs.
+- Preserve old `spot`, `--spot`, `TONK_SPOT`, and `account spots` spellings during this migration. The broader `spot` to `space` compatibility migration is a separate reviewable change.
+- Introduce no new cryptographic format or third-party dependency. Reuse the existing profile keys, account-session records, account repository, UCAN delegation validation, access-service protocol, and the existing workspace `tonk-worker-api` crate's `DeploymentConfig` contract.
+
+## User-visible semantics
+
+The install has a selected profile for account-scoped commands and unbound space creation, but a bound space carries its own profile context:
+
+```text
+cwd binding / --spot / TONK_SPOT
+        |
+        v
+ResolvedSpace { profile_id, name, site }
+        |
+        +--> Dialog profile and credential store
+        +--> profile-scoped account session and account repository
+        +--> profile-scoped content remote authorization
+```
+
+- In a directory bound to account A's `garden`, `tonk eval` opens A's profile even when account B is selected.
+- If A is logged out, the eval commits locally and reports that synchronization is pending for A. It does not try B's credentials.
+- `tonk account use work` changes the default profile locally and performs no network request.
+- `tonk account logout` detaches only the selected profile and leaves it selected.
+- `tonk account login` signs the selected, rooted profile back into the same account. A handoff returning another root is rejected without changing the profile.
+- `tonk account add --label work` creates a fresh local profile before starting the browser ceremony. An interrupted ceremony remains resumable in that profile.
+- `tonk account link` remains a compatibility alias: it adds the first profile or resumes an unrooted one, and otherwise behaves as `account login` for the selected profile.
+- `tonk account list` shows every local profile, its label, root, local sign-in state, and whether it is selected.
+- New `spot new`, `join`, and `account spots pull` operations use the selected profile and register the resulting space only in that profile's store.
+
+## On-disk layout and contracts
+
+Keep the current install root selected by `TONK_SPOTS_STATE`, but add an install-level profile registry:
+
+```text
+tonk/
+  profiles.json                 install-level profile roster and directory bindings
+  spots.json                    grandfathered profile's unchanged registry
+  spots/                        grandfathered profile's unchanged site directories
+  account/                      grandfathered profile's unchanged account state
+  profiles/
+    p-<32 lowercase hex>/
+      spots.json                this profile's named-space registry
+      spots/<name>/             this profile's canonical site directories
+      account/                  this profile's account session/repository state
+```
+
+Dialog profile key material remains in Dialog's existing platform profile storage. The install registry stores only non-secret routing metadata:
+
+```rust
+pub const LEGACY_PROFILE_ID: &str = "legacy";
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NativeProfileId(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeProfileRecord {
+    pub label: String,
+    pub dialog_profile_name: String,
+    pub account_root: Option<String>,
+    pub ceremony_origin: Option<String>,
+    pub default_access_remote: Option<String>,
+    pub default_revocation_relay: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundSpace {
+    pub profile: NativeProfileId,
+    pub space: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeProfileRegistryV1 {
+    pub version: u8, // exactly 1
+    pub selected: Option<NativeProfileId>,
+    pub profiles: BTreeMap<NativeProfileId, NativeProfileRecord>,
+    pub bindings: BTreeMap<PathBuf, BoundSpace>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+```
+
+`NativeProfileId::generate` uses 16 random bytes encoded as `p-` plus 32 lowercase hexadecimal characters. The generated Dialog profile name is `tonk-<32 hex>`; the legacy record alone uses the existing literal `tonk`. `account_root` is an index and mismatch guard, not the canonical root record; the signed `tonk-local-root-v1` credential inside the Dialog profile remains canonical.
+
+`label` is a unique, case-insensitive local slug using `[a-z0-9][a-z0-9-_]*`. `account use` accepts either that label or the exact profile ID. An omitted label chooses `account`, then `account-2`, `account-3`, and so on; the grandfathered profile uses `default`. Labels are routing conveniences only and never enter a signed account or authorization object.
+
+`NativeProfileContext` is the only value allowed to open native account or space state:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct NativeProfileContext {
+    pub id: NativeProfileId,
+    pub record: NativeProfileRecord,
+    pub store: SpotStore,
+}
+
+impl NativeProfileContext {
+    pub async fn open_profile(&self) -> anyhow::Result<dialog_operator::Profile>;
+    pub fn site_config(&self) -> site::SiteConfig;
+}
+```
+
+For `legacy`, `store` is the install root. For generated IDs, it is `install_root/profiles/<id>`. All account-session locks, account-repository bytes, spot registry reads, canonical site paths, backup sweeps, and migration loops take the context's `SpotStore`; none call the global `SpotStore::open()` after resolution.
+
+## File map
+
+- `plan/cli-multi-account-profiles.md`: Durable design, task order, acceptance criteria, and verification commands.
+- `rust/tonk-cli/src/account_profiles.rs`: Versioned install registry, legacy bootstrap, profile creation/selection, directory bindings, context opening, and deployment-default persistence.
+- `rust/tonk-cli/src/deployment.rs`: Validate the browser ceremony deployment and discover the default access remote and revocation relay.
+- `rust/tonk-cli/src/spot.rs`: Profile-local spot registry primitives; remove install-global directory-binding resolution from this layer.
+- `rust/tonk-cli/src/site.rs`: Open/create a site with the resolved profile context and account-state directory; split strict prefix loading from explicit adoption.
+- `rust/tonk-cli/src/identity.rs`: Open, inspect, and reset an explicitly selected Dialog profile rather than the fixed global profile.
+- `rust/tonk-cli/src/account_session.rs`: Scope transition locks, canonical session state, pending handoffs, and detach outboxes to one profile store.
+- `rust/tonk-cli/src/account.rs`: Add/login/logout/status operations for an explicit profile context and same-root login guard.
+- `rust/tonk-cli/src/account_state.rs`: Mount, hydrate, migrate, and retain delegations in only the resolved profile's account repository.
+- `rust/tonk-cli/src/account_authority.rs`: Authorize remote forks from the resolved profile's active grant and strict pre-existing space prefix.
+- `rust/tonk-cli/src/account_spots.rs`: List, pull, project, and reconcile only the resolved profile's spaces.
+- `rust/tonk-cli/src/account_sync.rs`: Profile-scoped provision/pull/push/retain/project reconciliation and confirmed-revision markers.
+- `rust/tonk-cli/src/auto_sync.rs`: Preserve successful local commits while reporting profile-specific pending synchronization.
+- `rust/tonk-cli/src/bin/tonk.rs`: Account profile commands, context resolution, profile-aware output, and reconciliation triggers.
+- `rust/tonk-cli/src/lib.rs`: Register the new modules and expose the bounded integration-test interfaces.
+- `rust/tonk-cli/Cargo.toml`: Register `account_profiles` integration tests and add the existing workspace `tonk-worker-api` crate for the deployment contract.
+- `rust/tonk-cli/tests/account_profiles.rs`: Registry migration, profile selection, interrupted add/login, same-root guard, and account-switch integration coverage.
+- `rust/tonk-cli/tests/account_authority.rs`: Cross-profile remote denial, explicit adoption, logout/offline edit, and later-sync coverage.
+- `rust/tonk-cli/tests/account_spots.rs`: Profile-filtered inventory, pull, backup projection, and convergence coverage.
+- `rust/tonk-cli/tests/spot.rs`: Profile-local duplicate names and stable binding resolution.
+- `rust/tonk-cli/tests/cli_spot.rs`: CLI output and directory-binding behavior across selected profiles.
+- `rust/tonk-cli/tests/site.rs`: Dynamic profile configuration and strict/adopt prefix behavior.
+- `rust/tonk-cli/tests/account_interrupt.rs`: Interrupted handoff recovery in the provisional profile.
+- `rust/tonk-cli/tests/common.rs`: Multi-profile account fixtures with isolated state roots.
+- `rust/tonk-cli/README.md`: Multi-account, offline edit, account selection, profile-bound space, and threat-boundary documentation.
+
+### Task 1: Add the install-level native profile registry and grandfather existing state
+
+**Files:**
+- Create: `rust/tonk-cli/src/account_profiles.rs`
+- Modify: `rust/tonk-cli/src/spot.rs:SpotStore path accessors and legacy binding helpers`
+- Modify: `rust/tonk-cli/src/lib.rs:module registration and test exports`
+- Modify: `rust/tonk-cli/Cargo.toml:[[test]] account_profiles`
+- Create: `rust/tonk-cli/tests/account_profiles.rs`
+
+**Interfaces:**
+- Consumes: `SpotStore::open/at`, the current `spots.json` registry, `site::PROFILE_NAME == "tonk"`, and `identity::local_root_with_operator`.
+- Produces: `NativeProfileId`, `NativeProfileRecord`, `BoundSpace`, `NativeProfileRegistryV1`, `NativeProfileContext`, and `NativeProfileStore::{open, at, load_or_bootstrap, selected, select, create_pending, context, bind, unbind}`.
+
+- [ ] Add `it_bootstraps_the_legacy_profile_without_moving_state`. Arrange an install root containing the current `spots.json`, one canonical site path, one directory binding, and existing `account/` bytes; run bootstrap and assert `profiles.json` contains one selected `legacy` record using Dialog profile `tonk`, the binding becomes `{ profile: legacy, space: garden }`, and every original path and byte remains unchanged.
+- [ ] Add `it_starts_empty_without_creating_a_dialog_profile`. An install with no `profiles.json`, `spots.json`, `spots/`, or `account/` returns no selected profile and performs no Dialog profile I/O.
+- [ ] Add `it_rejects_unknown_versions_corrupt_json_and_dangling_bindings`. Require errors that name `profiles.json`, the unsupported version, unknown profile ID, or missing profile-local space; never silently recreate the registry.
+- [ ] Add `it_preserves_unknown_registry_and_profile_fields` so a read/write round trip retains newer-version metadata.
+- [ ] Add `it_creates_distinct_pending_profiles_with_isolated_state_roots`. Use deterministic injected random bytes in the test, assert IDs/profile names follow the contract, and assert neither generated state root aliases the legacy root or another profile.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles`; expect compilation failure because the module and types do not exist.
+- [ ] Implement atomic `profiles.json.tmp` plus rename writes, canonicalized binding keys, exact version checking, generated IDs, derived state roots, and the legacy bootstrap. Copy legacy directory bindings into the install registry but leave the legacy `Registry.bindings` field on disk untouched for downgrade visibility.
+- [ ] Do not open/create a Dialog profile from a read-only registry/list command. `NativeProfileContext::open_profile` is the explicit boundary that may touch key storage.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles`; expect all registry and migration tests to pass.
+- [ ] Run `cargo test -p tonk-cli --test spot`; expect existing spot-registry behavior to remain green before resolution moves in Task 2.
+
+### Task 2: Resolve every space to an exact profile and keep profiles' local state disjoint
+
+**Files:**
+- Modify: `rust/tonk-cli/src/account_profiles.rs:resolve, bind, unbind, list_spaces`
+- Modify: `rust/tonk-cli/src/spot.rs:Registry, Resolved, listing, bind/unbind call boundaries`
+- Modify: `rust/tonk-cli/src/site.rs:SiteConfig, open_with, init_at_with, mount_delegated_at`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:open_selected, use_op, spot_op, join_op, active-context diagnostics`
+- Modify: `rust/tonk-cli/tests/spot.rs`
+- Modify: `rust/tonk-cli/tests/cli_spot.rs`
+- Modify: `rust/tonk-cli/tests/site.rs`
+
+**Interfaces:**
+- Consumes: Task 1's selected profile, per-profile `SpotStore`, install-level binding map, and existing `--spot > TONK_SPOT > nearest cwd binding` precedence.
+- Produces:
+
+```rust
+pub struct ResolvedSpace {
+    pub profile: NativeProfileContext,
+    pub name: String,
+    pub site: PathBuf,
+    pub source: spot::Source,
+}
+
+pub fn resolve(
+    &self,
+    flag: Option<&str>,
+    env: Option<&str>,
+    cwd: Option<&Path>,
+) -> Result<ResolvedSpace, ProfileError>;
+```
+
+- [ ] Add `it_resolves_a_directory_binding_to_its_profile_even_when_another_profile_is_selected`. Give A and B a `garden`, select B, bind the cwd to A/garden, and assert a bare resolve returns A while `--spot garden` and `TONK_SPOT=garden` resolve B under the existing precedence rules.
+- [ ] Add `it_keeps_equal_names_and_canonical_paths_disjoint_between_profiles`. Create `garden` in A and B and assert their `spots.json`, canonical site directories, account directories, and Dialog profile names differ.
+- [ ] Add `it_refuses_to_bind_a_space_absent_from_the_selected_profile` and require an error listing the selected profile's available names rather than names from every account.
+- [ ] Add a CLI regression that `tonk use garden` writes `{profile, space}` to the install registry and that `tonk spot unbind` removes only the exact cwd binding.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles --test spot --test cli_spot`; expect failures because resolution still uses the global store and name-only bindings.
+- [ ] Move directory binding lookup/write into `NativeProfileStore`. Keep `SpotStore` responsible only for one profile's named entries and canonical directories.
+- [ ] Extend `SiteConfig` with the resolved profile's account-state store/context; remove production calls to `default_config()` after a space has been resolved. `TonkSite::open_with`, `init_at_with`, and delegated mounts must pass that context into `account_authority::wrap` rather than reopening global state.
+- [ ] Make `open_selected` resolve once, then open the returned site's profile. Do not consult the selected account again after resolution.
+- [ ] Make create, join, pull, remove, list, and backup operations use the chosen profile's `SpotStore`. Register a newly created directory binding in the install registry only after site creation and profile-local registration succeed.
+- [ ] Preserve crash ordering: create/adopt the site, save its profile-local `spots.json`, then save the install-level binding. A failure before the last step leaves an unbound but listed space, never a binding to missing data.
+- [ ] Run the focused tests above; expect success.
+
+### Task 3: Implement explicit add, use, login, list, status, and logout profile lifecycle
+
+**Files:**
+- Modify: `rust/tonk-cli/src/identity.rs:open, exists, reset, profile_dir`
+- Modify: `rust/tonk-cli/src/account_session.rs:all state/lock functions`
+- Modify: `rust/tonk-cli/src/account.rs:LinkOptions, link, logout, status, provider connections`
+- Modify: `rust/tonk-cli/src/account_state.rs:credential operators and state paths`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:AccountCommand, account_op, identity, rendering`
+- Modify: `rust/tonk-cli/tests/account_profiles.rs`
+- Modify: `rust/tonk-cli/tests/account_interrupt.rs`
+- Modify: `rust/tonk-cli/tests/common.rs`
+
+**Interfaces:**
+- Consumes: Task 1's pending/selected profile records, existing resumable `PendingLogin`, `ActiveAccount`, detach outbox, and browser handoff.
+- Produces: `account add`, `account use`, `account login`, `account list`, profile-scoped `account status/logout`, and compatibility `account link` routing.
+
+- [ ] Add parser tests requiring `account add --label work`, `account use work`, `account login`, and `account list`, while preserving all existing `account link` flags and telemetry classification.
+- [ ] Add `it_adds_two_accounts_without_replacing_either_profile`. Authorize roots A and B through two generated profiles, assert distinct profile DIDs/session files/account directories, then switch locally in both directions without HTTP and verify both root records remain unchanged.
+- [ ] Add `it_keeps_a_second_profile_when_add_uses_the_same_account_again`. Link two generated profile DIDs to root A, assert both grants remain bound to their own audience/profile, preserve both rows, and print a warning naming the already-present profile rather than attempting to merge or move either grant.
+- [ ] Add label validation tests requiring case-insensitive uniqueness, the documented slug alphabet, deterministic `account`/`account-2` defaults, and exact lookup by label or profile ID.
+- [ ] Add `it_logs_out_only_the_selected_profile`. Activate both profiles, select A, log out, and assert A has no active session plus one appropriate detach intent while B remains active and unchanged.
+- [ ] Add `it_rejects_a_different_root_when_a_rooted_profile_logs_back_in`. A login handoff returning B's root must not mutate A's local-root record, provider record, account descriptor, selected profile, or spaces. Queue/deliver a detach for the mismatched provisional attachment using its own returned grant and print `this profile belongs to <A>; run tonk account add to use another account`.
+- [ ] Add `it_resumes_an_interrupted_add_in_the_same_pending_profile`. Interrupt during polling, rerun `account add`/compatibility `link`, and assert the same profile DID, secret, token hash, and state directory are reused rather than creating a third profile.
+- [ ] Add `it_lists_profiles_without_contacting_any_provider`, covering selected, signed-in, signed-out, and pending rows with stable labels and roots.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_profiles --test account_interrupt`; expect failures on the single fixed profile and global account-session lock.
+- [ ] Change `identity::open/reset/exists` to take `NativeProfileContext`. Keep a narrowly named `open_legacy_profile` helper only for Task 1 migration; `rg 'PROFILE_NAME|SpotStore::open\(' rust/tonk-cli/src` must leave no production account/space path that silently selects legacy state.
+- [ ] Scope `ACCOUNT_SESSION_SITE`, its sidecar state file, and `account-session.lock` through the context store. Cross-process shared/exclusive locking remains unchanged within one profile; independent accounts do not block each other's local operations.
+- [ ] Implement lifecycle commands. `account use` only changes `profiles.json.selected`; `account logout` uses the selected context; `account login` requires a rooted selected profile; `account add` creates/resumes an unrooted profile before opening the browser.
+- [ ] Make compatibility `account link` dispatch to add when no rooted profile is selected and to login otherwise. It must never reproduce the old logout-then-replace-root behavior.
+- [ ] Make `tonk identity` report the selected profile and account root. Make `identity --reset` refuse while that profile still owns registered spaces; do not delete another profile or the install registry.
+- [ ] Run the focused tests; expect success.
+
+### Task 4: Make the resolved profile the only remote authorization source
+
+**Files:**
+- Modify: `rust/tonk-cli/src/account_authority.rs:AccountBoundOperator, active, authorize_guarded, wrap`
+- Modify: `rust/tonk-cli/src/site.rs:account_root_prefix_for, recover_prefix, mint_prefix`
+- Modify: `rust/tonk-cli/src/invite.rs:join/claim prefix persistence`
+- Modify: `rust/tonk-cli/src/account_state.rs:migration and retained delegation paths`
+- Modify: `rust/tonk-cli/tests/account_authority.rs`
+- Modify: `rust/tonk-cli/tests/site.rs`
+
+**Interfaces:**
+- Consumes: `ResolvedSpace.profile`, its profile-scoped account-session store, existing root-to-profile grant validation, and account-root-specific `tonk-space-root-v2/{subject}/{root}` credentials.
+- Produces:
+
+```rust
+pub async fn load_account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain>;
+
+pub async fn adopt_account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain>;
+```
+
+- [ ] Replace `it_pushes_a_spot_whose_account_prefix_was_never_stored` with `it_refuses_remote_authorization_without_an_explicit_account_prefix`. Assert `AuthorizeError::UnprovenSubject` and that neither a root-specific prefix credential nor a network request is produced.
+- [ ] Keep explicit legacy adoption coverage, renamed `it_adopts_legacy_authority_only_when_requested`, proving `adopt_account_root_prefix_for` can recover/mint once and later strict loads reuse the exact bytes.
+- [ ] Add `it_never_uses_the_selected_b_account_for_an_a_space`. Select B globally, resolve an A-bound space, and assert the outgoing proof chain—when A is signed in—terminates at A. Then log out A while leaving B active and assert the same operation is rejected before HTTP rather than using B.
+- [ ] Add `it_allows_local_commits_for_a_while_a_is_logged_out`. Commit a fact through A's resolved site with B selected, assert the local revision advances, and assert automatic pull/push reports A as signed out without rolling back the commit.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_authority`; expect the first regression to fail because `authorize_guarded` currently calls the minting `account_root_prefix_for`.
+- [ ] Split prefix resolution. `load_account_root_prefix_for` may validate the root-specific credential and migrate an already-valid legacy key for the same root, but may not call `recover_prefix`, `mint_prefix`, `claim`, `delegate`, or save newly minted authority. `adopt_account_root_prefix_for` owns those explicit behaviors.
+- [ ] Change `AccountBoundOperator` to carry the resolved profile's account-session store. Preserve its current behavior of discarding historical authorization and rebuilding the outgoing chain, but load only that profile's `ActiveAccount` and strict prefix.
+- [ ] Route fresh create, explicit join/pull, and `account migrate` through `adopt_account_root_prefix_for`; route ordinary push, pull, fetch/status, invite sync, account backup, and background reconciliation through strict loading.
+- [ ] Run the focused account-authority and site tests; expect success.
+
+### Task 5: Discover and persist provider-matched content-sync defaults per profile
+
+**Files:**
+- Create: `rust/tonk-cli/src/deployment.rs`
+- Modify: `rust/tonk-cli/src/account_profiles.rs:NativeProfileRecord and deployment persistence`
+- Modify: `rust/tonk-cli/src/account.rs:successful add/login completion`
+- Modify: `rust/tonk-cli/src/lib.rs:deployment module`
+- Modify: `rust/tonk-cli/Cargo.toml:tonk-worker-api dependency`
+- Modify: `rust/tonk-cli/tests/account_profiles.rs`
+
+**Interfaces:**
+- Consumes: the selected ceremony URL, linked account service URL, `tonk_worker_api::DeploymentConfig`, and the browser convention `ceremony origin + /ucan/`.
+- Produces:
+
+```rust
+pub struct DeploymentDefaults {
+    pub ceremony_origin: url::Url,
+    pub access_remote: url::Url,
+    pub revocation_relay: url::Url,
+}
+
+pub async fn discover(
+    account_url: &str,
+    expected_account_service: &str,
+) -> anyhow::Result<DeploymentDefaults>;
+```
+
+- [ ] Add `it_discovers_the_access_remote_from_the_ceremony_deployment`. Serve `/.well-known/tonk`, pass `https://deployment.example/account/link`, and assert access is `https://deployment.example/ucan/`, relay is the typed response value, and the normalized response account-service URL matches the link provider.
+- [ ] Add rejection tests for relative/non-HTTP ceremony URLs, userinfo, malformed config, response account service differing by host/path, and a non-loopback HTTP origin. Loopback HTTP remains allowed for tests/local development.
+- [ ] Add `it_keeps_login_successful_when_deployment_discovery_is_offline`. The profile retains the ceremony origin, leaves defaults absent, reports `sync defaults: pending`, and retries on explicit reconciliation; it must not fall back silently to production.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_profiles deployment`; expect failure because discovery does not exist.
+- [ ] Implement bounded discovery using the ceremony URL's origin and `GET /.well-known/tonk`. Normalize trailing slashes for comparison but preserve validated typed URLs.
+- [ ] Persist only operational defaults in `profiles.json`; never place grants, passkey IDs, delegation bytes, or account descriptor bytes there.
+- [ ] On later successful discovery, update only that profile's record atomically. An explicit existing space upstream still wins over these defaults.
+- [ ] Run the focused discovery tests; expect success.
+
+### Task 6: Reconcile only the owning profile's spaces and prove remote durability before projection
+
+**Files:**
+- Create: `rust/tonk-cli/src/account_sync.rs`
+- Modify: `rust/tonk-cli/src/remote.rs:profile default setup helpers`
+- Modify: `rust/tonk-cli/src/sync.rs:confirmed revision access`
+- Modify: `rust/tonk-cli/src/account_spots.rs:profile filtering and projection order`
+- Modify: `rust/tonk-cli/src/account_state.rs:profile-scoped retain/push`
+- Modify: `rust/tonk-cli/src/auto_sync.rs:post-commit reconciliation`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:login/create/join/account sync triggers and rendering`
+- Modify: `rust/tonk-cli/tests/account_spots.rs`
+- Modify: `rust/tonk-cli/tests/account_authority.rs`
+
+**Interfaces:**
+- Consumes: profile-local `SpotStore`, Task 5 defaults, existing upstream configuration, `sync::{pull,push,status_with_hash}`, strict account authority, account-repository delegation retention, and account-service backup projection.
+- Produces:
+
+```rust
+pub enum EnrollmentPhase {
+    LocalOnly,
+    Provisioning,
+    PendingPush,
+    Connected { confirmed: TreeReference },
+    Error { step: &'static str, detail: String },
+}
+
+pub struct ReconcileRow {
+    pub name: String,
+    pub subject: Did,
+    pub phase: EnrollmentPhase,
+}
+
+pub struct ReconcileReport {
+    pub profile: NativeProfileId,
+    pub rows: Vec<ReconcileRow>,
+}
+
+pub async fn reconcile_profile(
+    context: &NativeProfileContext,
+) -> ReconcileReport;
+```
+
+- [ ] Add `it_reconciles_only_spaces_registered_in_the_requested_profile`. Give A and B one space each, reconcile A, and assert no B site is opened, configured, pushed, retained, or projected.
+- [ ] Add `it_preserves_a_custom_upstream`. A space already tracking `custom` must use it and must not create/set the profile's deployment default.
+- [ ] Add `it_provisions_pushes_retains_then_projects_in_order`. For a local-only A space with defaults, capture operations and require: configure default remote and upstream; pull/merge when the remote already exists; push local content; record the exact confirmed local revision; retain the existing prefix into A's account repository; push the account repository; then update the account-service projection. A failure before confirmed content push must produce no new projection claiming recovery.
+- [ ] Add `it_keeps_offline_and_non_fast_forward_spaces_pending`. Network failure must leave the local revision and configured upstream intact with a per-space error. A non-fast-forward must pull then retry one push; a second conflict remains visible and does not loop.
+- [ ] Add `it_resumes_a_logged_out_profiles_pending_change_after_same_root_login`. Commit locally while A is detached, reconcile and observe `PendingPush`, sign A into the same root, reconcile again, and assert the exact revision becomes `Connected`.
+- [ ] Add `it_does_not_adopt_unowned_legacy_or_other_profile_spaces`. A profile scan is its own `spots.json` only; no install-wide sweep exists.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_spots --test account_authority`; expect failures because current backup sweeps use the global registry and may project before a confirmed push.
+- [ ] Implement one bounded per-space state machine. Continue after individual failures and sort rows by name for deterministic output. Do not persist transient error strings.
+- [ ] Store the last confirmed content revision in a root-specific local credential site such as `tonk-space-confirmed-v1/{subject}/{account_root}` only after `sync::push` succeeds. Compare it with the current local revision to derive `PendingPush` without network access.
+- [ ] Trigger reconciliation after successful add/login, new-space creation, explicit join/pull, and a committed eval. During automatic paths, print warnings and keep the primary local command successful. Add explicit `tonk account sync` returning nonzero when any row remains `Error`.
+- [ ] Change account backup/projection copy and APIs to describe saved access metadata, not content backup. Only a matching confirmed revision may support `recoverable`/safe-delete language.
+- [ ] Run the focused tests; expect success.
+
+### Task 7: Expose the resolved profile and pending state clearly without making accounts a local security claim
+
+**Files:**
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:account/list/status, spot/list, context, status and failure context rendering`
+- Modify: `rust/tonk-cli/src/context.rs:profile/account fields`
+- Modify: `rust/tonk-cli/tests/cli_spot.rs`
+- Modify: `rust/tonk-cli/tests/context.rs`
+- Modify: `rust/tonk-cli/README.md`
+
+**Interfaces:**
+- Consumes: `ResolvedSpace`, profile lifecycle status, and `ReconcileRow`.
+- Produces: stable text/JSON fields `profile`, `accountRoot`, `signedIn`, `localPresence`, `syncPhase`, and `confirmedRevision` where applicable.
+
+- [ ] Add output regressions proving a bound A space reports `profile: personal`, `account: <A root>`, and `signed in: no` even while B is selected and signed in.
+- [ ] Add account-list output covering selected marker, label, root or `pending`, provider state, and number of local spaces; ensure no delegation bytes, credential IDs, secrets, or filesystem-internal profile names are printed.
+- [ ] Add status output for `local-only`, `provisioning`, `pending push`, `connected <revision>`, and per-step error. JSON must use separate fields rather than one overloaded `synced` boolean.
+- [ ] Add an error-context regression proving a failed remote command prints the resolved space/profile before the actionable `tonk account use/login` guidance.
+- [ ] Run `cargo test -p tonk-cli --test cli_spot --test context`; expect failures on missing profile fields.
+- [ ] Update renderers and documentation. State explicitly that the same OS user can read local files, profile separation prevents accidental CLI credential mixing, and remote services enforce signed delegation chains.
+- [ ] Document account commands, directory-binding semantics, same-name spaces, offline edits after logout, later sync, deployment-default discovery, and the difference between logout, account use, revocation, and the deferred destructive profile-forget operation.
+- [ ] Run the focused output tests; expect success.
+
+### Task 8: Verify migration, account switching, and the complete remote boundary
+
+**Files:**
+- Modify: `rust/tonk-cli/tests/account_profiles.rs:end-to-end scenario`
+- Modify: `rust/tonk-cli/tests/common.rs:two-account fixture`
+- Modify: any files above only for defects exposed by the final scenario
+
+**Interfaces:**
+- Consumes: Tasks 1–7.
+- Produces: one end-to-end proof of the accepted multi-account and offline behavior; no new production interface.
+
+- [ ] Add `it_keeps_two_accounts_and_their_spaces_disjoint_across_logout_switch_offline_edit_and_relogin` with this exact sequence: migrate a legacy A install; add/sign into B; create same-named `garden` in each profile; bind two directories; log out A; select B; commit in A's bound directory; assert B's account grant is never requested and A remains pending; reconcile B and assert only B moves; sign A back into the same root; reconcile A and assert its exact pending revision is confirmed; restart every store/profile handle and assert bindings, selected profile, roots, and confirmed revisions survive.
+- [ ] Add a negative end-to-end case that forces the A site through B's profile context and requires local mount/authorization failure without changing either site's branch revision or writing a B-rooted prefix for A's subject.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_profiles --test account_authority --test account_spots --test account_interrupt`; expect all multi-account and remote-boundary tests to pass.
+- [ ] Run `cargo test -p tonk-cli`; expect all ordinary library and integration tests to pass.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests`; expect all feature-gated native account tests to pass. If localhost binding is denied by the sandbox, rerun with the repository's permitted test environment and report that boundary rather than weakening assertions.
+- [ ] Run `cargo fmt --all -- --check`; expect no formatting diff.
+- [ ] Run `cargo clippy -p tonk-cli --all-targets --features integration-tests -- -D warnings`; expect no warnings introduced by this change.
+- [ ] Run `git diff --check`; expect no whitespace errors.
+- [ ] Inspect `git diff --stat` and `git status --short`; confirm only the planned CLI, shared deployment-contract dependency, tests, README, and this plan changed.
+
+## Acceptance criteria
+
+- One install can retain at least two rooted native profiles and switch the selected profile without a browser or network request.
+- Each profile has a distinct Dialog profile, account session/lock, account repository directory, spot registry, and canonical spot root.
+- Existing installations become the `legacy` profile without moving or deleting data.
+- Directory bindings select an exact profile and space. A bound A directory continues using A when B is selected.
+- Equal space names in different profiles are supported and unambiguous through directory bindings.
+- Logout A leaves A's local spaces editable, blocks A remote requests before HTTP, and leaves B unchanged.
+- Local A commits made while A is logged out synchronize after A signs back into the same immutable root.
+- A handoff returning a different root cannot overwrite a rooted profile and directs the user to `account add`.
+- Neither selecting B nor logging into B scans, retains, backs up, configures, or publishes A's spaces.
+- Generic remote authorization cannot mint a missing space-to-account prefix. Only explicit create/join/pull/adopt paths can establish one.
+- Automatic convergence preserves custom upstreams, provisions only missing remotes from provider-matched deployment defaults, proves a content push before projecting recoverability, and exposes offline/error states.
+- The CLI states the honest boundary: profiles are operational and credential isolation inside Tonk, not encryption against the local OS user.
+
+## Explicitly deferred
+
+- Encrypting profile credentials or space data at rest.
+- Protecting against a malicious process or user with access to the same OS account.
+- Signed per-revision author/account provenance. If Tonk later needs to prove which account context produced every offline revision—not merely which authorized profile pushed it—that requires a separately specified signed revision envelope and remote validation rule.
+- Account-level archive/removal tombstones and the browser's removed-space resurrection fix.
+- Deleting a profile or its local space data (`account forget`); the first release should only add, select, login, and logout profiles.
+- Duplicating/deduplicating immutable block storage across profiles. Initial profile stores remain physically separate for understandable failure behavior.
+- Renaming all public `spot` commands, environment variables, serialized files, or protocol identifiers to `space`.

--- a/plan/cli-space-parity.md
+++ b/plan/cli-space-parity.md
@@ -1,0 +1,406 @@
+# Local and account space ownership implementation plan
+
+**Goal:** Give the native CLI one simple space model: every installation starts with a local profile, linked accounts are labeled profiles, local replicas are listed together with their profile and role, remote account spaces can be listed and pulled, and a space may move exactly once from local-only ownership into one account.
+**Approach:** Reimplement the feature on `staging` after merged PR #726 (`53821ebe3`), using its account-as-profile-main upstream, signed account directory, membership roles, and `/provider/add` protocol. Preserve separate per-profile identities, credentials, registries, and replica storage internally, but aggregate them for inventory. Replace automatic profile-wide enrollment with an explicit, retryable `local -> account` move; an attempted account-to-account move becomes an explanatory error that can perform a targeted share-and-claim instead.
+**Constraints:**
+- Execute this plan in a fresh worktree based on the current `origin/staging`, which already contains PR #726. The dirty `feat/cli-parity` checkout is reference material only; do not merge or rebase its old account-backup implementation wholesale.
+- PR #726 removed the hidden account repository, `AccountSpotBackup`, `/chains/*` escrow APIs, and worker backup/restore modules. Do not recreate them. The account is the profile's `main` upstream, signed `tonk-schema::directory` facts are the remote-space inventory, and retained delegations replicate through that branch.
+- The built-in profile label and ID `local` are reserved. A new installation behaves as though `local` is selected before writing any state; the first mutating command persists it. Read-only commands must not create a Dialog profile or registry file.
+- Each profile retains an isolated Dialog identity, account session, account branch, credential store, `spots.json`, and replica directories. The aggregate inventory is a read model, not shared authority or shared mutable repository storage.
+- A local replica has exactly one profile association and one role: `local`, `owner`, or `member`. `local` means no account membership and no configured content upstream; `owner` means the profile's account initially provisioned the space; `member` means that account claimed an invitation.
+- `tonk space new` creates local-only when `local` is selected and creates an account-owned space when a linked account profile is selected. Linking an account never scans, provisions, or enrolls spaces in `local`.
+- The only ownership transition is `local -> owner account`, one space at a time. Account-owned and account-member spaces cannot move to `local` or another account.
+- An attempted account-to-account move must explain, without delegation terminology, that a synced space stays with its owning account to keep existing shares working. Interactive use may offer one-step targeted share-and-claim; non-interactive use must fail without mutation and print one exact alternative command.
+- Sharing never changes ownership. The target account becomes a `member`, may list the space in its signed directory, and may pull its own local replica.
+- Local removal, account ownership, provider hosting, collaboration membership, authority, and remote/peer bytes remain separate. Removing a local replica does not remove account directory facts, revoke grants, deprovision hosting, or delete peers' copies.
+- `/provider/remove` is destructive in PR #726 and is never part of move, retry, rollback, local removal, or share-and-claim. Account/hosted-space deletion stays a separately confirmed existing workflow.
+- A move must be resumable and fail safe. Until the destination account has pushed the exact content revision, retained authority, committed its directory record, and mounted a verified destination replica, the source remains registered and usable under `local`.
+- A local space with an existing upstream, durable membership beyond its founder, or recorded invitations is not eligible for move. Fail before provider or registry mutation and explain that only a genuinely local-only space can move.
+- Preserve canonical public vocabulary `space`, `--space`, `TONK_SPACE`, `account spaces`, and `share`, with visible `spot`, `--spot`, `TONK_SPOT`, `account spots`, and `invite` compatibility aliases.
+- This plan covers the native CLI and shared provider/schema behavior required by it. Browser profile UX, account-to-account ownership transfer, delegation-chain rebasing, rotating existing bearer links, and provider billing transfer are out of scope.
+
+## Approved product contract
+
+Users need remember only two rules:
+
+1. A local space can move into an account.
+2. Once a space belongs to an account, it stays there, but it can be shared with another account.
+
+The aggregate local inventory renders the distinction directly:
+
+```text
+NAME      SUBJECT         PROFILE     ROLE     LOCAL
+scratch   did:key:...     local       local    yes
+garden    did:key:...     personal    owner    yes
+garden    did:key:...     work        member   yes
+roadmap   did:key:...     work        owner    yes
+```
+
+An invalid move is actionable:
+
+```text
+$ tonk space move garden --to work
+
+Can't move "garden" from "personal" to "work".
+
+Once a space is synced with an account, it stays owned by that account.
+This keeps existing shares working.
+
+Share it with "work" and add it there instead? [y/N]
+```
+
+If stdin is not interactive, the command exits without mutation and prints:
+
+```text
+Run instead:
+  tonk space share garden --with work --claim
+```
+
+Accepted interactive remediation and the explicit non-interactive command perform the same operation: mint a targeted invitation from the source profile, claim it under the target account, register/pull the target's member replica, and leave the selected profile unchanged.
+
+## Rejected alternatives
+
+- Do not silently reinterpret `move` as `share`; that hides the owner/member distinction.
+- Do not support account-to-account ownership transfer; revoking the old shared authority prefix can invalidate downstream users and existing invite chains.
+- Do not bridge the new account back through the old account to preserve descendants; that leaves the old account broadly authoritative and is not a real transfer.
+- Do not enroll every local space when an account links; account attachment and per-space synchronization are separate choices.
+- Do not flatten all profiles into one credential or replica store; aggregate presentation must not weaken profile-bound authorization.
+
+## Durable data model
+
+Add an install-level registry while retaining one existing `SpotStore` per profile:
+
+```rust
+pub enum NativeProfileKind {
+    Local,
+    Account,
+}
+
+pub struct NativeProfileRecord {
+    pub kind: NativeProfileKind,
+    pub label: String,
+    pub dialog_profile_name: String,
+    pub state_dir: PathBuf,
+    pub account_root: Option<String>,
+    pub ceremony_origin: Option<String>,
+    pub default_access_remote: Option<String>,
+    pub default_revocation_relay: Option<String>,
+}
+
+pub struct BoundSpace {
+    pub profile: NativeProfileId,
+    pub space: String,
+}
+
+pub struct NativeProfileRegistryV1 {
+    pub version: u8,
+    pub selected: NativeProfileId,
+    pub profiles: BTreeMap<NativeProfileId, NativeProfileRecord>,
+    pub bindings: BTreeMap<PathBuf, BoundSpace>,
+}
+```
+
+`NativeProfileId::local()` serializes as `local`. Generated account-profile IDs remain opaque `p-<32 lowercase hex>`. A fresh `local` profile uses the legacy install root; the linked-legacy exception is defined below. Generated account profiles use `profiles/<id>/spots.json`, `profiles/<id>/spots/`, and `profiles/<id>/account/`; their Dialog key profiles remain in Dialog's platform profile storage.
+
+`state_dir` is a normalized path relative to the installation root; absolute paths, `..`, and aliases of another profile's directory are rejected. A fresh or unlinked legacy install records `local.state_dir = "."`. A linked legacy install instead records its grandfathered account profile with `state_dir = "."` and creates `local` at `profiles/local/`. Every subsequently added account uses `profiles/<id>/`. This makes the existing authority-bearing Dialog profile and bytes stay exactly where they are without letting two profiles share mutable state.
+
+Moves use a separate install-level `moves.json` journal written atomically through `moves.json.tmp` plus rename:
+
+```rust
+pub enum MovePhase {
+    Prepared,
+    AuthorityDeposited,
+    ProviderAdded,
+    ContentPushed,
+    AccountPublished,
+    DestinationVerified,
+    DestinationRegistered,
+    BindingsRewritten,
+}
+
+pub struct PendingMoveV1 {
+    pub version: u8,
+    pub subject: String,
+    pub source_profile: NativeProfileId,
+    pub source_space: String,
+    pub target_profile: NativeProfileId,
+    pub confirmed_revision: Option<String>,
+    pub phase: MovePhase,
+}
+```
+
+There is at most one journal row for `{subject, target_profile}`. Each phase records only after its postcondition is verified. Unknown versions or phases fail closed; a corrupt journal never triggers cleanup. The final commit unregisters and removes the source replica, verifies that cleanup, and only then removes the journal row.
+
+The local role is derived offline from the profile kind plus the space repository's signed `Membership` and `MemberRole` facts:
+
+```rust
+pub enum SpaceProfileRole {
+    Local,
+    Owner,
+    Member,
+}
+
+pub struct LocalSpaceInventoryRowV1 {
+    pub version: u8,
+    pub profile_id: String,
+    pub profile_label: String,
+    pub profile_kind: NativeProfileKind,
+    pub role: SpaceProfileRole,
+    pub name: String,
+    pub subject: String,
+    pub site: PathBuf,
+    pub local: bool, // always true in this local-replica inventory
+}
+```
+
+Do not store `role` as an independently mutable ownership flag. The registry selects the profile that may open the site; signed repository membership establishes founder versus invited member.
+
+## Legacy bootstrap
+
+- An empty install synthesizes selected `local` without writing files. The first local mutation persists the registry and opens Dialog profile `tonk`.
+- An existing unlinked single-profile install becomes `local` in place; its `spots.json`, `spots/`, bindings, Dialog profile `tonk`, and bytes do not move.
+- An existing linked PR-#726 install becomes grandfathered account profile ID `legacy` at state directory `.` because its `tonk` Dialog profile already carries the account grant. Create reserved profile ID `local` at `profiles/local/` with Dialog profile name `tonk-local`, and preserve `legacy` as selected so existing commands retain their authority context.
+- Bootstrap copies legacy name-only directory bindings into install-level `{ profile, space }` bindings but leaves old fields on disk for downgrade visibility.
+- Unknown registry/profile fields survive round trips. Corrupt JSON, unsupported versions, duplicate labels, unknown profiles, and dangling bindings fail closed.
+
+## File map
+
+- `plan/cli-space-parity.md`: Approved contract, implementation tasks, and verification state.
+- `rust/tonk-cli/src/account_profiles.rs`: Install-level local/account profile roster, migration, selection, profile contexts, and exact directory bindings.
+- `rust/tonk-cli/src/inventory.rs`: Aggregate offline local-replica inventory and rendered role classification.
+- `rust/tonk-cli/src/space_move.rs`: Durable local-to-account move state machine, install-level `moves.json`, and preflight.
+- `rust/tonk-cli/src/cross_profile_share.rs`: Targeted invite plus claim/pull across two locally linked accounts without changing selection.
+- `rust/tonk-cli/src/spot.rs`: One-profile registry primitives and move-safe register/unregister operations.
+- `rust/tonk-cli/src/site.rs`: Explicit profile configuration and authority adoption for move destination mounting.
+- `rust/tonk-cli/src/account.rs`: Link/login/logout against an explicit account profile atop PR #726 custody.
+- `rust/tonk-cli/src/account_state.rs`: Explicit profile/account-main hydration and retained delegation access.
+- `rust/tonk-cli/src/account_spots.rs`: Profile-explicit signed-directory list and pull.
+- `rust/tonk-cli/src/account_authority.rs`: Strict profile-bound remote authorization and local-to-account adoption boundary.
+- `rust/tonk-cli/src/invite.rs`: Profile-explicit targeted mint and durable claim adapters reused by assisted sharing.
+- `rust/tonk-cli/src/bin/tonk.rs`: Profile commands, aggregate inventory, move/share UX, prompts, and canonical aliases.
+- `rust/tonk-cli/src/lib.rs`: Export new modules.
+- `rust/tonk-cli/tests/account_profiles.rs`: Empty/local bootstrap, legacy migration, labels, switching, isolation, and bindings.
+- `rust/tonk-cli/tests/space_inventory.rs`: Aggregate role/profile rows, collision handling, and offline behavior.
+- `rust/tonk-cli/tests/space_move.rs`: Live provider local-to-account move and failure-injection coverage.
+- `rust/tonk-cli/tests/cross_profile_share.rs`: Invalid-move recovery, targeted claim, and member replica coverage.
+- `rust/tonk-cli/tests/account_spots.rs`: Per-account signed-directory list and pull coverage.
+- `rust/tonk-cli/tests/cli_spot.rs`: Parser, help, output, prompt, alias, and non-interactive regressions.
+- `rust/tonk-cli/tests/common.rs`: Two-account fixtures and explicit profile contexts.
+- `rust/tonk-cli/README.md`: Two-rule mental model, commands, inventory, failure copy, and lifecycle boundaries.
+- `rust/tonk-schema/src/directory.rs`: Reuse PR #726 signed remote-space directory; extend only if an owner/member projection cannot be derived from repository membership.
+- `rust/tonk-schema/src/membership.rs`: Reuse founder/member roles as canonical collaboration role.
+- `rust/tonk-account/src/delegations.rs`: Reuse retained `space -> account-root` authority in account `main`.
+- `rust/tonk-access-service/src/registration.rs`: Reuse idempotent `/provider/add`; change only if focused move tests expose a missing non-destructive idempotence case.
+
+### Task 1: Add the built-in local profile and isolated labeled account profiles
+
+**Files:**
+- Create: `rust/tonk-cli/src/account_profiles.rs`
+- Modify: `rust/tonk-cli/src/lib.rs:module exports`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:AccountCommand and account dispatch`
+- Test: `rust/tonk-cli/tests/account_profiles.rs`
+
+**Interfaces:**
+- Consumes: PR #726's fixed `tonk` Dialog profile, `SpotStore`, account link/session APIs, `TONK_SPOTS_STATE`, and existing name-only bindings.
+- Produces: `NativeProfileStore::{load_or_bootstrap, selected, select, create_account_pending, context, bind, resolve}`, reserved `NativeProfileId::local()`, and explicit `NativeProfileContext` values used by every later task.
+
+- [ ] Add `it_synthesizes_local_on_an_empty_install_without_writing_state`. Require `selected().label == "local"`, no `profiles.json`, no Dialog profile, and no `spots.json` after `account list` and `space list`.
+- [ ] Add `it_persists_local_on_the_first_space_write`. Require profile ID/label `local`, kind `local`, Dialog profile `tonk`, and the new space only in the install-root `spots.json`.
+- [ ] Add migration tests for an unlinked legacy install becoming `local` in place and a linked PR-#726 install becoming a selected grandfathered account profile beside an empty local profile. Snapshot every pre-existing path and byte before/after.
+- [ ] Add `it_creates_labels_and_switches_without_network_io`, including reserved/duplicate `local`, case-insensitive duplicate labels, exact generated IDs, and `account use local`.
+- [ ] Add `it_keeps_account_identity_session_directory_and_spots_disjoint`, creating two labeled account profiles whose Dialog names, account roots, account directories, and `spots.json` paths never alias.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles`; expect compilation failure because `account_profiles` and the commands do not exist on PR #726.
+- [ ] Implement atomic `profiles.json.tmp` plus rename persistence, strict version validation, flattened unknown fields, deterministic legacy bootstrap, and explicit context construction. Read-only synthesized local must remain allocation- and filesystem-only; it must not open Dialog storage.
+- [ ] Add `tonk account add --label <LABEL>`, `account use <LABEL|ID>`, `account list`, and same-root `account login`. `account link` remains compatibility behavior: from local it creates/resumes an account profile rather than converting local; from a rooted account profile it logs that profile back into the same immutable root.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles`; expect success.
+- [ ] Run `cargo test -p tonk-cli --test account_interrupt --test account_authority`; expect PR-#726 link interruption and authority checks to remain green under explicit contexts.
+
+### Task 2: Resolve profile-qualified spaces and aggregate every local replica
+
+**Files:**
+- Create: `rust/tonk-cli/src/inventory.rs`
+- Modify: `rust/tonk-cli/src/account_profiles.rs:bindings and aggregate iteration`
+- Modify: `rust/tonk-cli/src/spot.rs:profile-local registry adapters`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:space list, use, and selection output`
+- Test: `rust/tonk-cli/tests/space_inventory.rs`
+- Test: `rust/tonk-cli/tests/cli_spot.rs`
+
+**Interfaces:**
+- Consumes: Task 1 profile contexts, each profile's `spots.json`, repository DID, `Membership`, `MemberRole`, `--space/--spot`, environment selection, and install-level directory bindings.
+- Produces: `inventory::list_local(&NativeProfileStore) -> Result<Vec<LocalSpaceInventoryRowV1>>` and `ResolvedSpace { profile, name, site, source }`.
+
+- [ ] Add `it_lists_local_owner_and_member_replicas_with_their_profiles`. Arrange the four approved-contract rows and require stable sort by profile label, space name, then subject.
+- [ ] Add `it_lists_offline_without_opening_account_or_remote_services`. Deny all provider requests and require role/profile output from local registries and repository facts.
+- [ ] Add duplicate-name coverage: `personal/garden` and `work/garden` both render; an unqualified explicit name in the selected profile resolves there; a directory binding resolves its exact `{ profile, space }` even after another profile is selected.
+- [ ] Add corrupt/unreadable-site coverage that retains other rows and emits one row-specific diagnostic without borrowing another profile's identity to inspect it.
+- [ ] Add exact text and JSON snapshots for `PROFILE`, `PROFILE TYPE`, `ROLE`, `LOCAL`, canonical camelCase fields, and `local|owner|member` values.
+- [ ] Run `cargo test -p tonk-cli --test space_inventory --test cli_spot`; expect missing aggregate inventory/profile columns.
+- [ ] Move directory binding ownership into `NativeProfileStore`. Keep `SpotStore` responsible for one profile's entries and paths. Resolve once to `ResolvedSpace`; no later command may consult the globally selected profile again.
+- [ ] Classify `local` from profile kind and absence of account/remote state; classify `owner` from `MemberRole::FOUNDER`; classify `member` from `MemberRole::MEMBER`. Conflicting or absent signed role evidence on an account profile is an error row, never guessed ownership.
+- [ ] Make `tonk space list` installation-wide and offline. Preserve `tonk account spaces` for remote account-directory inventory rather than mixing absent remote rows into this command.
+- [ ] Run the focused tests; expect success.
+- [ ] Run `cargo test -p tonk-cli --test spot --test site`; expect one-profile registry and site behavior to remain green.
+
+### Task 3: Make account lifecycle operate on labeled account profiles without enrolling local spaces
+
+**Files:**
+- Modify: `rust/tonk-cli/src/account.rs:explicit profile link/login/logout`
+- Modify: `rust/tonk-cli/src/account_state.rs:profile-main account upstream adapters`
+- Modify: `rust/tonk-cli/src/account_authority.rs:profile-bound grants`
+- Modify: `rust/tonk-cli/src/site.rs:create under selected profile`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:account lifecycle and space new dispatch`
+- Test: `rust/tonk-cli/tests/account_profiles.rs`
+- Test: `rust/tonk-cli/tests/account_authority.rs`
+
+**Interfaces:**
+- Consumes: Task 1 account contexts and PR #726 custody/account-main APIs.
+- Produces: a linked account profile with immutable root/deployment defaults, plus account-owned creation only when that account profile is explicitly selected.
+
+- [ ] Add `it_links_an_account_without_touching_local_spaces`. Snapshot local registry, site bytes, revisions, remotes, memberships, and invitations; link `personal`; require every snapshot unchanged and no `/provider/add` for local subjects.
+- [ ] Add `it_creates_local_when_local_is_selected_and_owner_when_an_account_is_selected`. The local case has no upstream/account directory row; the account case provisions only the new subject, stamps founder role, pushes exact content, and records its mount in that account directory.
+- [ ] Add cross-profile denial coverage: selecting `work` cannot authorize, publish, list as local, or mutate a `personal` space unless resolution explicitly returns the `personal` context.
+- [ ] Run `cargo test -p tonk-cli --test account_profiles --test account_authority`; expect failures while production still assumes one fixed profile/store.
+- [ ] Thread `NativeProfileContext` through account session/state/authority/site APIs. Do not retain a space prefix, provision a consumer, or record a directory row from account link itself.
+- [ ] Keep logout local/offline and profile-scoped. Preserve local edits, account root, account branch, remote configuration, and replicas; deny later network operations before HTTP until that account profile logs in.
+- [ ] Run focused tests; expect success.
+
+### Task 4: List and pull each account's signed remote directory
+
+**Files:**
+- Modify: `rust/tonk-cli/src/account_spots.rs:list and pull`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:AccountSpotsCommand`
+- Test: `rust/tonk-cli/tests/account_spots.rs`
+
+**Interfaces:**
+- Consumes: explicit account-profile context, PR #726 `tonk_schema::directory::{spaces,mount_record}`, local aggregate inventory, and signed membership roles.
+- Produces: `account_spots::{list_in,pull_in}` pinned to one account profile and `tonk account spaces [--profile <LABEL>] list|pull`.
+
+- [ ] Add `it_lists_remote_spaces_for_each_account_without_cross_contamination`. Give `personal` owner/member rows and `work` different rows; require profile-qualified list results even while `local` is selected.
+- [ ] Add offline fallback coverage: a failed account pull warns and renders the last signed local directory; it does not silently use another profile's account branch.
+- [ ] Add `it_pulls_an_invited_space_as_a_member_replica`. Require target profile registration, member role, exact subject and remote, successful initial pull, and no owner/provider mutation.
+- [ ] Add same-name coverage within different account profiles and refusal to overwrite an existing entry or orphan inside the target profile.
+- [ ] Run `cargo test -p tonk-cli --test account_spots`; expect failures on fixed global profile/store usage.
+- [ ] Parameterize PR #726's list/pull implementation by `NativeProfileContext`. Default `--profile` to the selected account profile; if `local` is selected, require `--profile` and list available account labels instead of guessing.
+- [ ] Register pulled replicas only after mount, initial pull, and signed membership verification succeed. On failure remove only newly staged target storage and leave directory facts untouched.
+- [ ] Run focused tests; expect success.
+
+### Task 5: Implement a resumable one-space local-to-account move
+
+**Files:**
+- Create: `rust/tonk-cli/src/space_move.rs`
+- Modify: `rust/tonk-cli/src/spot.rs:move-safe register and unregister`
+- Modify: `rust/tonk-cli/src/site.rs:explicit target adoption`
+- Modify: `rust/tonk-cli/src/account_state.rs:retain and directory push`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:SpotCommand::Move`
+- Modify: `rust/tonk-cli/src/lib.rs:module export`
+- Test: `rust/tonk-cli/tests/space_move.rs`
+- Test: `rust/tonk-access-service/tests/registration.rs`
+
+**Interfaces:**
+- Consumes: exact local `ResolvedSpace`, linked target account context, source space signing authority, target deployment defaults, `/provider/add`, account-main delegation retention/directory record, and Task 4 pull.
+- Produces: `space_move::execute(store, source, target) -> MoveOutcome` and atomic install-level `moves.json` entries keyed by space subject and target profile.
+
+- [ ] Add preflight tests rejecting a source that is owner/member, has an upstream, lacks the space signing credential, has non-founder durable membership, has recorded invitations, targets `local`, or targets an unlinked/unhydrated/signed-out account. Assert zero provider, repository, registry, and binding mutation.
+- [ ] Add `it_moves_one_local_space_into_one_account`. Require the same repository subject and exact tree, idempotent provider ownership under the target account, target `space -> account-root` authority, confirmed content push, account-directory mount record, founder role, target local registration, rewritten directory bindings, and no remaining source registration/data.
+- [ ] Add failure injection after authority mint, `/provider/add`, content push, account retention, directory push, destination pull, destination registration, and binding rewrite. Before final commit the source remains registered/readable; retry resumes without another subject, provider, or account-directory entity.
+- [ ] Add crash recovery tests for every journal phase. A stale journal whose destination is fully verified finishes local registry cleanup; any earlier phase resumes forward and never calls `/provider/remove`.
+- [ ] Add exact revision coverage: move cannot commit merely because a remote exists; destination local revision, provider-accepted source revision, and account directory's mount configuration must all describe the moved subject.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test space_move`; expect missing command/state machine failures.
+- [ ] Implement the move in the journal phases above: preflight; mint/deposit target authority; add provider; attach/push source and record the confirmed revision; retain authority and record/push target account directory; pull/verify destination replica; register destination; atomically rewrite install-level bindings; unregister and delete source replica; verify source cleanup; clear the journal row. Provider/account side effects before commit are safe idempotent progress, not rollback targets.
+- [ ] Store no account-to-account move path. Re-running a completed move returns an already-owned success only when source subject and target account exactly match the committed destination.
+- [ ] Run the focused move and provider-registration tests; expect success.
+
+### Task 6: Turn invalid account moves into assisted targeted sharing
+
+**Files:**
+- Create: `rust/tonk-cli/src/cross_profile_share.rs`
+- Modify: `rust/tonk-cli/src/invite.rs:profile-explicit targeted mint and claim adapters`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:space move/share UX`
+- Modify: `rust/tonk-cli/src/lib.rs:module export`
+- Test: `rust/tonk-cli/tests/cross_profile_share.rs`
+- Test: `rust/tonk-cli/tests/cli_spot.rs`
+
+**Interfaces:**
+- Consumes: an account-owned/member source context, another linked account's immutable root DID, existing targeted invite mint, durable claim, Task 4 pull/register, and terminal interactivity.
+- Produces: `cross_profile_share::share_and_claim(source, target, subject) -> ShareClaimOutcome`, explicit `tonk space share <SPACE> --with <ACCOUNT> --claim`, and the approved invalid-move remediation.
+
+- [ ] Add exact output tests for the approved account-to-account move error, including source/target labels, the two simple explanatory sentences, `[y/N]`, and the one-line non-interactive alternative. Forbid “UCAN,” “delegation,” “provider,” “prefix,” and root DID strings in ordinary copy.
+- [ ] Add `it_declines_assisted_share_without_mutation`, covering `n`, EOF, and non-interactive stdin.
+- [ ] Add `it_shares_and_claims_in_one_step_without_switching_profiles`. Require a targeted audience equal to the target account root, durable member role, target account directory row, target local member replica, unchanged source ownership, and unchanged selected profile.
+- [ ] Add target-already-member coverage that pulls/registers the existing membership rather than minting a duplicate invitation.
+- [ ] Add claim/pull failure coverage: source ownership and current selection remain unchanged, no target local registration is claimed, and retry output names the exact `space share ... --with ... --claim` command without printing capability material.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test cross_profile_share --test cli_spot`; expect missing command and remediation failures.
+- [ ] Implement one shared operation used by both the explicit command and accepted prompt. Resolve source/target contexts once; do not call `account use`, mutate selection, or shell out to nested CLI processes.
+- [ ] Keep ownership immutable. The target is always stamped/verified as `member`; share-and-claim never calls `/provider/add` or changes the source account's directory/provider ownership.
+- [ ] Run focused tests; expect success.
+
+### Task 7: Make local removal and synchronization obey the two-rule model
+
+**Files:**
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:space rm, push/pull, account sync`
+- Modify: `rust/tonk-cli/src/auto_sync.rs:resolved-profile routing`
+- Modify: `rust/tonk-cli/src/account_spots.rs:directory persistence boundary`
+- Test: `rust/tonk-cli/tests/cli_spot.rs`
+- Test: `rust/tonk-cli/tests/account_authority.rs`
+- Test: `rust/tonk-cli/tests/account_spots.rs`
+
+**Interfaces:**
+- Consumes: role-aware `ResolvedSpace`, exact profile context, existing PR #726 sync, local registry removal, and hosted-space deletion commands.
+- Produces: profile-routed sync and local-only replica removal without account/provider mutation.
+
+- [ ] Add `it_removes_only_the_selected_local_replica`. For owner and member replicas require local registry/data removal according to flags while signed directory, memberships, invitations, provider row, authority, remote blobs, and another profile's replica remain unchanged.
+- [ ] Add `it_never_enrolls_local_spaces_during_link_login_or_sync`. Count provider calls and account-directory writes across all three commands.
+- [ ] Add profile-routing tests showing a cwd bound to `personal/garden` continues syncing with personal authority while `work` is selected; local spaces without upstream remain offline and editable.
+- [ ] Run focused CLI/account tests; expect failures where single-profile/global state or account-wide removal remains.
+- [ ] Route every space operation from `ResolvedSpace.profile`. Restrict account sync to replicas already registered under that account profile; do not scan `local` or other profiles.
+- [ ] Keep `account spaces delete` and account deletion as the existing explicit destructive browser-review paths. Do not alias them from `space rm`, `move`, or failed cleanup.
+- [ ] Run focused tests; expect success.
+
+### Task 8: Document and verify the complete CLI journey on top of PR #726
+
+**Files:**
+- Modify: `rust/tonk-cli/README.md`
+- Modify: `rust/tonk-cli/tests/cli_spot.rs`
+- Modify: `rust/tonk-cli/tests/common.rs`
+- Modify: `plan/cli-space-parity.md:verification checkpoint only`
+
+**Interfaces:**
+- Consumes: Tasks 1-7 and PR #726 provider/account fixtures.
+- Produces: one documented, compatibility-tested native CLI workflow; no new production interface.
+
+- [ ] Add `it_drives_the_two_rule_space_lifecycle`. Start empty; prove synthesized local; create two local spaces; link labeled personal/work accounts; move only one space to personal; list aggregate local rows; list each account's remote rows; reject move personal->work; accept assisted share; claim/pull a work member replica; and require source ownership plus selected profile unchanged.
+- [ ] Add restart persistence after every major step: local bootstrap, interrupted account add, completed move journal, assisted claim, local replica removal, logout/login, and account directory refresh.
+- [ ] Add canonical/legacy parser and help coverage for `space|spot`, `--space|--spot`, `TONK_SPACE|TONK_SPOT`, `account spaces|account spots`, and `share|invite`. Canonical terms lead help and output.
+- [ ] Update the README with only the two user rules, the aggregate inventory example, `account spaces --profile`, local-to-account move, assisted sharing copy, local removal boundary, and owner/member definitions. Keep internal profile storage and delegation details out of the quick-start mental model.
+- [ ] Run `cargo test -p tonk-cli`; expect success.
+- [ ] Run `cargo test -p tonk-cli --features integration-tests --test account_profiles --test space_inventory --test account_spots --test space_move --test cross_profile_share --test cli_spot --test account_authority --test account_interrupt --test site --test spot`; expect success with serial execution where provider fixtures require it.
+- [ ] Run `cargo test -p tonk-access-service --test registration`; expect success.
+- [ ] Run `nix develop . -c env CARGO_INCREMENTAL=0 test:web:debug`; expect the complete WASM suite to pass because shared schema/provider changes remain browser-compatible. Use `.`, not `path:.`, to avoid snapshotting the local `target` tree.
+- [ ] Run `cargo check --workspace --all-targets --all-features`; expect success.
+- [ ] Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`; expect success.
+- [ ] Run `cargo fmt --all -- --check`, `nixfmt --check flake.nix`, and `git diff --check`; expect no formatting or whitespace changes.
+- [ ] Inspect `git diff --stat`, `git status --short`, and the merge base. Confirm the implementation is based on current `origin/staging`, contains no retired backup/escrow API, no provider-remove move path, no account-to-account ownership transfer, no automatic local-space enrollment, and no unrelated browser redesign.
+
+## Acceptance criteria
+
+- A new install behaves as selected profile `local`; read-only commands create no state.
+- Users can add, label, list, select, log into, and log out of multiple isolated account profiles.
+- `tonk space list` shows every local replica with its exact profile and `local|owner|member` role, offline and deterministically.
+- `tonk account spaces --profile <LABEL>` lists that account's signed remote directory and can pull a missing owner/member space into that profile.
+- Linking or synchronizing an account never enrolls unrelated local spaces.
+- `tonk space move <SPACE> --to <ACCOUNT>` accepts only a genuinely local-only source and commits only after exact remote, account-directory, authority, and destination-replica verification.
+- A failed/interrupted move preserves the local source and resumes idempotently; no move path calls destructive provider removal.
+- Account-owned/member spaces never move. The error explains the rule in simple terms and offers one-step share-and-claim.
+- Assisted share-and-claim preserves ownership, creates/verifies target membership and a local member replica, and never changes the selected profile.
+- Local replica removal does not alter account discovery, membership, authority, hosting, remote data, or peer replicas.
+- The implementation uses PR #726's account-main directory and retained delegations and does not restore its removed hidden-account/escrow architecture.
+
+## Explicitly deferred
+
+- Account-to-account ownership transfer or account-to-local detachment.
+- Delegation-chain rebasing, bridge grants, or preservation of already-issued bearer links across ownership transfer.
+- Non-destructive provider/billing ownership handoff.
+- Compelling remote or peer deletion, or calling local removal “delete everywhere.”
+- Browser multi-profile UX and browser-assisted local-to-account moves.
+- Encrypting local profile/space data from another process running as the same OS user.
+- Removing compatibility aliases or renaming serialized/internal `Spot*`, `spots.json`, capability, or protocol identifiers.

--- a/rust/tonk-access-service/src/bin/local.rs
+++ b/rust/tonk-access-service/src/bin/local.rs
@@ -16,6 +16,10 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("REVOCATION_RELAY_URL"),
     ) {
         (Ok(account), Ok(revocations)) => Some(DeploymentConfig {
+            access_remote_url: std::env::var("ACCESS_REMOTE_URL")
+                .ok()
+                .map(|url| url.parse())
+                .transpose()?,
             account_service_url: account.parse()?,
             revocation_relay_url: revocations.parse()?,
             // Filled in by the server with its own generated identity.

--- a/rust/tonk-access-service/src/handlers/config.rs
+++ b/rust/tonk-access-service/src/handlers/config.rs
@@ -37,6 +37,7 @@ pub async fn handle(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
         .map(|signer| signer.did().to_string());
     let config = (|| {
         Ok::<_, Error>(DeploymentConfig {
+            access_remote_url: None,
             account_service_url: configured_url(&ctx, "ACCOUNT_SERVICE_URL")?,
             revocation_relay_url: configured_url(&ctx, "REVOCATION_RELAY_URL")?,
             service_did,

--- a/rust/tonk-access-service/tests/deployment_config.rs
+++ b/rust/tonk-access-service/tests/deployment_config.rs
@@ -6,6 +6,7 @@ use tonk_worker_api::DeploymentConfig;
 #[dialog_common::test]
 async fn it_serves_deployment_config_when_configured() -> anyhow::Result<()> {
     let expected = DeploymentConfig {
+        access_remote_url: Some("http://127.0.0.1:4200/ucan/".parse()?),
         account_service_url: "http://127.0.0.1:4100".parse()?,
         revocation_relay_url: "http://127.0.0.1:4100/revocations".parse()?,
         service_did: None,
@@ -25,6 +26,7 @@ async fn it_serves_deployment_config_when_configured() -> anyhow::Result<()> {
     .json()
     .await?;
     assert_eq!(actual.account_service_url, expected.account_service_url);
+    assert_eq!(actual.access_remote_url, expected.access_remote_url);
     assert_eq!(actual.revocation_relay_url, expected.revocation_relay_url);
     // The server fills discovery with its own generated identity.
     assert_eq!(

--- a/rust/tonk-account/Cargo.toml
+++ b/rust/tonk-account/Cargo.toml
@@ -14,6 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
+base58 = { workspace = true }
 blake3 = { workspace = true }
 dialog-capability = { workspace = true }
 dialog-common = { workspace = true }

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -75,6 +75,10 @@ name = "spot"
 path = "tests/spot.rs"
 
 [[test]]
+name = "account_profiles"
+path = "tests/account_profiles.rs"
+
+[[test]]
 name = "cli_spot"
 path = "tests/cli_spot.rs"
 
@@ -162,7 +166,7 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-axum = { workspace = true, features = ["form", "http1", "query", "tokio"] }
+axum = { workspace = true, features = ["form", "http1", "json", "query", "tokio"] }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "io-std", "io-util", "signal", "time"] }
 tokio-util = { workspace = true }
@@ -174,6 +178,7 @@ tonk-invite = { workspace = true }
 tonk-notation = { workspace = true }
 tonk-render = { workspace = true }
 tonk-schema = { workspace = true }
+tonk-worker-api = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 webbrowser = { workspace = true }

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -1,9 +1,10 @@
 # tonk
 
-A local-only CLI for reading and writing tonk facts via asserted-notation.
+A local-first CLI for reading, writing, synchronizing, and sharing Tonk facts
+via asserted notation.
 
 `tonk` is the headless companion to tonk-ui, without a browser: it operates on
-the selected **spot** — a named fact store resolved through a central
+the selected **space** — a named fact store resolved through a profile-local
 registry, so the CLI works from any directory. The mutating verb is `eval`,
 which runs a notation document through the analyze → query → plan → commit
 pipeline. The other subcommands are read-only introspection, one-shot setup,
@@ -14,9 +15,9 @@ drive the same code paths as the binary.
 ## Usage
 
 ```sh
-# Create a spot (stored canonically, e.g. ~/Library/Application Support/tonk/spots/garden).
-tonk spot new garden
-# Use an existing spot in another project directory:
+# Create a space (stored canonically, e.g. ~/Library/Application Support/tonk/spots/garden).
+tonk space new garden
+# Use an existing space in another project directory:
 tonk use garden
 
 # Evaluate a notation document: inline, from a file, or piped.
@@ -71,11 +72,18 @@ tonk account sync
 tonk account logout
 
 # Delegate access to the space.
-tonk invite                    # audience-open: anyone holding it can claim
-tonk invite --remote prod      # selected remote must carry a revocation relay
-tonk invite --recipient-root did:key:z6Mk... # seed-free targeted invite
-tonk invite --no-remote        # embed none; the claimer wires an upstream by hand
+tonk share                    # audience-open: anyone holding it can claim
+tonk share --remote prod      # selected remote must carry a revocation relay
+tonk share --recipient-root did:key:z6Mk... # seed-free targeted invite
+tonk share --no-remote        # embed none; the claimer wires an upstream by hand
 tonk join 'https://...#invite' --name garden
+
+# One lifecycle inventory, offline by default.
+tonk space list
+tonk space list --all --json
+tonk space list --refresh
+tonk account spaces pull did:key:z6Mk... --name garden
+tonk space archive did:key:z6Mk... --yes
 ```
 
 ## Telemetry
@@ -88,25 +96,28 @@ nothing. Full inventory: [`docs/telemetry.md`](../../docs/telemetry.md).
 
 ## How it works
 
-### Spots and sites
+### Spaces and sites
 
-A **spot** is a named entry in `spots.json`, a registry kept under the
+A **space** is a named entry in the internal `spots.json` registry kept under the
 platform data dir (`~/Library/Application Support/tonk/` on macOS). Each
 entry points at a **site**: the working directory holding the actual dialog
 repository (`main`, opened on the `main` branch — multi-branch and multi-repo
 workflows are intentionally not exposed). Sites live canonically under
-`spots/<name>/`, or anywhere you like via `tonk spot new --site <path>`.
-Commands resolve which spot to use as `--spot` > `TONK_SPOT` > the nearest
+`spots/<name>/`, or anywhere you like via `tonk space new --site <path>`.
+Commands resolve which space to use as `--space`/`--spot` >
+`TONK_SPACE`/`TONK_SPOT` > the nearest
 directory bound by `tonk use <name>`, then open its central site. There is no
 machine-global fallback. Parallel sessions in separate directories therefore
-hold their own spot without repeating a flag. The directory is only a key into
-the registry — no site data or pointer file is stored there. `tonk spot unbind`
+hold their own space without repeating a flag. Equal canonical and legacy
+environment values are accepted; conflicting values fail before opening a
+repository. The directory is only a key into the registry — no site data or
+pointer file is stored there. `tonk space unbind`
 removes an exact binding. `spots.json` is plain JSON, so any application can
 read the registry without going through the CLI.
 
-To adopt an existing `.tonk/` directory (from a pre-spots checkout, or
-somewhere you keep data outside the canonical store) as a spot, point
-`--site` at it: `tonk spot new proj --site ~/proj/.tonk`. The local identity
+To adopt an existing `.tonk/` directory (from a pre-registry checkout, or
+somewhere you keep data outside the canonical store) as a space, point
+`--site` at it: `tonk space new proj --site ~/proj/.tonk`. The local identity
 is a shared profile (`tonk identity` prints its DID; `--reset` mints a fresh
 one).
 
@@ -138,8 +149,9 @@ rooted selected profile back into that same account.
 
 Directory bindings carry both the profile and the space name. A directory
 bound to profile A's `garden` continues to open A even when B is selected;
-explicit `--spot garden`, `TONK_SPOT=garden`, new spaces, joins, pulls, and
-account commands use the selected profile. Different profiles may therefore
+explicit `--space garden` (or compatibility `--spot`), `TONK_SPACE` (or
+`TONK_SPOT`), new spaces, joins, pulls, and account commands use the selected
+profile. Different profiles may therefore
 both have a space named `garden` without sharing state or authority.
 
 After account login, Tonk asks that ceremony deployment for
@@ -188,8 +200,44 @@ provider, deployment, or account repository for profile A's space.
 | State | Local query/edit/commit | Remote sync |
 | --- | --- | --- |
 | Logged out | allowed | denied before HTTP |
-| Active account, spot delegated to it | allowed | allowed with only that account's grant |
-| Active account, spot delegated only to another account | allowed | denied before HTTP |
+| Active account, space delegated to it | allowed | allowed with only that account's grant |
+| Active account, space delegated only to another account | allowed | denied before HTTP |
+
+### Space inventory and lifecycle
+
+`tonk space list` joins local registration, signed account membership,
+transport, synchronization, authority, and device-local visibility without
+collapsing them into one “synced” flag. The default read is offline and does
+not mutate repositories. `--refresh` may fetch provider inventory and remote
+heads, but never pulls, merges, provisions, pushes, archives, or changes a
+directory binding. `--all` includes suppressed, archived, ambiguous, and
+orphaned rows; `--json` emits the stable version-1 lifecycle schema.
+
+“Remove from this device” and “Archive from account” are deliberately separate:
+
+| Operation | Local registration/data | Account discovery | Authority or remote/peer data |
+| --- | --- | --- | --- |
+| `tonk space rm` | hides locally; may delete local bytes | remains active | unchanged |
+| explicit `account spaces pull` | mounts locally and clears this profile's suppression | unchanged | unchanged |
+| `tonk space archive <SUBJECT>` | unchanged | permanently archived for this subject | unchanged |
+
+Archive writes a signed monotonic tombstone. It never means “delete
+everywhere”: offline peers and already-held copies cannot be compelled to
+erase data. A saved-access artifact is also not a content backup. Tonk reports
+an exact `confirmedRevision` only after that tree was accepted by the content
+remote; a remote URL alone is not evidence that current content is recoverable.
+
+Canonical vocabulary is `space`, `--space`, `TONK_SPACE`, `account spaces`,
+and `share`. For at least this compatibility release the visible aliases below
+reach the identical handlers and telemetry operation:
+
+| Compatibility spelling | Canonical spelling |
+| --- | --- |
+| `spot` | `space` |
+| `--spot` | `--space` |
+| `TONK_SPOT` | `TONK_SPACE` |
+| `account spots` | `account spaces` |
+| `invite` | `share` |
 
 ### Sync and sharing
 
@@ -200,12 +248,12 @@ with errors that name the upstream-not-configured and non-fast-forward cases.
 Remotes are UCAN-S3 access services registered on the repository's meta branch.
 Their immutable-artifact relay is separate metadata supplied with
 `tonk remote add --revocation-url`; it is never inferred from the access host.
-`tonk invite` mints a UCAN delegation chain over the repo and prints an
+`tonk share` mints a UCAN delegation chain over the repo and prints an
 audience-open invite URL (anyone holding it can claim by redelegating from the
-embedded ephemeral key); `tonk join` claims one into a fresh spot
-(`tonk join <url> --name <spot>`).
+embedded ephemeral key); `tonk join` claims one into a fresh space
+(`tonk join <url> --name <space>`).
 
-A bare `tonk invite` resolves the repo's remote, builds the link on that
+A bare `tonk share` resolves the repo's remote, builds the link on that
 remote's origin, and embeds it so the claimer auto-configures the same access
 service. `--remote <NAME>` picks one when several are registered; `--no-remote`
 mints without one. A selected remote without relay metadata remains listable

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -60,9 +60,14 @@ tonk push
 tonk pull
 tonk status       # synced | ahead | behind | diverged | no-upstream
 
-# Link this native profile to a passkey-backed account.
+# Manage several isolated native account profiles.
 tonk account status
-tonk account link --name workstation
+tonk account add --label personal --name workstation
+tonk account add --label work
+tonk account list
+tonk account use personal
+tonk account login
+tonk account sync
 tonk account logout
 
 # Delegate access to the space.
@@ -120,21 +125,39 @@ When an upstream is configured, a committing eval is wrapped with an automatic
 pull-before / push-after. `--no-sync` (or `TONK_NO_SYNC`) skips it; manual
 `tonk push` / `tonk pull` stay available either way.
 
-### Accounts
+### Accounts and profiles
 
-The CLI has at most one active remote account. Every `tonk account link`
-requires a fresh browser/passkey handoff; switching accounts is logout followed
-by link. Historical certificates remain available for local spot writes, but
-only the latest active attachment can authorize a remote request.
+One installation can retain several native profiles. Each profile owns a
+distinct Dialog identity, account session and lock, account repository, space
+registry, canonical space directory, deployment defaults, and credential
+store. `tonk account add --label <name>` creates a profile, `account use`
+selects one locally without a network request, and `account login` signs a
+rooted profile back into its immutable account root. `account link` remains a
+compatibility spelling: it creates or resumes an unrooted profile, and logs a
+rooted selected profile back into that same account.
 
-Interrupting `tonk account link` leaves the handoff recorded so the next run
-resumes it. A link token is one-time, so a service that refuses to reissue it
-has ended that handoff and not this profile's ability to link: the next run
+Directory bindings carry both the profile and the space name. A directory
+bound to profile A's `garden` continues to open A even when B is selected;
+explicit `--spot garden`, `TONK_SPOT=garden`, new spaces, joins, pulls, and
+account commands use the selected profile. Different profiles may therefore
+both have a space named `garden` without sharing state or authority.
+
+After account login, Tonk asks that ceremony deployment for
+`/.well-known/tonk`. A matching typed response supplies that profile's default
+content access endpoint and revocation relay. Discovery failure leaves login
+successful and reports `sync defaults: pending`; it never silently substitutes
+a production service. Existing custom upstreams always win.
+
+Interrupting `tonk account add` or `link` leaves the provisional profile and
+handoff recorded so the next run resumes both. A link token is one-time, so a
+service that refuses to reissue it has ended that handoff and not this
+profile's ability to link: the next run
 takes the completed grant if the browser approved in the meantime, and
 otherwise prints a fresh URL rather than re-offering a spent token.
 
 `tonk account logout` commits locally first, so it works offline. Existing
-spots remain readable and editable, while fetch, pull, push, account sync, and
+spaces remain readable and editable through their owning profile, while
+fetch, pull, push, account sync, and
 other access-service requests are denied before HTTP. Logout queues a
 signed, generation-specific detach intent; the device list may remain stale
 until a later account operation reaches the provider and flushes that outbox.
@@ -149,11 +172,18 @@ one-active-generation rule would reject the activation. `tonk account link
 --abandon-detach` drops those undelivered intents and links anyway; the
 earlier device can stay listed until `tonk account revoke` removes it.
 
-Detach is not revocation. It hides the exact attachment and permits a later
+Account selection and logout are not revocation. Selection only changes the
+default local profile. Detach hides the exact attachment and permits a later
 fresh handoff without publishing an immutable revocation. `tonk account revoke
 <DEVICE_DID>` permanently revokes the selected grant, which can never be
 reactivated. Use `tonk identity --reset` only for destructive local identity
-rotation.
+rotation; it refuses while the selected profile still owns registered spaces.
+
+Profiles are an operational isolation boundary inside supported Tonk CLI
+paths, not encryption or an OS-user security boundary. Another process running
+as the same user may read the unencrypted local files. Remote services enforce
+the signed delegation chain; Tonk prevents accidental use of profile B's grant,
+provider, deployment, or account repository for profile A's space.
 
 | State | Local query/edit/commit | Remote sync |
 | --- | --- | --- |

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -138,6 +138,8 @@ pub struct LinkOptions {
     /// Where account state lives. Defaults to the install's own store when
     /// absent; a caller running outside an install supplies its own.
     pub store: Option<crate::spot::SpotStore>,
+    /// Immutable account root required by a rooted profile login.
+    pub expected_root: Option<String>,
     /// Send the approval URL here instead of relying on the OS to open it.
     ///
     /// `webbrowser::open` is the product path; this exists for callers that
@@ -183,16 +185,7 @@ async fn decode_provider(
         .context("stored account provider is unusable")
 }
 
-/// Load the provider attachment through an already-mounted site operator.
-pub(crate) async fn stored_provider_with_operator(
-    profile: &Profile,
-    operator: &dialog_operator::Operator<NativeSpace>,
-) -> Result<Option<AccountProviderRecord>> {
-    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
-    stored_provider_for_store(profile, operator, &store).await
-}
-
-/// [`stored_provider_with_operator`] against a caller-supplied store.
+/// Load the provider attachment through an explicit profile store.
 pub(crate) async fn stored_provider_in(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
@@ -242,37 +235,43 @@ const ACCOUNT_REQUIRED: &str = "A Tonk account is required; run `tonk account li
 /// only ever issued to an account, so what it mints stays revocable and what
 /// it creates gets backed up. `Unhydrated` and `Unconfigured` accounts pass —
 /// an account that exists but has not synchronized is still an account.
-pub(crate) async fn require_account_with_operator(
+/// Refuse unless the explicit native profile store holds an attachment.
+pub(crate) async fn require_account_with_operator_in(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::spot::SpotStore,
 ) -> Result<()> {
-    match stored_provider_with_operator(profile, operator).await? {
+    match stored_provider_in(profile, operator, store).await? {
         Some(_) => Ok(()),
         None => bail!(ACCOUNT_REQUIRED),
     }
 }
 
-pub(crate) async fn stored_provider(profile: &Profile) -> Result<Option<AccountProviderRecord>> {
-    let operator = crate::account_state::credential_operator(profile).await?;
-    stored_provider_with_operator(profile, &operator).await
-}
-
 /// Disconnect provider services while preserving this profile's root,
 /// delegations, account repository, and spots.
 pub async fn logout(profile: &Profile) -> Result<()> {
-    let operator = crate::account_state::credential_operator(profile).await?;
-    logout_with_operator(profile, &operator).await
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    logout_in(profile, &store).await
+}
+
+/// Log out only the account session stored in `store`.
+pub async fn logout_in(profile: &Profile, store: &crate::spot::SpotStore) -> Result<()> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    logout_with_operator(profile, &operator, store).await
 }
 
 async fn logout_with_operator(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::spot::SpotStore,
 ) -> Result<()> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    for account in crate::account_session::logout_transition(profile, operator).await? {
+    for account in
+        crate::account_session::logout_transition_for_store(profile, operator, store).await?
+    {
         if let Err(error) = crate::account_session::deliver_detach(profile, &account, now).await {
             eprintln!(
                 "warning: logged out locally; the provider was not notified                  and may list this device until it is revoked: {error:#}"
@@ -294,18 +293,43 @@ fn parse_root_did(root_did: &str) -> Result<dialog_varsig::Did> {
 /// command. Hydration is [`crate::account_state::ensure`]'s job, and the
 /// paths that need it call it directly.
 pub async fn status(profile: &Profile) -> Result<AccountStatus> {
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    status_in(profile, &store).await
+}
+
+/// Read account state from one explicit profile store without contacting its
+/// provider.
+pub async fn status_in(profile: &Profile, store: &crate::spot::SpotStore) -> Result<AccountStatus> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    local_status_with_operator(profile, store, &operator).await
+}
+
+/// Read one profile's status using local durable state only.
+pub async fn local_status_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<AccountStatus> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    local_status_with_operator(profile, store, &operator).await
+}
+
+async fn local_status_with_operator(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+    operator: &dialog_operator::Operator<NativeSpace>,
+) -> Result<AccountStatus> {
     let device_did = profile.did().to_string();
-    let Some(root) = crate::identity::local_root(profile).await? else {
+    let Some(root) = crate::identity::local_root_with_operator(profile, operator).await? else {
         return Ok(AccountStatus::MissingRoot { device_did });
     };
-    match stored_provider(profile).await? {
+    match stored_provider_in(profile, operator, store).await? {
         None => Ok(AccountStatus::Unregistered {
             root_did: root.root_did,
             device_did,
         }),
         Some(provider) => {
             let account_state = if provider.descriptor().is_some() {
-                crate::account_state::status(profile).await?
+                crate::account_state::status_in(profile, store).await?
             } else {
                 AccountStateStatus::Unconfigured
             };
@@ -317,6 +341,15 @@ pub async fn status(profile: &Profile) -> Result<AccountStatus> {
             })
         }
     }
+}
+
+fn require_expected_root(options: &LinkOptions, actual: &str) -> Result<()> {
+    if let Some(expected) = options.expected_root.as_deref()
+        && expected != actual
+    {
+        bail!("this profile belongs to {expected}; run `tonk account add` to use another account");
+    }
+    Ok(())
 }
 
 /// Validate a delegation the browser returned as an `account → this profile`
@@ -410,6 +443,7 @@ async fn link_via_callback(
     let chain = validate_account_grant(profile, &grant_bytes).await?;
     let account_did = chain.issuer().clone();
     let root_did = account_did.to_string();
+    require_expected_root(options, &root_did)?;
 
     // Install the inbound half so this device can act, and record the root
     // the way a linked device does.
@@ -480,7 +514,7 @@ async fn link_via_callback(
         let account_state = match crate::account_state::ensure_with_operator_and_store(
             profile,
             operator.clone(),
-            store,
+            store.clone(),
         )
         .await
         {
@@ -488,7 +522,9 @@ async fn link_via_callback(
             Err(_) => AccountStateStatus::Unhydrated,
         };
         let mut warning = None;
-        if let Some(branch) = crate::account_state::open_account_branch(profile, operator).await? {
+        if let Some(branch) =
+            crate::account_state::open_account_branch_in(profile, operator, &store).await?
+        {
             let signer = profile.signer().signer().clone();
             let union =
                 tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
@@ -556,7 +592,11 @@ struct CallbackAuthorization {
 
 /// Start or resume a browser handoff and activate its fresh generation.
 pub async fn link(profile: &Profile, options: &LinkOptions) -> Result<LinkOutcome> {
-    let operator = crate::account_state::credential_operator(profile).await?;
+    let store = match options.store.as_ref() {
+        Some(store) => store.clone(),
+        None => crate::spot::SpotStore::open().context("failed to locate account state")?,
+    };
+    let operator = crate::account_state::credential_operator_for_store(profile, &store).await?;
     link_with_operator(profile, &operator, options).await
 }
 
@@ -570,7 +610,10 @@ pub async fn link_with_operator(
     operator: &dialog_operator::Operator<NativeSpace>,
     options: &LinkOptions,
 ) -> Result<LinkOutcome> {
-    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    let store = match options.store.as_ref() {
+        Some(store) => store.clone(),
+        None => crate::spot::SpotStore::open().context("failed to locate account state")?,
+    };
     {
         let guard = crate::account_session::exclusive_transition_guard(&store)?;
         crate::account_session::ensure_initialized(profile, operator, &guard).await?;
@@ -612,28 +655,13 @@ pub(crate) struct AccountConnection {
     store: crate::spot::SpotStore,
 }
 
-async fn connection_from_provider(
+/// Load an attachment through the account directory owned by an explicit
+/// spot store. Account-spots tests and isolated consumers use this without
+/// changing process-global profile paths.
+pub(crate) async fn connection_for_store(
     profile: &Profile,
-    provider: AccountProviderRecord,
+    store: &crate::spot::SpotStore,
 ) -> Result<AccountConnection> {
-    let service_url = provider.provider().to_string();
-    let root = crate::identity::local_root(profile)
-        .await?
-        .context("the provider attachment has no local root")?;
-    let bytes = hex::decode(root.delegation_hex).context("stored local-root hex is invalid")?;
-    let link = DelegationChain::try_from(bytes.as_slice())
-        .context("stored local-root delegation is invalid")?;
-    let root_did = link.issuer().clone();
-    Ok(AccountConnection {
-        service_url,
-        root_did,
-        link,
-        store: crate::spot::SpotStore::open().context("failed to locate account state")?,
-    })
-}
-
-/// Load the attached provider and exact `root → device` link when present.
-pub(crate) async fn optional_connection(profile: &Profile) -> Result<Option<AccountConnection>> {
     #[cfg(feature = "integration-tests")]
     if let Some((service_url, link, _)) = integration_connections()
         .lock()
@@ -641,17 +669,61 @@ pub(crate) async fn optional_connection(profile: &Profile) -> Result<Option<Acco
         .get(profile.did().as_ref())
         .cloned()
     {
-        return Ok(Some(AccountConnection {
+        return Ok(AccountConnection {
             service_url,
             root_did: link.issuer().clone(),
             link,
-            store: crate::spot::SpotStore::open().context("failed to locate account state")?,
-        }));
+            store: store.clone(),
+        });
     }
-    let Some(provider) = stored_provider(profile).await? else {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    let provider = stored_provider_for_store(profile, &operator, store)
+        .await?
+        .context("no account provider is attached; run `tonk account link`")?;
+    let root = crate::identity::local_root_with_operator(profile, &operator)
+        .await?
+        .context("the provider attachment has no local root")?;
+    let bytes = hex::decode(root.delegation_hex).context("stored local-root hex is invalid")?;
+    let link = DelegationChain::try_from(bytes.as_slice())
+        .context("stored local-root delegation is invalid")?;
+    Ok(AccountConnection {
+        service_url: provider.provider().to_string(),
+        root_did: link.issuer().clone(),
+        link,
+        store: store.clone(),
+    })
+}
+
+/// Load the attached provider and exact `root → device` link when present
+/// from one explicit profile store.
+pub(crate) async fn optional_connection_for_store(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<Option<AccountConnection>> {
+    #[cfg(feature = "integration-tests")]
+    if integration_connections()
+        .lock()
+        .expect("integration connection registry")
+        .contains_key(profile.did().as_ref())
+    {
+        return connection_for_store(profile, store).await.map(Some);
+    }
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    let Some(provider) = stored_provider_for_store(profile, &operator, store).await? else {
         return Ok(None);
     };
-    Ok(Some(connection_from_provider(profile, provider).await?))
+    let root = crate::identity::local_root_with_operator(profile, &operator)
+        .await?
+        .context("the provider attachment has no local root")?;
+    let bytes = hex::decode(root.delegation_hex).context("stored local-root hex is invalid")?;
+    let link = DelegationChain::try_from(bytes.as_slice())
+        .context("stored local-root delegation is invalid")?;
+    Ok(Some(AccountConnection {
+        service_url: provider.provider().to_string(),
+        root_did: link.issuer().clone(),
+        link,
+        store: store.clone(),
+    }))
 }
 
 #[cfg(feature = "integration-tests")]
@@ -751,6 +823,16 @@ pub async fn attach_for_integration_test(
     Ok(())
 }
 
+#[cfg(feature = "integration-tests")]
+/// Detach an isolated test profile through its already-mounted operator.
+#[doc(hidden)]
+pub async fn logout_for_integration_test(
+    profile: &Profile,
+    operator: &crate::account_authority::AccountBoundOperator,
+) -> Result<()> {
+    logout_with_operator(profile, operator.local(), operator.store()).await
+}
+
 impl AccountConnection {
     /// Sign and POST one account invocation, preserving the raw HTTP status
     /// so callers can implement rolling-deployment fallbacks.
@@ -839,7 +921,17 @@ async fn post_invocation_raw(
 /// recorded provider is authoritative; a `service_url` names one only
 /// to cross-check it against the active account.
 pub async fn devices(profile: &Profile, service_url: Option<&str>) -> Result<Vec<DeviceRow>> {
-    let connection = optional_connection(profile)
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    devices_in(profile, &store, service_url).await
+}
+
+/// List devices through one explicit profile store.
+pub async fn devices_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+    service_url: Option<&str>,
+) -> Result<Vec<DeviceRow>> {
+    let connection = optional_connection_for_store(profile, store)
         .await?
         .context("no active account; run `tonk account link`")?;
     if let Some(service_url) = service_url
@@ -909,6 +1001,8 @@ pub struct RevokeOptions {
     pub account_url: String,
     /// Whether to ask the OS to open the ceremony URL.
     pub open_browser: bool,
+    /// Profile-scoped account state.
+    pub store: Option<crate::spot::SpotStore>,
 }
 
 /// How a revocation request resolved. The caller owns the messaging.
@@ -927,10 +1021,12 @@ pub async fn revoke(
     options: &RevokeOptions,
     did: &str,
 ) -> Result<RevokeOutcome> {
+    let store = match options.store.as_ref() {
+        Some(store) => store.clone(),
+        None => crate::spot::SpotStore::open().context("failed to locate account state")?,
+    };
     if profile.did().as_ref() == did {
-        let connection = optional_connection(profile)
-            .await?
-            .context("no active account; run `tonk account link`")?;
+        let connection = connection_for_store(profile, &store).await?;
         let link = connection.link.clone();
         let target = link.proof_cids()[0];
         let artifact = tonk_identity::revocation::mint_self_revocation(
@@ -940,7 +1036,7 @@ pub async fn revoke(
         )
         .await
         .context("failed to sign self-revocation")?;
-        let rows = devices(profile, Some(&options.service_url)).await?;
+        let rows = devices_in(profile, &store, Some(&options.service_url)).await?;
         let row = rows
             .iter()
             .find(|row| row.did == did && row.delegation_cid == target.to_string())
@@ -977,7 +1073,7 @@ pub async fn revoke(
         return Ok(RevokeOutcome::Revoked);
     }
 
-    let rows = devices(profile, Some(&options.service_url)).await?;
+    let rows = devices_in(profile, &store, Some(&options.service_url)).await?;
     let target = rows
         .iter()
         .find(|row| row.did == did)
@@ -1023,7 +1119,7 @@ pub async fn revoke(
             }
         }
         tokio::select! {
-            rows = devices(profile, Some(&options.service_url)) => match rows {
+            rows = devices_in(profile, &store, Some(&options.service_url)) => match rows {
                 Ok(rows) => {
                     last_error = None;
                     if rows.iter().any(|row| {
@@ -1159,22 +1255,26 @@ mod tests {
         std::fs::write(&sentinel, b"keep").unwrap();
 
         assert!(
-            stored_provider_with_operator(&profile, &operator)
+            stored_provider_in(&profile, &operator, &store)
                 .await
                 .unwrap()
                 .is_some()
         );
 
-        logout_with_operator(&profile, &operator).await.unwrap();
+        logout_with_operator(&profile, &operator, &store)
+            .await
+            .unwrap();
 
         assert!(
-            stored_provider_with_operator(&profile, &operator)
+            stored_provider_in(&profile, &operator, &store)
                 .await
                 .unwrap()
                 .is_none()
         );
 
-        logout_with_operator(&profile, &operator).await.unwrap();
+        logout_with_operator(&profile, &operator, &store)
+            .await
+            .unwrap();
 
         assert_eq!(
             profile

--- a/rust/tonk-cli/src/account_authority.rs
+++ b/rust/tonk-cli/src/account_authority.rs
@@ -69,7 +69,7 @@ impl AccountBoundOperator {
         &self.inner
     }
 
-    #[cfg(feature = "integration-tests")]
+    /// Account/session store owned by the resolved native profile.
     pub(crate) fn store(&self) -> &SpotStore {
         &self.store
     }
@@ -164,18 +164,17 @@ impl AccountBoundOperator {
         let mut chain = if subject == root {
             grant
         } else {
-            // Resolving rather than reading: a spot predating this account,
-            // or created by a release that stored no prefix, still has to
-            // reach its own remote. Recovery is the same one every other
-            // account path uses, so the authority a spot syncs with is the
-            // authority it gets backed up with.
-            let prefix =
-                crate::site::account_root_prefix_for(&self.profile, &self.inner, &subject, &root)
-                    .await
-                    .map_err(|_| AuthorizeError::UnprovenSubject {
-                        claimed: root.clone(),
-                        authorized: subject.clone(),
-                    })?;
+            let prefix = crate::site::load_account_root_prefix_for(
+                &self.profile,
+                &self.inner,
+                &subject,
+                &root,
+            )
+            .await
+            .map_err(|_| AuthorizeError::UnprovenSubject {
+                claimed: root.clone(),
+                authorized: subject.clone(),
+            })?;
             let active_proof = grant.proofs().next().unwrap().clone();
             prefix
                 .push(active_proof)

--- a/rust/tonk-cli/src/account_profiles.rs
+++ b/rust/tonk-cli/src/account_profiles.rs
@@ -1,0 +1,904 @@
+//! Install-level routing for native account profiles.
+//!
+//! A profile owns one Dialog identity and one [`SpotStore`]. The install-level
+//! registry contains only the selected default profile and directory bindings;
+//! it never contains credentials or delegation bytes.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use dialog_effects::storage::Directory;
+use dialog_operator::Profile;
+use dialog_storage::provider::storage::{NativeSpace, Storage};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::spot::{self, Source, SpotStore};
+
+/// Stable ID assigned to the grandfathered single-profile installation.
+pub const LEGACY_PROFILE_ID: &str = "legacy";
+const REGISTRY_VERSION: u8 = 1;
+const REGISTRY_FILE: &str = "profiles.json";
+
+/// Opaque install-local identifier for one native profile.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct NativeProfileId(String);
+
+impl NativeProfileId {
+    /// Return the grandfathered profile ID.
+    pub fn legacy() -> Self {
+        Self(LEGACY_PROFILE_ID.to_owned())
+    }
+
+    /// Generate a cryptographically random native profile ID.
+    pub fn generate() -> Self {
+        Self::from_bytes(rand::random())
+    }
+
+    fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(format!("p-{}", hex::encode(bytes)))
+    }
+
+    /// Borrow the serialized identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn generated_hex(&self) -> Option<&str> {
+        self.0.strip_prefix("p-").filter(|suffix| {
+            suffix.len() == 32
+                && suffix
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        })
+    }
+
+    fn is_valid(&self) -> bool {
+        self.0 == LEGACY_PROFILE_ID || self.generated_hex().is_some()
+    }
+}
+
+/// Recover the deterministic Dialog profile name from a generated profile's
+/// isolated state root. Legacy and arbitrary test stores return `None`.
+pub(crate) fn generated_dialog_profile_name(store: &SpotStore) -> Option<String> {
+    let profile_id = store.root().file_name()?.to_str()?;
+    let suffix = profile_id.strip_prefix("p-")?;
+    (suffix.len() == 32
+        && suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
+    .then(|| format!("tonk-{suffix}"))
+}
+
+impl std::fmt::Display for NativeProfileId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Non-secret routing and deployment metadata for one native profile.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeProfileRecord {
+    /// Unique case-insensitive local label.
+    pub label: String,
+    /// Isolated Dialog key-profile name.
+    pub dialog_profile_name: String,
+    /// Immutable account-root index after the first successful ceremony.
+    pub account_root: Option<String>,
+    /// Origin that hosted the most recent successful ceremony.
+    pub ceremony_origin: Option<String>,
+    /// Provider-matched default content endpoint.
+    pub default_access_remote: Option<String>,
+    /// Provider-matched invitation-revocation relay.
+    pub default_revocation_relay: Option<String>,
+    /// Unknown forward-compatible profile fields.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Exact profile and space selected by a directory binding.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoundSpace {
+    /// Owning native profile.
+    pub profile: NativeProfileId,
+    /// Profile-local space name.
+    pub space: String,
+}
+
+/// Version-one install-level profile roster and directory bindings.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeProfileRegistryV1 {
+    /// Schema version, exactly one.
+    pub version: u8,
+    /// Default profile for account commands and explicit space names.
+    pub selected: Option<NativeProfileId>,
+    #[serde(default)]
+    /// Profiles keyed by opaque install-local ID.
+    pub profiles: BTreeMap<NativeProfileId, NativeProfileRecord>,
+    #[serde(default)]
+    /// Canonical directory paths mapped to exact profile-local spaces.
+    pub bindings: BTreeMap<PathBuf, BoundSpace>,
+    #[serde(flatten)]
+    /// Unknown forward-compatible registry fields.
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Default for NativeProfileRegistryV1 {
+    fn default() -> Self {
+        Self {
+            version: REGISTRY_VERSION,
+            selected: None,
+            profiles: BTreeMap::new(),
+            bindings: BTreeMap::new(),
+            extra: serde_json::Map::new(),
+        }
+    }
+}
+
+/// Fully resolved operational context for one native profile.
+#[derive(Clone, Debug)]
+pub struct NativeProfileContext {
+    /// Install-local profile identifier.
+    pub id: NativeProfileId,
+    /// Persisted non-secret metadata.
+    pub record: NativeProfileRecord,
+    /// Profile-local space and account-state store.
+    pub store: SpotStore,
+}
+
+/// Local provider session state shown by `tonk account list`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProfileSignIn {
+    /// No active provider attachment.
+    SignedOut,
+    /// A browser ceremony can be resumed.
+    Pending,
+    /// A provider attachment is active.
+    Active,
+}
+
+impl NativeProfileContext {
+    /// Open or create this context's isolated Dialog key profile.
+    pub async fn open_profile(&self) -> anyhow::Result<Profile> {
+        Profile::open(self.record.dialog_profile_name.clone())
+            .at(Directory::Profile)
+            .perform(&Storage::<NativeSpace>::default())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to open Dialog profile '{}' for native profile {}",
+                    self.record.dialog_profile_name, self.id
+                )
+            })
+    }
+
+    /// Load an existing Dialog profile without creating one.
+    pub async fn load_profile(&self) -> anyhow::Result<Profile> {
+        Profile::load(self.record.dialog_profile_name.clone())
+            .at(Directory::Profile)
+            .perform(&Storage::<NativeSpace>::default())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to load Dialog profile '{}' for native profile {}",
+                    self.record.dialog_profile_name, self.id
+                )
+            })
+    }
+
+    /// Build site configuration pinned to this context.
+    pub fn site_config(&self) -> crate::site::SiteConfig {
+        crate::site::SiteConfig {
+            profile_name: self.record.dialog_profile_name.clone(),
+            profile_directory: Directory::Profile,
+            require_account: std::env::var_os("TONK_UNSAFE_ALLOW_DEVICE_ROOT").is_none(),
+            account_store: self.store.clone(),
+        }
+    }
+
+    /// Inspect the local session sidecar without creating profile state.
+    pub fn sign_in_state(&self) -> Result<ProfileSignIn, ProfileError> {
+        crate::account_session::inspect_local(&self.store)
+            .map(|phase| match phase {
+                crate::account_session::LocalPhase::SignedOut => ProfileSignIn::SignedOut,
+                crate::account_session::LocalPhase::Pending => ProfileSignIn::Pending,
+                crate::account_session::LocalPhase::Active => ProfileSignIn::Active,
+            })
+            .map_err(|error| ProfileError::Io {
+                path: self.store.account_dir(),
+                detail: error.to_string(),
+            })
+    }
+}
+
+/// Space selection resolved to an immutable profile context.
+#[derive(Clone, Debug)]
+pub struct ResolvedSpace {
+    /// Owning native profile.
+    pub profile: NativeProfileContext,
+    /// Profile-local registered name.
+    pub name: String,
+    /// Canonical site directory.
+    pub site: PathBuf,
+    /// Precedence source that selected this space.
+    pub source: Source,
+}
+
+/// Install profile registry and routing failures.
+#[derive(Debug, Error)]
+pub enum ProfileError {
+    /// Registry JSON or shape is invalid.
+    #[error("corrupt native profile registry at {path}: {detail}")]
+    Corrupt {
+        /// Registry path.
+        path: PathBuf,
+        /// Parse or validation detail.
+        detail: String,
+    },
+    /// Registry version is unsupported.
+    #[error("unsupported version {version} in {path}")]
+    UnsupportedVersion {
+        /// Registry path.
+        path: PathBuf,
+        /// Unsupported serialized version.
+        version: u64,
+    },
+    /// A selected or bound profile is absent from the roster.
+    #[error("native profile registry at {path} references unknown profile '{profile}'")]
+    UnknownProfile {
+        /// Registry path.
+        path: PathBuf,
+        /// Referenced missing profile.
+        profile: NativeProfileId,
+    },
+    /// A binding points at a missing profile-local space.
+    #[error(
+        "unknown spot '{space}' in profile '{profile}'; native profile registry at {path} has a binding at {directory}; clear it with `tonk spot unbind {directory}`"
+    )]
+    DanglingBinding {
+        /// Registry path.
+        path: PathBuf,
+        /// Canonical bound directory.
+        directory: PathBuf,
+        /// Owning profile from the binding.
+        profile: NativeProfileId,
+        /// Missing profile-local name.
+        space: String,
+    },
+    /// No default profile exists yet.
+    #[error("no native account profile is selected; run `tonk account add`")]
+    NoSelectedProfile,
+    /// A label violates the documented slug contract.
+    #[error("invalid account profile label '{0}': use [a-z0-9][a-z0-9-_]*")]
+    InvalidLabel(String),
+    /// A label collides case-insensitively.
+    #[error("account profile label '{0}' is already in use")]
+    DuplicateLabel(String),
+    /// A serialized or generated profile ID is malformed.
+    #[error("invalid native profile id '{0}'")]
+    InvalidProfileId(String),
+    /// Filesystem persistence failed.
+    #[error("could not create or update {path}: {detail}")]
+    Io {
+        /// Affected path.
+        path: PathBuf,
+        /// Underlying error detail.
+        detail: String,
+    },
+    /// Profile-local spot registry failure.
+    #[error(transparent)]
+    Spot(#[from] spot::SpotError),
+}
+
+/// Install-level profile registry rooted beside legacy `spots.json`.
+#[derive(Clone, Debug)]
+pub struct NativeProfileStore {
+    install: SpotStore,
+}
+
+impl NativeProfileStore {
+    /// Locate the native install root from the normal environment contract.
+    pub fn open() -> Result<Self, ProfileError> {
+        Ok(Self {
+            install: SpotStore::open()?,
+        })
+    }
+
+    /// Construct a store at an explicit install root.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self {
+            install: SpotStore::at(root),
+        }
+    }
+
+    /// Borrow the install root.
+    pub fn root(&self) -> &Path {
+        self.install.root()
+    }
+
+    /// Return the install registry path.
+    pub fn registry_path(&self) -> PathBuf {
+        self.root().join(REGISTRY_FILE)
+    }
+
+    /// Load and validate the registry, bootstrapping legacy metadata only.
+    pub fn load_or_bootstrap(&self) -> Result<NativeProfileRegistryV1, ProfileError> {
+        let path = self.registry_path();
+        match std::fs::read_to_string(&path) {
+            Ok(text) => self.parse_and_validate(&path, &text),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => self.bootstrap_legacy(),
+            Err(error) => Err(ProfileError::Io {
+                path,
+                detail: error.to_string(),
+            }),
+        }
+    }
+
+    fn parse_and_validate(
+        &self,
+        path: &Path,
+        text: &str,
+    ) -> Result<NativeProfileRegistryV1, ProfileError> {
+        let value: serde_json::Value =
+            serde_json::from_str(text).map_err(|error| ProfileError::Corrupt {
+                path: path.to_path_buf(),
+                detail: error.to_string(),
+            })?;
+        let version = value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| ProfileError::Corrupt {
+                path: path.to_path_buf(),
+                detail: "missing integer field 'version'".to_owned(),
+            })?;
+        if version != u64::from(REGISTRY_VERSION) {
+            return Err(ProfileError::UnsupportedVersion {
+                path: path.to_path_buf(),
+                version,
+            });
+        }
+        let mut registry: NativeProfileRegistryV1 =
+            serde_json::from_value(value).map_err(|error| ProfileError::Corrupt {
+                path: path.to_path_buf(),
+                detail: error.to_string(),
+            })?;
+        registry.bindings = registry
+            .bindings
+            .into_iter()
+            .map(|(directory, binding)| (canonical(&directory), binding))
+            .collect();
+        self.validate(&registry)?;
+        Ok(registry)
+    }
+
+    fn bootstrap_legacy(&self) -> Result<NativeProfileRegistryV1, ProfileError> {
+        let has_legacy_state = self.install.registry_path().exists()
+            || self.install.spots_root().exists()
+            || self.install.account_dir().exists();
+        if !has_legacy_state {
+            return Ok(NativeProfileRegistryV1::default());
+        }
+
+        let spots = self.install.load()?;
+        let legacy = NativeProfileId::legacy();
+        let mut registry = NativeProfileRegistryV1 {
+            selected: Some(legacy.clone()),
+            ..NativeProfileRegistryV1::default()
+        };
+        registry.profiles.insert(
+            legacy.clone(),
+            NativeProfileRecord {
+                label: "default".to_owned(),
+                dialog_profile_name: crate::site::PROFILE_NAME.to_owned(),
+                account_root: None,
+                ceremony_origin: None,
+                default_access_remote: None,
+                default_revocation_relay: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+        registry.bindings = spots
+            .bindings
+            .into_iter()
+            .map(|(directory, space)| {
+                (
+                    canonical(&directory),
+                    BoundSpace {
+                        profile: legacy.clone(),
+                        space,
+                    },
+                )
+            })
+            .collect();
+        self.validate(&registry)?;
+        self.save(&registry)?;
+        Ok(registry)
+    }
+
+    fn validate(&self, registry: &NativeProfileRegistryV1) -> Result<(), ProfileError> {
+        let path = self.registry_path();
+        for id in registry.profiles.keys() {
+            if !id.is_valid() {
+                return Err(ProfileError::InvalidProfileId(id.to_string()));
+            }
+        }
+        if let Some(selected) = &registry.selected
+            && !registry.profiles.contains_key(selected)
+        {
+            return Err(ProfileError::UnknownProfile {
+                path,
+                profile: selected.clone(),
+            });
+        }
+        let mut labels = BTreeSet::new();
+        for record in registry.profiles.values() {
+            validate_label(&record.label)?;
+            if !labels.insert(record.label.to_ascii_lowercase()) {
+                return Err(ProfileError::DuplicateLabel(record.label.clone()));
+            }
+        }
+        for (directory, binding) in &registry.bindings {
+            let Some(_) = registry.profiles.get(&binding.profile) else {
+                return Err(ProfileError::UnknownProfile {
+                    path: path.clone(),
+                    profile: binding.profile.clone(),
+                });
+            };
+            let context = self.context_from(registry, &binding.profile)?;
+            if !context.store.load()?.spots.contains_key(&binding.space) {
+                return Err(ProfileError::DanglingBinding {
+                    path: path.clone(),
+                    directory: directory.clone(),
+                    profile: binding.profile.clone(),
+                    space: binding.space.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Atomically persist a validated version-one registry.
+    pub fn save(&self, registry: &NativeProfileRegistryV1) -> Result<(), ProfileError> {
+        self.validate(registry)?;
+        std::fs::create_dir_all(self.root()).map_err(|error| ProfileError::Io {
+            path: self.root().to_path_buf(),
+            detail: error.to_string(),
+        })?;
+        let path = self.registry_path();
+        let tmp = self.root().join(format!("{REGISTRY_FILE}.tmp"));
+        let bytes = serde_json::to_vec_pretty(registry).map_err(|error| ProfileError::Io {
+            path: path.clone(),
+            detail: error.to_string(),
+        })?;
+        std::fs::write(&tmp, bytes).map_err(|error| ProfileError::Io {
+            path: tmp.clone(),
+            detail: error.to_string(),
+        })?;
+        std::fs::rename(&tmp, &path).map_err(|error| ProfileError::Io {
+            path,
+            detail: error.to_string(),
+        })
+    }
+
+    /// Resolve the currently selected profile without opening Dialog state.
+    pub fn selected(&self) -> Result<Option<NativeProfileContext>, ProfileError> {
+        let registry = self.load_or_bootstrap()?;
+        registry
+            .selected
+            .as_ref()
+            .map(|id| self.context_from(&registry, id))
+            .transpose()
+    }
+
+    /// Return the selected context, creating the grandfathered local profile
+    /// only when an explicit write needs a profile on an otherwise empty
+    /// install. Read-only commands never call this boundary.
+    pub fn ensure_selected_for_local_write(&self) -> Result<NativeProfileContext, ProfileError> {
+        if let Some(selected) = self.selected()? {
+            return Ok(selected);
+        }
+        let mut registry = self.load_or_bootstrap()?;
+        let legacy = NativeProfileId::legacy();
+        registry.selected = Some(legacy.clone());
+        registry.profiles.insert(
+            legacy.clone(),
+            NativeProfileRecord {
+                label: "default".to_owned(),
+                dialog_profile_name: crate::site::PROFILE_NAME.to_owned(),
+                account_root: None,
+                ceremony_origin: None,
+                default_access_remote: None,
+                default_revocation_relay: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+        self.save(&registry)?;
+        self.context_from(&registry, &legacy)
+    }
+
+    /// Select a profile by case-insensitive label or exact ID.
+    pub fn select(&self, id_or_label: &str) -> Result<NativeProfileContext, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let id = lookup_id(&registry, id_or_label).ok_or_else(|| ProfileError::UnknownProfile {
+            path: self.registry_path(),
+            profile: NativeProfileId(id_or_label.to_owned()),
+        })?;
+        registry.selected = Some(id.clone());
+        self.save(&registry)?;
+        self.context_from(&registry, &id)
+    }
+
+    /// Resolve an exact profile ID without selecting or opening it.
+    pub fn context(&self, id: &NativeProfileId) -> Result<NativeProfileContext, ProfileError> {
+        let registry = self.load_or_bootstrap()?;
+        self.context_from(&registry, id)
+    }
+
+    /// Persist the immutable account-root index after a successful handoff.
+    pub fn record_account_root(
+        &self,
+        id: &NativeProfileId,
+        root: &str,
+        ceremony_origin: Option<&str>,
+    ) -> Result<NativeProfileContext, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let record = registry
+            .profiles
+            .get_mut(id)
+            .ok_or_else(|| ProfileError::UnknownProfile {
+                path: self.registry_path(),
+                profile: id.clone(),
+            })?;
+        if let Some(existing) = record.account_root.as_deref()
+            && existing != root
+        {
+            return Err(ProfileError::Io {
+                path: self.registry_path(),
+                detail: format!(
+                    "this profile belongs to {existing}; run `tonk account add` to use another account"
+                ),
+            });
+        }
+        record.account_root = Some(root.to_owned());
+        if let Some(origin) = ceremony_origin {
+            record.ceremony_origin = Some(origin.to_owned());
+        }
+        self.save(&registry)?;
+        self.context_from(&registry, id)
+    }
+
+    /// Atomically persist provider-matched content endpoints for one profile.
+    pub fn record_deployment_defaults(
+        &self,
+        id: &NativeProfileId,
+        defaults: &crate::deployment::DeploymentDefaults,
+    ) -> Result<NativeProfileContext, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let record = registry
+            .profiles
+            .get_mut(id)
+            .ok_or_else(|| ProfileError::UnknownProfile {
+                path: self.registry_path(),
+                profile: id.clone(),
+            })?;
+        record.ceremony_origin = Some(defaults.ceremony_origin.to_string());
+        record.default_access_remote = Some(defaults.access_remote.to_string());
+        record.default_revocation_relay = Some(defaults.revocation_relay.to_string());
+        self.save(&registry)?;
+        self.context_from(&registry, id)
+    }
+
+    fn context_from(
+        &self,
+        registry: &NativeProfileRegistryV1,
+        id: &NativeProfileId,
+    ) -> Result<NativeProfileContext, ProfileError> {
+        let record =
+            registry
+                .profiles
+                .get(id)
+                .cloned()
+                .ok_or_else(|| ProfileError::UnknownProfile {
+                    path: self.registry_path(),
+                    profile: id.clone(),
+                })?;
+        let store = if id.as_str() == LEGACY_PROFILE_ID {
+            self.install.clone()
+        } else {
+            SpotStore::at(self.root().join("profiles").join(id.as_str()))
+        };
+        Ok(NativeProfileContext {
+            id: id.clone(),
+            record,
+            store,
+        })
+    }
+
+    /// Create a fresh unrooted profile with a random ID.
+    pub fn create_pending(
+        &self,
+        label: Option<&str>,
+    ) -> Result<NativeProfileContext, ProfileError> {
+        self.create_pending_with_bytes(label, rand::random())
+    }
+
+    /// Resume the selected unrooted profile when it matches the requested
+    /// label, otherwise create a fresh provisional profile.
+    pub fn create_or_resume_pending(
+        &self,
+        label: Option<&str>,
+    ) -> Result<NativeProfileContext, ProfileError> {
+        if let Some(selected) = self.selected()?
+            && selected.record.account_root.is_none()
+            && label.is_none_or(|label| selected.record.label.eq_ignore_ascii_case(label))
+        {
+            return Ok(selected);
+        }
+        self.create_pending(label)
+    }
+
+    #[doc(hidden)]
+    pub fn create_pending_with_bytes(
+        &self,
+        label: Option<&str>,
+        bytes: [u8; 16],
+    ) -> Result<NativeProfileContext, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let id = NativeProfileId::from_bytes(bytes);
+        if registry.profiles.contains_key(&id) {
+            return Err(ProfileError::InvalidProfileId(format!(
+                "generated profile id collision: {id}"
+            )));
+        }
+        let label = match label {
+            Some(label) => {
+                validate_label(label)?;
+                label.to_owned()
+            }
+            None => next_default_label(&registry),
+        };
+        if registry
+            .profiles
+            .values()
+            .any(|record| record.label.eq_ignore_ascii_case(&label))
+        {
+            return Err(ProfileError::DuplicateLabel(label));
+        }
+        let suffix = id
+            .generated_hex()
+            .expect("generated native profile id has a hex suffix");
+        registry.profiles.insert(
+            id.clone(),
+            NativeProfileRecord {
+                label,
+                dialog_profile_name: format!("tonk-{suffix}"),
+                account_root: None,
+                ceremony_origin: None,
+                default_access_remote: None,
+                default_revocation_relay: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+        if registry.selected.is_none() {
+            registry.selected = Some(id.clone());
+        }
+        self.save(&registry)?;
+        self.context_from(&registry, &id)
+    }
+
+    /// Resolve a space using flag, environment, then nearest-binding precedence.
+    pub fn resolve(
+        &self,
+        flag: Option<&str>,
+        env: Option<&str>,
+        cwd: Option<&Path>,
+    ) -> Result<ResolvedSpace, ProfileError> {
+        let registry = self.load_or_bootstrap()?;
+        if flag.is_some() || env.is_some() {
+            let id = registry
+                .selected
+                .as_ref()
+                .ok_or(ProfileError::NoSelectedProfile)?;
+            let profile = self.context_from(&registry, id)?;
+            let resolved = profile.store.resolve(flag, env, None)?;
+            return Ok(ResolvedSpace {
+                profile,
+                name: resolved.name,
+                site: resolved.site,
+                source: resolved.source,
+            });
+        }
+        if let Some((directory, binding)) = cwd.and_then(|cwd| directory_binding(&registry, cwd)) {
+            let profile = self.context_from(&registry, &binding.profile)?;
+            let local = profile.store.load()?;
+            let entry =
+                local
+                    .spots
+                    .get(&binding.space)
+                    .ok_or_else(|| ProfileError::DanglingBinding {
+                        path: self.registry_path(),
+                        directory: directory.clone(),
+                        profile: binding.profile.clone(),
+                        space: binding.space.clone(),
+                    })?;
+            return Ok(ResolvedSpace {
+                profile,
+                name: binding.space,
+                site: entry.site.clone(),
+                source: Source::Directory(directory),
+            });
+        }
+        let id = match registry.selected.as_ref() {
+            Some(id) => id,
+            None if registry.profiles.is_empty() => {
+                return Err(ProfileError::Spot(spot::SpotError::NothingRegistered));
+            }
+            None => return Err(ProfileError::NoSelectedProfile),
+        };
+        let profile = self.context_from(&registry, id)?;
+        let resolved = profile.store.resolve(None, None, None)?;
+        Ok(ResolvedSpace {
+            profile,
+            name: resolved.name,
+            site: resolved.site,
+            source: resolved.source,
+        })
+    }
+
+    /// Bind a canonical directory to an existing profile-local space.
+    pub fn bind(
+        &self,
+        profile: &NativeProfileId,
+        space: &str,
+        directory: &Path,
+    ) -> Result<Option<BoundSpace>, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let context = self.context_from(&registry, profile)?;
+        let spaces = context.store.load()?;
+        if !spaces.spots.contains_key(space) {
+            return Err(spot::SpotError::Unknown {
+                name: space.to_owned(),
+                available: spaces.spots.keys().cloned().collect(),
+                binding: None,
+            }
+            .into());
+        }
+        let previous = registry.bindings.insert(
+            canonical(directory),
+            BoundSpace {
+                profile: profile.clone(),
+                space: space.to_owned(),
+            },
+        );
+        self.save(&registry)?;
+        Ok(previous)
+    }
+
+    /// Remove the exact nearest binding for a directory.
+    pub fn unbind(&self, directory: &Path) -> Result<BoundSpace, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let directory = canonical(directory);
+        let binding = registry.bindings.remove(&directory).ok_or_else(|| {
+            let ancestor = directory_binding(&registry, &directory)
+                .map(|(path, binding)| (path, binding.space));
+            ProfileError::Spot(spot::SpotError::NotBound {
+                directory: directory.clone(),
+                ancestor,
+            })
+        })?;
+        self.save(&registry)?;
+        Ok(binding)
+    }
+
+    /// Remove every install binding that names one exact profile-local space.
+    pub fn remove_space_bindings(
+        &self,
+        profile: &NativeProfileId,
+        space: &str,
+    ) -> Result<Vec<PathBuf>, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let removed: Vec<PathBuf> = registry
+            .bindings
+            .iter()
+            .filter(|(_, binding)| &binding.profile == profile && binding.space == space)
+            .map(|(directory, _)| directory.clone())
+            .collect();
+        for directory in &removed {
+            registry.bindings.remove(directory);
+        }
+        self.save(&registry)?;
+        Ok(removed)
+    }
+
+    /// Remove one profile-local space and then prune only bindings that name
+    /// that exact `(profile, space)` pair.
+    pub fn remove_space(
+        &self,
+        profile: &NativeProfileId,
+        space: &str,
+        data: spot::Data,
+    ) -> Result<spot::RemoveOutcome, ProfileError> {
+        let mut registry = self.load_or_bootstrap()?;
+        let context = self.context_from(&registry, profile)?;
+        let mut outcome = spot::remove(&context.store, space, data)?;
+        let removed: Vec<PathBuf> = registry
+            .bindings
+            .iter()
+            .filter(|(_, binding)| &binding.profile == profile && binding.space == space)
+            .map(|(directory, _)| directory.clone())
+            .collect();
+        for directory in &removed {
+            registry.bindings.remove(directory);
+        }
+        self.save(&registry)?;
+        outcome.unbound = removed;
+        Ok(outcome)
+    }
+}
+
+fn lookup_id(registry: &NativeProfileRegistryV1, id_or_label: &str) -> Option<NativeProfileId> {
+    let exact = NativeProfileId(id_or_label.to_owned());
+    if registry.profiles.contains_key(&exact) {
+        return Some(exact);
+    }
+    registry
+        .profiles
+        .iter()
+        .find(|(_, record)| record.label.eq_ignore_ascii_case(id_or_label))
+        .map(|(id, _)| id.clone())
+}
+
+fn validate_label(label: &str) -> Result<(), ProfileError> {
+    let mut chars = label.chars();
+    let head = chars
+        .next()
+        .is_some_and(|character| character.is_ascii_lowercase() || character.is_ascii_digit());
+    let tail = chars.all(|character| {
+        character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || character == '-'
+            || character == '_'
+    });
+    if head && tail {
+        Ok(())
+    } else {
+        Err(ProfileError::InvalidLabel(label.to_owned()))
+    }
+}
+
+fn next_default_label(registry: &NativeProfileRegistryV1) -> String {
+    let labels: BTreeSet<String> = registry
+        .profiles
+        .values()
+        .map(|record| record.label.to_ascii_lowercase())
+        .collect();
+    if !labels.contains("account") {
+        return "account".to_owned();
+    }
+    (2..)
+        .map(|suffix| format!("account-{suffix}"))
+        .find(|candidate| !labels.contains(candidate))
+        .expect("the account label sequence is unbounded")
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn directory_binding(
+    registry: &NativeProfileRegistryV1,
+    cwd: &Path,
+) -> Option<(PathBuf, BoundSpace)> {
+    let cwd = canonical(cwd);
+    cwd.ancestors().find_map(|directory| {
+        registry
+            .bindings
+            .get_key_value(directory)
+            .map(|(path, binding)| (path.clone(), binding.clone()))
+    })
+}

--- a/rust/tonk-cli/src/account_profiles.rs
+++ b/rust/tonk-cli/src/account_profiles.rs
@@ -258,7 +258,7 @@ pub enum ProfileError {
     },
     /// A binding points at a missing profile-local space.
     #[error(
-        "unknown spot '{space}' in profile '{profile}'; native profile registry at {path} has a binding at {directory}; clear it with `tonk spot unbind {directory}`"
+        "unknown space '{space}' in profile '{profile}'; native profile registry at {path} has a binding at {directory}; clear it with `tonk space unbind {directory}`"
     )]
     DanglingBinding {
         /// Registry path.
@@ -822,10 +822,14 @@ impl NativeProfileStore {
         profile: &NativeProfileId,
         space: &str,
         data: spot::Data,
+        subject: Option<&str>,
     ) -> Result<spot::RemoveOutcome, ProfileError> {
         let mut registry = self.load_or_bootstrap()?;
         let context = self.context_from(&registry, profile)?;
-        let mut outcome = spot::remove(&context.store, space, data)?;
+        let mut outcome = match subject {
+            Some(subject) => spot::remove_with_subject(&context.store, space, data, subject)?,
+            None => spot::remove(&context.store, space, data)?,
+        };
         let removed: Vec<PathBuf> = registry
             .bindings
             .iter()

--- a/rust/tonk-cli/src/account_session.rs
+++ b/rust/tonk-cli/src/account_session.rs
@@ -85,6 +85,63 @@ pub struct ActiveAccount {
     pub attached_at: u64,
 }
 
+/// Provider sign-in phase visible from install metadata without opening a
+/// Dialog profile or contacting a provider.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocalPhase {
+    /// No canonical session sidecar exists or it has no active/pending state.
+    SignedOut,
+    /// A browser handoff is durable but not active yet.
+    Pending,
+    /// One provider attachment is active.
+    Active,
+}
+
+/// Inspect a profile store without creating locks, directories, or profiles.
+pub fn inspect_local(store: &SpotStore) -> Result<LocalPhase> {
+    let account = store.account_dir();
+    let entries = match std::fs::read_dir(&account) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(LocalPhase::SignedOut);
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to inspect account state at {}", account.display())
+            });
+        }
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(STATE_FILE_PREFIX) || !name.ends_with(".json") {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path()).with_context(|| {
+            format!(
+                "failed to read account session at {}",
+                entry.path().display()
+            )
+        })?;
+        let state: AccountSessionState =
+            serde_json::from_slice(&bytes).context("stored account-session state is malformed")?;
+        if state.version != VERSION {
+            anyhow::bail!(
+                "unsupported account-session state version {}",
+                state.version
+            );
+        }
+        return Ok(if state.active.is_some() {
+            LocalPhase::Active
+        } else if state.pending_login.is_some() {
+            LocalPhase::Pending
+        } else {
+            LocalPhase::SignedOut
+        });
+    }
+    Ok(LocalPhase::SignedOut)
+}
+
 /// Held shared lock covering active-state read through remote dispatch.
 pub struct AccountSessionReadGuard {
     _file: File,
@@ -327,14 +384,24 @@ pub async fn active_guarded(
 /// A provider that misses it lists the device until the account page
 /// revokes it or the device links again (activation supersedes the
 /// stale attachment server-side).
+#[allow(dead_code)]
 pub async fn logout_transition(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
 ) -> Result<Vec<ActiveAccount>> {
     let store = SpotStore::open().context("failed to locate account state")?;
-    let guard = exclusive_transition_guard(&store)?;
+    logout_transition_for_store(profile, operator, &store).await
+}
+
+/// Commit local logout in one explicit profile store.
+pub async fn logout_transition_for_store(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    store: &SpotStore,
+) -> Result<Vec<ActiveAccount>> {
+    let guard = exclusive_transition_guard(store)?;
     ensure_initialized(profile, operator, &guard).await?;
-    let mut state = load_raw(profile, operator, &store)
+    let mut state = load_raw(profile, operator, store)
         .await?
         .unwrap_or_default();
     let mut detached = Vec::new();
@@ -347,7 +414,7 @@ pub async fn logout_transition(
     let existed = !detached.is_empty() || state.pending_login.is_some();
     state.pending_login = None;
     if existed {
-        save_raw(profile, operator, &store, &state).await?;
+        save_raw(profile, operator, store, &state).await?;
         // Compatibility only: canonical state is already authoritative.
         let _ = profile
             .credential()

--- a/rust/tonk-cli/src/account_spots.rs
+++ b/rust/tonk-cli/src/account_spots.rs
@@ -1,4 +1,4 @@
-//! Native account spot inventory, pull, and directory recording.
+//! Native account space inventory, pull, and directory recording.
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -76,16 +76,27 @@ pub struct RecordWarning {
     pub message: String,
 }
 
-fn site_config(_profile: &Profile) -> crate::site::SiteConfig {
+fn site_config(_profile: &Profile, store: &SpotStore) -> Result<crate::site::SiteConfig> {
     #[cfg(feature = "integration-tests")]
-    if let Some(config) = account::integration_site_config(_profile) {
-        return config;
+    if let Some(mut config) = account::integration_site_config(_profile) {
+        config.account_store = store.clone();
+        return Ok(config);
     }
-    crate::site::default_config()
+    Ok(crate::site::SiteConfig {
+        profile_name: crate::account_profiles::generated_dialog_profile_name(store)
+            .unwrap_or_else(|| crate::site::PROFILE_NAME.to_owned()),
+        profile_directory: dialog_effects::storage::Directory::Profile,
+        require_account: std::env::var_os("TONK_UNSAFE_ALLOW_DEVICE_ROOT").is_none(),
+        account_store: store.clone(),
+    })
 }
 
-async fn open_site(path: &std::path::Path, profile: &Profile) -> Result<TonkSite> {
-    let site = TonkSite::open_with(path, site_config(profile)).await?;
+async fn open_site(
+    path: &std::path::Path,
+    profile: &Profile,
+    store: &SpotStore,
+) -> Result<TonkSite> {
+    let site = TonkSite::open_with(path, site_config(profile, store)?).await?;
     if site.profile.did() != profile.did() {
         bail!("registered site profile does not match the active account profile");
     }
@@ -105,7 +116,7 @@ async fn local_subjects(
     let registry = store.load()?;
     let mut subjects: HashMap<String, LocalSpot> = HashMap::new();
     for (name, entry) in registry.spots {
-        let site = match open_site(&entry.site, profile).await {
+        let site = match open_site(&entry.site, profile, store).await {
             Ok(site) => site,
             Err(error) => {
                 eprintln!("warning: local spot '{name}' could not be inspected: {error:#}");
@@ -349,7 +360,7 @@ pub async fn pull(
     };
 
     let mut fresh_target = FreshPullTarget::new(target.clone());
-    let site = crate::site::mount_delegated_at(&target, chain, site_config(profile))
+    let site = crate::site::mount_delegated_at(&target, chain, site_config(profile, store)?)
         .await
         .context("failed to mount account spot")?;
     remote::add_with_revocation(
@@ -403,28 +414,39 @@ async fn repository_name(site: &TonkSite) -> Option<String> {
         .map(|row| row.name.0)
 }
 
-/// Whether the account directory lists `site`'s repository with a
-/// mount record — the claim `tonk spot rm` leans on when it tells
-/// someone their data is recoverable with `tonk account spots pull`.
+/// Whether the account directory lists `site`'s repository with a mount
+/// record and the site's exact current content revision is known to be
+/// durable on the content remote.
 ///
-/// Answered from the account branch's local copy of the directory; an
-/// absent or unhydrated account answers `false` rather than failing
-/// the command this probe is trying to make safe.
-pub async fn directory_lists(site: &TonkSite) -> Result<bool> {
-    let store = SpotStore::open()?;
+/// Both facts are local reads. An absent or unhydrated account, or local
+/// changes made after the last confirmed push, answer `false` rather than
+/// making a destructive command claim recoverability it cannot prove.
+pub async fn has_account_backup(site: &TonkSite) -> Result<bool> {
+    let store = site.operator.store();
     let operator =
-        crate::account_state::credential_operator_for_store(&site.profile, &store).await?;
+        crate::account_state::credential_operator_for_store(&site.profile, store).await?;
     let Some(account) =
-        crate::account_state::open_account_branch_in(&site.profile, &operator, &store).await?
+        crate::account_state::open_account_branch_in(&site.profile, &operator, store).await?
     else {
         return Ok(false);
     };
-    Ok(
-        tonk_schema::directory::mount_record(&account, &site.repository.did(), &operator)
-            .await
-            .map_err(|error| anyhow::anyhow!("account directory query failed: {error:?}"))?
-            .is_some(),
-    )
+    let listed = tonk_schema::directory::mount_record(&account, &site.repository.did(), &operator)
+        .await
+        .map_err(|error| anyhow::anyhow!("account directory query failed: {error:?}"))?
+        .is_some();
+    if !listed {
+        return Ok(false);
+    }
+    let Some(local_root) =
+        crate::identity::local_root_with_operator(&site.profile, site.operator.local()).await?
+    else {
+        return Ok(false);
+    };
+    let account_root = local_root
+        .root_did
+        .parse()
+        .context("stored local root DID is invalid")?;
+    crate::account_sync::current_revision_is_confirmed(site, &account_root).await
 }
 
 /// Mirror one site's name and mount configuration into the account
@@ -511,7 +533,7 @@ fn first_registry_name_for_site<'a>(
 
 /// Record the registry entry matching an already-open site.
 pub(crate) async fn record_current(site: &TonkSite) -> Result<RecordOutcome> {
-    let store = SpotStore::open()?;
+    let store = site.operator.store();
     let registry = store.load()?;
     let candidates: Vec<_> = registry
         .spots
@@ -531,7 +553,7 @@ pub(crate) async fn record_current(site: &TonkSite) -> Result<RecordOutcome> {
         &site.root,
     )
     .context("the evaluated site is not registered as a spot")?;
-    record_site(name, site).await
+    record_site_in(name, site, store).await
 }
 
 /// Best-effort directory sweep of every registered spot.
@@ -548,7 +570,7 @@ pub async fn record_registered(profile: &Profile, store: &SpotStore) -> Vec<Reco
     let mut warnings = Vec::new();
     let mut inspected_subjects = HashSet::new();
     for (name, entry) in registry.spots {
-        let site = match open_site(&entry.site, profile).await {
+        let site = match open_site(&entry.site, profile, store).await {
             Ok(site) => site,
             Err(error) => {
                 warnings.push(RecordWarning {

--- a/rust/tonk-cli/src/account_spots.rs
+++ b/rust/tonk-cli/src/account_spots.rs
@@ -52,6 +52,18 @@ pub struct PullOutcome {
     pub warning: Option<String>,
 }
 
+/// Result of canonically archiving one account-space subject.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchiveOutcome {
+    /// Exact archived repository subject.
+    pub subject: String,
+    /// Whether this call committed the monotonic marker.
+    pub newly_archived: bool,
+    /// Compatibility projection diagnostic. The directory-backed custody
+    /// model needs no provider projection, so this is normally absent.
+    pub projection_warning: Option<String>,
+}
+
 /// What recording a spot in the account directory did.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordOutcome {
@@ -274,6 +286,20 @@ pub async fn pull(
         );
     }
 
+    let account_root: Did = crate::identity::local_root_with_operator(profile, &operator)
+        .await?
+        .context("no account root is recorded on this profile")?
+        .root_did
+        .parse()
+        .context("stored root DID is invalid")?;
+    let archived = tonk_schema::account::list_account_spaces(&account, &operator)
+        .await?
+        .into_iter()
+        .any(|row| row.account == account_root && row.subject == requested && row.archived);
+    if archived {
+        bail!("account space {requested} is archived");
+    }
+
     let record = tonk_schema::directory::mount_record(&account, &requested, &operator)
         .await
         .map_err(|error| anyhow::anyhow!("account directory query failed: {error:?}"))?
@@ -291,6 +317,10 @@ pub async fn pull(
 
     let local = local_subjects(profile, store).await?;
     if let Some(local) = local.get(requested.as_ref()) {
+        let mut registry = store.load()?;
+        if registry.unsuppress(requested.as_ref()) {
+            store.save(&registry)?;
+        }
         return Ok(PullOutcome {
             subject: requested.to_string(),
             name: local.name.clone(),
@@ -335,12 +365,6 @@ pub async fn pull(
     // root is the linked account's root DID — NOT the account branch's
     // subject: the account is profile main's upstream, so the local
     // branch's subject is the profile itself.
-    let account_root: Did = crate::identity::local_root_with_operator(profile, &operator)
-        .await?
-        .context("no account root is recorded on this profile")?
-        .root_did
-        .parse()
-        .context("stored root DID is invalid")?;
     let chain = crate::site::recover_prefix(profile, &operator, &requested, &account_root)
         .await?
         .with_context(|| {
@@ -378,22 +402,72 @@ pub async fn pull(
     let canonical_target = target
         .canonicalize()
         .context("failed to canonicalize the mounted account spot")?;
-    spot::register_existing_unbound(store, &name, &canonical_target)?;
+    crate::sync::pull(&site)
+        .await
+        .with_context(|| format!("initial pull from '{DEFAULT_REMOTE}' failed"))?;
+    spot::register_pulled_space(store, &name, &canonical_target, requested.as_ref())?;
     fresh_target.commit();
 
-    let warning = match crate::sync::pull(&site).await {
-        Ok(_) => None,
-        Err(error) => Some(format!(
-            "initial pull from '{DEFAULT_REMOTE}' failed: {error}; run `tonk pull` before making changes so you don't diverge from upstream"
-        )),
-    };
     Ok(PullOutcome {
         subject: requested.to_string(),
         name,
         site: canonical_target,
         already_local: false,
-        warning,
+        warning: None,
     })
+}
+
+/// Commit a monotonic archive fact to the canonical account repository.
+pub async fn archive(
+    profile: &Profile,
+    store: &SpotStore,
+    subject: &str,
+) -> Result<ArchiveOutcome> {
+    let operator = crate::account_state::operator_for_store(profile, store).await?;
+    archive_with_operator(profile, store, subject, &operator).await
+}
+
+async fn archive_with_operator(
+    profile: &Profile,
+    store: &SpotStore,
+    subject: &str,
+    operator: &Operator<NativeSpace>,
+) -> Result<ArchiveOutcome> {
+    let subject: Did = subject
+        .parse()
+        .map_err(|error| anyhow::anyhow!("invalid account space subject '{subject}': {error:?}"))?;
+    let root: Did = crate::identity::local_root_with_operator(profile, operator)
+        .await?
+        .context("no account root is recorded on this profile")?
+        .root_did
+        .parse()
+        .context("stored root DID is invalid")?;
+    let branch = crate::account_state::open_account_branch_in(profile, operator, store)
+        .await?
+        .context("account repository is not hydrated")?;
+    let newly_archived =
+        tonk_schema::account::archive_account_space(&branch, &root, &subject, operator).await?;
+    branch
+        .push()
+        .perform(operator)
+        .await
+        .context("canonical account archive committed locally but its push failed")?;
+    Ok(ArchiveOutcome {
+        subject: subject.to_string(),
+        newly_archived,
+        projection_warning: None,
+    })
+}
+
+#[cfg(feature = "integration-tests")]
+#[doc(hidden)]
+pub async fn archive_with_operator_for_integration_test(
+    profile: &Profile,
+    store: &SpotStore,
+    subject: &str,
+    operator: &Operator<NativeSpace>,
+) -> Result<ArchiveOutcome> {
+    archive_with_operator(profile, store, subject, operator).await
 }
 
 async fn repository_name(site: &TonkSite) -> Option<String> {

--- a/rust/tonk-cli/src/account_state.rs
+++ b/rust/tonk-cli/src/account_state.rs
@@ -109,8 +109,17 @@ async fn descriptor_in(
 
 /// Read durable native account-state status without contacting the remote.
 pub async fn status(profile: &Profile) -> Result<AccountStateStatus> {
-    let operator = credential_operator(profile).await?;
-    let Some(descriptor) = descriptor(profile, &operator).await? else {
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    status_in(profile, &store).await
+}
+
+/// Read account repository status from one explicit profile store.
+pub async fn status_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<AccountStateStatus> {
+    let operator = credential_operator_for_store(profile, store).await?;
+    let Some(descriptor) = descriptor_in(profile, &operator, store).await? else {
         return Ok(AccountStateStatus::Unconfigured);
     };
     if marker_matches(marker(profile, &operator).await?.as_deref(), &descriptor) {
@@ -263,7 +272,18 @@ pub async fn retain_space_delegation(
     operator: &Operator<NativeSpace>,
     chain: &DelegationChain,
 ) -> Result<bool> {
-    let Some(branch) = open_account_branch(profile, operator).await? else {
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    retain_space_delegation_in(profile, operator, &store, chain).await
+}
+
+/// Retain one space delegation in the account repository owned by `store`.
+pub async fn retain_space_delegation_in(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    store: &crate::spot::SpotStore,
+    chain: &DelegationChain,
+) -> Result<bool> {
+    let Some(branch) = open_account_branch_in(profile, operator, store).await? else {
         return Ok(false);
     };
     tonk_account::delegations::retain_space_delegation(&branch, chain, operator)
@@ -395,7 +415,8 @@ pub async fn migrate_delegations(
         };
         let subject = site.repository.did();
         let Ok(chain) =
-            crate::site::account_root_prefix_for(profile, operator, &subject, &account_root).await
+            crate::site::adopt_account_root_prefix_for(profile, operator, &subject, &account_root)
+                .await
         else {
             continue;
         };
@@ -474,6 +495,9 @@ pub async fn credential_operator_for_store(
         )
         .await;
     }
+    if let Some(profile_name) = crate::account_profiles::generated_dialog_profile_name(store) {
+        return operator_with_profile(profile, &root, &profile_name, Directory::Profile).await;
+    }
     std::fs::create_dir_all(&root)
         .with_context(|| format!("failed to create account state at {}", root.display()))?;
     let root = root
@@ -489,6 +513,14 @@ pub async fn credential_operator_for_store(
         .build(Storage::<NativeSpace>::default())
         .await
         .context("failed to build account-state operator")
+}
+
+/// Build the account operator for one explicit native profile store.
+pub async fn operator_for_store(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<Operator<NativeSpace>> {
+    credential_operator_for_store(profile, store).await
 }
 
 pub(crate) async fn credential_operator(profile: &Profile) -> Result<Operator<NativeSpace>> {

--- a/rust/tonk-cli/src/account_sync.rs
+++ b/rust/tonk-cli/src/account_sync.rs
@@ -1,0 +1,358 @@
+//! Bounded reconciliation for the spaces owned by one native profile.
+
+use anyhow::{Context, Result};
+use dialog_varsig::Did;
+use serde::{Deserialize, Serialize};
+
+use crate::account_profiles::{NativeProfileContext, NativeProfileId, ProfileSignIn};
+use crate::remote::DEFAULT_REMOTE;
+use crate::site::TonkSite;
+
+const CONFIRMED_SITE_PREFIX: &str = "tonk-space-confirmed-v1/";
+
+/// Durable-enrollment state for one local space.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EnrollmentPhase {
+    /// The profile has no deployment default or the space intentionally has no remote.
+    LocalOnly,
+    /// Default remote creation began but content durability is not confirmed.
+    Provisioning,
+    /// Local work exists but the owning profile cannot currently publish it.
+    PendingPush,
+    /// This exact local tree was accepted by the content remote.
+    Connected {
+        /// Last locally recorded confirmed tree.
+        confirmed: dialog_repository::TreeReference,
+    },
+    /// A bounded reconciliation step failed.
+    Error {
+        /// Stable operation label.
+        step: &'static str,
+        /// Actionable underlying failure.
+        detail: String,
+    },
+}
+
+/// Reconciliation result for one profile-local registry entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconcileRow {
+    /// Profile-local space name.
+    pub name: String,
+    /// Repository subject, or the profile DID when the site could not open.
+    pub subject: Did,
+    /// Final enrollment phase for this pass.
+    pub phase: EnrollmentPhase,
+}
+
+/// Deterministic reconciliation result for one native profile.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Exact profile that was scanned.
+    pub profile: NativeProfileId,
+    /// Rows sorted by profile-local space name.
+    pub rows: Vec<ReconcileRow>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfirmedRevisionV1 {
+    version: u8,
+    tree: String,
+}
+
+fn confirmed_site(subject: &Did, account_root: &Did) -> String {
+    format!("{CONFIRMED_SITE_PREFIX}{subject}/{account_root}")
+}
+
+async fn current_tree(site: &TonkSite) -> Result<Option<dialog_repository::TreeReference>> {
+    let branch = site.branch().await.context("failed to open local branch")?;
+    Ok(branch.handle().revision().map(|revision| revision.tree))
+}
+
+async fn save_confirmed(
+    site: &TonkSite,
+    account_root: &Did,
+    tree: &dialog_repository::TreeReference,
+) -> Result<()> {
+    let marker = ConfirmedRevisionV1 {
+        version: 1,
+        tree: tree.to_string(),
+    };
+    site.profile
+        .credential()
+        .site(confirmed_site(&site.repository.did(), account_root))
+        .save(serde_json::to_vec(&marker)?)
+        .perform(&site.operator)
+        .await
+        .context("failed to save confirmed content revision")
+}
+
+/// Record the site's current tree after a successful content push.
+pub async fn record_current_revision_confirmed(
+    site: &TonkSite,
+    account_root: &Did,
+) -> Result<bool> {
+    let Some(tree) = current_tree(site).await? else {
+        return Ok(false);
+    };
+    save_confirmed(site, account_root, &tree).await?;
+    Ok(true)
+}
+
+/// Read the confirmed tree for one subject/root pair without contacting a
+/// remote. Missing and obsolete markers return `None`.
+pub async fn confirmed_revision(site: &TonkSite, account_root: &Did) -> Result<Option<String>> {
+    let bytes = match site
+        .profile
+        .credential()
+        .site(confirmed_site(&site.repository.did(), account_root))
+        .load::<Vec<u8>>()
+        .perform(&site.operator)
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(error) if crate::account_state::credential_is_missing(&error) => return Ok(None),
+        Err(error) => return Err(error).context("failed to load confirmed content revision"),
+    };
+    let marker: ConfirmedRevisionV1 =
+        serde_json::from_slice(&bytes).context("confirmed content revision is corrupt")?;
+    if marker.version != 1 {
+        return Ok(None);
+    }
+    Ok(Some(marker.tree))
+}
+
+/// True only when the local branch still equals its last successful push.
+pub async fn current_revision_is_confirmed(site: &TonkSite, account_root: &Did) -> Result<bool> {
+    let Some(current) = current_tree(site).await? else {
+        return Ok(false);
+    };
+    Ok(confirmed_revision(site, account_root).await?.as_deref() == Some(&current.to_string()))
+}
+
+async fn reconcile_site(
+    context: &NativeProfileContext,
+    name: String,
+    path: &std::path::Path,
+) -> ReconcileRow {
+    let fallback_subject = match context.open_profile().await {
+        Ok(profile) => profile.did(),
+        Err(_) => "did:key:z6MkhFDyBYNT1Y1jNj8RJKVc7CWurCVPmrnGEGmbYxvwHJkX"
+            .parse()
+            .expect("static fallback DID"),
+    };
+    let site = match TonkSite::open_with(path, context.site_config()).await {
+        Ok(site) => site,
+        Err(error) => {
+            return ReconcileRow {
+                name,
+                subject: fallback_subject,
+                phase: EnrollmentPhase::Error {
+                    step: "open",
+                    detail: format!("{error:#}"),
+                },
+            };
+        }
+    };
+    let subject = site.repository.did();
+    let Some(root_text) = context.record.account_root.as_deref() else {
+        return ReconcileRow {
+            name,
+            subject,
+            phase: EnrollmentPhase::LocalOnly,
+        };
+    };
+    let account_root: Did = match root_text.parse() {
+        Ok(root) => root,
+        Err(error) => {
+            return ReconcileRow {
+                name,
+                subject,
+                phase: EnrollmentPhase::Error {
+                    step: "profile",
+                    detail: format!("invalid account root: {error}"),
+                },
+            };
+        }
+    };
+
+    let upstream = match crate::remote::upstream_remote(&site).await {
+        Ok(upstream) => upstream,
+        Err(error) => return error_row(name, subject, "inspect", error),
+    };
+    if upstream.is_none() {
+        let (Some(endpoint), Some(relay)) = (
+            context.record.default_access_remote.as_deref(),
+            context.record.default_revocation_relay.as_deref(),
+        ) else {
+            return ReconcileRow {
+                name,
+                subject,
+                phase: EnrollmentPhase::LocalOnly,
+            };
+        };
+        if let Err(error) = crate::remote::add_with_revocation(
+            &site,
+            DEFAULT_REMOTE,
+            endpoint,
+            Some(subject.clone()),
+            Some(relay),
+        )
+        .await
+        {
+            return error_row(name, subject, "provision", error);
+        }
+        if let Err(error) = crate::remote::set_upstream(&site, DEFAULT_REMOTE).await {
+            return error_row(name, subject, "provision", error);
+        }
+    }
+
+    if !matches!(context.sign_in_state(), Ok(ProfileSignIn::Active)) {
+        return ReconcileRow {
+            name,
+            subject,
+            phase: EnrollmentPhase::PendingPush,
+        };
+    }
+
+    let pushed = match crate::sync::push(&site).await {
+        Ok(outcome) => Ok(outcome),
+        Err(crate::sync::SyncError::NonFastForward) => match crate::sync::pull(&site).await {
+            Ok(_) => crate::sync::push(&site).await,
+            Err(error) => Err(error),
+        },
+        Err(error) => Err(error),
+    };
+    if let Err(error) = pushed {
+        return error_row(name, subject, "push", error);
+    }
+    let tree = match current_tree(&site).await {
+        Ok(Some(tree)) => tree,
+        Ok(None) => {
+            return ReconcileRow {
+                name,
+                subject,
+                phase: EnrollmentPhase::Provisioning,
+            };
+        }
+        Err(error) => return error_row(name, subject, "confirm", error),
+    };
+    if let Err(error) = save_confirmed(&site, &account_root, &tree).await {
+        return error_row(name, subject, "confirm", error);
+    }
+    let prefix = match crate::site::load_account_root_prefix_for(
+        &site.profile,
+        site.operator.inner(),
+        &subject,
+        &account_root,
+    )
+    .await
+    {
+        Ok(prefix) => prefix,
+        Err(error) => return error_row(name, subject, "retain", error),
+    };
+    let account_operator =
+        match crate::account_state::operator_for_store(&site.profile, &context.store).await {
+            Ok(operator) => operator,
+            Err(error) => return error_row(name, subject, "account-open", error),
+        };
+    if let Err(error) = crate::account_state::retain_space_delegation_in(
+        &site.profile,
+        &account_operator,
+        &context.store,
+        &prefix,
+    )
+    .await
+    {
+        return error_row(name, subject, "retain", error);
+    }
+    match crate::account_state::open_account_branch_in(
+        &site.profile,
+        &account_operator,
+        &context.store,
+    )
+    .await
+    {
+        Ok(Some(branch)) => {
+            if let Err(error) = branch.push().perform(&account_operator).await {
+                return error_row(name, subject, "account-push", error);
+            }
+        }
+        Ok(None) => {
+            return error_row(
+                name,
+                subject,
+                "account-push",
+                "account repository is not hydrated",
+            );
+        }
+        Err(error) => return error_row(name, subject, "account-push", error),
+    }
+    if let Err(error) = crate::account_spots::record_site_in(&name, &site, &context.store).await {
+        return error_row(name, subject, "project", error);
+    }
+    ReconcileRow {
+        name,
+        subject,
+        phase: EnrollmentPhase::Connected { confirmed: tree },
+    }
+}
+
+fn error_row(
+    name: String,
+    subject: Did,
+    step: &'static str,
+    error: impl std::fmt::Display,
+) -> ReconcileRow {
+    ReconcileRow {
+        name,
+        subject,
+        phase: EnrollmentPhase::Error {
+            step,
+            detail: error.to_string(),
+        },
+    }
+}
+
+/// Reconcile only the spaces registered in `context`, continuing after each
+/// per-space failure and returning rows in stable name order.
+pub async fn reconcile_profile(context: &NativeProfileContext) -> ReconcileReport {
+    let mut rows = Vec::new();
+    match context.store.load() {
+        Ok(registry) => {
+            for (name, entry) in registry.spots {
+                rows.push(reconcile_site(context, name, &entry.site).await);
+            }
+        }
+        Err(error) => {
+            let subject = match context.open_profile().await {
+                Ok(profile) => profile.did(),
+                Err(_) => "did:key:z6MkhFDyBYNT1Y1jNj8RJKVc7CWurCVPmrnGEGmbYxvwHJkX"
+                    .parse()
+                    .expect("static fallback DID"),
+            };
+            rows.push(error_row(
+                "(registry)".to_owned(),
+                subject,
+                "registry",
+                error,
+            ));
+        }
+    }
+    rows.sort_by(|left, right| left.name.cmp(&right.name));
+    ReconcileReport {
+        profile: context.id.clone(),
+        rows,
+    }
+}
+
+/// Render a stable one-line phase for CLI status output.
+pub fn phase_label(phase: &EnrollmentPhase) -> String {
+    match phase {
+        EnrollmentPhase::LocalOnly => "local-only".to_owned(),
+        EnrollmentPhase::Provisioning => "provisioning".to_owned(),
+        EnrollmentPhase::PendingPush => "pending push".to_owned(),
+        EnrollmentPhase::Connected { confirmed } => format!("connected {confirmed}"),
+        EnrollmentPhase::Error { step, detail } => format!("error ({step}): {detail}"),
+    }
+}

--- a/rust/tonk-cli/src/account_sync.rs
+++ b/rust/tonk-cli/src/account_sync.rs
@@ -266,18 +266,14 @@ async fn reconcile_site(
     {
         return error_row(name, subject, "retain", error);
     }
-    match crate::account_state::open_account_branch_in(
+    let account_branch = match crate::account_state::open_account_branch_in(
         &site.profile,
         &account_operator,
         &context.store,
     )
     .await
     {
-        Ok(Some(branch)) => {
-            if let Err(error) = branch.push().perform(&account_operator).await {
-                return error_row(name, subject, "account-push", error);
-            }
-        }
+        Ok(Some(branch)) => branch,
         Ok(None) => {
             return error_row(
                 name,
@@ -287,6 +283,35 @@ async fn reconcile_site(
             );
         }
         Err(error) => return error_row(name, subject, "account-push", error),
+    };
+    let upstream = match crate::remote::upstream_remote(&site).await {
+        Ok(Some(upstream)) => upstream,
+        Ok(None) => return error_row(name, subject, "membership", "space has no upstream"),
+        Err(error) => return error_row(name, subject, "membership", error),
+    };
+    let remote = match crate::remote::find(&site, &upstream).await {
+        Ok(Some(remote)) => remote,
+        Ok(None) => return error_row(name, subject, "membership", "upstream is not registered"),
+        Err(error) => return error_row(name, subject, "membership", error),
+    };
+    if let Err(error) = tonk_schema::account::record_active_account_space(
+        &account_branch,
+        tonk_schema::account::AccountSpaceInput {
+            account: account_root,
+            subject: subject.clone(),
+            name: Some(name.clone()),
+            remote_url: Some(remote.endpoint),
+            revocation_url: remote.revocation_url,
+            confirmed_revision: Some(tree.to_string()),
+        },
+        &account_operator,
+    )
+    .await
+    {
+        return error_row(name, subject, "membership", error);
+    }
+    if let Err(error) = account_branch.push().perform(&account_operator).await {
+        return error_row(name, subject, "account-push", error);
     }
     if let Err(error) = crate::account_spots::record_site_in(&name, &site, &context.store).await {
         return error_row(name, subject, "project", error);
@@ -354,5 +379,67 @@ pub fn phase_label(phase: &EnrollmentPhase) -> String {
         EnrollmentPhase::PendingPush => "pending push".to_owned(),
         EnrollmentPhase::Connected { confirmed } => format!("connected {confirmed}"),
         EnrollmentPhase::Error { step, detail } => format!("error ({step}): {detail}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account_profiles::{NativeProfileId, NativeProfileRecord};
+    use crate::site::{SiteConfig, TonkSite};
+    use dialog_effects::storage::Directory;
+
+    fn local_context(root: &std::path::Path, label: &str) -> NativeProfileContext {
+        let id = NativeProfileId::generate();
+        NativeProfileContext {
+            record: NativeProfileRecord {
+                label: label.to_string(),
+                dialog_profile_name: format!("tonk-account-sync-test-{}", id.as_str()),
+                account_root: None,
+                ceremony_origin: None,
+                default_access_remote: None,
+                default_revocation_relay: None,
+                extra: serde_json::Map::new(),
+            },
+            store: crate::spot::SpotStore::at(root.join(id.as_str())),
+            id,
+        }
+    }
+
+    async fn add_local_space(context: &NativeProfileContext, name: &str) -> anyhow::Result<()> {
+        let path = context.store.canonical_site(name);
+        let site = TonkSite::init_at_with(
+            &path,
+            SiteConfig {
+                profile_name: context.record.dialog_profile_name.clone(),
+                profile_directory: Directory::Profile,
+                require_account: false,
+                account_store: context.store.clone(),
+            },
+        )
+        .await?;
+        crate::spot::register_existing_unbound(&context.store, name, &site.root)?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_reconciles_only_the_activated_profile() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let active = local_context(root.path(), "active");
+        let inactive = local_context(root.path(), "inactive");
+        add_local_space(&active, "active-garden").await?;
+        add_local_space(&inactive, "inactive-garden").await?;
+
+        let report = reconcile_profile(&active).await;
+
+        assert_eq!(report.profile, active.id);
+        assert_eq!(report.rows.len(), 1);
+        assert_eq!(report.rows[0].name, "active-garden");
+        assert_eq!(report.rows[0].phase, EnrollmentPhase::LocalOnly);
+        assert!(
+            inactive.store.load()?.spots.contains_key("inactive-garden"),
+            "reconciling the active context must not mutate another profile's registry"
+        );
+        Ok(())
     }
 }

--- a/rust/tonk-cli/src/agents.rs
+++ b/rust/tonk-cli/src/agents.rs
@@ -75,13 +75,13 @@ pub(crate) async fn get_declared(site: &TonkSite) -> Result<Option<SpotAgents>> 
     let doc = format!("{CONCEPT_NAME}:\n  this: {entity}\n  markdown: ?markdown\n");
     let outcome = eval::run_against_site(site, Source::Inline(doc), Options::default())
         .await
-        .context("query spot AGENTS.md claim")?;
+        .context("query space AGENTS.md claim")?;
     let revision = outcome
         .response
         .revision_before
         .as_ref()
         .map(|revision| revision.tree.to_string())
-        .ok_or_else(|| anyhow!("spot AGENTS.md query returned no branch revision"))?;
+        .ok_or_else(|| anyhow!("space AGENTS.md query returned no branch revision"))?;
     let Some(row) = outcome
         .response
         .matches_after
@@ -93,7 +93,7 @@ pub(crate) async fn get_declared(site: &TonkSite) -> Result<Option<SpotAgents>> 
     };
     if row.this != entity {
         return Err(anyhow!(
-            "spot AGENTS.md resolved on {}, expected repository subject {entity}",
+            "space AGENTS.md resolved on {}, expected repository subject {entity}",
             row.this
         ));
     }
@@ -101,7 +101,7 @@ pub(crate) async fn get_declared(site: &TonkSite) -> Result<Option<SpotAgents>> 
         .fields
         .get("markdown")
         .and_then(|value| value.as_str())
-        .ok_or_else(|| anyhow!("spot AGENTS.md claim has no text `markdown` field"))?
+        .ok_or_else(|| anyhow!("space AGENTS.md claim has no text `markdown` field"))?
         .to_owned();
     Ok(Some(SpotAgents {
         source: SOURCE,
@@ -142,7 +142,7 @@ tonk/agents!:
     );
     auto_sync::run_eval(site, Source::Inline(doc), Options::default(), sync)
         .await
-        .context("assert spot AGENTS.md claim")?;
+        .context("assert space AGENTS.md claim")?;
     get_declared(site)
         .await?
         .ok_or_else(|| anyhow!("AGENTS.md write committed but no claim was readable"))

--- a/rust/tonk-cli/src/auto_sync.rs
+++ b/rust/tonk-cli/src/auto_sync.rs
@@ -64,8 +64,19 @@ pub async fn run_eval(
         pull_before(site).await;
     }
     let outcome = eval::run_against_site(site, source, options).await?;
-    if sync && outcome.committed {
-        push_after(site).await;
+    let pushed = if sync && outcome.committed {
+        push_after(site).await
+    } else {
+        false
+    };
+    if pushed
+        && let Ok(crate::account::AccountStatus::Registered { root_did, .. }) =
+            crate::account::local_status_in(&site.profile, site.operator.store()).await
+        && let Ok(root) = root_did.parse()
+        && let Err(error) =
+            crate::account_sync::record_current_revision_confirmed(site, &root).await
+    {
+        eprintln!("warning: pushed content but could not record its confirmed revision: {error:#}");
     }
     if outcome.committed
         && let Err(error) = crate::account_spots::record_current(site).await
@@ -88,10 +99,14 @@ async fn pull_before(site: &TonkSite) {
 /// Push the local branch to its upstream after a write. A missing
 /// upstream is a silent skip; any other failure is a warning — the
 /// local write is already committed.
-async fn push_after(site: &TonkSite) {
+async fn push_after(site: &TonkSite) -> bool {
     match sync::push(site).await {
-        Ok(_) | Err(SyncError::UpstreamNotConfigured { .. }) => {}
-        Err(err) => warn("push", &err),
+        Ok(_) => true,
+        Err(SyncError::UpstreamNotConfigured { .. }) => false,
+        Err(err) => {
+            warn("push", &err);
+            false
+        }
     }
 }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -35,10 +35,15 @@ use tonk_cli::{ExitCode, account, account_spots, agents, context, guide, identit
     after_help = "Start with live state, not documentation:\n  tonk context\n  tonk query <CONCEPT> --json\n  tonk assert <CONCEPT> <ENTITY> --<field> <value>\n  tonk query <CONCEPT> <ENTITY> --json\n\nBare `tonk` runs `tonk context`. Use `tonk help <COMMAND>` for more workflows."
 )]
 struct Cli {
-    /// Operate on this spot instead of the active directory binding.
-    /// Precedence: --spot > TONK_SPOT > `tonk use` in the nearest
+    /// Operate on this space instead of the active directory binding.
+    /// Precedence: --space/--spot > TONK_SPACE/TONK_SPOT > `tonk use` in the nearest
     /// ancestor directory.
-    #[arg(long, global = true, value_name = "NAME")]
+    #[arg(
+        long = "space",
+        visible_alias = "spot",
+        global = true,
+        value_name = "NAME"
+    )]
     spot: Option<String>,
 
     /// Print full error chains: every layer of context down to the
@@ -68,7 +73,7 @@ enum Command {
         json: bool,
     },
 
-    /// Read or update the AGENTS.md claim carried by this spot
+    /// Read or update the AGENTS.md claim carried by this space
     ///
     /// With no subcommand, writes the raw Markdown to stdout so it can be
     /// projected with `tonk agents > AGENTS.md`. The claim on the repository
@@ -268,7 +273,9 @@ enum Command {
     /// recipient lands on the deployment that actually serves the
     /// repo — and that origin's shortcut service can shorten it.
     #[command(
-        after_help = "Examples:\n  tonk invite\n  tonk invite --remote prod\n  tonk invite --no-remote\n  tonk invite --no-shorten"
+        name = "share",
+        visible_alias = "invite",
+        after_help = "Examples:\n  tonk share\n  tonk share --remote prod\n  tonk share --no-remote\n  tonk share --no-shorten\n\nCompatibility alias: `tonk invite`"
     )]
     Invite {
         /// Override the URL prefix the invite is built against.
@@ -310,13 +317,13 @@ enum Command {
         no_shorten: bool,
     },
 
-    /// Join a shared repo from an invite URL into a new spot
+    /// Join a shared repo from an invite URL into a new space
     #[command(after_help = "Examples:\n  tonk join 'https://...#invite' --name garden")]
     Join {
         /// The invite URL (quote it - the #fragment matters).
         #[arg(value_name = "URL")]
         url: String,
-        /// Spot name to register the joined repo under.
+        /// Space name to register the joined repo under.
         #[arg(long, value_name = "NAME")]
         name: String,
     },
@@ -336,19 +343,20 @@ enum Command {
     },
 
     // -- setup --------------------------------------------------------
-    /// Use a spot in this directory and its descendants
+    /// Use a space in this directory and its descendants
     ///
-    /// Stores only a pointer in the central registry; spot data stays
+    /// Stores only a pointer in the profile registry; space data stays
     /// in its central site directory. A nested binding overrides this
-    /// one. Pin one invocation with --spot or TONK_SPOT instead.
+    /// one. Pin one invocation with --space or TONK_SPACE instead.
     #[command(after_help = "Examples:\n  tonk use\n  tonk use garden")]
     Use {
-        /// A registered spot name. Omit it to inspect the current selection.
+        /// A registered space name. Omit it to inspect the current selection.
         #[arg(value_name = "NAME")]
         name: Option<String>,
     },
 
-    /// Manage spots: named, centrally registered fact stores
+    /// Manage spaces: named, profile-local registered fact stores
+    #[command(name = "space", visible_alias = "spot")]
     Spot {
         #[command(subcommand)]
         command: SpotCommand,
@@ -435,7 +443,7 @@ enum Command {
         #[arg(long = "move")]
         do_move: bool,
 
-        /// Upgrade a spot written before the dialog format change.
+        /// Upgrade a space written before the dialog format change.
         ///
         /// Downloads the last build that can read it, exports each
         /// branch, rewrites the schema namespace, and imports the
@@ -443,18 +451,18 @@ enum Command {
         #[arg(long, conflicts_with_all = ["from", "do_move"])]
         legacy: bool,
 
-        /// Name of the registered legacy spot to upgrade. Required with
+        /// Name of the registered legacy space to upgrade. Required with
         /// `--legacy`.
         ///
         /// A name rather than a path: the build that reads it resolves
-        /// spots through the registry, so one that is not registered
+        /// spaces through the registry, so one that is not registered
         /// cannot be exported by it at all.
         #[arg(long, value_name = "NAME", requires = "legacy")]
         site: Option<String>,
 
         /// Branches to upgrade. Repeatable; defaults to `main`.
         ///
-        /// Branches are not discoverable on a legacy spot — listing them
+        /// Branches are not discoverable on a legacy space — listing them
         /// needs an open branch, which is what fails — so any beyond
         /// `main` must be named.
         #[arg(long, value_name = "NAME", requires = "legacy")]
@@ -489,7 +497,7 @@ enum Command {
 
 #[derive(Subcommand, Debug)]
 enum AgentsCommand {
-    /// Assert a Markdown document on the selected spot's repository subject
+    /// Assert a Markdown document on the selected space's repository subject
     Set {
         /// Markdown file to assert, or `-` for stdin.
         #[arg(value_name = "PATH", default_value = "AGENTS.md")]
@@ -591,7 +599,7 @@ enum AccountCommand {
 
     /// Disconnect account services on this device
     ///
-    /// Preserves the local identity, root, and spots without revoking this
+    /// Preserves the local identity, root, and spaces without revoking this
     /// device. Use `tonk account revoke <DID>` to revoke a device instead.
     Logout,
 
@@ -619,6 +627,7 @@ enum AccountCommand {
     Sync,
 
     /// List or pull the spaces your account directory lists
+    #[command(name = "spaces", visible_alias = "spots")]
     Spots {
         #[command(subcommand)]
         command: Option<AccountSpotsCommand>,
@@ -627,7 +636,7 @@ enum AccountCommand {
     /// Move stored delegations into their durable homes
     ///
     /// Drains the legacy certificate store into the profile's access branch
-    /// and retains each spot's authority into the account space, so another
+    /// and retains each space's authority into the account repository, so another
     /// device regains access by pulling the account. Safe to re-run.
     #[command(after_help = "Examples:\n  tonk account migrate")]
     Migrate,
@@ -672,14 +681,24 @@ enum AccountCommand {
 
 #[derive(Subcommand, Debug)]
 enum AccountSpotsCommand {
-    /// List remote account spots and local registration state
-    List,
+    /// List account spaces and local registration state
+    List {
+        /// Include hidden, archived, ambiguous, and orphaned rows.
+        #[arg(long)]
+        all: bool,
+        /// Refresh provider inventory and remote heads without mutating state.
+        #[arg(long)]
+        refresh: bool,
+        /// Emit stable version-one JSON rows.
+        #[arg(long)]
+        json: bool,
+    },
     /// Pull one exact repository subject into canonical local storage
     Pull {
         /// Full repository subject DID.
         #[arg(value_name = "SUBJECT")]
         subject: String,
-        /// Explicit local spot slug.
+        /// Explicit local space slug.
         #[arg(long, value_name = "SLUG")]
         name: Option<String>,
     },
@@ -749,7 +768,7 @@ enum RemoteCommand {
 
 #[derive(Subcommand, Debug)]
 enum SpotCommand {
-    /// Create (or adopt) a spot, register it, and use it here
+    /// Create (or adopt) a space, register it, and use it here
     ///
     /// The site lands in the canonical store
     /// (`~/Library/Application Support/tonk/spots/<name>` on macOS)
@@ -757,10 +776,10 @@ enum SpotCommand {
     /// site directory adopts it instead of creating fresh — the
     /// migration path for pre-registry `.tonk/` dirs.
     #[command(
-        after_help = "Examples:\n  tonk spot new garden\n  tonk spot new work --site ~/work/site\n  tonk spot new proj --site ~/proj/.tonk"
+        after_help = "Examples:\n  tonk space new garden\n  tonk space new work --site ~/work/site\n  tonk space new proj --site ~/proj/.tonk\n\nCompatibility alias: `tonk spot new`"
     )]
     New {
-        /// Spot name ([a-z0-9][a-z0-9-_]*).
+        /// Space name ([a-z0-9][a-z0-9-_]*).
         #[arg(value_name = "NAME")]
         name: String,
         /// Store the site at this directory instead of the
@@ -769,34 +788,44 @@ enum SpotCommand {
         site: Option<PathBuf>,
     },
 
-    /// List registered spots, directory bindings, and what is active here
-    #[command(after_help = "Examples:\n  tonk spot list")]
-    List,
+    /// List local and account spaces with independent lifecycle state
+    #[command(
+        after_help = "Examples:\n  tonk space list\n  tonk space list --all\n  tonk space list --json"
+    )]
+    List {
+        /// Include hidden, archived, ambiguous, and orphaned rows.
+        #[arg(long)]
+        all: bool,
+        /// Refresh provider inventory and remote heads without mutating state.
+        #[arg(long)]
+        refresh: bool,
+        /// Emit stable version-one JSON rows.
+        #[arg(long)]
+        json: bool,
+    },
 
-    /// Delete a spot and its data from disk
+    /// Remove a space from this device
     ///
-    /// This destroys the spot's facts, not just its registration.
-    /// It asks for confirmation first, and says whether the exact revision is
-    /// confirmed remotely and listed in your account directory (so you can
-    /// pull it again) or
-    /// local-only (so it is gone for good).
+    /// Records profile-local suppression before unregistering it. Local bytes
+    /// are deleted by default when safe; account membership, remote data,
+    /// peer copies, and authority are unchanged.
     ///
-    /// To stop a directory from resolving to a spot without touching
-    /// any data, use `tonk spot unbind`. To drop the registration but
+    /// To stop a directory from resolving to a space without touching
+    /// any data, use `tonk space unbind`. To drop the registration but
     /// keep the data, use --keep-data.
     #[command(
-        after_help = "Examples:\n  tonk spot rm garden\n  tonk spot rm garden --yes\n  tonk spot rm garden --keep-data"
+        after_help = "Examples:\n  tonk space rm garden\n  tonk space rm garden --yes\n  tonk space rm garden --keep-data\n\nCompatibility alias: `tonk spot rm`"
     )]
     Rm {
-        /// Spot name to delete.
+        /// Space name to remove from this device.
         #[arg(value_name = "NAME")]
         name: String,
-        /// Unregister the spot but leave its data on disk.
+        /// Unregister the space but leave its data on disk.
         ///
-        /// The data then belongs to no spot: `tonk spot list` reports
-        /// it, `tonk spot new <name> --site <path>` adopts it back,
+        /// The data then belongs to no space: `tonk space list --all` reports
+        /// it, `tonk space new <name> --site <path>` adopts it back,
         /// and it keeps its canonical name reserved against `tonk
-        /// join` and `tonk account spots pull`.
+        /// join` and `tonk account spaces pull`.
         #[arg(long, conflicts_with = "delete")]
         keep_data: bool,
         /// Delete without asking for confirmation.
@@ -808,14 +837,29 @@ enum SpotCommand {
         delete: bool,
     },
 
-    /// Unbind a directory from its spot (see `tonk use`)
+    /// Permanently archive a repository subject from this account
     ///
-    /// Only unlinks the directory: the spot stays registered and no
-    /// data is touched. `tonk spot rm` is the one that deletes.
+    /// This hides ordinary account discovery on every current client. It does
+    /// not delete local or remote bytes and does not revoke authority.
+    Archive {
+        /// Full repository subject DID.
+        #[arg(value_name = "SUBJECT")]
+        subject: String,
+        /// Archive without interactive confirmation.
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
+    /// Unbind a directory from its space (see `tonk use`)
+    ///
+    /// Only unlinks the directory: the space stays registered and no
+    /// data is touched. `tonk space rm` removes it from this device.
     ///
     /// Matches exactly: run from the directory that was bound,
     /// not a subdirectory of it.
-    #[command(after_help = "Examples:\n  tonk spot unbind\n  tonk spot unbind ~/old-project")]
+    #[command(
+        after_help = "Examples:\n  tonk space unbind\n  tonk space unbind ~/old-project\n\nCompatibility alias: `tonk spot unbind`"
+    )]
     Unbind {
         /// Directory to unbind. Default: the current directory. Pass
         /// an absolute path to clear an entry whose directory no
@@ -1000,11 +1044,12 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
         ),
         Command::Use { .. } => ("use", None),
         Command::Spot { command } => (
-            "spot",
+            "space",
             Some(match command {
                 SpotCommand::New { .. } => "new",
-                SpotCommand::List => "list",
+                SpotCommand::List { .. } => "list",
                 SpotCommand::Rm { .. } => "rm",
+                SpotCommand::Archive { .. } => "archive",
                 SpotCommand::Unbind { .. } => "unbind",
             }),
         ),
@@ -1022,9 +1067,9 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
                 AccountCommand::Delete { .. } => "delete",
                 AccountCommand::Sync => "sync",
                 AccountCommand::Spots { command } => match command {
-                    None | Some(AccountSpotsCommand::List) => "spots-list",
-                    Some(AccountSpotsCommand::Pull { .. }) => "spots-pull",
-                    Some(AccountSpotsCommand::Delete { .. }) => "spots-delete",
+                    None | Some(AccountSpotsCommand::List { .. }) => "spaces-list",
+                    Some(AccountSpotsCommand::Pull { .. }) => "spaces-pull",
+                    Some(AccountSpotsCommand::Delete { .. }) => "spaces-delete",
                 },
                 AccountCommand::Migrate => "migrate",
                 AccountCommand::Devices { .. } => "devices",
@@ -1044,7 +1089,7 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
         Command::Push => ("push", None),
         Command::Pull => ("pull", None),
         Command::Status => ("status", None),
-        Command::Invite { .. } => ("invite", None),
+        Command::Invite { .. } => ("share", None),
         Command::Join { .. } => ("join", None),
         Command::Remote { command } => (
             "remote",
@@ -1337,7 +1382,7 @@ async fn agents_op(json: bool, command: Option<AgentsCommand>, spot: Option<&str
                 Ok(Some(claim)) => claim,
                 Ok(None) => {
                     return print_error(
-                        "this spot has no AGENTS.md claim\ncreate one: tonk agents set AGENTS.md",
+                        "this space has no AGENTS.md claim\ncreate one: tonk agents set AGENTS.md",
                     );
                 }
                 Err(err) => return print_error(format!("could not read AGENTS.md claim: {err:#}")),
@@ -1807,7 +1852,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                         if outcome.certificates == 1 { "" } else { "s" }
                     );
                     println!(
-                        "retained {} spot{} into the account space ({} already there)",
+                        "retained {} space{} into the account repository ({} already there)",
                         outcome.spots,
                         if outcome.spots == 1 { "" } else { "s" },
                         outcome.already
@@ -1844,6 +1889,30 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             Err(error) => print_failure(error),
         },
         AccountCommand::Sync => {
+            let operator =
+                match tonk_cli::account_state::operator_for_store(&profile, &context.store).await {
+                    Ok(operator) => operator,
+                    Err(error) => return print_failure(error),
+                };
+            let account_state = match tonk_cli::account_state::ensure_with_operator_and_store(
+                &profile,
+                operator,
+                context.store.clone(),
+            )
+            .await
+            {
+                Ok(outcome) => outcome,
+                Err(error) => return print_failure(error),
+            };
+            if let Some(warning) = account_state.warning {
+                eprintln!("warning: account repository is not synchronized: {warning}");
+            }
+            if account_state.status != tonk_account::AccountStateStatus::Ready {
+                return print_error(format!(
+                    "account repository is {}; retry `tonk account sync` when its remote is reachable",
+                    account_state_label(account_state.status)
+                ));
+            }
             let context = retry_deployment_discovery(&profiles, context, &profile).await;
             let report = tonk_cli::account_sync::reconcile_profile(&context).await;
             let failed = report.rows.iter().any(|row| {
@@ -1869,32 +1938,22 @@ async fn account_op(command: AccountCommand) -> ExitCode {
         }
         AccountCommand::Spots { command } => {
             let store = &context.store;
-            match command.unwrap_or(AccountSpotsCommand::List) {
-                AccountSpotsCommand::List => match account_spots::list(&profile, store).await {
-                    Ok(rows) => {
-                        if rows.is_empty() {
-                            println!("(no spaces listed in the account directory)");
-                        } else {
-                            for row in rows {
-                                let state = if row.ambiguous {
-                                    "ambiguous"
-                                } else if row.local_name.is_some() {
-                                    "local"
-                                } else {
-                                    "remote"
-                                };
-                                let name = row
-                                    .remote_name
-                                    .as_deref()
-                                    .or(row.local_name.as_deref())
-                                    .unwrap_or("-");
-                                println!("{state}\t{name}\t{}", row.subject);
-                            }
-                        }
-                        ExitCode::Success
+            match command.unwrap_or(AccountSpotsCommand::List {
+                all: false,
+                refresh: false,
+                json: false,
+            }) {
+                AccountSpotsCommand::List { all, refresh, json } => {
+                    match tonk_cli::inventory::list(
+                        &context,
+                        tonk_cli::inventory::InventoryOptions { all, refresh },
+                    )
+                    .await
+                    {
+                        Ok(rows) => render_space_inventory(&rows, json),
+                        Err(error) => print_failure(error),
                     }
-                    Err(error) => print_failure(error),
-                },
+                }
                 AccountSpotsCommand::Pull { subject, name } => {
                     match account_spots::pull(&profile, store, &subject, name.as_deref()).await {
                         Ok(outcome) => {
@@ -2011,7 +2070,7 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
                 Ok(Some(selected)) => selected,
                 Ok(None) => {
                     return print_error(
-                        "no account profile is selected; create a spot or run `tonk account add`",
+                        "no account profile is selected; create a space or run `tonk account add`",
                     );
                 }
                 Err(error) => return print_failure(error),
@@ -2038,16 +2097,19 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
             }
         }
         None => {
-            let env = spot_from_environment();
+            let env = match spot_from_environment(flag) {
+                Ok(env) => env,
+                Err(error) => return print_failure(error),
+            };
             let active = profiles.resolve(flag, env.as_deref(), cwd.as_deref()).ok();
             match &active {
                 Some(active) => println!(
-                    "current spot: {} ({})\nselected via: {}",
+                    "current space: {} ({})\nselected via: {}",
                     active.name,
                     active.site.display(),
                     active.source
                 ),
-                None => println!("current spot: (none)"),
+                None => println!("current space: (none)"),
             }
             match profiles.selected() {
                 Ok(Some(selected)) => match selected.store.load() {
@@ -2075,7 +2137,41 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
     }
 }
 
-/// `tonk spot new|list|rm` — registry management.
+fn render_space_inventory(
+    rows: &[tonk_cli::inventory::SpaceInventoryRowV1],
+    json: bool,
+) -> ExitCode {
+    if json {
+        match serde_json::to_string_pretty(rows) {
+            Ok(json) => println!("{json}"),
+            Err(error) => return print_failure(error),
+        }
+    } else if rows.is_empty() {
+        println!("(no spaces visible; use `tonk space list --all` for hidden rows)");
+    } else {
+        println!(
+            "SUBJECT\tNAME\tLOCAL\tMEMBERSHIP\tTRANSPORT\tSYNC\tAUTHORITY\tVISIBILITY\tPULLABLE\tCONFIRMED"
+        );
+        for row in rows {
+            println!(
+                "{}\t{}\t{:?}\t{:?}\t{:?}\t{:?}\t{:?}\t{:?}\t{}\t{}",
+                row.subject,
+                row.name.as_deref().unwrap_or("-"),
+                row.local_presence,
+                row.account_membership,
+                row.transport,
+                row.sync,
+                row.authority,
+                row.visibility,
+                row.pullable,
+                row.confirmed_revision.as_deref().unwrap_or("-"),
+            );
+        }
+    }
+    ExitCode::Success
+}
+
+/// `tonk space new|list|rm|archive` — lifecycle management.
 async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
     let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
         Ok(store) => store,
@@ -2102,18 +2198,18 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                 Ok(outcome) => {
                     if let Err(error) = profiles.bind(&profile.id, &name, &cwd) {
                         return print_error(format!(
-                            "spot '{}' was created and registered, but binding {} failed: {error}",
+                            "space '{}' was created and registered, but binding {} failed: {error}",
                             outcome.name,
                             cwd.display()
                         ));
                     }
                     if outcome.adopted {
                         println!(
-                            "Registered spot '{}' on the site data already at that path",
+                            "Registered space '{}' on the site data already at that path",
                             outcome.name
                         );
                     } else {
-                        println!("Registered spot '{}'", outcome.name);
+                        println!("Registered space '{}'", outcome.name);
                     }
                     println!("site: {}", outcome.site.display());
                     println!("DID: {}", outcome.did);
@@ -2125,64 +2221,27 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                 Err(err) => print_failure(err),
             }
         }
-        SpotCommand::List => {
-            let env = std::env::var(tonk_cli::spot::SPOT_ENV)
-                .ok()
-                .filter(|value| !value.is_empty());
-            let cwd = working_directory();
+        SpotCommand::List { all, refresh, json } => {
             let profile = match profiles.selected() {
                 Ok(Some(profile)) => profile,
                 Ok(None) => {
-                    println!("(no spots registered; create one with `tonk spot new <name>`)");
+                    if json {
+                        println!("[]");
+                    } else {
+                        println!("(no spaces registered; create one with `tonk space new <name>`)");
+                    }
                     return ExitCode::Success;
                 }
                 Err(error) => return print_failure(error),
             };
-            match tonk_cli::spot::listing(&profile.store, flag, env.as_deref(), None) {
-                Ok(listing) => {
-                    if listing.rows.is_empty() {
-                        println!("(no spots registered; create one with `tonk spot new <name>`)");
-                        print_orphaned_sites(&listing.orphans);
-                        return ExitCode::Success;
-                    }
-                    let routed = profiles.resolve(flag, env.as_deref(), cwd.as_deref()).ok();
-                    let active = routed.as_ref().and_then(|resolved| {
-                        (resolved.profile.id == profile.id).then_some(resolved.name.as_str())
-                    });
-                    for (name, site) in &listing.rows {
-                        let marker = if Some(name.as_str()) == active {
-                            '*'
-                        } else {
-                            ' '
-                        };
-                        println!("{marker} {name}\t{site}", site = site.display());
-                    }
-                    if let Some(resolved) = &routed {
-                        println!(
-                            "active here: {name} ({source})",
-                            name = resolved.name,
-                            source = resolved.source,
-                        );
-                    }
-                    let install = match profiles.load_or_bootstrap() {
-                        Ok(install) => install,
-                        Err(error) => return print_failure(error),
-                    };
-                    if !install.bindings.is_empty() {
-                        println!();
-                        println!("directories:");
-                        for (directory, binding) in &install.bindings {
-                            println!(
-                                "  {directory}\t{name}",
-                                directory = directory.display(),
-                                name = binding.space
-                            );
-                        }
-                    }
-                    print_orphaned_sites(&listing.orphans);
-                    ExitCode::Success
-                }
-                Err(err) => print_failure(err),
+            match tonk_cli::inventory::list(
+                &profile,
+                tonk_cli::inventory::InventoryOptions { all, refresh },
+            )
+            .await
+            {
+                Ok(rows) => render_space_inventory(&rows, json),
+                Err(error) => print_failure(error),
             }
         }
         SpotCommand::Rm {
@@ -2197,6 +2256,48 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                 Err(error) => return print_failure(error),
             };
             spot_rm(&profiles, &profile, &name, keep_data, yes).await
+        }
+        SpotCommand::Archive { subject, yes } => {
+            if !yes {
+                if !std::io::stdin().is_terminal() {
+                    return print_error(
+                        "refusing to archive without confirmation: pass --yes in non-interactive use",
+                    );
+                }
+                println!(
+                    "This permanently archives account membership for {subject}. Local and remote data are not deleted, and authority is not revoked."
+                );
+                if !confirm_by_name(&subject) {
+                    println!("Aborted; account membership was not archived.");
+                    return ExitCode::IoError;
+                }
+            }
+            let profile = match profiles.selected() {
+                Ok(Some(profile)) => profile,
+                Ok(None) => return print_error("no account profile is selected"),
+                Err(error) => return print_failure(error),
+            };
+            let mounted = match profile.load_profile().await {
+                Ok(profile) => profile,
+                Err(error) => return print_failure(error),
+            };
+            match account_spots::archive(&mounted, &profile.store, &subject).await {
+                Ok(outcome) => {
+                    if outcome.newly_archived {
+                        println!("Archived account space {}", outcome.subject);
+                    } else {
+                        println!("Account space {} was already archived", outcome.subject);
+                    }
+                    println!("Local and remote data were not deleted; authority was not revoked.");
+                    if let Some(warning) = outcome.projection_warning {
+                        eprintln!(
+                            "warning: canonical archive succeeded, but provider projection is pending: {warning}"
+                        );
+                    }
+                    ExitCode::Success
+                }
+                Err(error) => print_failure(error),
+            }
         }
         SpotCommand::Unbind { path } => {
             let directory = match path.or_else(working_directory) {
@@ -2216,24 +2317,6 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
             }
         }
     }
-}
-
-/// Report canonical site data that no registered spot names.
-///
-/// Silent when there is none, so the common listing stays clean. When
-/// there is some it belongs on screen: it is otherwise entirely
-/// invisible, and it is the thing that will refuse a later `tonk
-/// join` or `tonk account spots pull` on the same name.
-fn print_orphaned_sites(orphans: &[PathBuf]) {
-    if orphans.is_empty() {
-        return;
-    }
-    println!();
-    println!("unregistered site data (belongs to no spot):");
-    for path in orphans {
-        println!("  {}", path.display());
-    }
-    println!("  adopt it with `tonk spot new <name> --site <path>`, or delete the directory");
 }
 
 /// `tonk spot rm` — delete a spot's data, or (with --keep-data) just
@@ -2269,18 +2352,32 @@ async fn spot_rm(
         });
     };
     let site = entry.site.clone();
+    let subject = if profile.record.account_root.is_some() {
+        let mut config = profile.site_config();
+        config.require_account = false;
+        match tonk_cli::site::TonkSite::open_with(&site, config).await {
+            Ok(site) => Some(site.repository.did().to_string()),
+            Err(error) => {
+                return print_failure(error.context(
+                    "cannot identify this account-backed space; nothing was removed or suppressed",
+                ));
+            }
+        }
+    } else {
+        None
+    };
 
     if keep_data {
-        return match profiles.remove_space(&profile.id, name, Data::Keep) {
+        return match profiles.remove_space(&profile.id, name, Data::Keep, subject.as_deref()) {
             Ok(outcome) => {
-                println!("Unregistered spot '{}'", outcome.name);
+                println!("Unregistered space '{}'", outcome.name);
                 println!("data kept at {}", outcome.site.display());
                 println!(
-                    "  it belongs to no spot now: re-adopt it with \
-                     `tonk spot new <name> --site {}`,",
+                    "  it belongs to no space now: re-adopt it with \
+                     `tonk space new <name> --site {}`,",
                     outcome.site.display()
                 );
-                println!("  or delete it with `tonk spot rm <name>` after re-adopting");
+                println!("  or remove it with `tonk space rm <name>` after re-adopting");
                 for directory in &outcome.unbound {
                     println!("unbound {}", directory.display());
                 }
@@ -2304,7 +2401,7 @@ async fn spot_rm(
         }
         let recovery = tonk_cli::recovery::inspect(&site, profile.site_config()).await;
         println!();
-        println!("This permanently deletes the spot's data from disk:");
+        println!("This removes the space from this device and permanently deletes its local data:");
         println!("  {}", site.display());
         println!();
         println!("{}", recovery.consequence(name));
@@ -2320,16 +2417,22 @@ async fn spot_rm(
         }
     }
 
-    match profiles.remove_space(&profile.id, name, Data::Delete) {
+    match profiles.remove_space(&profile.id, name, Data::Delete, subject.as_deref()) {
         Ok(outcome) => {
             match outcome.data {
                 Deletion::Deleted => {
-                    println!("Deleted spot '{}' and its data", outcome.name);
+                    println!(
+                        "Removed space '{}' from this device and deleted its local data",
+                        outcome.name
+                    );
                     println!("removed {}", outcome.site.display());
                 }
                 // Nothing was destroyed, so don't say it was.
                 Deletion::AlreadyGone => {
-                    println!("Unregistered spot '{}'", outcome.name);
+                    println!(
+                        "Removed space '{}' from this device; local data was kept",
+                        outcome.name
+                    );
                     println!("its data was already gone from {}", outcome.site.display());
                 }
                 Deletion::Kept => unreachable!("Data::Delete never keeps the site"),
@@ -2501,7 +2604,7 @@ async fn legacy_migrate(
 ) -> ExitCode {
     let Some(site) = site else {
         return print_failure(anyhow::anyhow!(
-            "--legacy needs --site <NAME>, the registered spot to upgrade"
+            "--legacy needs --site <NAME>, the registered space to upgrade"
         ));
     };
     let branches = if branches.is_empty() {
@@ -2699,7 +2802,7 @@ async fn status_op(spot: Option<&str>) -> ExitCode {
         Err(code) => return code,
     };
     println!(
-        "spot: {name} ({source})",
+        "space: {name} ({source})",
         name = resolved.name,
         source = resolved.source,
     );
@@ -3179,7 +3282,7 @@ async fn claim_invite(url: String, name: String, flag: Option<&str>) -> ExitCode
             }
             if let Err(error) = profiles.bind(&profile.id, &name, &cwd) {
                 return print_error(format!(
-                    "joined and registered spot '{name}', but binding {} failed: {error}",
+                    "joined and registered space '{name}', but binding {} failed: {error}",
                     cwd.display()
                 ));
             }
@@ -3201,7 +3304,7 @@ fn print_claim_outcome(
     directory: &std::path::Path,
     outcome: &ClaimOutcome,
 ) {
-    println!("Joined spot '{name}' ({})", root.display());
+    println!("Joined space '{name}' ({})", root.display());
     println!("subject: {}", outcome.subject);
     if let Some(remote) = &outcome.auto_configured_remote
         && let Some(url) = &outcome.remote_url
@@ -3237,7 +3340,7 @@ async fn migrate(from: Option<PathBuf>, do_move: bool) -> ExitCode {
             );
             println!("DID: {}", outcome.repo_did);
             println!(
-                "register it as a spot: `tonk spot new <name> --site {}`",
+                "register it as a space: `tonk space new <name> --site {}`",
                 outcome.destination.display()
             );
             println!(
@@ -3643,10 +3746,10 @@ fn working_directory() -> Option<PathBuf> {
     std::env::current_dir().ok()
 }
 
-fn spot_from_environment() -> Option<String> {
-    std::env::var(tonk_cli::spot::SPOT_ENV)
-        .ok()
-        .filter(|value| !value.is_empty())
+fn spot_from_environment(flag: Option<&str>) -> Result<Option<String>, tonk_cli::spot::SpotError> {
+    let space = std::env::var(tonk_cli::spot::SPACE_ENV).ok();
+    let spot = std::env::var(tonk_cli::spot::SPOT_ENV).ok();
+    tonk_cli::spot::environment_selection_for_flag(flag, space.as_deref(), spot.as_deref())
 }
 
 /// Report the spot that would actually answer a data command after a
@@ -3656,16 +3759,22 @@ fn print_active_resolution(
     flag: Option<&str>,
     cwd: Option<&std::path::Path>,
 ) {
-    let env = spot_from_environment();
+    let env = match spot_from_environment(flag) {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("warning: binding saved, but space environment is ambiguous: {error}");
+            return;
+        }
+    };
     match store.resolve(flag, env.as_deref(), cwd) {
         Ok(resolved) => println!(
-            "active spot: {name} ({source})\nsite: {site}",
+            "active space: {name} ({source})\nsite: {site}",
             name = resolved.name,
             source = resolved.source,
             site = resolved.site.display(),
         ),
         Err(err) => {
-            eprintln!("warning: binding saved, but the active spot does not resolve: {err}")
+            eprintln!("warning: binding saved, but the active space does not resolve: {err}")
         }
     }
 }
@@ -3677,11 +3786,13 @@ fn print_active_spot_context(flag: Option<&str>) {
     let Ok(store) = tonk_cli::account_profiles::NativeProfileStore::open() else {
         return;
     };
-    let env = spot_from_environment();
+    let Ok(env) = spot_from_environment(flag) else {
+        return;
+    };
     let cwd = working_directory();
     if let Ok(resolved) = store.resolve(flag, env.as_deref(), cwd.as_deref()) {
         eprintln!(
-            "active spot: {name} ({source})\nprofile: {profile}\naccount: {account}\nsigned in: {signed_in}\nsite: {site}",
+            "active space: {name} ({source})\nprofile: {profile}\naccount: {account}\nsigned in: {signed_in}\nsite: {site}",
             name = resolved.name,
             source = resolved.source,
             profile = resolved.profile.record.label,
@@ -3714,9 +3825,10 @@ async fn open_selected(
         Ok(store) => store,
         Err(err) => return Err(print_failure(err)),
     };
-    let env = std::env::var(tonk_cli::spot::SPOT_ENV)
-        .ok()
-        .filter(|value| !value.is_empty());
+    let env = match spot_from_environment(flag) {
+        Ok(env) => env,
+        Err(error) => return Err(print_failure(error)),
+    };
     let cwd = working_directory();
     let routed = match store.resolve(flag, env.as_deref(), cwd.as_deref()) {
         Ok(resolved) => resolved,
@@ -3725,7 +3837,7 @@ async fn open_selected(
     match site::TonkSite::open_with(&routed.site, routed.profile.site_config()).await {
         Ok(site) => Ok((routed, site)),
         Err(err) => Err(print_error(format!(
-            "could not open the active spot for profile '{}': {err:#}",
+            "could not open the active space for profile '{}': {err:#}",
             routed.profile.record.label
         ))),
     }
@@ -3742,6 +3854,7 @@ fn classify(err: &EvalError) -> ExitCode {
 #[cfg(test)]
 mod account_spots_parser_tests {
     use super::*;
+    use clap::CommandFactory as _;
 
     #[test]
     fn account_status_makes_sign_in_state_explicit() {
@@ -3888,7 +4001,7 @@ mod account_spots_parser_tests {
             else {
                 panic!("expected account spots");
             };
-            assert!(command.is_none() || matches!(command, Some(AccountSpotsCommand::List)));
+            assert!(command.is_none() || matches!(command, Some(AccountSpotsCommand::List { .. })));
         }
     }
 
@@ -3930,5 +4043,69 @@ mod account_spots_parser_tests {
         };
         assert_eq!(subject, did);
         assert!(no_open);
+    }
+
+    #[test]
+    fn canonical_space_share_and_account_spaces_aliases_parse_like_legacy_spellings() {
+        for args in [
+            ["tonk", "space", "list"].as_slice(),
+            ["tonk", "spot", "list"].as_slice(),
+        ] {
+            let cli = Cli::try_parse_from(args).expect("space alias parses");
+            assert!(matches!(
+                cli.command,
+                Some(Command::Spot {
+                    command: SpotCommand::List { .. }
+                })
+            ));
+        }
+        for verb in ["share", "invite"] {
+            let cli = Cli::try_parse_from(["tonk", verb, "--no-remote", "--no-shorten"])
+                .expect("share alias parses");
+            assert!(matches!(cli.command, Some(Command::Invite { .. })));
+        }
+        for noun in ["spaces", "spots"] {
+            let cli = Cli::try_parse_from(["tonk", "account", noun, "list"])
+                .expect("account spaces alias parses");
+            assert!(matches!(
+                cli.command,
+                Some(Command::Account {
+                    command: AccountCommand::Spots { .. }
+                })
+            ));
+        }
+        for flag in ["--space", "--spot"] {
+            let cli = Cli::try_parse_from(["tonk", flag, "garden", "status"])
+                .expect("space flag alias parses");
+            assert_eq!(cli.spot.as_deref(), Some("garden"));
+        }
+        let archive = Cli::try_parse_from(["tonk", "space", "archive", "did:key:zGarden", "--yes"])
+            .expect("space archive parses");
+        assert!(matches!(
+            archive.command,
+            Some(Command::Spot {
+                command: SpotCommand::Archive { yes: true, .. }
+            })
+        ));
+    }
+
+    #[test]
+    fn canonical_help_leads_with_space_and_share_and_keeps_aliases_visible() {
+        let mut root = Cli::command();
+        let root_help = root.render_long_help().to_string();
+        assert!(root_help.contains("space"));
+        assert!(root_help.contains("spot"));
+        assert!(root_help.contains("share"));
+        assert!(root_help.contains("invite"));
+
+        let mut new = Cli::command()
+            .find_subcommand("space")
+            .and_then(|space| space.find_subcommand("new"))
+            .expect("space new help")
+            .clone();
+        let help = new.render_long_help().to_string();
+        let canonical = help.find("tonk space new").expect("canonical example");
+        let compatibility = help.find("tonk spot new").expect("visible alias note");
+        assert!(canonical < compatibility);
     }
 }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1424,6 +1424,15 @@ fn render_account_status(status: account::AccountStatus) -> String {
     }
 }
 
+fn render_account_link(label: &str, outcome: &account::LinkOutcome) -> String {
+    format!(
+        "linked\nroot: {}\ndevice: {}\naccount state: {}\nprofile: {label}",
+        outcome.root_did,
+        outcome.device_did,
+        account_state_label(outcome.account_state)
+    )
+}
+
 /// Best-effort registration line, quiet about being offline: status must
 /// answer without depending on the sync service.
 async fn print_customer_line(
@@ -1539,13 +1548,7 @@ async fn link_native_profile(
     {
         return print_failure(error);
     }
-    println!(
-        "linked\nprofile: {}\nroot: {}\ndevice: {}\naccount state: {}",
-        context.record.label,
-        outcome.root_did,
-        outcome.device_did,
-        account_state_label(outcome.account_state)
-    );
+    println!("{}", render_account_link(&context.record.label, &outcome));
     if let Some(label) = duplicate {
         eprintln!(
             "warning: account root is already present in profile '{label}'; keeping both device profiles"
@@ -3801,6 +3804,24 @@ mod account_spots_parser_tests {
             panic!("expected account delete");
         };
         assert!(no_open);
+    }
+
+    #[test]
+    fn account_link_preserves_the_legacy_receipt_prefix() {
+        let receipt = render_account_link(
+            "personal",
+            &account::LinkOutcome {
+                url: "https://tonk.spot/account/link".to_string(),
+                root_did: "did:key:root".to_string(),
+                device_did: "did:key:device".to_string(),
+                account_state: tonk_account::AccountStateStatus::Ready,
+                warning: None,
+            },
+        );
+        assert_eq!(
+            receipt,
+            "linked\nroot: did:key:root\ndevice: did:key:device\naccount state: synced\nprofile: personal"
+        );
     }
 
     #[test]

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -505,6 +505,57 @@ enum AccountCommand {
     /// Show whether this native profile is linked to an account
     Status,
 
+    /// Create a fresh local profile and approve it in the browser
+    Add {
+        /// Unique local profile label.
+        #[arg(long, value_name = "LABEL")]
+        label: Option<String>,
+        /// Override the automatically generated OS/version device name.
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
+        /// Account service base URL (for staging or local development).
+        #[arg(long, value_name = "URL", default_value = account::DEFAULT_SERVICE_URL, hide = true)]
+        service_url: String,
+        /// Browser ceremony route (for staging or local development).
+        #[arg(long, value_name = "URL", default_value = account::DEFAULT_LINK_PAGE, hide = true)]
+        account_url: String,
+        /// Print the approval URL without asking the OS to open it.
+        #[arg(long)]
+        no_open: bool,
+        /// Authorize through a page that posts the grant back directly.
+        #[arg(long, value_name = "URL")]
+        via: Option<String>,
+    },
+
+    /// Select a local profile without contacting an account provider
+    Use {
+        /// Profile label or exact `p-...` identifier.
+        #[arg(value_name = "PROFILE")]
+        profile: String,
+    },
+
+    /// Sign the selected rooted profile back into its account
+    Login {
+        /// Override the automatically generated OS/version device name.
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
+        /// Account service base URL (for staging or local development).
+        #[arg(long, value_name = "URL", default_value = account::DEFAULT_SERVICE_URL, hide = true)]
+        service_url: String,
+        /// Browser ceremony route (for staging or local development).
+        #[arg(long, value_name = "URL", default_value = account::DEFAULT_LINK_PAGE, hide = true)]
+        account_url: String,
+        /// Print the approval URL without asking the OS to open it.
+        #[arg(long)]
+        no_open: bool,
+        /// Authorize through a page that posts the grant back directly.
+        #[arg(long, value_name = "URL")]
+        via: Option<String>,
+    },
+
+    /// List every local account profile without contacting providers
+    List,
+
     /// Approve this native profile with a synced passkey in the browser
     #[command(
         after_help = "Examples:\n  tonk account link\n  tonk account link --name workstation"
@@ -521,6 +572,14 @@ enum AccountCommand {
             hide = true
         )]
         service_url: String,
+        /// Browser ceremony route (for staging or local development).
+        #[arg(
+            long,
+            value_name = "URL",
+            default_value = account::DEFAULT_LINK_PAGE,
+            hide = true
+        )]
+        account_url: String,
         /// Print the approval URL without asking the OS to open it.
         #[arg(long)]
         no_open: bool,
@@ -556,7 +615,10 @@ enum AccountCommand {
         no_open: bool,
     },
 
-    /// List or pull the spots your account directory lists
+    /// Reconcile the selected profile's local spaces with their remotes
+    Sync,
+
+    /// List or pull the spaces your account directory lists
     Spots {
         #[command(subcommand)]
         command: Option<AccountSpotsCommand>,
@@ -714,8 +776,9 @@ enum SpotCommand {
     /// Delete a spot and its data from disk
     ///
     /// This destroys the spot's facts, not just its registration.
-    /// It asks for confirmation first, and says whether the data is
-    /// listed in your account directory (so you can pull it again) or
+    /// It asks for confirmation first, and says whether the exact revision is
+    /// confirmed remotely and listed in your account directory (so you can
+    /// pull it again) or
     /// local-only (so it is gone for good).
     ///
     /// To stop a directory from resolving to a spot without touching
@@ -950,9 +1013,14 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
             "account",
             Some(match command {
                 AccountCommand::Status => "status",
+                AccountCommand::Add { .. } => "add",
+                AccountCommand::Use { .. } => "use",
+                AccountCommand::Login { .. } => "login",
+                AccountCommand::List => "list",
                 AccountCommand::Link { .. } => "link",
                 AccountCommand::Logout => "logout",
                 AccountCommand::Delete { .. } => "delete",
+                AccountCommand::Sync => "sync",
                 AccountCommand::Spots { command } => match command {
                     None | Some(AccountSpotsCommand::List) => "spots-list",
                     Some(AccountSpotsCommand::Pull { .. }) => "spots-pull",
@@ -1187,15 +1255,41 @@ async fn main() {
 /// nothing backed up what it created. `tonk account link` runs the same
 /// handoff with an account behind it.
 async fn identity(reset: bool) -> ExitCode {
+    let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
+        Ok(profiles) => profiles,
+        Err(error) => return print_failure(error),
+    };
+    let context = match profiles.selected() {
+        Ok(Some(context)) => context,
+        Ok(None) => return print_error("no account profile is selected"),
+        Err(error) => return print_failure(error),
+    };
+    if reset {
+        match context.store.load() {
+            Ok(registry) if !registry.spots.is_empty() => {
+                return print_error(format!(
+                    "refusing to reset profile '{}': it still owns {} registered space(s)",
+                    context.record.label,
+                    registry.spots.len()
+                ));
+            }
+            Ok(_) => {}
+            Err(error) => return print_failure(error),
+        }
+    }
     let result = if reset {
-        identity::reset().await
+        identity::reset_in(&context).await
     } else {
-        identity::open().await
+        identity::open_in(&context).await
     };
     match result {
         Ok(profile) => {
+            println!(
+                "profile: {}\nprofile id: {}",
+                context.record.label, context.id
+            );
             println!("device: {}", profile.did());
-            match identity::local_root(&profile).await {
+            match identity::local_root_in(&profile, &context.store).await {
                 Ok(Some(root)) => println!("account: {}", root.root_did),
                 Ok(None) => println!("account: missing (run `tonk account link`)"),
                 Err(error) => return print_failure(error),
@@ -1212,7 +1306,7 @@ async fn context_op(json: bool, spot: Option<&str>) -> ExitCode {
         Ok(opened) => opened,
         Err(code) => return code,
     };
-    let report = match context::inspect(&resolved, &site).await {
+    let report = match context::inspect_profiled(&resolved, &site).await {
         Ok(report) => report,
         Err(err) => return print_error(format!("could not build live context: {err:#}")),
     };
@@ -1330,14 +1424,14 @@ fn render_account_status(status: account::AccountStatus) -> String {
     }
 }
 
-/// Best-effort registration line, quiet about being offline: status
-/// must answer without the network. Registration itself is web-only —
-/// the browser enrolls during its passkey ceremonies, which is where
-/// the account-signed deposits come from — so this only reads state
-/// and points at the account page when something is missing.
-async fn print_customer_line(profile: &dialog_operator::Profile) {
+/// Best-effort registration line, quiet about being offline: status must
+/// answer without depending on the sync service.
+async fn print_customer_line(
+    profile: &dialog_operator::Profile,
+    store: &tonk_cli::spot::SpotStore,
+) {
     use tonk_account::customer::CustomerStatus;
-    match tonk_cli::customer::registration_state(profile).await {
+    match tonk_cli::customer::registration_state_in(profile, store).await {
         Ok(Some(Some(receipt))) => match receipt.status {
             CustomerStatus::Active => println!("access service: registered"),
             CustomerStatus::Registered => {
@@ -1346,7 +1440,7 @@ async fn print_customer_line(profile: &dialog_operator::Profile) {
             CustomerStatus::Suspended => println!("access service: suspended"),
         },
         Ok(Some(None)) => {
-            let page = tonk_cli::customer::access_origin(profile)
+            let page = tonk_cli::customer::access_origin_in(profile, store)
                 .await
                 .ok()
                 .flatten()
@@ -1359,19 +1453,282 @@ async fn print_customer_line(profile: &dialog_operator::Profile) {
     }
 }
 
+fn account_list(profiles: &tonk_cli::account_profiles::NativeProfileStore) -> ExitCode {
+    let registry = match profiles.load_or_bootstrap() {
+        Ok(registry) => registry,
+        Err(error) => return print_failure(error),
+    };
+    if registry.profiles.is_empty() {
+        println!("(no account profiles; run `tonk account add`)");
+        return ExitCode::Success;
+    }
+    for (id, record) in &registry.profiles {
+        let context = match profiles.context(id) {
+            Ok(context) => context,
+            Err(error) => return print_failure(error),
+        };
+        let phase = match context.sign_in_state() {
+            Ok(tonk_cli::account_profiles::ProfileSignIn::Active) => "signed in",
+            Ok(tonk_cli::account_profiles::ProfileSignIn::Pending) => "pending",
+            Ok(tonk_cli::account_profiles::ProfileSignIn::SignedOut) => "signed out",
+            Err(error) => return print_failure(error),
+        };
+        let spaces = match context.store.load() {
+            Ok(registry) => registry.spots.len(),
+            Err(error) => return print_failure(error),
+        };
+        let selected = if registry.selected.as_ref() == Some(id) {
+            '*'
+        } else {
+            ' '
+        };
+        println!(
+            "{selected} {label}\t{id}\troot: {root}\t{phase}\tspaces: {spaces}",
+            label = record.label,
+            root = record.account_root.as_deref().unwrap_or("pending"),
+        );
+    }
+    ExitCode::Success
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn link_native_profile(
+    profiles: &tonk_cli::account_profiles::NativeProfileStore,
+    context: tonk_cli::account_profiles::NativeProfileContext,
+    name: Option<String>,
+    service_url: String,
+    account_url: String,
+    no_open: bool,
+    via: Option<String>,
+    expected_root: Option<String>,
+) -> ExitCode {
+    let discovery_url = via.as_deref().unwrap_or(&account_url).to_owned();
+    let ceremony_url = discovery_url.clone();
+    let profile = match identity::open_in(&context).await {
+        Ok(profile) => profile,
+        Err(error) => return print_failure(error),
+    };
+    let outcome = match account::link(
+        &profile,
+        &account::LinkOptions {
+            service_url: service_url.clone(),
+            device_name: name.unwrap_or_else(account::default_device_name),
+            open_browser: !no_open,
+            store: Some(context.store.clone()),
+            expected_root,
+            announce: None,
+            via: Some(ceremony_url),
+        },
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => return print_failure(error),
+    };
+    let duplicate = profiles.load_or_bootstrap().ok().and_then(|registry| {
+        registry.profiles.into_iter().find_map(|(id, record)| {
+            (id != context.id && record.account_root.as_deref() == Some(&outcome.root_did))
+                .then_some(record.label)
+        })
+    });
+    let ceremony_origin = tonk_cli::deployment::ceremony_origin(&discovery_url)
+        .ok()
+        .map(|url| url.to_string());
+    if let Err(error) =
+        profiles.record_account_root(&context.id, &outcome.root_did, ceremony_origin.as_deref())
+    {
+        return print_failure(error);
+    }
+    println!(
+        "linked\nprofile: {}\nroot: {}\ndevice: {}\naccount state: {}",
+        context.record.label,
+        outcome.root_did,
+        outcome.device_did,
+        account_state_label(outcome.account_state)
+    );
+    if let Some(label) = duplicate {
+        eprintln!(
+            "warning: account root is already present in profile '{label}'; keeping both device profiles"
+        );
+    }
+    if let Some(warning) = outcome.warning {
+        eprintln!("warning: account repository is not synchronized: {warning}");
+    }
+    print_customer_line(&profile, &context.store).await;
+    match tonk_cli::deployment::discover(&discovery_url, &service_url).await {
+        Ok(defaults) => {
+            if let Err(error) = profiles.record_deployment_defaults(&context.id, &defaults) {
+                eprintln!("warning: sync defaults: pending ({error})");
+            }
+        }
+        Err(error) => eprintln!("warning: sync defaults: pending ({error:#})"),
+    }
+    match profiles.context(&context.id) {
+        Ok(context) => reconcile_profile_best_effort(&context).await,
+        Err(error) => eprintln!("warning: account reconciliation skipped: {error}"),
+    }
+    ExitCode::Success
+}
+
+async fn retry_deployment_discovery(
+    profiles: &tonk_cli::account_profiles::NativeProfileStore,
+    context: tonk_cli::account_profiles::NativeProfileContext,
+    profile: &dialog_operator::Profile,
+) -> tonk_cli::account_profiles::NativeProfileContext {
+    if context.record.default_access_remote.is_some()
+        && context.record.default_revocation_relay.is_some()
+    {
+        return context;
+    }
+    let Some(origin) = context.record.ceremony_origin.as_deref() else {
+        return context;
+    };
+    let provider = match account::local_status_in(profile, &context.store).await {
+        Ok(account::AccountStatus::Registered { provider, .. }) => provider,
+        Ok(_) => return context,
+        Err(error) => {
+            eprintln!("warning: sync defaults: pending ({error:#})");
+            return context;
+        }
+    };
+    match tonk_cli::deployment::discover(origin, &provider).await {
+        Ok(defaults) => match profiles.record_deployment_defaults(&context.id, &defaults) {
+            Ok(context) => context,
+            Err(error) => {
+                eprintln!("warning: sync defaults: pending ({error})");
+                context
+            }
+        },
+        Err(error) => {
+            eprintln!("warning: sync defaults: pending ({error:#})");
+            context
+        }
+    }
+}
+
 async fn account_op(command: AccountCommand) -> ExitCode {
-    let profile = match identity::open().await {
+    let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
+        Ok(profiles) => profiles,
+        Err(error) => return print_failure(error),
+    };
+    let command = match command {
+        AccountCommand::Use { profile } => {
+            return match profiles.select(&profile) {
+                Ok(selected) => {
+                    println!(
+                        "selected profile: {}\nprofile id: {}",
+                        selected.record.label, selected.id
+                    );
+                    ExitCode::Success
+                }
+                Err(error) => print_failure(error),
+            };
+        }
+        AccountCommand::List => return account_list(&profiles),
+        AccountCommand::Add {
+            label,
+            name,
+            service_url,
+            account_url,
+            no_open,
+            via,
+        } => {
+            let context = match profiles.create_or_resume_pending(label.as_deref()) {
+                Ok(context) => context,
+                Err(error) => return print_failure(error),
+            };
+            if let Err(error) = profiles.select(context.id.as_str()) {
+                return print_failure(error);
+            }
+            return link_native_profile(
+                &profiles,
+                context,
+                name,
+                service_url,
+                account_url,
+                no_open,
+                via,
+                None,
+            )
+            .await;
+        }
+        AccountCommand::Login {
+            name,
+            service_url,
+            account_url,
+            no_open,
+            via,
+        } => {
+            let context = match profiles.selected() {
+                Ok(Some(context)) => context,
+                Ok(None) => return print_error("no account profile is selected"),
+                Err(error) => return print_failure(error),
+            };
+            let Some(root) = context.record.account_root.clone() else {
+                return print_error(
+                    "the selected profile has no account root; run `tonk account add`",
+                );
+            };
+            return link_native_profile(
+                &profiles,
+                context,
+                name,
+                service_url,
+                account_url,
+                no_open,
+                via,
+                Some(root),
+            )
+            .await;
+        }
+        AccountCommand::Link {
+            name,
+            service_url,
+            account_url,
+            no_open,
+            via,
+        } => {
+            let context = match profiles.selected() {
+                Ok(Some(context)) => context,
+                Ok(None) => match profiles.create_or_resume_pending(None) {
+                    Ok(context) => context,
+                    Err(error) => return print_failure(error),
+                },
+                Err(error) => return print_failure(error),
+            };
+            return link_native_profile(
+                &profiles,
+                context.clone(),
+                name,
+                service_url,
+                account_url,
+                no_open,
+                via,
+                context.record.account_root,
+            )
+            .await;
+        }
+        command => command,
+    };
+    let context = match profiles.selected() {
+        Ok(Some(context)) => context,
+        Ok(None) => return print_error("no account profile is selected"),
+        Err(error) => return print_failure(error),
+    };
+    let profile = match identity::open_in(&context).await {
         Ok(profile) => profile,
         Err(error) => return print_failure(error),
     };
     match command {
-        AccountCommand::Status => match account::status(&profile).await {
+        AccountCommand::Add { .. }
+        | AccountCommand::Use { .. }
+        | AccountCommand::Login { .. }
+        | AccountCommand::List
+        | AccountCommand::Link { .. } => unreachable!("profile lifecycle commands returned above"),
+        AccountCommand::Status => match account::status_in(&profile, &context.store).await {
             Ok(mut status) => {
-                // An unhydrated account retries its first sync right
-                // here, bounded: the status read is the natural moment
-                // someone notices "waiting for first sync", and leaving
-                // it sticky until the next link would report a state
-                // nothing is working to leave.
+                // An unhydrated account retries its first sync right here,
+                // bounded, using the selected profile's explicit store.
                 if matches!(
                     &status,
                     account::AccountStatus::Registered {
@@ -1379,17 +1736,25 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                         ..
                     }
                 ) {
-                    match tokio::time::timeout(
-                        std::time::Duration::from_secs(10),
-                        tonk_cli::account_state::ensure(&profile),
-                    )
-                    .await
-                    {
+                    let ensure = async {
+                        let operator = tonk_cli::account_state::credential_operator_for_store(
+                            &profile,
+                            &context.store,
+                        )
+                        .await?;
+                        tonk_cli::account_state::ensure_with_operator_and_store(
+                            &profile,
+                            operator,
+                            context.store.clone(),
+                        )
+                        .await
+                    };
+                    match tokio::time::timeout(std::time::Duration::from_secs(10), ensure).await {
                         Ok(Ok(outcome)) => {
                             if let Some(warning) = outcome.warning {
                                 eprintln!("warning: account sync attempt: {warning}");
                             }
-                            if let Ok(fresh) = account::status(&profile).await {
+                            if let Ok(fresh) = account::status_in(&profile, &context.store).await {
                                 status = fresh;
                             }
                         }
@@ -1400,14 +1765,38 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 let linked = matches!(status, account::AccountStatus::Registered { .. });
                 println!("{}", render_account_status(status));
                 if linked {
-                    print_customer_line(&profile).await;
+                    print_customer_line(&profile, &context.store).await;
                 }
                 ExitCode::Success
             }
             Err(error) => print_failure(error),
         },
         AccountCommand::Migrate => {
-            match tonk_cli::account_state::migrate_delegations_here().await {
+            let storage = dialog_storage::provider::storage::Storage::<
+                dialog_storage::provider::storage::NativeSpace,
+            >::default();
+            let mounted =
+                match dialog_operator::Profile::load(context.record.dialog_profile_name.clone())
+                    .at(dialog_effects::storage::Directory::Profile)
+                    .perform(&storage)
+                    .await
+                {
+                    Ok(profile) => profile,
+                    Err(error) => return print_failure(error),
+                };
+            let operator =
+                match tonk_cli::account_state::operator_for_store(&mounted, &context.store).await {
+                    Ok(operator) => operator,
+                    Err(error) => return print_failure(error),
+                };
+            match tonk_cli::account_state::migrate_delegations(
+                &mounted,
+                &operator,
+                &storage,
+                &context.store,
+            )
+            .await
+            {
                 Ok(outcome) => {
                     println!(
                         "migrated {} certificate{} into access facts",
@@ -1431,41 +1820,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 Err(error) => print_failure(error),
             }
         }
-        AccountCommand::Link {
-            name,
-            service_url,
-            no_open,
-            via,
-        } => match account::link(
-            &profile,
-            &account::LinkOptions {
-                service_url,
-                device_name: name.unwrap_or_else(account::default_device_name),
-                open_browser: !no_open,
-                via,
-                announce: None,
-                store: None,
-            },
-        )
-        .await
-        {
-            Ok(outcome) => {
-                println!(
-                    "linked\naccount: {}\ndevice: {}\nstatus: {}",
-                    outcome.root_did,
-                    outcome.device_did,
-                    account_state_label(outcome.account_state)
-                );
-                if let Some(warning) = outcome.warning {
-                    eprintln!("warning: account repository is not synchronized: {warning}");
-                }
-                print_customer_line(&profile).await;
-                record_all_spots_best_effort(&profile).await;
-                ExitCode::Success
-            }
-            Err(error) => print_failure(error),
-        },
-        AccountCommand::Logout => match account::logout(&profile).await {
+        AccountCommand::Logout => match account::logout_in(&profile, &context.store).await {
             Ok(()) => {
                 println!("logged out\ndevice: {}", profile.did());
                 ExitCode::Success
@@ -1485,16 +1840,37 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             }
             Err(error) => print_failure(error),
         },
+        AccountCommand::Sync => {
+            let context = retry_deployment_discovery(&profiles, context, &profile).await;
+            let report = tonk_cli::account_sync::reconcile_profile(&context).await;
+            let failed = report.rows.iter().any(|row| {
+                matches!(
+                    row.phase,
+                    tonk_cli::account_sync::EnrollmentPhase::Error { .. }
+                )
+            });
+            println!("profile: {}", context.record.label);
+            for row in report.rows {
+                println!(
+                    "{}\t{}\t{}",
+                    row.name,
+                    row.subject,
+                    tonk_cli::account_sync::phase_label(&row.phase)
+                );
+            }
+            if failed {
+                ExitCode::IoError
+            } else {
+                ExitCode::Success
+            }
+        }
         AccountCommand::Spots { command } => {
-            let store = match tonk_cli::spot::SpotStore::open() {
-                Ok(store) => store,
-                Err(error) => return print_failure(error),
-            };
+            let store = &context.store;
             match command.unwrap_or(AccountSpotsCommand::List) {
-                AccountSpotsCommand::List => match account_spots::list(&profile, &store).await {
+                AccountSpotsCommand::List => match account_spots::list(&profile, store).await {
                     Ok(rows) => {
                         if rows.is_empty() {
-                            println!("(no spots listed in the account directory)");
+                            println!("(no spaces listed in the account directory)");
                         } else {
                             for row in rows {
                                 let state = if row.ambiguous {
@@ -1517,7 +1893,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                     Err(error) => print_failure(error),
                 },
                 AccountSpotsCommand::Pull { subject, name } => {
-                    match account_spots::pull(&profile, &store, &subject, name.as_deref()).await {
+                    match account_spots::pull(&profile, store, &subject, name.as_deref()).await {
                         Ok(outcome) => {
                             if outcome.already_local {
                                 println!("already local\t{}\t{}", outcome.name, outcome.subject);
@@ -1528,6 +1904,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                             if let Some(warning) = outcome.warning {
                                 eprintln!("warning: {warning}");
                             }
+                            reconcile_profile_best_effort(&context).await;
                             ExitCode::Success
                         }
                         Err(error) => print_failure(error),
@@ -1552,7 +1929,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             }
         }
         AccountCommand::Devices { service_url } => {
-            match account::devices(&profile, service_url.as_deref()).await {
+            match account::devices_in(&profile, &context.store, service_url.as_deref()).await {
                 Ok(rows) => {
                     let own = profile.did().to_string();
                     for row in rows {
@@ -1574,6 +1951,7 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                 service_url,
                 account_url,
                 open_browser: !no_open,
+                store: Some(context.store.clone()),
             };
             match account::revoke(&profile, &options, &did).await {
                 Ok(account::RevokeOutcome::Revoked) => {
@@ -1590,31 +1968,33 @@ async fn account_op(command: AccountCommand) -> ExitCode {
     }
 }
 
-async fn record_all_spots_best_effort(profile: &dialog_operator::Profile) {
-    let store = match tonk_cli::spot::SpotStore::open() {
-        Ok(store) => store,
-        Err(error) => {
-            eprintln!("warning: account directory update skipped: {error}");
-            return;
+async fn reconcile_profile_best_effort(context: &tonk_cli::account_profiles::NativeProfileContext) {
+    for row in tonk_cli::account_sync::reconcile_profile(context)
+        .await
+        .rows
+    {
+        if let tonk_cli::account_sync::EnrollmentPhase::Error { step, detail } = row.phase {
+            eprintln!(
+                "warning: account sync for '{}' failed during {step}: {detail}",
+                row.name
+            );
         }
-    };
-    for warning in account_spots::record_registered(profile, &store).await {
-        eprintln!(
-            "warning: account directory update for '{}' failed: {}",
-            warning.name, warning.message
-        );
     }
 }
 
-async fn record_spot_best_effort(name: &str, site: &site::TonkSite) {
-    if let Err(error) = account_spots::record_site(name, site).await {
+async fn record_spot_best_effort(
+    name: &str,
+    site: &site::TonkSite,
+    store: &tonk_cli::spot::SpotStore,
+) {
+    if let Err(error) = account_spots::record_site_in(name, site, store).await {
         eprintln!("warning: account directory update failed: {error:#}");
     }
 }
 
 /// `tonk use [name]` — inspect the active spot or bind this directory.
 async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
-    let store = match tonk_cli::spot::SpotStore::open() {
+    let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
         Ok(store) => store,
         Err(err) => return print_failure(err),
     };
@@ -1624,20 +2004,30 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
             let Some(cwd) = cwd else {
                 return print_error("could not read the current directory".to_owned());
             };
-            match tonk_cli::spot::bind(&store, &name, &cwd) {
-                Ok(outcome) => {
-                    let was = match &outcome.previous {
-                        Some(previous) if previous != &outcome.name => {
-                            format!(" (was {previous})")
+            let selected = match profiles.selected() {
+                Ok(Some(selected)) => selected,
+                Ok(None) => {
+                    return print_error(
+                        "no account profile is selected; create a spot or run `tonk account add`",
+                    );
+                }
+                Err(error) => return print_failure(error),
+            };
+            match profiles.bind(&selected.id, &name, &cwd) {
+                Ok(previous) => {
+                    let was = match previous {
+                        Some(previous)
+                            if previous.profile != selected.id || previous.space != name =>
+                        {
+                            format!(" (was {})", previous.space)
                         }
                         _ => String::new(),
                     };
                     println!(
                         "binding: {name}{was}\ndirectory: {directory}",
-                        name = outcome.name,
-                        directory = outcome.directory.display(),
+                        directory = cwd.display(),
                     );
-                    print_active_resolution(&store, flag, Some(&cwd));
+                    print_active_resolution(&profiles, flag, Some(&cwd));
                     println!("next: tonk context");
                     ExitCode::Success
                 }
@@ -1646,12 +2036,8 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
         }
         None => {
             let env = spot_from_environment();
-            let listing =
-                match tonk_cli::spot::listing(&store, flag, env.as_deref(), cwd.as_deref()) {
-                    Ok(listing) => listing,
-                    Err(err) => return print_failure(err),
-                };
-            match listing.active {
+            let active = profiles.resolve(flag, env.as_deref(), cwd.as_deref()).ok();
+            match &active {
                 Some(active) => println!(
                     "current spot: {} ({})\nselected via: {}",
                     active.name,
@@ -1660,11 +2046,25 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
                 ),
                 None => println!("current spot: (none)"),
             }
-            if !listing.rows.is_empty() {
-                println!("registered:");
-                for (registered, site) in listing.rows {
-                    println!("  {registered}\t{}", site.display());
-                }
+            match profiles.selected() {
+                Ok(Some(selected)) => match selected.store.load() {
+                    Ok(registry) if !registry.spots.is_empty() => {
+                        println!("registered:");
+                        for (registered, entry) in registry.spots {
+                            println!("  {registered}\t{}", entry.site.display());
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(error) => return print_failure(error),
+                },
+                Ok(None) => {}
+                Err(error) => return print_failure(error),
+            }
+            if active.is_none()
+                && (flag.is_some() || env.is_some())
+                && let Err(error) = profiles.resolve(flag, env.as_deref(), cwd.as_deref())
+            {
+                return print_failure(error);
             }
             println!("next: tonk context");
             ExitCode::Success
@@ -1674,7 +2074,7 @@ async fn use_op(name: Option<String>, flag: Option<&str>) -> ExitCode {
 
 /// `tonk spot new|list|rm` — registry management.
 async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
-    let store = match tonk_cli::spot::SpotStore::open() {
+    let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
         Ok(store) => store,
         Err(err) => return print_failure(err),
     };
@@ -1683,16 +2083,27 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
             let Some(cwd) = working_directory() else {
                 return print_error("could not read the current directory".to_owned());
             };
+            let profile = match profiles.ensure_selected_for_local_write() {
+                Ok(profile) => profile,
+                Err(error) => return print_failure(error),
+            };
             match tonk_cli::spot::create(
-                &store,
+                &profile.store,
                 &name,
                 site.as_deref(),
-                Some(&cwd),
-                site::default_config(),
+                None,
+                profile.site_config(),
             )
             .await
             {
                 Ok(outcome) => {
+                    if let Err(error) = profiles.bind(&profile.id, &name, &cwd) {
+                        return print_error(format!(
+                            "spot '{}' was created and registered, but binding {} failed: {error}",
+                            outcome.name,
+                            cwd.display()
+                        ));
+                    }
                     if outcome.adopted {
                         println!(
                             "Registered spot '{}' on the site data already at that path",
@@ -1704,13 +2115,8 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                     println!("site: {}", outcome.site.display());
                     println!("DID: {}", outcome.did);
                     println!("binding: {}", cwd.display());
-                    print_active_resolution(&store, flag, Some(&cwd));
-                    match site::TonkSite::open(&outcome.site).await {
-                        Ok(site) => record_spot_best_effort(&outcome.name, &site).await,
-                        Err(error) => {
-                            eprintln!("warning: account directory update skipped: {error:#}")
-                        }
-                    }
+                    print_active_resolution(&profiles, flag, Some(&cwd));
+                    reconcile_profile_best_effort(&profile).await;
                     ExitCode::Success
                 }
                 Err(err) => print_failure(err),
@@ -1721,14 +2127,25 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                 .ok()
                 .filter(|value| !value.is_empty());
             let cwd = working_directory();
-            match tonk_cli::spot::listing(&store, flag, env.as_deref(), cwd.as_deref()) {
+            let profile = match profiles.selected() {
+                Ok(Some(profile)) => profile,
+                Ok(None) => {
+                    println!("(no spots registered; create one with `tonk spot new <name>`)");
+                    return ExitCode::Success;
+                }
+                Err(error) => return print_failure(error),
+            };
+            match tonk_cli::spot::listing(&profile.store, flag, env.as_deref(), None) {
                 Ok(listing) => {
                     if listing.rows.is_empty() {
                         println!("(no spots registered; create one with `tonk spot new <name>`)");
                         print_orphaned_sites(&listing.orphans);
                         return ExitCode::Success;
                     }
-                    let active = listing.active.as_ref().map(|c| c.name.as_str());
+                    let routed = profiles.resolve(flag, env.as_deref(), cwd.as_deref()).ok();
+                    let active = routed.as_ref().and_then(|resolved| {
+                        (resolved.profile.id == profile.id).then_some(resolved.name.as_str())
+                    });
                     for (name, site) in &listing.rows {
                         let marker = if Some(name.as_str()) == active {
                             '*'
@@ -1737,18 +2154,26 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
                         };
                         println!("{marker} {name}\t{site}", site = site.display());
                     }
-                    if let Some(resolved) = &listing.active {
+                    if let Some(resolved) = &routed {
                         println!(
                             "active here: {name} ({source})",
                             name = resolved.name,
                             source = resolved.source,
                         );
                     }
-                    if !listing.bindings.is_empty() {
+                    let install = match profiles.load_or_bootstrap() {
+                        Ok(install) => install,
+                        Err(error) => return print_failure(error),
+                    };
+                    if !install.bindings.is_empty() {
                         println!();
                         println!("directories:");
-                        for (directory, name) in &listing.bindings {
-                            println!("  {directory}\t{name}", directory = directory.display());
+                        for (directory, binding) in &install.bindings {
+                            println!(
+                                "  {directory}\t{name}",
+                                directory = directory.display(),
+                                name = binding.space
+                            );
                         }
                     }
                     print_orphaned_sites(&listing.orphans);
@@ -1762,18 +2187,25 @@ async fn spot_op(command: SpotCommand, flag: Option<&str>) -> ExitCode {
             keep_data,
             yes,
             delete: _,
-        } => spot_rm(&store, &name, keep_data, yes).await,
+        } => {
+            let profile = match profiles.selected() {
+                Ok(Some(profile)) => profile,
+                Ok(None) => return print_error("no account profile is selected"),
+                Err(error) => return print_failure(error),
+            };
+            spot_rm(&profiles, &profile, &name, keep_data, yes).await
+        }
         SpotCommand::Unbind { path } => {
             let directory = match path.or_else(working_directory) {
                 Some(directory) => directory,
                 None => return print_error("could not read the current directory".to_owned()),
             };
-            match tonk_cli::spot::unbind(&store, &directory) {
+            match profiles.unbind(&directory) {
                 Ok(outcome) => {
                     println!(
                         "unbound {directory} from {name}",
-                        directory = outcome.directory.display(),
-                        name = outcome.name,
+                        directory = directory.display(),
+                        name = outcome.space,
                     );
                     ExitCode::Success
                 }
@@ -1811,14 +2243,15 @@ fn print_orphaned_sites(orphans: &[PathBuf]) {
 /// that the accident-shaped path instead of the deliberate one is
 /// what this command is for.
 async fn spot_rm(
-    store: &tonk_cli::spot::SpotStore,
+    profiles: &tonk_cli::account_profiles::NativeProfileStore,
+    profile: &tonk_cli::account_profiles::NativeProfileContext,
     name: &str,
     keep_data: bool,
     yes: bool,
 ) -> ExitCode {
     use tonk_cli::spot::{Data, Deletion};
 
-    let registry = match store.load() {
+    let registry = match profile.store.load() {
         Ok(registry) => registry,
         Err(err) => return print_failure(err),
     };
@@ -1835,7 +2268,7 @@ async fn spot_rm(
     let site = entry.site.clone();
 
     if keep_data {
-        return match tonk_cli::spot::remove(store, name, Data::Keep) {
+        return match profiles.remove_space(&profile.id, name, Data::Keep) {
             Ok(outcome) => {
                 println!("Unregistered spot '{}'", outcome.name);
                 println!("data kept at {}", outcome.site.display());
@@ -1866,7 +2299,7 @@ async fn spot_rm(
                  confirming, or --keep-data to unregister without deleting."
             ));
         }
-        let recovery = tonk_cli::recovery::inspect(&site, site::default_config()).await;
+        let recovery = tonk_cli::recovery::inspect(&site, profile.site_config()).await;
         println!();
         println!("This permanently deletes the spot's data from disk:");
         println!("  {}", site.display());
@@ -1884,7 +2317,7 @@ async fn spot_rm(
         }
     }
 
-    match tonk_cli::spot::remove(store, name, Data::Delete) {
+    match profiles.remove_space(&profile.id, name, Data::Delete) {
         Ok(outcome) => {
             match outcome.data {
                 Deletion::Deleted => {
@@ -2028,7 +2461,20 @@ async fn sync_op(op: SyncOp, spot: Option<&str>) -> ExitCode {
     match result {
         Ok(outcome) => {
             print_sync_outcome(op, &outcome);
-            record_spot_best_effort(&resolved.name, &site).await;
+            if let Some(root) = resolved
+                .profile
+                .record
+                .account_root
+                .as_deref()
+                .and_then(|root| root.parse().ok())
+                && let Err(error) =
+                    tonk_cli::account_sync::record_current_revision_confirmed(&site, &root).await
+            {
+                eprintln!(
+                    "warning: sync succeeded but its confirmed revision was not recorded: {error:#}"
+                );
+            }
+            record_spot_best_effort(&resolved.name, &site, &resolved.profile.store).await;
             ExitCode::Success
         }
         Err(err) => {
@@ -2254,6 +2700,27 @@ async fn status_op(spot: Option<&str>) -> ExitCode {
         name = resolved.name,
         source = resolved.source,
     );
+    println!("profile: {}", resolved.profile.record.label);
+    println!(
+        "account: {}",
+        resolved
+            .profile
+            .record
+            .account_root
+            .as_deref()
+            .unwrap_or("pending")
+    );
+    println!(
+        "signed in: {}",
+        if matches!(
+            resolved.profile.sign_in_state(),
+            Ok(tonk_cli::account_profiles::ProfileSignIn::Active)
+        ) {
+            "yes"
+        } else {
+            "no"
+        }
+    );
 
     match sync::status_with_hash(&site).await {
         Ok(status) => {
@@ -2329,13 +2796,19 @@ async fn remote_op(command: RemoteCommand, spot: Option<&str>) -> ExitCode {
                     // An existing upstream is never touched.
                     match remote::upstream_configured(&site).await {
                         Ok(true) => {
-                            record_spot_best_effort(&resolved.name, &site).await;
+                            record_spot_best_effort(&resolved.name, &site, &resolved.profile.store)
+                                .await;
                             ExitCode::Success
                         }
                         Ok(false) => match remote::set_upstream(&site, &name).await {
                             Ok(upstream) => {
                                 print_set_upstream_outcome(&upstream);
-                                record_spot_best_effort(&resolved.name, &site).await;
+                                record_spot_best_effort(
+                                    &resolved.name,
+                                    &site,
+                                    &resolved.profile.store,
+                                )
+                                .await;
                                 ExitCode::Success
                             }
                             Err(err) => {
@@ -2375,7 +2848,7 @@ async fn remote_op(command: RemoteCommand, spot: Option<&str>) -> ExitCode {
             match remote::set_upstream(&site, &name).await {
                 Ok(outcome) => {
                     print_set_upstream_outcome(&outcome);
-                    record_spot_best_effort(&resolved.name, &site).await;
+                    record_spot_best_effort(&resolved.name, &site, &resolved.profile.store).await;
                     ExitCode::Success
                 }
                 Err(err) => {
@@ -2639,10 +3112,15 @@ async fn claim_invite(url: String, name: String, flag: Option<&str>) -> ExitCode
     if let Err(err) = tonk_cli::spot::validate_name(&name) {
         return print_failure(err);
     }
-    let store = match tonk_cli::spot::SpotStore::open() {
-        Ok(store) => store,
+    let profiles = match tonk_cli::account_profiles::NativeProfileStore::open() {
+        Ok(profiles) => profiles,
         Err(err) => return print_failure(err),
     };
+    let profile = match profiles.ensure_selected_for_local_write() {
+        Ok(profile) => profile,
+        Err(error) => return print_failure(error),
+    };
+    let store = &profile.store;
     let cwd = match working_directory().and_then(|path| path.canonicalize().ok()) {
         Some(cwd) => cwd,
         None => return print_error("could not read the current directory".to_owned()),
@@ -2658,7 +3136,7 @@ async fn claim_invite(url: String, name: String, flag: Option<&str>) -> ExitCode
 
     // Same default site config `tonk spot new` writes against, so
     // the joined site picks up the user's normal profile.
-    match invite::claim(&root, &url, site::default_config()).await {
+    match invite::claim(&root, &url, profile.site_config()).await {
         Ok(outcome) => {
             // Match `spot new`'s canonicalized form, so registered
             // paths compare equal regardless of how they were added.
@@ -2689,7 +3167,6 @@ async fn claim_invite(url: String, name: String, flag: Option<&str>) -> ExitCode
                 name.clone(),
                 tonk_cli::spot::SpotEntry { site: root.clone() },
             );
-            registry.bindings.insert(cwd.clone(), name.clone());
             if let Err(err) = store.save(&registry) {
                 return print_error(format!(
                     "joined, but registering spot '{name}' failed: {err}\n\
@@ -2697,12 +3174,15 @@ async fn claim_invite(url: String, name: String, flag: Option<&str>) -> ExitCode
                     root = root.display(),
                 ));
             }
-            print_claim_outcome(&name, &root, &cwd, &outcome);
-            print_active_resolution(&store, flag, Some(&cwd));
-            match site::TonkSite::open(&root).await {
-                Ok(site) => record_spot_best_effort(&name, &site).await,
-                Err(error) => eprintln!("warning: account directory update skipped: {error:#}"),
+            if let Err(error) = profiles.bind(&profile.id, &name, &cwd) {
+                return print_error(format!(
+                    "joined and registered spot '{name}', but binding {} failed: {error}",
+                    cwd.display()
+                ));
             }
+            print_claim_outcome(&name, &root, &cwd, &outcome);
+            print_active_resolution(&profiles, flag, Some(&cwd));
+            reconcile_profile_best_effort(&profile).await;
             ExitCode::Success
         }
         Err(err) => {
@@ -3169,7 +3649,7 @@ fn spot_from_environment() -> Option<String> {
 /// Report the spot that would actually answer a data command after a
 /// binding write, including any flag or environment override.
 fn print_active_resolution(
-    store: &tonk_cli::spot::SpotStore,
+    store: &tonk_cli::account_profiles::NativeProfileStore,
     flag: Option<&str>,
     cwd: Option<&std::path::Path>,
 ) {
@@ -3191,16 +3671,31 @@ fn print_active_resolution(
 /// deliberately does not fetch sync state while handling another
 /// error.
 fn print_active_spot_context(flag: Option<&str>) {
-    let Ok(store) = tonk_cli::spot::SpotStore::open() else {
+    let Ok(store) = tonk_cli::account_profiles::NativeProfileStore::open() else {
         return;
     };
     let env = spot_from_environment();
     let cwd = working_directory();
     if let Ok(resolved) = store.resolve(flag, env.as_deref(), cwd.as_deref()) {
         eprintln!(
-            "active spot: {name} ({source})\nsite: {site}",
+            "active spot: {name} ({source})\nprofile: {profile}\naccount: {account}\nsigned in: {signed_in}\nsite: {site}",
             name = resolved.name,
             source = resolved.source,
+            profile = resolved.profile.record.label,
+            account = resolved
+                .profile
+                .record
+                .account_root
+                .as_deref()
+                .unwrap_or("pending"),
+            signed_in = if matches!(
+                resolved.profile.sign_in_state(),
+                Ok(tonk_cli::account_profiles::ProfileSignIn::Active)
+            ) {
+                "yes"
+            } else {
+                "no"
+            },
             site = resolved.site.display(),
         );
     }
@@ -3211,8 +3706,8 @@ fn print_active_spot_context(flag: Option<&str>) {
 /// into the binding map — it never locates site data.
 async fn open_selected(
     flag: Option<&str>,
-) -> Result<(tonk_cli::spot::Resolved, site::TonkSite), ExitCode> {
-    let store = match tonk_cli::spot::SpotStore::open() {
+) -> Result<(tonk_cli::account_profiles::ResolvedSpace, site::TonkSite), ExitCode> {
+    let store = match tonk_cli::account_profiles::NativeProfileStore::open() {
         Ok(store) => store,
         Err(err) => return Err(print_failure(err)),
     };
@@ -3220,14 +3715,15 @@ async fn open_selected(
         .ok()
         .filter(|value| !value.is_empty());
     let cwd = working_directory();
-    let resolved = match store.resolve(flag, env.as_deref(), cwd.as_deref()) {
+    let routed = match store.resolve(flag, env.as_deref(), cwd.as_deref()) {
         Ok(resolved) => resolved,
         Err(err) => return Err(print_failure(err)),
     };
-    match site::TonkSite::open(&resolved.site).await {
-        Ok(site) => Ok((resolved, site)),
+    match site::TonkSite::open_with(&routed.site, routed.profile.site_config()).await {
+        Ok(site) => Ok((routed, site)),
         Err(err) => Err(print_error(format!(
-            "could not open the active spot: {err:#}"
+            "could not open the active spot for profile '{}': {err:#}",
+            routed.profile.record.label
         ))),
     }
 }
@@ -3305,6 +3801,43 @@ mod account_spots_parser_tests {
             panic!("expected account delete");
         };
         assert!(no_open);
+    }
+
+    #[test]
+    fn account_profile_lifecycle_commands_parse_and_classify() {
+        let add = Cli::try_parse_from(["tonk", "account", "add", "--label", "work"])
+            .expect("account add parses");
+        let add_command = add.command.as_ref().expect("account command");
+        assert!(matches!(
+            add_command,
+            Command::Account {
+                command: AccountCommand::Add { label: Some(label), .. }
+            } if label == "work"
+        ));
+        assert_eq!(descriptor(add_command), ("account", Some("add")));
+
+        let use_profile =
+            Cli::try_parse_from(["tonk", "account", "use", "work"]).expect("account use parses");
+        let use_command = use_profile.command.as_ref().expect("account command");
+        assert!(matches!(
+            use_command,
+            Command::Account {
+                command: AccountCommand::Use { profile }
+            } if profile == "work"
+        ));
+        assert_eq!(descriptor(use_command), ("account", Some("use")));
+
+        for (args, expected) in [
+            (vec!["tonk", "account", "login"], "login"),
+            (vec!["tonk", "account", "list"], "list"),
+            (vec!["tonk", "account", "sync"], "sync"),
+        ] {
+            let cli = Cli::try_parse_from(args).expect("profile command parses");
+            assert_eq!(
+                descriptor(cli.command.as_ref().expect("account command")),
+                ("account", Some(expected))
+            );
+        }
     }
 
     #[test]

--- a/rust/tonk-cli/src/context.rs
+++ b/rust/tonk-cli/src/context.rs
@@ -289,7 +289,7 @@ impl ContextReport {
         let _ = writeln!(out, "# Tonk context");
         let _ = writeln!(
             out,
-            "spot: `{}` · branch: `{}` · selected via: `{}`",
+            "space: `{}` · branch: `{}` · selected via: `{}`",
             self.spot.name, self.spot.branch, self.spot.selected_via
         );
         let _ = writeln!(out, "site: `{}`", self.spot.site);

--- a/rust/tonk-cli/src/context.rs
+++ b/rust/tonk-cli/src/context.rs
@@ -38,6 +38,12 @@ pub struct ContextReport {
 /// Selected spot information.
 #[derive(Debug, Serialize)]
 pub struct SpotContext {
+    /// Owning native profile label, when resolved by the install router.
+    pub profile: Option<String>,
+    /// Immutable account root indexed by that profile.
+    pub account_root: Option<String>,
+    /// Whether the owning profile currently has an active provider session.
+    pub signed_in: Option<bool>,
     /// Registry name.
     pub name: String,
     /// Absolute site path.
@@ -109,6 +115,40 @@ impl From<FieldSummary> for FieldContext {
 
 /// Read the selected spot and derive direct workflows from its live schema.
 pub async fn inspect(resolved: &Resolved, site: &TonkSite) -> Result<ContextReport> {
+    inspect_inner(resolved, site, None, None, None).await
+}
+
+/// Read a profile-qualified selected space and expose its account context.
+pub async fn inspect_profiled(
+    resolved: &crate::account_profiles::ResolvedSpace,
+    site: &TonkSite,
+) -> Result<ContextReport> {
+    let legacy = Resolved {
+        name: resolved.name.clone(),
+        site: resolved.site.clone(),
+        source: resolved.source.clone(),
+    };
+    let signed_in = matches!(
+        resolved.profile.sign_in_state(),
+        Ok(crate::account_profiles::ProfileSignIn::Active)
+    );
+    inspect_inner(
+        &legacy,
+        site,
+        Some(resolved.profile.record.label.clone()),
+        resolved.profile.record.account_root.clone(),
+        Some(signed_in),
+    )
+    .await
+}
+
+async fn inspect_inner(
+    resolved: &Resolved,
+    site: &TonkSite,
+    profile: Option<String>,
+    account_root: Option<String>,
+    signed_in: Option<bool>,
+) -> Result<ContextReport> {
     let live_concepts = schema::list_concepts(site).await?;
     let agents_declared = live_concepts
         .iter()
@@ -193,6 +233,9 @@ pub async fn inspect(resolved: &Resolved, site: &TonkSite) -> Result<ContextRepo
     Ok(ContextReport {
         schema_version: SCHEMA_VERSION,
         spot: SpotContext {
+            profile,
+            account_root,
+            signed_in,
             name: resolved.name.clone(),
             site: resolved.site.display().to_string(),
             selected_via: resolved.source.to_string(),
@@ -250,6 +293,18 @@ impl ContextReport {
             self.spot.name, self.spot.branch, self.spot.selected_via
         );
         let _ = writeln!(out, "site: `{}`", self.spot.site);
+        if let Some(profile) = &self.spot.profile {
+            let account = self.spot.account_root.as_deref().unwrap_or("pending");
+            let signed_in = if self.spot.signed_in == Some(true) {
+                "yes"
+            } else {
+                "no"
+            };
+            let _ = writeln!(
+                out,
+                "profile: `{profile}` · account: `{account}` · signed in: {signed_in}"
+            );
+        }
         out.push_str("Changing cwd does not change the selected Tonk data.\n");
 
         if let Some(agents) = &self.agents {

--- a/rust/tonk-cli/src/customer.rs
+++ b/rust/tonk-cli/src/customer.rs
@@ -17,7 +17,18 @@ use dialog_operator::Profile;
 /// The access service origin for this profile's account: the attached
 /// repository descriptor's remote, with its `/ucan/` path stripped.
 pub async fn access_origin(profile: &Profile) -> Result<Option<Url>> {
-    let Some(provider) = crate::account::stored_provider(profile).await? else {
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    access_origin_in(profile, &store).await
+}
+
+/// The access service origin resolved from one explicit account profile.
+pub async fn access_origin_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<Option<Url>> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    let Some(provider) = crate::account::stored_provider_in(profile, &operator, store).await?
+    else {
         return Ok(None);
     };
     let Some(descriptor) = provider.descriptor() else {
@@ -64,10 +75,21 @@ pub async fn provision(
     consumer: &Did,
     consent: &dialog_ucan_core::DelegationChain,
 ) -> Result<()> {
-    let connection = crate::account::optional_connection(profile)
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    provision_in(profile, &store, consumer, consent).await
+}
+
+/// Provision a consumer through one explicit account profile.
+pub async fn provision_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+    consumer: &Did,
+    consent: &dialog_ucan_core::DelegationChain,
+) -> Result<()> {
+    let connection = crate::account::optional_connection_for_store(profile, store)
         .await?
         .context("no active account; run `tonk account link`")?;
-    let origin = access_origin(profile)
+    let origin = access_origin_in(profile, store)
         .await?
         .context("the account has no repository descriptor to locate its service by")?;
     let body = tonk_identity::request::build_provider_add_invocation(
@@ -102,10 +124,20 @@ pub async fn provision(
 /// profile is not linked or its account has no located service, and an
 /// inner `None` when the service does not know the customer.
 pub async fn registration_state(profile: &Profile) -> Result<Option<Option<Receipt>>> {
-    let Some(origin) = access_origin(profile).await? else {
+    let store = crate::spot::SpotStore::open().context("failed to locate account state")?;
+    registration_state_in(profile, &store).await
+}
+
+/// The service's view of one explicit account profile.
+pub async fn registration_state_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<Option<Option<Receipt>>> {
+    let Some(origin) = access_origin_in(profile, store).await? else {
         return Ok(None);
     };
-    let Some(connection) = crate::account::optional_connection(profile).await? else {
+    let Some(connection) = crate::account::optional_connection_for_store(profile, store).await?
+    else {
         return Ok(None);
     };
     Ok(Some(probe(&origin, &connection.root_did).await?))

--- a/rust/tonk-cli/src/deployment.rs
+++ b/rust/tonk-cli/src/deployment.rs
@@ -57,9 +57,12 @@ pub async fn discover(
         config.revocation_relay_url.as_str(),
         "advertised revocation relay URL",
     )?;
-    let access_remote = ceremony_origin
-        .join("/ucan/")
-        .context("failed to form deployment access URL")?;
+    let access_remote = match config.access_remote_url {
+        Some(url) => validated_http_url(url.as_str(), "advertised access remote URL")?,
+        None => ceremony_origin
+            .join("/ucan/")
+            .context("failed to form deployment access URL")?,
+    };
     Ok(DeploymentDefaults {
         ceremony_origin,
         access_remote,
@@ -115,6 +118,7 @@ mod tests {
 
     async fn deployment_server(
         account_path: &str,
+        access_remote_url: Option<Url>,
     ) -> Result<(String, tokio::task::JoinHandle<()>)> {
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
         let origin = format!("http://{}", listener.local_addr()?);
@@ -125,8 +129,10 @@ mod tests {
             get(move || {
                 let account = account.clone();
                 let relay = relay.clone();
+                let access_remote_url = access_remote_url.clone();
                 async move {
                     Json(DeploymentConfig {
+                        access_remote_url,
                         account_service_url: account,
                         revocation_relay_url: relay,
                         service_did: None,
@@ -142,7 +148,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_discovers_the_access_remote_from_the_ceremony_deployment() -> Result<()> {
-        let (origin, server) = deployment_server("/accounts/").await?;
+        let (origin, server) = deployment_server("/accounts/", None).await?;
         let defaults = discover(
             &format!("{origin}/account/link?intent=login"),
             &format!("{origin}/accounts"),
@@ -154,6 +160,20 @@ mod tests {
             defaults.revocation_relay.as_str(),
             format!("{origin}/revocations/")
         );
+        server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn it_prefers_an_advertised_loopback_access_remote() -> Result<()> {
+        let remote: Url = "http://127.0.0.1:4200/ucan/".parse()?;
+        let (origin, server) = deployment_server("/accounts/", Some(remote.clone())).await?;
+        let defaults = discover(
+            &format!("{origin}/account/link"),
+            &format!("{origin}/accounts"),
+        )
+        .await?;
+        assert_eq!(defaults.access_remote, remote);
         server.abort();
         Ok(())
     }
@@ -174,7 +194,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_rejects_a_different_advertised_account_service() -> Result<()> {
-        let (origin, server) = deployment_server("/other/").await?;
+        let (origin, server) = deployment_server("/other/", None).await?;
         let error = discover(
             &format!("{origin}/account/link"),
             &format!("{origin}/accounts"),

--- a/rust/tonk-cli/src/deployment.rs
+++ b/rust/tonk-cli/src/deployment.rs
@@ -1,0 +1,188 @@
+//! Provider-matched deployment-default discovery for native profiles.
+
+use anyhow::{Context, Result, bail};
+use tonk_worker_api::DeploymentConfig;
+use url::Url;
+
+/// Content-service endpoints advertised by the deployment that hosted the
+/// account ceremony.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeploymentDefaults {
+    /// Normalized origin that hosted the ceremony.
+    pub ceremony_origin: Url,
+    /// Same-origin UCAN content endpoint.
+    pub access_remote: Url,
+    /// Typed revocation relay advertised by the deployment.
+    pub revocation_relay: Url,
+}
+
+/// Discover content defaults from the exact deployment used for account
+/// linking, refusing configs that point at a different account provider.
+pub async fn discover(
+    account_url: &str,
+    expected_account_service: &str,
+) -> Result<DeploymentDefaults> {
+    let ceremony_origin = ceremony_origin(account_url)?;
+    let expected = validated_http_url(expected_account_service, "account service URL")?;
+    let endpoint = ceremony_origin
+        .join("/.well-known/tonk")
+        .context("failed to form deployment discovery URL")?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(3))
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("failed to build deployment discovery client")?;
+    let config = client
+        .get(endpoint)
+        .send()
+        .await
+        .context("deployment discovery is unavailable")?
+        .error_for_status()
+        .context("deployment discovery returned an error")?
+        .json::<DeploymentConfig>()
+        .await
+        .context("deployment discovery returned malformed configuration")?;
+    let advertised = validated_http_url(
+        config.account_service_url.as_str(),
+        "advertised account service URL",
+    )?;
+    if normalized_service(&advertised) != normalized_service(&expected) {
+        bail!(
+            "deployment advertises account service {}, expected {}",
+            advertised,
+            expected
+        );
+    }
+    let revocation_relay = validated_http_url(
+        config.revocation_relay_url.as_str(),
+        "advertised revocation relay URL",
+    )?;
+    let access_remote = ceremony_origin
+        .join("/ucan/")
+        .context("failed to form deployment access URL")?;
+    Ok(DeploymentDefaults {
+        ceremony_origin,
+        access_remote,
+        revocation_relay,
+    })
+}
+
+/// Validate a ceremony URL and return only its origin for safe persistence.
+pub fn ceremony_origin(account_url: &str) -> Result<Url> {
+    let ceremony = validated_http_url(account_url, "account ceremony URL")?;
+    origin_url(&ceremony)
+}
+
+fn validated_http_url(value: &str, label: &str) -> Result<Url> {
+    let url = Url::parse(value).with_context(|| format!("invalid {label}"))?;
+    if url.scheme() != "https" && url.scheme() != "http" {
+        bail!("{label} must use https (or loopback http)");
+    }
+    if url.host_str().is_none() || !url.username().is_empty() || url.password().is_some() {
+        bail!("{label} must be an absolute URL without userinfo");
+    }
+    if url.scheme() == "http" && !url.host().is_some_and(is_loopback) {
+        bail!("{label} must use https unless its host is loopback");
+    }
+    Ok(url)
+}
+
+fn is_loopback(host: url::Host<&str>) -> bool {
+    match host {
+        url::Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        url::Host::Ipv4(address) => address.is_loopback(),
+        url::Host::Ipv6(address) => address.is_loopback(),
+    }
+}
+
+fn origin_url(url: &Url) -> Result<Url> {
+    Url::parse(&format!("{}/", url.origin().ascii_serialization()))
+        .context("account ceremony URL has no usable origin")
+}
+
+fn normalized_service(url: &Url) -> String {
+    let mut normalized = url.clone();
+    normalized.set_fragment(None);
+    let path = normalized.path().trim_end_matches('/').to_owned();
+    normalized.set_path(if path.is_empty() { "/" } else { &path });
+    normalized.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, routing::get};
+
+    async fn deployment_server(
+        account_path: &str,
+    ) -> Result<(String, tokio::task::JoinHandle<()>)> {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+        let origin = format!("http://{}", listener.local_addr()?);
+        let account: Url = format!("{origin}{account_path}").parse()?;
+        let relay: Url = format!("{origin}/revocations/").parse()?;
+        let app = Router::new().route(
+            "/.well-known/tonk",
+            get(move || {
+                let account = account.clone();
+                let relay = relay.clone();
+                async move {
+                    Json(DeploymentConfig {
+                        account_service_url: account,
+                        revocation_relay_url: relay,
+                        service_did: None,
+                    })
+                }
+            }),
+        );
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Ok((origin, handle))
+    }
+
+    #[tokio::test]
+    async fn it_discovers_the_access_remote_from_the_ceremony_deployment() -> Result<()> {
+        let (origin, server) = deployment_server("/accounts/").await?;
+        let defaults = discover(
+            &format!("{origin}/account/link?intent=login"),
+            &format!("{origin}/accounts"),
+        )
+        .await?;
+        assert_eq!(defaults.ceremony_origin.as_str(), format!("{origin}/"));
+        assert_eq!(defaults.access_remote.as_str(), format!("{origin}/ucan/"));
+        assert_eq!(
+            defaults.revocation_relay.as_str(),
+            format!("{origin}/revocations/")
+        );
+        server.abort();
+        Ok(())
+    }
+
+    #[test]
+    fn it_rejects_unsafe_ceremony_urls_before_network_access() {
+        for url in [
+            "relative",
+            "ftp://deployment.example/account/link",
+            "https://user@deployment.example/account/link",
+            "http://deployment.example/account/link",
+        ] {
+            let error = validated_http_url(url, "account ceremony URL")
+                .expect_err("unsafe URL must be rejected");
+            assert!(!error.to_string().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn it_rejects_a_different_advertised_account_service() -> Result<()> {
+        let (origin, server) = deployment_server("/other/").await?;
+        let error = discover(
+            &format!("{origin}/account/link"),
+            &format!("{origin}/accounts"),
+        )
+        .await
+        .expect_err("provider mismatch must be rejected");
+        assert!(error.to_string().contains("expected"), "{error:#}");
+        server.abort();
+        Ok(())
+    }
+}

--- a/rust/tonk-cli/src/identity.rs
+++ b/rust/tonk-cli/src/identity.rs
@@ -57,6 +57,15 @@ pub async fn local_root(profile: &Profile) -> Result<Option<LocalRoot>> {
     local_root_with_operator(profile, &operator).await
 }
 
+/// Load the local root from one explicit native profile store.
+pub async fn local_root_in(
+    profile: &Profile,
+    store: &crate::spot::SpotStore,
+) -> Result<Option<LocalRoot>> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    local_root_with_operator(profile, &operator).await
+}
+
 /// Load the local root through an already-mounted site operator.
 pub(crate) async fn local_root_with_operator(
     profile: &Profile,
@@ -149,6 +158,11 @@ pub async fn open() -> Result<Profile> {
         .with_context(|| format!("failed to open profile '{PROFILE_NAME}'"))
 }
 
+/// Open the Dialog identity owned by one explicit native profile.
+pub async fn open_in(context: &crate::account_profiles::NativeProfileContext) -> Result<Profile> {
+    context.open_profile().await
+}
+
 /// Wipe the on-disk profile directory and create a fresh
 /// profile. The new profile has a brand-new DID — every site
 /// (`.tonk/`) the previous identity owned will be unreachable
@@ -162,6 +176,16 @@ pub async fn reset() -> Result<Profile> {
     open().await
 }
 
+/// Reset only the Dialog identity owned by `context`.
+pub async fn reset_in(context: &crate::account_profiles::NativeProfileContext) -> Result<Profile> {
+    let dir = profile_dir_for(&context.record.dialog_profile_name)?;
+    if dir.is_dir() {
+        std::fs::remove_dir_all(&dir)
+            .with_context(|| format!("failed to remove profile directory {}", dir.display()))?;
+    }
+    open_in(context).await
+}
+
 /// Whether a profile already exists on disk. Telemetry uses this to
 /// avoid creating a profile as a side effect of computing a hashed
 /// distinct id for a command that never touches the profile.
@@ -169,10 +193,21 @@ pub fn exists() -> bool {
     profile_dir().map(|dir| dir.is_dir()).unwrap_or(false)
 }
 
+/// Whether one explicit native profile's Dialog identity exists.
+pub fn exists_in(context: &crate::account_profiles::NativeProfileContext) -> bool {
+    profile_dir_for(&context.record.dialog_profile_name)
+        .map(|dir| dir.is_dir())
+        .unwrap_or(false)
+}
+
 /// Filesystem path to the profile directory. `tonk identity
 /// --reset` calls `remove_dir_all` on this path; nothing else
 /// inside the crate depends on the on-disk layout.
 fn profile_dir() -> Result<PathBuf> {
+    profile_dir_for(PROFILE_NAME)
+}
+
+fn profile_dir_for(name: &str) -> Result<PathBuf> {
     let data_dir = dirs::data_dir().context("could not determine platform data directory")?;
-    Ok(data_dir.join(STORAGE_NAMESPACE).join(PROFILE_NAME))
+    Ok(data_dir.join(STORAGE_NAMESPACE).join(name))
 }

--- a/rust/tonk-cli/src/inventory.rs
+++ b/rust/tonk-cli/src/inventory.rs
@@ -1,0 +1,611 @@
+//! Stable CLI space inventory assembled from independent lifecycle facts.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::account_profiles::NativeProfileContext;
+
+/// Whether this profile has local repository state for the subject.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LocalPresence {
+    /// No local registration or inspectable orphan.
+    Absent,
+    /// A profile-local registry entry exists.
+    Registered,
+    /// Local storage exists without a registry entry.
+    Orphaned,
+}
+
+/// Canonical account membership state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountMembership {
+    /// No canonical membership fact is present.
+    Unassociated,
+    /// Canonical membership exists without an archive marker.
+    Active,
+    /// A monotonic canonical archive marker exists.
+    Archived,
+}
+
+/// Content-transport configuration state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransportState {
+    /// No content remote is configured.
+    LocalOnly,
+    /// Provisioning has begun but is not confirmed.
+    Provisioning,
+    /// A content remote is configured.
+    Configured,
+    /// Transport inspection failed.
+    Error,
+}
+
+/// Relationship between local and remote content trees.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncState {
+    /// No fresh comparison is available.
+    Unknown,
+    /// Local and remote trees match.
+    Current,
+    /// Local history is ahead.
+    Ahead,
+    /// Remote history is ahead.
+    Behind,
+    /// Histories have diverged.
+    Diverged,
+}
+
+/// Repository authority available to the selected profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorityState {
+    /// No usable authority is present.
+    Absent,
+    /// Authority is retained by the account/profile.
+    Retained,
+    /// Authority is known to be revoked.
+    Revoked,
+    /// Authority could not be determined offline.
+    Unknown,
+}
+
+/// Device-local visibility independent from account membership.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LocalVisibility {
+    /// Shown in ordinary local/account inventory.
+    Visible,
+    /// Explicitly hidden on this profile/device.
+    HiddenOnThisDevice,
+}
+
+/// Stable version-one JSON inventory row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpaceInventoryRowV1 {
+    /// Schema version, exactly one.
+    pub version: u8,
+    /// Native profile identifier.
+    pub profile: String,
+    /// Repository subject DID.
+    pub subject: String,
+    /// Preferred display name; local registration wins over remote metadata.
+    pub name: Option<String>,
+    /// Independent local presence axis.
+    pub local_presence: LocalPresence,
+    /// Independent canonical account membership axis.
+    pub account_membership: AccountMembership,
+    /// Independent content transport axis.
+    pub transport: TransportState,
+    /// Independent content revision relationship.
+    pub sync: SyncState,
+    /// Independent authority axis.
+    pub authority: AuthorityState,
+    /// Independent profile/device visibility axis.
+    pub visibility: LocalVisibility,
+    /// Exact tree accepted by the content remote, when confirmed.
+    pub confirmed_revision: Option<String>,
+    /// Whether an explicit ordinary pull can safely proceed.
+    pub pullable: bool,
+}
+
+#[derive(Clone, Debug)]
+struct InventoryInput {
+    profile: String,
+    subject: String,
+    local_name: Option<String>,
+    remote_name: Option<String>,
+    local_presence: LocalPresence,
+    account_membership: AccountMembership,
+    transport: TransportState,
+    sync: SyncState,
+    authority: AuthorityState,
+    suppressed: bool,
+    confirmed_revision: Option<String>,
+    ambiguous: bool,
+}
+
+impl InventoryInput {
+    fn absent(profile: &NativeProfileContext, subject: String) -> Self {
+        Self {
+            profile: profile.id.to_string(),
+            subject,
+            local_name: None,
+            remote_name: None,
+            local_presence: LocalPresence::Absent,
+            account_membership: AccountMembership::Unassociated,
+            transport: TransportState::LocalOnly,
+            sync: SyncState::Unknown,
+            authority: AuthorityState::Unknown,
+            suppressed: false,
+            confirmed_revision: None,
+            ambiguous: false,
+        }
+    }
+}
+
+/// Read-only inventory controls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InventoryOptions {
+    /// Include suppressed, archived, ambiguous, and orphaned rows.
+    pub all: bool,
+    /// Fetch remote content heads without merging or writing.
+    pub refresh: bool,
+}
+
+fn normalize(inputs: Vec<InventoryInput>, all: bool) -> Vec<SpaceInventoryRowV1> {
+    let mut rows = inputs
+        .into_iter()
+        .map(|input| {
+            let visibility = if input.suppressed {
+                LocalVisibility::HiddenOnThisDevice
+            } else {
+                LocalVisibility::Visible
+            };
+            let pullable = input.local_presence == LocalPresence::Absent
+                && input.account_membership == AccountMembership::Active
+                && input.transport == TransportState::Configured
+                && input.authority == AuthorityState::Retained
+                && !input.ambiguous;
+            SpaceInventoryRowV1 {
+                version: 1,
+                profile: input.profile,
+                subject: input.subject,
+                name: input.local_name.or(input.remote_name),
+                local_presence: input.local_presence,
+                account_membership: input.account_membership,
+                transport: input.transport,
+                sync: input.sync,
+                authority: input.authority,
+                visibility,
+                confirmed_revision: input.confirmed_revision,
+                pullable,
+            }
+        })
+        .filter(|row| {
+            all || row.visibility == LocalVisibility::Visible
+                && (row.local_presence == LocalPresence::Registered
+                    || row.account_membership == AccountMembership::Active)
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.subject.cmp(&right.subject));
+    rows
+}
+
+/// Assemble one stable inventory for an exact native profile.
+///
+/// The default path opens only local profile/account state. `refresh` adds
+/// provider rows and remote head observations but never pulls, pushes,
+/// provisions, archives, or changes a binding.
+pub async fn list(
+    context: &NativeProfileContext,
+    options: InventoryOptions,
+) -> Result<Vec<SpaceInventoryRowV1>> {
+    let registry = context.store.load()?;
+    let profile = context.load_profile().await?;
+    let mut inputs: BTreeMap<String, InventoryInput> = BTreeMap::new();
+
+    for (name, entry) in &registry.spots {
+        let site = crate::site::TonkSite::open_with(&entry.site, context.site_config())
+            .await
+            .with_context(|| format!("failed to inspect registered space '{name}'"))?;
+        let subject = site.repository.did().to_string();
+        let input = inputs
+            .entry(subject.clone())
+            .or_insert_with(|| InventoryInput::absent(context, subject.clone()));
+        input.local_name = Some(name.clone());
+        input.local_presence = LocalPresence::Registered;
+        input.suppressed = registry.is_suppressed(&subject);
+        input.transport = match crate::remote::upstream_remote(&site).await {
+            Ok(Some(_)) => TransportState::Configured,
+            Ok(None) => TransportState::LocalOnly,
+            Err(_) => TransportState::Error,
+        };
+        if let Some(root) = context.record.account_root.as_deref() {
+            input.authority = match root.parse().ok() {
+                Some(root) if crate::site::account_root_prefix(&site, &root).await.is_ok() => {
+                    AuthorityState::Retained
+                }
+                Some(_) => AuthorityState::Absent,
+                None => AuthorityState::Unknown,
+            };
+        }
+        if options.refresh && input.transport == TransportState::Configured {
+            input.sync = match crate::sync::status_with_hash(&site).await {
+                Ok(status) => match status.state {
+                    tonk_schema::SyncState::Synced => SyncState::Current,
+                    tonk_schema::SyncState::Ahead => SyncState::Ahead,
+                    tonk_schema::SyncState::Behind => SyncState::Behind,
+                    tonk_schema::SyncState::Diverged => SyncState::Diverged,
+                    tonk_schema::SyncState::NoUpstream => SyncState::Unknown,
+                },
+                Err(_) => SyncState::Unknown,
+            };
+        }
+    }
+
+    if options.all {
+        for path in context.store.orphaned_sites(&registry) {
+            let Ok(site) = crate::site::TonkSite::open_with(&path, context.site_config()).await
+            else {
+                continue;
+            };
+            let subject = site.repository.did().to_string();
+            let input = inputs
+                .entry(subject.clone())
+                .or_insert_with(|| InventoryInput::absent(context, subject.clone()));
+            input.local_presence = LocalPresence::Orphaned;
+            input.suppressed = registry.is_suppressed(&subject);
+        }
+    }
+
+    if let Some(account_root) = context.record.account_root.as_deref() {
+        let account_root = account_root
+            .parse()
+            .context("native profile account root is invalid")?;
+        let operator = crate::account_state::operator_for_store(&profile, &context.store).await?;
+        if let Some(branch) =
+            crate::account_state::open_account_branch_in(&profile, &operator, &context.store)
+                .await?
+        {
+            for record in tonk_schema::account::list_account_spaces(&branch, &operator).await? {
+                if record.account != account_root {
+                    continue;
+                }
+                let subject = record.subject.to_string();
+                let input = inputs
+                    .entry(subject.clone())
+                    .or_insert_with(|| InventoryInput::absent(context, subject.clone()));
+                input.account_membership = if record.archived {
+                    AccountMembership::Archived
+                } else {
+                    AccountMembership::Active
+                };
+                if record.name.is_some() {
+                    input.remote_name = record.name;
+                }
+                if record.remote_url.is_some() {
+                    input.transport = TransportState::Configured;
+                }
+                if record.confirmed_revision.is_some() {
+                    input.confirmed_revision = record.confirmed_revision;
+                }
+                let retained_by_account = branch
+                    .delegations()
+                    .prove(
+                        account_root.clone(),
+                        dialog_ucan::Scope {
+                            subject: dialog_ucan_core::subject::Subject::Specific(
+                                record.subject.clone(),
+                            ),
+                            command: dialog_ucan_core::command::Command::parse("/")
+                                .expect("root command is valid"),
+                            parameters: dialog_ucan::Parameters::default(),
+                        },
+                    )
+                    .perform(&operator)
+                    .await
+                    .is_ok();
+                let retained_by_profile = crate::site::inspect_account_root_prefix_for(
+                    &profile,
+                    &operator,
+                    &record.subject,
+                    &account_root,
+                )
+                .await
+                .is_ok();
+                input.authority = if retained_by_account || retained_by_profile {
+                    AuthorityState::Retained
+                } else if input.authority == AuthorityState::Retained {
+                    // A refreshed provider artifact is not canonical
+                    // membership, but its verified root-ending chain is
+                    // cryptographic authority evidence in its own right.
+                    AuthorityState::Retained
+                } else {
+                    AuthorityState::Absent
+                };
+                input.suppressed = registry.is_suppressed(&subject);
+            }
+            for input in inputs.values_mut() {
+                if input.account_membership != AccountMembership::Active
+                    || input.authority != AuthorityState::Unknown
+                {
+                    continue;
+                }
+                let Ok(subject) = input.subject.parse() else {
+                    input.authority = AuthorityState::Absent;
+                    continue;
+                };
+                input.authority = if crate::site::inspect_account_root_prefix_for(
+                    &profile,
+                    &operator,
+                    &subject,
+                    &account_root,
+                )
+                .await
+                .is_ok()
+                {
+                    AuthorityState::Retained
+                } else {
+                    AuthorityState::Absent
+                };
+            }
+        }
+    }
+
+    Ok(normalize(inputs.into_values().collect(), options.all))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account_profiles::{NativeProfileId, NativeProfileRecord};
+    use crate::site::{SiteConfig, TonkSite};
+    use dialog_effects::storage::Directory;
+
+    fn input(subject: &str) -> InventoryInput {
+        InventoryInput {
+            profile: "personal".into(),
+            subject: subject.into(),
+            local_name: None,
+            remote_name: None,
+            local_presence: LocalPresence::Absent,
+            account_membership: AccountMembership::Unassociated,
+            transport: TransportState::LocalOnly,
+            sync: SyncState::Unknown,
+            authority: AuthorityState::Unknown,
+            suppressed: false,
+            confirmed_revision: None,
+            ambiguous: false,
+        }
+    }
+
+    fn local_context(root: &std::path::Path) -> NativeProfileContext {
+        let id = NativeProfileId::generate();
+        NativeProfileContext {
+            record: NativeProfileRecord {
+                label: "inventory".to_string(),
+                dialog_profile_name: format!("tonk-inventory-test-{}", id.as_str()),
+                account_root: None,
+                ceremony_origin: None,
+                default_access_remote: None,
+                default_revocation_relay: None,
+                extra: serde_json::Map::new(),
+            },
+            store: crate::spot::SpotStore::at(root.join(id.as_str())),
+            id,
+        }
+    }
+
+    async fn configured_local_space(
+        context: &NativeProfileContext,
+        endpoint: &str,
+    ) -> anyhow::Result<TonkSite> {
+        let path = context.store.canonical_site("garden");
+        let site = TonkSite::init_at_with(
+            &path,
+            SiteConfig {
+                profile_name: context.record.dialog_profile_name.clone(),
+                profile_directory: Directory::Profile,
+                require_account: false,
+                account_store: context.store.clone(),
+            },
+        )
+        .await?;
+        crate::remote::add(&site, crate::remote::DEFAULT_REMOTE, endpoint, None).await?;
+        crate::remote::set_upstream(&site, crate::remote::DEFAULT_REMOTE).await?;
+        crate::spot::register_existing_unbound(&context.store, "garden", &site.root)?;
+        Ok(site)
+    }
+
+    #[test]
+    fn it_normalizes_lifecycle_axes_without_collapsing_them() {
+        let rows = normalize(
+            vec![
+                InventoryInput {
+                    profile: "personal".to_string(),
+                    subject: "did:key:zLocal".to_string(),
+                    local_name: Some("garden".to_string()),
+                    remote_name: Some("remote-garden".to_string()),
+                    local_presence: LocalPresence::Registered,
+                    account_membership: AccountMembership::Active,
+                    transport: TransportState::Configured,
+                    sync: SyncState::Current,
+                    authority: AuthorityState::Retained,
+                    suppressed: false,
+                    confirmed_revision: Some("#tree".to_string()),
+                    ambiguous: false,
+                },
+                InventoryInput {
+                    profile: "personal".to_string(),
+                    subject: "did:key:zRemote".to_string(),
+                    local_name: None,
+                    remote_name: Some("shared".to_string()),
+                    local_presence: LocalPresence::Absent,
+                    account_membership: AccountMembership::Active,
+                    transport: TransportState::Configured,
+                    sync: SyncState::Unknown,
+                    authority: AuthorityState::Retained,
+                    suppressed: true,
+                    confirmed_revision: Some("#other".to_string()),
+                    ambiguous: false,
+                },
+                InventoryInput {
+                    profile: "personal".to_string(),
+                    subject: "did:key:zArchived".to_string(),
+                    local_name: Some("old".to_string()),
+                    remote_name: None,
+                    local_presence: LocalPresence::Registered,
+                    account_membership: AccountMembership::Archived,
+                    transport: TransportState::Configured,
+                    sync: SyncState::Unknown,
+                    authority: AuthorityState::Retained,
+                    suppressed: false,
+                    confirmed_revision: None,
+                    ambiguous: false,
+                },
+            ],
+            true,
+        );
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].name.as_deref(), Some("old"));
+        assert!(!rows[0].pullable);
+        assert_eq!(rows[1].name.as_deref(), Some("garden"));
+        assert_eq!(rows[2].visibility, LocalVisibility::HiddenOnThisDevice);
+        assert!(rows[2].pullable);
+        let json = serde_json::to_value(&rows[2]).unwrap();
+        assert_eq!(json["localPresence"], "absent");
+        assert_eq!(json["accountMembership"], "active");
+        assert_eq!(json["visibility"], "hiddenOnThisDevice");
+        assert_eq!(json["confirmedRevision"], "#other");
+    }
+
+    #[test]
+    fn it_covers_the_space_inventory_lifecycle_table() {
+        let mut local_only = input("01-local-only");
+        local_only.local_presence = LocalPresence::Registered;
+        let mut local_current = input("02-local-current");
+        local_current.local_presence = LocalPresence::Registered;
+        local_current.account_membership = AccountMembership::Active;
+        local_current.transport = TransportState::Configured;
+        local_current.sync = SyncState::Current;
+        local_current.authority = AuthorityState::Retained;
+        let mut local_ahead = local_current.clone();
+        local_ahead.subject = "03-local-ahead".into();
+        local_ahead.sync = SyncState::Ahead;
+        let mut pullable = input("04-account-only");
+        pullable.account_membership = AccountMembership::Active;
+        pullable.transport = TransportState::Configured;
+        pullable.authority = AuthorityState::Retained;
+        let mut ambiguous = pullable.clone();
+        ambiguous.subject = "05-ambiguous".into();
+        ambiguous.ambiguous = true;
+        let mut suppressed = pullable.clone();
+        suppressed.subject = "06-suppressed".into();
+        suppressed.suppressed = true;
+        let mut archived_local = local_current.clone();
+        archived_local.subject = "07-archived-local".into();
+        archived_local.account_membership = AccountMembership::Archived;
+        let mut archived_absent = pullable.clone();
+        archived_absent.subject = "08-archived-absent".into();
+        archived_absent.account_membership = AccountMembership::Archived;
+        let mut orphaned = input("09-orphaned");
+        orphaned.local_presence = LocalPresence::Orphaned;
+        let mut missing_authority = pullable.clone();
+        missing_authority.subject = "10-missing-authority".into();
+        missing_authority.authority = AuthorityState::Absent;
+        let mut provider_legacy = pullable.clone();
+        provider_legacy.subject = "11-provider-legacy".into();
+
+        let rows = normalize(
+            vec![
+                local_only,
+                local_current,
+                local_ahead,
+                pullable,
+                ambiguous,
+                suppressed,
+                archived_local,
+                archived_absent,
+                orphaned,
+                missing_authority,
+                provider_legacy,
+            ],
+            true,
+        );
+        assert_eq!(rows.len(), 11);
+        let pullability: Vec<_> = rows.iter().map(|row| row.pullable).collect();
+        assert_eq!(
+            pullability,
+            vec![
+                false, false, false, true, false, true, false, false, false, false, true
+            ]
+        );
+        assert_eq!(rows[1].sync, SyncState::Current);
+        assert_eq!(rows[2].sync, SyncState::Ahead);
+        assert_eq!(rows[5].visibility, LocalVisibility::HiddenOnThisDevice);
+        assert_eq!(rows[6].account_membership, AccountMembership::Archived);
+        assert_eq!(rows[8].local_presence, LocalPresence::Orphaned);
+    }
+
+    #[dialog_common::test]
+    async fn it_lists_offline_without_provider_or_remote_requests() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let context = local_context(root.path());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        listener.set_nonblocking(true)?;
+        let endpoint = format!("http://{}/ucan/", listener.local_addr()?);
+        configured_local_space(&context, &endpoint).await?;
+
+        let rows = list(&context, InventoryOptions::default()).await?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].local_presence, LocalPresence::Registered);
+        assert_eq!(rows[0].transport, TransportState::Configured);
+        assert_eq!(rows[0].sync, SyncState::Unknown);
+        assert!(
+            matches!(listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+            "offline inventory must not contact the configured content remote"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_refreshes_read_only() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let context = local_context(root.path());
+        let site = configured_local_space(&context, "http://127.0.0.1:9/ucan/").await?;
+        let registry_path = context.store.registry_path();
+        let registry_before = std::fs::read(&registry_path)?;
+        let revision_before = site.branch().await?.handle().revision();
+        let remote_before =
+            serde_json::to_value(crate::remote::find(&site, crate::remote::DEFAULT_REMOTE).await?)?;
+
+        let rows = list(
+            &context,
+            InventoryOptions {
+                all: true,
+                refresh: true,
+            },
+        )
+        .await?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].sync, SyncState::Unknown);
+        assert_eq!(std::fs::read(&registry_path)?, registry_before);
+        assert_eq!(site.branch().await?.handle().revision(), revision_before);
+        assert_eq!(
+            serde_json::to_value(crate::remote::find(&site, crate::remote::DEFAULT_REMOTE).await?,)?,
+            remote_before,
+            "refresh may inspect but must not rewrite remote configuration"
+        );
+        Ok(())
+    }
+}

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -420,9 +420,13 @@ pub async fn claim(
     // what a later `tonk invite` delegates from. Rooting that chain in an
     // anonymous key leaves it with no owner and nothing able to revoke it.
     if config.require_account {
-        crate::account::require_account_with_operator(&profile, &operator)
-            .await
-            .map_err(|e| InviteError::Io(e.to_string()))?;
+        crate::account::require_account_with_operator_in(
+            &profile,
+            &operator,
+            &config.account_store,
+        )
+        .await
+        .map_err(|e| InviteError::Io(e.to_string()))?;
     }
     let member = local_root
         .ok_or_else(|| {

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -34,9 +34,11 @@
 
 pub mod account;
 mod account_authority;
+pub mod account_profiles;
 mod account_session;
 pub mod account_spots;
 pub mod account_state;
+pub mod account_sync;
 pub mod agents;
 pub mod authoring;
 pub mod auto_sync;
@@ -47,6 +49,7 @@ pub mod context;
 pub mod customer;
 pub mod data;
 pub mod data_ops;
+pub mod deployment;
 pub mod eval;
 pub mod guide;
 pub mod identity;

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -53,6 +53,7 @@ pub mod deployment;
 pub mod eval;
 pub mod guide;
 pub mod identity;
+pub mod inventory;
 pub mod invite;
 /// Migrating a CSV export written by a pre-dialog-upgrade build.
 pub mod legacy;

--- a/rust/tonk-cli/src/recovery.rs
+++ b/rust/tonk-cli/src/recovery.rs
@@ -1,19 +1,19 @@
 //! Whether a spot's data survives being deleted.
 //!
 //! `tonk spot rm` destroys a site directory, and how bad that is
-//! depends entirely on where else the facts exist. A spot the account
-//! directory lists can be pulled down again; a spot that only ever
+//! depends entirely on where else the facts exist. A spot whose exact
+//! content revision is confirmed remotely and whose access metadata is saved
+//! to an account can be pulled down again; a spot that only ever
 //! pushed to a remote can be recovered from that remote if the
 //! operator still holds authority over it; a spot with no upstream at
 //! all exists nowhere else, and deleting it is final.
 //!
 //! The registry cannot answer this — [`crate::spot::SpotEntry`] is a
 //! path and nothing more — so the answer is read out of the site
-//! itself: the `main` branch's upstream, plus the account branch's
-//! local copy of the directory. Both are local reads. Deliberately no
-//! network round trip: a confirmation prompt that hangs on an
-//! unreachable remote is a worse failure than one that reports what
-//! this device knows.
+//! itself: the `main` branch's upstream, plus the local account
+//! access and revision markers. These are local reads. Deliberately no network call:
+//! a confirmation prompt that hangs on a dead account service is a
+//! worse failure than one that reports what this device knows.
 
 use std::path::Path;
 
@@ -22,8 +22,8 @@ use crate::site::{SiteConfig, TonkSite};
 /// Where a spot's data exists besides this directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Recovery {
-    /// Listed in the linked account's directory, and pullable again
-    /// by subject.
+    /// Exact content confirmed remotely with account access metadata saved,
+    /// and pullable again by subject.
     Account {
         /// Repository subject DID, the argument `tonk account spots
         /// pull` takes.
@@ -63,19 +63,19 @@ impl Recovery {
     pub fn consequence(&self, name: &str) -> String {
         match self {
             Recovery::Account { subject } => format!(
-                "'{name}' is listed in your account directory ({subject}).\n\
-                 You can pull it down again after deleting it."
+                "'{name}' has confirmed remote content and saved account access ({subject}).\n\
+                 You can pull that confirmed revision down again after deleting it."
             ),
             Recovery::Remote {
                 name: remote,
                 endpoint,
             } => format!(
-                "'{name}' pushes to '{remote}' ({endpoint}) but is not listed in\n\
-                 your account directory. Deleting it here keeps whatever the remote\n\
+                "'{name}' pushes to '{remote}' ({endpoint}) but has no saved account\n\
+                 access on this device. Deleting it here keeps whatever the remote\n\
                  already holds, but this device loses its access to it."
             ),
             Recovery::LocalOnly => format!(
-                "'{name}' is local-only: it has no upstream and no account listing,\n\
+                "'{name}' is local-only: it has no upstream or confirmed remote copy,\n\
                  so this is the only copy and deleting it cannot be undone."
             ),
             Recovery::Unknown { detail } => format!(
@@ -124,9 +124,9 @@ pub async fn inspect(path: &Path, config: SiteConfig) -> Recovery {
         }
     };
 
-    // A directory mount record is only ever written for a site that
-    // has an upstream, so this is checked second and only here.
-    match crate::account_spots::directory_lists(&site).await {
+    // Account access metadata is only projected for a site that has an
+    // upstream, so this exact-revision check is second and only here.
+    match crate::account_spots::has_account_backup(&site).await {
         Ok(true) => {
             return Recovery::Account {
                 subject: site.repository.did().to_string(),

--- a/rust/tonk-cli/src/recovery.rs
+++ b/rust/tonk-cli/src/recovery.rs
@@ -89,7 +89,7 @@ impl Recovery {
     pub fn restore_hint(&self) -> Option<String> {
         match self {
             Recovery::Account { subject } => Some(format!(
-                "restore it later with `tonk account spots pull {subject}`"
+                "restore it later with `tonk account spaces pull {subject}`"
             )),
             Recovery::Remote { .. } | Recovery::LocalOnly | Recovery::Unknown { .. } => None,
         }

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -618,6 +618,33 @@ pub async fn load_account_root_prefix_for(
     )
 }
 
+/// Inspect held authority without migrating or writing credential records.
+pub async fn inspect_account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain> {
+    let current = space_root_site(subject, account_root);
+    if let Some(bytes) = optional_credential(profile, operator, current).await? {
+        return validate_prefix(bytes, account_root)
+            .await
+            .context("stored account-root prefix is invalid");
+    }
+    let legacy = format!("{SPACE_ROOT_SITE_PREFIX}{subject}");
+    if let Some(bytes) = optional_credential(profile, operator, legacy).await? {
+        return validate_prefix(bytes, account_root)
+            .await
+            .context("stored legacy account-root prefix is invalid");
+    }
+    if let Some(chain) = recover_prefix(profile, operator, subject, account_root).await? {
+        return Ok(chain);
+    }
+    anyhow::bail!(
+        "no stored account-root prefix proves subject {subject} for account {account_root}"
+    )
+}
+
 async fn existing_account_root_prefix_for(
     profile: &Profile,
     operator: &Operator<NativeSpace>,

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -123,7 +123,7 @@ impl TonkSite {
     /// Errors if the directory exists but the dialog repository
     /// inside it is missing or unreadable.
     pub async fn open(root: &Path) -> Result<Self> {
-        Self::open_with(root, default_config()).await
+        Self::open_with(root, default_config()?).await
     }
 
     /// [`Self::open`] with caller-supplied [`SiteConfig`] —
@@ -179,7 +179,7 @@ impl TonkSite {
         let operator = crate::account_authority::wrap(
             operator,
             profile.clone(),
-            crate::spot::SpotStore::open().context("failed to locate account state")?,
+            config.account_store.clone(),
             config.require_account,
         )
         .await?;
@@ -243,9 +243,14 @@ impl TonkSite {
         {
             Ok(repository) => (repository, false),
             Err(_) => (
-                bootstrap_repository(&profile, &operator, config.require_account)
-                    .await
-                    .with_context(|| format!("failed to bootstrap repository '{REPO_NAME}'"))?,
+                bootstrap_repository(
+                    &profile,
+                    &operator,
+                    &config.account_store,
+                    config.require_account,
+                )
+                .await
+                .with_context(|| format!("failed to bootstrap repository '{REPO_NAME}'"))?,
                 true,
             ),
         };
@@ -254,7 +259,7 @@ impl TonkSite {
         let operator = crate::account_authority::wrap(
             operator,
             profile.clone(),
-            crate::spot::SpotStore::open().context("failed to locate account state")?,
+            config.account_store.clone(),
             config.require_account,
         )
         .await?;
@@ -356,6 +361,7 @@ impl TonkSite {
 async fn bootstrap_repository(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
+    account_store: &crate::spot::SpotStore,
     require_account: bool,
 ) -> Result<Repository> {
     let signer_repo = profile
@@ -367,7 +373,7 @@ async fn bootstrap_repository(
 
     let local_root = crate::identity::local_root_with_operator(profile, operator).await?;
     if require_account {
-        crate::account::require_account_with_operator(profile, operator).await?;
+        crate::account::require_account_with_operator_in(profile, operator, account_store).await?;
     }
     let durable_did: dialog_varsig::Did = local_root
         .context("local root provisioning did not produce a record")?
@@ -406,7 +412,8 @@ async fn bootstrap_repository(
     // the account rather than by fetching an artifact. Non-fatal: a space that
     // works but is not yet backed up beats no space at all.
     if let Err(error) =
-        crate::account_state::retain_space_delegation(profile, operator, &prefix).await
+        crate::account_state::retain_space_delegation_in(profile, operator, account_store, &prefix)
+            .await
     {
         eprintln!("warning: space not retained into the account space: {error:#}");
     }
@@ -414,7 +421,9 @@ async fn bootstrap_repository(
     // The billing half of the same act: provision the new space as a
     // consumer of the access service, depositing the powerline as its
     // consent. Non-fatal for the same reason retain is.
-    if let Err(error) = crate::customer::provision(profile, &signer_repo.did(), &prefix).await {
+    if let Err(error) =
+        crate::customer::provision_in(profile, account_store, &signer_repo.did(), &prefix).await
+    {
         eprintln!("warning: space not provisioned with the sync service: {error:#}");
     }
 
@@ -471,7 +480,12 @@ async fn mount_delegated_inner(
         .await?
         .context("local root provisioning did not produce a record")?;
     if config.require_account {
-        crate::account::require_account_with_operator(&profile, &operator).await?;
+        crate::account::require_account_with_operator_in(
+            &profile,
+            &operator,
+            &config.account_store,
+        )
+        .await?;
     }
     let account_root: Did = local_root
         .root_did
@@ -530,7 +544,7 @@ async fn mount_delegated_inner(
     let operator = crate::account_authority::wrap(
         operator,
         profile.clone(),
-        crate::spot::SpotStore::open().context("failed to locate account state")?,
+        config.account_store.clone(),
         config.require_account,
     )
     .await?;
@@ -543,10 +557,13 @@ async fn mount_delegated_inner(
     })
 }
 
-/// Load the exact reusable prefix for a site, recovering it from pre-feature
-/// profile authority when the dedicated credential is absent.
+/// Strictly load the exact reusable prefix for a site.
+///
+/// This ordinary-operation path never creates authority. Call
+/// [`adopt_account_root_prefix_for`] from an explicit create, join, pull, or
+/// migration boundary when adopting held legacy authority is intended.
 pub async fn account_root_prefix(site: &TonkSite, account_root: &Did) -> Result<DelegationChain> {
-    account_root_prefix_for(
+    load_account_root_prefix_for(
         &site.profile,
         site.operator.local(),
         &site.repository.did(),
@@ -580,28 +597,39 @@ async fn optional_credential(
     }
 }
 
-/// Resolve the reusable `subject → … → account_root` prefix, minting it
-/// when this profile holds the subject's authority but no chain to the
-/// account reaches it yet.
+/// Load a pre-existing `subject → … → account_root` prefix.
 ///
-/// Every path that authorizes a remote request for a spot needs this exact
-/// prefix, so all of them recover the same way. A spot created before the
-/// account existed — or by a release that stored no prefix at all — has
-/// repository authority that stops at the profile, and refusing it would
-/// strand data the device demonstrably owns. Extending that authority to
-/// the account root is local bookkeeping: it delegates to the root this
-/// profile already holds a grant from, and publishes nothing.
-pub async fn account_root_prefix_for(
+/// An already-valid legacy credential may be copied to its root-specific v2
+/// key. Missing authority is an error and is never recovered or minted here.
+pub async fn load_account_root_prefix_for(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
     subject: &Did,
     account_root: &Did,
 ) -> Result<DelegationChain> {
+    if let Some(chain) =
+        existing_account_root_prefix_for(profile, operator, subject, account_root).await?
+    {
+        return Ok(chain);
+    }
+
+    anyhow::bail!(
+        "no stored account-root prefix proves subject {subject} for account {account_root}"
+    )
+}
+
+async fn existing_account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<Option<DelegationChain>> {
     let current = space_root_site(subject, account_root);
     if let Some(bytes) = optional_credential(profile, operator, current.clone()).await? {
         return validate_prefix(bytes, account_root)
             .await
-            .context("stored account-root prefix is invalid");
+            .context("stored account-root prefix is invalid")
+            .map(Some);
     }
 
     // A v1 credential is copied only when its signatures and terminal root
@@ -613,8 +641,28 @@ pub async fn account_root_prefix_for(
         save_prefix(profile, operator, &current, bytes)
             .await
             .context("failed to migrate the account-root prefix")?;
+        return Ok(Some(chain));
+    }
+    Ok(None)
+}
+
+/// Explicitly adopt held authority for `subject` into `account_root`.
+///
+/// This is the only path allowed to recover or mint a missing prefix and must
+/// therefore be called only by an explicit create, join, pull, or migration
+/// operation for the resolved native profile.
+pub async fn adopt_account_root_prefix_for(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    subject: &Did,
+    account_root: &Did,
+) -> Result<DelegationChain> {
+    if let Some(chain) =
+        existing_account_root_prefix_for(profile, operator, subject, account_root).await?
+    {
         return Ok(chain);
     }
+    let current = space_root_site(subject, account_root);
 
     let chain = match recover_prefix(profile, operator, subject, account_root).await? {
         Some(chain) => chain,
@@ -727,18 +775,22 @@ pub struct SiteConfig {
     /// and get a software-generated root instead (see
     /// [`build_profile_and_operator`]).
     pub require_account: bool,
+    /// Profile-scoped account repository and session state.
+    pub account_store: crate::spot::SpotStore,
 }
 
 impl SiteConfig {
     /// Builder shortcut: same as [`default_config`] but with the
     /// profile name overridden. Lets tests namespace their
     /// profile so parallel runs don't collide.
-    pub fn with_profile_name(name: impl Into<String>) -> Self {
-        Self {
+    pub fn with_profile_name(name: impl Into<String>) -> Result<Self> {
+        Ok(Self {
             profile_name: name.into(),
             profile_directory: Directory::Profile,
             require_account: false,
-        }
+            account_store: crate::spot::SpotStore::open()
+                .context("failed to locate account state")?,
+        })
     }
 }
 
@@ -747,12 +799,13 @@ impl SiteConfig {
 /// so the binary and other crate modules can pass it to
 /// `*_with` constructors without reaching into `dialog-effects`
 /// for [`Directory::Profile`].
-pub fn default_config() -> SiteConfig {
-    SiteConfig {
+pub fn default_config() -> Result<SiteConfig> {
+    Ok(SiteConfig {
         profile_name: PROFILE_NAME.to_string(),
         profile_directory: Directory::Profile,
         require_account: std::env::var_os("TONK_UNSAFE_ALLOW_DEVICE_ROOT").is_none(),
-    }
+        account_store: crate::spot::SpotStore::open().context("failed to locate account state")?,
+    })
 }
 
 /// Open (or create) the shared profile and build a tonk

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -258,6 +258,11 @@ impl SpotStore {
         Self { dir: dir.into() }
     }
 
+    /// Root directory containing this profile's spot and account state.
+    pub fn root(&self) -> &Path {
+        &self.dir
+    }
+
     /// Path to `spots.json` inside this store.
     pub fn registry_path(&self) -> PathBuf {
         self.dir.join(REGISTRY_FILE)

--- a/rust/tonk-cli/src/spot.rs
+++ b/rust/tonk-cli/src/spot.rs
@@ -25,15 +25,18 @@
 //! go through a temp file + atomic rename. A corrupt registry is a
 //! hard error naming the file — never silently recreated.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tonk_schema::{RepositoryName, prelude::DidExt as _};
 
-/// Environment variable naming the spot to use, beaten only by the
-/// `--spot` flag. Automation (agents, bench, CI) should always set
+/// Canonical environment variable naming the space to use.
+pub const SPACE_ENV: &str = "TONK_SPACE";
+
+/// Compatibility environment variable naming the spot to use, beaten only by the
+/// `--space`/`--spot` flag. Automation (agents, bench, CI) should always set
 /// this (or pass `--spot`) to override a directory binding.
 pub const SPOT_ENV: &str = "TONK_SPOT";
 
@@ -70,6 +73,14 @@ pub struct Registry {
         skip_serializing_if = "BTreeMap::is_empty"
     )]
     pub bindings: BTreeMap<PathBuf, String>,
+    /// Repository subjects explicitly hidden on this profile/device.
+    /// Account membership and authority remain unchanged.
+    #[serde(
+        default,
+        rename = "suppressedSubjects",
+        skip_serializing_if = "BTreeSet::is_empty"
+    )]
+    pub suppressed_subjects: BTreeSet<String>,
     /// Fields this binary does not recognise. `spots.json` is a public
     /// format other applications read and rewrite directly, and this
     /// binary is not necessarily the newest one touching it — an
@@ -78,6 +89,23 @@ pub struct Registry {
     /// heard of just because it round-tripped the registry.
     #[serde(flatten)]
     extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Registry {
+    /// Hide a repository subject on this profile/device.
+    pub fn suppress(&mut self, subject: impl Into<String>) -> bool {
+        self.suppressed_subjects.insert(subject.into())
+    }
+
+    /// Clear this profile/device's hidden marker after an explicit successful pull.
+    pub fn unsuppress(&mut self, subject: &str) -> bool {
+        self.suppressed_subjects.remove(subject)
+    }
+
+    /// Whether this profile/device has explicitly hidden the repository subject.
+    pub fn is_suppressed(&self, subject: &str) -> bool {
+        self.suppressed_subjects.contains(subject)
+    }
 }
 
 /// One registered spot.
@@ -126,21 +154,31 @@ pub struct Resolved {
 /// Failure modes for registry access and resolution.
 #[derive(Debug, Error)]
 pub enum SpotError {
-    /// Spots exist but neither the process nor cwd selects one.
+    /// Canonical and compatibility environment variables disagree.
     #[error(
-        "no spot active for this directory; run `tonk use <name>`, \
-         pass --spot, or set TONK_SPOT"
+        "TONK_SPACE selects '{space}' but TONK_SPOT selects '{spot}'; unset one or give both the same value"
+    )]
+    EnvironmentConflict {
+        /// Canonical value.
+        space: String,
+        /// Compatibility value.
+        spot: String,
+    },
+    /// Spaces exist but neither the process nor cwd selects one.
+    #[error(
+        "no space active for this directory; run `tonk use <name>`, \
+         pass --space, or set TONK_SPACE"
     )]
     NoSelection,
-    /// The registry has zero spots — selection is moot; the fix is
+    /// The registry has zero spaces — selection is moot; the fix is
     /// creating one.
     #[error(
-        "no spots registered; create one with `tonk spot new <name>` \
+        "no spaces registered; create one with `tonk space new <name>` \
          (add --site <path> to adopt an existing .tonk directory)"
     )]
     NothingRegistered,
     /// A name that isn't in the registry.
-    #[error("unknown spot '{name}'{}", unknown_hint(.available, .binding))]
+    #[error("unknown space '{name}'{}", unknown_hint(.available, .binding))]
     Unknown {
         /// The name that failed to resolve.
         name: String,
@@ -175,7 +213,7 @@ pub enum SpotError {
     /// The registry file exists but doesn't parse. Deliberately
     /// not self-healing: silently recreating it would orphan every
     /// registered spot.
-    #[error("corrupt spot registry at {path}: {detail}")]
+    #[error("corrupt space registry at {path}: {detail}")]
     Corrupt {
         /// Path to the offending `spots.json`.
         path: PathBuf,
@@ -184,7 +222,7 @@ pub enum SpotError {
     },
     /// A name outside the allowed slug. Canonical names become
     /// directory names, so the alphabet is conservative.
-    #[error("invalid spot name '{0}': use [a-z0-9][a-z0-9-_]*")]
+    #[error("invalid space name '{0}': use [a-z0-9][a-z0-9-_]*")]
     InvalidName(String),
     /// The platform reports no data directory (no home).
     #[error("could not determine the platform data directory")]
@@ -197,6 +235,38 @@ pub enum SpotError {
     Io(String),
 }
 
+/// Resolve canonical and compatibility environment values without silently
+/// choosing when both are present and disagree.
+pub fn environment_selection(
+    space: Option<&str>,
+    spot: Option<&str>,
+) -> Result<Option<String>, SpotError> {
+    let space = space.filter(|value| !value.is_empty());
+    let spot = spot.filter(|value| !value.is_empty());
+    match (space, spot) {
+        (Some(space), Some(spot)) if space != spot => Err(SpotError::EnvironmentConflict {
+            space: space.to_owned(),
+            spot: spot.to_owned(),
+        }),
+        (Some(value), _) | (_, Some(value)) => Ok(Some(value.to_owned())),
+        (None, None) => Ok(None),
+    }
+}
+
+/// Evaluate environment variables only when no explicit command-line value
+/// already won the selection precedence.
+pub fn environment_selection_for_flag(
+    flag: Option<&str>,
+    space: Option<&str>,
+    spot: Option<&str>,
+) -> Result<Option<String>, SpotError> {
+    if flag.is_some() {
+        Ok(None)
+    } else {
+        environment_selection(space, spot)
+    }
+}
+
 /// Hint suffix for [`SpotError::Unknown`]: list what is registered,
 /// or point at `spot new` when nothing is; when the name came from a
 /// directory binding, name the directory too and point at `spot
@@ -204,13 +274,13 @@ pub enum SpotError {
 /// there is no obvious way to clear it.
 fn unknown_hint(available: &[String], binding: &Option<PathBuf>) -> String {
     let registered = if available.is_empty() {
-        "; none registered (create one with `tonk spot new <name>`)".to_string()
+        "; none registered (create one with `tonk space new <name>`)".to_string()
     } else {
         format!("; registered: {}", available.join(", "))
     };
     match binding {
         Some(directory) => format!(
-            "{registered}; via binding at {directory} — clear it with `tonk spot unbind {directory}`",
+            "{registered}; via binding at {directory} — clear it with `tonk space unbind {directory}`",
             directory = directory.display(),
         ),
         None => registered,
@@ -552,6 +622,26 @@ pub fn register_existing_unbound(
     name: &str,
     site: &Path,
 ) -> Result<(), SpotError> {
+    register_existing_unbound_inner(store, name, site, None)
+}
+
+/// Atomically register a successfully pulled canonical site and clear only
+/// that repository subject's local suppression marker.
+pub fn register_pulled_space(
+    store: &SpotStore,
+    name: &str,
+    site: &Path,
+    subject: &str,
+) -> Result<(), SpotError> {
+    register_existing_unbound_inner(store, name, site, Some(subject))
+}
+
+fn register_existing_unbound_inner(
+    store: &SpotStore,
+    name: &str,
+    site: &Path,
+    unsuppress: Option<&str>,
+) -> Result<(), SpotError> {
     validate_name(name)?;
     let site = site.canonicalize().map_err(|error| {
         SpotError::Io(format!(
@@ -561,13 +651,13 @@ pub fn register_existing_unbound(
     })?;
     let canonical = store.canonical_site(name).canonicalize().map_err(|error| {
         SpotError::Io(format!(
-            "account spot is not mounted at canonical site {}: {error}",
+            "account space is not mounted at canonical site {}: {error}",
             store.canonical_site(name).display()
         ))
     })?;
     if site != canonical {
         return Err(SpotError::Io(format!(
-            "account spot must be mounted at canonical site {}",
+            "account space must be mounted at canonical site {}",
             canonical.display()
         )));
     }
@@ -577,6 +667,9 @@ pub fn register_existing_unbound(
         return Err(SpotError::Exists(name.to_owned()));
     }
     registry.spots.insert(name.to_owned(), SpotEntry { site });
+    if let Some(subject) = unsuppress {
+        registry.unsuppress(subject);
+    }
     store.save(&registry)
 }
 
@@ -788,13 +881,68 @@ pub fn remove(store: &SpotStore, name: &str, data: Data) -> Result<RemoveOutcome
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Deletion::AlreadyGone,
             Err(e) => {
                 return Err(SpotError::Io(format!(
-                    "could not delete {}: {e}; spot '{name}' is still registered",
+                    "could not delete {}: {e}; space '{name}' is still registered",
                     entry.site.display()
                 )));
             }
         },
     };
     store.save(&registry)?;
+
+    Ok(RemoveOutcome {
+        name: name.to_owned(),
+        site: entry.site,
+        data: deletion,
+        unbound,
+    })
+}
+
+/// Remove a locally registered account space and atomically record that its
+/// repository subject is hidden on this profile/device.
+///
+/// The registry commit happens before optional byte deletion so a crash cannot
+/// leave an account-backed subject absent but unsuppressed. A deletion failure
+/// reports that bytes remain; it never rolls back or weakens the durable
+/// suppression marker.
+pub fn remove_with_subject(
+    store: &SpotStore,
+    name: &str,
+    data: Data,
+    subject: &str,
+) -> Result<RemoveOutcome, SpotError> {
+    let mut registry = store.load()?;
+    let Some(entry) = registry.spots.remove(name) else {
+        return Err(SpotError::Unknown {
+            name: name.to_owned(),
+            available: registry.spots.keys().cloned().collect(),
+            binding: None,
+        });
+    };
+    let unbound: Vec<PathBuf> = registry
+        .bindings
+        .iter()
+        .filter(|(_, spot)| spot.as_str() == name)
+        .map(|(directory, _)| directory.clone())
+        .collect();
+    for directory in &unbound {
+        registry.bindings.remove(directory);
+    }
+    registry.suppress(subject);
+    store.save(&registry)?;
+
+    let deletion = match data {
+        Data::Keep => Deletion::Kept,
+        Data::Delete => match std::fs::remove_dir_all(&entry.site) {
+            Ok(()) => Deletion::Deleted,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Deletion::AlreadyGone,
+            Err(error) => {
+                return Err(SpotError::Io(format!(
+                    "could not delete {}: {error}; space '{name}' is hidden on this device but its data remains",
+                    entry.site.display()
+                )));
+            }
+        },
+    };
 
     Ok(RemoveOutcome {
         name: name.to_owned(),
@@ -829,6 +977,7 @@ mod tests {
                 })
                 .collect(),
             bindings: BTreeMap::new(),
+            suppressed_subjects: BTreeSet::new(),
             extra: serde_json::Map::new(),
         }
     }
@@ -854,9 +1003,11 @@ mod tests {
         #[test]
         fn it_round_trips_the_registry() {
             let (_tmp, store) = store();
-            let registry = registry_with(&[("garden", "/tmp/garden")], None);
+            let mut registry = registry_with(&[("garden", "/tmp/garden")], None);
+            registry.suppress("did:key:zSpace");
             store.save(&registry).expect("save");
             assert_eq!(store.load().expect("load"), registry);
+            assert!(store.load().expect("load").is_suppressed("did:key:zSpace"));
         }
 
         #[test]
@@ -901,6 +1052,7 @@ mod tests {
 
             let registry = store.load().expect("load");
             assert_eq!(registry.legacy_current.as_deref(), Some("garden"));
+            assert!(registry.suppressed_subjects.is_empty());
             assert_eq!(
                 registry.spots.get("garden").map(|e| &e.site),
                 Some(&PathBuf::from("/tmp/garden"))
@@ -914,6 +1066,7 @@ mod tests {
                 serde_json::from_str(&std::fs::read_to_string(store.registry_path()).unwrap())
                     .expect("parse");
             assert_eq!(reloaded["futureField"]["some"], "value");
+            assert!(reloaded.get("suppressedSubjects").is_none());
             assert!(reloaded.get("current").is_none());
             assert_eq!(reloaded["spots"]["garden"]["site"], "/tmp/garden");
         }
@@ -970,6 +1123,36 @@ mod tests {
         use super::*;
 
         #[test]
+        fn it_resolves_canonical_and_legacy_environment_without_ambiguity() {
+            assert_eq!(
+                environment_selection(Some("garden"), None)
+                    .unwrap()
+                    .as_deref(),
+                Some("garden")
+            );
+            assert_eq!(
+                environment_selection(None, Some("garden"))
+                    .unwrap()
+                    .as_deref(),
+                Some("garden")
+            );
+            assert_eq!(
+                environment_selection(Some("garden"), Some("garden"))
+                    .unwrap()
+                    .as_deref(),
+                Some("garden")
+            );
+            let error = environment_selection(Some("garden"), Some("work")).unwrap_err();
+            assert!(error.to_string().contains("TONK_SPACE"));
+            assert!(error.to_string().contains("TONK_SPOT"));
+            assert_eq!(
+                environment_selection_for_flag(Some("explicit"), Some("garden"), Some("work"))
+                    .unwrap(),
+                None
+            );
+        }
+
+        #[test]
         fn it_prefers_flag_over_env() {
             let (_tmp, store) = store();
             let registry = registry_with(&[("a", "/s/a"), ("b", "/s/b"), ("c", "/s/c")], Some("c"));
@@ -1002,7 +1185,7 @@ mod tests {
             let (_tmp, store) = store();
             let err = store.resolve(None, None, None).expect_err("empty");
             assert!(matches!(err, SpotError::NothingRegistered), "{err}");
-            assert!(err.to_string().contains("tonk spot new"), "{err}");
+            assert!(err.to_string().contains("tonk space new"), "{err}");
         }
 
         #[test]
@@ -1112,7 +1295,7 @@ mod tests {
             };
             assert_eq!(binding.as_deref(), Some(Path::new("/proj")));
             assert!(err.to_string().contains("/proj"), "{err}");
-            assert!(err.to_string().contains("spot unbind"), "{err}");
+            assert!(err.to_string().contains("space unbind"), "{err}");
         }
 
         #[dialog_common::test]
@@ -1129,7 +1312,7 @@ mod tests {
                 panic!("{err}");
             };
             assert_eq!(*binding, None);
-            assert!(!err.to_string().contains("spot unbind"), "{err}");
+            assert!(!err.to_string().contains("space unbind"), "{err}");
         }
     }
 
@@ -1211,6 +1394,44 @@ mod tests {
 
     mod removal {
         use super::*;
+
+        #[dialog_common::test]
+        fn it_suppresses_an_account_space_when_removed_locally() {
+            let (tmp, store) = store();
+            let other = SpotStore::at(tmp.path().join("other-profile"));
+            store
+                .save(&registry_with(&[("garden", "/tmp/garden")], None))
+                .expect("save");
+            other.save(&Registry::default()).expect("save other");
+
+            remove_with_subject(&store, "garden", Data::Keep, "did:key:zGarden").expect("remove");
+
+            let registry = store.load().expect("load");
+            assert!(!registry.spots.contains_key("garden"));
+            assert!(registry.is_suppressed("did:key:zGarden"));
+            assert!(other.load().expect("other").suppressed_subjects.is_empty());
+        }
+
+        #[dialog_common::test]
+        fn it_clears_suppression_only_after_an_explicit_pull_commits() {
+            let (tmp, store) = store();
+            let mut registry = Registry::default();
+            registry.suppress("did:key:zGarden");
+            store.save(&registry).expect("save");
+            let target = store.canonical_site("garden");
+            std::fs::create_dir_all(&target).expect("target");
+
+            let wrong = tmp.path().join("wrong");
+            std::fs::create_dir_all(&wrong).expect("wrong");
+            register_pulled_space(&store, "garden", &wrong, "did:key:zGarden")
+                .expect_err("wrong target");
+            assert!(store.load().expect("load").is_suppressed("did:key:zGarden"));
+
+            register_pulled_space(&store, "garden", &target, "did:key:zGarden").expect("register");
+            let registry = store.load().expect("load");
+            assert!(registry.spots.contains_key("garden"));
+            assert!(!registry.is_suppressed("did:key:zGarden"));
+        }
 
         /// A failed delete must leave the spot registered. The
         /// alternative — name unregistered, data still on disk — is

--- a/rust/tonk-cli/src/telemetry.rs
+++ b/rust/tonk-cli/src/telemetry.rs
@@ -100,14 +100,11 @@ pub async fn begin(command: &'static str, subcommand: Option<&'static str>) -> O
     if !settings.enabled {
         return None;
     }
-    let distinct = if crate::identity::exists() {
-        match crate::identity::open().await {
-            Ok(profile) => tonk_analytics::distinct_id(profile.did().as_ref()),
-            Err(_) => "tonk:anonymous".to_owned(),
-        }
-    } else {
-        "tonk:anonymous".to_owned()
-    };
+    let distinct = crate::account_profiles::NativeProfileStore::open()
+        .ok()
+        .and_then(|profiles| profiles.selected().ok().flatten())
+        .map(|context| tonk_analytics::distinct_id(context.id.as_str()))
+        .unwrap_or_else(|| "tonk:anonymous".to_owned());
     let client = tonk_analytics::native::Client::from_env(distinct, true);
     if !client.is_enabled() {
         return None;

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -6,6 +6,8 @@ use anyhow::{Context, Result};
 use tonk_access_service::helpers::AccessServiceAddress;
 use tonk_account::prefix::space_root_site;
 use tonk_cli::site::{SiteConfig, TonkSite};
+use tonk_schema::RepositoryName;
+use tonk_schema::prelude::DidExt as _;
 
 /// Open sites the way a real install does, with the account boundary in
 /// front of every remote fork. The shared fixture config leaves it off so
@@ -23,20 +25,138 @@ async fn configure_upstream(site: &TonkSite, endpoint: &str) -> Result<()> {
     Ok(())
 }
 
-/// Releases before the account-root prefix existed stored no such
-/// credential, so upgrading left every spot they created with nothing under
-/// that key. Authorization has to rebuild the prefix from the certificates
-/// the profile already holds instead of reporting the spot as undelegated.
+async fn name_repository(site: &TonkSite, name: &str) -> Result<()> {
+    site.branch()
+        .await?
+        .handle()
+        .transaction()
+        .assert(RepositoryName {
+            this: site.repository.did().this(),
+            name: tonk_schema::domain::repo::Name(name.to_owned()),
+        })
+        .commit()
+        .perform(&site.operator)
+        .await?;
+    Ok(())
+}
+
 #[dialog_common::test]
-async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
+async fn it_keeps_an_offline_profiles_pending_revision_out_of_another_account(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let a = common::AccountFixture::with_account_remote_and_root(&remote, [0xa1; 32]).await?;
+    let b = common::AccountFixture::with_account_remote_and_root(&remote, [0xb2; 32]).await?;
+    assert_ne!(a.link.issuer(), b.link.issuer());
+
+    let a_path = a.tmp.path().join("a-garden");
+    let a_site = TonkSite::init_at_with(&a_path, account_config(&a)).await?;
+    configure_upstream(&a_site, &remote).await?;
+    tonk_cli::sync::push(&a_site).await?;
+    let b_site = TonkSite::init_at_with(&b.tmp.path().join("b-garden"), account_config(&b)).await?;
+    configure_upstream(&b_site, &remote).await?;
+    tonk_cli::sync::push(&b_site).await?;
+    let initial = a_site
+        .branch()
+        .await?
+        .handle()
+        .revision()
+        .expect("seeded site revision")
+        .tree;
+
+    tonk_cli::account::logout_for_integration_test(&a.profile, &a.pre_account_site.operator)
+        .await?;
+    name_repository(&a_site, "offline-a").await?;
+    let pending = a_site
+        .branch()
+        .await?
+        .handle()
+        .revision()
+        .expect("offline revision")
+        .tree;
+    assert_ne!(pending, initial, "the offline local commit must survive");
+    let error = tonk_cli::sync::push(&a_site)
+        .await
+        .expect_err("A cannot publish through B while A is logged out");
+    assert!(
+        format!("{error:#}").contains("log in") || format!("{error:#}").contains("active account"),
+        "{error:#}"
+    );
+    tonk_cli::sync::push(&b_site)
+        .await
+        .context("B must remain independently authorized after A logs out")?;
+
+    // The same OS user may read and mount local bytes. The enforced boundary
+    // is remote authority: B has no explicit A-space -> B-root prefix, and an
+    // ordinary push must neither mint one nor reach the remote.
+    let forced = TonkSite::open_with(&a_path, account_config(&b)).await?;
+    let forced_error = tonk_cli::sync::push(&forced)
+        .await
+        .expect_err("B must not publish A's repository");
+    assert!(
+        format!("{forced_error:#}").contains("not proven")
+            || format!("{forced_error:#}").contains("unproven")
+            || format!("{forced_error:#}").contains("No delegation chain proves"),
+        "{forced_error:#}"
+    );
+    assert!(
+        tonk_cli::site::load_account_root_prefix_for(
+            &forced.profile,
+            forced.operator.inner(),
+            &forced.repository.did(),
+            b.link.issuer(),
+        )
+        .await
+        .is_err(),
+        "the denied push must not mint B-rooted authority for A's subject"
+    );
+    let reopened = TonkSite::open_with(&a_path, account_config(&a)).await?;
+    assert_eq!(
+        reopened
+            .branch()
+            .await?
+            .handle()
+            .revision()
+            .expect("reopened revision")
+            .tree,
+        pending,
+        "failed cross-profile access must not mutate A's branch"
+    );
+
+    tonk_cli::account::attach_for_integration_test(
+        &a.profile,
+        &a.pre_account_site.operator,
+        a.config.clone(),
+        &a.server.endpoint,
+        "fixture-credential",
+        a.link.clone(),
+        &a.descriptor,
+    )
+    .await?;
+    tonk_cli::sync::push(&reopened).await?;
+    assert!(
+        tonk_cli::account_sync::record_current_revision_confirmed(&reopened, a.link.issuer())
+            .await?
+    );
+    assert!(
+        tonk_cli::account_sync::current_revision_is_confirmed(&reopened, a.link.issuer()).await?
+    );
+    tonk_cli::sync::push(&b_site)
+        .await
+        .context("A's relogin must not disturb B's active authority")?;
+    Ok(())
+}
+
+/// Ordinary remote authorization must never turn held local authority into a
+/// delegation for whichever account happens to be active. Adoption is an
+/// explicit lifecycle operation.
+#[dialog_common::test]
+async fn it_refuses_remote_authorization_without_an_explicit_account_prefix(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
-    let site = TonkSite::init_at_with(
-        &fixture.tmp.path().join("upgraded"),
-        account_config(&fixture),
-    )
-    .await?;
+    let site =
+        TonkSite::open_with(&fixture.pre_account_site.root, account_config(&fixture)).await?;
     let prefix_site = space_root_site(&site.repository.did(), fixture.link.issuer());
     fixture
         .profile
@@ -47,7 +167,16 @@ async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
         .await?;
     configure_upstream(&site, &env.access_service_url).await?;
 
-    tonk_cli::sync::push(&site).await?;
+    let error = tonk_cli::sync::push(&site)
+        .await
+        .expect_err("a missing prefix must fail before the request is sent");
+    assert!(
+        error.to_string().contains("not proven")
+            || error.to_string().contains("unproven")
+            || format!("{error:#}").contains("No delegation chain proves")
+            || format!("{error:#}").contains("UnprovenSubject"),
+        "the refusal must preserve the authorization cause: {error:#}"
+    );
 
     let restored = fixture
         .profile
@@ -56,10 +185,7 @@ async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
         .load::<Vec<u8>>()
         .perform(&site.operator)
         .await?;
-    assert!(
-        !restored.is_empty(),
-        "authorizing a remote must leave the recovered prefix stored"
-    );
+    assert!(restored.is_empty(), "authorization must not mint a prefix");
     Ok(())
 }
 
@@ -268,7 +394,7 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
     .await?;
     configure_upstream(&site, &env.access_service_url).await?;
     let subject = site.repository.did();
-    let prefix = tonk_cli::site::account_root_prefix_for(
+    let prefix = tonk_cli::site::adopt_account_root_prefix_for(
         &owner.profile,
         owner_operator,
         &subject,
@@ -342,6 +468,7 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
             store: Some(tonk_cli::spot::SpotStore::at(
                 joiner.parent.join("account-state"),
             )),
+            expected_root: None,
         },
     )
     .await?;
@@ -466,9 +593,13 @@ async fn it_recovers_space_access_on_a_second_device(env: AccessServiceAddress) 
         .expect("device one has a hydrated account");
     // The space -> account-root prefix: the authority device two needs and
     // cannot mint for itself. `tonk space create` retains exactly this.
-    let chain =
-        tonk_cli::site::account_root_prefix_for(&first.profile, operator, &subject, &account_root)
-            .await?;
+    let chain = tonk_cli::site::adopt_account_root_prefix_for(
+        &first.profile,
+        operator,
+        &subject,
+        &account_root,
+    )
+    .await?;
     assert!(
         !tonk_account::delegations::retain_space_delegation(&account, &chain, operator).await?,
         "creation already retained device one's space authority into the account"
@@ -596,7 +727,7 @@ async fn it_migrates_delegations_idempotently() -> Result<()> {
 /// profile held at the time and reaches no account root at all. Linking an
 /// account must adopt it rather than strand it offline.
 #[dialog_common::test]
-async fn it_pushes_a_spot_created_before_the_account_existed(
+async fn it_explicitly_adopts_then_pushes_a_spot_created_before_the_account_existed(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
@@ -604,9 +735,18 @@ async fn it_pushes_a_spot_created_before_the_account_existed(
     let site = TonkSite::open_with(&path, account_config(&fixture)).await?;
     configure_upstream(&site, &env.access_service_url).await?;
 
+    let adopted = tonk_cli::site::adopt_account_root_prefix_for(
+        &site.profile,
+        site.operator.inner(),
+        &site.repository.did(),
+        fixture.link.issuer(),
+    )
+    .await?;
+
     tonk_cli::sync::push(&site).await?;
 
     let prefix = tonk_cli::site::account_root_prefix(&site, fixture.link.issuer()).await?;
+    assert_eq!(adopted.to_bytes()?, prefix.to_bytes()?);
     assert_eq!(prefix.subject(), Some(&site.repository.did()));
     assert_eq!(prefix.audience(), fixture.link.issuer());
     Ok(())

--- a/rust/tonk-cli/tests/account_profiles.rs
+++ b/rust/tonk-cli/tests/account_profiles.rs
@@ -1,0 +1,384 @@
+use std::path::Path;
+
+use anyhow::Result;
+use serde_json::json;
+use tonk_cli::account_profiles::{LEGACY_PROFILE_ID, NativeProfileId, NativeProfileStore};
+use tonk_cli::spot::{Registry, SpotEntry};
+
+fn write_json(path: &Path, value: serde_json::Value) -> Result<()> {
+    std::fs::write(path, serde_json::to_vec_pretty(&value)?)?;
+    Ok(())
+}
+
+#[test]
+fn it_bootstraps_the_legacy_profile_without_moving_state() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    let work = tmp.path().join("work");
+    let site = root.join("spots/garden");
+    std::fs::create_dir_all(&work)?;
+    std::fs::create_dir_all(&site)?;
+    std::fs::create_dir_all(root.join("account"))?;
+    std::fs::write(site.join("sentinel"), b"site bytes")?;
+    std::fs::write(root.join("account/sentinel"), b"account bytes")?;
+    let work_key = work.canonicalize()?.display().to_string();
+    write_json(
+        &root.join("spots.json"),
+        json!({
+            "spots": { "garden": { "site": site.canonicalize()? } },
+            "bindings": { (work_key): "garden" },
+            "futureSpotField": { "preserved": true }
+        }),
+    )?;
+    let spots_before = std::fs::read(root.join("spots.json"))?;
+
+    let profiles = NativeProfileStore::at(&root);
+    let registry = profiles.load_or_bootstrap()?;
+
+    assert_eq!(
+        registry.selected.as_ref().map(NativeProfileId::as_str),
+        Some(LEGACY_PROFILE_ID)
+    );
+    assert_eq!(registry.profiles.len(), 1);
+    let legacy = &registry.profiles[&NativeProfileId::legacy()];
+    assert_eq!(legacy.label, "default");
+    assert_eq!(legacy.dialog_profile_name, "tonk");
+    let bound = &registry.bindings[&work.canonicalize()?];
+    assert_eq!(bound.profile, NativeProfileId::legacy());
+    assert_eq!(bound.space, "garden");
+
+    assert_eq!(std::fs::read(root.join("spots.json"))?, spots_before);
+    assert_eq!(std::fs::read(site.join("sentinel"))?, b"site bytes");
+    assert_eq!(
+        std::fs::read(root.join("account/sentinel"))?,
+        b"account bytes"
+    );
+    Ok(())
+}
+
+#[test]
+fn it_starts_empty_without_creating_a_dialog_profile() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    let profiles = NativeProfileStore::at(&root);
+
+    let registry = profiles.load_or_bootstrap()?;
+
+    assert!(registry.selected.is_none());
+    assert!(registry.profiles.is_empty());
+    assert!(!root.join("profiles.json").exists());
+    assert!(
+        !root.exists(),
+        "read-only bootstrap must not create install state"
+    );
+    Ok(())
+}
+
+#[test]
+fn it_rejects_unknown_versions_corrupt_json_and_dangling_bindings() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    std::fs::create_dir_all(&root)?;
+    let profiles = NativeProfileStore::at(&root);
+
+    std::fs::write(root.join("profiles.json"), b"{not json")?;
+    let error = profiles.load_or_bootstrap().expect_err("corrupt registry");
+    assert!(error.to_string().contains("profiles.json"), "{error}");
+
+    write_json(&root.join("profiles.json"), json!({ "version": 2 }))?;
+    let error = profiles.load_or_bootstrap().expect_err("unknown version");
+    assert!(
+        error.to_string().contains("unsupported version 2"),
+        "{error}"
+    );
+
+    write_json(
+        &root.join("profiles.json"),
+        json!({
+            "version": 1,
+            "selected": "legacy",
+            "profiles": {
+                "legacy": {
+                    "label": "default",
+                    "dialogProfileName": "tonk",
+                    "accountRoot": null,
+                    "ceremonyOrigin": null,
+                    "defaultAccessRemote": null,
+                    "defaultRevocationRelay": null
+                }
+            },
+            "bindings": { (tmp.path().display().to_string()): { "profile": "missing", "space": "garden" } }
+        }),
+    )?;
+    let error = profiles
+        .load_or_bootstrap()
+        .expect_err("unknown binding profile");
+    assert!(error.to_string().contains("missing"), "{error}");
+
+    write_json(
+        &root.join("profiles.json"),
+        json!({
+            "version": 1,
+            "selected": "legacy",
+            "profiles": {
+                "legacy": {
+                    "label": "default",
+                    "dialogProfileName": "tonk",
+                    "accountRoot": null,
+                    "ceremonyOrigin": null,
+                    "defaultAccessRemote": null,
+                    "defaultRevocationRelay": null
+                }
+            },
+            "bindings": { (tmp.path().display().to_string()): { "profile": "legacy", "space": "garden" } }
+        }),
+    )?;
+    let error = profiles
+        .load_or_bootstrap()
+        .expect_err("missing local space");
+    assert!(error.to_string().contains("garden"), "{error}");
+    Ok(())
+}
+
+#[test]
+fn it_preserves_unknown_registry_and_profile_fields() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    std::fs::create_dir_all(&root)?;
+    write_json(
+        &root.join("profiles.json"),
+        json!({
+            "version": 1,
+            "selected": "legacy",
+            "profiles": {
+                "legacy": {
+                    "label": "default",
+                    "dialogProfileName": "tonk",
+                    "accountRoot": null,
+                    "ceremonyOrigin": null,
+                    "defaultAccessRemote": null,
+                    "defaultRevocationRelay": null,
+                    "futureProfileField": { "kept": 1 }
+                }
+            },
+            "bindings": {},
+            "futureRegistryField": ["kept"]
+        }),
+    )?;
+    let profiles = NativeProfileStore::at(&root);
+
+    let registry = profiles.load_or_bootstrap()?;
+    profiles.save(&registry)?;
+
+    let saved: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("profiles.json"))?)?;
+    assert_eq!(saved["futureRegistryField"], json!(["kept"]));
+    assert_eq!(
+        saved["profiles"]["legacy"]["futureProfileField"],
+        json!({ "kept": 1 })
+    );
+    Ok(())
+}
+
+#[test]
+fn it_creates_distinct_pending_profiles_with_isolated_state_roots() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    let profiles = NativeProfileStore::at(&root);
+
+    let a = profiles.create_pending_with_bytes(Some("personal"), [0x11; 16])?;
+    let b = profiles.create_pending_with_bytes(Some("work"), [0x22; 16])?;
+
+    assert_eq!(a.id.as_str(), "p-11111111111111111111111111111111");
+    assert_eq!(
+        a.record.dialog_profile_name,
+        "tonk-11111111111111111111111111111111"
+    );
+    assert_eq!(b.id.as_str(), "p-22222222222222222222222222222222");
+    assert_eq!(
+        b.record.dialog_profile_name,
+        "tonk-22222222222222222222222222222222"
+    );
+    assert_ne!(a.store.root(), b.store.root());
+    assert_ne!(a.store.root(), root.as_path());
+    assert_ne!(b.store.root(), root.as_path());
+    assert_eq!(a.site_config().profile_name, a.record.dialog_profile_name);
+    assert_eq!(b.site_config().profile_name, b.record.dialog_profile_name);
+    assert_eq!(profiles.load_or_bootstrap()?.selected, Some(a.id));
+    Ok(())
+}
+
+fn register_space(
+    context: &tonk_cli::account_profiles::NativeProfileContext,
+    name: &str,
+) -> Result<()> {
+    let site = context.store.canonical_site(name);
+    std::fs::create_dir_all(&site)?;
+    let site = site.canonicalize()?;
+    let mut registry = Registry::default();
+    registry.spots.insert(name.to_owned(), SpotEntry { site });
+    context.store.save(&registry)?;
+    Ok(())
+}
+
+#[test]
+fn it_resolves_a_directory_binding_to_its_profile_even_when_another_profile_is_selected()
+-> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().join("state");
+    let work = tmp.path().join("work");
+    std::fs::create_dir_all(&work)?;
+    let profiles = NativeProfileStore::at(&root);
+    let a = profiles.create_pending_with_bytes(Some("personal"), [0x33; 16])?;
+    let b = profiles.create_pending_with_bytes(Some("work"), [0x44; 16])?;
+    register_space(&a, "garden")?;
+    register_space(&b, "garden")?;
+    profiles.bind(&a.id, "garden", &work)?;
+    profiles.select("work")?;
+
+    let bound = profiles.resolve(None, None, Some(&work))?;
+    assert_eq!(bound.profile.id, a.id);
+    assert_eq!(bound.name, "garden");
+
+    let flagged = profiles.resolve(Some("garden"), None, Some(&work))?;
+    assert_eq!(flagged.profile.id, b.id);
+
+    let from_env = profiles.resolve(None, Some("garden"), Some(&work))?;
+    assert_eq!(from_env.profile.id, b.id);
+    Ok(())
+}
+
+#[test]
+fn it_keeps_equal_names_and_canonical_paths_disjoint_between_profiles() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let a = profiles.create_pending_with_bytes(Some("personal"), [0x55; 16])?;
+    let b = profiles.create_pending_with_bytes(Some("work"), [0x66; 16])?;
+    register_space(&a, "garden")?;
+    register_space(&b, "garden")?;
+
+    assert_ne!(a.store.registry_path(), b.store.registry_path());
+    assert_ne!(
+        a.store.canonical_site("garden"),
+        b.store.canonical_site("garden")
+    );
+    assert_ne!(a.store.account_dir(), b.store.account_dir());
+    assert_ne!(a.record.dialog_profile_name, b.record.dialog_profile_name);
+    Ok(())
+}
+
+#[test]
+fn it_refuses_to_bind_a_space_absent_from_the_selected_profile() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let a = profiles.create_pending_with_bytes(Some("personal"), [0x77; 16])?;
+    let b = profiles.create_pending_with_bytes(Some("work"), [0x88; 16])?;
+    register_space(&a, "personal-only")?;
+    register_space(&b, "work-only")?;
+    profiles.select("work")?;
+
+    let error = profiles
+        .bind(&b.id, "personal-only", tmp.path())
+        .expect_err("the selected profile cannot borrow another profile's names");
+    let message = error.to_string();
+    assert!(message.contains("work-only"), "{message}");
+    assert!(!message.contains("registered: personal-only"), "{message}");
+    Ok(())
+}
+
+#[test]
+fn it_validates_labels_and_selects_by_label_or_exact_id() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let first = profiles.create_pending_with_bytes(None, [0x91; 16])?;
+    let second = profiles.create_pending_with_bytes(None, [0x92; 16])?;
+    assert_eq!(first.record.label, "account");
+    assert_eq!(second.record.label, "account-2");
+
+    let duplicate = profiles
+        .create_pending_with_bytes(Some("ACCOUNT"), [0x93; 16])
+        .expect_err("labels are unique without regard to case");
+    assert!(
+        duplicate
+            .to_string()
+            .contains("invalid account profile label")
+    );
+    assert!(
+        profiles
+            .create_pending_with_bytes(Some("bad label"), [0x94; 16])
+            .is_err()
+    );
+
+    assert_eq!(profiles.select("account-2")?.id, second.id);
+    assert_eq!(profiles.select(first.id.as_str())?.id, first.id);
+    Ok(())
+}
+
+#[test]
+fn it_never_replaces_a_rooted_profile_with_another_account() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let profile = profiles.create_pending_with_bytes(Some("personal"), [0xa1; 16])?;
+    profiles.record_account_root(&profile.id, "did:key:root-a", None)?;
+
+    let error = profiles
+        .record_account_root(&profile.id, "did:key:root-b", None)
+        .expect_err("a rooted profile is immutable");
+    assert!(
+        error
+            .to_string()
+            .contains("this profile belongs to did:key:root-a")
+    );
+    assert_eq!(
+        profiles
+            .context(&profile.id)?
+            .record
+            .account_root
+            .as_deref(),
+        Some("did:key:root-a")
+    );
+    Ok(())
+}
+
+#[test]
+fn it_resumes_an_unrooted_selected_profile_instead_of_creating_another() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let pending = profiles.create_pending_with_bytes(Some("work"), [0xb1; 16])?;
+
+    let resumed = profiles.create_or_resume_pending(Some("work"))?;
+
+    assert_eq!(resumed.id, pending.id);
+    assert_eq!(resumed.store.root(), pending.store.root());
+    assert_eq!(profiles.load_or_bootstrap()?.profiles.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn it_persists_deployment_defaults_only_on_the_target_profile() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let profiles = NativeProfileStore::at(tmp.path().join("state"));
+    let personal = profiles.create_pending_with_bytes(Some("personal"), [0xd1; 16])?;
+    let work = profiles.create_pending_with_bytes(Some("work"), [0xd2; 16])?;
+    let defaults = tonk_cli::deployment::DeploymentDefaults {
+        ceremony_origin: "https://personal.example/".parse()?,
+        access_remote: "https://personal.example/ucan/".parse()?,
+        revocation_relay: "https://relay.example/revocations/".parse()?,
+    };
+
+    profiles.record_deployment_defaults(&personal.id, &defaults)?;
+
+    let personal = profiles.context(&personal.id)?;
+    let work = profiles.context(&work.id)?;
+    assert_eq!(
+        personal.record.default_access_remote.as_deref(),
+        Some("https://personal.example/ucan/")
+    );
+    assert_eq!(
+        personal.record.default_revocation_relay.as_deref(),
+        Some("https://relay.example/revocations/")
+    );
+    assert!(work.record.default_access_remote.is_none());
+    assert!(work.record.default_revocation_relay.is_none());
+    Ok(())
+}

--- a/rust/tonk-cli/tests/account_spots.rs
+++ b/rust/tonk-cli/tests/account_spots.rs
@@ -3,6 +3,9 @@
 
 mod common;
 
+use std::collections::BTreeMap;
+use std::path::Path;
+
 use anyhow::Result;
 use dialog_query::{Output as _, Query, Term};
 use tonk_access_service::helpers::AccessServiceAddress;
@@ -158,36 +161,29 @@ async fn pull_requires_an_explicit_name_before_local_mutation() -> Result<()> {
 }
 
 #[tokio::test]
-async fn pull_retains_an_unbound_canonical_spot_when_initial_sync_is_offline() -> Result<()> {
+async fn pull_preserves_suppression_and_cleans_up_when_initial_sync_is_offline() -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
     let subject = fixture
         .record_directory_space(85, Some("garden"), Some("http://127.0.0.1:9/ucan/"))
         .await?;
+    let mut registry = fixture.store.load()?;
+    registry.suppress(subject.as_ref());
+    fixture.store.save(&registry)?;
 
-    let outcome =
-        account_spots::pull(&fixture.profile, &fixture.store, subject.as_ref(), None).await?;
-    assert!(!outcome.already_local);
+    let error = account_spots::pull(&fixture.profile, &fixture.store, subject.as_ref(), None)
+        .await
+        .expect_err("an unreachable initial sync must not register a partial space");
     assert!(
-        outcome
-            .warning
-            .as_deref()
-            .is_some_and(|warning| { warning.contains("run `tonk pull`") })
-    );
-    assert_eq!(
-        outcome.site,
-        fixture.store.canonical_site("garden").canonicalize()?
+        error
+            .to_string()
+            .contains("initial pull from 'origin' failed"),
+        "{error:#}"
     );
     let registry = fixture.store.load()?;
-    assert_eq!(registry.spots["garden"].site, outcome.site);
+    assert!(!registry.spots.contains_key("garden"));
+    assert!(registry.is_suppressed(subject.as_ref()));
     assert!(registry.bindings.is_empty());
-
-    let second =
-        account_spots::pull(&fixture.profile, &fixture.store, subject.as_ref(), None).await?;
-    assert!(second.already_local);
-    assert_eq!(second.name, "garden");
-
-    let rows = account_spots::list(&fixture.profile, &fixture.store).await?;
-    assert_eq!(rows[0].local_name.as_deref(), Some("garden"));
+    assert!(!fixture.store.canonical_site("garden").exists());
     Ok(())
 }
 
@@ -372,6 +368,126 @@ async fn mark_content_confirmed(
             "the seeded fixture site must have a local revision"
         );
     }
+    Ok(())
+}
+
+fn directory_bytes(root: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    fn visit(root: &Path, path: &Path, files: &mut BTreeMap<String, Vec<u8>>) -> Result<()> {
+        let mut entries = std::fs::read_dir(path)?.collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            if path.is_dir() {
+                visit(root, &path, files)?;
+            } else if path.is_file() {
+                files.insert(
+                    path.strip_prefix(root)?.to_string_lossy().into_owned(),
+                    std::fs::read(path)?,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = BTreeMap::new();
+    visit(root, root, &mut files)?;
+    Ok(files)
+}
+
+#[dialog_common::test]
+async fn archive_preserves_local_data_and_authority(env: AccessServiceAddress) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    let store = fixture.config.account_store.clone();
+    let local_root = store.canonical_site("garden");
+    let site = TonkSite::init_at_with(&local_root, fixture.config.clone()).await?;
+    name_repository(&site, "garden").await?;
+    configure_upstream(&site, &remote).await?;
+    tonk_cli::spot::register_existing_unbound(&store, "garden", &site.root)?;
+
+    let operator = fixture.pre_account_site.operator.inner();
+    let account =
+        tonk_cli::account_state::open_account_branch_in(&fixture.profile, operator, &store)
+            .await?
+            .expect("the linked fixture account is hydrated");
+    let subject = site.repository.did();
+    let prefix = tonk_cli::site::account_root_prefix(&site, fixture.link.issuer()).await?;
+    tonk_schema::account::record_active_account_space(
+        &account,
+        tonk_schema::account::AccountSpaceInput {
+            account: fixture.link.issuer().clone(),
+            subject: subject.clone(),
+            name: Some("garden".to_string()),
+            remote_url: Some(remote),
+            revocation_url: None,
+            confirmed_revision: None,
+        },
+        operator,
+    )
+    .await?;
+    account.push().perform(operator).await?;
+    assert_eq!(
+        account_spots::record_site_in("garden", &site, &store).await?,
+        account_spots::RecordOutcome::Recorded
+    );
+
+    let revision_before = site.branch().await?.handle().revision();
+    let bytes_before = directory_bytes(&site.root)?;
+    let registry_before = store.load()?;
+    let authority_before = prefix.to_bytes()?;
+
+    let archived = account_spots::archive_with_operator_for_integration_test(
+        &fixture.profile,
+        &store,
+        subject.as_ref(),
+        operator,
+    )
+    .await?;
+
+    assert!(archived.newly_archived);
+    assert!(archived.projection_warning.is_none(), "{archived:?}");
+    let updated_account =
+        tonk_cli::account_state::open_account_branch_in(&fixture.profile, operator, &store)
+            .await?
+            .expect("the account remains hydrated after archive");
+    let rows = tonk_schema::account::list_account_spaces(&updated_account, operator).await?;
+    assert!(
+        rows.iter()
+            .any(|row| row.subject == subject && row.archived),
+        "the canonical account fact remains queryable"
+    );
+    assert_eq!(store.load()?, registry_before);
+    assert_eq!(site.branch().await?.handle().revision(), revision_before);
+    assert_eq!(directory_bytes(&site.root)?, bytes_before);
+    assert_eq!(
+        tonk_cli::site::load_account_root_prefix_for(
+            &site.profile,
+            site.operator.inner(),
+            &subject,
+            fixture.link.issuer(),
+        )
+        .await?
+        .to_bytes()?,
+        authority_before,
+        "archive must not revoke repository authority"
+    );
+    let pull_error = account_spots::pull(&fixture.profile, &store, subject.as_ref(), None)
+        .await
+        .expect_err("an archived account space must not be pullable");
+    assert!(
+        pull_error.to_string().contains("is archived"),
+        "{pull_error:#}"
+    );
+
+    let again = account_spots::archive_with_operator_for_integration_test(
+        &fixture.profile,
+        &store,
+        subject.as_ref(),
+        operator,
+    )
+    .await?;
+    assert!(!again.newly_archived);
+    assert_eq!(directory_bytes(&site.root)?, bytes_before);
     Ok(())
 }
 

--- a/rust/tonk-cli/tests/account_spots.rs
+++ b/rust/tonk-cli/tests/account_spots.rs
@@ -47,6 +47,7 @@ async fn list_and_pull_choose_the_first_alias_for_a_local_subject() -> Result<()
     )
     .await?;
     configure_upstream(&site, "http://127.0.0.1:9/ucan/").await?;
+    mark_content_confirmed(&site, fixture.link.issuer(), "alpha").await?;
     let canonical = site.root.canonicalize()?;
     let mut registry = fixture.store.load()?;
     for name in ["zeta", "alpha"] {
@@ -359,6 +360,21 @@ async fn configure_upstream(site: &TonkSite, endpoint: &str) -> Result<()> {
     Ok(())
 }
 
+async fn mark_content_confirmed(
+    site: &TonkSite,
+    account_root: &dialog_varsig::Did,
+    name: &str,
+) -> Result<()> {
+    if !tonk_cli::account_sync::record_current_revision_confirmed(site, account_root).await? {
+        name_repository(site, name).await?;
+        assert!(
+            tonk_cli::account_sync::record_current_revision_confirmed(site, account_root).await?,
+            "the seeded fixture site must have a local revision"
+        );
+    }
+    Ok(())
+}
+
 #[tokio::test]
 async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     use tonk_cli::account_spots::RecordOutcome;
@@ -373,6 +389,7 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     .await?;
     name_repository(&owned, "synced-owned").await?;
     configure_upstream(&owned, dead_remote).await?;
+    mark_content_confirmed(&owned, fixture.link.issuer(), "synced-owned").await?;
     tonk_cli::spot::register_existing_unbound(&fixture.store, "owned-alias", &owned.root)?;
     assert_eq!(
         account_spots::record_site_in("owned-alias", &owned, &fixture.store).await?,
@@ -392,6 +409,7 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     )
     .await?;
     configure_upstream(&joined, dead_remote).await?;
+    mark_content_confirmed(&joined, fixture.link.issuer(), "joined-alias").await?;
     tonk_cli::spot::register_existing_unbound(&fixture.store, "joined-alias", &joined.root)?;
     assert_eq!(
         account_spots::record_site_in("joined-alias", &joined, &fixture.store).await?,
@@ -461,6 +479,7 @@ async fn record_sweep_uses_the_first_alias_once() -> Result<()> {
     )
     .await?;
     configure_upstream(&site, "http://127.0.0.1:9/ucan/").await?;
+    mark_content_confirmed(&site, fixture.link.issuer(), "alpha").await?;
     let canonical = site.root.canonicalize()?;
     let mut registry = fixture.store.load()?;
     for name in ["zeta", "alpha"] {

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -39,6 +39,7 @@ fn tonk_cmd(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Comm
         // These fixtures exercise remote selection, not identity provisioning.
         // Production omits this explicit unsafe compatibility override.
         .env("TONK_UNSAFE_ALLOW_DEVICE_ROOT", "1")
+        .env_remove("TONK_SPACE")
         .env_remove("TONK_SPOT");
     for (key, value) in extra_env {
         cmd.env(key, value);
@@ -148,7 +149,7 @@ mod when_nothing_is_registered {
         let output = run(state.path(), &[], &[]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("no spots registered"), "{stderr}");
+        assert!(stderr.contains("no spaces registered"), "{stderr}");
         assert!(!stderr.contains("Usage: tonk"), "{stderr}");
     }
 
@@ -181,7 +182,7 @@ mod when_nothing_is_registered {
         let output = run(state.path(), &["status"], &[]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("no spots registered"), "{stderr}");
+        assert!(stderr.contains("no spaces registered"), "{stderr}");
         assert!(stderr.contains("--site"), "{stderr}");
     }
 }
@@ -226,7 +227,7 @@ mod when_resolving_with_precedence {
         );
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("active spot: a (flag)"), "{stderr}");
+        assert!(stderr.contains("active space: a (flag)"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -237,7 +238,7 @@ mod when_resolving_with_precedence {
         let output = run(state.path(), &["status"], &[("TONK_SPOT", "a")]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("active spot: a (env)"), "{stderr}");
+        assert!(stderr.contains("active space: a (env)"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -249,7 +250,7 @@ mod when_resolving_with_precedence {
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
         assert!(
-            stderr.contains("no spot active for this directory"),
+            stderr.contains("no space active for this directory"),
             "{stderr}"
         );
     }
@@ -262,7 +263,7 @@ mod when_resolving_with_precedence {
         let output = run(state.path(), &["use"], &[("TONK_SPOT", "a")]);
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
-        assert!(stdout.contains("current spot: a"), "{stdout}");
+        assert!(stdout.contains("current space: a"), "{stdout}");
         assert!(stdout.contains("selected via: env"), "{stdout}");
         assert!(stdout.contains("next: tonk context"), "{stdout}");
     }
@@ -277,7 +278,7 @@ mod when_resolving_with_precedence {
         let output = run(state.path(), &["status"], &[("TONK_SPOT", "nope")]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("unknown spot 'nope'"), "{stderr}");
+        assert!(stderr.contains("unknown space 'nope'"), "{stderr}");
         assert!(stderr.contains("registered: a"), "{stderr}");
     }
 }
@@ -790,7 +791,7 @@ mod when_a_directory_is_bound {
         let output = run_in(state.path(), &nested, &["status"], &[]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("active spot: a (directory"), "{stderr}");
+        assert!(stderr.contains("active space: a (directory"), "{stderr}");
         assert!(stderr.contains(&shown(&work)), "{stderr}");
     }
 
@@ -816,7 +817,7 @@ mod when_a_directory_is_bound {
         let output = run_in(state.path(), &nested, &["status"], &[("TONK_SPOT", "b")]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("active spot: b (env)"), "{stderr}");
+        assert!(stderr.contains("active space: b (env)"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -828,7 +829,7 @@ mod when_a_directory_is_bound {
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
         assert!(stdout.contains("binding: a"), "{stdout}");
-        assert!(stdout.contains("active spot: b (env)"), "{stdout}");
+        assert!(stdout.contains("active space: b (env)"), "{stdout}");
     }
 
     #[dialog_common::test]
@@ -841,19 +842,21 @@ mod when_a_directory_is_bound {
         let output = run_in(state.path(), &nested, &["status"], &[]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("active spot: b (directory"), "{stderr}");
+        assert!(stderr.contains("active space: b (directory"), "{stderr}");
     }
 
     #[dialog_common::test]
-    fn it_lists_bindings() {
+    fn directory_binding_still_resolves_after_the_inventory_change() {
         let state = tempfile::tempdir().expect("tempdir");
         let (work, _nested) = fixture(state.path());
         bind(state.path(), &work, "a");
 
-        let output = run_in(state.path(), state.path(), &["spot", "list"], &[]);
-        let stdout = stdout_of(&output);
-        assert!(stdout.contains("directories:"), "{stdout}");
-        assert!(stdout.contains(&shown(&work)), "{stdout}");
+        let status = run_in(state.path(), &work, &["status"], &[]);
+        assert!(
+            stderr_of(&status).contains("active space: a (directory"),
+            "{}",
+            stderr_of(&status)
+        );
     }
 
     #[dialog_common::test]
@@ -873,7 +876,7 @@ mod when_a_directory_is_bound {
         let output = run_in(state.path(), &nested, &["status"], &[]);
         let stderr = stderr_of(&output);
         assert!(
-            stderr.contains("no spot active for this directory"),
+            stderr.contains("no space active for this directory"),
             "{stderr}"
         );
     }
@@ -888,7 +891,7 @@ mod when_a_directory_is_bound {
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
         assert!(stdout.contains("binding: b (was a)"), "{stdout}");
-        assert!(stdout.contains("active spot: b (directory"), "{stdout}");
+        assert!(stdout.contains("active space: b (directory"), "{stdout}");
     }
 
     #[dialog_common::test]
@@ -902,11 +905,11 @@ mod when_a_directory_is_bound {
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
         assert!(stdout.contains("binding: b (was a)"), "{stdout}");
-        assert!(stdout.contains("active spot: b (directory"), "{stdout}");
+        assert!(stdout.contains("active space: b (directory"), "{stdout}");
 
         let status = run_in(state.path(), &work, &["status"], &[]);
         let stderr = stderr_of(&status);
-        assert!(stderr.contains("active spot: b (directory"), "{stderr}");
+        assert!(stderr.contains("active space: b (directory"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -936,12 +939,12 @@ mod when_a_directory_is_bound {
         );
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
-        assert!(stdout.contains("active spot: c (directory"), "{stdout}");
+        assert!(stdout.contains("active space: c (directory"), "{stdout}");
 
         let status = run_in(state.path(), &work, &["status"], &[]);
         assert!(status.status.success(), "{}", stderr_of(&status));
         let stdout = stdout_of(&status);
-        assert!(stdout.contains("spot: c (directory"), "{stdout}");
+        assert!(stdout.contains("space: c (directory"), "{stdout}");
     }
 }
 
@@ -973,12 +976,12 @@ mod when_a_binding_is_orphaned {
         let output = run_in(state.path(), &work, &["status"], &[]);
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
-        assert!(stderr.contains("unknown spot 'a'"), "{stderr}");
+        assert!(stderr.contains("unknown space 'a'"), "{stderr}");
         assert!(
             stderr.contains(&work_canon.display().to_string()),
             "{stderr}"
         );
-        assert!(stderr.contains("spot unbind"), "{stderr}");
+        assert!(stderr.contains("space unbind"), "{stderr}");
     }
 }
 
@@ -1036,13 +1039,13 @@ mod when_deleting_a_spot {
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
         assert!(
-            stdout.contains("Deleted spot 'garden' and its data"),
+            stdout.contains("Removed space 'garden' from this device and deleted its local data"),
             "{stdout}"
         );
         assert!(!site.exists(), "data deleted");
 
         let listed = stdout_of(&run(state.path(), &["spot", "list"], &[]));
-        assert!(listed.contains("no spots registered"), "{listed}");
+        assert!(listed.contains("no spaces visible"), "{listed}");
         assert!(!listed.contains("unregistered site data"), "{listed}");
     }
 
@@ -1062,17 +1065,12 @@ mod when_deleting_a_spot {
         );
         assert!(output.status.success(), "{}", stderr_of(&output));
         let stdout = stdout_of(&output);
-        assert!(stdout.contains("Unregistered spot 'garden'"), "{stdout}");
+        assert!(stdout.contains("Unregistered space 'garden'"), "{stdout}");
         assert!(stdout.contains("data kept at"), "{stdout}");
         assert!(site.is_dir(), "data kept");
 
-        let listed = stdout_of(&run(state.path(), &["spot", "list"], &[]));
-        assert!(listed.contains("unregistered site data"), "{listed}");
-        let canonical = site.canonicalize().expect("canonicalize site");
-        assert!(
-            listed.contains(&canonical.display().to_string()),
-            "{listed}"
-        );
+        let listed = stdout_of(&run(state.path(), &["space", "list", "--all"], &[]));
+        assert!(listed.contains("\tOrphaned\t"), "{listed}");
     }
 
     /// Re-using the name after `--keep-data` silently picks the old
@@ -1098,5 +1096,77 @@ mod when_deleting_a_spot {
             stdout.contains("on the site data already at that path"),
             "{stdout}"
         );
+    }
+}
+
+mod when_using_canonical_and_legacy_spellings {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct WorkflowOutcome {
+        exit_codes: Vec<Option<i32>>,
+        inventory: serde_json::Value,
+        share_path: String,
+        share_query_keys: Vec<String>,
+        orphaned_inventory: serde_json::Value,
+    }
+
+    fn normalized_inventory(output: &Output) -> serde_json::Value {
+        assert!(output.status.success(), "{}", stderr_of(output));
+        let mut rows: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("inventory is valid JSON");
+        for row in rows.as_array_mut().expect("inventory is an array") {
+            row["subject"] = serde_json::Value::String("<subject>".to_string());
+        }
+        rows
+    }
+
+    fn workflow(canonical: bool) -> WorkflowOutcome {
+        let state = tempfile::tempdir().expect("tempdir");
+        let site = state.path().join("site");
+        let site = site.to_str().expect("utf-8 site path");
+        let noun = if canonical { "space" } else { "spot" };
+        let selector = if canonical { "TONK_SPACE" } else { "TONK_SPOT" };
+        let share = if canonical { "share" } else { "invite" };
+
+        let created = run(state.path(), &[noun, "new", "garden", "--site", site], &[]);
+        let status = run(state.path(), &["status"], &[(selector, "garden")]);
+        let shared = run(
+            state.path(),
+            &[share, "--no-remote", "--no-shorten"],
+            &[(selector, "garden")],
+        );
+        let inventory = run(state.path(), &[noun, "list", "--json"], &[]);
+        let removed = run(state.path(), &[noun, "rm", "garden", "--keep-data"], &[]);
+        let orphaned = run(state.path(), &[noun, "list", "--all", "--json"], &[]);
+
+        for output in [&created, &status, &shared, &inventory, &removed, &orphaned] {
+            assert!(output.status.success(), "{}", stderr_of(output));
+        }
+        let share_url = stdout_of(&shared)
+            .lines()
+            .find_map(|line| url::Url::parse(line).ok())
+            .expect("share output contains its URL");
+        let mut share_query_keys: Vec<_> = share_url
+            .query_pairs()
+            .map(|(key, _)| key.into_owned())
+            .collect();
+        share_query_keys.sort();
+
+        WorkflowOutcome {
+            exit_codes: [&created, &status, &shared, &inventory, &removed, &orphaned]
+                .into_iter()
+                .map(|output| output.status.code())
+                .collect(),
+            inventory: normalized_inventory(&inventory),
+            share_path: share_url.path().to_string(),
+            share_query_keys,
+            orphaned_inventory: normalized_inventory(&orphaned),
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_preserves_every_legacy_cli_spelling() {
+        assert_eq!(workflow(true), workflow(false));
     }
 }

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -79,6 +79,7 @@ pub fn isolated_config(parent: &std::path::Path) -> Result<SiteConfig> {
         profile_name: format!("tonk-test-{suffix:x}"),
         profile_directory: Directory::At(profile_dir.to_string_lossy().into_owned()),
         require_account: false,
+        account_store: tonk_cli::spot::SpotStore::at(parent.join("_account")),
     })
 }
 
@@ -109,22 +110,27 @@ impl AccountFixture {
     /// A fixture whose account repository points at a REAL remote, for tests
     /// that sync the account between devices.
     pub async fn with_account_remote(remote: &str) -> Result<Self> {
-        Self::build(remote, true).await
+        Self::build(remote, [77; 32], true).await
     }
 
     /// A fixture that has linked but never hydrated: the trusted-base
     /// marker is absent, exactly like a fresh device right after
     /// `tonk account link`.
     pub async fn unhydrated_with_account_remote(remote: &str) -> Result<Self> {
-        Self::build(remote, false).await
+        Self::build(remote, [77; 32], false).await
     }
 
-    async fn build(remote: &str, hydrated: bool) -> Result<Self> {
+    /// A fixture with an explicit account-root seed, used when one test needs
+    /// two genuinely different account roots rather than two devices.
+    pub async fn with_account_remote_and_root(remote: &str, root_prf: [u8; 32]) -> Result<Self> {
+        Self::build(remote, root_prf, true).await
+    }
+
+    async fn build(remote: &str, root_prf: [u8; 32], hydrated: bool) -> Result<Self> {
         let test = TestSite::new().await?;
         let profile = test.site.profile.clone();
         let store = tonk_cli::spot::SpotStore::at(test.parent.join("state"));
         let server = tonk_account_service::helpers::AccountServer::start().await;
-        let root_prf = [77; 32];
         let root = dialog_credentials::Ed25519Signer::import(&root_prf).await?;
         let link =
             tonk_identity::delegation::mint_device_delegation(root.clone(), &profile.did()).await?;

--- a/rust/tonk-cli/tests/context.rs
+++ b/rust/tonk-cli/tests/context.rs
@@ -95,3 +95,28 @@ async fn it_exposes_claim_backed_agent_context_with_source_revision() -> Result<
     assert_eq!(value["agents"]["markdown"], expected);
     Ok(())
 }
+
+#[dialog_common::test]
+async fn it_exposes_the_resolved_profile_and_local_sign_in_state() -> Result<()> {
+    let test = TestSite::new().await?;
+    let profiles = tonk_cli::account_profiles::NativeProfileStore::at(test.parent.join("install"));
+    let profile = profiles.create_pending_with_bytes(Some("personal"), [0xc1; 16])?;
+    profiles.record_account_root(&profile.id, "did:key:account-a", None)?;
+    let resolved = tonk_cli::account_profiles::ResolvedSpace {
+        profile: profiles.context(&profile.id)?,
+        name: "garden".to_owned(),
+        site: test.site.root.clone(),
+        source: Source::Directory(test.parent.clone()),
+    };
+
+    let report = context::inspect_profiled(&resolved, &test.site).await?;
+    let value: serde_json::Value = serde_json::from_str(&report.render_json()?)?;
+    let markdown = report.render_markdown();
+
+    assert_eq!(value["spot"]["profile"], "personal");
+    assert_eq!(value["spot"]["account_root"], "did:key:account-a");
+    assert_eq!(value["spot"]["signed_in"], false);
+    assert!(markdown.contains("profile: `personal`"), "{markdown}");
+    assert!(markdown.contains("signed in: no"), "{markdown}");
+    Ok(())
+}

--- a/rust/tonk-cli/tests/legacy_migration.rs
+++ b/rust/tonk-cli/tests/legacy_migration.rs
@@ -437,6 +437,7 @@ async fn it_migrates_credentials_before_repositories(
         .context("the migration steps join")?
 }
 
+#[allow(dead_code)]
 fn migrate_and_publish(endpoint: &str) -> Result<()> {
     let workspace = tempfile::tempdir()?;
 
@@ -658,6 +659,7 @@ fn migrate_and_publish(endpoint: &str) -> Result<()> {
 }
 
 /// Number of regular files beneath a directory, recursively.
+#[allow(dead_code)]
 fn count_files(root: &Path) -> Result<usize> {
     let mut total = 0;
     let mut pending = vec![root.to_path_buf()];

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -679,9 +679,10 @@ mod when_minting_and_claiming_an_invite {
     /// pub(crate) re-export, so a quick smoke check belongs
     /// here.
     #[dialog_common::test]
-    fn default_config_uses_the_canonical_profile_name() {
-        let config = site::default_config();
+    fn default_config_uses_the_canonical_profile_name() -> Result<()> {
+        let config = site::default_config()?;
         assert_eq!(config.profile_name, site::PROFILE_NAME);
+        Ok(())
     }
 }
 
@@ -1357,7 +1358,7 @@ mod when_mounting_account_authority {
     }
 
     #[dialog_common::test]
-    async fn it_recovers_a_pre_feature_prefix_from_profile_authority() -> Result<()> {
+    async fn it_adopts_legacy_authority_only_when_requested() -> Result<()> {
         let test = common::TestSite::new().await?;
         let root = local_root(&test.site).await?;
         let key = space_root_site(&test.site.repository.did(), &root);
@@ -1369,7 +1370,13 @@ mod when_mounting_account_authority {
             .perform(&test.site.operator)
             .await?;
 
-        let recovered = site::account_root_prefix(&test.site, &root).await?;
+        let recovered = site::adopt_account_root_prefix_for(
+            &test.site.profile,
+            test.site.operator.inner(),
+            &test.site.repository.did(),
+            &root,
+        )
+        .await?;
         assert_eq!(recovered.subject(), Some(&test.site.repository.did()));
         assert_eq!(recovered.audience(), &root);
         let persisted = test
@@ -1394,7 +1401,13 @@ mod when_mounting_account_authority {
         let account_root = Ed25519Signer::import(&[73; 32]).await?.did();
         assert_ne!(local_root(&test.site).await?, account_root);
 
-        let adopted = site::account_root_prefix(&test.site, &account_root).await?;
+        let adopted = site::adopt_account_root_prefix_for(
+            &test.site.profile,
+            test.site.operator.inner(),
+            &test.site.repository.did(),
+            &account_root,
+        )
+        .await?;
 
         assert_eq!(adopted.subject(), Some(&test.site.repository.did()));
         assert_eq!(adopted.audience(), &account_root);
@@ -1417,7 +1430,13 @@ mod when_mounting_account_authority {
         let test = common::TestSite::new().await?;
         let account_root = Ed25519Signer::import(&[74; 32]).await?.did();
 
-        let first = site::account_root_prefix(&test.site, &account_root).await?;
+        let first = site::adopt_account_root_prefix_for(
+            &test.site.profile,
+            test.site.operator.inner(),
+            &test.site.repository.did(),
+            &account_root,
+        )
+        .await?;
         let second = site::account_root_prefix(&test.site, &account_root).await?;
 
         assert_eq!(first.to_bytes()?, second.to_bytes()?);

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -541,20 +541,20 @@ view/directory!:
             <span class="srow-dot"><ui-sync-status with={subject}></ui-sync-status></span>
             <span class="srow-name">{name}</span>
           </a>
-          <label class="srm-open" for="rm-{subject}" aria-label="Remove spot">
+          <label class="srm-open" for="rm-{subject}" aria-label="Remove space from this device">
             <wa-icon name="xmark"></wa-icon>
           </label>
           <div class="srm-overlay">
             <form class="srm-card" onsubmit=space/remove data-remove={subject} data-close-radio="rm-closed">
-              <h3 class="srm-title">Delete this spot?</h3>
+              <h3 class="srm-title">Remove this space from this device?</h3>
               <div class="srm-name">{name}</div>
-              <p class="onb-lede">Removes this spot from your account, on every device.
-                A synced spot can be rejoined with an invite link; a local-only spot is gone for good.</p>
+              <p class="onb-lede">Hides this space on this device and may remove its local data.
+                Account membership, remote data, peer copies, and authority are unchanged.</p>
               <div class="srm-actions">
                 <label class="srm-cancel" for="rm-closed">
                   <wa-button variant="neutral" appearance="plain" size="small">cancel</wa-button>
                 </label>
-                <wa-button type="submit" variant="danger" size="small">delete spot</wa-button>
+                <wa-button type="submit" variant="danger" size="small">remove from this device</wa-button>
               </div>
             </form>
           </div>

--- a/rust/tonk-schema/src/account.rs
+++ b/rust/tonk-schema/src/account.rs
@@ -1,9 +1,25 @@
 //! Root-owned facts stored in the hidden account repository.
 
-use dialog_artifacts::Entity;
-use dialog_query::Concept;
+use std::collections::BTreeMap;
 
-use crate::domain::account::{DisplayName, PasskeyCreatedAt, PasskeyCreatedOn};
+use base58::FromBase58 as _;
+use dialog_artifacts::Entity;
+use dialog_capability::Provider;
+use dialog_effects::archive::Import;
+use dialog_effects::authority::Attest;
+use dialog_effects::memory::Publish;
+use dialog_query::Concept;
+use dialog_query::{Output as _, Query, Term};
+use dialog_repository::Branch;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+use crate::concept::QueryEnv;
+use crate::domain::account::{
+    Archived, DisplayName, Name, PasskeyCreatedAt, PasskeyCreatedOn, Relay, Remote, Root, Space,
+    Tree,
+};
+use crate::prelude::{DidExt as _, EntityExt as _};
 
 /// The account-wide display name, keyed by the immutable account subject.
 ///
@@ -72,6 +88,433 @@ impl AccountPasskeyCreated {
     }
 }
 
+/// Canonical record that an account has known one repository subject.
+///
+/// The entity is derived from the immutable `(account root, repository
+/// subject)` pair so every client and replica converges on the same fact.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpace {
+    /// Entity derived from the account and repository DIDs.
+    pub this: Entity,
+    /// Immutable account root.
+    pub account: Root,
+    /// Immutable repository subject.
+    pub subject: Space,
+}
+
+#[derive(Debug, Clone, Serialize)]
+enum AccountSpaceEntity<'a> {
+    AccountSpace { account: &'a Did, subject: &'a Did },
+}
+
+impl AccountSpace {
+    /// Derive the canonical membership entity for an account and repository.
+    pub fn new(account: Did, subject: Did) -> Self {
+        Self {
+            this: Entity::of(&AccountSpaceEntity::AccountSpace {
+                account: &account,
+                subject: &subject,
+            }),
+            account: Root(account.this()),
+            subject: Space(subject.this()),
+        }
+    }
+}
+
+/// Optional display name for an [`AccountSpace`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpaceName {
+    /// Account-space entity being named.
+    pub this: Entity,
+    /// Current account-facing name.
+    pub name: Name,
+}
+
+/// Optional content remote for an [`AccountSpace`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpaceRemote {
+    /// Account-space entity being described.
+    pub this: Entity,
+    /// Current content remote URL.
+    pub remote: Remote,
+}
+
+/// Optional invitation-revocation relay for an [`AccountSpace`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpaceRevocationRelay {
+    /// Account-space entity being described.
+    pub this: Entity,
+    /// Current relay URL.
+    pub relay: Relay,
+}
+
+/// Exact content revision confirmed by the remote for an [`AccountSpace`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpaceConfirmedRevision {
+    /// Account-space entity being described.
+    pub this: Entity,
+    /// Exact confirmed tree reference.
+    pub tree: Tree,
+}
+
+/// Monotonic archive stamp for an [`AccountSpace`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSpaceArchived {
+    /// Account-space entity being archived.
+    pub this: Entity,
+    /// Presence marker; consumers treat any row as archived.
+    pub marker: Archived,
+}
+
+/// Raw account-space query rows before they are joined by canonical entity.
+#[derive(Clone, Debug, Default)]
+pub struct AccountSpaceRows {
+    /// Base membership facts.
+    pub spaces: Vec<AccountSpace>,
+    /// Optional display-name stamps.
+    pub names: Vec<AccountSpaceName>,
+    /// Optional remote stamps.
+    pub remotes: Vec<AccountSpaceRemote>,
+    /// Optional revocation-relay stamps.
+    pub relays: Vec<AccountSpaceRevocationRelay>,
+    /// Optional exact confirmed-tree stamps.
+    pub confirmed_revisions: Vec<AccountSpaceConfirmedRevision>,
+    /// Monotonic archive stamps.
+    pub archives: Vec<AccountSpaceArchived>,
+}
+
+/// One normalized canonical account-space record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountSpaceRecord {
+    /// Immutable account root.
+    pub account: Did,
+    /// Immutable repository subject.
+    pub subject: Did,
+    /// Current account-facing name.
+    pub name: Option<String>,
+    /// Current content remote URL.
+    pub remote_url: Option<String>,
+    /// Current invitation-revocation relay URL.
+    pub revocation_url: Option<String>,
+    /// Exact tree last accepted by the content remote.
+    pub confirmed_revision: Option<String>,
+    /// Whether a monotonic archive marker exists.
+    pub archived: bool,
+}
+
+/// Metadata to assert alongside one canonical active membership fact.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountSpaceInput {
+    /// Immutable account root.
+    pub account: Did,
+    /// Immutable repository subject.
+    pub subject: Did,
+    /// Account-facing display name to update, when known.
+    pub name: Option<String>,
+    /// Content remote URL to update, when known.
+    pub remote_url: Option<String>,
+    /// Invitation-revocation relay URL to update, when known.
+    pub revocation_url: Option<String>,
+    /// Exact confirmed content tree to update, when known.
+    pub confirmed_revision: Option<String>,
+}
+
+#[derive(Default)]
+struct PartialAccountSpaceRecord {
+    account: Option<Did>,
+    subject: Option<Did>,
+    name: Option<String>,
+    remote_url: Option<String>,
+    revocation_url: Option<String>,
+    confirmed_revision: Option<String>,
+    archived: bool,
+}
+
+/// Stable failures while normalizing canonical account-space facts.
+#[derive(Debug, thiserror::Error)]
+pub enum AccountSpaceError {
+    /// A stored base row does not match its deterministic entity.
+    #[error("invalid account-space fact: {0}")]
+    InvalidFact(String),
+    /// A branch query failed.
+    #[error("failed to query account-space facts: {0}")]
+    Query(String),
+    /// A fact commit failed.
+    #[error("failed to commit account-space facts: {0}")]
+    Commit(String),
+    /// Monotonic archive state forbids reactivation.
+    #[error("account space {subject} is permanently archived")]
+    Archived {
+        /// Repository subject that cannot be reactivated.
+        subject: Did,
+    },
+    /// Archive was requested for an account/subject pair with no base fact.
+    #[error("account space {subject} is not known to account {account}")]
+    Unknown {
+        /// Account root searched.
+        account: Did,
+        /// Repository subject searched.
+        subject: Did,
+    },
+}
+
+/// Join independently queried account-space concepts by their deterministic
+/// entity. Archive presence always dominates metadata and input ordering.
+pub fn normalize_account_spaces(
+    rows: AccountSpaceRows,
+) -> Result<Vec<AccountSpaceRecord>, AccountSpaceError> {
+    let mut records: BTreeMap<Entity, PartialAccountSpaceRecord> = BTreeMap::new();
+    for space in rows.spaces {
+        let account = parse_did(&space.account.0, "account root")?;
+        let subject = parse_did(&space.subject.0, "repository subject")?;
+        let expected = AccountSpace::new(account.clone(), subject.clone()).this;
+        if expected != space.this {
+            return Err(AccountSpaceError::InvalidFact(format!(
+                "entity {} does not match account {} and subject {}",
+                space.this, account, subject
+            )));
+        }
+        let record = records.entry(space.this).or_default();
+        record.account = Some(account);
+        record.subject = Some(subject);
+    }
+    for row in rows.names {
+        records.entry(row.this).or_default().name = Some(row.name.0);
+    }
+    for row in rows.remotes {
+        records.entry(row.this).or_default().remote_url = Some(row.remote.0);
+    }
+    for row in rows.relays {
+        records.entry(row.this).or_default().revocation_url = Some(row.relay.0);
+    }
+    for row in rows.confirmed_revisions {
+        validate_tree_reference(&row.tree.0)?;
+        records.entry(row.this).or_default().confirmed_revision = Some(row.tree.0);
+    }
+    for row in rows.archives {
+        records.entry(row.this).or_default().archived = true;
+    }
+
+    let mut normalized = records
+        .into_values()
+        .filter_map(|record| {
+            Some(AccountSpaceRecord {
+                account: record.account?,
+                subject: record.subject?,
+                name: record.name,
+                remote_url: record.remote_url,
+                revocation_url: record.revocation_url,
+                confirmed_revision: record.confirmed_revision,
+                archived: record.archived,
+            })
+        })
+        .collect::<Vec<_>>();
+    normalized.sort_by(|left, right| left.subject.cmp(&right.subject));
+    Ok(normalized)
+}
+
+fn parse_did(entity: &Entity, label: &str) -> Result<Did, AccountSpaceError> {
+    entity.to_string().parse().map_err(|error| {
+        AccountSpaceError::InvalidFact(format!("{label} {entity} is not a DID: {error}"))
+    })
+}
+
+fn validate_tree_reference(value: &str) -> Result<(), AccountSpaceError> {
+    let encoded = value.strip_prefix('#').ok_or_else(|| {
+        AccountSpaceError::InvalidFact(format!(
+            "confirmed revision '{value}' is not a tree reference"
+        ))
+    })?;
+    let decoded = encoded.from_base58().map_err(|error| {
+        AccountSpaceError::InvalidFact(format!(
+            "confirmed revision '{value}' is not base58: {error:?}"
+        ))
+    })?;
+    if decoded.len() != 32 {
+        return Err(AccountSpaceError::InvalidFact(format!(
+            "confirmed revision '{value}' has {} bytes, expected 32",
+            decoded.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Query and normalize all canonical account-space rows on a branch.
+pub async fn list_account_spaces<Env: QueryEnv>(
+    branch: &Branch,
+    env: &Env,
+) -> Result<Vec<AccountSpaceRecord>, AccountSpaceError> {
+    let spaces = branch
+        .query()
+        .select(Query::<AccountSpace> {
+            this: Term::var("this"),
+            account: Term::var("account"),
+            subject: Term::var("subject"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("base rows: {error:?}")))?;
+    let names = branch
+        .query()
+        .select(Query::<AccountSpaceName> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("name rows: {error:?}")))?;
+    let remotes = branch
+        .query()
+        .select(Query::<AccountSpaceRemote> {
+            this: Term::var("this"),
+            remote: Term::var("remote"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("remote rows: {error:?}")))?;
+    let relays = branch
+        .query()
+        .select(Query::<AccountSpaceRevocationRelay> {
+            this: Term::var("this"),
+            relay: Term::var("relay"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("relay rows: {error:?}")))?;
+    let confirmed_revisions = branch
+        .query()
+        .select(Query::<AccountSpaceConfirmedRevision> {
+            this: Term::var("this"),
+            tree: Term::var("tree"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("confirmed rows: {error:?}")))?;
+    let archives = branch
+        .query()
+        .select(Query::<AccountSpaceArchived> {
+            this: Term::var("this"),
+            marker: Term::var("marker"),
+        })
+        .perform(env)
+        .try_vec()
+        .await
+        .map_err(|error| AccountSpaceError::Query(format!("archive rows: {error:?}")))?;
+
+    normalize_account_spaces(AccountSpaceRows {
+        spaces,
+        names,
+        remotes,
+        relays,
+        confirmed_revisions,
+        archives,
+    })
+}
+
+/// Assert active membership and only the metadata supplied by this call.
+/// Existing optional metadata is preserved; an archive marker is never removed.
+pub async fn record_active_account_space<Env>(
+    branch: &Branch,
+    input: AccountSpaceInput,
+    env: &Env,
+) -> Result<bool, AccountSpaceError>
+where
+    Env: QueryEnv + Provider<Publish> + Provider<Import> + Provider<Attest>,
+{
+    if let Some(tree) = input.confirmed_revision.as_deref() {
+        validate_tree_reference(tree)?;
+    }
+    if list_account_spaces(branch, env)
+        .await?
+        .iter()
+        .any(|record| {
+            record.account == input.account && record.subject == input.subject && record.archived
+        })
+    {
+        return Err(AccountSpaceError::Archived {
+            subject: input.subject,
+        });
+    }
+
+    let space = AccountSpace::new(input.account, input.subject);
+    let this = space.this.clone();
+    let mut transaction = branch.transaction().assert(space);
+    if let Some(name) = input.name {
+        transaction = transaction.assert(AccountSpaceName {
+            this: this.clone(),
+            name: Name(name),
+        });
+    }
+    if let Some(remote) = input.remote_url {
+        transaction = transaction.assert(AccountSpaceRemote {
+            this: this.clone(),
+            remote: Remote(remote),
+        });
+    }
+    if let Some(relay) = input.revocation_url {
+        transaction = transaction.assert(AccountSpaceRevocationRelay {
+            this: this.clone(),
+            relay: Relay(relay),
+        });
+    }
+    if let Some(tree) = input.confirmed_revision {
+        transaction = transaction.assert(AccountSpaceConfirmedRevision {
+            this,
+            tree: Tree(tree),
+        });
+    }
+    transaction
+        .commit()
+        .perform(env)
+        .await
+        .map_err(|error| AccountSpaceError::Commit(error.to_string()))?;
+    Ok(true)
+}
+
+/// Add the monotonic archive marker for an exact account/subject pair.
+/// Returns `false` when that marker already exists.
+pub async fn archive_account_space<Env>(
+    branch: &Branch,
+    account: &Did,
+    subject: &Did,
+    env: &Env,
+) -> Result<bool, AccountSpaceError>
+where
+    Env: QueryEnv + Provider<Publish> + Provider<Import> + Provider<Attest>,
+{
+    let existing = list_account_spaces(branch, env).await?;
+    let Some(record) = existing
+        .iter()
+        .find(|record| &record.account == account && &record.subject == subject)
+    else {
+        return Err(AccountSpaceError::Unknown {
+            account: account.clone(),
+            subject: subject.clone(),
+        });
+    };
+    if record.archived {
+        return Ok(false);
+    }
+
+    let this = AccountSpace::new(account.clone(), subject.clone()).this;
+    branch
+        .transaction()
+        .assert(AccountSpaceArchived {
+            this,
+            marker: Archived(true),
+        })
+        .commit()
+        .perform(env)
+        .await
+        .map_err(|error| AccountSpaceError::Commit(error.to_string()))?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
@@ -82,10 +525,12 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;
 
     use super::*;
-    use crate::prelude::DidExt as _;
-
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
+
+    fn tree(byte: u8) -> String {
+        dialog_artifacts::TreeReference::from([byte; 32]).to_string()
+    }
 
     async fn converge(a_first: bool) -> Result<String> {
         let (operator, profile) = helpers::test_operator_with_profile().await;
@@ -218,6 +663,166 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].seconds(), 1_754_380_800);
         assert_eq!(rows[0].created_on.0, "Chrome on macOS");
+        Ok(())
+    }
+
+    #[test]
+    fn it_derives_one_account_space_entity_per_root_and_subject() {
+        let first = AccountSpace::new(did!("test:account-a"), did!("test:space-a"));
+        let same = AccountSpace::new(did!("test:account-a"), did!("test:space-a"));
+        let other_account = AccountSpace::new(did!("test:account-b"), did!("test:space-a"));
+        let other_subject = AccountSpace::new(did!("test:account-a"), did!("test:space-b"));
+
+        assert_eq!(first.this, same.this);
+        assert_ne!(first.this, other_account.this);
+        assert_ne!(first.this, other_subject.this);
+        assert_eq!(first.account.0.to_string(), "did:test:account-a");
+        assert_eq!(first.subject.0.to_string(), "did:test:space-a");
+    }
+
+    #[test]
+    fn it_assembles_active_and_archived_records_independently_of_query_order() {
+        let account = did!("test:account");
+        let active = AccountSpace::new(account.clone(), did!("test:active"));
+        let archived = AccountSpace::new(account, did!("test:archived"));
+        let rows = AccountSpaceRows {
+            spaces: vec![active.clone(), archived.clone()],
+            names: vec![AccountSpaceName {
+                this: active.this.clone(),
+                name: Name("Garden".to_string()),
+            }],
+            remotes: vec![],
+            relays: vec![],
+            confirmed_revisions: vec![AccountSpaceConfirmedRevision {
+                this: archived.this.clone(),
+                tree: Tree(tree(1)),
+            }],
+            archives: vec![AccountSpaceArchived {
+                this: archived.this,
+                marker: Archived(true),
+            }],
+        };
+        let mut reversed = rows.clone();
+        reversed.spaces.reverse();
+        reversed.names.reverse();
+        reversed.confirmed_revisions.reverse();
+        reversed.archives.reverse();
+
+        let forward = normalize_account_spaces(rows).unwrap();
+        let reverse = normalize_account_spaces(reversed).unwrap();
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.len(), 2);
+        assert!(!forward[0].archived);
+        assert!(forward[1].archived);
+        assert_eq!(forward[1].confirmed_revision, Some(tree(1)));
+    }
+
+    #[dialog_common::test]
+    async fn it_refuses_to_reactivate_an_archived_subject() -> Result<()> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let branch = repository.branch("main").open().perform(&operator).await?;
+        let input = AccountSpaceInput {
+            account: did!("test:account"),
+            subject: did!("test:space"),
+            name: Some("Garden".to_string()),
+            remote_url: None,
+            revocation_url: None,
+            confirmed_revision: Some(tree(2)),
+        };
+
+        record_active_account_space(&branch, input.clone(), &operator).await?;
+        assert!(archive_account_space(&branch, &input.account, &input.subject, &operator).await?);
+        let error = record_active_account_space(&branch, input, &operator)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, AccountSpaceError::Archived { .. }));
+        let records = list_account_spaces(&branch, &operator).await?;
+        assert!(records[0].archived);
+        assert_eq!(records[0].confirmed_revision, Some(tree(2)));
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_archives_idempotently() -> Result<()> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let branch = repository.branch("main").open().perform(&operator).await?;
+        let account = did!("test:account");
+        let subject = did!("test:space");
+        record_active_account_space(
+            &branch,
+            AccountSpaceInput {
+                account: account.clone(),
+                subject: subject.clone(),
+                name: None,
+                remote_url: None,
+                revocation_url: None,
+                confirmed_revision: None,
+            },
+            &operator,
+        )
+        .await?;
+
+        assert!(archive_account_space(&branch, &account, &subject, &operator).await?);
+        assert!(!archive_account_space(&branch, &account, &subject, &operator).await?);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_converges_an_account_space_archive_across_two_replicas() -> Result<()> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let base = repository.branch("base").open().perform(&operator).await?;
+        let base_revision = base.transaction().commit().perform(&operator).await?;
+        let a = repository
+            .branch("account-space-a")
+            .open()
+            .perform(&operator)
+            .await?;
+        let b = repository
+            .branch("account-space-b")
+            .open()
+            .perform(&operator)
+            .await?;
+        a.reset(base_revision.clone()).perform(&operator).await?;
+        b.reset(base_revision).perform(&operator).await?;
+        a.set_upstream(&b).perform(&operator).await?;
+        b.set_upstream(&a).perform(&operator).await?;
+
+        let account = did!("test:archive-account");
+        let subject = did!("test:archive-space");
+        record_active_account_space(
+            &a,
+            AccountSpaceInput {
+                account: account.clone(),
+                subject: subject.clone(),
+                name: Some("archive me".to_string()),
+                remote_url: None,
+                revocation_url: None,
+                confirmed_revision: Some(tree(3)),
+            },
+            &operator,
+        )
+        .await?;
+        b.pull().perform(&operator).await?;
+        assert!(archive_account_space(&b, &account, &subject, &operator).await?);
+
+        a.pull().perform(&operator).await?;
+        b.pull().perform(&operator).await?;
+
+        for branch in [&a, &b] {
+            let rows = list_account_spaces(branch, &operator).await?;
+            let row = rows.first().expect("one account-space row");
+            assert!(row.archived, "archive marker must dominate after merge");
+            assert_eq!(
+                row.confirmed_revision,
+                Some(tree(3)),
+                "archive keeps the last confirmed revision as history"
+            );
+        }
         Ok(())
     }
 

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -573,7 +573,7 @@ pub mod profile {
 
 /// Root-owned account state replicated through the hidden account repository.
 pub mod account {
-    use super::Attribute;
+    use super::{Attribute, Entity};
 
     /// The account-wide display name. Cardinality-one merge semantics choose a
     /// deterministic winner when linked devices write concurrently.
@@ -600,6 +600,47 @@ pub mod account {
     #[domain("xyz.tonk.account")]
     #[cardinality(one)]
     pub struct PasskeyCreatedOn(pub String);
+
+    /// Immutable account root that owns an account-space membership fact.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Root(pub Entity);
+
+    /// Repository subject known to an account.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Space(pub Entity);
+
+    /// Account-facing repository display name.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Name(pub String);
+
+    /// Content synchronization endpoint associated with the repository.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Remote(pub String);
+
+    /// Invitation-revocation relay associated with the repository.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Relay(pub String);
+
+    /// Exact content tree accepted by the configured remote.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    #[cardinality(one)]
+    pub struct Tree(pub String);
+
+    /// Monotonic archive marker. Its presence, rather than its payload, is the state.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account-space")]
+    pub struct Archived(pub bool);
 }
 
 /// Attributes that describe a repository on its content branch, keyed by the

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -10,7 +10,7 @@
   <h1>Account</h1>
 
   <section id="account-choice" class="account__panel" hidden>
-    <p class="account__lede">Create an account to keep your spots and access them on any device.</p>
+    <p class="account__lede">Create an account to discover your synchronized spaces and access them on another device.</p>
     <div class="account__actions">
       <button id="account-choose-create" class="account__button" type="button">Create account</button>
       <button id="account-choose-link" class="account__button account__button--secondary" type="button">Log in</button>
@@ -96,15 +96,31 @@
     <section class="account__section account__device-section" aria-labelledby="account-devices-title">
       <div class="account__section-heading">
         <h2 id="account-devices-title">Devices</h2>
-        <p>These devices can open and sync your Tonk spots. Remove any device you no longer use or recognise.</p>
+        <p>These devices can open and sync your Tonk spaces. Remove any device you no longer use or recognise.</p>
       </div>
       <ul id="account-device-list" class="account__devices"></ul>
+    </section>
+
+    <section class="account__section account__spaces-section" aria-labelledby="account-spaces-title">
+      <div class="account__section-heading">
+        <h2 id="account-spaces-title">Spaces</h2>
+        <p>Account discovery is separate from what is downloaded on this device.</p>
+      </div>
+      <ul id="account-space-list" class="account__devices"></ul>
+      <details id="account-hidden-spaces">
+        <summary>Show hidden</summary>
+        <ul id="account-hidden-space-list" class="account__devices"></ul>
+      </details>
+      <details id="account-archived-spaces">
+        <summary>Show archived</summary>
+        <ul id="account-archived-space-list" class="account__devices"></ul>
+      </details>
     </section>
 
     <section class="account__section account__profiles-section" aria-labelledby="account-profiles-title">
       <div class="account__section-heading">
         <h2 id="account-profiles-title">Accounts on this browser</h2>
-        <p>Each account keeps its own spots. Switching swaps which one this browser shows.</p>
+        <p>Each account keeps its own spaces. Switching swaps which one this browser shows.</p>
       </div>
       <ul id="account-profile-list" class="account__profiles"></ul>
       <button id="account-add-profile" class="account__button account__button--secondary account__button--compact" type="button">Add account</button>
@@ -113,7 +129,7 @@
     <section class="account__signout" aria-labelledby="account-signout-title">
       <div>
         <h2 id="account-signout-title">Sign out on this device</h2>
-        <p>Your existing spots will stay on this device, but syncing will stop until you sign in again.</p>
+        <p>Your existing spaces stay on this device. Account discovery and recovery pause, while already configured content remotes may continue to sync.</p>
       </div>
       <button id="account-unlink" class="account__button account__button--secondary account__button--compact" type="button">Sign out</button>
     </section>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -9,7 +9,8 @@ use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement, window};
 
 use tonk_account::{AccountStateStatus, handoff::ResolvedLink};
 use tonk_worker_api::{
-    AccountDeletionPlan, AccountDeletionRequest, AccountSpaceDeletionRequest, AccountStatus,
+    AccountDeletionPlan, AccountDeletionRequest, AccountSpaceDeletionRequest,
+    AccountSpaceEnrollment, AccountSpaceMembership, AccountSpaceVisibility, AccountStatus,
     RevocationProjection, RevokeDeviceAcknowledgement,
 };
 
@@ -191,6 +192,7 @@ fn show_success(host: &HtmlElement) {
     set_mode(host, "success");
     load_summary(host.clone());
     load_devices(host.clone());
+    load_spaces(host.clone());
     load_profiles(host.clone());
     load_activation_notice(host.clone());
 }
@@ -588,6 +590,109 @@ fn render_devices(host: &HtmlElement, devices: &[tonk_worker_api::AccountDevice]
         }
         let _ = list.append_child(&item);
     }
+}
+
+fn render_spaces(host: &HtmlElement, spaces: &[tonk_worker_api::AccountSpaceRow]) {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    for selector in [
+        "#account-space-list",
+        "#account-hidden-space-list",
+        "#account-archived-space-list",
+    ] {
+        if let Ok(Some(list)) = host.query_selector(selector) {
+            list.set_inner_html("");
+        }
+    }
+
+    for space in spaces {
+        let selector = if space.membership == AccountSpaceMembership::Archived {
+            "#account-archived-space-list"
+        } else if space.visibility == AccountSpaceVisibility::HiddenOnThisDevice {
+            "#account-hidden-space-list"
+        } else {
+            "#account-space-list"
+        };
+        let Ok(Some(list)) = host.query_selector(selector) else {
+            continue;
+        };
+        let Ok(item) = document.create_element("li") else {
+            continue;
+        };
+        let _ = item.set_attribute("class", "account__device-row");
+        let Ok(identity) = document.create_element("div") else {
+            continue;
+        };
+        let _ = identity.set_attribute("class", "account__device-identity");
+        let Ok(name) = document.create_element("strong") else {
+            continue;
+        };
+        let _ = name.set_attribute("class", "account__device-name");
+        name.set_text_content(Some(space.name.as_deref().unwrap_or("Unnamed space")));
+        let _ = identity.append_child(&name);
+        let Ok(meta) = document.create_element("span") else {
+            continue;
+        };
+        let _ = meta.set_attribute("class", "account__device-meta");
+        let local = if space.local {
+            "On this device; remove from this device in the Hub"
+        } else if space.pullable {
+            "Available to download"
+        } else {
+            "Not recoverable from saved access"
+        };
+        let enrollment = match space.enrollment {
+            AccountSpaceEnrollment::LocalOnly => "Local only".to_string(),
+            AccountSpaceEnrollment::Provisioning => "Provisioning remote".to_string(),
+            AccountSpaceEnrollment::PendingPush => "Waiting for confirmed push".to_string(),
+            AccountSpaceEnrollment::Connected => "Connected to account recovery".to_string(),
+            AccountSpaceEnrollment::Error => format!(
+                "Enrollment error: {}",
+                space.enrollment_error.as_deref().unwrap_or("unknown error")
+            ),
+        };
+        meta.set_text_content(Some(&format!("{} · {local} · {enrollment}", space.subject)));
+        let _ = identity.append_child(&meta);
+        let _ = item.append_child(&identity);
+
+        if space.pullable {
+            if let Ok(button) = document.create_element("button") {
+                let _ = button.set_attribute("type", "button");
+                let _ = button.set_attribute(
+                    "class",
+                    "account__button account__button--secondary account__button--compact",
+                );
+                let _ = button.set_attribute("data-download-space", &space.subject);
+                button.set_text_content(Some("Download"));
+                let _ = item.append_child(&button);
+            }
+        }
+        if space.membership == AccountSpaceMembership::Active {
+            if let Ok(button) = document.create_element("button") {
+                let _ = button.set_attribute("type", "button");
+                let _ = button.set_attribute(
+                    "class",
+                    "account__button account__button--secondary account__button--compact",
+                );
+                let _ = button.set_attribute("data-archive-space", &space.subject);
+                button.set_text_content(Some("Archive from account"));
+                let _ = item.append_child(&button);
+            }
+        }
+        let _ = list.append_child(&item);
+    }
+}
+
+fn load_spaces(host: HtmlElement) {
+    spawn_local(async move {
+        match crate::api::account_spaces().await {
+            Ok(spaces) => render_spaces(&host, &spaces),
+            Err(error) => {
+                web_sys::console::warn_1(&format!("account spaces unavailable: {error}").into());
+            }
+        }
+    });
 }
 
 /// What a switcher row is titled: the roster's display name, else the
@@ -1187,14 +1292,17 @@ async fn persist(
         .await
         .map_err(|error| error.to_string())?;
     }
-    crate::api::save_account_link(
-        provider.to_string(),
-        ceremony.root_did.clone(),
-        ceremony.credential_id.clone(),
-        ceremony.delegation_hex.clone(),
+    let deployment = crate::deployment::get().await.ok();
+    crate::api::save_account_link(tonk_worker_api::AccountLinkRequest {
+        provider: provider.to_string(),
+        root_did: ceremony.root_did.clone(),
+        credential_id: ceremony.credential_id.clone(),
+        delegation_hex: ceremony.delegation_hex.clone(),
         descriptor_hex,
         initialize_name,
-    )
+        access_remote: proposed_remote().await.ok(),
+        revocation_relay: deployment.map(|config| config.revocation_relay_url.to_string()),
+    })
     .await
     .map_err(|error| error.to_string())
 }
@@ -1238,7 +1346,12 @@ async fn deployment_service_did() -> Option<String> {
 /// The account repository remote this browser proposes: its own origin's
 /// `/ucan/` endpoint. Only a ceremony ever signs one; the stored descriptor is
 /// always the service-selected winner.
-fn proposed_remote() -> Result<String, String> {
+async fn proposed_remote() -> Result<String, String> {
+    if let Ok(config) = crate::deployment::get().await
+        && let Some(remote) = config.access_remote_url
+    {
+        return Ok(remote.to_string());
+    }
     window()
         .and_then(|window| window.location().origin().ok())
         .map(|origin| format!("{}/ucan/", origin.trim_end_matches('/')))
@@ -1445,8 +1558,8 @@ fn bind(host: &HtmlElement) {
                     email: email.clone(),
                     device_did,
                     device_name,
-                    remote: proposed_remote()?,
-                    endpoint: proposed_remote()?,
+                    remote: proposed_remote().await?,
+                    endpoint: proposed_remote().await?,
                     created_on: Some(crate::device_name::current()),
                     service_did: deployment_service_did().await,
                 })
@@ -1512,7 +1625,7 @@ fn bind(host: &HtmlElement) {
                 let enrolled = enroll_custody_passkey(EnrollCustodyInput {
                     account_did: root_did,
                     label,
-                    endpoint: proposed_remote()?,
+                    endpoint: proposed_remote().await?,
                 })
                 .await
                 .map_err(|error| error.to_string())?;
@@ -1568,7 +1681,7 @@ fn bind(host: &HtmlElement) {
                 let ceremony = unlock_with_passkey(UnlockWithPasskeyInput {
                     device_did,
                     device_name,
-                    endpoint: proposed_remote()?,
+                    endpoint: proposed_remote().await?,
                     service_did: deployment_service_did().await,
                 })
                 .await
@@ -1626,8 +1739,8 @@ fn bind(host: &HtmlElement) {
                     let authorized = crate::identity_bridge::authorize_device(
                         crate::identity_bridge::AuthorizeDeviceInput {
                             device_did: audience.clone(),
-                            remote: proposed_remote()?,
-                            endpoint: proposed_remote()?,
+                            remote: proposed_remote().await?,
+                            endpoint: proposed_remote().await?,
                         },
                     )
                     .await
@@ -1694,7 +1807,7 @@ fn bind(host: &HtmlElement) {
                     token_hash: handoff.token_hash,
                     device_did: handoff.device_did,
                     device_name: handoff.device_name,
-                    endpoint: proposed_remote()?,
+                    endpoint: proposed_remote().await?,
                 })
                 .await
                 .map_err(|error| error.to_string())?;
@@ -1751,7 +1864,7 @@ fn bind(host: &HtmlElement) {
             .map(|window| {
                 window
                     .confirm_with_message(
-                        "Sign out on this device? Your existing spots will stay here, but account syncing will stop until you sign in again.",
+                        "Sign out on this device? Existing spaces stay here. Account discovery and recovery pause, while already configured content remotes may continue to sync.",
                     )
                     .unwrap_or(false)
             })
@@ -2010,6 +2123,81 @@ fn bind(host: &HtmlElement) {
         closure.forget();
     }
 
+    for selector in [
+        "#account-space-list",
+        "#account-hidden-space-list",
+        "#account-archived-space-list",
+    ] {
+        let Ok(Some(list)) = host.query_selector(selector) else {
+            continue;
+        };
+        let host_for_space = host.clone();
+        let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let Some(target) = event
+                .target()
+                .and_then(|target| target.dyn_into::<web_sys::Element>().ok())
+            else {
+                return;
+            };
+            if let Some(subject) = target.get_attribute("data-download-space") {
+                let host = host_for_space.clone();
+                set_busy(&host, true, "Downloading space…");
+                spawn_local(async move {
+                    match crate::api::download_account_space(&subject).await {
+                        Ok(_) => {
+                            set_busy(&host, false, "");
+                            load_spaces(host);
+                        }
+                        Err(error) => {
+                            set_busy(&host, false, "");
+                            show_error(&host, error.to_string());
+                        }
+                    }
+                });
+                return;
+            }
+            let Some(subject) = target.get_attribute("data-archive-space") else {
+                return;
+            };
+            let confirmed = window()
+                .map(|window| {
+                    window
+                        .confirm_with_message(
+                            "Archive this space from the account? This permanently hides account discovery for this subject. It does not remove local or remote bytes, erase peer copies, or revoke access.",
+                        )
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
+            if !confirmed {
+                return;
+            }
+            let host = host_for_space.clone();
+            set_busy(&host, true, "Archiving account space…");
+            spawn_local(async move {
+                match crate::api::archive_account_space(&subject).await {
+                    Ok(response) => {
+                        set_busy(&host, false, "");
+                        if let Some(warning) = response.warning {
+                            show_error(
+                                &host,
+                                format!(
+                                    "The canonical archive succeeded, but its provider projection is pending: {warning}"
+                                ),
+                            );
+                        }
+                        load_spaces(host);
+                    }
+                    Err(error) => {
+                        set_busy(&host, false, "");
+                        show_error(&host, error.to_string());
+                    }
+                }
+            });
+        });
+        let _ = list.add_event_listener_with_callback("click", closure.as_ref().unchecked_ref());
+        closure.forget();
+    }
+
     if let Ok(Some(list)) = host.query_selector("#account-device-list") {
         let host_for_revoke = host.clone();
         let closure = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
@@ -2085,7 +2273,7 @@ fn begin_revoke(
         let revocation_hex = if self_revoke {
             String::new()
         } else {
-            let endpoint = match proposed_remote() {
+            let endpoint = match proposed_remote().await {
                 Ok(endpoint) => endpoint,
                 Err(error) => {
                     set_busy(&host, false, "");
@@ -2395,6 +2583,9 @@ mod tests {
             "#account-email-value",
             "#account-passkey-created-value",
             "#account-passkey-device-value",
+            "#account-space-list",
+            "#account-hidden-spaces",
+            "#account-archived-spaces",
             "#account-profile-list",
             "#account-add-profile",
             ".account__passkey",
@@ -2419,7 +2610,8 @@ mod tests {
         let copy = dashboard.text_content().unwrap();
         assert!(copy.contains("device, browser profile, or password manager"));
         assert!(copy.contains("do not tell Tonk which passkey manager currently stores it"));
-        assert!(copy.contains("syncing will stop until you sign in again"));
+        assert!(copy.contains("Account discovery and recovery pause"));
+        assert!(copy.contains("content remotes may continue to sync"));
         assert!(copy.contains("This is not sign out"));
         assert!(copy.contains("Spaces created by other people will not be deleted"));
         assert!(copy.contains("cannot erase copies that other devices have already replicated"));

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -63,6 +63,45 @@ mod tests {
         }
     }
 
+    async fn click_in_guest(driver: &WebDriver, selector: &str) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let mut paths = vec![Vec::<u16>::new()];
+            for _depth in 0..5 {
+                let current = std::mem::take(&mut paths);
+                for path in current {
+                    driver.enter_default_frame().await?;
+                    let mut reachable = true;
+                    for index in &path {
+                        if driver.enter_frame(*index).await.is_err() {
+                            reachable = false;
+                            break;
+                        }
+                    }
+                    if !reachable {
+                        continue;
+                    }
+                    if let Ok(element) = driver.find(By::Css(selector.to_string())).await {
+                        element.click().await?;
+                        driver.enter_default_frame().await?;
+                        return Ok(());
+                    }
+                    let count = driver.find_all(By::Css("iframe".to_string())).await?.len();
+                    for index in 0..count.min(u16::MAX as usize) {
+                        let mut child = path.clone();
+                        child.push(index as u16);
+                        paths.push(child);
+                    }
+                }
+            }
+            driver.enter_default_frame().await?;
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow!("timed out waiting for {selector} in guest frames"));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
     async fn wait_for_text(driver: &WebDriver, selector: &str, expected: &str) -> Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         loop {
@@ -333,6 +372,7 @@ mod tests {
             .env("DO_NOT_TRACK", "1")
             .env("NO_PROXY", "127.0.0.1,localhost,tonk.network")
             .env_remove("TONK_TELEMETRY")
+            .env_remove("TONK_SPACE")
             .env_remove("TONK_SPOT")
             .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT");
         command
@@ -583,6 +623,82 @@ mod tests {
             "{operation} failed: {result}"
         );
         &result["body"]
+    }
+
+    fn profile_space_keys(body: &serde_json::Value) -> Vec<String> {
+        body["space"]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| entry["key"].as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn wait_for_account_space(
+        driver: &WebDriver,
+        subject: &str,
+        membership: &str,
+        visibility: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            let response = get_json(driver, "/api/account/spaces").await?;
+            if response["status"]
+                .as_u64()
+                .is_some_and(|status| (200..300).contains(&status))
+                && let Some(row) = response["body"].as_array().and_then(|rows| {
+                    rows.iter().find(|row| {
+                        row["subject"] == subject
+                            && row["membership"] == membership
+                            && visibility.is_none_or(|expected| row["visibility"] == expected)
+                    })
+                })
+            {
+                return Ok(row.clone());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "timed out waiting for account space {subject} membership={membership} visibility={visibility:?}: {response}"
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+
+    async fn create_connected_space(
+        driver: &WebDriver,
+        env: &TestEnvironment,
+        name: &str,
+    ) -> Result<String> {
+        let created = post_json(
+            driver,
+            "/api/spaces",
+            serde_json::json!({
+                "name": name,
+                "remote": env.tonk_web.join("ucan/")?,
+                "revocation_url": env.account_service.join("revocations")?,
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let subject = successful_body("create connected space", &created)["key"]
+            .as_str()
+            .context("create response omitted the space key")?
+            .to_string();
+        let pushed = post_json(
+            driver,
+            &format!("/api/repository/{subject}/branch/main/sync/push"),
+            serde_json::json!({}),
+        )
+        .await?;
+        successful_body("push connected space", &pushed);
+        let row = wait_for_account_space(driver, &subject, "active", Some("visible")).await?;
+        assert_eq!(row["enrollment"], "connected");
+        assert!(row["confirmedRevision"].is_string());
+        Ok(subject)
     }
 
     fn did_for_device<'a>(output: &'a str, name: &str) -> Option<&'a str> {
@@ -847,6 +963,388 @@ mod tests {
         assert_eq!(
             after["status"], 404,
             "a deleted account leaves nothing to plan against: {after}"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_shares_inventory_between_cli_and_browser(env: TestEnvironment) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, "inventory@example.com").await?;
+
+        let created = post_json(
+            &driver,
+            "/api/spaces",
+            serde_json::json!({
+                "name": "Cross-client Garden",
+                "remote": env.tonk_web.join("ucan/")?,
+                "revocation_url": env.account_service.join("revocations")?,
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let subject = successful_body("create cross-client space", &created)["key"]
+            .as_str()
+            .context("create response omitted the space key")?
+            .to_string();
+        let pushed = post_json(
+            &driver,
+            &format!("/api/repository/{subject}/branch/main/sync/push"),
+            serde_json::json!({}),
+        )
+        .await?;
+        successful_body("push cross-client space", &pushed);
+
+        // Reconciliation is deliberately asynchronous. Provider projection is
+        // its final step, so an inventory row with an exact confirmed revision
+        // proves all earlier canonical writes completed too.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let browser_row = loop {
+            let response = get_json(&driver, "/api/account/spaces").await?;
+            if response["status"]
+                .as_u64()
+                .is_some_and(|status| (200..300).contains(&status))
+                && let Some(row) = response["body"].as_array().and_then(|rows| {
+                    rows.iter().find(|row| {
+                        row["subject"] == subject
+                            && row["membership"] == "active"
+                            && row["enrollment"] == "connected"
+                            && row["confirmedRevision"].is_string()
+                    })
+                })
+            {
+                break row.clone();
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "timed out waiting for connected browser account inventory: {response}"
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        };
+        assert_eq!(browser_row["local"], true);
+        assert_eq!(browser_row["pullable"], false);
+        let confirmed = browser_row["confirmedRevision"]
+            .as_str()
+            .context("browser inventory omitted the confirmed revision")?
+            .to_string();
+        let remote = browser_row["remoteUrl"]
+            .as_str()
+            .context("browser inventory omitted the content remote")?
+            .parse::<url::Url>()?;
+        assert_eq!(remote.scheme(), "http");
+        assert_eq!(remote.host_str(), Some("127.0.0.1"));
+        assert_eq!(remote.path(), "/ucan/");
+
+        let account = get_json(&driver, "/api/account").await?;
+        let root = successful_body("read inventory account", &account)["rootDid"]
+            .as_str()
+            .context("inventory account status omitted its root DID")?
+            .to_string();
+        let provider_snapshot: Vec<serde_json::Value> = reqwest::Client::new()
+            .get(env.account_service.join("_test/spots")?)
+            .header("X-Test-Root", &root)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        assert!(
+            provider_snapshot
+                .iter()
+                .any(|row| row["subject"] == subject && row["key"].is_string()),
+            "connected browser inventory has no selected provider artifact: {provider_snapshot:?}"
+        );
+
+        let linked = link_cli(&driver, &env).await?;
+        assert!(linked.link.status.success());
+        let synced = run_cli(
+            &linked.profile,
+            &["account".to_string(), "sync".to_string()],
+        )
+        .await?;
+        assert!(
+            synced.status.success(),
+            "account sync failed after link: stdout={} stderr={}",
+            synced.stdout,
+            synced.stderr
+        );
+        let status = run_cli(
+            &linked.profile,
+            &["account".to_string(), "status".to_string()],
+        )
+        .await?;
+        assert!(
+            status.status.success(),
+            "account status failed: {}",
+            status.stderr
+        );
+        assert!(
+            status.stdout.contains(&root),
+            "CLI linked to a different account root; browser={root} status={}",
+            status.stdout
+        );
+        let provider = status
+            .stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("provider: "))
+            .context("account status omitted the provider")?;
+        assert_eq!(url::Url::parse(provider)?, env.account_service);
+        let listed = run_cli(
+            &linked.profile,
+            &[
+                "space".to_string(),
+                "list".to_string(),
+                "--all".to_string(),
+                "--refresh".to_string(),
+                "--json".to_string(),
+            ],
+        )
+        .await?;
+        assert!(
+            listed.status.success(),
+            "space list failed: {}",
+            listed.stderr
+        );
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&listed.stdout)?;
+        let cli_row = rows
+            .iter()
+            .find(|row| row["subject"] == subject)
+            .with_context(|| {
+                format!(
+                    "CLI inventory omitted the browser-created subject; link={} rows={}",
+                    linked.link.stdout, listed.stdout
+                )
+            })?;
+        assert_eq!(cli_row["accountMembership"], "active");
+        assert_eq!(cli_row["localPresence"], "absent");
+        assert_eq!(cli_row["transport"], "configured");
+        assert_eq!(
+            cli_row["authority"], "retained",
+            "refreshed CLI inventory rejected saved authority: {}",
+            listed.stderr
+        );
+        assert_eq!(cli_row["confirmedRevision"], confirmed);
+        assert_eq!(cli_row["pullable"], true);
+
+        let pulled = run_cli(
+            &linked.profile,
+            &[
+                "account".to_string(),
+                "spaces".to_string(),
+                "pull".to_string(),
+                subject.clone(),
+                "--name".to_string(),
+                "cross-client-garden".to_string(),
+            ],
+        )
+        .await?;
+        assert!(
+            pulled.status.success(),
+            "space pull failed: {}",
+            pulled.stderr
+        );
+        assert!(pulled.stdout.contains("pulled\tcross-client-garden\t"));
+
+        let listed = run_cli(
+            &linked.profile,
+            &[
+                "space".to_string(),
+                "list".to_string(),
+                "--all".to_string(),
+                "--json".to_string(),
+            ],
+        )
+        .await?;
+        assert!(
+            listed.status.success(),
+            "space relist failed: {}",
+            listed.stderr
+        );
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&listed.stdout)?;
+        let cli_row = rows
+            .iter()
+            .find(|row| row["subject"] == subject)
+            .context("CLI inventory lost the pulled subject")?;
+        assert_eq!(cli_row["localPresence"], "registered");
+        assert_eq!(cli_row["pullable"], false);
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_device_local_removal_hidden_across_reload_and_profile_switch(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, "hidden-space@example.com").await?;
+        let subject = create_connected_space(&driver, &env, "Hidden Garden").await?;
+        let linked = link_cli(&driver, &env).await?;
+        let synced = run_cli(
+            &linked.profile,
+            &["account".to_string(), "sync".to_string()],
+        )
+        .await?;
+        assert!(
+            synced.status.success(),
+            "account sync failed: {}",
+            synced.stderr
+        );
+
+        driver.goto(env.tonk_web.as_str()).await?;
+        click_in_guest(&driver, &format!("label[for=\"rm-{subject}\"]")).await?;
+        click_in_guest(
+            &driver,
+            &format!("form[data-remove=\"{subject}\"] wa-button[type=\"submit\"]"),
+        )
+        .await?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let profile = get_json(&driver, "/api/profile").await?;
+            if !profile_space_keys(successful_body("read profile after removal", &profile))
+                .contains(&subject)
+            {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow!("device-local removal did not retract {subject}"));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let hidden =
+            wait_for_account_space(&driver, &subject, "active", Some("hiddenOnThisDevice")).await?;
+        assert_eq!(hidden["local"], false);
+
+        driver.refresh().await?;
+        element(&driver, "tonk-site").await?;
+        let reloaded = get_json(&driver, "/api/profile").await?;
+        assert!(
+            !profile_space_keys(successful_body("read reloaded profile", &reloaded))
+                .contains(&subject)
+        );
+        wait_for_account_space(&driver, &subject, "active", Some("hiddenOnThisDevice")).await?;
+
+        let profiles = get_json(&driver, "/api/profiles").await?;
+        let first_profile = successful_body("read first profile", &profiles)["active"]
+            .as_str()
+            .context("profiles response omitted active profile")?
+            .to_string();
+        driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        click(&driver, "#account-add-profile").await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        sign_up(&driver, &env, "other-profile@example.com").await?;
+        click(
+            &driver,
+            &format!("#account-profile-list button[data-activate=\"{first_profile}\"]"),
+        )
+        .await?;
+        wait_for_text_containing(&driver, "#account-email-value", "hidden-space@example.com")
+            .await?;
+        let switched_back = get_json(&driver, "/api/profile").await?;
+        assert!(
+            !profile_space_keys(successful_body("read switched profile", &switched_back))
+                .contains(&subject)
+        );
+        wait_for_account_space(&driver, &subject, "active", Some("hiddenOnThisDevice")).await?;
+
+        let listed = run_cli(
+            &linked.profile,
+            &[
+                "space".to_string(),
+                "list".to_string(),
+                "--all".to_string(),
+                "--refresh".to_string(),
+                "--json".to_string(),
+            ],
+        )
+        .await?;
+        assert!(
+            listed.status.success(),
+            "CLI list failed: {}",
+            listed.stderr
+        );
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&listed.stdout)?;
+        let cli_row = rows
+            .iter()
+            .find(|row| row["subject"] == subject)
+            .context("another device lost active account membership")?;
+        assert_eq!(cli_row["accountMembership"], "active");
+        assert_eq!(cli_row["localPresence"], "absent");
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_archives_account_membership_without_claiming_remote_or_peer_deletion(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, "archive-space@example.com").await?;
+        let subject = create_connected_space(&driver, &env, "Archive Garden").await?;
+        let linked = link_cli(&driver, &env).await?;
+        let synced = run_cli(
+            &linked.profile,
+            &["account".to_string(), "sync".to_string()],
+        )
+        .await?;
+        assert!(
+            synced.status.success(),
+            "account sync failed: {}",
+            synced.stderr
+        );
+        let devices_before = devices(&linked.profile, &env).await?;
+        assert!(devices_before.status.success(), "{}", devices_before.stderr);
+
+        let archived = run_cli(
+            &linked.profile,
+            &[
+                "space".to_string(),
+                "archive".to_string(),
+                subject.clone(),
+                "--yes".to_string(),
+            ],
+        )
+        .await?;
+        assert!(
+            archived.status.success(),
+            "CLI archive failed: stdout={} stderr={}",
+            archived.stdout,
+            archived.stderr
+        );
+        assert!(archived.stdout.contains("Archived account space"));
+
+        let row = wait_for_account_space(&driver, &subject, "archived", None).await?;
+        assert_eq!(row["local"], true, "archive must not unmount the peer copy");
+        assert_eq!(row["pullable"], false);
+        let readable = get_json(&driver, &format!("/api/repository/{subject}")).await?;
+        successful_body("read already-mounted archived space", &readable);
+
+        let account = get_json(&driver, "/api/account").await?;
+        let root = successful_body("read archive account", &account)["rootDid"]
+            .as_str()
+            .context("account response omitted root DID")?;
+        let active_provider: Vec<serde_json::Value> = reqwest::Client::new()
+            .get(env.account_service.join("_test/spots")?)
+            .header("X-Test-Root", root)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        assert!(
+            active_provider.iter().all(|row| row["subject"] != subject),
+            "the archived tombstone must replace the active provider head: {active_provider:?}"
+        );
+        let devices_after = devices(&linked.profile, &env).await?;
+        assert!(devices_after.status.success(), "{}", devices_after.stderr);
+        assert_eq!(
+            devices_after.stdout, devices_before.stdout,
+            "archive must not revoke devices or authority"
         );
 
         driver.quit().await?;

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -3,7 +3,8 @@ use serde::Deserialize;
 use tonk_account::handoff::{LinkSecretRequest, ResolvedLink};
 use tonk_worker_api::{
     AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult, AccountDevice,
-    AccountLinkRequest, AccountStatus, AccountSummary, ActivateProfileRequest, EvaluateResponse,
+    AccountLinkRequest, AccountSpaceArchiveResponse, AccountSpaceDownloadResponse, AccountSpaceRow,
+    AccountStatus, AccountSummary, ActivateProfileRequest, EvaluateResponse,
     HostedSpaceDeletionResult, IdentifyResponse, JoinRequest, JoinResponse, MembershipResponse,
     ProfilesResponse, QueryResponse, RepositoryInfo, RevokeDeviceAcknowledgement,
     RevokeDeviceRequest, RootStatus, SaveRootRequest, SyncResponse, SyncStatusResponse,
@@ -570,25 +571,11 @@ pub async fn account_status() -> Result<AccountStatus, TonkUiError> {
 }
 
 /// Persist a verified account-root delegation in the local profile.
-pub async fn save_account_link(
-    provider: String,
-    root_did: String,
-    credential_id: String,
-    delegation_hex: String,
-    descriptor_hex: String,
-    initialize_name: bool,
-) -> Result<AccountStatus, TonkUiError> {
+pub async fn save_account_link(request: AccountLinkRequest) -> Result<AccountStatus, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/account/attach", origin()))
-        .json(&AccountLinkRequest {
-            provider,
-            root_did,
-            credential_id,
-            delegation_hex,
-            descriptor_hex,
-            initialize_name,
-        })
+        .json(&request)
         .send()
         .await
         .map_err(into_api_error)?;
@@ -637,6 +624,70 @@ pub async fn account_summary() -> Result<AccountSummary, TonkUiError> {
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "GET /api/account/summary returned {status}: {text}"
+        )))
+    }
+}
+
+/// List account spaces without mounting account-only rows into the Hub.
+pub async fn account_spaces() -> Result<Vec<AccountSpaceRow>, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/account/spaces", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "GET /api/account/spaces returned {status}: {text}"
+        )))
+    }
+}
+
+/// Explicitly download one active account space onto this profile.
+pub async fn download_account_space(
+    subject: &str,
+) -> Result<AccountSpaceDownloadResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/api/account/spaces/{subject}/download",
+            origin()
+        ))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST account-space download returned {status}: {text}"
+        )))
+    }
+}
+
+/// Archive one subject in the signed account repository.
+pub async fn archive_account_space(
+    subject: &str,
+) -> Result<AccountSpaceArchiveResponse, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/account/spaces/{subject}/archive", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST account-space archive returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -172,8 +172,18 @@ mod native {
             // access service's own port.
             let web_port =
                 free_local_port().expect("Could not get a free local port for test server");
+            let native_web_port = loop {
+                let candidate = free_local_port()
+                    .expect("Could not get a free local port for native test access");
+                if candidate != web_port {
+                    break candidate;
+                }
+            };
             let settings = AccessServiceSettings {
                 deployment: Some(DeploymentConfig {
+                    access_remote_url: Some(Url::parse(&format!(
+                        "http://127.0.0.1:{native_web_port}/ucan/"
+                    ))?),
                     account_service_url: account_service_url.clone(),
                     revocation_relay_url: Url::parse(&format!(
                         "{}/revocations",
@@ -202,6 +212,7 @@ mod native {
                         "--",
                         &format!("{web_port}"),
                         &format!("{access_service_port}"),
+                        &format!("{native_web_port}"),
                     ])
                     // Pin Caddy's data dir so its per-run internal CA
                     // root lands at a knowable path: native CLI
@@ -245,6 +256,25 @@ mod native {
             }
             if !listening {
                 return Err(anyhow!("test web server did not bind port {web_port}"));
+            }
+            let mut native_listening = false;
+            for _ in 0..100 {
+                if tokio::net::TcpStream::connect(("127.0.0.1", native_web_port))
+                    .await
+                    .is_ok()
+                {
+                    native_listening = true;
+                    break;
+                }
+                if let Some(status) = web_server.child_mut().try_wait()? {
+                    return Err(anyhow!("test web server exited before binding: {status}"));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            if !native_listening {
+                return Err(anyhow!(
+                    "test web server did not bind native port {native_web_port}"
+                ));
             }
 
             // Caddy mints its internal CA lazily; wait for the root and

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -103,6 +103,13 @@ pub struct AccountLinkRequest {
     /// Seed the current profile name only for a new-account creation winner.
     #[serde(default)]
     pub initialize_name: bool,
+    /// Default content access remote for local-only spaces, when deployment
+    /// discovery supplied one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_remote: Option<String>,
+    /// Default invitation-revocation relay paired with `access_remote`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revocation_relay: Option<String>,
 }
 
 /// Local identity and provider attachment state.
@@ -166,6 +173,95 @@ pub struct AccountDisplayNameResponse {
     pub name: String,
     /// Idempotent projection work completed after the account commit.
     pub convergence: AccountConvergenceReport,
+}
+
+/// Canonical account membership state for one repository subject.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSpaceMembership {
+    /// The account currently discovers this subject.
+    Active,
+    /// A monotonic account-owned archive marker hides this subject.
+    Archived,
+}
+
+/// Whether one account space is visible on this browser profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSpaceVisibility {
+    /// Not suppressed on this profile.
+    Visible,
+    /// Explicitly removed from this device/profile.
+    HiddenOnThisDevice,
+}
+
+/// Durable browser enrollment phase for one locally known space.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSpaceEnrollment {
+    /// No automatic remote enrollment has begun.
+    #[default]
+    LocalOnly,
+    /// Remote provisioning is in progress or remains retryable.
+    Provisioning,
+    /// A remote exists but the exact content tree is not yet confirmed.
+    PendingPush,
+    /// Content, canonical membership, and saved access all converged.
+    Connected,
+    /// The last bounded enrollment pass failed at a named step.
+    Error,
+}
+
+/// One browser account-space inventory row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSpaceRow {
+    /// Wire schema version; exactly 1.
+    pub version: u8,
+    /// Immutable repository subject DID.
+    pub subject: String,
+    /// Account-facing display name when known.
+    pub name: Option<String>,
+    /// Signed account-repository membership state.
+    pub membership: AccountSpaceMembership,
+    /// Whether a local replica is mounted in this profile.
+    pub local: bool,
+    /// Device-local discovery visibility.
+    pub visibility: AccountSpaceVisibility,
+    /// Configured content remote when known.
+    pub remote_url: Option<String>,
+    /// Exact tree last accepted by that content remote.
+    pub confirmed_revision: Option<String>,
+    /// Whether explicit download has unambiguous saved access.
+    pub pullable: bool,
+    /// Last durable enrollment phase recorded on this browser profile.
+    #[serde(default)]
+    pub enrollment: AccountSpaceEnrollment,
+    /// Last enrollment error, present only for `error`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrollment_error: Option<String>,
+}
+
+/// Result of explicitly downloading one account space.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSpaceDownloadResponse {
+    /// Subject mounted locally.
+    pub subject: String,
+    /// Whether this profile now has a local replica.
+    pub local: bool,
+}
+
+/// Result of writing an account-owned archive marker.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSpaceArchiveResponse {
+    /// Subject archived in the canonical account repository.
+    pub subject: String,
+    /// Whether this request committed a new marker.
+    pub newly_archived: bool,
+    /// Best-effort provider-projection warning, if canonical commit succeeded.
+    pub warning: Option<String>,
 }
 
 /// One device registered under the attached provider account.
@@ -270,12 +366,31 @@ mod tests {
             delegation_hex: "aa".into(),
             descriptor_hex: "bb".into(),
             initialize_name: true,
+            access_remote: Some("https://sync.example/ucan/".into()),
+            revocation_relay: Some("https://relay.example/revocations/".into()),
         })
         .unwrap();
         assert_eq!(link["credentialId"], "cred");
         assert_eq!(link["delegationHex"], "aa");
         assert_eq!(link["descriptorHex"], "bb");
         assert_eq!(link["initializeName"], true);
+        assert_eq!(link["accessRemote"], "https://sync.example/ucan/");
+        assert_eq!(
+            link["revocationRelay"],
+            "https://relay.example/revocations/"
+        );
+
+        let legacy: AccountLinkRequest = serde_json::from_value(serde_json::json!({
+            "provider": "https://accounts.example",
+            "rootDid": "did:key:root",
+            "credentialId": "cred",
+            "delegationHex": "aa",
+            "descriptorHex": "bb",
+            "initializeName": false
+        }))
+        .unwrap();
+        assert_eq!(legacy.access_remote, None);
+        assert_eq!(legacy.revocation_relay, None);
     }
 
     #[dialog_common::test]
@@ -309,6 +424,44 @@ mod tests {
         assert_eq!(value["convergence"]["profileChanged"], true);
         assert_eq!(value["convergence"]["changedKeys"][0], "one");
         assert_eq!(value["convergence"]["failedKeys"][0], "two");
+    }
+
+    #[dialog_common::test]
+    fn it_serializes_account_space_lifecycle_without_collapsing_visibility() {
+        let value = serde_json::to_value(AccountSpaceRow {
+            version: 1,
+            subject: "did:key:space".into(),
+            name: Some("garden".into()),
+            membership: AccountSpaceMembership::Active,
+            local: false,
+            visibility: AccountSpaceVisibility::HiddenOnThisDevice,
+            remote_url: Some("https://sync.example/ucan/".into()),
+            confirmed_revision: Some("#tree".into()),
+            pullable: true,
+            enrollment: AccountSpaceEnrollment::PendingPush,
+            enrollment_error: None,
+        })
+        .unwrap();
+        assert_eq!(value["membership"], "active");
+        assert_eq!(value["visibility"], "hiddenOnThisDevice");
+        assert_eq!(value["confirmedRevision"], "#tree");
+        assert_eq!(value["enrollment"], "pendingPush");
+        assert!(value.get("confirmed_revision").is_none());
+
+        let legacy: AccountSpaceRow = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "subject": "did:key:legacy",
+            "name": null,
+            "membership": "active",
+            "local": false,
+            "visibility": "visible",
+            "remoteUrl": null,
+            "confirmedRevision": null,
+            "pullable": false
+        }))
+        .unwrap();
+        assert_eq!(legacy.enrollment, AccountSpaceEnrollment::LocalOnly);
+        assert_eq!(legacy.enrollment_error, None);
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker-api/src/deployment.rs
+++ b/rust/tonk-worker-api/src/deployment.rs
@@ -7,6 +7,10 @@ use url::Url;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeploymentConfig {
+    /// Content repository access remote. Absent on deployments where clients
+    /// should derive the same-origin `/ucan/` endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_remote_url: Option<Url>,
     /// Account linking, custody, and device-management service.
     pub account_service_url: Url,
     /// Relay accepting immutable invitation and device revocation artifacts.
@@ -25,11 +29,13 @@ mod tests {
     #[test]
     fn it_serializes_canonical_camel_case_urls() {
         let config = DeploymentConfig {
+            access_remote_url: Some("https://sync.example/ucan/".parse().unwrap()),
             account_service_url: "https://accounts.example/".parse().unwrap(),
             revocation_relay_url: "https://relay.example/revocations".parse().unwrap(),
             service_did: None,
         };
         let value = serde_json::to_value(config).unwrap();
+        assert_eq!(value["accessRemoteUrl"], "https://sync.example/ucan/");
         assert_eq!(value["accountServiceUrl"], "https://accounts.example/");
         assert_eq!(
             value["revocationRelayUrl"],
@@ -38,6 +44,13 @@ mod tests {
         // Absent identity serializes to nothing, so configs written by a
         // deployment without one keep parsing in strict old clients.
         assert!(value.get("serviceDid").is_none());
+
+        let legacy: DeploymentConfig = serde_json::from_value(serde_json::json!({
+            "accountServiceUrl": "https://accounts.example/",
+            "revocationRelayUrl": "https://relay.example/revocations"
+        }))
+        .unwrap();
+        assert_eq!(legacy.access_remote_url, None);
     }
 
     #[test]

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -31,9 +31,10 @@ mod sync;
 pub use account::{
     AccountConvergenceReport, AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult,
     AccountDeletionSpace, AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse,
-    AccountLinkRequest, AccountSpaceDeletionRequest, AccountStatus, AccountSummary,
-    HostedSpaceDeletionResult, RevocationProjection, RevokeDeviceAcknowledgement,
-    RevokeDeviceRequest,
+    AccountLinkRequest, AccountSpaceArchiveResponse, AccountSpaceDeletionRequest,
+    AccountSpaceDownloadResponse, AccountSpaceEnrollment, AccountSpaceMembership, AccountSpaceRow,
+    AccountSpaceVisibility, AccountStatus, AccountSummary, HostedSpaceDeletionResult,
+    RevocationProjection, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
 };
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};

--- a/rust/tonk-worker/src/device.rs
+++ b/rust/tonk-worker/src/device.rs
@@ -18,6 +18,8 @@
 //! profile rather than inside the profile it names: a pointer stored in
 //! the thing it points at could not be read before opening it.
 
+use std::collections::BTreeSet;
+
 use dialog_effects::storage::Directory;
 use dialog_operator::Profile;
 use dialog_storage::provider::storage::Storage;
@@ -48,6 +50,28 @@ const ACTIVE_PROFILE_SITE: &str = "tonk-active-profile-v1";
 /// credential load, maintained by the worker at the moments it already
 /// has the facts in hand (boot, link, unlink, rename, switch).
 const PROFILE_ROSTER_SITE: &str = "tonk-profile-roster-v1";
+
+/// Prefix for one versioned suppression document per browser profile.
+///
+/// These records live on the fixed registry profile so restore can read
+/// them before opening or activating the profile they describe.
+const SPACE_SUPPRESSIONS_SITE_PREFIX: &str = "tonk-space-suppressions-v1/";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SpaceSuppressionsV1 {
+    version: u8,
+    subjects: BTreeSet<String>,
+}
+
+impl Default for SpaceSuppressionsV1 {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            subjects: BTreeSet::new(),
+        }
+    }
+}
 
 /// One profile this browser knows about, as the switcher renders it.
 ///
@@ -275,6 +299,100 @@ impl Registry {
             })
     }
 
+    /// Device-local subjects hidden for one browser profile.
+    pub(crate) async fn read_space_suppressions(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        profile_name: &str,
+    ) -> Result<BTreeSet<String>, TonkWorkerError> {
+        let registry = self.open_self(storage).await?;
+        let site = format!("{SPACE_SUPPRESSIONS_SITE_PREFIX}{profile_name}");
+        let bytes = match registry
+            .credential()
+            .site(site)
+            .load::<Vec<u8>>()
+            .perform(storage)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(error) if crate::credential::is_missing(&error) => return Ok(BTreeSet::new()),
+            Err(error) => {
+                return Err(TonkWorkerError::Internal(format!(
+                    "failed to read space suppressions for profile '{profile_name}': {error}"
+                )));
+            }
+        };
+        let document: SpaceSuppressionsV1 = serde_json::from_slice(&bytes).map_err(|error| {
+            TonkWorkerError::Internal(format!(
+                "stored space suppressions for profile '{profile_name}' are malformed: {error}"
+            ))
+        })?;
+        if document.version != 1 {
+            return Err(TonkWorkerError::Internal(format!(
+                "unsupported space suppression version {} for profile '{profile_name}'",
+                document.version
+            )));
+        }
+        Ok(document.subjects)
+    }
+
+    async fn write_space_suppressions(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        profile_name: &str,
+        subjects: BTreeSet<String>,
+    ) -> Result<(), TonkWorkerError> {
+        let bytes = serde_json::to_vec(&SpaceSuppressionsV1 {
+            version: 1,
+            subjects,
+        })
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to serialize space suppressions: {error}"))
+        })?;
+        let registry = self.open_self(storage).await?;
+        registry
+            .credential()
+            .site(format!("{SPACE_SUPPRESSIONS_SITE_PREFIX}{profile_name}"))
+            .save(bytes)
+            .perform(storage)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to save space suppressions for profile '{profile_name}': {error}"
+                ))
+            })
+    }
+
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        allow(dead_code)
+    )]
+    pub(crate) async fn suppress_space(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        profile_name: &str,
+        subject: &str,
+    ) -> Result<(), TonkWorkerError> {
+        let mut subjects = self.read_space_suppressions(storage, profile_name).await?;
+        subjects.insert(subject.to_string());
+        self.write_space_suppressions(storage, profile_name, subjects)
+            .await
+    }
+
+    pub(crate) async fn unsuppress_space(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        profile_name: &str,
+        subject: &str,
+    ) -> Result<(), TonkWorkerError> {
+        let mut subjects = self.read_space_suppressions(storage, profile_name).await?;
+        if subjects.remove(subject) {
+            self.write_space_suppressions(storage, profile_name, subjects)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Generate a fresh profile and make it the active one.
     pub(crate) async fn rotate(
         &self,
@@ -450,6 +568,138 @@ mod tests {
             "the entry keeps its position and takes the new value"
         );
         assert_eq!(roster[1].profile_name, "two");
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_space_suppressions_disjoint_between_profiles() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        registry
+            .suppress_space(&storage, "profile-one", "did:key:space-one")
+            .await
+            .unwrap();
+        registry
+            .suppress_space(&storage, "profile-two", "did:key:space-two")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry
+                .read_space_suppressions(&storage, "profile-one")
+                .await
+                .unwrap(),
+            ["did:key:space-one".to_string()].into_iter().collect()
+        );
+        assert_eq!(
+            registry
+                .read_space_suppressions(&storage, "profile-two")
+                .await
+                .unwrap(),
+            ["did:key:space-two".to_string()].into_iter().collect()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reads_absent_suppressions_as_empty_and_round_trips_updates() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+
+        assert!(
+            registry
+                .read_space_suppressions(&storage, "profile")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        registry
+            .suppress_space(&storage, "profile", "did:key:space-one")
+            .await
+            .unwrap();
+        registry
+            .suppress_space(&storage, "profile", "did:key:space-two")
+            .await
+            .unwrap();
+        registry
+            .unsuppress_space(&storage, "profile", "did:key:space-one")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry
+                .read_space_suppressions(&storage, "profile")
+                .await
+                .unwrap(),
+            ["did:key:space-two".to_string()].into_iter().collect()
+        );
+    }
+
+    async fn save_raw_suppressions(
+        registry: &Registry,
+        storage: &Storage<DefaultSpace>,
+        profile_name: &str,
+        bytes: &[u8],
+    ) {
+        registry
+            .open_self(storage)
+            .await
+            .unwrap()
+            .credential()
+            .site(format!("{SPACE_SUPPRESSIONS_SITE_PREFIX}{profile_name}"))
+            .save(bytes.to_vec())
+            .perform(storage)
+            .await
+            .unwrap();
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_closed_on_corrupt_space_suppressions() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        save_raw_suppressions(&registry, &storage, "profile", b"not-json").await;
+
+        let error = registry
+            .read_space_suppressions(&storage, "profile")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("malformed"), "{error}");
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_closed_on_unknown_suppression_versions_or_fields() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        save_raw_suppressions(
+            &registry,
+            &storage,
+            "profile",
+            br#"{"version":2,"subjects":[]}"#,
+        )
+        .await;
+
+        let version_error = registry
+            .read_space_suppressions(&storage, "profile")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(version_error.contains("unsupported"), "{version_error}");
+
+        save_raw_suppressions(
+            &registry,
+            &storage,
+            "profile",
+            br#"{"version":1,"subjects":[],"future":true}"#,
+        )
+        .await;
+        let field_error = registry
+            .read_space_suppressions(&storage, "profile")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(field_error.contains("unknown field"), "{field_error}");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -23,6 +23,9 @@ mod customer;
 pub(crate) mod account_state;
 pub use account_state::AccountKeys;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) mod account_reconcile;
+mod account_spaces;
 mod http;
 
 pub(crate) mod adopt;
@@ -173,6 +176,15 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route("/api/custody/provision", post(customer::provision_custody))
         .route("/api/account/devices", get(account_devices::list))
         .route("/api/account/summary", get(account_devices::summary))
+        .route("/api/account/spaces", get(account_spaces::list))
+        .route(
+            "/api/account/spaces/{subject}/download",
+            post(account_spaces::download),
+        )
+        .route(
+            "/api/account/spaces/{subject}/archive",
+            post(account_spaces::archive),
+        )
         .route(
             "/api/account/devices/register",
             post(account_devices::register),

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -3,6 +3,7 @@
 
 use axum::{Json, extract::State};
 use axum_wasm_macros::wasm_compat;
+use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
 use tonk_account::{AccountProviderRecord, AccountRepositoryDescriptorV1, AccountStateStatus};
@@ -15,6 +16,114 @@ use super::AppState;
 use crate::TonkWorkerError;
 
 const ACCOUNT_PROVIDER_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE;
+const ACCOUNT_DEPLOYMENT_SITE: &str = "tonk-account-deployment-v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AccountDeploymentDefaultsV1 {
+    version: u8,
+    pub(crate) access_remote: Option<String>,
+    pub(crate) revocation_relay: Option<String>,
+}
+
+fn validate_deployment_url(label: &str, value: &str) -> Result<(), TonkWorkerError> {
+    let url = url::Url::parse(value)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid {label}: {error}")))?;
+    let loopback = url
+        .host_str()
+        .is_some_and(|host| host == "localhost" || host == "127.0.0.1" || host == "::1");
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        return Err(TonkWorkerError::Router(format!(
+            "{label} must use HTTPS (loopback HTTP is allowed for local development)"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod deployment_url_tests {
+    use super::validate_deployment_url;
+
+    #[test]
+    fn it_accepts_https_and_loopback_http_deployment_defaults() {
+        assert!(validate_deployment_url("remote", "https://sync.example/ucan/").is_ok());
+        assert!(validate_deployment_url("remote", "http://127.0.0.1:8787/ucan/").is_ok());
+        assert!(validate_deployment_url("remote", "http://localhost:8787/ucan/").is_ok());
+        assert!(validate_deployment_url("remote", "http://sync.example/ucan/").is_err());
+        assert!(validate_deployment_url("remote", "relative").is_err());
+    }
+}
+
+async fn save_deployment_defaults(
+    state: &crate::worker::TonkState,
+    request: &AccountLinkRequest,
+) -> Result<(), TonkWorkerError> {
+    if let Some(remote) = request.access_remote.as_deref() {
+        validate_deployment_url("access remote", remote)?;
+    }
+    if let Some(relay) = request.revocation_relay.as_deref() {
+        validate_deployment_url("revocation relay", relay)?;
+    }
+    if request.access_remote.is_none() && request.revocation_relay.is_none() {
+        return Ok(());
+    }
+    let bytes = serde_json::to_vec(&AccountDeploymentDefaultsV1 {
+        version: 1,
+        access_remote: request.access_remote.clone(),
+        revocation_relay: request.revocation_relay.clone(),
+    })
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("serialize account deployment defaults: {error}"))
+    })?;
+    state
+        .profile
+        .credential()
+        .site(ACCOUNT_DEPLOYMENT_SITE)
+        .save(bytes)
+        .perform(&state.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("save account deployment defaults: {error}"))
+        })
+}
+
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    allow(dead_code)
+)]
+pub(crate) async fn deployment_defaults(
+    state: &crate::worker::TonkState,
+) -> Result<Option<AccountDeploymentDefaultsV1>, TonkWorkerError> {
+    let bytes = match state
+        .profile
+        .credential()
+        .site(ACCOUNT_DEPLOYMENT_SITE)
+        .load::<Vec<u8>>()
+        .perform(&state.operator)
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(error) if crate::credential::is_missing(&error) => return Ok(None),
+        Err(error) => {
+            return Err(TonkWorkerError::Internal(format!(
+                "load account deployment defaults: {error}"
+            )));
+        }
+    };
+    let defaults: AccountDeploymentDefaultsV1 =
+        serde_json::from_slice(&bytes).map_err(|error| {
+            TonkWorkerError::Internal(format!(
+                "stored account deployment defaults are invalid: {error}"
+            ))
+        })?;
+    if defaults.version != 1 {
+        return Err(TonkWorkerError::Internal(format!(
+            "unsupported account deployment defaults version {}",
+            defaults.version
+        )));
+    }
+    Ok(Some(defaults))
+}
 
 /// Map an attachment failure onto the router's error taxonomy. A rejected
 /// descriptor is the caller presenting the wrong account's bytes, not a local
@@ -352,6 +461,7 @@ pub(crate) async fn persist_link(
             ));
         }
     }
+    save_deployment_defaults(state, request).await?;
     save_provider(state, &record).await?;
     // This profile now has an account repository to keep hidden.
     state.account_keys.invalidate();
@@ -382,6 +492,8 @@ pub async fn link(
     // so what gets backed up is the account-rooted authority.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     super::repository::adopt_profile_spaces(&state).await;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    crate::router::account_reconcile::reconcile(&state).await;
 
     // Roster upkeep: this profile just became an account row. The email
     // comes best-effort from the provider; a failed fetch leaves it
@@ -445,6 +557,8 @@ pub(crate) async fn tests_matching_request(
         delegation_hex: hex::encode(root.bytes),
         descriptor_hex: hex::encode(descriptor.bytes()),
         initialize_name: false,
+        access_remote: None,
+        revocation_relay: None,
     }
 }
 

--- a/rust/tonk-worker/src/router/account_reconcile.rs
+++ b/rust/tonk-worker/src/router/account_reconcile.rs
@@ -1,0 +1,411 @@
+//! Bounded, retryable browser enrollment for locally mounted spaces.
+
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+use dialog_repository::RepositoryExt as _;
+use dialog_varsig::Did;
+use serde::{Deserialize, Serialize};
+use tonk_common::log;
+use tonk_worker_api::AccountSpaceEnrollment;
+
+use crate::TonkWorkerError;
+use crate::worker::TonkState;
+
+static RECONCILE_IN_FLIGHT: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+const ENROLLMENT_PREFIX: &str = "tonk-account-enrollment-v1/";
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EnrollmentRecord {
+    version: u8,
+    subject: String,
+    phase: AccountSpaceEnrollment,
+    #[serde(default)]
+    connected: bool,
+    error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RemotePlan {
+    Preserve,
+    AddDefaultRelay,
+    ProvisionDefaults,
+}
+
+fn remote_plan(
+    execution: &super::create_invite::ConfiguredRemoteRequirement,
+    has_default_relay: bool,
+) -> Result<RemotePlan, super::create_invite::RemoteRefusal> {
+    match execution {
+        super::create_invite::ConfiguredRemoteRequirement::Ready(remote)
+            if remote.revocation_url.is_none() && has_default_relay =>
+        {
+            Ok(RemotePlan::AddDefaultRelay)
+        }
+        super::create_invite::ConfiguredRemoteRequirement::Ready(_) => Ok(RemotePlan::Preserve),
+        super::create_invite::ConfiguredRemoteRequirement::Refused(
+            super::create_invite::RemoteRefusal::NotSynced,
+        ) => Ok(RemotePlan::ProvisionDefaults),
+        super::create_invite::ConfiguredRemoteRequirement::Refused(reason) => Err(*reason),
+    }
+}
+
+async fn save_status(
+    tonk: &TonkState,
+    subject: &str,
+    phase: AccountSpaceEnrollment,
+    error: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    let bytes = serde_json::to_vec(&EnrollmentRecord {
+        version: 1,
+        subject: subject.to_owned(),
+        phase,
+        connected: phase == AccountSpaceEnrollment::Connected,
+        error: error.map(str::to_owned),
+    })
+    .map_err(|error| TonkWorkerError::Internal(format!("serialize enrollment state: {error}")))?;
+    tonk.profile
+        .credential()
+        .site(format!("{ENROLLMENT_PREFIX}{subject}"))
+        .save(bytes)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("save enrollment state: {error}")))
+}
+
+async fn reconcile_one(
+    tonk: &TonkState,
+    account: &Did,
+    account_key: &str,
+    key: &str,
+    default_remote: &str,
+    default_relay: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    let repository = tonk
+        .profile
+        .repository(key)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("load enrollment target: {error}")))?;
+    let subject = repository.did();
+    let subject_text = subject.to_string();
+    save_status(
+        tonk,
+        &subject_text,
+        AccountSpaceEnrollment::Provisioning,
+        None,
+    )
+    .await?;
+
+    let mut execution =
+        super::create_invite::resolve_configured_remote_url(tonk, &repository).await?;
+    match remote_plan(&execution, default_relay.is_some()) {
+        Ok(RemotePlan::AddDefaultRelay) => {
+            let super::create_invite::ConfiguredRemoteRequirement::Ready(remote) = &execution
+            else {
+                unreachable!("relay augmentation requires a configured remote")
+            };
+            super::repository::ensure_account_remote(
+                tonk,
+                key,
+                remote.access_url.as_str(),
+                default_relay,
+            )
+            .await?;
+            execution =
+                super::create_invite::resolve_configured_remote_url(tonk, &repository).await?;
+        }
+        Ok(RemotePlan::Preserve) => {}
+        Ok(RemotePlan::ProvisionDefaults) => {
+            super::repository::ensure_account_remote(tonk, key, default_remote, default_relay)
+                .await?;
+            execution =
+                super::create_invite::resolve_configured_remote_url(tonk, &repository).await?;
+        }
+        Err(reason) => {
+            return Err(TonkWorkerError::Conflict(format!(
+                "existing upstream is not eligible for automatic enrollment: {}",
+                reason.code()
+            )));
+        }
+    }
+    let super::create_invite::ConfiguredRemoteRequirement::Ready(remote) = execution else {
+        return Err(TonkWorkerError::Conflict(
+            "space has no usable remote after enrollment".to_string(),
+        ));
+    };
+
+    save_status(
+        tonk,
+        &subject_text,
+        AccountSpaceEnrollment::PendingPush,
+        None,
+    )
+    .await?;
+    let content = tonk
+        .reactor
+        .repository(key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("open content branch: {error}")))?;
+    tonk.reactor
+        .repository(key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .push()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("push content branch: {error}")))?;
+    let tree = content
+        .handle()
+        .revision()
+        .ok_or_else(|| TonkWorkerError::Internal("content branch has no confirmed head".into()))?
+        .tree
+        .to_string();
+
+    let account_branch = tonk
+        .reactor
+        .repository(account_key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("open account branch: {error}")))?;
+    let prefix = super::repository::space_root_prefix(tonk, &subject).await?;
+    let retained = tonk_account::delegations::retain_space_delegation(
+        account_branch.handle(),
+        &prefix,
+        &tonk.operator,
+    )
+    .await
+    .map_err(|error| TonkWorkerError::Internal(format!("retain space authority: {error}")))?;
+    if retained {
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        tonk.sync_queue.mark_dirty(account_key, js_sys::Date::now());
+    }
+    let name = super::repository::repository_label(tonk, &repository, key).await;
+    let remote_url = remote.access_url.to_string();
+    let revocation_url = remote.revocation_url.as_ref().map(ToString::to_string);
+    tonk_schema::account::record_active_account_space(
+        account_branch.handle(),
+        tonk_schema::account::AccountSpaceInput {
+            account: account.clone(),
+            subject: subject.clone(),
+            name: Some(name.clone()),
+            remote_url: Some(remote_url.clone()),
+            revocation_url: revocation_url.clone(),
+            confirmed_revision: Some(tree.clone()),
+        },
+        &tonk.operator,
+    )
+    .await
+    .map_err(|error| TonkWorkerError::Conflict(error.to_string()))?;
+    let configuration = super::repository::space_config(&remote_url, revocation_url.as_deref())
+        .map_err(|error| TonkWorkerError::Internal(error.to_string()))?;
+    super::repository::record_space_mount(tonk, &subject, &configuration, Some(name.as_str()))
+        .await;
+    tonk.reactor
+        .repository(account_key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .push()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("push account membership: {error}")))?;
+    save_status(tonk, &subject_text, AccountSpaceEnrollment::Connected, None).await?;
+    Ok(())
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod planning_tests {
+    use super::*;
+    use url::Url;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    fn ready(
+        url: &str,
+        relay: Option<&str>,
+    ) -> crate::router::create_invite::ConfiguredRemoteRequirement {
+        crate::router::create_invite::ConfiguredRemoteRequirement::Ready(
+            crate::router::create_invite::ConfiguredRemoteExecutionUrls {
+                access_url: Url::parse(url).unwrap(),
+                revocation_url: relay.map(|relay| Url::parse(relay).unwrap()),
+            },
+        )
+    }
+
+    #[dialog_common::test]
+    async fn it_converges_pre_account_local_spaces_after_attachment() {
+        let custom = ready(
+            "https://custom.example/ucan/",
+            Some("https://custom.example/revocations/"),
+        );
+        assert_eq!(remote_plan(&custom, true), Ok(RemotePlan::Preserve));
+
+        let custom_without_relay = ready("https://custom.example/ucan/", None);
+        assert_eq!(
+            remote_plan(&custom_without_relay, true),
+            Ok(RemotePlan::AddDefaultRelay),
+            "the existing content upstream is preserved while only missing metadata is added"
+        );
+        assert_eq!(
+            remote_plan(
+                &crate::router::create_invite::ConfiguredRemoteRequirement::Refused(
+                    crate::router::create_invite::RemoteRefusal::NotSynced,
+                ),
+                true,
+            ),
+            Ok(RemotePlan::ProvisionDefaults),
+            "only a space with no upstream is provisioned from deployment defaults"
+        );
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod retry_tests {
+    use super::*;
+    use dialog_repository::RepositoryExt as _;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[dialog_common::test]
+    async fn it_retries_remote_attachment_after_create_failure() {
+        let state = crate::router::tests::test_state().await;
+        let (app, shared, _lsp) = crate::router::api_router_with_state(state);
+        let key = crate::router::tests::put_repo(&app, "retry-enrollment").await;
+        let tonk = shared.read().await;
+        let repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        let subject = repository.did().to_string();
+        let revision = tonk
+            .reactor
+            .repository(&key)
+            .branch(tonk_account::MAIN_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .unwrap()
+            .handle()
+            .revision();
+
+        save_status(
+            &tonk,
+            &subject,
+            AccountSpaceEnrollment::Error,
+            Some("provision: create remote failed"),
+        )
+        .await
+        .unwrap();
+        save_status(&tonk, &subject, AccountSpaceEnrollment::Provisioning, None)
+            .await
+            .unwrap();
+        save_status(&tonk, &subject, AccountSpaceEnrollment::PendingPush, None)
+            .await
+            .unwrap();
+
+        let retry_repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        assert_eq!(retry_repository.did().to_string(), subject);
+        assert_eq!(
+            tonk.reactor
+                .repository(&key)
+                .branch(tonk_account::MAIN_BRANCH)
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .revision(),
+            revision,
+            "retry state must not create or rewrite the local space"
+        );
+        let bytes = tonk
+            .profile
+            .credential()
+            .site(format!("{ENROLLMENT_PREFIX}{subject}"))
+            .load::<Vec<u8>>()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        let record: EnrollmentRecord = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(record.subject, subject);
+        assert_eq!(record.phase, AccountSpaceEnrollment::PendingPush);
+        assert!(!record.connected);
+    }
+}
+
+/// Run one coalesced, bounded pass for the currently active profile.
+pub(crate) async fn reconcile(tonk: &TonkState) {
+    {
+        let mut in_flight = RECONCILE_IN_FLIGHT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !in_flight.insert(tonk.profile_name.clone()) {
+            return;
+        }
+    }
+    let result = async {
+        let Some(defaults) = super::account::deployment_defaults(tonk).await? else {
+            return Ok::<(), TonkWorkerError>(());
+        };
+        let Some(default_remote) = defaults.access_remote.as_deref() else {
+            return Ok(());
+        };
+        let ready = super::account_state::require_ready_account_state(tonk).await?;
+        for key in super::profile_name::real_space_keys(tonk)
+            .await
+            .into_iter()
+            .take(32)
+        {
+            if let Err(error) = reconcile_one(
+                tonk,
+                &ready.subject,
+                &ready.key,
+                &key,
+                default_remote,
+                defaults.revocation_relay.as_deref(),
+            )
+            .await
+            {
+                let subject = tonk
+                    .profile
+                    .repository(&key)
+                    .load()
+                    .perform(&tonk.operator)
+                    .await
+                    .map(|repository| repository.did().to_string())
+                    .unwrap_or(key.clone());
+                let message = error.to_string();
+                let _ = save_status(
+                    tonk,
+                    &subject,
+                    AccountSpaceEnrollment::Error,
+                    Some(&message),
+                )
+                .await;
+                log!("account enrollment of '{key}' remains pending: {error}");
+            }
+        }
+        Ok(())
+    }
+    .await;
+    if let Err(error) = result {
+        log!("account enrollment pass skipped: {error}");
+    }
+    RECONCILE_IN_FLIGHT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&tonk.profile_name);
+}

--- a/rust/tonk-worker/src/router/account_spaces.rs
+++ b/rust/tonk-worker/src/router/account_spaces.rs
@@ -1,0 +1,311 @@
+//! Browser account-space discovery, explicit download, and archive routes.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use axum_wasm_macros::wasm_compat;
+use dialog_varsig::Did;
+use serde::Deserialize;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_worker_api::{
+    AccountSpaceArchiveResponse, AccountSpaceDownloadResponse, AccountSpaceEnrollment,
+    AccountSpaceMembership, AccountSpaceRow, AccountSpaceVisibility,
+};
+
+use super::AppState;
+use crate::TonkWorkerError;
+use crate::worker::TonkState;
+
+const ENROLLMENT_PREFIX: &str = "tonk-account-enrollment-v1/";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EnrollmentRecord {
+    version: u8,
+    subject: String,
+    phase: AccountSpaceEnrollment,
+    #[serde(default)]
+    connected: bool,
+    error: Option<String>,
+}
+
+fn decode_enrollment(bytes: &[u8], subject: &str) -> (AccountSpaceEnrollment, Option<String>) {
+    match serde_json::from_slice::<EnrollmentRecord>(bytes) {
+        Ok(record)
+            if record.version == 1
+                && record.subject == subject
+                && record.connected == (record.phase == AccountSpaceEnrollment::Connected) =>
+        {
+            (record.phase, record.error)
+        }
+        Ok(_) => (
+            AccountSpaceEnrollment::Error,
+            Some("enrollment state has an unsupported version or subject".to_string()),
+        ),
+        Err(error) => (AccountSpaceEnrollment::Error, Some(error.to_string())),
+    }
+}
+
+async fn enrollment(tonk: &TonkState, subject: &str) -> (AccountSpaceEnrollment, Option<String>) {
+    let bytes = match tonk
+        .profile
+        .credential()
+        .site(format!("{ENROLLMENT_PREFIX}{subject}"))
+        .load::<Vec<u8>>()
+        .perform(&tonk.operator)
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(error) if crate::credential::is_missing(&error) => {
+            return (AccountSpaceEnrollment::LocalOnly, None);
+        }
+        Err(error) => {
+            return (AccountSpaceEnrollment::Error, Some(error.to_string()));
+        }
+    };
+    decode_enrollment(&bytes, subject)
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod enrollment_tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[dialog_common::test]
+    async fn it_decodes_durable_pending_and_error_enrollment_states() {
+        let pending = br#"{
+            "version": 1,
+            "subject": "did:key:space",
+            "phase": "pendingPush",
+            "connected": false,
+            "error": null
+        }"#;
+        assert_eq!(
+            decode_enrollment(pending, "did:key:space"),
+            (AccountSpaceEnrollment::PendingPush, None)
+        );
+
+        let failed = br#"{
+            "version": 1,
+            "subject": "did:key:space",
+            "phase": "error",
+            "connected": false,
+            "error": "push failed"
+        }"#;
+        assert_eq!(
+            decode_enrollment(failed, "did:key:space"),
+            (
+                AccountSpaceEnrollment::Error,
+                Some("push failed".to_string())
+            )
+        );
+        assert_eq!(
+            decode_enrollment(pending, "did:key:other").0,
+            AccountSpaceEnrollment::Error
+        );
+        assert_eq!(
+            decode_enrollment(b"not json", "did:key:space").0,
+            AccountSpaceEnrollment::Error
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_failures_pending_without_false_recovery() {
+        for (step, message) in [
+            ("provision", "create remote failed"),
+            ("push", "content push failed"),
+            ("account-push", "account push failed"),
+            ("project", "provider projection failed"),
+        ] {
+            let bytes = serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "subject": "did:key:space",
+                "phase": "error",
+                "connected": false,
+                "error": format!("{step}: {message}"),
+            }))
+            .unwrap();
+            let (phase, error) = decode_enrollment(&bytes, "did:key:space");
+            assert_eq!(phase, AccountSpaceEnrollment::Error);
+            assert!(error.as_deref().is_some_and(|error| error.contains(step)));
+        }
+
+        let false_recovery = br#"{
+            "version": 1,
+            "subject": "did:key:space",
+            "phase": "connected",
+            "connected": false,
+            "error": null
+        }"#;
+        assert_eq!(
+            decode_enrollment(false_recovery, "did:key:space").0,
+            AccountSpaceEnrollment::Error,
+            "a phase label alone must not claim recovery"
+        );
+    }
+}
+
+async fn canonical_rows(
+    tonk: &TonkState,
+) -> Result<
+    (
+        dialog_varsig::Did,
+        Vec<tonk_schema::account::AccountSpaceRecord>,
+    ),
+    TonkWorkerError,
+> {
+    let ready = super::account_state::require_ready_account_state(tonk).await?;
+    let branch = tonk
+        .reactor
+        .repository(&ready.key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("open account-space branch: {error}"))
+        })?;
+    let rows = tonk_schema::account::list_account_spaces(branch.handle(), &tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("read account spaces: {error}")))?;
+    Ok((ready.subject, rows))
+}
+
+async fn inventory(tonk: &TonkState) -> Result<Vec<AccountSpaceRow>, TonkWorkerError> {
+    let (_account, canonical) = canonical_rows(tonk).await?;
+    let suppressions = tonk
+        .registry
+        .read_space_suppressions(&tonk.storage, &tonk.profile_name)
+        .await?;
+    let mut rows = Vec::new();
+
+    for record in canonical {
+        let subject_text = record.subject.to_string();
+        let local = super::join::find_replica_for_subject(tonk, &record.subject).await?;
+        let hidden = suppressions.contains(&subject_text);
+        let authority = super::repository::space_root_prefix(tonk, &record.subject)
+            .await
+            .is_ok();
+        let mountable = super::adopt::directory_configuration(tonk, &record.subject)
+            .await
+            .is_some();
+        let pullable = !record.archived && !local && authority && mountable;
+        let (enrollment, enrollment_error) = enrollment(tonk, &subject_text).await;
+        rows.push(AccountSpaceRow {
+            version: 1,
+            subject: subject_text,
+            name: record.name,
+            membership: if record.archived {
+                AccountSpaceMembership::Archived
+            } else {
+                AccountSpaceMembership::Active
+            },
+            local,
+            visibility: if hidden {
+                AccountSpaceVisibility::HiddenOnThisDevice
+            } else {
+                AccountSpaceVisibility::Visible
+            },
+            remote_url: record.remote_url,
+            confirmed_revision: record.confirmed_revision,
+            pullable,
+            enrollment,
+            enrollment_error,
+        });
+    }
+
+    rows.sort_by(|left, right| left.subject.cmp(&right.subject));
+    Ok(rows)
+}
+
+/// List canonical account spaces without mounting account-only rows.
+#[wasm_compat]
+pub async fn list(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<AccountSpaceRow>>, TonkWorkerError> {
+    let tonk = state.read().await;
+    Ok(Json(inventory(&tonk).await?))
+}
+
+/// Explicitly download one active account space.
+#[wasm_compat]
+pub async fn download(
+    State(state): State<AppState>,
+    Path(subject): Path<String>,
+) -> Result<Json<AccountSpaceDownloadResponse>, TonkWorkerError> {
+    let subject_did: Did = subject
+        .parse()
+        .map_err(|error| TonkWorkerError::Router(format!("invalid space subject: {error:?}")))?;
+    let tonk = state.read().await;
+    let active = canonical_rows(&tonk)
+        .await?
+        .1
+        .into_iter()
+        .any(|record| record.subject == subject_did && !record.archived);
+    if !active {
+        return Err(TonkWorkerError::Conflict(format!(
+            "account space '{subject}' is unknown or archived"
+        )));
+    }
+    if !super::adopt::ensure_space_mounted(&tonk, subject_did.as_ref()).await? {
+        return Err(TonkWorkerError::NotFound(format!(
+            "account space '{subject}' has no mountable directory record"
+        )));
+    }
+    tonk.registry
+        .unsuppress_space(&tonk.storage, &tonk.profile_name, subject_did.as_ref())
+        .await?;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    super::account_reconcile::reconcile(&tonk).await;
+    Ok(Json(AccountSpaceDownloadResponse {
+        subject,
+        local: true,
+    }))
+}
+
+/// Commit a monotonic canonical archive, then project it best-effort.
+#[wasm_compat]
+pub async fn archive(
+    State(state): State<AppState>,
+    Path(subject): Path<String>,
+) -> Result<Json<AccountSpaceArchiveResponse>, TonkWorkerError> {
+    let subject_did: Did = subject
+        .parse()
+        .map_err(|error| TonkWorkerError::Router(format!("invalid space subject: {error:?}")))?;
+    let tonk = state.read().await;
+    let (account, _) = canonical_rows(&tonk).await?;
+    let ready = super::account_state::require_ready_account_state(&tonk).await?;
+    let branch = tonk
+        .reactor
+        .repository(&ready.key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("open account-space branch: {error}"))
+        })?;
+    let newly_archived = tonk_schema::account::archive_account_space(
+        branch.handle(),
+        &account,
+        &subject_did,
+        &tonk.operator,
+    )
+    .await
+    .map_err(|error| TonkWorkerError::Conflict(error.to_string()))?;
+    tonk.reactor
+        .repository(&ready.key)
+        .branch(tonk_account::MAIN_BRANCH)
+        .push()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("push account archive: {error}")))?;
+
+    Ok(Json(AccountSpaceArchiveResponse {
+        subject,
+        newly_archived,
+        warning: None,
+    }))
+}

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1489,6 +1489,8 @@ mod tests {
                 delegation_hex,
                 descriptor_hex: hex::encode(descriptor.bytes()),
                 initialize_name: false,
+                access_remote: None,
+                revocation_relay: None,
             },
         )
         .await

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -573,6 +573,19 @@ where
     }
 }
 
+/// Probe `main` for the configured content endpoint, whether or not it has a
+/// revocation relay suitable for invitations.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn resolve_configured_remote_url<R>(
+    tonk: &crate::worker::TonkState,
+    repository: &dialog_repository::Repository<R>,
+) -> Result<ConfiguredRemoteRequirement, TonkWorkerError>
+where
+    R: Principal + Clone,
+{
+    resolve_configured_remote_url_with(repository, &tonk.operator).await
+}
+
 /// Probe `main` for an invite-ready endpoint. Unlike generic sync and account
 /// backup, invites require an explicit revocation relay.
 pub(crate) async fn resolve_remote_url<R>(

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -594,14 +594,22 @@ pub async fn join(
     State(state): State<AppState>,
     Json(body): Json<JoinRequest>,
 ) -> Result<(StatusCode, Json<JoinResponse>), TonkWorkerError> {
-    let tonk = state.write().await;
-    let outcome = join_invite(&tonk, &body.url, JoinMode::Durable).await?;
-    log!(
-        "POST /api/profile/join -> subject {} (key {})",
-        outcome.subject,
-        outcome.key
-    );
-    joined_response(&tonk, outcome).await
+    let response = {
+        let tonk = state.write().await;
+        let outcome = join_invite(&tonk, &body.url, JoinMode::Durable).await?;
+        log!(
+            "POST /api/profile/join -> subject {} (key {})",
+            outcome.subject,
+            outcome.key
+        );
+        joined_response(&tonk, outcome).await?
+    };
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let tonk = state.read().await;
+        super::account_reconcile::reconcile(&tonk).await;
+    }
+    Ok(response)
 }
 
 /// Load the committed replica and shape the route's success body.

--- a/rust/tonk-worker/src/router/profiles.rs
+++ b/rust/tonk-worker/src/router/profiles.rs
@@ -266,6 +266,7 @@ async fn finish_swap(
         wasm_bindgen_futures::spawn_local(async move {
             let tonk = state.read().await;
             super::account_state::ensure_account_state(&tonk).await;
+            super::account_reconcile::reconcile(&tonk).await;
         });
     }
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -22,7 +22,6 @@ use dialog_repository::{
     RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
 };
 use dialog_ucan::UcanDelegation;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use dialog_ucan_core::DelegationChain;
 use dialog_varsig::{Did, Principal};
 use serde::{Deserialize, Serialize};
@@ -1831,6 +1830,12 @@ pub(crate) async fn remove_space_inner(
         {
             return Err(RepositoryError::Internal(error.to_string()));
         }
+        // Persist the device-local restore veto before hiding the replica.
+        // If this write fails, the visible local registration remains intact.
+        tonk.registry
+            .suppress_space(&tonk.storage, &tonk.profile_name, &subject.to_string())
+            .await
+            .map_err(|error| RepositoryError::Internal(error.to_string()))?;
         remove_replica_from_profile(&tonk, subject).await?;
         // Drain the poll the retraction scheduled so the Hub's meta
         // subscription reflects the removal (mirrors set_replica_status).
@@ -2198,7 +2203,7 @@ async fn run_pause_sync(
 /// Shared by [`enable_sync_inner`] (called for both the create and
 /// enable-sync forms) so they produce an identical remote shape.
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
-fn space_config(
+pub(crate) fn space_config(
     remote: &str,
     revocation_url: Option<&str>,
 ) -> Result<RepositoryConfiguration, RepositoryError> {
@@ -2550,6 +2555,8 @@ async fn seed_and_initialize(
         set_replica_status(&tonk, subject, Replica::initialized_status()).await?;
     }
     log!("Repository '{}' initialized", key);
+    let tonk = state.read().await;
+    super::account_reconcile::reconcile(&tonk).await;
     Ok(())
 }
 
@@ -2832,7 +2839,6 @@ pub async fn create_repository(
 }
 
 /// Load the exact provider-neutral `space → root` prefix persisted at creation.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) async fn space_root_prefix(
     tonk: &TonkState,
     subject: &Did,
@@ -3671,7 +3677,11 @@ const CONTENT_BRANCH: &str = "main";
 /// visible everywhere the content branch syncs. Falls back to the
 /// routing `key` when the content branch can't be opened or carries no
 /// name yet (a freshly created repo before its name is seeded).
-async fn repository_label<R>(tonk: &TonkState, repository: &Repository<R>, key: &str) -> String
+pub(crate) async fn repository_label<R>(
+    tonk: &TonkState,
+    repository: &Repository<R>,
+    key: &str,
+) -> String
 where
     R: Principal + Clone,
 {
@@ -4381,6 +4391,30 @@ where
     }
 
     Ok(effective)
+}
+
+/// Attach the deployment default only when reconciliation has already
+/// established that this repository has no usable upstream.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn ensure_account_remote(
+    tonk: &TonkState,
+    key: &str,
+    remote: &str,
+    revocation_url: Option<&str>,
+) -> Result<(), RepositoryError> {
+    let repository = tonk
+        .profile
+        .repository(key)
+        .load()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| {
+            RepositoryError::Internal(format!("failed to load account enrollment target: {error}"))
+        })?;
+    let configuration = space_config(remote, revocation_url)?;
+    ensure_remote_config(tonk, &repository, key, &configuration)
+        .await
+        .map(|_| ())
 }
 
 /// Attach remotes (and branch upstreams) to an **existing**
@@ -5180,6 +5214,14 @@ mod tests {
         );
         {
             let tonk = state.read().await;
+            assert!(
+                tonk.registry
+                    .read_space_suppressions(&tonk.storage, &tonk.profile_name)
+                    .await
+                    .expect("suppression record loads")
+                    .contains(&subject.to_string()),
+                "removal must persist suppression before retracting the replica"
+            );
             assert!(
                 !tonk.reactor.repos().read().contains_key(&key),
                 "the repo must be evicted from the reactor cache"

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -1284,6 +1284,15 @@ pub async fn drain_sync(state: &AppState) {
             log!("drain_sync: account state did not fully reconcile: {error}");
         }
     }
+
+    // The same drain is used by confirmed pushes, connectivity recovery, and
+    // visibility recovery. Retry account enrollment only after that work has
+    // settled; the reconciler is profile-coalesced and remains best-effort.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let tonk = state.read().await;
+        super::account_reconcile::reconcile(&tonk).await;
+    }
 }
 
 /// How long before a guest delegation lapses it is replayed.

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1831,6 +1831,7 @@ impl TonkServiceWorker {
                 // Overlay locality stamps for the Hub's hollow-spot
                 // styling — device-local, re-stamped every boot.
                 crate::router::adopt::stamp_local_spaces(&tonk).await;
+                crate::router::account_reconcile::reconcile(&tonk).await;
             });
         }
 


### PR DESCRIPTION
## Summary

- add a durable native account-profile registry with add, use, login, list, status, logout, and sync lifecycle commands
- isolate identity, account session, spot inventory, bindings, and account-backed operations per profile while preserving legacy bootstrap behavior
- reconcile per-profile spaces and deployment defaults, including the current callback login and sync-service registration flow from staging

## Testing

- RUST_TEST_THREADS=1 cargo test -p tonk-cli --features integration-tests
- RUST_TEST_THREADS=1 cargo test -p tonk-cli
- cargo clippy -p tonk-cli --all-targets --features integration-tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Limitations

- browser approval ceremonies and hosted provider deployments were not exercised; coverage is local unit and integration testing

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `tonk-cli` tool by introducing new features, improving account management, and refining the handling of profiles and deployments. It adds new modules and functions to manage account states and improve integration tests.

### Detailed summary
- Added `tonk-worker-api` dependency to `Cargo.lock`.
- Introduced `root` function in `rust/tonk-cli/src/spot.rs`.
- Added `account_profiles` module in `rust/tonk-cli/src/lib.rs`.
- Added `DEAD_RELAY` constant for integration tests in `rust/tonk-cli/tests/cli_spot.rs`.
- Enhanced account management functions to support profile-specific operations.
- Updated `account` functions to accept `SpotStore` for better state management.
- Improved telemetry handling in `rust/tonk-cli/src/telemetry.rs`.
- Enhanced error handling and logging in various modules.
- Added new tests for account profiles and integration scenarios in `rust/tonk-cli/tests/`.
- Improved documentation and comments for clarity throughout the codebase.

> The following files were skipped due to too many changes: `rust/tonk-cli/src/site.rs`, `rust/tonk-cli/src/account_sync.rs`, `rust/tonk-cli/tests/account_profiles.rs`, `rust/tonk-cli/src/account.rs`, `rust/tonk-cli/src/account_profiles.rs`, `rust/tonk-cli/src/bin/tonk.rs`, `plan/cli-multi-account-profiles.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->