### PR TITLE
chore: move stable deployment to tonk.network

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -35,7 +35,7 @@ before a profile exists report as `tonk:anonymous`.
 | `panic` | `message` (first line of the panic message) |
 
 Every web event additionally carries an `environment` super property
-derived from the hostname: `production` (hub.tonk.xyz), `staging`
+derived from the hostname: `production` (tonk.network), `staging`
 (staging.tonk.xyz), or `dev` (anything else). The marketing site's
 own snippet registers `environment = "website"` in its repo, so all
 surfaces share one filterable dimension within the PostHog project.

--- a/flake.nix
+++ b/flake.nix
@@ -535,7 +535,7 @@
               PORT=''${1:-8080}
               ACCESS_SERVICE_PORT=''${2:-8090}
 
-              echo "Test server live at https://tonk.spot:$PORT"
+              echo "Test server live at https://tonk.network:$PORT"
               # `nix run` execs this script, and this exec in turn makes Caddy
               # the process owned by the test helper. Killing its `Child` then
               # cannot orphan a grandchild. Stdin avoids leaking a temp config.
@@ -547,7 +547,7 @@
                       protocols h1 h2
                   }
               }
-              https://tonk.spot:$PORT {
+              https://tonk.network:$PORT {
                   tls internal
                   handle /.well-known/tonk {
                       reverse_proxy localhost:$ACCESS_SERVICE_PORT

--- a/plan/invite-origin-followups.md
+++ b/plan/invite-origin-followups.md
@@ -108,8 +108,8 @@ consequence `resolve`'s doc left implicit: a repo with two registered
 remotes where one fails to decode resolves the other implicitly.
 
 **Analytics classified CLI invitees as `dev`.**
-`rust/tonk-analytics/src/web.rs` knew only `hub.tonk.xyz` and
-`staging.tonk.xyz`. It now maps the production alias `tonk.spot` too.
+`rust/tonk-analytics/src/web.rs` knew only the old production host and
+`staging.tonk.xyz`. It now maps the production origin `tonk.network` too.
 
 **Stale command names.** `tonk concepts` → `tonk concept ls` in
 `.claude/skills/tonk-bug/SKILL.md` (agent-facing, so a live footgun)
@@ -121,14 +121,13 @@ they record what past runs actually did.
 
 ## Resolved without action
 
-**Production serves the shortcut service.** `PUT /@` returned 404 on
-`tonk.spot` when this was written, because the deployed worker predated
-`run_worker_first = ["/@", "/@/*", ...]` in `wrangler.toml`. Prod has
-since been redeployed. All four hosts now answer 200 and redirect
-correctly:
+**Production serves the shortcut service.** The checked-in Worker configuration
+routes `PUT /@` through the Worker via
+`run_worker_first = ["/@", "/@/*", ...]` in `wrangler.toml`. After moving the
+production route, verify the new origin directly:
 
 ```bash
-curl -s -X PUT https://tonk.spot/@ --data-binary "/join?access=probe" -w " [%{http_code}]\n"
+curl -s -X PUT https://tonk.network/@ --data-binary "/join?access=probe" -w " [%{http_code}]\n"
 ```
 
 ## Test-harness traps worth knowing

--- a/rust/tonk-access-service/README.md
+++ b/rust/tonk-access-service/README.md
@@ -78,7 +78,7 @@ The S3 address uses region `auto`, as R2 requires.
 
 As a Cloudflare Worker, build and deploy with `worker-build` / `wrangler` like any `worker`-based crate (the `cdylib` target).
 
-`wrangler.toml` at the repo root carries three environments. The top level is production on `hub.tonk.xyz`, `[env.staging]` is `staging.tonk.xyz`, and `[env.preview]` is on no route: the deploy workflow uploads one version of it per pull request under a `pr-<number>` preview alias, reached at a workers.dev URL. Each has its own R2 buckets, because this Worker presigns writes into whichever bucket it is bound to and a preview must not be able to write into a real one.
+`wrangler.toml` at the repo root carries three environments. The top level is production on `tonk.network`, `[env.staging]` is `staging.tonk.xyz`, and `[env.preview]` is on no route: the deploy workflow uploads one version of it per pull request under a `pr-<number>` preview alias, reached at a workers.dev URL. Each has its own R2 buckets, because this Worker presigns writes into whichever bucket it is bound to and a preview must not be able to write into a real one.
 
 `ACCOUNT_SERVICE_URL` and `REVOCATION_RELAY_URL` are checked in for production and staging but overridden per pull request for preview, since the account worker's own alias URL is not known until its upload returns. The checked-in preview values point at an unresolvable host on purpose: a preview that failed to wire itself has to break rather than serve a real registry through `/.well-known/tonk` to browsers that trust it. Bootstrapping the preview environment is described in `tonk-account-service`'s README.
 

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -113,7 +113,7 @@ pub struct Registration<'a, S, E> {
     pub email: &'a E,
     /// The service's signing identity, issuer of activation delegations.
     pub service: &'a Ed25519Signer,
-    /// Origin the activation link points at, e.g. `https://hub.tonk.xyz`.
+    /// Origin the activation link points at, e.g. `https://tonk.network`.
     pub origin: &'a str,
     /// Lifetime of the emailed activation delegation, in seconds.
     pub activation_ttl: u64,

--- a/rust/tonk-access-service/src/service.rs
+++ b/rust/tonk-access-service/src/service.rs
@@ -73,8 +73,8 @@ mod tests {
     #[dialog_common::test]
     fn it_documents_the_key_under_the_web_did() {
         let signer = signer_from_hex(&"11".repeat(32)).unwrap();
-        let document = did_document("hub.tonk.xyz", &signer);
-        assert_eq!(document["id"], "did:web:hub.tonk.xyz");
+        let document = did_document("tonk.network", &signer);
+        assert_eq!(document["id"], "did:web:tonk.network");
         let multibase = document["verificationMethod"][0]["publicKeyMultibase"]
             .as_str()
             .unwrap();

--- a/rust/tonk-access-service/tests/shortcut.rs
+++ b/rust/tonk-access-service/tests/shortcut.rs
@@ -21,10 +21,10 @@ use tonk_access_service::shortcut::{
 
 #[dialog_common::test]
 fn it_accepts_a_rooted_path_with_query() {
-    let shortcut = Shortcut::new(b"/join?access=abc&remote=https%3A%2F%2Fhub.tonk.xyz").unwrap();
+    let shortcut = Shortcut::new(b"/join?access=abc&remote=https%3A%2F%2Ftonk.network").unwrap();
     assert_eq!(
         shortcut.target,
-        "/join?access=abc&remote=https%3A%2F%2Fhub.tonk.xyz"
+        "/join?access=abc&remote=https%3A%2F%2Ftonk.network"
     );
     assert!(shortcut.object_key().starts_with(KEY_PREFIX));
     assert_eq!(
@@ -108,7 +108,7 @@ mod http {
 
     #[dialog_common::test]
     async fn it_stores_and_redirects(env: AccessServiceAddress) -> anyhow::Result<()> {
-        let target = "/join?access=abc123&remote=https%3A%2F%2Fhub.tonk.xyz%2Fucan%2F";
+        let target = "/join?access=abc123&remote=https%3A%2F%2Ftonk.network%2Fucan%2F";
         let client = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .build()?;

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -32,16 +32,16 @@ handoff requires its 256-bit bearer secret.
 
 The passkey RP ID is the root-key custody boundary: any origin allowed to use
 it can derive any visiting user's root key from the PRF output. This service
-relies on `rp.id` being pinned to exactly one origin, `tonk.spot` (see
-`tonk-identity`'s `apex_rp_id`). Every other host — `www.tonk.spot`, staging,
+relies on `rp.id` being pinned to exactly one origin, `tonk.network` (see
+`tonk-identity`'s `apex_rp_id`). Every other host — `www.tonk.network`, staging,
 and any wildcard hostname under the apex — is its own relying party with its
 own disjoint credentials, so none of them can derive an apex root key.
 
-Two things follow. Production account ceremonies run only on `tonk.spot`;
-`hub.tonk.xyz` serves the same build but is a different relying party, so
-`tonk-ui` refuses ceremonies there rather than writing a second, disjoint
-identity for the same person into this registry. And staging runs off-apex on
-`staging.tonk.xyz` against its own registry, minting staging-only credentials.
+Two things follow. Production account ceremonies run only on `tonk.network`;
+`tonk-ui` refuses ceremonies on every other production-facing host rather than
+writing a second, disjoint identity for the same person into this registry.
+And staging runs off-apex on `staging.tonk.xyz` against its own registry,
+minting staging-only credentials.
 
 Widening the RP ID later is possible via Related Origin Requests. Narrowing it
 is not: it orphans every credential minted under the wider boundary.
@@ -165,8 +165,8 @@ First deploy, in order:
 3. `wrangler r2 bucket create tonk-account-chains`.
 4. `wrangler r2 bucket create tonk-revocations`.
 5. `wrangler secret put RESEND_API_KEY -c wrangler.account.toml`.
-6. Add the DKIM records Resend requires for sending from `tonk.spot` in the
-   Cloudflare dashboard (DNS for the zone), so `accounts@tonk.spot` mail is
+6. Add the DKIM records Resend requires for sending from `tonk.xyz` in the
+   Cloudflare dashboard (DNS for the zone), so `accounts@tonk.xyz` mail is
    authenticated.
 7. Add a WAF rate limiting rule for unauthenticated request creation (zone `tonk.xyz`,
    Security > WAF > Rate limiting rules): expression

--- a/rust/tonk-analytics/src/web.rs
+++ b/rust/tonk-analytics/src/web.rs
@@ -64,13 +64,11 @@ export function ph_init(key, host) {
         // staging, dev, and the marketing site (which registers
         // environment = "website" in its own repo) apart within the
         // shared PostHog project.
-        // Production answers on both hub.tonk.xyz and tonk.spot.
-        // tonk.spot is the canonical one the CLI builds invite links
-        // against, so a recipient arriving from `tonk invite` lands
-        // there. Staging has only its staging.tonk.xyz origin.
+        // tonk.network is the production origin the CLI builds invite links
+        // against. Staging has only its staging.tonk.xyz origin.
         var host = location.hostname;
         var environment =
-            (host === "hub.tonk.xyz" || host === "tonk.spot") ? "production"
+            host === "tonk.network" ? "production"
             : host === "staging.tonk.xyz" ? "staging"
             : "dev";
         window.posthog.register({ environment: environment });

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -16,10 +16,10 @@ use url::Url;
 /// Production account API used unless explicitly overridden.
 pub const DEFAULT_SERVICE_URL: &str = "https://accounts.tonk.xyz";
 /// Production account page, where the revoke ceremony runs.
-pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.spot/account";
+pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.network/account";
 /// Production link ceremony page: it reads `?audience=` and `?callback=`
 /// and posts the grant back to the waiting CLI.
-pub const DEFAULT_LINK_PAGE: &str = "https://tonk.spot/account/link";
+pub const DEFAULT_LINK_PAGE: &str = "https://tonk.network/account/link";
 /// Credential-store key for optional provider attachment metadata.
 pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE;
 
@@ -1282,7 +1282,7 @@ mod tests {
         );
         assert_eq!(
             url,
-            "https://tonk.spot/account/link\
+            "https://tonk.network/account/link\
              ?audience=did%3Akey%3AzProfile\
              &callback=http%3A%2F%2F127.0.0.1%3A54321\
              &name=Kitchen%20laptop"
@@ -1364,7 +1364,7 @@ mod tests {
     fn it_points_the_revoke_ceremony_at_the_named_device() {
         assert_eq!(
             revoke_url(DEFAULT_ACCOUNT_PAGE, "did:key:zDevice"),
-            "https://tonk.spot/account?revoke=did:key:zDevice"
+            "https://tonk.network/account?revoke=did:key:zDevice"
         );
     }
 

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -614,7 +614,7 @@ mod when_minting_against_a_live_remote {
             url.starts_with(&format!("{origin}/@/")),
             "short link sits on the remote's origin: {url}"
         );
-        assert!(!url.contains("tonk.spot"), "not the default base: {url}");
+        assert!(!url.contains("tonk.network"), "not the default base: {url}");
         Ok(())
     }
 
@@ -664,7 +664,7 @@ mod when_minting_against_a_live_remote {
             url.starts_with(&format!("{origin}/@/")),
             "short link sits on the remote's origin: {url}"
         );
-        assert!(!url.contains("tonk.spot"), "not the default base: {url}");
+        assert!(!url.contains("tonk.network"), "not the default base: {url}");
 
         let target = shortcut_target(url).await?;
         assert!(target.contains("access="), "still a real invite: {target}");

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1638,14 +1638,14 @@ mod enable_sync_claim {
     fn it_names_the_space_remote_and_share_marker() {
         let claim = enable_sync_claim_json(
             "did:key:z6Mk",
-            "https://tonk.spot/ucan/",
+            "https://tonk.network/ucan/",
             Some("https://accounts.tonk.xyz/revocations"),
             true,
             7.0,
         );
         let app = &claim["claims"][0]["application"];
         assert_eq!(app["parameters"]["space"], "did:key:z6Mk");
-        assert_eq!(app["parameters"]["remote"], "https://tonk.spot/ucan/");
+        assert_eq!(app["parameters"]["remote"], "https://tonk.network/ucan/");
         assert_eq!(
             app["parameters"]["revocation"],
             "https://accounts.tonk.xyz/revocations"
@@ -1713,16 +1713,16 @@ mod default_remote {
     #[test]
     fn it_appends_the_access_service_path() {
         assert_eq!(
-            default_remote_url("https://tonk.spot"),
-            "https://tonk.spot/ucan/"
+            default_remote_url("https://tonk.network"),
+            "https://tonk.network/ucan/"
         );
     }
 
     #[test]
     fn it_does_not_double_slash_an_origin_that_already_has_one() {
         assert_eq!(
-            default_remote_url("https://tonk.spot/"),
-            "https://tonk.spot/ucan/"
+            default_remote_url("https://tonk.network/"),
+            "https://tonk.network/ucan/"
         );
     }
 }

--- a/rust/tonk-guest/src/guest_host.rs
+++ b/rust/tonk-guest/src/guest_host.rs
@@ -182,7 +182,7 @@ fn scroll_to_fragment(fragment: &str) -> bool {
 
 /// Decide what a click means.
 ///
-/// The guest sets a `<base href="https://{label}.tonk.spot/">` to its
+/// The guest sets a `<base href="https://{label}.tonk.network/">` to its
 /// per-space SYNTHETIC origin, so the BROWSER resolves `anchor.href` for us —
 /// a real URL, not the opaque `null/…` it would be with no base. So we
 /// classify by ORIGIN, the way a normal page does:
@@ -262,7 +262,7 @@ fn classify_click(event: &Event) -> Intent {
 /// The origin a link in this guest is judged against.
 ///
 /// A space guest resolves against its synthetic per-space base
-/// (`https://{label}.tonk.spot`), so that is the origin that means "in-app".
+/// (`https://{label}.tonk.network`), so that is the origin that means "in-app".
 /// The profile/Hub guest has no synthetic origin — `space_origin_for` only
 /// answers for a `did:key`, and the profile is not one — and its links are
 /// genuinely top-level, resolving against the REAL host origin. Judging those

--- a/rust/tonk-host/src/space_origin.rs
+++ b/rust/tonk-host/src/space_origin.rs
@@ -1,7 +1,7 @@
 //! The per-space fake origin a sealed guest believes it lives at.
 //!
 //! A space rendered in a sealed portal iframe is given its own synthetic
-//! origin — `https://{label}.tonk.spot/` — so that navigation inside the
+//! origin — `https://{label}.tonk.network/` — so that navigation inside the
 //! guest resolves like an ordinary web page: in-space routes are plain
 //! absolute paths (`/`, `/activity`, `/activity/{id}`) under that origin,
 //! and any href that escapes the origin is, by definition, external. The
@@ -26,11 +26,11 @@ use multibase::Base;
 /// The host suffix every space origin lives under. Purely internal (never
 /// resolved by real DNS), so the literal value only has to be stable and
 /// distinct from the real host origin.
-const SPACE_ORIGIN_SUFFIX: &str = "tonk.spot";
+const SPACE_ORIGIN_SUFFIX: &str = "tonk.network";
 
 /// The synthetic origin a guest rendering `space` (a `did:key` string)
 /// believes it lives at, WITH a trailing slash so it is a directory base
-/// (`https://{label}.tonk.spot/`). Relative in-space hrefs resolve under
+/// (`https://{label}.tonk.network/`). Relative in-space hrefs resolve under
 /// it; the browser's own URL resolution does the rest.
 ///
 /// Returns `None` for anything that is not a `did:key` space (e.g. the
@@ -95,7 +95,7 @@ mod tests {
     fn origin_has_trailing_slash_directory_base() {
         let origin = space_origin_for("did:key:z6MkTest").expect("origin");
         assert!(origin.starts_with("https://"));
-        assert!(origin.ends_with(".tonk.spot/"));
+        assert!(origin.ends_with(".tonk.network/"));
     }
 
     #[test]

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -78,10 +78,10 @@ fn prf_extensions() -> AuthenticationExtensionsClientInputs {
 /// boundary — any origin allowed to use it can silently derive a visiting
 /// user's root key with one discoverable-credential assertion — so it is
 /// pinned to this exact origin and nothing else. Every other host under
-/// `tonk.spot`, including any wildcard hostname, is its own relying party
+/// `tonk.network`, including any wildcard hostname, is its own relying party
 /// with its own disjoint credentials. Widening later is
 /// possible via Related Origin Requests; narrowing never is.
-const RP_APEX: &str = "tonk.spot";
+const RP_APEX: &str = "tonk.network";
 
 /// The pinned RP ID on the apex origin itself; `None` (WebAuthn's
 /// per-host default) everywhere else, which gives localhost tests,
@@ -318,16 +318,16 @@ mod tests {
 
     #[dialog_common::test]
     fn it_pins_the_rp_id_to_the_apex_origin_only() {
-        assert_eq!(apex_rp_id("tonk.spot"), Some("tonk.spot"));
+        assert_eq!(apex_rp_id("tonk.network"), Some("tonk.network"));
         // Every other host under the apex is its own relying party, so it
         // cannot derive an apex root key from a visiting user's passkey.
-        assert_eq!(apex_rp_id("www.tonk.spot"), None);
-        assert_eq!(apex_rp_id("hub.tonk.spot"), None);
-        assert_eq!(apex_rp_id("a.b.tonk.spot"), None);
+        assert_eq!(apex_rp_id("www.tonk.network"), None);
+        assert_eq!(apex_rp_id("hub.tonk.network"), None);
+        assert_eq!(apex_rp_id("a.b.tonk.network"), None);
         assert_eq!(apex_rp_id("staging.tonk.xyz"), None);
         assert_eq!(apex_rp_id("localhost"), None);
         // A suffix match must not treat a sibling registrable domain as ours.
-        assert_eq!(apex_rp_id("evil-tonk.spot"), None);
+        assert_eq!(apex_rp_id("evil-tonk.network"), None);
     }
 
     #[dialog_common::test]
@@ -338,7 +338,7 @@ mod tests {
         let rp = Reflect::get(&options, &"rp".into()).unwrap();
         assert!(
             Reflect::get(&rp, &"id".into()).unwrap().is_undefined(),
-            "rp.id must stay unset off the tonk.spot apex"
+            "rp.id must stay unset off the tonk.network apex"
         );
     }
 }

--- a/rust/tonk-invite/README.md
+++ b/rust/tonk-invite/README.md
@@ -35,7 +35,7 @@ audience-scoped ([`InviteAudience::Scoped`]): only the chain's recorded
 audience DID can claim. The *subject* axis (which repo) is always scoped and is
 orthogonal to this.
 
-[`DEFAULT_BASE_URL`] (`https://tonk.spot/join`) is the canonical base for
+[`DEFAULT_BASE_URL`] (`https://tonk.network/join`) is the canonical base for
 generic non-browser callers. Browser mint routes use `/join` on the exact
 request origin when `baseUrl` is omitted.
 

--- a/rust/tonk-invite/src/lib.rs
+++ b/rust/tonk-invite/src/lib.rs
@@ -44,12 +44,12 @@ use url::Url;
 
 /// Canonical base URL for tonk invite links, and the fallback for a repo
 /// with no remote to take an origin from. Callers serializing an [`Invite`]
-/// pass this to [`Invite::to_url`] to mint a link rooted at tonk.spot.
+/// pass this to [`Invite::to_url`] to mint a link rooted at tonk.network.
 ///
 /// Changing it does not invalidate outstanding invites: the base is not a
 /// lookup key, so a link already minted against another host keeps
 /// redeeming for as long as that host stays up.
-pub const DEFAULT_BASE_URL: &str = "https://tonk.spot/join";
+pub const DEFAULT_BASE_URL: &str = "https://tonk.network/join";
 
 /// Lifetime of the authority installed by [`Invite::visit`].
 ///
@@ -536,7 +536,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_missing_access_parameter() {
-        let err = Invite::parse_url("https://hub.tonk.xyz/join")
+        let err = Invite::parse_url("https://tonk.network/join")
             .await
             .unwrap_err();
         assert!(err.to_string().contains("`access`"), "{err}");
@@ -544,7 +544,7 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_rejects_invalid_base58_in_access() {
-        let err = Invite::parse_url("https://hub.tonk.xyz/join?access=!!!not-b58!!!")
+        let err = Invite::parse_url("https://tonk.network/join?access=!!!not-b58!!!")
             .await
             .unwrap_err();
         assert!(err.to_string().contains("valid base58"), "{err}");
@@ -578,7 +578,7 @@ mod tests {
         let audience_signer = signer(&AUDIENCE_SEED).await;
         let audience = audience_signer.did();
         let chain = make_chain(&ISSUER_SEED, &audience, &subject).await;
-        let remote = Url::parse("https://hub.tonk.xyz/ucan/").unwrap();
+        let remote = Url::parse("https://tonk.network/ucan/").unwrap();
 
         // Scoped, with remote
         let invite = Invite::new(chain.clone(), InviteAudience::Scoped, Some(remote.clone()))

--- a/rust/tonk-invite/src/shortcut.rs
+++ b/rust/tonk-invite/src/shortcut.rs
@@ -130,46 +130,46 @@ mod tests {
     #[dialog_common::test]
     fn it_splits_a_long_url_into_shortcut_parts() {
         let request =
-            ShortcutRequest::new("https://hub.tonk.xyz/join?access=abc&remote=r#seed123").unwrap();
-        assert_eq!(request.endpoint.as_str(), "https://hub.tonk.xyz/@");
+            ShortcutRequest::new("https://tonk.network/join?access=abc&remote=r#seed123").unwrap();
+        assert_eq!(request.endpoint.as_str(), "https://tonk.network/@");
         assert_eq!(request.target, "/join?access=abc&remote=r");
 
         let short = request.short_url(HASH).unwrap();
-        assert_eq!(short, format!("https://hub.tonk.xyz/@/{HASH}#seed123"));
+        assert_eq!(short, format!("https://tonk.network/@/{HASH}#seed123"));
     }
 
     #[dialog_common::test]
     fn it_keeps_fragmentless_urls_fragmentless() {
-        let request = ShortcutRequest::new("https://hub.tonk.xyz/join?access=abc").unwrap();
+        let request = ShortcutRequest::new("https://tonk.network/join?access=abc").unwrap();
         let short = request.short_url(HASH).unwrap();
         assert!(!short.contains('#'), "{short}");
     }
 
     #[dialog_common::test]
     fn it_rejects_hashes_that_are_not_base58_of_32_bytes() {
-        let request = ShortcutRequest::new("https://hub.tonk.xyz/join?access=abc").unwrap();
+        let request = ShortcutRequest::new("https://tonk.network/join?access=abc").unwrap();
         assert!(request.short_url("!!!").is_err());
         assert!(request.short_url("3vQB7B6MdGQZcSvtzcXAyC").is_err());
     }
 
     #[dialog_common::test]
     fn it_recognizes_shortcut_links() {
-        assert!(is_shortcut(&format!("https://hub.tonk.xyz/@/{HASH}#s")));
-        assert!(!is_shortcut("https://hub.tonk.xyz/join?access=abc#s"));
+        assert!(is_shortcut(&format!("https://tonk.network/@/{HASH}#s")));
+        assert!(!is_shortcut("https://tonk.network/join?access=abc#s"));
         assert!(!is_shortcut("not a url"));
     }
 
     #[dialog_common::test]
     fn it_resolves_locations_with_fragment_inheritance() {
-        let short = format!("https://hub.tonk.xyz/@/{HASH}#seed123");
+        let short = format!("https://tonk.network/@/{HASH}#seed123");
         let resolved = resolve_location(&short, "/join?access=abc&remote=r").unwrap();
         assert_eq!(
             resolved,
-            "https://hub.tonk.xyz/join?access=abc&remote=r#seed123"
+            "https://tonk.network/join?access=abc&remote=r#seed123"
         );
 
         // An explicit fragment in Location wins, mirroring browsers.
         let resolved = resolve_location(&short, "/join?access=abc#other").unwrap();
-        assert_eq!(resolved, "https://hub.tonk.xyz/join?access=abc#other");
+        assert_eq!(resolved, "https://tonk.network/join?access=abc#other");
     }
 }

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -452,7 +452,7 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     // cross-origin fetch (CORS-blocked, origin `null`), so strip the origin
     // prefix and relay the path. TWO origins qualify: the REAL host origin
     // (`context.origin`), and the guest's SYNTHETIC per-space base origin
-    // (`context.base`, e.g. `https://{label}.tonk.spot`) — with a `<base>` set
+    // (`context.base`, e.g. `https://{label}.tonk.network`) — with a `<base>` set
     // to the latter, a relative `/api/…` resolves against it, so a `Request`
     // built from it is fake-origin-absolute and must be stripped the same way.
     var ctx=(window.tonk&&window.tonk.context)||{};
@@ -742,7 +742,7 @@ fn base_tag(base: &str) -> String {
     if base.is_empty() {
         String::new()
     } else {
-        // `base` is a same-origin literal we built (`https://{label}.tonk.spot/`),
+        // `base` is a same-origin literal we built (`https://{label}.tonk.network/`),
         // so there is nothing to escape, but keep it minimal and attribute-safe.
         format!("<base href=\"{base}\">")
     }
@@ -1795,7 +1795,7 @@ fn handle_navigate(state: &Rc<RefCell<PortalState>>, data: &JsValue) {
 /// Translate a guest-world href into the REAL route the host navigates to.
 ///
 /// The guest resolves links against its synthetic per-space origin
-/// (`https://{label}.tonk.spot/`), so an in-space link arrives as a bare
+/// (`https://{label}.tonk.network/`), so an in-space link arrives as a bare
 /// absolute path (`/activity`). The document is really served at
 /// `/space/{did}/...`, so prefix the space segment. A guest with no space
 /// context (profile/Hub), or an already-`/space/...` path, is left as-is.
@@ -2430,7 +2430,7 @@ fn build_context(host: &Element, state: &Rc<RefCell<PortalState>>) -> Object {
     let _ = Reflect::set(&context, &"model".into(), &JsValue::from_str(&model));
     let _ = Reflect::set(&context, &"origin".into(), &JsValue::from_str(&origin));
     // The per-space SYNTHETIC origin this guest believes it lives at
-    // (`https://{label}.tonk.spot/`), so in-guest navigation resolves like an
+    // (`https://{label}.tonk.network/`), so in-guest navigation resolves like an
     // ordinary page: in-space routes are plain absolute paths under it, and an
     // href that escapes it is external. Distinct from `origin` (the REAL host
     // origin, which propagates down nesting and keys the `/api` relay strip).

--- a/rust/tonk-portal/src/shared.rs
+++ b/rust/tonk-portal/src/shared.rs
@@ -122,7 +122,7 @@ pub(crate) fn reload_portal(host: &Element, state: &Rc<RefCell<PortalState>>) {
     }
 }
 
-/// The per-space synthetic origin (`https://{label}.tonk.spot/`) for this
+/// The per-space synthetic origin (`https://{label}.tonk.network/`) for this
 /// portal's routing context, or empty when the portal targets no space (the
 /// profile/Hub) — where in-guest links are genuinely top-level.
 fn space_base(state: &bridge::PortalState) -> String {

--- a/rust/tonk-ui/README.md
+++ b/rust/tonk-ui/README.md
@@ -29,7 +29,7 @@ revoked, wrong-recipient, and unavailable joins leave no visible replica.
 ## Account route
 
 `/account` is mounted directly in the top document rather than inside a sealed
-`<tonk-site>` guest. WebAuthn must run on the `tonk.spot` RP-ID origin, so
+`<tonk-site>` guest. WebAuthn must run on the `tonk.network` RP-ID origin, so
 `<tonk-account>` owns account creation and passkey self-link there. It reads the
 local profile DID from `/api/identify`, sends root-signed ceremony bytes to the
 configured account service, then attaches provider metadata through

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -335,7 +335,7 @@ mod tests {
             .env("TONK_UPDATE_STATE", profile.path().join("update"))
             .env("TONK_NO_UPDATE_CHECK", "1")
             .env("DO_NOT_TRACK", "1")
-            .env("NO_PROXY", "127.0.0.1,localhost,tonk.spot")
+            .env("NO_PROXY", "127.0.0.1,localhost,tonk.network")
             .env_remove("TONK_TELEMETRY")
             .env_remove("TONK_SPOT")
             .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT");

--- a/rust/tonk-ui/src/account_gate.rs
+++ b/rust/tonk-ui/src/account_gate.rs
@@ -316,7 +316,7 @@ mod tests {
     #[dialog_common::test]
     fn it_discards_a_parked_intent() {
         park(&PendingIntent::DurableJoin {
-            url: "https://tonk.spot/join#seed".into(),
+            url: "https://tonk.network/join#seed".into(),
         });
         discard_pending();
         assert!(take_pending().is_none());

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -79,7 +79,7 @@ mod native {
                 caps.set_headless()?;
             }
 
-            caps.add_arg("--host-resolver-rules=MAP tonk.spot 127.0.0.1")?;
+            caps.add_arg("--host-resolver-rules=MAP tonk.network 127.0.0.1")?;
             caps.accept_insecure_certs(true)?;
             let secure_origin = format!(
                 "--unsafely-treat-insecure-origin-as-secure={}",
@@ -182,7 +182,7 @@ mod native {
                     // Filled in by the server with its own generated identity.
                     service_did: None,
                 }),
-                public_origin: Some(format!("https://tonk.spot:{web_port}")),
+                public_origin: Some(format!("https://tonk.network:{web_port}")),
                 ..Default::default()
             };
             let access_service = tonk_access_service::helpers::access_service(settings).await?;
@@ -274,7 +274,7 @@ mod native {
                     account_service: Some(account_service),
                 },
                 TestEnvironment {
-                    tonk_web: Url::parse(&format!("https://tonk.spot:{web_port}"))?,
+                    tonk_web: Url::parse(&format!("https://tonk.network:{web_port}"))?,
                     chromedriver: Url::parse(&format!("http://127.0.0.1:{chromedriver_port}"))?,
                     account_service: account_service_url,
                     access_service: Url::parse(&access_service_address.access_service_url)?,

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -397,7 +397,7 @@ mod tests {
                 if (input.email !== "fresh@example.test"
                     || input.deviceDid !== "did:key:device" || input.deviceName !== "Browser"
                     || input.createdOn !== "Chrome on macOS"
-                    || input.remote !== "https://tonk.spot/ucan/")
+                    || input.remote !== "https://tonk.network/ucan/")
                     return Promise.reject(new Error("property"));
                 return Promise.resolve({{
                     rootDid: "did:key:root", deviceDid: input.deviceDid,
@@ -411,7 +411,7 @@ mod tests {
             email: "fresh@example.test".into(),
             device_did: "did:key:device".into(),
             device_name: "Browser".into(),
-            remote: "https://tonk.spot/ucan/".into(),
+            remote: "https://tonk.network/ucan/".into(),
             created_on: "Chrome on macOS".into(),
             service_did: None,
         })
@@ -430,7 +430,7 @@ mod tests {
                     || input.delegationHex !== "delegation"
                     || input.passkey.createdAt !== 1754380800
                     || input.passkey.createdOn !== "Chrome on macOS"
-                    || input.remote !== "https://tonk.spot/ucan/")
+                    || input.remote !== "https://tonk.network/ucan/")
                     return Promise.reject(new Error("property"));
                 return Promise.resolve({{
                     rootDid: input.rootDid, credentialId: input.credentialId,
@@ -451,7 +451,7 @@ mod tests {
                     created_at: 1_754_380_800,
                     created_on: "Chrome on macOS".into(),
                 }),
-                remote: "https://tonk.spot/ucan/".into(),
+                remote: "https://tonk.network/ucan/".into(),
             })
             .await
             .unwrap()

--- a/rust/tonk-worker-api/src/identity.rs
+++ b/rust/tonk-worker-api/src/identity.rs
@@ -166,7 +166,7 @@ mod tests {
 
     #[dialog_common::test]
     fn it_omits_invite_urls_from_debug_output() {
-        let secret = "https://tonk.spot/join#authority";
+        let secret = "https://tonk.network/join#authority";
         let debug = format!("{:?}", PendingIntent::DurableJoin { url: secret.into() });
         assert!(!debug.contains(secret));
         assert!(debug.contains("<redacted>"));
@@ -179,7 +179,7 @@ mod tests {
         let message = AccountRequired {
             message_type: ACCOUNT_REQUIRED.to_string(),
             intent: PendingIntent::DurableJoin {
-                url: "https://tonk.spot/join#authority".into(),
+                url: "https://tonk.network/join#authority".into(),
             },
         };
         let value = serde_json::to_value(&message).expect("serializes");

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1380,7 +1380,7 @@ pub mod tests {
         .with_revocation_url(
             remote.map(|_| "https://relay.example.test/revocations/".parse().unwrap()),
         );
-        (invite.to_url("https://hub.tonk.xyz/join").unwrap(), key)
+        (invite.to_url("https://tonk.network/join").unwrap(), key)
     }
 
     /// `POST /api/profile/visit` — an accountless guest visit.

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -1042,14 +1042,14 @@ mod guest_record {
     #[dialog_common::test]
     async fn it_reads_a_v1_guest_record_as_a_legacy_lease() {
         let subject = subject().await;
-        let bytes = serde_json::json!({ "version": 1, "url": "https://hub.tonk.xyz/join?x=1#s" })
+        let bytes = serde_json::json!({ "version": 1, "url": "https://tonk.network/join?x=1#s" })
             .to_string()
             .into_bytes();
 
         let (url, audience, expires_at) = decode_guest_record(&subject, &bytes).unwrap();
 
         assert_eq!(
-            url, "https://hub.tonk.xyz/join?x=1#s",
+            url, "https://tonk.network/join?x=1#s",
             "the retained URL is what a legacy record still carries",
         );
         assert!(
@@ -1065,7 +1065,7 @@ mod guest_record {
         let audience = Ed25519Signer::import(&[11u8; 32]).await.unwrap().did();
         let bytes = serde_json::json!({
             "version": GUEST_RECORD_VERSION,
-            "url": "https://hub.tonk.xyz/join?x=1#s",
+            "url": "https://tonk.network/join?x=1#s",
             "audience": audience.to_string(),
             "expires_at": 1_700_000_000u64,
         })
@@ -1077,7 +1077,7 @@ mod guest_record {
         assert_eq!(
             decoded,
             (
-                "https://hub.tonk.xyz/join?x=1#s".to_string(),
+                "https://tonk.network/join?x=1#s".to_string(),
                 Some(audience),
                 Some(1_700_000_000),
             )
@@ -1090,12 +1090,12 @@ mod guest_record {
         for partial in [
             serde_json::json!({
                 "version": GUEST_RECORD_VERSION,
-                "url": "https://hub.tonk.xyz/join",
+                "url": "https://tonk.network/join",
                 "expires_at": 1_700_000_000u64,
             }),
             serde_json::json!({
                 "version": GUEST_RECORD_VERSION,
-                "url": "https://hub.tonk.xyz/join",
+                "url": "https://tonk.network/join",
                 "audience": "did:key:z6MkeTG3bFFSLYVU7VqhgZxqr6YzpaGrQtFMh1uvqGy1vDnP",
             }),
         ] {
@@ -1110,7 +1110,7 @@ mod guest_record {
     #[dialog_common::test]
     async fn it_refuses_a_guest_record_from_an_unsupported_version() {
         let subject = subject().await;
-        let bytes = serde_json::json!({ "version": 99, "url": "https://hub.tonk.xyz/join" })
+        let bytes = serde_json::json!({ "version": 99, "url": "https://tonk.network/join" })
             .to_string()
             .into_bytes();
 
@@ -2598,7 +2598,7 @@ mod tests {
         )
         .await
         .unwrap();
-        (invite.to_url("https://hub.tonk.xyz/join").unwrap(), key)
+        (invite.to_url("https://tonk.network/join").unwrap(), key)
     }
 
     /// Everything a failed join must leave untouched, in one value.
@@ -3153,7 +3153,7 @@ mod tests {
                     .uri(format!("/api/repository/{key}/invite"))
                     .method("POST")
                     .header("content-type", "application/json")
-                    .extension(crate::axum::RequestOrigin::parse("https://hub.tonk.xyz/").unwrap())
+                    .extension(crate::axum::RequestOrigin::parse("https://tonk.network/").unwrap())
                     .body(Body::from("{}"))
                     .unwrap(),
             )
@@ -3259,7 +3259,7 @@ mod tests {
         let before = snapshot(&state, &key).await;
 
         assert_eq!(
-            post_join(&app, "https://hub.tonk.xyz/join?access=not-base58").await,
+            post_join(&app, "https://tonk.network/join?access=not-base58").await,
             StatusCode::BAD_REQUEST,
         );
 

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -1585,7 +1585,7 @@ mod tests {
     async fn lease(audience: Option<&Did>, expires_at: Option<u64>) -> GuestLease {
         GuestLease {
             subject: signer(&[3u8; 32]).await,
-            url: "https://hub.tonk.xyz/join?access=x#seed".to_string(),
+            url: "https://tonk.network/join?access=x#seed".to_string(),
             audience: audience.cloned(),
             expires_at,
         }

--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -27,7 +27,7 @@ EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 
 # Staging. Disjoint from production in every dimension that holds state:
 # its own worker, route, database, and bucket. The route stays off the
-# tonk.spot apex so staging mints its own passkey credentials rather than
+# tonk.network apex so staging mints its own passkey credentials rather than
 # production ones (see the RP ID invariants in the crate README).
 [env.staging]
 routes = [{ pattern = "accounts-staging.tonk.xyz", custom_domain = true }]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "./result/tonk-access-service/worker/shim.mjs"
 compatibility_date = "2026-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-routes = [{ pattern = "hub.tonk.xyz", custom_domain = true }]
+routes = [{ pattern = "tonk.network", custom_domain = true }]
 
 [build]
 command = "nix build .#tonk-cloudflare-artifacts"
@@ -101,7 +101,7 @@ EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 # `--preview-alias` and is reached at its own workers.dev URL, so the
 # environment holds no route of its own. `routes = []` is load-bearing: a named
 # environment inherits the top-level `routes`, and deploying it with that
-# inherited entry would reassign the `hub.tonk.xyz` custom domain away from
+# inherited entry would reassign the `tonk.network` custom domain away from
 # production.
 #
 # Its state is disjoint from staging as well as production. A pull request


### PR DESCRIPTION
## Summary

- move the production Cloudflare custom-domain route from the legacy production hosts to `tonk.network`
- update canonical invite, account, passkey RP-ID, synthetic space-origin, analytics, and test-server URLs
- align affected tests and operational documentation, while keeping staging and `accounts.tonk.xyz` service boundaries unchanged

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/staging...HEAD`
- tracked-tree scan found no remaining `tonk.spot` or `hub.tonk.xyz` references
- `cargo test -p tonk-invite -p tonk-host -p tonk-identity -p tonk-worker-api -p tonk-fab` (183 passed plus doc tests)
- focused access-service shortcut and DID-document tests passed
- focused CLI account-link and revoke URL tests passed
- `cargo test -p tonk-worker --lib guest_record` (4 passed)
- `cargo check -p tonk-ui -p tonk-portal -p tonk-guest -p tonk-analytics`
- Wasm debug archive: 1,299 tests passed in the broad run; the sole remaining unrelated display test hung in the suite runner, then passed in 2 seconds when rerun alone, covering all 1,300 tests successfully
- `wrangler deploy --dry-run -c wrangler.toml` built the Cloudflare artifacts, validated 979 UI assets and production bindings, and exited successfully without deploying

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating various URLs in the codebase from `tonk.spot` and `hub.tonk.xyz` to `tonk.network`, ensuring consistency across the application.

### Detailed summary
- Updated `GuestLease` URL from `hub.tonk.xyz` to `tonk.network`.
- Changed `PendingIntent::DurableJoin` URL to `tonk.network`.
- Modified `invite.to_url` calls to point to `tonk.network`.
- Adjusted environment variables to replace `tonk.spot` with `tonk.network`.
- Updated documentation to reflect the new base URL.
- Changed synthetic origin references from `tonk.spot` to `tonk.network`.
- Updated activation link origin in `registration.rs` to `tonk.network`.
- Adjusted telemetry documentation to reflect the new hostname.
- Updated tests to use `tonk.network` instead of `tonk.spot` and `hub.tonk.xyz`.
- Modified the shortcut service to reference `tonk.network`.
- Updated the passkey RP ID to `tonk.network` in identity handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->